### PR TITLE
Change revapi-config.json comment to be more general

### DIFF
--- a/optaplanner-benchmark/src/build/revapi-config.json
+++ b/optaplanner-benchmark/src/build/revapi-config.json
@@ -18,7 +18,7 @@
 
   "ignores": {
     "revapi": {
-      "_comment": "Changes between 6.5.0.Final and master. These changes are desired and thus ignored. They should be removed when 7.0.0.Final is available.",
+      "_comment": "Changes between 6.5.0.Final and the current branch. These changes are desired and thus ignored. They should be removed when 7.0.0.Final is available.",
       "ignore": [
         {
           "code": "java.field.removedWithConstant",

--- a/optaplanner-core/src/build/revapi-config.json
+++ b/optaplanner-core/src/build/revapi-config.json
@@ -18,7 +18,7 @@
 
   "ignores": {
     "revapi": {
-      "_comment": "Changes between 6.5.0.Final and master. These changes are desired and thus ignored. They should be removed when 7.0.0.Final is available.",
+      "_comment": "Changes between 6.5.0.Final and the current branch. These changes are desired and thus ignored. They should be removed when 7.0.0.Final is available.",
       "ignore": [
         {
           "code": "java.class.removed",


### PR DESCRIPTION
Hi, @ge0ffrey,

this is only a minor change to the revapi-config.json file, since these files are no more only on master branch, but on 7.0.x as well.

Marian

P.S. I still have in plan to fine tune revapi in benchmark config classes. Sadly, there isn't time for this now, but I will try to incorporate this in the near future. Thanks for your understanding.