### PR TITLE
PLANNER-793 Cover more autodiscovery use cases

### DIFF
--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/testdata/domain/collection/TestdataArrayBasedSolution.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/testdata/domain/collection/TestdataArrayBasedSolution.java
@@ -29,7 +29,7 @@ import org.optaplanner.core.impl.testdata.domain.TestdataValue;
 @PlanningSolution
 public class TestdataArrayBasedSolution extends TestdataObject {
 
-    public static SolutionDescriptor buildSolutionDescriptor() {
+    public static SolutionDescriptor<TestdataArrayBasedSolution> buildSolutionDescriptor() {
         return SolutionDescriptor.buildSolutionDescriptor(TestdataArrayBasedSolution.class, TestdataArrayBasedEntity.class);
     }
 

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/testdata/domain/collection/TestdataSetBasedSolution.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/testdata/domain/collection/TestdataSetBasedSolution.java
@@ -31,7 +31,7 @@ import org.optaplanner.core.impl.testdata.domain.TestdataValue;
 @PlanningSolution
 public class TestdataSetBasedSolution extends TestdataObject {
 
-    public static SolutionDescriptor buildSolutionDescriptor() {
+    public static SolutionDescriptor<TestdataSetBasedSolution> buildSolutionDescriptor() {
         return SolutionDescriptor.buildSolutionDescriptor(TestdataSetBasedSolution.class, TestdataSetBasedEntity.class);
     }
 

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/testdata/domain/extended/abstractsolution/TestdataExtendedAbstractSolution.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/testdata/domain/extended/abstractsolution/TestdataExtendedAbstractSolution.java
@@ -30,7 +30,7 @@ import org.optaplanner.core.impl.testdata.domain.TestdataValue;
 @PlanningSolution
 public class TestdataExtendedAbstractSolution extends AbstractSolution<HardSoftScore> {
 
-    public static SolutionDescriptor buildSolutionDescriptor() {
+    public static SolutionDescriptor<TestdataExtendedAbstractSolution> buildSolutionDescriptor() {
         return SolutionDescriptor.buildSolutionDescriptor(TestdataExtendedAbstractSolution.class, TestdataEntity.class);
     }
 

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/testdata/domain/extended/abstractsolution/TestdataExtendedAbstractSolutionOverridesGetScore.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/testdata/domain/extended/abstractsolution/TestdataExtendedAbstractSolutionOverridesGetScore.java
@@ -31,8 +31,9 @@ import org.optaplanner.core.impl.testdata.domain.TestdataValue;
 @PlanningSolution
 public class TestdataExtendedAbstractSolutionOverridesGetScore extends AbstractSolution<BendableScore> {
 
-    public static SolutionDescriptor buildSolutionDescriptor() {
-        return SolutionDescriptor.buildSolutionDescriptor(TestdataExtendedAbstractSolutionOverridesGetScore.class, TestdataEntity.class);
+    public static SolutionDescriptor<TestdataExtendedAbstractSolutionOverridesGetScore> buildSolutionDescriptor() {
+        return SolutionDescriptor.buildSolutionDescriptor(
+                TestdataExtendedAbstractSolutionOverridesGetScore.class, TestdataEntity.class);
     }
 
     private List<TestdataValue> valueList;

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/testdata/domain/extended/legacysolution/TestdataLegacySolution.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/testdata/domain/extended/legacysolution/TestdataLegacySolution.java
@@ -32,7 +32,7 @@ import org.optaplanner.core.impl.testdata.domain.TestdataValue;
 @Deprecated
 public class TestdataLegacySolution implements Solution<SimpleScore> {
 
-    public static SolutionDescriptor buildSolutionDescriptor() {
+    public static SolutionDescriptor<TestdataLegacySolution> buildSolutionDescriptor() {
         return SolutionDescriptor.buildSolutionDescriptor(TestdataLegacySolution.class, TestdataEntity.class);
     }
 

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/testdata/domain/reflect/generic/TestdataGenericSolution.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/testdata/domain/reflect/generic/TestdataGenericSolution.java
@@ -31,7 +31,7 @@ import org.optaplanner.core.impl.testdata.domain.TestdataObject;
 @PlanningSolution
 public class TestdataGenericSolution<T> extends TestdataObject {
 
-    public static SolutionDescriptor buildSolutionDescriptor() {
+    public static SolutionDescriptor<TestdataGenericSolution> buildSolutionDescriptor() {
         return SolutionDescriptor.buildSolutionDescriptor(TestdataGenericSolution.class, TestdataGenericEntity.class);
     }
 

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/testdata/domain/solutionproperties/TestdataProblemFactPropertySolution.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/testdata/domain/solutionproperties/TestdataProblemFactPropertySolution.java
@@ -33,7 +33,7 @@ import org.optaplanner.core.impl.testdata.domain.TestdataValue;
 @PlanningSolution
 public class TestdataProblemFactPropertySolution extends TestdataObject {
 
-    public static SolutionDescriptor buildSolutionDescriptor() {
+    public static SolutionDescriptor<TestdataProblemFactPropertySolution> buildSolutionDescriptor() {
         return SolutionDescriptor.buildSolutionDescriptor(TestdataProblemFactPropertySolution.class, TestdataEntity.class);
     }
 

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/testdata/domain/solutionproperties/TestdataReadMethodProblemFactCollectionPropertySolution.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/testdata/domain/solutionproperties/TestdataReadMethodProblemFactCollectionPropertySolution.java
@@ -33,8 +33,9 @@ import org.optaplanner.core.impl.testdata.domain.TestdataValue;
 @PlanningSolution
 public class TestdataReadMethodProblemFactCollectionPropertySolution extends TestdataObject {
 
-    public static SolutionDescriptor buildSolutionDescriptor() {
-        return SolutionDescriptor.buildSolutionDescriptor(TestdataReadMethodProblemFactCollectionPropertySolution.class, TestdataEntity.class);
+    public static SolutionDescriptor<TestdataReadMethodProblemFactCollectionPropertySolution> buildSolutionDescriptor() {
+        return SolutionDescriptor.buildSolutionDescriptor(
+                TestdataReadMethodProblemFactCollectionPropertySolution.class, TestdataEntity.class);
     }
 
     private List<TestdataValue> valueList;

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/testdata/domain/solutionproperties/autodiscover/TestdataAutoDiscoverFieldOverrideSolution.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/testdata/domain/solutionproperties/autodiscover/TestdataAutoDiscoverFieldOverrideSolution.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.optaplanner.core.impl.testdata.domain.solutionproperties.autodiscover;
+
+import java.util.List;
+
+import org.optaplanner.core.api.domain.autodiscover.AutoDiscoverMemberType;
+import org.optaplanner.core.api.domain.solution.PlanningSolution;
+import org.optaplanner.core.api.domain.solution.drools.ProblemFactProperty;
+import org.optaplanner.core.api.domain.valuerange.ValueRangeProvider;
+import org.optaplanner.core.api.score.buildin.simple.SimpleScore;
+import org.optaplanner.core.impl.domain.solution.descriptor.SolutionDescriptor;
+import org.optaplanner.core.impl.testdata.domain.TestdataEntity;
+import org.optaplanner.core.impl.testdata.domain.TestdataObject;
+import org.optaplanner.core.impl.testdata.domain.TestdataValue;
+
+@PlanningSolution(autoDiscoverMemberType = AutoDiscoverMemberType.FIELD)
+public class TestdataAutoDiscoverFieldOverrideSolution extends TestdataObject {
+
+    public static SolutionDescriptor<TestdataAutoDiscoverFieldOverrideSolution> buildSolutionDescriptor() {
+        return SolutionDescriptor.buildSolutionDescriptor(TestdataAutoDiscoverFieldOverrideSolution.class, TestdataEntity.class);
+    }
+
+    private TestdataObject singleProblemFact;
+    @ValueRangeProvider(id = "valueRange")
+    private List<TestdataValue> problemFactList;
+    @ProblemFactProperty // would have been autodiscovered as @ProblemFactCollectionProperty
+    private List<String> listProblemFact;
+
+    private List<TestdataEntity> entityList;
+    private TestdataEntity otherEntity;
+
+    private SimpleScore score;
+
+    public TestdataAutoDiscoverFieldOverrideSolution() {
+    }
+
+    public TestdataAutoDiscoverFieldOverrideSolution(String code) {
+        super(code);
+    }
+
+    public TestdataAutoDiscoverFieldOverrideSolution(String code, TestdataObject singleProblemFact,
+            List<TestdataValue> problemFactList, List<TestdataEntity> entityList,
+            TestdataEntity otherEntity, List<String> listFact) {
+        super(code);
+        this.singleProblemFact = singleProblemFact;
+        this.problemFactList = problemFactList;
+        this.entityList = entityList;
+        this.otherEntity = otherEntity;
+        this.listProblemFact = listFact;
+    }
+
+    public SimpleScore getScore() {
+        return score;
+    }
+
+    public void setScore(SimpleScore score) {
+        this.score = score;
+    }
+
+}

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/testdata/domain/solutionproperties/autodiscover/TestdataAutoDiscoverFieldSolution.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/testdata/domain/solutionproperties/autodiscover/TestdataAutoDiscoverFieldSolution.java
@@ -30,7 +30,7 @@ import org.optaplanner.core.impl.testdata.domain.TestdataValue;
 @PlanningSolution(autoDiscoverMemberType = AutoDiscoverMemberType.FIELD)
 public class TestdataAutoDiscoverFieldSolution extends TestdataObject {
 
-    public static SolutionDescriptor buildSolutionDescriptor() {
+    public static SolutionDescriptor<TestdataAutoDiscoverFieldSolution> buildSolutionDescriptor() {
         return SolutionDescriptor.buildSolutionDescriptor(TestdataAutoDiscoverFieldSolution.class, TestdataEntity.class);
     }
 

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/testdata/domain/solutionproperties/autodiscover/TestdataAutoDiscoverGetterOverrideSolution.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/testdata/domain/solutionproperties/autodiscover/TestdataAutoDiscoverGetterOverrideSolution.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.optaplanner.core.impl.testdata.domain.solutionproperties.autodiscover;
+
+import java.util.List;
+
+import org.optaplanner.core.api.domain.autodiscover.AutoDiscoverMemberType;
+import org.optaplanner.core.api.domain.solution.PlanningSolution;
+import org.optaplanner.core.api.domain.solution.drools.ProblemFactProperty;
+import org.optaplanner.core.api.domain.valuerange.ValueRangeProvider;
+import org.optaplanner.core.api.score.buildin.simple.SimpleScore;
+import org.optaplanner.core.impl.domain.solution.descriptor.SolutionDescriptor;
+import org.optaplanner.core.impl.testdata.domain.TestdataEntity;
+import org.optaplanner.core.impl.testdata.domain.TestdataObject;
+import org.optaplanner.core.impl.testdata.domain.TestdataValue;
+
+@PlanningSolution(autoDiscoverMemberType = AutoDiscoverMemberType.GETTER)
+public class TestdataAutoDiscoverGetterOverrideSolution extends TestdataObject {
+
+    public static SolutionDescriptor<TestdataAutoDiscoverGetterOverrideSolution> buildSolutionDescriptor() {
+        return SolutionDescriptor.buildSolutionDescriptor(
+                TestdataAutoDiscoverGetterOverrideSolution.class, TestdataEntity.class);
+    }
+
+    private TestdataObject singleProblemFactField;
+    private List<TestdataValue> problemFactListField;
+    private List<String> listProblemFactField;
+
+    private List<TestdataEntity> entityListField;
+    private TestdataEntity otherEntityField;
+
+    private SimpleScore score;
+
+    public TestdataAutoDiscoverGetterOverrideSolution() {
+    }
+
+    public TestdataAutoDiscoverGetterOverrideSolution(String code) {
+        super(code);
+    }
+
+    public TestdataAutoDiscoverGetterOverrideSolution(String code, TestdataObject singleProblemFact,
+            List<TestdataValue> problemFactList, List<TestdataEntity> entityList,
+            TestdataEntity otherEntity, List<String> listFact) {
+        super(code);
+        this.singleProblemFactField = singleProblemFact;
+        this.problemFactListField = problemFactList;
+        this.entityListField = entityList;
+        this.otherEntityField = otherEntity;
+        this.listProblemFactField = listFact;
+    }
+
+    public TestdataObject getSingleProblemFact() {
+        return singleProblemFactField;
+    }
+
+    @ValueRangeProvider(id = "valueRange")
+    public List<TestdataValue> getProblemFactList() {
+        return problemFactListField;
+    }
+
+    @ProblemFactProperty // would have been autodiscovered as @ProblemFactCollectionProperty
+    public List<String> getListProblemFact() {
+        return listProblemFactField;
+    }
+
+    public List<TestdataEntity> getEntityList() {
+        return entityListField;
+    }
+
+    public TestdataEntity getOtherEntity() {
+        return otherEntityField;
+    }
+
+    public SimpleScore getScore() {
+        return score;
+    }
+
+    public void setScore(SimpleScore score) {
+        this.score = score;
+    }
+
+}

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/testdata/domain/solutionproperties/autodiscover/TestdataAutoDiscoverGetterSolution.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/testdata/domain/solutionproperties/autodiscover/TestdataAutoDiscoverGetterSolution.java
@@ -30,7 +30,7 @@ import org.optaplanner.core.impl.testdata.domain.TestdataValue;
 @PlanningSolution(autoDiscoverMemberType = AutoDiscoverMemberType.GETTER)
 public class TestdataAutoDiscoverGetterSolution extends TestdataObject {
 
-    public static SolutionDescriptor buildSolutionDescriptor() {
+    public static SolutionDescriptor<TestdataAutoDiscoverGetterSolution> buildSolutionDescriptor() {
         return SolutionDescriptor.buildSolutionDescriptor(TestdataAutoDiscoverGetterSolution.class, TestdataEntity.class);
     }
 

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/testdata/domain/solutionproperties/autodiscover/TestdataAutoDiscoverGetterSubclassSolution.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/testdata/domain/solutionproperties/autodiscover/TestdataAutoDiscoverGetterSubclassSolution.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.optaplanner.core.impl.testdata.domain.solutionproperties.autodiscover;
+
+import java.util.List;
+
+import org.optaplanner.core.api.domain.solution.drools.ProblemFactProperty;
+import org.optaplanner.core.impl.testdata.domain.TestdataEntity;
+import org.optaplanner.core.impl.testdata.domain.TestdataObject;
+import org.optaplanner.core.impl.testdata.domain.TestdataValue;
+
+public class TestdataAutoDiscoverGetterSubclassSolution extends TestdataAutoDiscoverGetterSolution {
+
+    private TestdataObject singleProblemFactFieldOverride;
+    private List<TestdataValue> problemFactListFieldOverride;
+
+    private List<TestdataEntity> entityListFieldOverride;
+    private TestdataEntity otherEntityFieldOverride;
+
+    public TestdataAutoDiscoverGetterSubclassSolution() {
+    }
+
+    public TestdataAutoDiscoverGetterSubclassSolution(String code) {
+        super(code);
+    }
+
+    public TestdataAutoDiscoverGetterSubclassSolution(String code, TestdataObject singleProblemFact,
+            List<TestdataValue> problemFactList, List<TestdataEntity> entityList,
+            TestdataEntity otherEntity) {
+        super(code);
+        this.singleProblemFactFieldOverride = singleProblemFact;
+        this.problemFactListFieldOverride = problemFactList;
+        this.entityListFieldOverride = entityList;
+        this.otherEntityFieldOverride = otherEntity;
+    }
+
+    @Override
+    public TestdataObject getSingleProblemFact() {
+        return singleProblemFactFieldOverride;
+    }
+
+    @ProblemFactProperty // CHANGE! from a collection to a single fact
+    @Override
+    public List<TestdataValue> getProblemFactList() {
+        return problemFactListFieldOverride;
+    }
+
+    @Override
+    public List<TestdataEntity> getEntityList() {
+        return entityListFieldOverride;
+    }
+
+    @Override
+    public TestdataEntity getOtherEntity() {
+        return otherEntityFieldOverride;
+    }
+
+}

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/testdata/domain/solutionproperties/autodiscover/TestdataAutoDiscoverUnannotatedEntitySolution.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/testdata/domain/solutionproperties/autodiscover/TestdataAutoDiscoverUnannotatedEntitySolution.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.optaplanner.core.impl.testdata.domain.solutionproperties.autodiscover;
+
+import java.util.List;
+
+import org.optaplanner.core.api.domain.autodiscover.AutoDiscoverMemberType;
+import org.optaplanner.core.api.domain.solution.PlanningSolution;
+import org.optaplanner.core.api.domain.valuerange.ValueRangeProvider;
+import org.optaplanner.core.api.score.buildin.simple.SimpleScore;
+import org.optaplanner.core.impl.domain.solution.descriptor.SolutionDescriptor;
+import org.optaplanner.core.impl.testdata.domain.TestdataEntity;
+import org.optaplanner.core.impl.testdata.domain.TestdataObject;
+import org.optaplanner.core.impl.testdata.domain.TestdataValue;
+import org.optaplanner.core.impl.testdata.domain.extended.TestdataUnannotatedExtendedEntity;
+
+@PlanningSolution(autoDiscoverMemberType = AutoDiscoverMemberType.GETTER)
+public class TestdataAutoDiscoverUnannotatedEntitySolution extends TestdataObject {
+
+    public static SolutionDescriptor<TestdataAutoDiscoverUnannotatedEntitySolution> buildSolutionDescriptor() {
+        return SolutionDescriptor.buildSolutionDescriptor(
+                TestdataAutoDiscoverUnannotatedEntitySolution.class, TestdataEntity.class);
+    }
+
+    private TestdataObject singleProblemFactField;
+    private List<TestdataValue> problemFactListField;
+
+    private List<TestdataUnannotatedExtendedEntity> entityListField;
+    private TestdataUnannotatedExtendedEntity otherEntityField;
+
+    private SimpleScore score;
+
+    public TestdataAutoDiscoverUnannotatedEntitySolution() {
+    }
+
+    public TestdataAutoDiscoverUnannotatedEntitySolution(String code) {
+        super(code);
+    }
+
+    public TestdataAutoDiscoverUnannotatedEntitySolution(String code, TestdataObject singleProblemFact,
+            List<TestdataValue> problemFactList, List<TestdataUnannotatedExtendedEntity> entityList,
+            TestdataUnannotatedExtendedEntity otherEntity) {
+        super(code);
+        this.singleProblemFactField = singleProblemFact;
+        this.problemFactListField = problemFactList;
+        this.entityListField = entityList;
+        this.otherEntityField = otherEntity;
+    }
+
+    public TestdataObject getSingleProblemFact() {
+        return singleProblemFactField;
+    }
+
+    @ValueRangeProvider(id = "valueRange")
+    public List<TestdataValue> getProblemFactList() {
+        return problemFactListField;
+    }
+
+    // should be auto discovered as an entity collection
+    public List<TestdataUnannotatedExtendedEntity> getEntityList() {
+        return entityListField;
+    }
+
+    // should be auto discovered as a single entity property
+    public TestdataUnannotatedExtendedEntity getOtherEntity() {
+        return otherEntityField;
+    }
+
+    public SimpleScore getScore() {
+        return score;
+    }
+
+    public void setScore(SimpleScore score) {
+        this.score = score;
+    }
+
+}

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/testdata/domain/solutionproperties/invalid/TestdataDuplicatePlanningEntityCollectionPropertySolution.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/testdata/domain/solutionproperties/invalid/TestdataDuplicatePlanningEntityCollectionPropertySolution.java
@@ -32,7 +32,7 @@ import org.optaplanner.core.impl.testdata.domain.TestdataValue;
 @PlanningSolution
 public class TestdataDuplicatePlanningEntityCollectionPropertySolution extends TestdataObject {
 
-    public static SolutionDescriptor buildSolutionDescriptor() {
+    public static SolutionDescriptor<TestdataDuplicatePlanningEntityCollectionPropertySolution> buildSolutionDescriptor() {
         return SolutionDescriptor.buildSolutionDescriptor(
                 TestdataDuplicatePlanningEntityCollectionPropertySolution.class, TestdataEntity.class);
     }

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/testdata/domain/solutionproperties/invalid/TestdataDuplicatePlanningScorePropertySolution.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/testdata/domain/solutionproperties/invalid/TestdataDuplicatePlanningScorePropertySolution.java
@@ -32,7 +32,7 @@ import org.optaplanner.core.impl.testdata.domain.TestdataValue;
 @PlanningSolution
 public class TestdataDuplicatePlanningScorePropertySolution extends TestdataObject {
 
-    public static SolutionDescriptor buildSolutionDescriptor() {
+    public static SolutionDescriptor<TestdataDuplicatePlanningScorePropertySolution> buildSolutionDescriptor() {
         return SolutionDescriptor.buildSolutionDescriptor(
                 TestdataDuplicatePlanningScorePropertySolution.class, TestdataEntity.class);
     }

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/testdata/domain/solutionproperties/invalid/TestdataDuplicateProblemFactCollectionPropertySolution.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/testdata/domain/solutionproperties/invalid/TestdataDuplicateProblemFactCollectionPropertySolution.java
@@ -32,7 +32,7 @@ import org.optaplanner.core.impl.testdata.domain.TestdataValue;
 @PlanningSolution
 public class TestdataDuplicateProblemFactCollectionPropertySolution extends TestdataObject {
 
-    public static SolutionDescriptor buildSolutionDescriptor() {
+    public static SolutionDescriptor<TestdataDuplicateProblemFactCollectionPropertySolution> buildSolutionDescriptor() {
         return SolutionDescriptor.buildSolutionDescriptor(
                 TestdataDuplicateProblemFactCollectionPropertySolution.class, TestdataEntity.class);
     }

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/testdata/domain/solutionproperties/invalid/TestdataProblemFactCollectionPropertyWithArgumentSolution.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/testdata/domain/solutionproperties/invalid/TestdataProblemFactCollectionPropertyWithArgumentSolution.java
@@ -34,7 +34,7 @@ import org.optaplanner.core.impl.testdata.domain.TestdataValue;
 @PlanningSolution
 public class TestdataProblemFactCollectionPropertyWithArgumentSolution extends TestdataObject {
 
-    public static SolutionDescriptor buildSolutionDescriptor() {
+    public static SolutionDescriptor<TestdataProblemFactCollectionPropertyWithArgumentSolution> buildSolutionDescriptor() {
         return SolutionDescriptor.buildSolutionDescriptor(
                 TestdataProblemFactCollectionPropertyWithArgumentSolution.class, TestdataEntity.class);
     }

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/testdata/domain/solutionproperties/invalid/TestdataProblemFactIsPlanningEntityCollectionPropertySolution.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/testdata/domain/solutionproperties/invalid/TestdataProblemFactIsPlanningEntityCollectionPropertySolution.java
@@ -32,7 +32,7 @@ import org.optaplanner.core.impl.testdata.domain.TestdataValue;
 @PlanningSolution
 public class TestdataProblemFactIsPlanningEntityCollectionPropertySolution extends TestdataObject {
 
-    public static SolutionDescriptor buildSolutionDescriptor() {
+    public static SolutionDescriptor<TestdataProblemFactIsPlanningEntityCollectionPropertySolution> buildSolutionDescriptor() {
         return SolutionDescriptor.buildSolutionDescriptor(
                 TestdataProblemFactIsPlanningEntityCollectionPropertySolution.class, TestdataEntity.class);
     }

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/testdata/domain/solutionproperties/invalid/TestdataUnknownFactTypeSolution.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/testdata/domain/solutionproperties/invalid/TestdataUnknownFactTypeSolution.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.optaplanner.core.impl.testdata.domain.solutionproperties.invalid;
+
+import java.util.Collection;
+import java.util.List;
+
+import org.optaplanner.core.api.domain.autodiscover.AutoDiscoverMemberType;
+import org.optaplanner.core.api.domain.solution.PlanningSolution;
+import org.optaplanner.core.api.domain.valuerange.ValueRangeProvider;
+import org.optaplanner.core.api.score.buildin.simple.SimpleScore;
+import org.optaplanner.core.impl.domain.solution.descriptor.SolutionDescriptor;
+import org.optaplanner.core.impl.testdata.domain.TestdataEntity;
+import org.optaplanner.core.impl.testdata.domain.TestdataObject;
+import org.optaplanner.core.impl.testdata.domain.TestdataValue;
+
+@PlanningSolution(autoDiscoverMemberType = AutoDiscoverMemberType.FIELD)
+public class TestdataUnknownFactTypeSolution extends TestdataObject {
+
+    public static SolutionDescriptor<TestdataUnknownFactTypeSolution> buildSolutionDescriptor() {
+        return SolutionDescriptor.buildSolutionDescriptor(TestdataUnknownFactTypeSolution.class,
+                TestdataEntity.class);
+    }
+
+    private List<TestdataValue> valueList;
+    private List<TestdataEntity> entityList;
+    private SimpleScore score;
+    // this can't work with autodiscovery because it's difficult/impossible to resolve the type of collection elements
+    private MyStringCollection facts;
+
+    public TestdataUnknownFactTypeSolution() {
+    }
+
+    public TestdataUnknownFactTypeSolution(String code) {
+        super(code);
+    }
+
+    @ValueRangeProvider(id = "valueRange")
+    public List<TestdataValue> getValueList() {
+        return valueList;
+    }
+
+    public static interface MyStringCollection extends Collection<String> {
+
+    }
+}

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/testdata/domain/solutionproperties/invalid/TestdataUnsupportedFactTypeSolution.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/testdata/domain/solutionproperties/invalid/TestdataUnsupportedFactTypeSolution.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.optaplanner.core.impl.testdata.domain.solutionproperties.invalid;
+
+import java.util.Collection;
+import java.util.List;
+
+import org.optaplanner.core.api.domain.autodiscover.AutoDiscoverMemberType;
+import org.optaplanner.core.api.domain.solution.PlanningEntityCollectionProperty;
+import org.optaplanner.core.api.domain.solution.PlanningScore;
+import org.optaplanner.core.api.domain.solution.PlanningSolution;
+import org.optaplanner.core.api.domain.solution.drools.ProblemFactCollectionProperty;
+import org.optaplanner.core.api.domain.valuerange.ValueRangeProvider;
+import org.optaplanner.core.api.score.buildin.simple.SimpleScore;
+import org.optaplanner.core.impl.domain.solution.descriptor.SolutionDescriptor;
+import org.optaplanner.core.impl.testdata.domain.TestdataEntity;
+import org.optaplanner.core.impl.testdata.domain.TestdataObject;
+import org.optaplanner.core.impl.testdata.domain.TestdataValue;
+
+@PlanningSolution(autoDiscoverMemberType = AutoDiscoverMemberType.GETTER)
+public class TestdataUnsupportedFactTypeSolution extends TestdataObject {
+
+    public static SolutionDescriptor<TestdataUnsupportedFactTypeSolution> buildSolutionDescriptor() {
+        return SolutionDescriptor.buildSolutionDescriptor(TestdataUnsupportedFactTypeSolution.class,
+                TestdataEntity.class);
+    }
+
+    private List<TestdataValue> valueList;
+    private List<TestdataEntity> entityList;
+
+    private SimpleScore score;
+
+    public TestdataUnsupportedFactTypeSolution() {
+    }
+
+    public TestdataUnsupportedFactTypeSolution(String code) {
+        super(code);
+    }
+
+    @ValueRangeProvider(id = "valueRange")
+    @ProblemFactCollectionProperty
+    public List<TestdataValue> getValueList() {
+        return valueList;
+    }
+
+    public void setValueList(List<TestdataValue> valueList) {
+        this.valueList = valueList;
+    }
+
+    @PlanningEntityCollectionProperty
+    public List<TestdataEntity> getEntityList() {
+        return entityList;
+    }
+
+    public void setEntityList(List<TestdataEntity> entityList) {
+        this.entityList = entityList;
+    }
+
+    @PlanningScore
+    public SimpleScore getScore() {
+        return score;
+    }
+
+    public void setScore(SimpleScore score) {
+        this.score = score;
+    }
+
+    // ************************************************************************
+    // Complex methods
+    // ************************************************************************
+    //
+    public Collection<?> getProblemFacts() { // unspecified element type is unsupported
+        return null;
+    }
+
+}

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/testdata/util/TestdataCodeAssertableArrayList.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/testdata/util/TestdataCodeAssertableArrayList.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.optaplanner.core.impl.testdata.util;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+public class TestdataCodeAssertableArrayList<E> extends ArrayList<E> implements CodeAssertable {
+
+    private static final long serialVersionUID = -6085607048567865778L;
+
+    private final String code;
+
+    public TestdataCodeAssertableArrayList(String code, Collection<? extends E> c) {
+        super(c);
+        this.code = code;
+    }
+
+    @Override
+    public String getCode() {
+        return code;
+    }
+
+}

--- a/optaplanner-docs/src/main/asciidoc/PlannerConfiguration/PlannerConfiguration-chapter.adoc
+++ b/optaplanner-docs/src/main/asciidoc/PlannerConfiguration/PlannerConfiguration-chapter.adoc
@@ -1308,7 +1308,7 @@ Those can even return a `Collection` with the same entity class type.
 
 [NOTE]
 ====
-A `@PlanningEntityCollectionProperty annotation needs to be on a member in a class with a @PlanningSolution annotation.
+A `@PlanningEntityCollectionProperty` annotation needs to be on a member in a class with a `@PlanningSolution` annotation.
 It is ignored on parent classes or subclasses without that annotation.
 ====
 
@@ -1462,7 +1462,7 @@ Where a score constraint needs to check that no two exams with a topic that shar
 ==== Auto Discover Solution Properties
 
 Instead of configuring each property (or field) annotation explicitly,
-some can also be deducted automatically by Planner.
+some can also be deduced automatically by Planner.
 For example, on the cloud balancing example:
 
 [source,java,options="nowrap"]


### PR DESCRIPTION
Covered use cases requested in https://issues.jboss.org/browse/PLANNER-793:
- member is a subclass of an entity class
- member is a collection of entity subclass elements
- field/getter would be autodiscovered but it uses an annotation to override the autodiscovery result
- getter is overriden and the parent was autodiscovered but the child has an explicit annotation **(broken)**

Negative test cases:
- Autodiscovery will fail with `Collection<?> getFacts()` (unsupported element type)
- Autodiscovery will fail with `MyFactCollection getFacts()` (element type is unknown)
