### PR TITLE
PLANNER-784: Workbench: AbstractSolution.score can't be marshaled when using JAXB

### DIFF
--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/solution/AbstractSolution.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/solution/AbstractSolution.java
@@ -32,12 +32,17 @@ import org.optaplanner.core.api.domain.solution.drools.ProblemFactCollectionProp
 import org.optaplanner.core.api.score.Score;
 import org.optaplanner.core.impl.domain.common.ReflectionHelper;
 
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+
 /**
  * Currently only used by OptaPlanner Workbench.
  * TODO Should we promote using this class in the examples and docs too?
  * We can never enforce it, as the user might want to use a different superclass.
  * @param <S> the {@link Score} type used by this use case
  */
+// JAXB can't resolve score implementation type, getScore method needs to be overridden in a subclass
+@XmlAccessorType(XmlAccessType.NONE)
 @PlanningSolution
 public abstract class AbstractSolution<S extends Score> implements Serializable {
 

--- a/optaplanner-persistence/optaplanner-persistence-jaxb/src/test/java/org/optaplanner/persistence/jaxb/impl/domain/solution/JaxbSolutionFileIOTest.java
+++ b/optaplanner-persistence/optaplanner-persistence-jaxb/src/test/java/org/optaplanner/persistence/jaxb/impl/domain/solution/JaxbSolutionFileIOTest.java
@@ -23,6 +23,7 @@ import java.util.Arrays;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.optaplanner.core.api.score.buildin.simple.SimpleScore;
+import org.optaplanner.persistence.jaxb.impl.testdata.domain.JaxbTestdataAbstractSolution;
 import org.optaplanner.persistence.jaxb.impl.testdata.domain.JaxbTestdataEntity;
 import org.optaplanner.persistence.jaxb.impl.testdata.domain.JaxbTestdataSolution;
 import org.optaplanner.persistence.jaxb.impl.testdata.domain.JaxbTestdataValue;
@@ -67,4 +68,28 @@ public class JaxbSolutionFileIOTest {
         assertEquals(SimpleScore.valueOf(-123), copy.getScore());
     }
 
+    @Test
+    public void readAndWriteAbstractSolution() {
+        JaxbSolutionFileIO<JaxbTestdataAbstractSolution> solutionFileIO = new JaxbSolutionFileIO<>(JaxbTestdataAbstractSolution.class);
+        File file = new File(solutionTestDir, "testdataAbstractSolution.xml");
+
+        JaxbTestdataAbstractSolution original = new JaxbTestdataAbstractSolution("s1");
+        JaxbTestdataValue originalV1 = new JaxbTestdataValue("v1");
+        original.setValueList(Arrays.asList(originalV1, new JaxbTestdataValue("v2")));
+        original.setEntityList(Arrays.asList(
+                new JaxbTestdataEntity("e1"), new JaxbTestdataEntity("e2", originalV1), new JaxbTestdataEntity("e3")));
+        original.setScore(SimpleScore.valueOf(-123));
+        solutionFileIO.write(original, file);
+        JaxbTestdataAbstractSolution copy = solutionFileIO.read(file);
+
+        assertNotSame(original, copy);
+        assertCode("s1", copy);
+        assertAllCodesOfIterator(copy.getValueList().iterator(), "v1", "v2");
+        assertAllCodesOfIterator(copy.getEntityList().iterator(), "e1", "e2", "e3");
+        JaxbTestdataValue copyV1 = copy.getValueList().get(0);
+        JaxbTestdataEntity copyE2 = copy.getEntityList().get(1);
+        assertCode("v1", copyE2.getValue());
+        assertSame(copyV1, copyE2.getValue());
+        assertEquals(SimpleScore.valueOf(-123), copy.getScore());
+    }
 }

