### PR TITLE
Add weight type param to weight factory and WF selection sorter

### DIFF
--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/entity/descriptor/EntityDescriptor.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/entity/descriptor/EntityDescriptor.java
@@ -137,7 +137,7 @@ public class EntityDescriptor<Solution_> {
                     difficultyComparator, SelectionSorterOrder.DESCENDING);
         }
         if (difficultyWeightFactoryClass != null) {
-            SelectionSorterWeightFactory<Solution_, Object> difficultyWeightFactory = ConfigUtils.newInstance(this,
+            SelectionSorterWeightFactory<Solution_, Object, ?> difficultyWeightFactory = ConfigUtils.newInstance(this,
                     "difficultyWeightFactoryClass", difficultyWeightFactoryClass);
             decreasingDifficultySorter = new WeightFactorySelectionSorter<>(
                     difficultyWeightFactory, SelectionSorterOrder.DESCENDING);

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/heuristic/selector/common/decorator/SelectionSorterWeightFactory.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/heuristic/selector/common/decorator/SelectionSorterWeightFactory.java
@@ -28,14 +28,15 @@ import org.optaplanner.core.impl.heuristic.selector.Selector;
  * normally ascending unless its configured descending.
  * @param <Solution_> the solution type, the class with the {@link PlanningSolution} annotation
  * @param <T> the selection type
+ * @param <W> the weight type
  */
-public interface SelectionSorterWeightFactory<Solution_, T> {
+public interface SelectionSorterWeightFactory<Solution_, T, W extends Comparable<W>> {
 
     /**
      * @param solution never null, the {@link PlanningSolution} to which the selection belongs or applies to
      * @param selection never null, a {@link PlanningEntity}, a planningValue, a {@link Move} or a {@link Selector}
      * @return never null, for example a {@link Integer}, {@link Double} or a more complex {@link Comparable}
      */
-    Comparable createSorterWeight(Solution_ solution, T selection);
+    W createSorterWeight(Solution_ solution, T selection);
 
 }

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/heuristic/selector/common/decorator/WeightFactorySelectionSorter.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/heuristic/selector/common/decorator/WeightFactorySelectionSorter.java
@@ -34,13 +34,15 @@ import org.optaplanner.core.impl.score.director.ScoreDirector;
  * Sorts a selection {@link List} based on a {@link SelectionSorterWeightFactory}.
  * @param <Solution_> the solution type, the class with the {@link PlanningSolution} annotation
  * @param <T> the selection type
+ * @param <W> the weight type
  */
-public class WeightFactorySelectionSorter<Solution_, T> implements SelectionSorter<Solution_, T> {
+public class WeightFactorySelectionSorter<Solution_, T, W extends Comparable<W>>
+        implements SelectionSorter<Solution_, T> {
 
-    private final SelectionSorterWeightFactory<Solution_, T> selectionSorterWeightFactory;
-    private final Comparator<Comparable> appliedWeightComparator;
+    private final SelectionSorterWeightFactory<Solution_, T, W> selectionSorterWeightFactory;
+    private final Comparator<W> appliedWeightComparator;
 
-    public WeightFactorySelectionSorter(SelectionSorterWeightFactory<Solution_, T> selectionSorterWeightFactory,
+    public WeightFactorySelectionSorter(SelectionSorterWeightFactory<Solution_, T, W> selectionSorterWeightFactory,
             SelectionSorterOrder selectionSorterOrder) {
         this.selectionSorterWeightFactory = selectionSorterWeightFactory;
         switch (selectionSorterOrder) {
@@ -67,9 +69,9 @@ public class WeightFactorySelectionSorter<Solution_, T> implements SelectionSort
      * of {@link PlanningEntity}, planningValue,  {@link Move} or {@link Selector}
      */
     public void sort(Solution_ solution, List<T> selectionList) {
-        SortedMap<Comparable, T> selectionMap = new TreeMap<>(appliedWeightComparator);
+        SortedMap<W, T> selectionMap = new TreeMap<>(appliedWeightComparator);
         for (T selection : selectionList) {
-            Comparable difficultyWeight = selectionSorterWeightFactory.createSorterWeight(solution, selection);
+            W difficultyWeight = selectionSorterWeightFactory.createSorterWeight(solution, selection);
             T previous = selectionMap.put(difficultyWeight, selection);
             if (previous != null) {
                 throw new IllegalStateException("The selectionList contains 2 times the same selection ("

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/heuristic/selector/common/decorator/WeightFactorySelectionSorterTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/heuristic/selector/common/decorator/WeightFactorySelectionSorterTest.java
@@ -32,10 +32,10 @@ public class WeightFactorySelectionSorterTest {
 
     @Test
     public void sortAscending() {
-        SelectionSorterWeightFactory<TestdataSolution, TestdataEntity> weightFactory
+        SelectionSorterWeightFactory<TestdataSolution, TestdataEntity, Integer> weightFactory
                 = (solution, selection) -> Integer.valueOf(selection.getCode().charAt(0));
-        WeightFactorySelectionSorter<TestdataSolution, TestdataEntity> selectionSorter = new WeightFactorySelectionSorter<>(
-                weightFactory, SelectionSorterOrder.ASCENDING);
+        WeightFactorySelectionSorter<TestdataSolution, TestdataEntity, Integer> selectionSorter
+                = new WeightFactorySelectionSorter<>(weightFactory, SelectionSorterOrder.ASCENDING);
         ScoreDirector scoreDirector = mock(ScoreDirector.class);
         List<TestdataEntity> selectionList = new ArrayList<>();
         selectionList.add(new TestdataEntity("C"));
@@ -48,10 +48,10 @@ public class WeightFactorySelectionSorterTest {
 
     @Test
     public void sortDescending() {
-        SelectionSorterWeightFactory<TestdataSolution, TestdataEntity> weightFactory
+        SelectionSorterWeightFactory<TestdataSolution, TestdataEntity, Integer> weightFactory
                 = (solution, selection) -> Integer.valueOf(selection.getCode().charAt(0));
-        WeightFactorySelectionSorter<TestdataSolution, TestdataEntity> selectionSorter = new WeightFactorySelectionSorter<>(
-                weightFactory, SelectionSorterOrder.DESCENDING);
+        WeightFactorySelectionSorter<TestdataSolution, TestdataEntity, Integer> selectionSorter
+                = new WeightFactorySelectionSorter<>(weightFactory, SelectionSorterOrder.DESCENDING);
         ScoreDirector scoreDirector = mock(ScoreDirector.class);
         List<TestdataEntity> selectionList = new ArrayList<>();
         selectionList.add(new TestdataEntity("C"));

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/coachshuttlegathering/domain/solver/DepotAngleBusStopDifficultyWeightFactory.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/coachshuttlegathering/domain/solver/DepotAngleBusStopDifficultyWeightFactory.java
@@ -21,20 +21,21 @@ import org.optaplanner.core.impl.heuristic.selector.common.decorator.SelectionSo
 import org.optaplanner.examples.coachshuttlegathering.domain.BusHub;
 import org.optaplanner.examples.coachshuttlegathering.domain.BusOrStop;
 import org.optaplanner.examples.coachshuttlegathering.domain.CoachShuttleGatheringSolution;
+import org.optaplanner.examples.coachshuttlegathering.domain.solver.DepotAngleBusStopDifficultyWeightFactory.DepotAngleBusStopDifficultyWeight;
 
 /**
  * On large datasets, the constructed solution looks like pizza slices.
  */
 public class DepotAngleBusStopDifficultyWeightFactory
-        implements SelectionSorterWeightFactory<CoachShuttleGatheringSolution, BusOrStop> {
+        implements SelectionSorterWeightFactory<CoachShuttleGatheringSolution, BusOrStop, DepotAngleBusStopDifficultyWeight> {
 
     @Override
-    public Comparable createSorterWeight(CoachShuttleGatheringSolution solution, BusOrStop busOrStop) {
+    public DepotAngleBusStopDifficultyWeight createSorterWeight(CoachShuttleGatheringSolution solution, BusOrStop busOrStop) {
         BusHub hub = solution.getHub();
         return new DepotAngleBusStopDifficultyWeight(busOrStop,
                 busOrStop.getLocation().getAngle(hub.getLocation()),
                 busOrStop.getLocation().getMaximumDistanceTo(hub.getLocation())
-                        + hub.getLocation().getMaximumDistanceTo(busOrStop.getLocation()));
+                + hub.getLocation().getMaximumDistanceTo(busOrStop.getLocation()));
     }
 
     public static class DepotAngleBusStopDifficultyWeight

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/curriculumcourse/domain/solver/LectureDifficultyWeightFactory.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/curriculumcourse/domain/solver/LectureDifficultyWeightFactory.java
@@ -22,11 +22,13 @@ import org.optaplanner.examples.curriculumcourse.domain.Course;
 import org.optaplanner.examples.curriculumcourse.domain.CourseSchedule;
 import org.optaplanner.examples.curriculumcourse.domain.Lecture;
 import org.optaplanner.examples.curriculumcourse.domain.UnavailablePeriodPenalty;
+import org.optaplanner.examples.curriculumcourse.domain.solver.LectureDifficultyWeightFactory.LectureDifficultyWeight;
 
-public class LectureDifficultyWeightFactory implements SelectionSorterWeightFactory<CourseSchedule, Lecture> {
+public class LectureDifficultyWeightFactory
+        implements SelectionSorterWeightFactory<CourseSchedule, Lecture, LectureDifficultyWeight> {
 
     @Override
-    public Comparable createSorterWeight(CourseSchedule schedule, Lecture lecture) {
+    public LectureDifficultyWeight createSorterWeight(CourseSchedule schedule, Lecture lecture) {
         Course course = lecture.getCourse();
         int unavailablePeriodPenaltyCount = 0;
         for (UnavailablePeriodPenalty penalty : schedule.getUnavailablePeriodPenaltyList()) {

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/curriculumcourse/domain/solver/PeriodStrengthWeightFactory.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/curriculumcourse/domain/solver/PeriodStrengthWeightFactory.java
@@ -21,11 +21,13 @@ import org.optaplanner.core.impl.heuristic.selector.common.decorator.SelectionSo
 import org.optaplanner.examples.curriculumcourse.domain.CourseSchedule;
 import org.optaplanner.examples.curriculumcourse.domain.Period;
 import org.optaplanner.examples.curriculumcourse.domain.UnavailablePeriodPenalty;
+import org.optaplanner.examples.curriculumcourse.domain.solver.PeriodStrengthWeightFactory.PeriodStrengthWeight;
 
-public class PeriodStrengthWeightFactory implements SelectionSorterWeightFactory<CourseSchedule, Period> {
+public class PeriodStrengthWeightFactory
+        implements SelectionSorterWeightFactory<CourseSchedule, Period, PeriodStrengthWeight> {
 
     @Override
-    public Comparable createSorterWeight(CourseSchedule schedule, Period period) {
+    public PeriodStrengthWeight createSorterWeight(CourseSchedule schedule, Period period) {
         int unavailablePeriodPenaltyCount = 0;
         for (UnavailablePeriodPenalty penalty : schedule.getUnavailablePeriodPenaltyList()) {
             if (penalty.getPeriod().equals(period)) {

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/curriculumcourse/domain/solver/RoomStrengthWeightFactory.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/curriculumcourse/domain/solver/RoomStrengthWeightFactory.java
@@ -21,10 +21,11 @@ import org.optaplanner.core.impl.heuristic.selector.common.decorator.SelectionSo
 import org.optaplanner.examples.curriculumcourse.domain.CourseSchedule;
 import org.optaplanner.examples.curriculumcourse.domain.Room;
 
-public class RoomStrengthWeightFactory implements SelectionSorterWeightFactory<CourseSchedule, Room> {
+public class RoomStrengthWeightFactory
+        implements SelectionSorterWeightFactory<CourseSchedule, Room, RoomStrengthWeightFactory.RoomStrengthWeight> {
 
     @Override
-    public Comparable createSorterWeight(CourseSchedule schedule, Room room) {
+    public RoomStrengthWeight createSorterWeight(CourseSchedule schedule, Room room) {
         return new RoomStrengthWeight(room);
     }
 

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/examination/domain/solver/ExamDifficultyWeightFactory.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/examination/domain/solver/ExamDifficultyWeightFactory.java
@@ -23,10 +23,11 @@ import org.optaplanner.examples.examination.domain.Examination;
 import org.optaplanner.examples.examination.domain.LeadingExam;
 import org.optaplanner.examples.examination.domain.PeriodPenalty;
 
-public class ExamDifficultyWeightFactory implements SelectionSorterWeightFactory<Examination, Exam> {
+public class ExamDifficultyWeightFactory
+        implements SelectionSorterWeightFactory<Examination, Exam, ExamDifficultyWeightFactory.ExamDifficultyWeight> {
 
     @Override
-    public Comparable createSorterWeight(Examination examination, Exam exam) {
+    public ExamDifficultyWeight createSorterWeight(Examination examination, Exam exam) {
         int studentSizeTotal = exam.getTopicStudentSize();
         int maximumDuration = exam.getTopicDuration();
         for (PeriodPenalty periodPenalty : examination.getPeriodPenaltyList()) {

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/examination/domain/solver/RoomStrengthWeightFactory.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/examination/domain/solver/RoomStrengthWeightFactory.java
@@ -21,10 +21,11 @@ import org.optaplanner.core.impl.heuristic.selector.common.decorator.SelectionSo
 import org.optaplanner.examples.examination.domain.Examination;
 import org.optaplanner.examples.examination.domain.Room;
 
-public class RoomStrengthWeightFactory implements SelectionSorterWeightFactory<Examination, Room> {
+public class RoomStrengthWeightFactory
+        implements SelectionSorterWeightFactory<Examination, Room, RoomStrengthWeightFactory.RoomStrengthWeight> {
 
     @Override
-    public Comparable createSorterWeight(Examination examination, Room room) {
+    public RoomStrengthWeight createSorterWeight(Examination examination, Room room) {
         return new RoomStrengthWeight(room);
     }
 

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/nqueens/domain/solution/QueenDifficultyWeightFactory.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/nqueens/domain/solution/QueenDifficultyWeightFactory.java
@@ -21,10 +21,11 @@ import org.optaplanner.core.impl.heuristic.selector.common.decorator.SelectionSo
 import org.optaplanner.examples.nqueens.domain.NQueens;
 import org.optaplanner.examples.nqueens.domain.Queen;
 
-public class QueenDifficultyWeightFactory implements SelectionSorterWeightFactory<NQueens, Queen> {
+public class QueenDifficultyWeightFactory
+        implements SelectionSorterWeightFactory<NQueens, Queen, QueenDifficultyWeightFactory.QueenDifficultyWeight> {
 
     @Override
-    public Comparable createSorterWeight(NQueens nQueens, Queen queen) {
+    public QueenDifficultyWeight createSorterWeight(NQueens nQueens, Queen queen) {
         int distanceFromMiddle = calculateDistanceFromMiddle(nQueens.getN(), queen.getColumnIndex());
         return new QueenDifficultyWeight(queen, distanceFromMiddle);
     }

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/nqueens/domain/solution/RowStrengthWeightFactory.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/nqueens/domain/solution/RowStrengthWeightFactory.java
@@ -21,10 +21,11 @@ import org.optaplanner.core.impl.heuristic.selector.common.decorator.SelectionSo
 import org.optaplanner.examples.nqueens.domain.NQueens;
 import org.optaplanner.examples.nqueens.domain.Row;
 
-public class RowStrengthWeightFactory implements SelectionSorterWeightFactory<NQueens, Row> {
+public class RowStrengthWeightFactory
+        implements SelectionSorterWeightFactory<NQueens, Row, RowStrengthWeightFactory.RowStrengthWeight> {
 
     @Override
-    public Comparable createSorterWeight(NQueens nQueens, Row row) {
+    public RowStrengthWeight createSorterWeight(NQueens nQueens, Row row) {
         int distanceFromMiddle = calculateDistanceFromMiddle(nQueens.getN(), row.getIndex());
         return new RowStrengthWeight(row, distanceFromMiddle);
     }

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/pas/domain/solver/BedDesignationDifficultyWeightFactory.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/pas/domain/solver/BedDesignationDifficultyWeightFactory.java
@@ -21,12 +21,14 @@ import org.optaplanner.core.impl.heuristic.selector.common.decorator.SelectionSo
 import org.optaplanner.examples.pas.domain.BedDesignation;
 import org.optaplanner.examples.pas.domain.PatientAdmissionSchedule;
 import org.optaplanner.examples.pas.domain.Room;
+import org.optaplanner.examples.pas.domain.solver.BedDesignationDifficultyWeightFactory.BedDesignationDifficultyWeight;
 
-public class BedDesignationDifficultyWeightFactory
-        implements SelectionSorterWeightFactory<PatientAdmissionSchedule, BedDesignation> {
+public class BedDesignationDifficultyWeightFactory implements
+        SelectionSorterWeightFactory<PatientAdmissionSchedule, BedDesignation, BedDesignationDifficultyWeight> {
 
     @Override
-    public Comparable createSorterWeight(PatientAdmissionSchedule schedule, BedDesignation bedDesignation) {
+    public BedDesignationDifficultyWeight createSorterWeight(
+            PatientAdmissionSchedule schedule, BedDesignation bedDesignation) {
         int hardDisallowedCount = 0;
         int softDisallowedCount = 0;
         for (Room room : schedule.getRoomList()) {

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/projectjobscheduling/domain/solver/ExecutionModeStrengthWeightFactory.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/projectjobscheduling/domain/solver/ExecutionModeStrengthWeightFactory.java
@@ -25,11 +25,13 @@ import org.optaplanner.examples.projectjobscheduling.domain.ExecutionMode;
 import org.optaplanner.examples.projectjobscheduling.domain.ResourceRequirement;
 import org.optaplanner.examples.projectjobscheduling.domain.Schedule;
 import org.optaplanner.examples.projectjobscheduling.domain.resource.Resource;
+import org.optaplanner.examples.projectjobscheduling.domain.solver.ExecutionModeStrengthWeightFactory.ExecutionModeStrengthWeight;
 
-public class ExecutionModeStrengthWeightFactory implements SelectionSorterWeightFactory<Schedule, ExecutionMode> {
+public class ExecutionModeStrengthWeightFactory
+        implements SelectionSorterWeightFactory<Schedule, ExecutionMode, ExecutionModeStrengthWeight> {
 
     @Override
-    public Comparable createSorterWeight(Schedule schedule, ExecutionMode executionMode) {
+    public ExecutionModeStrengthWeight createSorterWeight(Schedule schedule, ExecutionMode executionMode) {
         Map<Resource, Integer> requirementTotalMap = new HashMap<>(
                 executionMode.getResourceRequirementList().size());
         for (ResourceRequirement resourceRequirement : executionMode.getResourceRequirementList()) {

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/tsp/domain/solver/DomicileAngleVisitDifficultyWeightFactory.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/tsp/domain/solver/DomicileAngleVisitDifficultyWeightFactory.java
@@ -21,15 +21,16 @@ import org.optaplanner.core.impl.heuristic.selector.common.decorator.SelectionSo
 import org.optaplanner.examples.tsp.domain.Domicile;
 import org.optaplanner.examples.tsp.domain.TspSolution;
 import org.optaplanner.examples.tsp.domain.Visit;
+import org.optaplanner.examples.tsp.domain.solver.DomicileAngleVisitDifficultyWeightFactory.DomicileAngleVisitDifficultyWeight;
 
 /**
  * On large datasets, the constructed solution looks like pizza slices.
  */
 public class DomicileAngleVisitDifficultyWeightFactory
-        implements SelectionSorterWeightFactory<TspSolution, Visit> {
+        implements SelectionSorterWeightFactory<TspSolution, Visit, DomicileAngleVisitDifficultyWeight> {
 
     @Override
-    public Comparable createSorterWeight(TspSolution vehicleRoutingSolution, Visit visit) {
+    public DomicileAngleVisitDifficultyWeight createSorterWeight(TspSolution vehicleRoutingSolution, Visit visit) {
         Domicile domicile = vehicleRoutingSolution.getDomicile();
         return new DomicileAngleVisitDifficultyWeight(visit,
                 visit.getLocation().getAngle(domicile.getLocation()),

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/tsp/domain/solver/DomicileDistanceStandstillStrengthWeightFactory.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/tsp/domain/solver/DomicileDistanceStandstillStrengthWeightFactory.java
@@ -21,11 +21,13 @@ import org.optaplanner.core.impl.heuristic.selector.common.decorator.SelectionSo
 import org.optaplanner.examples.tsp.domain.Domicile;
 import org.optaplanner.examples.tsp.domain.Standstill;
 import org.optaplanner.examples.tsp.domain.TspSolution;
+import org.optaplanner.examples.tsp.domain.solver.DomicileDistanceStandstillStrengthWeightFactory.DomicileDistanceStandstillStrengthWeight;
 
-public class DomicileDistanceStandstillStrengthWeightFactory implements SelectionSorterWeightFactory<TspSolution, Standstill> {
+public class DomicileDistanceStandstillStrengthWeightFactory
+        implements SelectionSorterWeightFactory<TspSolution, Standstill, DomicileDistanceStandstillStrengthWeight> {
 
     @Override
-    public Comparable createSorterWeight(TspSolution tspSolution, Standstill standstill) {
+    public DomicileDistanceStandstillStrengthWeight createSorterWeight(TspSolution tspSolution, Standstill standstill) {
         Domicile domicile = tspSolution.getDomicile();
         long domicileRoundTripDistance = domicile.getDistanceTo(standstill) + standstill.getDistanceTo(domicile);
         return new DomicileDistanceStandstillStrengthWeight(standstill, domicileRoundTripDistance);

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/tsp/domain/solver/DomicileDistanceVisitDifficultyWeightFactory.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/tsp/domain/solver/DomicileDistanceVisitDifficultyWeightFactory.java
@@ -21,11 +21,13 @@ import org.optaplanner.core.impl.heuristic.selector.common.decorator.SelectionSo
 import org.optaplanner.examples.tsp.domain.Domicile;
 import org.optaplanner.examples.tsp.domain.TspSolution;
 import org.optaplanner.examples.tsp.domain.Visit;
+import org.optaplanner.examples.tsp.domain.solver.DomicileDistanceVisitDifficultyWeightFactory.DomicileDistanceVisitDifficultyWeight;
 
-public class DomicileDistanceVisitDifficultyWeightFactory implements SelectionSorterWeightFactory<TspSolution, Visit> {
+public class DomicileDistanceVisitDifficultyWeightFactory
+        implements SelectionSorterWeightFactory<TspSolution, Visit, DomicileDistanceVisitDifficultyWeight> {
 
     @Override
-    public Comparable createSorterWeight(TspSolution tspSolution, Visit visit) {
+    public DomicileDistanceVisitDifficultyWeight createSorterWeight(TspSolution tspSolution, Visit visit) {
         Domicile domicile = tspSolution.getDomicile();
         long domicileRoundTripDistance = domicile.getDistanceTo(visit) + visit.getDistanceTo(domicile);
         return new DomicileDistanceVisitDifficultyWeight(visit, domicileRoundTripDistance);

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/vehiclerouting/domain/solver/DepotAngleCustomerDifficultyWeightFactory.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/vehiclerouting/domain/solver/DepotAngleCustomerDifficultyWeightFactory.java
@@ -21,15 +21,17 @@ import org.optaplanner.core.impl.heuristic.selector.common.decorator.SelectionSo
 import org.optaplanner.examples.vehiclerouting.domain.Customer;
 import org.optaplanner.examples.vehiclerouting.domain.Depot;
 import org.optaplanner.examples.vehiclerouting.domain.VehicleRoutingSolution;
+import org.optaplanner.examples.vehiclerouting.domain.solver.DepotAngleCustomerDifficultyWeightFactory.DepotAngleCustomerDifficultyWeight;
 
 /**
  * On large datasets, the constructed solution looks like pizza slices.
  */
 public class DepotAngleCustomerDifficultyWeightFactory
-        implements SelectionSorterWeightFactory<VehicleRoutingSolution, Customer> {
+        implements SelectionSorterWeightFactory<VehicleRoutingSolution, Customer, DepotAngleCustomerDifficultyWeight> {
 
     @Override
-    public Comparable createSorterWeight(VehicleRoutingSolution vehicleRoutingSolution, Customer customer) {
+    public DepotAngleCustomerDifficultyWeight createSorterWeight(
+            VehicleRoutingSolution vehicleRoutingSolution, Customer customer) {
         Depot depot = vehicleRoutingSolution.getDepotList().get(0);
         return new DepotAngleCustomerDifficultyWeight(customer,
                 customer.getLocation().getAngle(depot.getLocation()),

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/vehiclerouting/domain/solver/DepotDistanceCustomerDifficultyWeightFactory.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/vehiclerouting/domain/solver/DepotDistanceCustomerDifficultyWeightFactory.java
@@ -21,15 +21,17 @@ import org.optaplanner.core.impl.heuristic.selector.common.decorator.SelectionSo
 import org.optaplanner.examples.vehiclerouting.domain.Customer;
 import org.optaplanner.examples.vehiclerouting.domain.Depot;
 import org.optaplanner.examples.vehiclerouting.domain.VehicleRoutingSolution;
+import org.optaplanner.examples.vehiclerouting.domain.solver.DepotDistanceCustomerDifficultyWeightFactory.DepotDistanceCustomerDifficultyWeight;
 
 /**
  * On large datasets, the constructed solution looks like a Matryoshka doll.
  */
-public class DepotDistanceCustomerDifficultyWeightFactory
-        implements SelectionSorterWeightFactory<VehicleRoutingSolution, Customer> {
+public class DepotDistanceCustomerDifficultyWeightFactory implements
+        SelectionSorterWeightFactory<VehicleRoutingSolution, Customer, DepotDistanceCustomerDifficultyWeight> {
 
     @Override
-    public Comparable createSorterWeight(VehicleRoutingSolution vehicleRoutingSolution, Customer customer) {
+    public DepotDistanceCustomerDifficultyWeight createSorterWeight(
+            VehicleRoutingSolution vehicleRoutingSolution, Customer customer) {
         Depot depot = vehicleRoutingSolution.getDepotList().get(0);
         return new DepotDistanceCustomerDifficultyWeight(customer,
                 customer.getLocation().getDistanceTo(depot.getLocation())


### PR DESCRIPTION
Removes some rawtype and unchecked warnings.

From the user's perspective it makes the type system more explicit. For example it makes it very clear from the start that weight is something different than the selection (entity/value).

Also it is clear that `MyWeight` is going to implement `Comparable<MyWeight>` and not `Comparable<MyEntity>`, which is of course a stupid mistake, but it's something I myself did and I wouldn't have done it with this more explicit type declaration.

So, I would highlight that the extra type parameter saves the time it takes to understand "_How am I going to implement the weight factory?_" for first-time users.