### PR TITLE
Add DefaultPartitionedSearchPhase test coverage

### DIFF
--- a/optaplanner-core/src/main/java/org/optaplanner/core/config/partitionedsearch/PartitionedSearchPhaseConfig.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/config/partitionedsearch/PartitionedSearchPhaseConfig.java
@@ -54,7 +54,7 @@ public class PartitionedSearchPhaseConfig extends PhaseConfig<PartitionedSearchP
     // Warning: all fields are null (and not defaulted) because they can be inherited
     // and also because the input config file should match the output config file
 
-    protected Class<SolutionPartitioner> solutionPartitionerClass = null;
+    protected Class<? extends SolutionPartitioner<?>> solutionPartitionerClass = null;
     @XStreamConverter(KeyAsElementMapConverter.class)
     protected Map<String, String> solutionPartitionerCustomProperties = null;
 
@@ -68,11 +68,11 @@ public class PartitionedSearchPhaseConfig extends PhaseConfig<PartitionedSearchP
     // Constructors and simple getters/setters
     // ************************************************************************
 
-    public Class<SolutionPartitioner> getSolutionPartitionerClass() {
+    public Class<? extends SolutionPartitioner<?>> getSolutionPartitionerClass() {
         return solutionPartitionerClass;
     }
 
-    public void setSolutionPartitionerClass(Class<SolutionPartitioner> solutionPartitionerClass) {
+    public void setSolutionPartitionerClass(Class<? extends SolutionPartitioner<?>> solutionPartitionerClass) {
         this.solutionPartitionerClass = solutionPartitionerClass;
     }
 
@@ -163,7 +163,7 @@ public class PartitionedSearchPhaseConfig extends PhaseConfig<PartitionedSearchP
 
     private SolutionPartitioner buildSolutionPartitioner() {
         if (solutionPartitionerClass != null) {
-            SolutionPartitioner solutionPartitioner = ConfigUtils.newInstance(this,
+            SolutionPartitioner<?> solutionPartitioner = ConfigUtils.newInstance(this,
                     "solutionPartitionerClass", solutionPartitionerClass);
             ConfigUtils.applyCustomProperties(solutionPartitioner, "solutionPartitionerClass",
                     solutionPartitionerCustomProperties);

--- a/optaplanner-core/src/main/java/org/optaplanner/core/config/partitionedsearch/PartitionedSearchPhaseConfig.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/config/partitionedsearch/PartitionedSearchPhaseConfig.java
@@ -19,10 +19,7 @@ package org.optaplanner.core.config.partitionedsearch;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.ThreadFactory;
-import java.util.concurrent.ThreadPoolExecutor;
-import java.util.concurrent.TimeUnit;
 
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 import com.thoughtworks.xstream.annotations.XStreamConverter;
@@ -143,7 +140,7 @@ public class PartitionedSearchPhaseConfig extends PhaseConfig<PartitionedSearchP
                 phaseIndex, solverConfigPolicy.getLogIndentation(), bestSolutionRecaller,
                 buildPhaseTermination(phaseConfigPolicy, solverTermination));
         phase.setSolutionPartitioner(buildSolutionPartitioner());
-        phase.setThreadPoolExecutor(buildThreadPoolExecutor());
+        phase.setThreadFactory(buildThreadFactory());
         phase.setRunnablePartThreadLimit(resolvedActiveThreadCount());
         List<PhaseConfig> phaseConfigList_ = phaseConfigList;
         if (ConfigUtils.isEmptyCollection(phaseConfigList_)) {
@@ -182,18 +179,12 @@ public class PartitionedSearchPhaseConfig extends PhaseConfig<PartitionedSearchP
         }
     }
 
-    private ThreadPoolExecutor buildThreadPoolExecutor() {
-        ThreadFactory threadFactory;
+    private ThreadFactory buildThreadFactory() {
         if (threadFactoryClass != null) {
-            threadFactory = ConfigUtils.newInstance(this, "threadFactoryClass", threadFactoryClass);
+            return ConfigUtils.newInstance(this, "threadFactoryClass", threadFactoryClass);
         } else {
-            threadFactory = new DefaultSolverThreadFactory("PartThread");
+            return new DefaultSolverThreadFactory("PartThread");
         }
-        // Based on Executors.newCachedThreadPool(...)
-        return new ThreadPoolExecutor(0, Integer.MAX_VALUE,
-                60L, TimeUnit.SECONDS,
-                new SynchronousQueue<>(),
-                threadFactory);
     }
 
     private Integer resolvedActiveThreadCount() {

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/partitionedsearch/DefaultPartitionedSearchPhase.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/partitionedsearch/DefaultPartitionedSearchPhase.java
@@ -128,6 +128,7 @@ public class DefaultPartitionedSearchPhase<Solution_> extends AbstractPhase<Solu
                         partitionSolver.solve(part);
                         partitionQueue.addFinish(partIndex);
                     } catch (Throwable throwable) {
+                        // TODO is it a good idea to catch Throwables including OOME for example?
                         partitionQueue.addExceptionThrown(partIndex, throwable);
                     }
                 });

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/partitionedsearch/partitioner/SolutionPartitioner.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/partitionedsearch/partitioner/SolutionPartitioner.java
@@ -39,7 +39,7 @@ public interface SolutionPartitioner<Solution_> {
      * Problem facts can be multiple partitions (with our without cloning).
      * <p>
      * Any class that is {@link SolutionCloner solution cloned} must also be partitioned cloned.
-     * A class can be partitioned cloned without being solution cloned.
+     * A class can be partition cloned without being solution cloned.
      * @param scoreDirector never null, the {@link ScoreDirector}
      * which has the {@link ScoreDirector#getWorkingSolution()} that needs to be split up
      * @param runnablePartThreadLimit null if unlimited, never negative

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/partitionedsearch/scope/PartitionChangeMove.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/partitionedsearch/scope/PartitionChangeMove.java
@@ -137,4 +137,5 @@ public final class PartitionChangeMove<Solution_> extends AbstractMove<Solution_
         return new PartitionChangeMove<>(destinationChangeMap);
     }
 
+    // TODO implement toString()
 }

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/partitionedsearch/scope/PartitionChangeMove.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/partitionedsearch/scope/PartitionChangeMove.java
@@ -85,13 +85,14 @@ public final class PartitionChangeMove<Solution_> extends AbstractMove<Solution_
     }
 
     @Override
-    public boolean isMoveDoable(ScoreDirector<Solution_>  scoreDirector) {
+    public boolean isMoveDoable(ScoreDirector<Solution_> scoreDirector) {
         return true;
     }
 
     @Override
-    public PartitionChangeMove<Solution_> createUndoMove(ScoreDirector<Solution_> scoreDirector) {
-        throw new UnsupportedOperationException();
+    protected AbstractMove<Solution_> createUndoMove(ScoreDirector<Solution_> scoreDirector) {
+        // TODO not yet implemented, returns null to fail fast if it is used
+        return null;
     }
 
     @Override

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/partitionedsearch/scope/PartitionedSearchStepScope.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/partitionedsearch/scope/PartitionedSearchStepScope.java
@@ -26,7 +26,7 @@ public class PartitionedSearchStepScope<Solution_> extends AbstractStepScope<Sol
 
     private final PartitionedSearchPhaseScope<Solution_> phaseScope;
 
-    private PartitionChangeMove step = null;
+    private PartitionChangeMove<Solution_> step = null;
     private String stepString = null;
 
     public PartitionedSearchStepScope(PartitionedSearchPhaseScope<Solution_> phaseScope) {
@@ -43,11 +43,11 @@ public class PartitionedSearchStepScope<Solution_> extends AbstractStepScope<Sol
         return phaseScope;
     }
 
-    public PartitionChangeMove getStep() {
+    public PartitionChangeMove<Solution_> getStep() {
         return step;
     }
 
-    public void setStep(PartitionChangeMove step) {
+    public void setStep(PartitionChangeMove<Solution_> step) {
         this.step = step;
     }
 

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/solver/scope/DefaultSolverScope.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/solver/scope/DefaultSolverScope.java
@@ -256,12 +256,11 @@ public class DefaultSolverScope<Solution_> {
     /**
      * Similar to {@link Thread#yield()}, but allows capping the number of active solver threads
      * at less than the CPU processor count, so other threads (for example servlet threads that handle REST calls)
-     * and other processes (such as SSH) have access to uncontested CPU's and don't suffer any latency.
+     * and other processes (such as SSH) have access to uncontested CPUs and don't suffer any latency.
      * <p>
      * Needs to be called <b>before</b> {@link Termination#isPhaseTerminated(AbstractPhaseScope)},
      * so the decision to start a new iteration is after any yield waiting time has been consumed
      * (so {@link Solver#terminateEarly()} reacts immediately).
-     * Furthermore, this method will
      */
     public void checkYielding() {
         if (runnableThreadSemaphore != null) {

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/partitionedsearch/DefaultPartitionedSearchPhaseTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/partitionedsearch/DefaultPartitionedSearchPhaseTest.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.optaplanner.core.impl.partitionedsearch;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.SynchronousQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.Test;
+import org.optaplanner.core.api.score.buildin.simple.SimpleScore;
+import org.optaplanner.core.api.solver.SolverFactory;
+import org.optaplanner.core.config.constructionheuristic.ConstructionHeuristicPhaseConfig;
+import org.optaplanner.core.config.heuristic.policy.HeuristicConfigPolicy;
+import org.optaplanner.core.config.solver.EnvironmentMode;
+import org.optaplanner.core.config.solver.recaller.BestSolutionRecallerConfig;
+import org.optaplanner.core.config.solver.termination.TerminationConfig;
+import org.optaplanner.core.impl.partitionedsearch.partitioner.SolutionPartitioner;
+import org.optaplanner.core.impl.partitionedsearch.scope.PartitionedSearchPhaseScope;
+import org.optaplanner.core.impl.phase.event.PhaseLifecycleListenerAdapter;
+import org.optaplanner.core.impl.phase.event.PhaseLifecycleSupport;
+import org.optaplanner.core.impl.phase.scope.AbstractPhaseScope;
+import org.optaplanner.core.impl.score.director.InnerScoreDirectorFactory;
+import org.optaplanner.core.impl.score.director.ScoreDirector;
+import org.optaplanner.core.impl.solver.event.SolverEventSupport;
+import org.optaplanner.core.impl.solver.recaller.BestSolutionRecaller;
+import org.optaplanner.core.impl.solver.scope.DefaultSolverScope;
+import org.optaplanner.core.impl.solver.termination.BasicPlumbingTermination;
+import org.optaplanner.core.impl.solver.termination.Termination;
+import org.optaplanner.core.impl.testdata.domain.TestdataEntity;
+import org.optaplanner.core.impl.testdata.domain.TestdataSolution;
+import org.optaplanner.core.impl.testdata.domain.TestdataValue;
+import org.optaplanner.core.impl.testdata.util.PlannerTestUtils;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+
+public class DefaultPartitionedSearchPhaseTest {
+
+    @Test
+    public void solve() {
+        BestSolutionRecaller<TestdataSolution> bestSolutionRecaller = new BestSolutionRecallerConfig()
+                .buildBestSolutionRecaller(EnvironmentMode.REPRODUCIBLE);
+        bestSolutionRecaller.setSolverEventSupport(mock(SolverEventSupport.class));
+
+        SolverFactory<TestdataSolution> sf = PlannerTestUtils
+                .buildSolverFactory(TestdataSolution.class, TestdataEntity.class);
+        HeuristicConfigPolicy configPolicy = new HeuristicConfigPolicy(EnvironmentMode.REPRODUCIBLE,
+                (InnerScoreDirectorFactory) sf.buildSolver().getScoreDirectorFactory());
+
+        DefaultSolverScope<TestdataSolution> scope = new DefaultSolverScope<>();
+        scope.setScoreDirector(configPolicy.getScoreDirectorFactory().buildScoreDirector());
+
+        TestdataSolution solution = new TestdataSolution();
+        solution.setEntityList(Arrays.asList(new TestdataEntity("A")));
+        solution.setValueList(Arrays.asList(new TestdataValue("1"), new TestdataValue("2")));
+
+        scope.setBestSolution(solution);
+        scope.setBestScore(SimpleScore.valueOfUninitialized(-1, 0));
+        scope.setWorkingSolutionFromBestSolution();
+        scope.setWorkingRandom(new Random(0));
+
+        PhaseLifecycleSupport<TestdataSolution> phaseLifecycleSupport = new PhaseLifecycleSupport<>();
+        Termination termination = new TerminationConfig().buildTermination(configPolicy, new BasicPlumbingTermination(false));
+
+        DefaultPartitionedSearchPhase<TestdataSolution> phase
+                = new DefaultPartitionedSearchPhase<>(0, "", bestSolutionRecaller, termination);
+        phase.setSolverPhaseLifecycleSupport(phaseLifecycleSupport);
+        phase.setSolutionPartitioner(new TestdataSolutionPartitioner());
+        phase.setRunnablePartThreadLimit(1);
+        phase.setThreadPoolExecutor(new ThreadPoolExecutor(0, Integer.MAX_VALUE, 1L, TimeUnit.SECONDS, new SynchronousQueue<>()));
+        phase.setConfigPolicy(configPolicy);
+        ConstructionHeuristicPhaseConfig constructionHeuristicPhaseConfig = new ConstructionHeuristicPhaseConfig();
+        phase.setPhaseConfigList(Arrays.asList(constructionHeuristicPhaseConfig));
+
+        // test partCount
+        phase.addPhaseLifecycleListener(new PhaseLifecycleListenerAdapter<TestdataSolution>() {
+            @Override
+            public void phaseStarted(AbstractPhaseScope<TestdataSolution> phaseScope) {
+                // TODO? should be possible to phase.addPartitionPhaseLifecycleListener() to avoid the cast?
+                assertEquals(Integer.valueOf(1), ((PartitionedSearchPhaseScope) phaseScope).getPartCount());
+            }
+        });
+
+        scope.startingNow();
+        phase.solve(scope);
+    }
+
+    public static class TestdataSolutionPartitioner implements SolutionPartitioner<TestdataSolution> {
+
+        @Override
+        public List<TestdataSolution> splitWorkingSolution(
+                ScoreDirector<TestdataSolution> scoreDirector, Integer runnablePartThreadLimit) {
+            return Arrays.asList(scoreDirector.getWorkingSolution());
+        }
+
+    }
+}

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/partitionedsearch/DefaultPartitionedSearchPhaseTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/partitionedsearch/DefaultPartitionedSearchPhaseTest.java
@@ -19,37 +19,27 @@ import java.lang.management.ManagementFactory;
 import java.lang.management.ThreadMXBean;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Random;
 
 import org.junit.Before;
 import org.junit.Test;
-import org.optaplanner.core.api.score.buildin.simple.SimpleScore;
 import org.optaplanner.core.api.solver.SolverFactory;
 import org.optaplanner.core.config.constructionheuristic.ConstructionHeuristicPhaseConfig;
-import org.optaplanner.core.config.heuristic.policy.HeuristicConfigPolicy;
-import org.optaplanner.core.config.solver.EnvironmentMode;
-import org.optaplanner.core.config.solver.recaller.BestSolutionRecallerConfig;
+import org.optaplanner.core.config.localsearch.LocalSearchPhaseConfig;
+import org.optaplanner.core.config.partitionedsearch.PartitionedSearchPhaseConfig;
+import org.optaplanner.core.config.solver.SolverConfig;
 import org.optaplanner.core.config.solver.termination.TerminationConfig;
 import org.optaplanner.core.impl.partitionedsearch.partitioner.SolutionPartitioner;
 import org.optaplanner.core.impl.partitionedsearch.scope.PartitionedSearchPhaseScope;
 import org.optaplanner.core.impl.phase.event.PhaseLifecycleListenerAdapter;
-import org.optaplanner.core.impl.phase.event.PhaseLifecycleSupport;
 import org.optaplanner.core.impl.phase.scope.AbstractPhaseScope;
-import org.optaplanner.core.impl.score.director.InnerScoreDirectorFactory;
 import org.optaplanner.core.impl.score.director.ScoreDirector;
-import org.optaplanner.core.impl.solver.event.SolverEventSupport;
-import org.optaplanner.core.impl.solver.recaller.BestSolutionRecaller;
-import org.optaplanner.core.impl.solver.scope.DefaultSolverScope;
-import org.optaplanner.core.impl.solver.termination.BasicPlumbingTermination;
-import org.optaplanner.core.impl.solver.termination.Termination;
-import org.optaplanner.core.impl.solver.thread.DefaultSolverThreadFactory;
+import org.optaplanner.core.impl.solver.DefaultSolver;
 import org.optaplanner.core.impl.testdata.domain.TestdataEntity;
 import org.optaplanner.core.impl.testdata.domain.TestdataSolution;
 import org.optaplanner.core.impl.testdata.domain.TestdataValue;
 import org.optaplanner.core.impl.testdata.util.PlannerTestUtils;
 
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.mock;
 
 public class DefaultPartitionedSearchPhaseTest {
 
@@ -63,40 +53,10 @@ public class DefaultPartitionedSearchPhaseTest {
 
     @Test
     public void solve() {
-        BestSolutionRecaller<TestdataSolution> bestSolutionRecaller = new BestSolutionRecallerConfig()
-                .buildBestSolutionRecaller(EnvironmentMode.REPRODUCIBLE);
-        bestSolutionRecaller.setSolverEventSupport(mock(SolverEventSupport.class));
-
-        SolverFactory<TestdataSolution> sf = PlannerTestUtils
-                .buildSolverFactory(TestdataSolution.class, TestdataEntity.class);
-        HeuristicConfigPolicy configPolicy = new HeuristicConfigPolicy(EnvironmentMode.REPRODUCIBLE,
-                (InnerScoreDirectorFactory) sf.buildSolver().getScoreDirectorFactory());
-
-        DefaultSolverScope<TestdataSolution> scope = new DefaultSolverScope<>();
-        scope.setScoreDirector(configPolicy.getScoreDirectorFactory().buildScoreDirector());
-
-        TestdataSolution solution = new TestdataSolution();
-        solution.setEntityList(Arrays.asList(new TestdataEntity("A")));
-        solution.setValueList(Arrays.asList(new TestdataValue("1"), new TestdataValue("2")));
-
-        scope.setBestSolution(solution);
-        scope.setBestScore(SimpleScore.valueOfUninitialized(-1, 0));
-        scope.setWorkingSolutionFromBestSolution();
-        scope.setWorkingRandom(new Random(0));
-
-        PhaseLifecycleSupport<TestdataSolution> phaseLifecycleSupport = new PhaseLifecycleSupport<>();
-        Termination termination = new TerminationConfig()
-                .buildTermination(configPolicy, new BasicPlumbingTermination(false));
-
-        DefaultPartitionedSearchPhase<TestdataSolution> phase
-                = new DefaultPartitionedSearchPhase<>(0, "", bestSolutionRecaller, termination);
-        phase.setSolverPhaseLifecycleSupport(phaseLifecycleSupport);
-        phase.setSolutionPartitioner(new TestdataSolutionPartitioner());
-        phase.setRunnablePartThreadLimit(1);
-        phase.setThreadFactory(new DefaultSolverThreadFactory("PartThread"));
-        phase.setConfigPolicy(configPolicy);
-        ConstructionHeuristicPhaseConfig constructionHeuristicPhaseConfig = new ConstructionHeuristicPhaseConfig();
-        phase.setPhaseConfigList(Arrays.asList(constructionHeuristicPhaseConfig));
+        SolverFactory<TestdataSolution> solverFactory = createSolverFactory();
+        DefaultSolver<TestdataSolution> solver = (DefaultSolver<TestdataSolution>) solverFactory.buildSolver();
+        PartitionedSearchPhase<TestdataSolution> phase
+                = (PartitionedSearchPhase<TestdataSolution>) solver.getPhaseList().get(0);
 
         // test partCount
         phase.addPhaseLifecycleListener(new PhaseLifecycleListenerAdapter<TestdataSolution>() {
@@ -107,10 +67,31 @@ public class DefaultPartitionedSearchPhaseTest {
             }
         });
 
-        scope.startingNow();
-        phase.solve(scope);
-        phase.solve(scope);
+        solver.solve(createSolution());
         assertEquals(initialThreadCount, threads.getThreadCount());
+    }
+
+    private static SolverFactory<TestdataSolution> createSolverFactory() {
+        SolverFactory<TestdataSolution> solverFactory = PlannerTestUtils
+                .buildSolverFactory(TestdataSolution.class, TestdataEntity.class);
+        SolverConfig solverConfig = solverFactory.getSolverConfig();
+        PartitionedSearchPhaseConfig partitionedSearchPhaseConfig = new PartitionedSearchPhaseConfig();
+        partitionedSearchPhaseConfig.setSolutionPartitionerClass(TestdataSolutionPartitioner.class);
+        solverConfig.setPhaseConfigList(Arrays.asList(partitionedSearchPhaseConfig));
+        ConstructionHeuristicPhaseConfig constructionHeuristicPhaseConfig = new ConstructionHeuristicPhaseConfig();
+        LocalSearchPhaseConfig localSearchPhaseConfig = new LocalSearchPhaseConfig();
+        TerminationConfig terminationConfig = new TerminationConfig();
+        terminationConfig.setStepCountLimit(1);
+        localSearchPhaseConfig.setTerminationConfig(terminationConfig);
+        partitionedSearchPhaseConfig.setPhaseConfigList(Arrays.asList(constructionHeuristicPhaseConfig, localSearchPhaseConfig));
+        return solverFactory;
+    }
+
+    private static TestdataSolution createSolution() {
+        TestdataSolution solution = new TestdataSolution();
+        solution.setEntityList(Arrays.asList(new TestdataEntity("A")));
+        solution.setValueList(Arrays.asList(new TestdataValue("1"), new TestdataValue("2")));
+        return solution;
     }
 
     public static class TestdataSolutionPartitioner implements SolutionPartitioner<TestdataSolution> {

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/partitionedsearch/queue/PartitionQueueTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/partitionedsearch/queue/PartitionQueueTest.java
@@ -139,12 +139,11 @@ public class PartitionQueueTest {
         assertSame(true, it.hasNext());
         assertSame(moveC2, it.next());
         try {
-            assertSame(false, it.hasNext());
+            it.hasNext();
+            fail("There was no RuntimeException thrown.");
         } catch (RuntimeException e) {
             assertSame(exception, e.getCause());
-            return;
         }
-        fail("There was no RuntimeException thrown.");
     }
 
     public PartitionChangeMove<TestdataSolution> buildMove() {

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/partitionedsearch/queue/PartitionQueueTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/partitionedsearch/queue/PartitionQueueTest.java
@@ -20,16 +20,29 @@ import java.util.Iterator;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 
+import org.junit.After;
 import org.junit.Test;
 import org.optaplanner.core.impl.partitionedsearch.scope.PartitionChangeMove;
 import org.optaplanner.core.impl.testdata.domain.TestdataSolution;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import static org.junit.Assert.*;
 
 public class PartitionQueueTest {
 
-    private ExecutorService executorService = Executors.newFixedThreadPool(2);
+    private static final Logger logger = LoggerFactory.getLogger(PartitionQueueTest.class);
+    private final ExecutorService executorService = Executors.newFixedThreadPool(2);
+
+    @After
+    public void tearDown() throws InterruptedException {
+        executorService.shutdownNow();
+        if (!executorService.awaitTermination(1, TimeUnit.MILLISECONDS)) {
+            logger.warn("Thread pool didn't terminate within the timeout.");
+        }
+    }
 
     @Test
     public void addMove() throws ExecutionException, InterruptedException {
@@ -72,7 +85,6 @@ public class PartitionQueueTest {
         assertSame(moveB6, it.next());
         assertSame(moveA6, it.next());
         assertSame(moveC1, it.next());
-
 
         executorService.submit(() -> partitionQueue.addFinish(0)).get();
         PartitionChangeMove<TestdataSolution> moveC2 = buildMove();

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/phase/PhaseLifecycleTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/phase/PhaseLifecycleTest.java
@@ -44,7 +44,7 @@ public class PhaseLifecycleTest {
 
         // prepare solution
         TestdataSolution solution = new TestdataSolution("s1");
-        solution.setValueList(Arrays.asList(new TestdataValue("v1"), new TestdataValue("v1")));
+        solution.setValueList(Arrays.asList(new TestdataValue("v1"), new TestdataValue("v2")));
         final int entitiesCount = 17;
         ArrayList<TestdataEntity> entities = new ArrayList<>(entitiesCount);
         for (int i = 0; i < entitiesCount; i++) {

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/testdata/domain/TestdataObject.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/testdata/domain/TestdataObject.java
@@ -16,10 +16,12 @@
 
 package org.optaplanner.core.impl.testdata.domain;
 
+import org.optaplanner.core.api.domain.lookup.PlanningId;
 import org.optaplanner.core.impl.testdata.util.CodeAssertable;
 
 public abstract class TestdataObject implements CodeAssertable {
 
+    @PlanningId
     protected String code;
 
     public TestdataObject() {

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/testdata/domain/customcloner/TestdataCorrectlyClonedSolution.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/testdata/domain/customcloner/TestdataCorrectlyClonedSolution.java
@@ -35,13 +35,13 @@ public class TestdataCorrectlyClonedSolution implements SolutionCloner<TestdataC
     @PlanningScore
     private SimpleScore score;
     @PlanningEntityProperty
-    private TestdataEntity entity = new TestdataEntity();
+    private TestdataEntity entity = new TestdataEntity("A");
 
     @ValueRangeProvider(id = "valueRange")
     @ProblemFactCollectionProperty
     public List<TestdataValue> valueRange() {
         // two values needed to allow for at least one doable move, otherwise the second step ends in an infinite loop
-        return Arrays.asList(new TestdataValue(), new TestdataValue());
+        return Arrays.asList(new TestdataValue("1"), new TestdataValue("2"));
     }
 
     @Override

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/testdata/domain/customcloner/TestdataScoreNotClonedSolution.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/testdata/domain/customcloner/TestdataScoreNotClonedSolution.java
@@ -34,12 +34,12 @@ public class TestdataScoreNotClonedSolution implements SolutionCloner<TestdataSc
     @PlanningScore
     private SimpleScore score;
     @PlanningEntityProperty
-    private TestdataEntity entity = new TestdataEntity();
+    private TestdataEntity entity = new TestdataEntity("A");
 
     @ValueRangeProvider(id = "valueRange")
     @ProblemFactCollectionProperty
     public List<TestdataValue> valueRange() {
-        return Collections.singletonList(new TestdataValue());
+        return Collections.singletonList(new TestdataValue("1"));
     }
 
     @Override


### PR DESCRIPTION
- Fixed a few typos in Javadoc.
- Fixed implementation of `PartitionChangeMove.createUndoMove()`. It now returns null instead of throwing `UnsupportedOperationException`.
- Added thread pool shutdown when PS phase ends.
- Improved `PartitionedSearchPhaseConfig` API. Now it's possible to set custom `SolutionPartitioner`.
- Added `@PlanningId` on `TestdataObject`.