### PR TITLE
Added jboss-web.xml to set context-root.

### DIFF
--- a/optaplanner-webexamples/src/main/webapp/WEB-INF/jboss-web.xml
+++ b/optaplanner-webexamples/src/main/webapp/WEB-INF/jboss-web.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jboss-web version="10.0"
+           xmlns="http://www.jboss.com/xml/ns/javaee"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://www.jboss.com/xml/ns/javaee http://www.jboss.org/j2ee/schema/jboss-web_10_0.xsd">
+    <context-root>optaplanner-webexamples</context-root>
+</jboss-web>


### PR DESCRIPTION
This allows us to use a context-root "optaplanner-webexamples", without a version number, which is a lot easier to communicate to (potential) customers when we run this demo in a cloud/container/OpenShift environment.