### PR TITLE
Add Pitest plugin configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -189,6 +189,30 @@
             </execution>
           </executions>
         </plugin>
+        <plugin>
+          <groupId>org.pitest</groupId>
+          <artifactId>pitest-maven</artifactId>
+          <version>1.1.11</version>
+          <configuration>
+            <reportsDirectory>local/pit-reports</reportsDirectory>
+            <timestampedReports>false</timestampedReports>
+            <timeoutConstant>1000</timeoutConstant>
+            <mutators>
+              <!--
+              <mutator>CONDITIONALS_BOUNDARY</mutator>
+              <mutator>NEGATE_CONDITIONALS</mutator>
+              <mutator>MATH</mutator>
+              <mutator>INCREMENTS</mutator>
+              <mutator>INVERT_NEGS</mutator>
+              <mutator>RETURN_VALS</mutator>
+              <mutator>VOID_METHOD_CALLS</mutator>
+              -->
+              <mutator>DEFAULTS</mutator>
+              <mutator>NON_VOID_METHOD_CALLS</mutator>
+            </mutators>
+            <avoidCallsTo>java.lang.StringBuilder</avoidCallsTo>
+          </configuration>
+        </plugin>
       </plugins>
     </pluginManagement>
   </build>


### PR DESCRIPTION
This allows to run Pitest mutation coverage analysis with a command
similar to:
```
mvn org.pitest:pitest-maven:mutationCoverage -Dpitest.classes=org.optaplanner.core.impl.score*
```
or just:
```
mvn org.pitest:pitest-maven:mutationCoverage
```
for analysis of the whole module.