### PR TITLE
Eliminate raw types in MoveListFactory and MoveIteratorFactory interfaces

### DIFF
--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/factory/MoveIteratorFactory.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/factory/MoveIteratorFactory.java
@@ -49,7 +49,7 @@ public interface MoveIteratorFactory<Solution_> {
      * @throws UnsupportedOperationException if only {@link #createRandomMoveIterator(ScoreDirector, Random)} is
      * supported
      */
-    Iterator<Move> createOriginalMoveIterator(ScoreDirector<Solution_> scoreDirector);
+    Iterator<? extends Move<Solution_>> createOriginalMoveIterator(ScoreDirector<Solution_> scoreDirector);
 
     /**
      * When it is called depends on the configured {@link SelectionCacheType}.
@@ -60,6 +60,7 @@ public interface MoveIteratorFactory<Solution_> {
      * @return never null, an {@link Iterator} that is allowed (or even presumed) to be never ending
      * @throws UnsupportedOperationException if only {@link #createOriginalMoveIterator(ScoreDirector)} is supported
      */
-    Iterator<Move> createRandomMoveIterator(ScoreDirector<Solution_> scoreDirector, Random workingRandom);
+    Iterator<? extends Move<Solution_>> createRandomMoveIterator(
+            ScoreDirector<Solution_> scoreDirector, Random workingRandom);
 
 }

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/factory/MoveListFactory.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/factory/MoveListFactory.java
@@ -39,6 +39,6 @@ public interface MoveListFactory<Solution_> {
      * @param solution never null, the {@link PlanningSolution} of which the {@link Move}s need to be generated
      * @return never null
      */
-    List<? extends Move> createMoveList(Solution_ solution);
+    List<? extends Move<Solution_>> createMoveList(Solution_ solution);
 
 }

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/cheaptime/solver/move/factory/CheapTimePillarSlideMoveIteratorFactory.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/cheaptime/solver/move/factory/CheapTimePillarSlideMoveIteratorFactory.java
@@ -40,12 +40,13 @@ public class CheapTimePillarSlideMoveIteratorFactory implements MoveIteratorFact
     }
 
     @Override
