### PR TITLE
Eliminate raw Move in LS move and step scopes and some tests

### DIFF
--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/localsearch/decider/LocalSearchDecider.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/localsearch/decider/LocalSearchDecider.java
@@ -130,7 +130,7 @@ public class LocalSearchDecider<Solution_> {
         scoreDirector.setAllChangesWillBeUndoneBeforeStepEnds(false);
         LocalSearchMoveScope<Solution_> pickedMoveScope = forager.pickMove(stepScope);
         if (pickedMoveScope != null) {
-            Move<?> step = pickedMoveScope.getMove();
+            Move<Solution_> step = pickedMoveScope.getMove();
             stepScope.setStep(step);
             if (logger.isDebugEnabled()) {
                 stepScope.setStepString(step.toString());

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/localsearch/scope/LocalSearchMoveScope.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/localsearch/scope/LocalSearchMoveScope.java
@@ -31,8 +31,8 @@ public class LocalSearchMoveScope<Solution_> {
     private final LocalSearchStepScope<Solution_> stepScope;
 
     private int moveIndex;
-    private Move move = null;
-    private Move undoMove = null;
+    private Move<Solution_> move = null;
+    private Move<Solution_> undoMove = null;
     private Score score = null;
     private Boolean accepted = null;
 
@@ -52,19 +52,19 @@ public class LocalSearchMoveScope<Solution_> {
         this.moveIndex = moveIndex;
     }
 
-    public Move getMove() {
+    public Move<Solution_> getMove() {
         return move;
     }
 
-    public void setMove(Move move) {
+    public void setMove(Move<Solution_> move) {
         this.move = move;
     }
 
-    public Move getUndoMove() {
+    public Move<Solution_> getUndoMove() {
         return undoMove;
     }
 
-    public void setUndoMove(Move undoMove) {
+    public void setUndoMove(Move<Solution_> undoMove) {
         this.undoMove = undoMove;
     }
 

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/localsearch/scope/LocalSearchStepScope.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/localsearch/scope/LocalSearchStepScope.java
@@ -28,9 +28,9 @@ public class LocalSearchStepScope<Solution_> extends AbstractStepScope<Solution_
     private final LocalSearchPhaseScope<Solution_> phaseScope;
 
     private double timeGradient = Double.NaN;
-    private Move step = null;
+    private Move<Solution_> step = null;
     private String stepString = null;
-    private Move undoStep = null;
+    private Move<Solution_> undoStep = null;
     private Long selectedMoveCount = null;
     private Long acceptedMoveCount = null;
 
@@ -56,11 +56,11 @@ public class LocalSearchStepScope<Solution_> extends AbstractStepScope<Solution_
         this.timeGradient = timeGradient;
     }
 
-    public Move getStep() {
+    public Move<Solution_> getStep() {
         return step;
     }
 
-    public void setStep(Move step) {
+    public void setStep(Move<Solution_> step) {
         this.step = step;
     }
 
@@ -75,11 +75,11 @@ public class LocalSearchStepScope<Solution_> extends AbstractStepScope<Solution_
         this.stepString = stepString;
     }
 
-    public Move getUndoStep() {
+    public Move<Solution_> getUndoStep() {
         return undoStep;
     }
 
-    public void setUndoStep(Move undoStep) {
+    public void setUndoStep(Move<Solution_> undoStep) {
         this.undoStep = undoStep;
     }
 

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/localsearch/decider/acceptor/AbstractAcceptorTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/localsearch/decider/acceptor/AbstractAcceptorTest.java
@@ -25,9 +25,10 @@ import static org.mockito.Mockito.*;
 
 public abstract class AbstractAcceptorTest {
 
-    protected LocalSearchMoveScope buildMoveScope(LocalSearchStepScope stepScope, int score) {
-        LocalSearchMoveScope moveScope = new LocalSearchMoveScope(stepScope);
-        Move move = mock(Move.class);
+    protected <Solution_> LocalSearchMoveScope<Solution_> buildMoveScope(
+            LocalSearchStepScope<Solution_> stepScope, int score) {
+        LocalSearchMoveScope<Solution_> moveScope = new LocalSearchMoveScope<>(stepScope);
+        Move<Solution_> move = mock(Move.class);
         moveScope.setMove(move);
         moveScope.setScore(SimpleScore.valueOf(score));
         return moveScope;

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/localsearch/decider/acceptor/hillclimbing/HillClimbingAcceptorTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/localsearch/decider/acceptor/hillclimbing/HillClimbingAcceptorTest.java
@@ -23,6 +23,7 @@ import org.optaplanner.core.impl.localsearch.scope.LocalSearchMoveScope;
 import org.optaplanner.core.impl.localsearch.scope.LocalSearchPhaseScope;
 import org.optaplanner.core.impl.localsearch.scope.LocalSearchStepScope;
 import org.optaplanner.core.impl.solver.scope.DefaultSolverScope;
+import org.optaplanner.core.impl.testdata.domain.TestdataSolution;
 
 import static org.junit.Assert.*;
 
@@ -32,17 +33,17 @@ public class HillClimbingAcceptorTest extends AbstractAcceptorTest {
     public void hillClimbingEnabled() {
         HillClimbingAcceptor acceptor = new HillClimbingAcceptor();
 
-        DefaultSolverScope solverScope = new DefaultSolverScope();
+        DefaultSolverScope<TestdataSolution> solverScope = new DefaultSolverScope<>();
         solverScope.setBestScore(SimpleScore.valueOf(-1000));
-        LocalSearchPhaseScope phaseScope = new LocalSearchPhaseScope(solverScope);
-        LocalSearchStepScope lastCompletedStepScope = new LocalSearchStepScope(phaseScope, -1);
+        LocalSearchPhaseScope<TestdataSolution> phaseScope = new LocalSearchPhaseScope<>(solverScope);
+        LocalSearchStepScope<TestdataSolution> lastCompletedStepScope = new LocalSearchStepScope<>(phaseScope, -1);
         lastCompletedStepScope.setScore(SimpleScore.valueOf(-1000));
         phaseScope.setLastCompletedStepScope(lastCompletedStepScope);
         acceptor.phaseStarted(phaseScope);
 
         // lastCompletedStepScore = -1000
-        LocalSearchStepScope stepScope0 = new LocalSearchStepScope(phaseScope);
-        LocalSearchMoveScope moveScope0 = buildMoveScope(stepScope0, -500);
+        LocalSearchStepScope<TestdataSolution> stepScope0 = new LocalSearchStepScope<>(phaseScope);
+        LocalSearchMoveScope<TestdataSolution> moveScope0 = buildMoveScope(stepScope0, -500);
         assertEquals(true, acceptor.isAccepted(buildMoveScope(stepScope0, -900)));
         assertEquals(true, acceptor.isAccepted(moveScope0));
         assertEquals(true, acceptor.isAccepted(buildMoveScope(stepScope0, -800)));
@@ -56,8 +57,8 @@ public class HillClimbingAcceptorTest extends AbstractAcceptorTest {
         phaseScope.setLastCompletedStepScope(stepScope0);
 
         // lastCompletedStepScore = -500
-        LocalSearchStepScope stepScope1 = new LocalSearchStepScope(phaseScope);
-        LocalSearchMoveScope moveScope1 = buildMoveScope(stepScope1, 600);
+        LocalSearchStepScope<TestdataSolution> stepScope1 = new LocalSearchStepScope<>(phaseScope);
+        LocalSearchMoveScope<TestdataSolution> moveScope1 = buildMoveScope(stepScope1, 600);
         assertEquals(false, acceptor.isAccepted(buildMoveScope(stepScope1, -900)));
         assertEquals(false, acceptor.isAccepted(buildMoveScope(stepScope1, -2000)));
         assertEquals(false, acceptor.isAccepted(buildMoveScope(stepScope1, -700)));

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/localsearch/decider/acceptor/lateacceptance/LateAcceptanceAcceptorTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/localsearch/decider/acceptor/lateacceptance/LateAcceptanceAcceptorTest.java
@@ -23,6 +23,7 @@ import org.optaplanner.core.impl.localsearch.scope.LocalSearchMoveScope;
 import org.optaplanner.core.impl.localsearch.scope.LocalSearchPhaseScope;
 import org.optaplanner.core.impl.localsearch.scope.LocalSearchStepScope;
 import org.optaplanner.core.impl.solver.scope.DefaultSolverScope;
+import org.optaplanner.core.impl.testdata.domain.TestdataSolution;
 
 import static org.junit.Assert.*;
 
@@ -34,17 +35,17 @@ public class LateAcceptanceAcceptorTest extends AbstractAcceptorTest {
         acceptor.setLateAcceptanceSize(3);
         acceptor.setHillClimbingEnabled(false);
 
-        DefaultSolverScope solverScope = new DefaultSolverScope();
+        DefaultSolverScope<TestdataSolution> solverScope = new DefaultSolverScope<>();
         solverScope.setBestScore(SimpleScore.valueOf(-1000));
-        LocalSearchPhaseScope phaseScope = new LocalSearchPhaseScope(solverScope);
-        LocalSearchStepScope lastCompletedStepScope = new LocalSearchStepScope(phaseScope, -1);
+        LocalSearchPhaseScope<TestdataSolution> phaseScope = new LocalSearchPhaseScope<>(solverScope);
+        LocalSearchStepScope<TestdataSolution> lastCompletedStepScope = new LocalSearchStepScope<>(phaseScope, -1);
         lastCompletedStepScope.setScore(SimpleScore.valueOf(Integer.MIN_VALUE));
         phaseScope.setLastCompletedStepScope(lastCompletedStepScope);
         acceptor.phaseStarted(phaseScope);
 
         // lateScore = -1000
-        LocalSearchStepScope stepScope0 = new LocalSearchStepScope(phaseScope);
-        LocalSearchMoveScope moveScope0 = buildMoveScope(stepScope0, -500);
+        LocalSearchStepScope<TestdataSolution> stepScope0 = new LocalSearchStepScope<>(phaseScope);
+        LocalSearchMoveScope<TestdataSolution> moveScope0 = buildMoveScope(stepScope0, -500);
         assertEquals(true, acceptor.isAccepted(buildMoveScope(stepScope0, -900)));
         assertEquals(true, acceptor.isAccepted(moveScope0));
         assertEquals(true, acceptor.isAccepted(buildMoveScope(stepScope0, -800)));
@@ -58,8 +59,8 @@ public class LateAcceptanceAcceptorTest extends AbstractAcceptorTest {
         phaseScope.setLastCompletedStepScope(stepScope0);
 
         // lateScore = -1000
-        LocalSearchStepScope stepScope1 = new LocalSearchStepScope(phaseScope);
-        LocalSearchMoveScope moveScope1 = buildMoveScope(stepScope1, -700);
+        LocalSearchStepScope<TestdataSolution> stepScope1 = new LocalSearchStepScope<>(phaseScope);
+        LocalSearchMoveScope<TestdataSolution> moveScope1 = buildMoveScope(stepScope1, -700);
         assertEquals(true, acceptor.isAccepted(buildMoveScope(stepScope1, -900)));
         assertEquals(false, acceptor.isAccepted(buildMoveScope(stepScope1, -2000)));
         assertEquals(true, acceptor.isAccepted(moveScope1));
@@ -73,8 +74,8 @@ public class LateAcceptanceAcceptorTest extends AbstractAcceptorTest {
         phaseScope.setLastCompletedStepScope(stepScope1);
 
         // lateScore = -1000
-        LocalSearchStepScope stepScope2 = new LocalSearchStepScope(phaseScope);
-        LocalSearchMoveScope moveScope2 = buildMoveScope(stepScope1, -400);
+        LocalSearchStepScope<TestdataSolution> stepScope2 = new LocalSearchStepScope<>(phaseScope);
+        LocalSearchMoveScope<TestdataSolution> moveScope2 = buildMoveScope(stepScope1, -400);
         assertEquals(true, acceptor.isAccepted(buildMoveScope(stepScope2, -900)));
         assertEquals(false, acceptor.isAccepted(buildMoveScope(stepScope2, -2000)));
         assertEquals(false, acceptor.isAccepted(buildMoveScope(stepScope2, -1001)));
@@ -88,8 +89,8 @@ public class LateAcceptanceAcceptorTest extends AbstractAcceptorTest {
         phaseScope.setLastCompletedStepScope(stepScope2);
 
         // lateScore = -500
-        LocalSearchStepScope stepScope3 = new LocalSearchStepScope(phaseScope);
-        LocalSearchMoveScope moveScope3 = buildMoveScope(stepScope1, -200);
+        LocalSearchStepScope<TestdataSolution> stepScope3 = new LocalSearchStepScope<>(phaseScope);
+        LocalSearchMoveScope<TestdataSolution> moveScope3 = buildMoveScope(stepScope1, -200);
         assertEquals(false, acceptor.isAccepted(buildMoveScope(stepScope3, -900)));
         assertEquals(true, acceptor.isAccepted(buildMoveScope(stepScope3, -500)));
         assertEquals(false, acceptor.isAccepted(buildMoveScope(stepScope3, -501)));
@@ -103,8 +104,8 @@ public class LateAcceptanceAcceptorTest extends AbstractAcceptorTest {
         phaseScope.setLastCompletedStepScope(stepScope3);
 
         // lateScore = -700 (not the best score of -500!)
-        LocalSearchStepScope stepScope4 = new LocalSearchStepScope(phaseScope);
-        LocalSearchMoveScope moveScope4 = buildMoveScope(stepScope1, -300);
+        LocalSearchStepScope<TestdataSolution> stepScope4 = new LocalSearchStepScope<>(phaseScope);
+        LocalSearchMoveScope<TestdataSolution> moveScope4 = buildMoveScope(stepScope1, -300);
         assertEquals(true, acceptor.isAccepted(buildMoveScope(stepScope4, -700)));
         assertEquals(true, acceptor.isAccepted(moveScope4));
         assertEquals(true, acceptor.isAccepted(buildMoveScope(stepScope4, -500)));
@@ -118,8 +119,8 @@ public class LateAcceptanceAcceptorTest extends AbstractAcceptorTest {
         phaseScope.setLastCompletedStepScope(stepScope4);
 
         // lateScore = -400
-        LocalSearchStepScope stepScope5 = new LocalSearchStepScope(phaseScope);
-        LocalSearchMoveScope moveScope5 = buildMoveScope(stepScope1, -300);
+        LocalSearchStepScope<TestdataSolution> stepScope5 = new LocalSearchStepScope<>(phaseScope);
+        LocalSearchMoveScope<TestdataSolution> moveScope5 = buildMoveScope(stepScope1, -300);
         assertEquals(false, acceptor.isAccepted(buildMoveScope(stepScope5, -401)));
         assertEquals(true, acceptor.isAccepted(buildMoveScope(stepScope5, -400)));
         assertEquals(true, acceptor.isAccepted(moveScope5));
@@ -141,17 +142,17 @@ public class LateAcceptanceAcceptorTest extends AbstractAcceptorTest {
         acceptor.setLateAcceptanceSize(2);
         acceptor.setHillClimbingEnabled(true);
 
-        DefaultSolverScope solverScope = new DefaultSolverScope();
+        DefaultSolverScope<TestdataSolution> solverScope = new DefaultSolverScope<>();
         solverScope.setBestScore(SimpleScore.valueOf(-1000));
-        LocalSearchPhaseScope phaseScope = new LocalSearchPhaseScope(solverScope);
-        LocalSearchStepScope lastCompletedStepScope = new LocalSearchStepScope(phaseScope, -1);
+        LocalSearchPhaseScope<TestdataSolution> phaseScope = new LocalSearchPhaseScope<>(solverScope);
+        LocalSearchStepScope<TestdataSolution> lastCompletedStepScope = new LocalSearchStepScope<>(phaseScope, -1);
         lastCompletedStepScope.setScore(solverScope.getBestScore());
         phaseScope.setLastCompletedStepScope(lastCompletedStepScope);
         acceptor.phaseStarted(phaseScope);
 
         // lateScore = -1000, lastCompletedStepScore = Integer.MIN_VALUE
-        LocalSearchStepScope stepScope0 = new LocalSearchStepScope(phaseScope);
-        LocalSearchMoveScope moveScope0 = buildMoveScope(stepScope0, -500);
+        LocalSearchStepScope<TestdataSolution> stepScope0 = new LocalSearchStepScope<>(phaseScope);
+        LocalSearchMoveScope<TestdataSolution> moveScope0 = buildMoveScope(stepScope0, -500);
         assertEquals(true, acceptor.isAccepted(buildMoveScope(stepScope0, -900)));
         assertEquals(true, acceptor.isAccepted(moveScope0));
         assertEquals(true, acceptor.isAccepted(buildMoveScope(stepScope0, -800)));
@@ -165,8 +166,8 @@ public class LateAcceptanceAcceptorTest extends AbstractAcceptorTest {
         phaseScope.setLastCompletedStepScope(stepScope0);
 
         // lateScore = -1000, lastCompletedStepScore = -500
-        LocalSearchStepScope stepScope1 = new LocalSearchStepScope(phaseScope);
-        LocalSearchMoveScope moveScope1 = buildMoveScope(stepScope1, -700);
+        LocalSearchStepScope<TestdataSolution> stepScope1 = new LocalSearchStepScope<>(phaseScope);
+        LocalSearchMoveScope<TestdataSolution> moveScope1 = buildMoveScope(stepScope1, -700);
         assertEquals(true, acceptor.isAccepted(buildMoveScope(stepScope1, -900)));
         assertEquals(false, acceptor.isAccepted(buildMoveScope(stepScope1, -2000)));
         assertEquals(true, acceptor.isAccepted(moveScope1));
@@ -180,8 +181,8 @@ public class LateAcceptanceAcceptorTest extends AbstractAcceptorTest {
         phaseScope.setLastCompletedStepScope(stepScope1);
 
         // lateScore = -500, lastCompletedStepScore = -700
-        LocalSearchStepScope stepScope2 = new LocalSearchStepScope(phaseScope);
-        LocalSearchMoveScope moveScope2 = buildMoveScope(stepScope1, -400);
+        LocalSearchStepScope<TestdataSolution> stepScope2 = new LocalSearchStepScope<>(phaseScope);
+        LocalSearchMoveScope<TestdataSolution> moveScope2 = buildMoveScope(stepScope1, -400);
         assertEquals(true, acceptor.isAccepted(buildMoveScope(stepScope2, -700)));
         assertEquals(false, acceptor.isAccepted(buildMoveScope(stepScope2, -2000)));
         assertEquals(false, acceptor.isAccepted(buildMoveScope(stepScope2, -701)));
@@ -195,8 +196,8 @@ public class LateAcceptanceAcceptorTest extends AbstractAcceptorTest {
         phaseScope.setLastCompletedStepScope(stepScope2);
 
         // lateScore = -700, lastCompletedStepScore = -400
-        LocalSearchStepScope stepScope3 = new LocalSearchStepScope(phaseScope);
-        LocalSearchMoveScope moveScope3 = buildMoveScope(stepScope1, -200);
+        LocalSearchStepScope<TestdataSolution> stepScope3 = new LocalSearchStepScope<>(phaseScope);
+        LocalSearchMoveScope<TestdataSolution> moveScope3 = buildMoveScope(stepScope1, -200);
         assertEquals(false, acceptor.isAccepted(buildMoveScope(stepScope3, -900)));
         assertEquals(true, acceptor.isAccepted(buildMoveScope(stepScope3, -700)));
         assertEquals(false, acceptor.isAccepted(buildMoveScope(stepScope3, -701)));
@@ -210,8 +211,8 @@ public class LateAcceptanceAcceptorTest extends AbstractAcceptorTest {
         phaseScope.setLastCompletedStepScope(stepScope3);
 
         // lateScore = -400 (not the best score of -200!), lastCompletedStepScore = -200
-        LocalSearchStepScope stepScope4 = new LocalSearchStepScope(phaseScope);
-        LocalSearchMoveScope moveScope4 = buildMoveScope(stepScope1, -300);
+        LocalSearchStepScope<TestdataSolution> stepScope4 = new LocalSearchStepScope<>(phaseScope);
+        LocalSearchMoveScope<TestdataSolution> moveScope4 = buildMoveScope(stepScope1, -300);
         assertEquals(true, acceptor.isAccepted(buildMoveScope(stepScope4, -400)));
         assertEquals(true, acceptor.isAccepted(moveScope4));
         assertEquals(false, acceptor.isAccepted(buildMoveScope(stepScope4, -500)));
@@ -225,8 +226,8 @@ public class LateAcceptanceAcceptorTest extends AbstractAcceptorTest {
         phaseScope.setLastCompletedStepScope(stepScope4);
 
         // lateScore = -200, lastCompletedStepScore = -300
-        LocalSearchStepScope stepScope5 = new LocalSearchStepScope(phaseScope);
-        LocalSearchMoveScope moveScope5 = buildMoveScope(stepScope1, -300);
+        LocalSearchStepScope<TestdataSolution> stepScope5 = new LocalSearchStepScope<>(phaseScope);
+        LocalSearchMoveScope<TestdataSolution> moveScope5 = buildMoveScope(stepScope1, -300);
         assertEquals(false, acceptor.isAccepted(buildMoveScope(stepScope5, -301)));
         assertEquals(false, acceptor.isAccepted(buildMoveScope(stepScope5, -400)));
         assertEquals(true, acceptor.isAccepted(moveScope5));

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/localsearch/decider/acceptor/simulatedannealing/SimulatedAnnealingAcceptorTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/localsearch/decider/acceptor/simulatedannealing/SimulatedAnnealingAcceptorTest.java
@@ -26,6 +26,7 @@ import org.optaplanner.core.impl.localsearch.scope.LocalSearchMoveScope;
 import org.optaplanner.core.impl.localsearch.scope.LocalSearchPhaseScope;
 import org.optaplanner.core.impl.localsearch.scope.LocalSearchStepScope;
 import org.optaplanner.core.impl.solver.scope.DefaultSolverScope;
+import org.optaplanner.core.impl.testdata.domain.TestdataSolution;
 
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
@@ -37,20 +38,20 @@ public class SimulatedAnnealingAcceptorTest extends AbstractAcceptorTest {
         SimulatedAnnealingAcceptor acceptor = new SimulatedAnnealingAcceptor();
         acceptor.setStartingTemperature(SimpleScore.valueOf(200));
 
-        DefaultSolverScope solverScope = new DefaultSolverScope();
+        DefaultSolverScope<TestdataSolution> solverScope = new DefaultSolverScope<>();
         solverScope.setBestScore(SimpleScore.valueOf(-1000));
         Random workingRandom = mock(Random.class);
         solverScope.setWorkingRandom(workingRandom);
-        LocalSearchPhaseScope phaseScope = new LocalSearchPhaseScope(solverScope);
-        LocalSearchStepScope lastCompletedStepScope = new LocalSearchStepScope(phaseScope, -1);
+        LocalSearchPhaseScope<TestdataSolution> phaseScope = new LocalSearchPhaseScope<>(solverScope);
+        LocalSearchStepScope<TestdataSolution> lastCompletedStepScope = new LocalSearchStepScope<>(phaseScope, -1);
         lastCompletedStepScope.setScore(SimpleScore.valueOf(-1000));
         phaseScope.setLastCompletedStepScope(lastCompletedStepScope);
         acceptor.phaseStarted(phaseScope);
 
-        LocalSearchStepScope stepScope0 = new LocalSearchStepScope(phaseScope);
+        LocalSearchStepScope<TestdataSolution> stepScope0 = new LocalSearchStepScope<>(phaseScope);
         stepScope0.setTimeGradient(0.0);
         acceptor.stepStarted(stepScope0);
-        LocalSearchMoveScope moveScope0 = buildMoveScope(stepScope0, -500);
+        LocalSearchMoveScope<TestdataSolution> moveScope0 = buildMoveScope(stepScope0, -500);
         when(workingRandom.nextDouble()).thenReturn(0.3);
         assertEquals(false, acceptor.isAccepted(buildMoveScope(stepScope0, -1300)));
         when(workingRandom.nextDouble()).thenReturn(0.3);
@@ -64,10 +65,10 @@ public class SimulatedAnnealingAcceptorTest extends AbstractAcceptorTest {
         acceptor.stepEnded(stepScope0);
         phaseScope.setLastCompletedStepScope(stepScope0);
 
-        LocalSearchStepScope stepScope1 = new LocalSearchStepScope(phaseScope);
+        LocalSearchStepScope<TestdataSolution> stepScope1 = new LocalSearchStepScope<>(phaseScope);
         stepScope1.setTimeGradient(0.5);
         acceptor.stepStarted(stepScope1);
-        LocalSearchMoveScope moveScope1 = buildMoveScope(stepScope1, -800);
+        LocalSearchMoveScope<TestdataSolution> moveScope1 = buildMoveScope(stepScope1, -800);
         when(workingRandom.nextDouble()).thenReturn(0.13);
         assertEquals(true, acceptor.isAccepted(buildMoveScope(stepScope1, -700)));
         when(workingRandom.nextDouble()).thenReturn(0.14);
@@ -80,10 +81,10 @@ public class SimulatedAnnealingAcceptorTest extends AbstractAcceptorTest {
         acceptor.stepEnded(stepScope1);
         phaseScope.setLastCompletedStepScope(stepScope1);
 
-        LocalSearchStepScope stepScope2 = new LocalSearchStepScope(phaseScope);
+        LocalSearchStepScope<TestdataSolution> stepScope2 = new LocalSearchStepScope<>(phaseScope);
         stepScope2.setTimeGradient(1.0);
         acceptor.stepStarted(stepScope2);
-        LocalSearchMoveScope moveScope2 = buildMoveScope(stepScope1, -400);
+        LocalSearchMoveScope<TestdataSolution> moveScope2 = buildMoveScope(stepScope1, -400);
         when(workingRandom.nextDouble()).thenReturn(0.01);
         assertEquals(true, acceptor.isAccepted(buildMoveScope(stepScope2, -800)));
         when(workingRandom.nextDouble()).thenReturn(0.01);

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/localsearch/decider/acceptor/stepcountinghillclimbing/StepCountingHillClimbingAcceptorTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/localsearch/decider/acceptor/stepcountinghillclimbing/StepCountingHillClimbingAcceptorTest.java
@@ -24,6 +24,7 @@ import org.optaplanner.core.impl.localsearch.scope.LocalSearchMoveScope;
 import org.optaplanner.core.impl.localsearch.scope.LocalSearchPhaseScope;
 import org.optaplanner.core.impl.localsearch.scope.LocalSearchStepScope;
 import org.optaplanner.core.impl.solver.scope.DefaultSolverScope;
+import org.optaplanner.core.impl.testdata.domain.TestdataSolution;
 
 import static org.junit.Assert.*;
 
@@ -34,17 +35,17 @@ public class StepCountingHillClimbingAcceptorTest extends AbstractAcceptorTest {
         StepCountingHillClimbingAcceptor acceptor = new StepCountingHillClimbingAcceptor(2,
                 StepCountingHillClimbingType.STEP);
 
-        DefaultSolverScope solverScope = new DefaultSolverScope();
+        DefaultSolverScope<TestdataSolution> solverScope = new DefaultSolverScope<>();
         solverScope.setBestScore(SimpleScore.valueOf(-1000));
-        LocalSearchPhaseScope phaseScope = new LocalSearchPhaseScope(solverScope);
-        LocalSearchStepScope lastCompletedStepScope = new LocalSearchStepScope(phaseScope, -1);
+        LocalSearchPhaseScope<TestdataSolution> phaseScope = new LocalSearchPhaseScope<>(solverScope);
+        LocalSearchStepScope<TestdataSolution> lastCompletedStepScope = new LocalSearchStepScope<>(phaseScope, -1);
         lastCompletedStepScope.setScore(solverScope.getBestScore());
         phaseScope.setLastCompletedStepScope(lastCompletedStepScope);
         acceptor.phaseStarted(phaseScope);
 
         // thresholdScore = -1000, lastCompletedStepScore = Integer.MIN_VALUE
-        LocalSearchStepScope stepScope0 = new LocalSearchStepScope(phaseScope);
-        LocalSearchMoveScope moveScope0 = buildMoveScope(stepScope0, -500);
+        LocalSearchStepScope<TestdataSolution> stepScope0 = new LocalSearchStepScope<>(phaseScope);
+        LocalSearchMoveScope<TestdataSolution> moveScope0 = buildMoveScope(stepScope0, -500);
         assertEquals(true, acceptor.isAccepted(buildMoveScope(stepScope0, -900)));
         assertEquals(true, acceptor.isAccepted(moveScope0));
         assertEquals(true, acceptor.isAccepted(buildMoveScope(stepScope0, -800)));
@@ -58,8 +59,8 @@ public class StepCountingHillClimbingAcceptorTest extends AbstractAcceptorTest {
         phaseScope.setLastCompletedStepScope(stepScope0);
 
         // thresholdScore = -1000, lastCompletedStepScore = -500
-        LocalSearchStepScope stepScope1 = new LocalSearchStepScope(phaseScope);
-        LocalSearchMoveScope moveScope1 = buildMoveScope(stepScope1, -700);
+        LocalSearchStepScope<TestdataSolution> stepScope1 = new LocalSearchStepScope<>(phaseScope);
+        LocalSearchMoveScope<TestdataSolution> moveScope1 = buildMoveScope(stepScope1, -700);
         assertEquals(true, acceptor.isAccepted(buildMoveScope(stepScope1, -900)));
         assertEquals(false, acceptor.isAccepted(buildMoveScope(stepScope1, -2000)));
         assertEquals(true, acceptor.isAccepted(moveScope1));
@@ -73,8 +74,8 @@ public class StepCountingHillClimbingAcceptorTest extends AbstractAcceptorTest {
         phaseScope.setLastCompletedStepScope(stepScope1);
 
         // thresholdScore = -700, lastCompletedStepScore = -700
-        LocalSearchStepScope stepScope2 = new LocalSearchStepScope(phaseScope);
-        LocalSearchMoveScope moveScope2 = buildMoveScope(stepScope1, -400);
+        LocalSearchStepScope<TestdataSolution> stepScope2 = new LocalSearchStepScope<>(phaseScope);
+        LocalSearchMoveScope<TestdataSolution> moveScope2 = buildMoveScope(stepScope1, -400);
         assertEquals(true, acceptor.isAccepted(buildMoveScope(stepScope2, -700)));
         assertEquals(false, acceptor.isAccepted(buildMoveScope(stepScope2, -2000)));
         assertEquals(false, acceptor.isAccepted(buildMoveScope(stepScope2, -701)));
@@ -88,8 +89,8 @@ public class StepCountingHillClimbingAcceptorTest extends AbstractAcceptorTest {
         phaseScope.setLastCompletedStepScope(stepScope2);
 
         // thresholdScore = -700, lastCompletedStepScore = -400
-        LocalSearchStepScope stepScope3 = new LocalSearchStepScope(phaseScope);
-        LocalSearchMoveScope moveScope3 = buildMoveScope(stepScope1, -400);
+        LocalSearchStepScope<TestdataSolution> stepScope3 = new LocalSearchStepScope<>(phaseScope);
+        LocalSearchMoveScope<TestdataSolution> moveScope3 = buildMoveScope(stepScope1, -400);
         assertEquals(false, acceptor.isAccepted(buildMoveScope(stepScope3, -900)));
         assertEquals(true, acceptor.isAccepted(buildMoveScope(stepScope3, -700)));
         assertEquals(false, acceptor.isAccepted(buildMoveScope(stepScope3, -701)));
@@ -103,8 +104,8 @@ public class StepCountingHillClimbingAcceptorTest extends AbstractAcceptorTest {
         phaseScope.setLastCompletedStepScope(stepScope3);
 
         // thresholdScore = -400 (not the best score of -200!), lastCompletedStepScore = -400
-        LocalSearchStepScope stepScope4 = new LocalSearchStepScope(phaseScope);
-        LocalSearchMoveScope moveScope4 = buildMoveScope(stepScope1, -300);
+        LocalSearchStepScope<TestdataSolution> stepScope4 = new LocalSearchStepScope<>(phaseScope);
+        LocalSearchMoveScope<TestdataSolution> moveScope4 = buildMoveScope(stepScope1, -300);
         assertEquals(true, acceptor.isAccepted(buildMoveScope(stepScope4, -400)));
         assertEquals(true, acceptor.isAccepted(moveScope4));
         assertEquals(false, acceptor.isAccepted(buildMoveScope(stepScope4, -500)));
@@ -118,8 +119,8 @@ public class StepCountingHillClimbingAcceptorTest extends AbstractAcceptorTest {
         phaseScope.setLastCompletedStepScope(stepScope4);
 
         // thresholdScore = -400, lastCompletedStepScore = -300
-        LocalSearchStepScope stepScope5 = new LocalSearchStepScope(phaseScope);
-        LocalSearchMoveScope moveScope5 = buildMoveScope(stepScope1, -300);
+        LocalSearchStepScope<TestdataSolution> stepScope5 = new LocalSearchStepScope<>(phaseScope);
+        LocalSearchMoveScope<TestdataSolution> moveScope5 = buildMoveScope(stepScope1, -300);
         assertEquals(true, acceptor.isAccepted(buildMoveScope(stepScope5, -301)));
         assertEquals(true, acceptor.isAccepted(buildMoveScope(stepScope5, -400)));
         assertEquals(true, acceptor.isAccepted(moveScope5));
@@ -140,17 +141,17 @@ public class StepCountingHillClimbingAcceptorTest extends AbstractAcceptorTest {
         StepCountingHillClimbingAcceptor acceptor = new StepCountingHillClimbingAcceptor(2,
                 StepCountingHillClimbingType.EQUAL_OR_IMPROVING_STEP);
 
-        DefaultSolverScope solverScope = new DefaultSolverScope();
+        DefaultSolverScope<TestdataSolution> solverScope = new DefaultSolverScope<>();
         solverScope.setBestScore(SimpleScore.valueOf(-1000));
-        LocalSearchPhaseScope phaseScope = new LocalSearchPhaseScope(solverScope);
-        LocalSearchStepScope lastCompletedStepScope = new LocalSearchStepScope(phaseScope, -1);
+        LocalSearchPhaseScope<TestdataSolution> phaseScope = new LocalSearchPhaseScope<>(solverScope);
+        LocalSearchStepScope<TestdataSolution> lastCompletedStepScope = new LocalSearchStepScope<>(phaseScope, -1);
         lastCompletedStepScope.setScore(solverScope.getBestScore());
         phaseScope.setLastCompletedStepScope(lastCompletedStepScope);
         acceptor.phaseStarted(phaseScope);
 
         // thresholdScore = -1000, lastCompletedStepScore = Integer.MIN_VALUE
-        LocalSearchStepScope stepScope0 = new LocalSearchStepScope(phaseScope);
-        LocalSearchMoveScope moveScope0 = buildMoveScope(stepScope0, -500);
+        LocalSearchStepScope<TestdataSolution> stepScope0 = new LocalSearchStepScope<>(phaseScope);
+        LocalSearchMoveScope<TestdataSolution> moveScope0 = buildMoveScope(stepScope0, -500);
         assertEquals(true, acceptor.isAccepted(buildMoveScope(stepScope0, -900)));
         assertEquals(true, acceptor.isAccepted(moveScope0));
         assertEquals(true, acceptor.isAccepted(buildMoveScope(stepScope0, -800)));
@@ -164,8 +165,8 @@ public class StepCountingHillClimbingAcceptorTest extends AbstractAcceptorTest {
         phaseScope.setLastCompletedStepScope(stepScope0);
 
         // thresholdScore = -1000, lastCompletedStepScore = -500
-        LocalSearchStepScope stepScope1 = new LocalSearchStepScope(phaseScope);
-        LocalSearchMoveScope moveScope1 = buildMoveScope(stepScope1, -700);
+        LocalSearchStepScope<TestdataSolution> stepScope1 = new LocalSearchStepScope<>(phaseScope);
+        LocalSearchMoveScope<TestdataSolution> moveScope1 = buildMoveScope(stepScope1, -700);
         assertEquals(true, acceptor.isAccepted(buildMoveScope(stepScope1, -900)));
         assertEquals(false, acceptor.isAccepted(buildMoveScope(stepScope1, -2000)));
         assertEquals(true, acceptor.isAccepted(moveScope1));
@@ -179,8 +180,8 @@ public class StepCountingHillClimbingAcceptorTest extends AbstractAcceptorTest {
         phaseScope.setLastCompletedStepScope(stepScope1);
 
         // thresholdScore = -1000, lastCompletedStepScore = -700
-        LocalSearchStepScope stepScope2 = new LocalSearchStepScope(phaseScope);
-        LocalSearchMoveScope moveScope2 = buildMoveScope(stepScope1, -400);
+        LocalSearchStepScope<TestdataSolution> stepScope2 = new LocalSearchStepScope<>(phaseScope);
+        LocalSearchMoveScope<TestdataSolution> moveScope2 = buildMoveScope(stepScope1, -400);
         assertEquals(true, acceptor.isAccepted(buildMoveScope(stepScope2, -700)));
         assertEquals(false, acceptor.isAccepted(buildMoveScope(stepScope2, -2000)));
         assertEquals(true, acceptor.isAccepted(buildMoveScope(stepScope2, 1000)));
@@ -195,8 +196,8 @@ public class StepCountingHillClimbingAcceptorTest extends AbstractAcceptorTest {
         phaseScope.setLastCompletedStepScope(stepScope2);
 
         // thresholdScore = -400, lastCompletedStepScore = -400
-        LocalSearchStepScope stepScope3 = new LocalSearchStepScope(phaseScope);
-        LocalSearchMoveScope moveScope3 = buildMoveScope(stepScope1, -400);
+        LocalSearchStepScope<TestdataSolution> stepScope3 = new LocalSearchStepScope<>(phaseScope);
+        LocalSearchMoveScope<TestdataSolution> moveScope3 = buildMoveScope(stepScope1, -400);
         assertEquals(false, acceptor.isAccepted(buildMoveScope(stepScope3, -900)));
         assertEquals(false, acceptor.isAccepted(buildMoveScope(stepScope3, -401)));
         assertEquals(true, acceptor.isAccepted(moveScope3));
@@ -209,8 +210,8 @@ public class StepCountingHillClimbingAcceptorTest extends AbstractAcceptorTest {
         phaseScope.setLastCompletedStepScope(stepScope3);
 
         // thresholdScore = -400, lastCompletedStepScore = -400
-        LocalSearchStepScope stepScope4 = new LocalSearchStepScope(phaseScope);
-        LocalSearchMoveScope moveScope4 = buildMoveScope(stepScope1, -300);
+        LocalSearchStepScope<TestdataSolution> stepScope4 = new LocalSearchStepScope<>(phaseScope);
+        LocalSearchMoveScope<TestdataSolution> moveScope4 = buildMoveScope(stepScope1, -300);
         assertEquals(true, acceptor.isAccepted(buildMoveScope(stepScope4, -400)));
         assertEquals(true, acceptor.isAccepted(moveScope4));
         assertEquals(false, acceptor.isAccepted(buildMoveScope(stepScope4, -500)));
@@ -224,8 +225,8 @@ public class StepCountingHillClimbingAcceptorTest extends AbstractAcceptorTest {
         phaseScope.setLastCompletedStepScope(stepScope4);
 
         // thresholdScore = -300, lastCompletedStepScore = -300
-        LocalSearchStepScope stepScope5 = new LocalSearchStepScope(phaseScope);
-        LocalSearchMoveScope moveScope5 = buildMoveScope(stepScope1, -300);
+        LocalSearchStepScope<TestdataSolution> stepScope5 = new LocalSearchStepScope<>(phaseScope);
+        LocalSearchMoveScope<TestdataSolution> moveScope5 = buildMoveScope(stepScope1, -300);
         assertEquals(false, acceptor.isAccepted(buildMoveScope(stepScope5, -301)));
         assertEquals(false, acceptor.isAccepted(buildMoveScope(stepScope5, -400)));
         assertEquals(true, acceptor.isAccepted(moveScope5));
@@ -246,17 +247,17 @@ public class StepCountingHillClimbingAcceptorTest extends AbstractAcceptorTest {
         StepCountingHillClimbingAcceptor acceptor = new StepCountingHillClimbingAcceptor(2,
                 StepCountingHillClimbingType.IMPROVING_STEP);
 
-        DefaultSolverScope solverScope = new DefaultSolverScope();
+        DefaultSolverScope<TestdataSolution> solverScope = new DefaultSolverScope<>();
         solverScope.setBestScore(SimpleScore.valueOf(-1000));
-        LocalSearchPhaseScope phaseScope = new LocalSearchPhaseScope(solverScope);
-        LocalSearchStepScope lastCompletedStepScope = new LocalSearchStepScope(phaseScope, -1);
+        LocalSearchPhaseScope<TestdataSolution> phaseScope = new LocalSearchPhaseScope<>(solverScope);
+        LocalSearchStepScope<TestdataSolution> lastCompletedStepScope = new LocalSearchStepScope<>(phaseScope, -1);
         lastCompletedStepScope.setScore(solverScope.getBestScore());
         phaseScope.setLastCompletedStepScope(lastCompletedStepScope);
         acceptor.phaseStarted(phaseScope);
 
         // thresholdScore = -1000, lastCompletedStepScore = Integer.MIN_VALUE
-        LocalSearchStepScope stepScope0 = new LocalSearchStepScope(phaseScope);
-        LocalSearchMoveScope moveScope0 = buildMoveScope(stepScope0, -500);
+        LocalSearchStepScope<TestdataSolution> stepScope0 = new LocalSearchStepScope<>(phaseScope);
+        LocalSearchMoveScope<TestdataSolution> moveScope0 = buildMoveScope(stepScope0, -500);
         assertEquals(true, acceptor.isAccepted(buildMoveScope(stepScope0, -900)));
         assertEquals(true, acceptor.isAccepted(moveScope0));
         assertEquals(true, acceptor.isAccepted(buildMoveScope(stepScope0, -800)));
@@ -270,8 +271,8 @@ public class StepCountingHillClimbingAcceptorTest extends AbstractAcceptorTest {
         phaseScope.setLastCompletedStepScope(stepScope0);
 
         // thresholdScore = -1000, lastCompletedStepScore = -500
-        LocalSearchStepScope stepScope1 = new LocalSearchStepScope(phaseScope);
-        LocalSearchMoveScope moveScope1 = buildMoveScope(stepScope1, -700);
+        LocalSearchStepScope<TestdataSolution> stepScope1 = new LocalSearchStepScope<>(phaseScope);
+        LocalSearchMoveScope<TestdataSolution> moveScope1 = buildMoveScope(stepScope1, -700);
         assertEquals(true, acceptor.isAccepted(buildMoveScope(stepScope1, -900)));
         assertEquals(false, acceptor.isAccepted(buildMoveScope(stepScope1, -2000)));
         assertEquals(true, acceptor.isAccepted(moveScope1));
@@ -285,8 +286,8 @@ public class StepCountingHillClimbingAcceptorTest extends AbstractAcceptorTest {
         phaseScope.setLastCompletedStepScope(stepScope1);
 
         // thresholdScore = -1000, lastCompletedStepScore = -700
-        LocalSearchStepScope stepScope2 = new LocalSearchStepScope(phaseScope);
-        LocalSearchMoveScope moveScope2 = buildMoveScope(stepScope1, -400);
+        LocalSearchStepScope<TestdataSolution> stepScope2 = new LocalSearchStepScope<>(phaseScope);
+        LocalSearchMoveScope<TestdataSolution> moveScope2 = buildMoveScope(stepScope1, -400);
         assertEquals(true, acceptor.isAccepted(buildMoveScope(stepScope2, -700)));
         assertEquals(false, acceptor.isAccepted(buildMoveScope(stepScope2, -2000)));
         assertEquals(true, acceptor.isAccepted(buildMoveScope(stepScope2, 1000)));
@@ -301,8 +302,8 @@ public class StepCountingHillClimbingAcceptorTest extends AbstractAcceptorTest {
         phaseScope.setLastCompletedStepScope(stepScope2);
 
         // thresholdScore = -400, lastCompletedStepScore = -400
-        LocalSearchStepScope stepScope3 = new LocalSearchStepScope(phaseScope);
-        LocalSearchMoveScope moveScope3 = buildMoveScope(stepScope1, -400);
+        LocalSearchStepScope<TestdataSolution> stepScope3 = new LocalSearchStepScope<>(phaseScope);
+        LocalSearchMoveScope<TestdataSolution> moveScope3 = buildMoveScope(stepScope1, -400);
         assertEquals(false, acceptor.isAccepted(buildMoveScope(stepScope3, -900)));
         assertEquals(false, acceptor.isAccepted(buildMoveScope(stepScope3, -401)));
         assertEquals(true, acceptor.isAccepted(moveScope3));
@@ -315,8 +316,8 @@ public class StepCountingHillClimbingAcceptorTest extends AbstractAcceptorTest {
         phaseScope.setLastCompletedStepScope(stepScope3);
 
         // thresholdScore = -400, lastCompletedStepScore = -400
-        LocalSearchStepScope stepScope4 = new LocalSearchStepScope(phaseScope);
-        LocalSearchMoveScope moveScope4 = buildMoveScope(stepScope1, -300);
+        LocalSearchStepScope<TestdataSolution> stepScope4 = new LocalSearchStepScope<>(phaseScope);
+        LocalSearchMoveScope<TestdataSolution> moveScope4 = buildMoveScope(stepScope1, -300);
         assertEquals(true, acceptor.isAccepted(buildMoveScope(stepScope4, -400)));
         assertEquals(true, acceptor.isAccepted(moveScope4));
         assertEquals(false, acceptor.isAccepted(buildMoveScope(stepScope4, -500)));
@@ -330,8 +331,8 @@ public class StepCountingHillClimbingAcceptorTest extends AbstractAcceptorTest {
         phaseScope.setLastCompletedStepScope(stepScope4);
 
         // thresholdScore = -400, lastCompletedStepScore = -300
-        LocalSearchStepScope stepScope5 = new LocalSearchStepScope(phaseScope);
-        LocalSearchMoveScope moveScope5 = buildMoveScope(stepScope1, -300);
+        LocalSearchStepScope<TestdataSolution> stepScope5 = new LocalSearchStepScope<>(phaseScope);
+        LocalSearchMoveScope<TestdataSolution> moveScope5 = buildMoveScope(stepScope1, -300);
         assertEquals(true, acceptor.isAccepted(buildMoveScope(stepScope5, -301)));
         assertEquals(true, acceptor.isAccepted(buildMoveScope(stepScope5, -400)));
         assertEquals(false, acceptor.isAccepted(buildMoveScope(stepScope5, -401)));

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/localsearch/decider/acceptor/tabu/EntityTabuAcceptorTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/localsearch/decider/acceptor/tabu/EntityTabuAcceptorTest.java
@@ -28,6 +28,7 @@ import org.optaplanner.core.impl.localsearch.scope.LocalSearchPhaseScope;
 import org.optaplanner.core.impl.localsearch.scope.LocalSearchStepScope;
 import org.optaplanner.core.impl.solver.scope.DefaultSolverScope;
 import org.optaplanner.core.impl.testdata.domain.TestdataEntity;
+import org.optaplanner.core.impl.testdata.domain.TestdataSolution;
 
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
@@ -46,13 +47,13 @@ public class EntityTabuAcceptorTest {
         TestdataEntity e3 = new TestdataEntity("e3");
         TestdataEntity e4 = new TestdataEntity("e4");
 
-        DefaultSolverScope solverScope = new DefaultSolverScope();
+        DefaultSolverScope<TestdataSolution> solverScope = new DefaultSolverScope<>();
         solverScope.setBestScore(SimpleScore.valueOf(0));
-        LocalSearchPhaseScope phaseScope = new LocalSearchPhaseScope(solverScope);
+        LocalSearchPhaseScope<TestdataSolution> phaseScope = new LocalSearchPhaseScope<>(solverScope);
         acceptor.phaseStarted(phaseScope);
 
-        LocalSearchStepScope stepScope0 = new LocalSearchStepScope(phaseScope);
-        LocalSearchMoveScope moveScope1 = buildMoveScope(stepScope0, e1);
+        LocalSearchStepScope<TestdataSolution> stepScope0 = new LocalSearchStepScope<>(phaseScope);
+        LocalSearchMoveScope<TestdataSolution> moveScope1 = buildMoveScope(stepScope0, e1);
         assertEquals(true, acceptor.isAccepted(buildMoveScope(stepScope0, e0)));
         assertEquals(true, acceptor.isAccepted(moveScope1));
         assertEquals(true, acceptor.isAccepted(buildMoveScope(stepScope0, e2)));
@@ -63,8 +64,8 @@ public class EntityTabuAcceptorTest {
         acceptor.stepEnded(stepScope0);
         phaseScope.setLastCompletedStepScope(stepScope0);
 
-        LocalSearchStepScope stepScope1 = new LocalSearchStepScope(phaseScope);
-        LocalSearchMoveScope moveScope2 = buildMoveScope(stepScope1, e2);
+        LocalSearchStepScope<TestdataSolution> stepScope1 = new LocalSearchStepScope<>(phaseScope);
+        LocalSearchMoveScope<TestdataSolution> moveScope2 = buildMoveScope(stepScope1, e2);
         assertEquals(true, acceptor.isAccepted(buildMoveScope(stepScope1, e0)));
         assertEquals(false, acceptor.isAccepted(buildMoveScope(stepScope1, e1)));
         assertEquals(true, acceptor.isAccepted(moveScope2));
@@ -75,8 +76,8 @@ public class EntityTabuAcceptorTest {
         acceptor.stepEnded(stepScope1);
         phaseScope.setLastCompletedStepScope(stepScope1);
 
-        LocalSearchStepScope stepScope2 = new LocalSearchStepScope(phaseScope);
-        LocalSearchMoveScope moveScope4 = buildMoveScope(stepScope2, e4);
+        LocalSearchStepScope<TestdataSolution> stepScope2 = new LocalSearchStepScope<>(phaseScope);
+        LocalSearchMoveScope<TestdataSolution> moveScope4 = buildMoveScope(stepScope2, e4);
         assertEquals(true, acceptor.isAccepted(buildMoveScope(stepScope2, e0)));
         assertEquals(false, acceptor.isAccepted(buildMoveScope(stepScope2, e1)));
         assertEquals(false, acceptor.isAccepted(buildMoveScope(stepScope2, e2)));
@@ -87,8 +88,8 @@ public class EntityTabuAcceptorTest {
         acceptor.stepEnded(stepScope2);
         phaseScope.setLastCompletedStepScope(stepScope2);
 
-        LocalSearchStepScope stepScope3 = new LocalSearchStepScope(phaseScope);
-        LocalSearchMoveScope moveScope3 = buildMoveScope(stepScope3, e3);
+        LocalSearchStepScope<TestdataSolution> stepScope3 = new LocalSearchStepScope<>(phaseScope);
+        LocalSearchMoveScope<TestdataSolution> moveScope3 = buildMoveScope(stepScope3, e3);
         assertEquals(true, acceptor.isAccepted(buildMoveScope(stepScope3, e0)));
         assertEquals(true, acceptor.isAccepted(buildMoveScope(stepScope3, e1)));
         assertEquals(false, acceptor.isAccepted(buildMoveScope(stepScope3, e2)));
@@ -99,8 +100,8 @@ public class EntityTabuAcceptorTest {
         acceptor.stepEnded(stepScope3);
         phaseScope.setLastCompletedStepScope(stepScope3);
 
-        LocalSearchStepScope stepScope4 = new LocalSearchStepScope(phaseScope);
-        LocalSearchMoveScope moveScope1Again = buildMoveScope(stepScope4, e1);
+        LocalSearchStepScope<TestdataSolution> stepScope4 = new LocalSearchStepScope<>(phaseScope);
+        LocalSearchMoveScope<TestdataSolution> moveScope1Again = buildMoveScope(stepScope4, e1);
         assertEquals(true, acceptor.isAccepted(buildMoveScope(stepScope4, e0)));
         assertEquals(true, acceptor.isAccepted(moveScope1Again));
         assertEquals(true, acceptor.isAccepted(buildMoveScope(stepScope4, e2)));
@@ -126,12 +127,12 @@ public class EntityTabuAcceptorTest {
         TestdataEntity e3 = new TestdataEntity("e3");
         TestdataEntity e4 = new TestdataEntity("e4");
 
-        DefaultSolverScope solverScope = new DefaultSolverScope();
+        DefaultSolverScope<TestdataSolution> solverScope = new DefaultSolverScope<>();
         solverScope.setBestScore(SimpleScore.valueOf(0));
-        LocalSearchPhaseScope phaseScope = new LocalSearchPhaseScope(solverScope);
+        LocalSearchPhaseScope<TestdataSolution> phaseScope = new LocalSearchPhaseScope<>(solverScope);
         acceptor.phaseStarted(phaseScope);
 
-        LocalSearchStepScope stepScope0 = new LocalSearchStepScope(phaseScope);
+        LocalSearchStepScope<TestdataSolution> stepScope0 = new LocalSearchStepScope<>(phaseScope);
         assertEquals(true, acceptor.isAccepted(buildMoveScope(stepScope0, e0)));
         assertEquals(true, acceptor.isAccepted(buildMoveScope(stepScope0, e1)));
         assertEquals(true, acceptor.isAccepted(buildMoveScope(stepScope0, e2)));
@@ -151,7 +152,7 @@ public class EntityTabuAcceptorTest {
         acceptor.stepEnded(stepScope0);
         phaseScope.setLastCompletedStepScope(stepScope0);
 
-        LocalSearchStepScope stepScope1 = new LocalSearchStepScope(phaseScope);
+        LocalSearchStepScope<TestdataSolution> stepScope1 = new LocalSearchStepScope<>(phaseScope);
         assertEquals(false, acceptor.isAccepted(buildMoveScope(stepScope1, e0)));
         assertEquals(true, acceptor.isAccepted(buildMoveScope(stepScope1, e1)));
         assertEquals(false, acceptor.isAccepted(buildMoveScope(stepScope1, e2)));
@@ -171,7 +172,7 @@ public class EntityTabuAcceptorTest {
         acceptor.stepEnded(stepScope1);
         phaseScope.setLastCompletedStepScope(stepScope1);
 
-        LocalSearchStepScope stepScope2 = new LocalSearchStepScope(phaseScope);
+        LocalSearchStepScope<TestdataSolution> stepScope2 = new LocalSearchStepScope<>(phaseScope);
         assertEquals(false, acceptor.isAccepted(buildMoveScope(stepScope2, e0)));
         assertEquals(false, acceptor.isAccepted(buildMoveScope(stepScope2, e1)));
         assertEquals(false, acceptor.isAccepted(buildMoveScope(stepScope2, e2)));
@@ -191,7 +192,7 @@ public class EntityTabuAcceptorTest {
         acceptor.stepEnded(stepScope2);
         phaseScope.setLastCompletedStepScope(stepScope2);
 
-        LocalSearchStepScope stepScope3 = new LocalSearchStepScope(phaseScope);
+        LocalSearchStepScope<TestdataSolution> stepScope3 = new LocalSearchStepScope<>(phaseScope);
         assertEquals(true, acceptor.isAccepted(buildMoveScope(stepScope3, e0)));
         assertEquals(false, acceptor.isAccepted(buildMoveScope(stepScope3, e1)));
         assertEquals(true, acceptor.isAccepted(buildMoveScope(stepScope3, e2)));
@@ -223,17 +224,17 @@ public class EntityTabuAcceptorTest {
         TestdataEntity e0 = new TestdataEntity("e0");
         TestdataEntity e1 = new TestdataEntity("e1");
 
-        DefaultSolverScope solverScope = new DefaultSolverScope();
+        DefaultSolverScope<TestdataSolution> solverScope = new DefaultSolverScope<>();
         solverScope.setBestScore(SimpleScore.valueOf(-100));
-        LocalSearchPhaseScope phaseScope = new LocalSearchPhaseScope(solverScope);
+        LocalSearchPhaseScope<TestdataSolution> phaseScope = new LocalSearchPhaseScope<>(solverScope);
         acceptor.phaseStarted(phaseScope);
 
-        LocalSearchStepScope stepScope0 = new LocalSearchStepScope(phaseScope);
+        LocalSearchStepScope<TestdataSolution> stepScope0 = new LocalSearchStepScope<>(phaseScope);
         stepScope0.setStep(buildMoveScope(stepScope0, e1).getMove());
         acceptor.stepEnded(stepScope0);
         phaseScope.setLastCompletedStepScope(stepScope0);
 
-        LocalSearchStepScope stepScope1 = new LocalSearchStepScope(phaseScope);
+        LocalSearchStepScope<TestdataSolution> stepScope1 = new LocalSearchStepScope<>(phaseScope);
         assertEquals(true, acceptor.isAccepted(buildMoveScope(stepScope1, -120, e0)));
         assertEquals(true, acceptor.isAccepted(buildMoveScope(stepScope1, -20, e0)));
         assertEquals(false, acceptor.isAccepted(buildMoveScope(stepScope1, -120, e1)));
@@ -247,12 +248,14 @@ public class EntityTabuAcceptorTest {
         acceptor.phaseEnded(phaseScope);
     }
 
-    private LocalSearchMoveScope buildMoveScope(LocalSearchStepScope stepScope, TestdataEntity... entities) {
+    private <Solution_> LocalSearchMoveScope<Solution_> buildMoveScope(
+            LocalSearchStepScope<Solution_> stepScope, TestdataEntity... entities) {
         return buildMoveScope(stepScope, 0, entities);
     }
 
-    private LocalSearchMoveScope buildMoveScope(LocalSearchStepScope stepScope, int score, TestdataEntity... entities) {
-        LocalSearchMoveScope moveScope = new LocalSearchMoveScope(stepScope);
+    private <Solution_> LocalSearchMoveScope<Solution_> buildMoveScope(
+            LocalSearchStepScope<Solution_> stepScope, int score, TestdataEntity... entities) {
+        LocalSearchMoveScope<Solution_> moveScope = new LocalSearchMoveScope<>(stepScope);
         Move move = mock(Move.class);
         when(move.getPlanningEntities()).thenReturn((Collection) Arrays.asList(entities));
         moveScope.setMove(move);

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/localsearch/decider/acceptor/tabu/ValueTabuAcceptorTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/localsearch/decider/acceptor/tabu/ValueTabuAcceptorTest.java
@@ -27,6 +27,7 @@ import org.optaplanner.core.impl.localsearch.scope.LocalSearchMoveScope;
 import org.optaplanner.core.impl.localsearch.scope.LocalSearchPhaseScope;
 import org.optaplanner.core.impl.localsearch.scope.LocalSearchStepScope;
 import org.optaplanner.core.impl.solver.scope.DefaultSolverScope;
+import org.optaplanner.core.impl.testdata.domain.TestdataSolution;
 import org.optaplanner.core.impl.testdata.domain.TestdataValue;
 
 import static org.junit.Assert.*;
@@ -46,13 +47,13 @@ public class ValueTabuAcceptorTest {
         TestdataValue v3 = new TestdataValue("v3");
         TestdataValue v4 = new TestdataValue("v4");
 
-        DefaultSolverScope solverScope = new DefaultSolverScope();
+        DefaultSolverScope<TestdataSolution> solverScope = new DefaultSolverScope<>();
         solverScope.setBestScore(SimpleScore.valueOf(0));
-        LocalSearchPhaseScope phaseScope = new LocalSearchPhaseScope(solverScope);
+        LocalSearchPhaseScope<TestdataSolution> phaseScope = new LocalSearchPhaseScope<>(solverScope);
         acceptor.phaseStarted(phaseScope);
 
-        LocalSearchStepScope stepScope0 = new LocalSearchStepScope(phaseScope);
-        LocalSearchMoveScope moveScope1 = buildMoveScope(stepScope0, v1);
+        LocalSearchStepScope<TestdataSolution> stepScope0 = new LocalSearchStepScope<>(phaseScope);
+        LocalSearchMoveScope<TestdataSolution> moveScope1 = buildMoveScope(stepScope0, v1);
         assertEquals(true, acceptor.isAccepted(buildMoveScope(stepScope0, v0)));
         assertEquals(true, acceptor.isAccepted(moveScope1));
         assertEquals(true, acceptor.isAccepted(buildMoveScope(stepScope0, v2)));
@@ -63,8 +64,8 @@ public class ValueTabuAcceptorTest {
         acceptor.stepEnded(stepScope0);
         phaseScope.setLastCompletedStepScope(stepScope0);
 
-        LocalSearchStepScope stepScope1 = new LocalSearchStepScope(phaseScope);
-        LocalSearchMoveScope moveScope2 = buildMoveScope(stepScope1, v2);
+        LocalSearchStepScope<TestdataSolution> stepScope1 = new LocalSearchStepScope<>(phaseScope);
+        LocalSearchMoveScope<TestdataSolution> moveScope2 = buildMoveScope(stepScope1, v2);
         assertEquals(true, acceptor.isAccepted(buildMoveScope(stepScope1, v0)));
         assertEquals(false, acceptor.isAccepted(buildMoveScope(stepScope1, v1)));
         assertEquals(true, acceptor.isAccepted(moveScope2));
@@ -75,8 +76,8 @@ public class ValueTabuAcceptorTest {
         acceptor.stepEnded(stepScope1);
         phaseScope.setLastCompletedStepScope(stepScope1);
 
-        LocalSearchStepScope stepScope2 = new LocalSearchStepScope(phaseScope);
-        LocalSearchMoveScope moveScope4 = buildMoveScope(stepScope2, v4);
+        LocalSearchStepScope<TestdataSolution> stepScope2 = new LocalSearchStepScope<>(phaseScope);
+        LocalSearchMoveScope<TestdataSolution> moveScope4 = buildMoveScope(stepScope2, v4);
         assertEquals(true, acceptor.isAccepted(buildMoveScope(stepScope2, v0)));
         assertEquals(false, acceptor.isAccepted(buildMoveScope(stepScope2, v1)));
         assertEquals(false, acceptor.isAccepted(buildMoveScope(stepScope2, v2)));
@@ -87,8 +88,8 @@ public class ValueTabuAcceptorTest {
         acceptor.stepEnded(stepScope2);
         phaseScope.setLastCompletedStepScope(stepScope2);
 
-        LocalSearchStepScope stepScope3 = new LocalSearchStepScope(phaseScope);
-        LocalSearchMoveScope moveScope3 = buildMoveScope(stepScope3, v3);
+        LocalSearchStepScope<TestdataSolution> stepScope3 = new LocalSearchStepScope<>(phaseScope);
+        LocalSearchMoveScope<TestdataSolution> moveScope3 = buildMoveScope(stepScope3, v3);
         assertEquals(true, acceptor.isAccepted(buildMoveScope(stepScope3, v0)));
         assertEquals(true, acceptor.isAccepted(buildMoveScope(stepScope3, v1)));
         assertEquals(false, acceptor.isAccepted(buildMoveScope(stepScope3, v2)));
@@ -99,8 +100,8 @@ public class ValueTabuAcceptorTest {
         acceptor.stepEnded(stepScope3);
         phaseScope.setLastCompletedStepScope(stepScope3);
 
-        LocalSearchStepScope stepScope4 = new LocalSearchStepScope(phaseScope);
-        LocalSearchMoveScope moveScope1Again = buildMoveScope(stepScope4, v1);
+        LocalSearchStepScope<TestdataSolution> stepScope4 = new LocalSearchStepScope<>(phaseScope);
+        LocalSearchMoveScope<TestdataSolution> moveScope1Again = buildMoveScope(stepScope4, v1);
         assertEquals(true, acceptor.isAccepted(buildMoveScope(stepScope4, v0)));
         assertEquals(true, acceptor.isAccepted(moveScope1Again));
         assertEquals(true, acceptor.isAccepted(buildMoveScope(stepScope4, v2)));
@@ -126,12 +127,12 @@ public class ValueTabuAcceptorTest {
         TestdataValue v3 = new TestdataValue("v3");
         TestdataValue v4 = new TestdataValue("v4");
 
-        DefaultSolverScope solverScope = new DefaultSolverScope();
+        DefaultSolverScope<TestdataSolution> solverScope = new DefaultSolverScope<>();
         solverScope.setBestScore(SimpleScore.valueOf(0));
-        LocalSearchPhaseScope phaseScope = new LocalSearchPhaseScope(solverScope);
+        LocalSearchPhaseScope<TestdataSolution> phaseScope = new LocalSearchPhaseScope<>(solverScope);
         acceptor.phaseStarted(phaseScope);
 
-        LocalSearchStepScope stepScope0 = new LocalSearchStepScope(phaseScope);
+        LocalSearchStepScope<TestdataSolution> stepScope0 = new LocalSearchStepScope<>(phaseScope);
         assertEquals(true, acceptor.isAccepted(buildMoveScope(stepScope0, v0)));
         assertEquals(true, acceptor.isAccepted(buildMoveScope(stepScope0, v1)));
         assertEquals(true, acceptor.isAccepted(buildMoveScope(stepScope0, v2)));
@@ -151,7 +152,7 @@ public class ValueTabuAcceptorTest {
         acceptor.stepEnded(stepScope0);
         phaseScope.setLastCompletedStepScope(stepScope0);
 
-        LocalSearchStepScope stepScope1 = new LocalSearchStepScope(phaseScope);
+        LocalSearchStepScope<TestdataSolution> stepScope1 = new LocalSearchStepScope<>(phaseScope);
         assertEquals(false, acceptor.isAccepted(buildMoveScope(stepScope1, v0)));
         assertEquals(true, acceptor.isAccepted(buildMoveScope(stepScope1, v1)));
         assertEquals(false, acceptor.isAccepted(buildMoveScope(stepScope1, v2)));
@@ -171,7 +172,7 @@ public class ValueTabuAcceptorTest {
         acceptor.stepEnded(stepScope1);
         phaseScope.setLastCompletedStepScope(stepScope1);
 
-        LocalSearchStepScope stepScope2 = new LocalSearchStepScope(phaseScope);
+        LocalSearchStepScope<TestdataSolution> stepScope2 = new LocalSearchStepScope<>(phaseScope);
         assertEquals(false, acceptor.isAccepted(buildMoveScope(stepScope2, v0)));
         assertEquals(false, acceptor.isAccepted(buildMoveScope(stepScope2, v1)));
         assertEquals(false, acceptor.isAccepted(buildMoveScope(stepScope2, v2)));
@@ -191,7 +192,7 @@ public class ValueTabuAcceptorTest {
         acceptor.stepEnded(stepScope2);
         phaseScope.setLastCompletedStepScope(stepScope2);
 
-        LocalSearchStepScope stepScope3 = new LocalSearchStepScope(phaseScope);
+        LocalSearchStepScope<TestdataSolution> stepScope3 = new LocalSearchStepScope<>(phaseScope);
         assertEquals(true, acceptor.isAccepted(buildMoveScope(stepScope3, v0)));
         assertEquals(false, acceptor.isAccepted(buildMoveScope(stepScope3, v1)));
         assertEquals(true, acceptor.isAccepted(buildMoveScope(stepScope3, v2)));
@@ -223,17 +224,17 @@ public class ValueTabuAcceptorTest {
         TestdataValue v0 = new TestdataValue("v0");
         TestdataValue v1 = new TestdataValue("v1");
 
-        DefaultSolverScope solverScope = new DefaultSolverScope();
+        DefaultSolverScope<TestdataSolution> solverScope = new DefaultSolverScope<>();
         solverScope.setBestScore(SimpleScore.valueOf(-100));
-        LocalSearchPhaseScope phaseScope = new LocalSearchPhaseScope(solverScope);
+        LocalSearchPhaseScope<TestdataSolution> phaseScope = new LocalSearchPhaseScope<>(solverScope);
         acceptor.phaseStarted(phaseScope);
 
-        LocalSearchStepScope stepScope0 = new LocalSearchStepScope(phaseScope);
+        LocalSearchStepScope<TestdataSolution> stepScope0 = new LocalSearchStepScope<>(phaseScope);
         stepScope0.setStep(buildMoveScope(stepScope0, v1).getMove());
         acceptor.stepEnded(stepScope0);
         phaseScope.setLastCompletedStepScope(stepScope0);
 
-        LocalSearchStepScope stepScope1 = new LocalSearchStepScope(phaseScope);
+        LocalSearchStepScope<TestdataSolution> stepScope1 = new LocalSearchStepScope<>(phaseScope);
         assertEquals(true, acceptor.isAccepted(buildMoveScope(stepScope1, -120, v0)));
         assertEquals(true, acceptor.isAccepted(buildMoveScope(stepScope1, -20, v0)));
         assertEquals(false, acceptor.isAccepted(buildMoveScope(stepScope1, -120, v1)));
@@ -247,12 +248,14 @@ public class ValueTabuAcceptorTest {
         acceptor.phaseEnded(phaseScope);
     }
 
-    private LocalSearchMoveScope buildMoveScope(LocalSearchStepScope stepScope, TestdataValue... values) {
+    private <Solution_> LocalSearchMoveScope<Solution_> buildMoveScope(
+            LocalSearchStepScope<Solution_> stepScope, TestdataValue... values) {
         return buildMoveScope(stepScope, 0, values);
     }
 
-    private LocalSearchMoveScope buildMoveScope(LocalSearchStepScope stepScope, int score, TestdataValue... values) {
-        LocalSearchMoveScope moveScope = new LocalSearchMoveScope(stepScope);
+    private <Solution_> LocalSearchMoveScope<Solution_> buildMoveScope(
+            LocalSearchStepScope<Solution_> stepScope, int score, TestdataValue... values) {
+        LocalSearchMoveScope<Solution_> moveScope = new LocalSearchMoveScope<>(stepScope);
         Move move = mock(Move.class);
         when(move.getPlanningValues()).thenReturn((Collection) Arrays.asList(values));
         moveScope.setMove(move);

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/localsearch/decider/forager/AcceptedForagerTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/localsearch/decider/forager/AcceptedForagerTest.java
@@ -42,16 +42,16 @@ public class AcceptedForagerTest {
         // Setup
         Forager forager = new AcceptedForager(new HighestScoreFinalistPodium(),
                 LocalSearchPickEarlyType.NEVER, Integer.MAX_VALUE, true);
-        LocalSearchPhaseScope phaseScope = createPhaseScope();
+        LocalSearchPhaseScope<TestdataSolution> phaseScope = createPhaseScope();
         forager.phaseStarted(phaseScope);
-        LocalSearchStepScope stepScope = new LocalSearchStepScope(phaseScope);
+        LocalSearchStepScope<TestdataSolution> stepScope = new LocalSearchStepScope<>(phaseScope);
         forager.stepStarted(stepScope);
         // Pre conditions
-        LocalSearchMoveScope a = createMoveScope(stepScope, SimpleScore.valueOf(-20), true);
-        LocalSearchMoveScope b = createMoveScope(stepScope, SimpleScore.valueOf(-1), false);
-        LocalSearchMoveScope c = createMoveScope(stepScope, SimpleScore.valueOf(-20), false);
-        LocalSearchMoveScope d = createMoveScope(stepScope, SimpleScore.valueOf(-2), true);
-        LocalSearchMoveScope e = createMoveScope(stepScope, SimpleScore.valueOf(-300), true);
+        LocalSearchMoveScope<TestdataSolution> a = createMoveScope(stepScope, SimpleScore.valueOf(-20), true);
+        LocalSearchMoveScope<TestdataSolution> b = createMoveScope(stepScope, SimpleScore.valueOf(-1), false);
+        LocalSearchMoveScope<TestdataSolution> c = createMoveScope(stepScope, SimpleScore.valueOf(-20), false);
+        LocalSearchMoveScope<TestdataSolution> d = createMoveScope(stepScope, SimpleScore.valueOf(-2), true);
+        LocalSearchMoveScope<TestdataSolution> e = createMoveScope(stepScope, SimpleScore.valueOf(-300), true);
         // Do stuff
         forager.addMove(a);
         assertFalse(forager.isQuitEarly());
@@ -74,16 +74,16 @@ public class AcceptedForagerTest {
         // Setup
         Forager forager = new AcceptedForager(new HighestScoreFinalistPodium(),
                 LocalSearchPickEarlyType.NEVER, Integer.MAX_VALUE, true);
-        LocalSearchPhaseScope phaseScope = createPhaseScope();
+        LocalSearchPhaseScope<TestdataSolution> phaseScope = createPhaseScope();
         forager.phaseStarted(phaseScope);
-        LocalSearchStepScope stepScope = new LocalSearchStepScope(phaseScope);
+        LocalSearchStepScope<TestdataSolution> stepScope = new LocalSearchStepScope<>(phaseScope);
         forager.stepStarted(stepScope);
         // Pre conditions
-        LocalSearchMoveScope a = createMoveScope(stepScope, SimpleScore.valueOf(-20), false);
-        LocalSearchMoveScope b = createMoveScope(stepScope, SimpleScore.valueOf(-1), false);
-        LocalSearchMoveScope c = createMoveScope(stepScope, SimpleScore.valueOf(-20), false);
-        LocalSearchMoveScope d = createMoveScope(stepScope, SimpleScore.valueOf(-2), false);
-        LocalSearchMoveScope e = createMoveScope(stepScope, SimpleScore.valueOf(-300), false);
+        LocalSearchMoveScope<TestdataSolution> a = createMoveScope(stepScope, SimpleScore.valueOf(-20), false);
+        LocalSearchMoveScope<TestdataSolution> b = createMoveScope(stepScope, SimpleScore.valueOf(-1), false);
+        LocalSearchMoveScope<TestdataSolution> c = createMoveScope(stepScope, SimpleScore.valueOf(-20), false);
+        LocalSearchMoveScope<TestdataSolution> d = createMoveScope(stepScope, SimpleScore.valueOf(-2), false);
+        LocalSearchMoveScope<TestdataSolution> e = createMoveScope(stepScope, SimpleScore.valueOf(-300), false);
         // Do stuff
         forager.addMove(a);
         assertFalse(forager.isQuitEarly());
@@ -106,15 +106,15 @@ public class AcceptedForagerTest {
         // Setup
         Forager forager = new AcceptedForager(new HighestScoreFinalistPodium(),
                 LocalSearchPickEarlyType.FIRST_BEST_SCORE_IMPROVING, Integer.MAX_VALUE, true);
-        LocalSearchPhaseScope phaseScope = createPhaseScope();
+        LocalSearchPhaseScope<TestdataSolution> phaseScope = createPhaseScope();
         forager.phaseStarted(phaseScope);
-        LocalSearchStepScope stepScope = new LocalSearchStepScope(phaseScope);
+        LocalSearchStepScope<TestdataSolution> stepScope = new LocalSearchStepScope<>(phaseScope);
         forager.stepStarted(stepScope);
         // Pre conditions
-        LocalSearchMoveScope a = createMoveScope(stepScope, SimpleScore.valueOf(-1), false);
-        LocalSearchMoveScope b = createMoveScope(stepScope, SimpleScore.valueOf(-20), true);
-        LocalSearchMoveScope c = createMoveScope(stepScope, SimpleScore.valueOf(-300), true);
-        LocalSearchMoveScope d = createMoveScope(stepScope, SimpleScore.valueOf(-1), true);
+        LocalSearchMoveScope<TestdataSolution> a = createMoveScope(stepScope, SimpleScore.valueOf(-1), false);
+        LocalSearchMoveScope<TestdataSolution> b = createMoveScope(stepScope, SimpleScore.valueOf(-20), true);
+        LocalSearchMoveScope<TestdataSolution> c = createMoveScope(stepScope, SimpleScore.valueOf(-300), true);
+        LocalSearchMoveScope<TestdataSolution> d = createMoveScope(stepScope, SimpleScore.valueOf(-1), true);
         // Do stuff
         forager.addMove(a);
         assertFalse(forager.isQuitEarly());
@@ -135,15 +135,15 @@ public class AcceptedForagerTest {
         // Setup
         Forager forager = new AcceptedForager(new HighestScoreFinalistPodium(),
                 LocalSearchPickEarlyType.FIRST_LAST_STEP_SCORE_IMPROVING, Integer.MAX_VALUE, true);
-        LocalSearchPhaseScope phaseScope = createPhaseScope();
+        LocalSearchPhaseScope<TestdataSolution> phaseScope = createPhaseScope();
         forager.phaseStarted(phaseScope);
-        LocalSearchStepScope stepScope = new LocalSearchStepScope(phaseScope);
+        LocalSearchStepScope<TestdataSolution> stepScope = new LocalSearchStepScope<>(phaseScope);
         forager.stepStarted(stepScope);
         // Pre conditions
-        LocalSearchMoveScope a = createMoveScope(stepScope, SimpleScore.valueOf(-1), false);
-        LocalSearchMoveScope b = createMoveScope(stepScope, SimpleScore.valueOf(-300), true);
-        LocalSearchMoveScope c = createMoveScope(stepScope, SimpleScore.valueOf(-4000), true);
-        LocalSearchMoveScope d = createMoveScope(stepScope, SimpleScore.valueOf(-20), true);
+        LocalSearchMoveScope<TestdataSolution> a = createMoveScope(stepScope, SimpleScore.valueOf(-1), false);
+        LocalSearchMoveScope<TestdataSolution> b = createMoveScope(stepScope, SimpleScore.valueOf(-300), true);
+        LocalSearchMoveScope<TestdataSolution> c = createMoveScope(stepScope, SimpleScore.valueOf(-4000), true);
+        LocalSearchMoveScope<TestdataSolution> d = createMoveScope(stepScope, SimpleScore.valueOf(-20), true);
         // Do stuff
         forager.addMove(a);
         assertFalse(forager.isQuitEarly());
@@ -164,16 +164,16 @@ public class AcceptedForagerTest {
         // Setup
         Forager forager = new AcceptedForager(new HighestScoreFinalistPodium(),
                 LocalSearchPickEarlyType.NEVER, 4, true);
-        LocalSearchPhaseScope phaseScope = createPhaseScope();
+        LocalSearchPhaseScope<TestdataSolution> phaseScope = createPhaseScope();
         forager.phaseStarted(phaseScope);
-        LocalSearchStepScope stepScope = new LocalSearchStepScope(phaseScope);
+        LocalSearchStepScope<TestdataSolution> stepScope = new LocalSearchStepScope<>(phaseScope);
         forager.stepStarted(stepScope);
         // Pre conditions
-        LocalSearchMoveScope a = createMoveScope(stepScope, SimpleScore.valueOf(-20), false);
-        LocalSearchMoveScope b = createMoveScope(stepScope, SimpleScore.valueOf(-1), true);
-        LocalSearchMoveScope c = createMoveScope(stepScope, SimpleScore.valueOf(-1), true);
-        LocalSearchMoveScope d = createMoveScope(stepScope, SimpleScore.valueOf(-20), true);
-        LocalSearchMoveScope e = createMoveScope(stepScope, SimpleScore.valueOf(-1), true);
+        LocalSearchMoveScope<TestdataSolution> a = createMoveScope(stepScope, SimpleScore.valueOf(-20), false);
+        LocalSearchMoveScope<TestdataSolution> b = createMoveScope(stepScope, SimpleScore.valueOf(-1), true);
+        LocalSearchMoveScope<TestdataSolution> c = createMoveScope(stepScope, SimpleScore.valueOf(-1), true);
+        LocalSearchMoveScope<TestdataSolution> d = createMoveScope(stepScope, SimpleScore.valueOf(-20), true);
+        LocalSearchMoveScope<TestdataSolution> e = createMoveScope(stepScope, SimpleScore.valueOf(-1), true);
         // Do stuff
         forager.addMove(a);
         assertFalse(forager.isQuitEarly());
@@ -196,16 +196,16 @@ public class AcceptedForagerTest {
         // Setup
         Forager forager = new AcceptedForager(new HighestScoreFinalistPodium(),
                 LocalSearchPickEarlyType.NEVER, 4, false);
-        LocalSearchPhaseScope phaseScope = createPhaseScope();
+        LocalSearchPhaseScope<TestdataSolution> phaseScope = createPhaseScope();
         forager.phaseStarted(phaseScope);
-        LocalSearchStepScope stepScope = new LocalSearchStepScope(phaseScope);
+        LocalSearchStepScope<TestdataSolution> stepScope = new LocalSearchStepScope<>(phaseScope);
         forager.stepStarted(stepScope);
         // Pre conditions
-        LocalSearchMoveScope a = createMoveScope(stepScope, SimpleScore.valueOf(-20), false);
-        LocalSearchMoveScope b = createMoveScope(stepScope, SimpleScore.valueOf(-1), true);
-        LocalSearchMoveScope c = createMoveScope(stepScope, SimpleScore.valueOf(-1), true);
-        LocalSearchMoveScope d = createMoveScope(stepScope, SimpleScore.valueOf(-20), true);
-        LocalSearchMoveScope e = createMoveScope(stepScope, SimpleScore.valueOf(-1), true);
+        LocalSearchMoveScope<TestdataSolution> a = createMoveScope(stepScope, SimpleScore.valueOf(-20), false);
+        LocalSearchMoveScope<TestdataSolution> b = createMoveScope(stepScope, SimpleScore.valueOf(-1), true);
+        LocalSearchMoveScope<TestdataSolution> c = createMoveScope(stepScope, SimpleScore.valueOf(-1), true);
+        LocalSearchMoveScope<TestdataSolution> d = createMoveScope(stepScope, SimpleScore.valueOf(-20), true);
+        LocalSearchMoveScope<TestdataSolution> e = createMoveScope(stepScope, SimpleScore.valueOf(-1), true);
         // Do stuff
         forager.addMove(a);
         assertFalse(forager.isQuitEarly());
@@ -223,9 +223,9 @@ public class AcceptedForagerTest {
         forager.phaseEnded(phaseScope);
     }
 
-    private LocalSearchPhaseScope createPhaseScope() {
-        DefaultSolverScope solverScope = new DefaultSolverScope();
-        LocalSearchPhaseScope phaseScope = new LocalSearchPhaseScope(solverScope);
+    private LocalSearchPhaseScope<TestdataSolution> createPhaseScope() {
+        DefaultSolverScope<TestdataSolution> solverScope = new DefaultSolverScope<>();
+        LocalSearchPhaseScope<TestdataSolution> phaseScope = new LocalSearchPhaseScope<>(solverScope);
         InnerScoreDirector scoreDirector = mock(InnerScoreDirector.class);
         when(scoreDirector.getSolutionDescriptor()).thenReturn(TestdataSolution.buildSolutionDescriptor());
         when(scoreDirector.getScoreDefinition()).thenReturn(new SimpleScoreDefinition());
@@ -234,14 +234,15 @@ public class AcceptedForagerTest {
         when(workingRandom.nextInt(3)).thenReturn(1);
         solverScope.setWorkingRandom(workingRandom);
         solverScope.setBestScore(SimpleScore.valueOf(-10));
-        LocalSearchStepScope lastLocalSearchStepScope = new LocalSearchStepScope(phaseScope);
+        LocalSearchStepScope<TestdataSolution> lastLocalSearchStepScope = new LocalSearchStepScope<>(phaseScope);
         lastLocalSearchStepScope.setScore(SimpleScore.valueOf(-100));
         phaseScope.setLastCompletedStepScope(lastLocalSearchStepScope);
         return phaseScope;
     }
 
-    public LocalSearchMoveScope createMoveScope(LocalSearchStepScope stepScope, Score score, boolean accepted) {
-        LocalSearchMoveScope moveScope = new LocalSearchMoveScope(stepScope);
+    public LocalSearchMoveScope<TestdataSolution> createMoveScope(LocalSearchStepScope<TestdataSolution> stepScope,
+            Score score, boolean accepted) {
+        LocalSearchMoveScope<TestdataSolution> moveScope = new LocalSearchMoveScope<>(stepScope);
         moveScope.setMove(new DummyMove());
         moveScope.setScore(score);
         moveScope.setAccepted(accepted);

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/localsearch/decider/forager/finalist/StrategicOscillationByLevelFinalistPodiumTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/localsearch/decider/forager/finalist/StrategicOscillationByLevelFinalistPodiumTest.java
@@ -24,6 +24,7 @@ import org.optaplanner.core.impl.localsearch.scope.LocalSearchMoveScope;
 import org.optaplanner.core.impl.localsearch.scope.LocalSearchPhaseScope;
 import org.optaplanner.core.impl.localsearch.scope.LocalSearchStepScope;
 import org.optaplanner.core.impl.solver.scope.DefaultSolverScope;
+import org.optaplanner.core.impl.testdata.domain.TestdataSolution;
 
 import static org.junit.Assert.assertSame;
 import static org.mockito.Mockito.*;
@@ -35,17 +36,17 @@ public class StrategicOscillationByLevelFinalistPodiumTest {
     public void referenceLastStepScore() {
         StrategicOscillationByLevelFinalistPodium finalistPodium = new StrategicOscillationByLevelFinalistPodium(false);
 
-        DefaultSolverScope solverScope = new DefaultSolverScope();
+        DefaultSolverScope<TestdataSolution> solverScope = new DefaultSolverScope<>();
         solverScope.setBestScore(HardSoftScore.valueOf(-200, -5000));
-        LocalSearchPhaseScope phaseScope = new LocalSearchPhaseScope(solverScope);
-        LocalSearchStepScope lastCompletedStepScope = new LocalSearchStepScope(phaseScope, -1);
+        LocalSearchPhaseScope<TestdataSolution> phaseScope = new LocalSearchPhaseScope<>(solverScope);
+        LocalSearchStepScope<TestdataSolution> lastCompletedStepScope = new LocalSearchStepScope<>(phaseScope, -1);
         lastCompletedStepScope.setScore(solverScope.getBestScore());
         phaseScope.setLastCompletedStepScope(lastCompletedStepScope);
         finalistPodium.phaseStarted(phaseScope);
 
-        LocalSearchStepScope stepScope0 = new LocalSearchStepScope(phaseScope);
+        LocalSearchStepScope<TestdataSolution> stepScope0 = new LocalSearchStepScope<>(phaseScope);
         finalistPodium.stepStarted(stepScope0);
-        LocalSearchMoveScope moveScope0 = buildMoveScope(stepScope0, -100, -7000);
+        LocalSearchMoveScope<TestdataSolution> moveScope0 = buildMoveScope(stepScope0, -100, -7000);
         finalistPodium.addMove(buildMoveScope(stepScope0, -150, -2000));
         finalistPodium.addMove(moveScope0);
         finalistPodium.addMove(buildMoveScope(stepScope0, -100, -7100));
@@ -55,9 +56,9 @@ public class StrategicOscillationByLevelFinalistPodiumTest {
         finalistPodium.stepEnded(stepScope0);
         phaseScope.setLastCompletedStepScope(stepScope0);
 
-        LocalSearchStepScope stepScope1 = new LocalSearchStepScope(phaseScope);
+        LocalSearchStepScope<TestdataSolution> stepScope1 = new LocalSearchStepScope<>(phaseScope);
         finalistPodium.stepStarted(stepScope1);
-        LocalSearchMoveScope moveScope1 = buildMoveScope(stepScope1, -120, -4000);
+        LocalSearchMoveScope<TestdataSolution> moveScope1 = buildMoveScope(stepScope1, -120, -4000);
         finalistPodium.addMove(buildMoveScope(stepScope1, -100, -8000));
         finalistPodium.addMove(buildMoveScope(stepScope1, -100, -7000));
         finalistPodium.addMove(buildMoveScope(stepScope1, -150, -3000));
@@ -69,9 +70,9 @@ public class StrategicOscillationByLevelFinalistPodiumTest {
         finalistPodium.stepEnded(stepScope1);
         phaseScope.setLastCompletedStepScope(stepScope1);
 
-        LocalSearchStepScope stepScope2 = new LocalSearchStepScope(phaseScope);
+        LocalSearchStepScope<TestdataSolution> stepScope2 = new LocalSearchStepScope<>(phaseScope);
         finalistPodium.stepStarted(stepScope2);
-        LocalSearchMoveScope moveScope2 = buildMoveScope(stepScope2, -150, -1000);
+        LocalSearchMoveScope<TestdataSolution> moveScope2 = buildMoveScope(stepScope2, -150, -1000);
         finalistPodium.addMove(buildMoveScope(stepScope2, -120, -4000));
         finalistPodium.addMove(buildMoveScope(stepScope2, -120, -5000));
         finalistPodium.addMove(buildMoveScope(stepScope2, -150, -3000));
@@ -88,17 +89,17 @@ public class StrategicOscillationByLevelFinalistPodiumTest {
     public void referenceBestScore() {
         StrategicOscillationByLevelFinalistPodium finalistPodium = new StrategicOscillationByLevelFinalistPodium(true);
 
-        DefaultSolverScope solverScope = new DefaultSolverScope();
+        DefaultSolverScope<TestdataSolution> solverScope = new DefaultSolverScope<>();
         solverScope.setBestScore(HardSoftScore.valueOf(-200, -5000));
-        LocalSearchPhaseScope phaseScope = new LocalSearchPhaseScope(solverScope);
-        LocalSearchStepScope lastCompletedStepScope = new LocalSearchStepScope(phaseScope, -1);
+        LocalSearchPhaseScope<TestdataSolution> phaseScope = new LocalSearchPhaseScope<>(solverScope);
+        LocalSearchStepScope<TestdataSolution> lastCompletedStepScope = new LocalSearchStepScope<>(phaseScope, -1);
         lastCompletedStepScope.setScore(solverScope.getBestScore());
         phaseScope.setLastCompletedStepScope(lastCompletedStepScope);
         finalistPodium.phaseStarted(phaseScope);
 
-        LocalSearchStepScope stepScope0 = new LocalSearchStepScope(phaseScope);
+        LocalSearchStepScope<TestdataSolution> stepScope0 = new LocalSearchStepScope<>(phaseScope);
         finalistPodium.stepStarted(stepScope0);
-        LocalSearchMoveScope moveScope0 = buildMoveScope(stepScope0, -100, -7000);
+        LocalSearchMoveScope<TestdataSolution> moveScope0 = buildMoveScope(stepScope0, -100, -7000);
         finalistPodium.addMove(buildMoveScope(stepScope0, -150, -2000));
         finalistPodium.addMove(moveScope0);
         finalistPodium.addMove(buildMoveScope(stepScope0, -100, -7100));
@@ -109,9 +110,9 @@ public class StrategicOscillationByLevelFinalistPodiumTest {
         phaseScope.setLastCompletedStepScope(stepScope0);
         solverScope.setBestScore(stepScope0.getScore());
 
-        LocalSearchStepScope stepScope1 = new LocalSearchStepScope(phaseScope);
+        LocalSearchStepScope<TestdataSolution> stepScope1 = new LocalSearchStepScope<>(phaseScope);
         finalistPodium.stepStarted(stepScope1);
-        LocalSearchMoveScope moveScope1 = buildMoveScope(stepScope1, -120, -4000);
+        LocalSearchMoveScope<TestdataSolution> moveScope1 = buildMoveScope(stepScope1, -120, -4000);
         finalistPodium.addMove(buildMoveScope(stepScope1, -100, -8000));
         finalistPodium.addMove(buildMoveScope(stepScope1, -100, -7000));
         finalistPodium.addMove(buildMoveScope(stepScope1, -150, -3000));
@@ -124,9 +125,9 @@ public class StrategicOscillationByLevelFinalistPodiumTest {
         phaseScope.setLastCompletedStepScope(stepScope1);
         // do not change bestScore
 
-        LocalSearchStepScope stepScope2 = new LocalSearchStepScope(phaseScope);
+        LocalSearchStepScope<TestdataSolution> stepScope2 = new LocalSearchStepScope<>(phaseScope);
         finalistPodium.stepStarted(stepScope2);
-        LocalSearchMoveScope moveScope2 = buildMoveScope(stepScope2, -110, -6000);
+        LocalSearchMoveScope<TestdataSolution> moveScope2 = buildMoveScope(stepScope2, -110, -6000);
         finalistPodium.addMove(buildMoveScope(stepScope2, -110, -8000));
         finalistPodium.addMove(buildMoveScope(stepScope2, -150, -3000));
         finalistPodium.addMove(buildMoveScope(stepScope2, -150, -1000));
@@ -140,9 +141,10 @@ public class StrategicOscillationByLevelFinalistPodiumTest {
         // do not change bestScore
     }
 
-    protected LocalSearchMoveScope buildMoveScope(LocalSearchStepScope stepScope, int hardScore, int softScore) {
-        LocalSearchMoveScope moveScope = new LocalSearchMoveScope(stepScope);
-        Move move = mock(Move.class);
+    protected <Solution_> LocalSearchMoveScope<Solution_> buildMoveScope(
+            LocalSearchStepScope<Solution_> stepScope, int hardScore, int softScore) {
+        LocalSearchMoveScope<Solution_> moveScope = new LocalSearchMoveScope<>(stepScope);
+        Move<Solution_> move = mock(Move.class);
         moveScope.setAccepted(true);
         moveScope.setMove(move);
         moveScope.setScore(HardSoftScore.valueOf(hardScore, softScore));
@@ -153,17 +155,17 @@ public class StrategicOscillationByLevelFinalistPodiumTest {
     public void referenceLastStepScore3Levels() {
         StrategicOscillationByLevelFinalistPodium finalistPodium = new StrategicOscillationByLevelFinalistPodium(false);
 
-        DefaultSolverScope solverScope = new DefaultSolverScope();
+        DefaultSolverScope<TestdataSolution> solverScope = new DefaultSolverScope<>();
         solverScope.setBestScore(HardMediumSoftScore.valueOf(-200, -5000, -10));
-        LocalSearchPhaseScope phaseScope = new LocalSearchPhaseScope(solverScope);
-        LocalSearchStepScope lastCompletedStepScope = new LocalSearchStepScope(phaseScope, -1);
+        LocalSearchPhaseScope<TestdataSolution> phaseScope = new LocalSearchPhaseScope<>(solverScope);
+        LocalSearchStepScope<TestdataSolution> lastCompletedStepScope = new LocalSearchStepScope<>(phaseScope, -1);
         lastCompletedStepScope.setScore(solverScope.getBestScore());
         phaseScope.setLastCompletedStepScope(lastCompletedStepScope);
         finalistPodium.phaseStarted(phaseScope);
 
-        LocalSearchStepScope stepScope0 = new LocalSearchStepScope(phaseScope);
+        LocalSearchStepScope<TestdataSolution> stepScope0 = new LocalSearchStepScope<>(phaseScope);
         finalistPodium.stepStarted(stepScope0);
-        LocalSearchMoveScope moveScope0 = buildMoveScope(stepScope0, -100, -7000, -20);
+        LocalSearchMoveScope<TestdataSolution> moveScope0 = buildMoveScope(stepScope0, -100, -7000, -20);
         finalistPodium.addMove(buildMoveScope(stepScope0, -150, -2000, -10));
         finalistPodium.addMove(moveScope0);
         finalistPodium.addMove(buildMoveScope(stepScope0, -100, -7100, -5));
@@ -173,9 +175,9 @@ public class StrategicOscillationByLevelFinalistPodiumTest {
         finalistPodium.stepEnded(stepScope0);
         phaseScope.setLastCompletedStepScope(stepScope0);
 
-        LocalSearchStepScope stepScope1 = new LocalSearchStepScope(phaseScope);
+        LocalSearchStepScope<TestdataSolution> stepScope1 = new LocalSearchStepScope<>(phaseScope);
         finalistPodium.stepStarted(stepScope1);
-        LocalSearchMoveScope moveScope1 = buildMoveScope(stepScope1, -120, -4000, -40);
+        LocalSearchMoveScope<TestdataSolution> moveScope1 = buildMoveScope(stepScope1, -120, -4000, -40);
         finalistPodium.addMove(buildMoveScope(stepScope1, -100, -8000, -10));
         finalistPodium.addMove(buildMoveScope(stepScope1, -100, -7000, -10));
         finalistPodium.addMove(buildMoveScope(stepScope1, -150, -3000, -10));
@@ -187,9 +189,9 @@ public class StrategicOscillationByLevelFinalistPodiumTest {
         finalistPodium.stepEnded(stepScope1);
         phaseScope.setLastCompletedStepScope(stepScope1);
 
-        LocalSearchStepScope stepScope2 = new LocalSearchStepScope(phaseScope);
+        LocalSearchStepScope<TestdataSolution> stepScope2 = new LocalSearchStepScope<>(phaseScope);
         finalistPodium.stepStarted(stepScope2);
-        LocalSearchMoveScope moveScope2 = buildMoveScope(stepScope2, -150, -1000, -20);
+        LocalSearchMoveScope<TestdataSolution> moveScope2 = buildMoveScope(stepScope2, -150, -1000, -20);
         finalistPodium.addMove(buildMoveScope(stepScope2, -120, -4000, -10));
         finalistPodium.addMove(buildMoveScope(stepScope2, -120, -5000, -10));
         finalistPodium.addMove(buildMoveScope(stepScope2, -150, -3000, -10));
@@ -202,10 +204,10 @@ public class StrategicOscillationByLevelFinalistPodiumTest {
         phaseScope.setLastCompletedStepScope(stepScope2);
     }
 
-    protected LocalSearchMoveScope buildMoveScope(LocalSearchStepScope stepScope,
-            int hardScore, int mediumScore, int softScore) {
-        LocalSearchMoveScope moveScope = new LocalSearchMoveScope(stepScope);
-        Move move = mock(Move.class);
+    protected <Solution_> LocalSearchMoveScope<Solution_> buildMoveScope(
+            LocalSearchStepScope<Solution_> stepScope, int hardScore, int mediumScore, int softScore) {
+        LocalSearchMoveScope<Solution_> moveScope = new LocalSearchMoveScope<>(stepScope);
+        Move<Solution_> move = mock(Move.class);
         moveScope.setAccepted(true);
         moveScope.setMove(move);
         moveScope.setScore(HardMediumSoftScore.valueOf(hardScore, mediumScore, softScore));


### PR DESCRIPTION
The most important change is the return type of `LocalSearchStepScope.getStep()` which makes it possible to observe steps through `PhaseLifecycleListener` so it makes sense to avoid the rawtype here.

Same changes made in `LocalSearchMoveScope` for consistency.

The changes in tests are not implied by the `LocalSearchStepScope` and `LocalSearchMoveScope` changes, they are just rawtype elimination in related code.