### PR TITLE
Revapi: filter only public fields and getters/setters

### DIFF
--- a/optaplanner-benchmark/src/build/revapi-config.json
+++ b/optaplanner-benchmark/src/build/revapi-config.json
@@ -1,6 +1,14 @@
 {
   "filters": {
     "revapi": {
+      "filter": {
+        "elements": {
+          "exclude": [
+            "method .* org\\.optaplanner\\.benchmark\\.config.*::(?!(set|get)).*",
+            "parameter .* org\\.optaplanner\\.benchmark\\.config.*::(?!(set|get)).*"
+          ]
+        }
+      },
       "java": {
         "filter": {
           "packages": {

--- a/optaplanner-core/src/build/revapi-config.json
+++ b/optaplanner-core/src/build/revapi-config.json
@@ -1,6 +1,14 @@
 {
   "filters": {
     "revapi": {
+      "filter": {
+        "elements": {
+          "exclude": [
+            "method .* org\\.optaplanner\\.core\\.config.*::(?!(set|get)).*",
+            "parameter .* org\\.optaplanner\\.core\\.config.*::(?!(set|get)).*"
+          ]
+        }
+      },
       "java": {
         "filter": {
           "packages": {


### PR DESCRIPTION
Hi, @ge0ffrey,

here is the promised custom config for OptaPlanner. It should check from now on only public fields + getters and setters, as you wanted.

Marian