--- a/optaplanner-persistence/optaplanner-persistence-jaxb/src/test/java/org/optaplanner/persistence/jaxb/impl/testdata/domain/JaxbTestdataAbstractSolution.java
+++ b/optaplanner-persistence/optaplanner-persistence-jaxb/src/test/java/org/optaplanner/persistence/jaxb/impl/testdata/domain/JaxbTestdataAbstractSolution.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.persistence.jaxb.impl.testdata.domain;
+
+import java.util.List;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlElementWrapper;
+import javax.xml.bind.annotation.XmlID;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlType;
+import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
+
+import org.optaplanner.core.api.domain.solution.PlanningEntityCollectionProperty;
+import org.optaplanner.core.api.domain.solution.PlanningScore;
+import org.optaplanner.core.api.domain.solution.PlanningSolution;
+import org.optaplanner.core.api.domain.solution.drools.ProblemFactCollectionProperty;
+import org.optaplanner.core.api.domain.valuerange.ValueRangeProvider;
+import org.optaplanner.core.api.score.buildin.simple.SimpleScore;
+import org.optaplanner.core.impl.domain.solution.AbstractSolution;
+import org.optaplanner.core.impl.domain.solution.descriptor.SolutionDescriptor;
+import org.optaplanner.core.impl.testdata.util.CodeAssertable;
+import org.optaplanner.persistence.jaxb.api.score.buildin.simple.SimpleScoreJaxbXmlAdapter;
+
+@PlanningSolution
+@XmlRootElement
+@XmlType(propOrder = {"code", "valueList", "entityList", "score"})
+@XmlAccessorType(XmlAccessType.PROPERTY)
+public class JaxbTestdataAbstractSolution extends AbstractSolution<SimpleScore> implements CodeAssertable {
+
+    protected String code;
+
+    public static SolutionDescriptor<JaxbTestdataAbstractSolution> buildSolutionDescriptor() {
+        return SolutionDescriptor.buildSolutionDescriptor(JaxbTestdataAbstractSolution.class, JaxbTestdataEntity.class);
+    }
+
+    private List<JaxbTestdataValue> valueList;
+    private List<JaxbTestdataEntity> entityList;
+
+    private SimpleScore score;
+
+    public JaxbTestdataAbstractSolution() {
+    }
+
+    public JaxbTestdataAbstractSolution(String code) {
+        this.code = code;
+    }
+
+    @Override
+    @XmlID
+    public String getCode() {
+        return code;
+    }
+
+    public void setCode(String code) {
+        this.code = code;
+    }
+
+    @ValueRangeProvider(id = "valueRange")
+    @ProblemFactCollectionProperty
+    @XmlElementWrapper(name = "valueList")
+    @XmlElement(name = "jaxbTestdataValue")
+    public List<JaxbTestdataValue> getValueList() {
+        return valueList;
+    }
+
+    public void setValueList(List<JaxbTestdataValue> valueList) {
+        this.valueList = valueList;
+    }
+
+    @PlanningEntityCollectionProperty
+    @XmlElementWrapper(name = "entityList")
+    @XmlElement(name = "jaxbTestdataEntity")
+    public List<JaxbTestdataEntity> getEntityList() {
+        return entityList;
+    }
+
+    public void setEntityList(List<JaxbTestdataEntity> entityList) {
+        this.entityList = entityList;
+    }
+
+    @PlanningScore
+    @XmlJavaTypeAdapter(SimpleScoreJaxbXmlAdapter.class)
+    public SimpleScore getScore() {
+        return score;
+    }
+
+    public void setScore(SimpleScore score) {
+        this.score = score;
+    }
+
+    @Override
+    public String toString() {
+        return code;
+    }
+
+    // ************************************************************************
+    // Complex methods
+    // ************************************************************************
+
+}


### PR DESCRIPTION
@ge0ffrey This is a major issue that causes JAXB-related exceptions when using AbstractSolution superclass. The score type needs to be defined on the child level to make sure the score type can be resolved by JAXB.

```
Caused by: com.sun.xml.bind.v2.runtime.IllegalAnnotationsException: 1 counts of IllegalAnnotationExceptions
org.optaplanner.core.api.score.Score is an interface, and JAXB can't handle interfaces.
this problem is related to the following location:
at org.optaplanner.core.api.score.Score
at public org.optaplanner.core.api.score.Score org.optaplanner.core.impl.domain.solution.AbstractSolution.getScore()
at org.optaplanner.core.impl.domain.solution.AbstractSolution
at org.optaplanner.persistence.jaxb.impl.testdata.domain.JaxbTestdataAbstractSolution

at com.sun.xml.bind.v2.runtime.IllegalAnnotationsException$Builder.check(IllegalAnnotationsException.java:106)
at com.sun.xml.bind.v2.runtime.JAXBContextImpl.getTypeInfoSet(JAXBContextImpl.java:460)
at com.sun.xml.bind.v2.runtime.JAXBContextImpl.<init>(JAXBContextImpl.java:292)
at com.sun.xml.bind.v2.runtime.JAXBContextImpl.<init>(JAXBContextImpl.java:139)
at com.sun.xml.bind.v2.runtime.JAXBContextImpl$JAXBContextBuilder.build(JAXBContextImpl.java:1138)
at com.sun.xml.bind.v2.ContextFactory.createContext(ContextFactory.java:162)
at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
at java.lang.reflect.Method.invoke(Method.java:498)
at javax.xml.bind.ContextFinder.newInstance(ContextFinder.java:247)
at javax.xml.bind.ContextFinder.newInstance(ContextFinder.java:234)
at javax.xml.bind.ContextFinder.find(ContextFinder.java:441)
at javax.xml.bind.JAXBContext.newInstance(JAXBContext.java:641)
at javax.xml.bind.JAXBContext.newInstance(JAXBContext.java:584)
at org.optaplanner.persistence.jaxb.impl.domain.solution.JaxbSolutionFileIO.<init>(JaxbSolutionFileIO.java:48)
... 29 more
```
Part of:
https://github.com/kiegroup/optaplanner/pull/305
https://github.com/kiegroup/optaplanner-wb/pull/158