### PR TITLE
[PREVIEW] PLANNER-667 Introduce annotation-driven difficulty comparator definition

### DIFF
--- a/optaplanner-core/src/main/java/org/optaplanner/core/api/domain/entity/comparator/ComparatorDefinition.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/api/domain/entity/comparator/ComparatorDefinition.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.core.api.domain.entity.comparator;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Encapsulation of all problem fact fields used for planning entity comparison.
+ *
+ * TODO: extend documentation
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ComparatorDefinition {
+
+    ComparatorFieldChain[] fieldChains() default {};
+
+}

--- a/optaplanner-core/src/main/java/org/optaplanner/core/api/domain/entity/comparator/ComparatorField.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/api/domain/entity/comparator/ComparatorField.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.core.api.domain.entity.comparator;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Represents single problem fact field, e.g. Course -> lectureSize : int
+ *
+ * TODO: extend documentation
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ComparatorField {
+
+    String name();
+
+    Class type();
+}

--- a/optaplanner-core/src/main/java/org/optaplanner/core/api/domain/entity/comparator/ComparatorFieldChain.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/api/domain/entity/comparator/ComparatorFieldChain.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.core.api.domain.entity.comparator;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Chain of variables with defined order, e.g. Course -> teacher : Teacher -> age : String, false
+ *
+ * TODO: extend documentation
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ComparatorFieldChain {
+
+    ComparatorField[] fields() default {};
+
+    boolean ascending() default true;
+
+}


### PR DESCRIPTION
Initial proposal of the mechanism to define difficulty comparator (and perhaps other comparators in the future) using annotations. This is especially useful in the Workbench app - we need to capture the fields used for the comparison of Planning entities and generate comparator code based on this.

https://github.com/droolsjbpm/optaplanner-wb/pull/106 currently uses a slight modification of the annotation hierarchy suggested here. Based on the discussion with @ge0ffrey it might be useful to move the generating code into the core module to provide an alternative way to define the comparator.

As described in the JIRA, this consists of 3-level hierarchy.
`ComparatorField` - Represents single problem fact field, e.g. Course -> lectureSize : int
`ComparatorFieldChain` - Chain of variables with defined order, e.g. Course -> teacher : Teacher -> age : String, false
`ComparatorDefinition` - Encapsulation of all problem fact fields used for planning entity comparison.

This is how the definition might look like with Cloud balancing example.
`@PlanningEntity(difficultyComparatorDefinition = 
@ComparatorDefinition(fieldChains = {
            @ComparatorFieldChain(fields = {@ComparatorField(name = "requiredCpuPower", type = int.class)}, ascending = true),
            @ComparatorFieldChain(fields = {@ComparatorField(name = "requiredMemory", type = int.class)}, ascending = true),
            @ComparatorFieldChain(fields = {@ComparatorField(name = "requiredNetworkBandwidth", type = int.class)}, ascending = true)})
)`

Things to agree on:
- naming
- location of the annotations - currently they reside in `org.optaplanner.core.api.domain.entity.comparator` package, but this may change if we want to reuse the comparator definition elsewhere
- implementation of the generating code - IMO this should be in first so that https://github.com/droolsjbpm/optaplanner-wb/pull/106 can be integrated. Implement the code generation in the second round.  