-    public Iterator<Move> createOriginalMoveIterator(ScoreDirector<CheapTimeSolution> scoreDirector) {
+    public Iterator<Move<CheapTimeSolution>> createOriginalMoveIterator(ScoreDirector<CheapTimeSolution> scoreDirector) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public Iterator<Move> createRandomMoveIterator(ScoreDirector<CheapTimeSolution> scoreDirector, Random workingRandom) {
+    public RandomCheapTimePillarSlideMoveIterator createRandomMoveIterator(ScoreDirector<CheapTimeSolution> scoreDirector,
+            Random workingRandom) {
         CheapTimeSolution cheapTimeSolution = scoreDirector.getWorkingSolution();
         Map<Machine, List<TaskAssignment>> positivePillarMap = new LinkedHashMap<>(
                 cheapTimeSolution.getGlobalPeriodRangeTo());
@@ -85,7 +86,7 @@ public class CheapTimePillarSlideMoveIteratorFactory implements MoveIteratorFact
         return new RandomCheapTimePillarSlideMoveIterator(positivePillarList, negativePillarList, workingRandom);
     }
 
-    private class RandomCheapTimePillarSlideMoveIterator implements Iterator<Move> {
+    public static class RandomCheapTimePillarSlideMoveIterator implements Iterator<CheapTimePillarSlideMove> {
 
         private final List<List<TaskAssignment>> positivePillarList;
         private final List<List<TaskAssignment>> negativePillarList;
@@ -106,7 +107,7 @@ public class CheapTimePillarSlideMoveIteratorFactory implements MoveIteratorFact
         }
 
         @Override
-        public Move next() {
+        public CheapTimePillarSlideMove next() {
             int listIndex = workingRandom.nextInt(totalSize);
             boolean positive = listIndex < positivePillarList.size();
             List<TaskAssignment> basePillar = positive ? positivePillarList.get(listIndex)

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/investment/solver/move/factory/InvestmentBiQuantityTransferMoveIteratorFactory.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/investment/solver/move/factory/InvestmentBiQuantityTransferMoveIteratorFactory.java
@@ -44,12 +44,14 @@ public class InvestmentBiQuantityTransferMoveIteratorFactory implements MoveIter
     }
 
     @Override
-    public Iterator<Move> createOriginalMoveIterator(ScoreDirector<InvestmentSolution> scoreDirector) {
+    public Iterator<Move<InvestmentSolution>> createOriginalMoveIterator(
+            ScoreDirector<InvestmentSolution> scoreDirector) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public Iterator<Move> createRandomMoveIterator(ScoreDirector<InvestmentSolution> scoreDirector, Random workingRandom) {
+    public Iterator<Move<InvestmentSolution>> createRandomMoveIterator(
+            ScoreDirector<InvestmentSolution> scoreDirector, Random workingRandom) {
         InvestmentSolution solution = scoreDirector.getWorkingSolution();
         List<AssetClassAllocation> allocationList = solution.getAssetClassAllocationList();
         List<AssetClassAllocation> nonEmptyAllocationList = new ArrayList<>(allocationList);
@@ -63,7 +65,7 @@ public class InvestmentBiQuantityTransferMoveIteratorFactory implements MoveIter
                 nonEmptyAllocationList, workingRandom);
     }
 
-    private class RandomInvestmentBiQuantityTransferMoveIterator implements Iterator<Move> {
+    private static class RandomInvestmentBiQuantityTransferMoveIterator implements Iterator<Move<InvestmentSolution>> {
 
         private final List<AssetClassAllocation> allocationList;
         private final List<AssetClassAllocation> nonEmptyAllocationList;
@@ -82,7 +84,7 @@ public class InvestmentBiQuantityTransferMoveIteratorFactory implements MoveIter
         }
 
         @Override
-        public Move next() {
+        public Move<InvestmentSolution> next() {
             AssetClassAllocation firstFrom;
             AssetClassAllocation secondFrom;
             int nonEmptyAllocationListSize = nonEmptyAllocationList.size();

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/investment/solver/move/factory/InvestmentQuantityTransferMoveIteratorFactory.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/investment/solver/move/factory/InvestmentQuantityTransferMoveIteratorFactory.java
@@ -43,12 +43,14 @@ public class InvestmentQuantityTransferMoveIteratorFactory implements MoveIterat
     }
 
     @Override
-    public Iterator<Move> createOriginalMoveIterator(ScoreDirector<InvestmentSolution> scoreDirector) {
+    public Iterator<Move<InvestmentSolution>> createOriginalMoveIterator(
+            ScoreDirector<InvestmentSolution> scoreDirector) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public Iterator<Move> createRandomMoveIterator(ScoreDirector<InvestmentSolution> scoreDirector, Random workingRandom) {
+    public RandomInvestmentQuantityTransferMoveIterator createRandomMoveIterator(
+            ScoreDirector<InvestmentSolution> scoreDirector, Random workingRandom) {
         InvestmentSolution solution = scoreDirector.getWorkingSolution();
         List<AssetClassAllocation> allocationList = solution.getAssetClassAllocationList();
         NavigableMap<Long, AssetClassAllocation> quantityMillisIncrementToAllocationMap = new TreeMap<>();
@@ -69,7 +71,8 @@ public class InvestmentQuantityTransferMoveIteratorFactory implements MoveIterat
                 quantityMillisIncrementToAllocationMap, workingRandom);
     }
 
-    private class RandomInvestmentQuantityTransferMoveIterator implements Iterator<Move> {
+    public static class RandomInvestmentQuantityTransferMoveIterator
+            implements Iterator<InvestmentQuantityTransferMove> {
 
         private final List<AssetClassAllocation> allocationList;
         private final NavigableMap<Long, AssetClassAllocation> quantityMillisIncrementToAllocationMap;
@@ -88,7 +91,7 @@ public class InvestmentQuantityTransferMoveIteratorFactory implements MoveIterat
         }
 
         @Override
-        public Move next() {
+        public InvestmentQuantityTransferMove next() {
             long transferMillis
                     = RandomUtils.nextLong(workingRandom, InvestmentNumericUtil.MAXIMUM_QUANTITY_MILLIS) + 1L;
             Map.Entry<Long, AssetClassAllocation> lowerEntry

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/nqueens/solver/move/factory/RowChangeMoveFactory.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/nqueens/solver/move/factory/RowChangeMoveFactory.java
@@ -19,7 +19,6 @@ package org.optaplanner.examples.nqueens.solver.move.factory;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.optaplanner.core.impl.heuristic.move.Move;
 import org.optaplanner.core.impl.heuristic.selector.move.factory.MoveListFactory;
 import org.optaplanner.examples.nqueens.domain.NQueens;
 import org.optaplanner.examples.nqueens.domain.Queen;
@@ -29,8 +28,8 @@ import org.optaplanner.examples.nqueens.solver.move.RowChangeMove;
 public class RowChangeMoveFactory implements MoveListFactory<NQueens> {
 
     @Override
-    public List<Move> createMoveList(NQueens nQueens) {
-        List<Move> moveList = new ArrayList<>();
+    public List<RowChangeMove> createMoveList(NQueens nQueens) {
+        List<RowChangeMove> moveList = new ArrayList<>();
         for (Queen queen : nQueens.getQueenList()) {
             for (Row toRow : nQueens.getRowList()) {
                 moveList.add(new RowChangeMove(queen, toRow));

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/nurserostering/solver/move/factory/EmployeeChangeMoveFactory.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/nurserostering/solver/move/factory/EmployeeChangeMoveFactory.java
@@ -19,7 +19,6 @@ package org.optaplanner.examples.nurserostering.solver.move.factory;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.optaplanner.core.impl.heuristic.move.Move;
 import org.optaplanner.core.impl.heuristic.selector.move.factory.MoveListFactory;
 import org.optaplanner.examples.nurserostering.domain.Employee;
 import org.optaplanner.examples.nurserostering.domain.NurseRoster;
@@ -32,8 +31,8 @@ public class EmployeeChangeMoveFactory implements MoveListFactory<NurseRoster> {
     private MovableShiftAssignmentSelectionFilter filter = new MovableShiftAssignmentSelectionFilter();
 
     @Override
-    public List<Move> createMoveList(NurseRoster nurseRoster) {
-        List<Move> moveList = new ArrayList<>();
+    public List<EmployeeChangeMove> createMoveList(NurseRoster nurseRoster) {
+        List<EmployeeChangeMove> moveList = new ArrayList<>();
         List<Employee> employeeList = nurseRoster.getEmployeeList();
         for (ShiftAssignment shiftAssignment : nurseRoster.getShiftAssignmentList()) {
             if (filter.accept(nurseRoster, shiftAssignment)) {

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/nurserostering/solver/move/factory/ShiftAssignmentPillarPartSwapMoveFactory.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/nurserostering/solver/move/factory/ShiftAssignmentPillarPartSwapMoveFactory.java
@@ -39,7 +39,7 @@ public class ShiftAssignmentPillarPartSwapMoveFactory implements MoveListFactory
     private MovableShiftAssignmentSelectionFilter filter = new MovableShiftAssignmentSelectionFilter();
 
     @Override
-    public List<Move> createMoveList(NurseRoster nurseRoster) {
+    public List<Move<NurseRoster>> createMoveList(NurseRoster nurseRoster) {
         List<Employee> employeeList = nurseRoster.getEmployeeList();
         // This code assumes the shiftAssignmentList is sorted
         // Filter out every immovable ShiftAssignment
@@ -79,7 +79,7 @@ public class ShiftAssignmentPillarPartSwapMoveFactory implements MoveListFactory
         }
 
         // The create the move list
-        List<Move> moveList = new ArrayList<>();
+        List<Move<NurseRoster>> moveList = new ArrayList<>();
         // For every 2 distinct employees
         for (ListIterator<Employee> leftEmployeeIt = employeeList.listIterator(); leftEmployeeIt.hasNext();) {
             Employee leftEmployee = leftEmployeeIt.next();

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/nurserostering/solver/move/factory/ShiftAssignmentSequenceSwitchLength2MoveFactory.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/nurserostering/solver/move/factory/ShiftAssignmentSequenceSwitchLength2MoveFactory.java
@@ -38,7 +38,7 @@ public class ShiftAssignmentSequenceSwitchLength2MoveFactory implements MoveList
     private MovableShiftAssignmentSelectionFilter filter = new MovableShiftAssignmentSelectionFilter();
 
     @Override
-    public List<Move> createMoveList(NurseRoster nurseRoster) {
+    public List<Move<NurseRoster>> createMoveList(NurseRoster nurseRoster) {
         List<Employee> employeeList = nurseRoster.getEmployeeList();
         // This code assumes the shiftAssignmentList is sorted
         // Filter out every immovable ShiftAssignment
@@ -78,7 +78,7 @@ public class ShiftAssignmentSequenceSwitchLength2MoveFactory implements MoveList
         }
 
         // The create the move list
-        List<Move> moveList = new ArrayList<>();
+        List<Move<NurseRoster>> moveList = new ArrayList<>();
         // For every 2 distinct employees
         for (ListIterator<Employee> leftEmployeeIt = employeeList.listIterator(); leftEmployeeIt.hasNext();) {
             Employee leftEmployee = leftEmployeeIt.next();

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/nurserostering/solver/move/factory/ShiftAssignmentSequenceSwitchLength3MoveFactory.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/nurserostering/solver/move/factory/ShiftAssignmentSequenceSwitchLength3MoveFactory.java
@@ -38,7 +38,7 @@ public class ShiftAssignmentSequenceSwitchLength3MoveFactory implements MoveList
     private MovableShiftAssignmentSelectionFilter filter = new MovableShiftAssignmentSelectionFilter();
 
     @Override
-    public List<Move> createMoveList(NurseRoster nurseRoster) {
+    public List<Move<NurseRoster>> createMoveList(NurseRoster nurseRoster) {
         List<Employee> employeeList = nurseRoster.getEmployeeList();
         // This code assumes the shiftAssignmentList is sorted
         // Filter out every immovable ShiftAssignment
@@ -78,7 +78,7 @@ public class ShiftAssignmentSequenceSwitchLength3MoveFactory implements MoveList
         }
 
         // The create the move list
-        List<Move> moveList = new ArrayList<>();
+        List<Move<NurseRoster>> moveList = new ArrayList<>();
         // For every 2 distinct employees
         for (ListIterator<Employee> leftEmployeeIt = employeeList.listIterator(); leftEmployeeIt.hasNext();) {
             Employee leftEmployee = leftEmployeeIt.next();

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/nurserostering/solver/move/factory/ShiftAssignmentSwapMoveFactory.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/nurserostering/solver/move/factory/ShiftAssignmentSwapMoveFactory.java
@@ -21,7 +21,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.ListIterator;
 
-import org.optaplanner.core.impl.heuristic.move.Move;
 import org.optaplanner.core.impl.heuristic.selector.move.factory.MoveListFactory;
 import org.optaplanner.examples.nurserostering.domain.NurseRoster;
 import org.optaplanner.examples.nurserostering.domain.ShiftAssignment;
@@ -33,7 +32,7 @@ public class ShiftAssignmentSwapMoveFactory implements MoveListFactory<NurseRost
     private MovableShiftAssignmentSelectionFilter filter = new MovableShiftAssignmentSelectionFilter();
 
     @Override
-    public List<Move> createMoveList(NurseRoster nurseRoster) {
+    public List<ShiftAssignmentSwapMove> createMoveList(NurseRoster nurseRoster) {
         // Filter out every immovable ShiftAssignment
         List<ShiftAssignment> shiftAssignmentList = new ArrayList<>(
                 nurseRoster.getShiftAssignmentList());
@@ -43,7 +42,7 @@ public class ShiftAssignmentSwapMoveFactory implements MoveListFactory<NurseRost
                 it.remove();
             }
         }
-        List<Move> moveList = new ArrayList<>();
+        List<ShiftAssignmentSwapMove> moveList = new ArrayList<>();
         for (ListIterator<ShiftAssignment> leftIt = shiftAssignmentList.listIterator(); leftIt.hasNext();) {
             ShiftAssignment leftShiftAssignment = leftIt.next();
             for (ListIterator<ShiftAssignment> rightIt = shiftAssignmentList.listIterator(leftIt.nextIndex()); rightIt.hasNext();) {

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/pas/solver/move/factory/BedDesignationPillarPartSwapMoveFactory.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/pas/solver/move/factory/BedDesignationPillarPartSwapMoveFactory.java
@@ -38,7 +38,7 @@ import org.optaplanner.examples.pas.solver.move.BedChangeMove;
 public class BedDesignationPillarPartSwapMoveFactory implements MoveListFactory<PatientAdmissionSchedule> {
 
     @Override
-    public List<Move> createMoveList(PatientAdmissionSchedule patientAdmissionSchedule) {
+    public List<Move<PatientAdmissionSchedule>> createMoveList(PatientAdmissionSchedule patientAdmissionSchedule) {
         Map<Bed, List<BedDesignation>> bedToBedDesignationList = new HashMap<>(
                 patientAdmissionSchedule.getBedList().size());
         for (BedDesignation bedDesignation : patientAdmissionSchedule.getBedDesignationList()) {
@@ -63,7 +63,7 @@ public class BedDesignationPillarPartSwapMoveFactory implements MoveListFactory<
         }
 
         List<Bed> bedList = patientAdmissionSchedule.getBedList();
-        List<Move> moveList = new ArrayList<>();
+        List<Move<PatientAdmissionSchedule>> moveList = new ArrayList<>();
 
         // For every 2 distinct beds
         for (ListIterator<Bed> leftBedIt = bedList.listIterator(); leftBedIt.hasNext();) {

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/pas/solver/move/factory/BedDesignationSwapMoveFactory.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/pas/solver/move/factory/BedDesignationSwapMoveFactory.java
@@ -20,7 +20,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.ListIterator;
 
-import org.optaplanner.core.impl.heuristic.move.Move;
 import org.optaplanner.core.impl.heuristic.selector.move.factory.MoveListFactory;
 import org.optaplanner.examples.pas.domain.BedDesignation;
 import org.optaplanner.examples.pas.domain.PatientAdmissionSchedule;
@@ -29,9 +28,9 @@ import org.optaplanner.examples.pas.solver.move.BedDesignationSwapMove;
 public class BedDesignationSwapMoveFactory implements MoveListFactory<PatientAdmissionSchedule> {
 
     @Override
-    public List<Move> createMoveList(PatientAdmissionSchedule patientAdmissionSchedule) {
+    public List<BedDesignationSwapMove> createMoveList(PatientAdmissionSchedule patientAdmissionSchedule) {
         List<BedDesignation> bedDesignationList = patientAdmissionSchedule.getBedDesignationList();
-        List<Move> moveList = new ArrayList<>();
+        List<BedDesignationSwapMove> moveList = new ArrayList<>();
         for (ListIterator<BedDesignation> leftIt = bedDesignationList.listIterator(); leftIt.hasNext();) {
             BedDesignation leftBedDesignation = leftIt.next();
             for (ListIterator<BedDesignation> rightIt = bedDesignationList.listIterator(leftIt.nextIndex());

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/travelingtournament/solver/move/factory/MatchChainRotationsMoveFactory.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/travelingtournament/solver/move/factory/MatchChainRotationsMoveFactory.java
@@ -35,8 +35,8 @@ import org.optaplanner.examples.travelingtournament.solver.move.MatchChainRotati
 public class MatchChainRotationsMoveFactory implements MoveListFactory<TravelingTournament> {
 
     @Override
-    public List<Move> createMoveList(TravelingTournament travelingTournament) {
-        List<Move> moveList = new ArrayList<>();
+    public List<Move<TravelingTournament>> createMoveList(TravelingTournament travelingTournament) {
+        List<Move<TravelingTournament>> moveList = new ArrayList<>();
         RotationMovesFactory rotationMovesFactory = new RotationMovesFactory(travelingTournament);
         rotationMovesFactory.addDayRotation(moveList);
         rotationMovesFactory.addTeamRotation(moveList);
@@ -89,7 +89,7 @@ public class MatchChainRotationsMoveFactory implements MoveListFactory<Traveling
         /**
          * @TODO clean up this code
          */
-        private void addDayRotation(List<Move> moveList) {
+        private void addDayRotation(List<Move<TravelingTournament>> moveList) {
             for (ListIterator<Day> firstDayIt = dayList.listIterator(); firstDayIt.hasNext();) {
                 Day firstDay = firstDayIt.next();
                 Map<Team, Match> firstDayTeamMap = dayTeamMap.get(firstDay);
@@ -118,7 +118,7 @@ public class MatchChainRotationsMoveFactory implements MoveListFactory<Traveling
                         // if size is 2 then addCachedHomeAwaySwapMoves will have done it
                         if (rotateList.size() > 2) {
                             List<Match> emptyList = Collections.emptyList();
-                            Move rotateMove = new MatchChainRotationsMove(rotateList, emptyList);
+                            MatchChainRotationsMove rotateMove = new MatchChainRotationsMove(rotateList, emptyList);
                             moveList.add(rotateMove);
                         }
                     }
@@ -129,7 +129,7 @@ public class MatchChainRotationsMoveFactory implements MoveListFactory<Traveling
         /**
          * @TODO clean up this code
          */
-        private void addTeamRotation(List<Move> moveList) {
+        private void addTeamRotation(List<Move<TravelingTournament>> moveList) {
             for (ListIterator<Team> firstTeamIt = teamList.listIterator(); firstTeamIt.hasNext();) {
                 Team firstTeam = firstTeamIt.next();
                 Map<Day, Match> firstTeamDayMap = teamDayMap.get(firstTeam);
@@ -206,12 +206,13 @@ public class MatchChainRotationsMoveFactory implements MoveListFactory<Traveling
 
         }
 
-        private void addTeamRotateMove(List<Move> moveList, List<Match> firstRotateList, List<Match> secondRotateList) {
+        private void addTeamRotateMove(List<Move<TravelingTournament>> moveList,
+                List<Match> firstRotateList, List<Match> secondRotateList) {
             assert (firstRotateList.size() == secondRotateList.size());
             // if size is 1 then addCachedHomeAwaySwapMoves will have done it
             // if size is 2 then addDayRotation will have done it by 1 list of size 4
             if (firstRotateList.size() > 2) {
-                Move rotateMove = new MatchChainRotationsMove(firstRotateList, secondRotateList);
+                MatchChainRotationsMove rotateMove = new MatchChainRotationsMove(firstRotateList, secondRotateList);
                 moveList.add(rotateMove);
             }
         }


### PR DESCRIPTION
I'm not sure if this has any benefit for the user. The "nice" thing is that you have to declare the move type as the factory type parameter. This way it is guaranteed that `MoveIteratorFactory`'s `createOriginalMoveIterator()` and `createRandomMoveIterator()` both return the same type of moves. And there is less rawtypes warnings. 😄 On the other hand, any factory implementations need to be updated.