### PR TITLE
Increase TemporalValueRange test coverage

### DIFF
--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/valuerange/buildin/bigdecimal/BigDecimalValueRange.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/valuerange/buildin/bigdecimal/BigDecimalValueRange.java
@@ -74,7 +74,7 @@ public class BigDecimalValueRange extends AbstractCountableValueRange<BigDecimal
         if (!to.unscaledValue().subtract(from.unscaledValue()).remainder(incrementUnit.unscaledValue())
                 .equals(BigInteger.ZERO)) {
             throw new IllegalArgumentException("The " + getClass().getSimpleName()
-                    + " 's incrementUnit (" + incrementUnit
+                    + "'s incrementUnit (" + incrementUnit
                     + ") must fit an integer number of times between from (" + from + ") and to (" + to + ").");
         }
     }

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/valuerange/buildin/biginteger/BigIntegerValueRange.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/valuerange/buildin/biginteger/BigIntegerValueRange.java
@@ -59,7 +59,7 @@ public class BigIntegerValueRange extends AbstractCountableValueRange<BigInteger
 
         if (!to.subtract(from).remainder(incrementUnit).equals(BigInteger.ZERO)) {
             throw new IllegalArgumentException("The " + getClass().getSimpleName()
-                    + " 's incrementUnit (" + incrementUnit
+                    + "'s incrementUnit (" + incrementUnit
                     + ") must fit an integer number of times between from (" + from + ") and to (" + to + ").");
         }
     }

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/valuerange/buildin/primint/IntValueRange.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/valuerange/buildin/primint/IntValueRange.java
@@ -57,7 +57,7 @@ public class IntValueRange extends AbstractCountableValueRange<Integer> {
         }
         if (((long) to - (long) from) % incrementUnit != 0L) {
             throw new IllegalArgumentException("The " + getClass().getSimpleName()
-                    + " 's incrementUnit (" + incrementUnit
+                    + "'s incrementUnit (" + incrementUnit
                     + ") must fit an integer number of times between from (" + from + ") and to (" + to + ").");
         }
     }

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/valuerange/buildin/primlong/LongValueRange.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/valuerange/buildin/primlong/LongValueRange.java
@@ -62,7 +62,7 @@ public class LongValueRange extends AbstractCountableValueRange<Long> {
         }
         if ((to - from) % incrementUnit != 0L) {
             throw new IllegalArgumentException("The " + getClass().getSimpleName()
-                    + " 's incrementUnit (" + incrementUnit
+                    + "'s incrementUnit (" + incrementUnit
                     + ") must fit an integer number of times between from (" + from + ") and to (" + to + ").");
         }
     }

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/valuerange/buildin/temporal/TemporalValueRange.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/valuerange/buildin/temporal/TemporalValueRange.java
@@ -80,7 +80,7 @@ public class TemporalValueRange<Temporal_ extends Temporal & Comparable<? super 
         // Fail fast if there's a remainder on amount (to be consistent with other value ranges)
         if (space % incrementUnitAmount > 0) {
             throw new IllegalArgumentException("The " + getClass().getSimpleName()
-                    + " 's incrementUnitAmount (" + incrementUnitAmount
+                    + "'s incrementUnitAmount (" + incrementUnitAmount
                     + ") must fit an integer number of times in the space (" + space
                     + ") between from (" + from + ") and to (" + to + ").");
         }
@@ -94,7 +94,7 @@ public class TemporalValueRange<Temporal_ extends Temporal & Comparable<? super 
         }
         if (typeRemainder) {
             throw new IllegalArgumentException("The " + getClass().getSimpleName()
-                    + " 's incrementUnitType (" + incrementUnitType
+                    + "'s incrementUnitType (" + incrementUnitType
                     + ") must fit an integer number of times in the space (" + space
                     + ") between from (" + from + ") and to (" + to + ").\n"
                     + "The to (" + from.plus(space, incrementUnitType) + ") is not the expected to (" + to + ").");

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/valuerange/buildin/temporal/TemporalValueRange.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/valuerange/buildin/temporal/TemporalValueRange.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.optaplanner.core.impl.domain.valuerange.buildin.temporal;
 
 import java.time.temporal.Temporal;

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/domain/valuerange/buildin/temporal/TemporalValueRangeTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/domain/valuerange/buildin/temporal/TemporalValueRangeTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.optaplanner.core.impl.domain.valuerange.buildin.temporal;
 
 import java.time.LocalDate;


### PR DESCRIPTION
Includes a fix that avoids an unexpected `DateFormatException` when creating ranges that use extreme upper bounds like `LocalDateTime.MAX`.