### PR TITLE
Partially revert 8e0d114c528d3d0a47c3e6fcb179e7df0e169a4c

### DIFF
--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/reproducer/TestGenCorruptedScoreReproducer.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/reproducer/TestGenCorruptedScoreReproducer.java
@@ -66,10 +66,10 @@ public class TestGenCorruptedScoreReproducer implements TestGenOriginalProblemRe
         } catch (RuntimeException e) {
             if (e.getMessage() != null && e.getMessage().startsWith("No fact handle for ")) {
                 // this is common when removing insert of a fact that is later updated - not interesting
-                logger.debug("    Can't remove insert: {}", (Object) e);
+                logger.debug("    Can't remove insert: {}", e.toString());
             } else if (e.getMessage() != null && e.getMessage().startsWith("Error evaluating constraint '")) {
                 // this is common after pruning setup code, which can lead to NPE during rule evaluation
-                logger.debug("    Can't drop field setup: {}", (Object) e);
+                logger.debug("    Can't drop field setup: {}", e.toString());
             } else {
                 logger.info("Unexpected exception", e);
             }

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/reproducer/TestGenCorruptedVariableListenerReproducer.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/reproducer/TestGenCorruptedVariableListenerReproducer.java
@@ -70,15 +70,15 @@ public class TestGenCorruptedVariableListenerReproducer implements
         } catch (TestGenCorruptedScoreException e) {
             return true;
         } catch (ConsequenceException e) {
-            logger.debug("    Journal pruning not possible: {}", (Object) e);
+            logger.debug("    Journal pruning not possible: {}", e.toString());
             return false;
         } catch (RuntimeException e) {
             if (e.getMessage() != null && e.getMessage().startsWith("No fact handle for ")) {
                 // this is common when removing insert of a fact that is later updated - not interesting
-                logger.debug("    Can't remove insert: {}", (Object) e);
+                logger.debug("    Can't remove insert: {}", e.toString());
             } else if (e.getMessage() != null && e.getMessage().startsWith("Error evaluating constraint '")) {
                 // this is common after pruning setup code, which can lead to NPE during rule evaluation
-                logger.debug("    Can't drop field setup: {}", (Object) e);
+                logger.debug("    Can't drop field setup: {}", e.toString());
             } else {
                 logger.info("Unexpected exception", e);
             }

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/reproducer/TestGenDroolsExceptionReproducer.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/reproducer/TestGenDroolsExceptionReproducer.java
@@ -49,11 +49,11 @@ public class TestGenDroolsExceptionReproducer implements TestGenOriginalProblemR
                 if (reproducedException.getMessage() != null
                         && reproducedException.getMessage().startsWith("No fact handle for ")) {
                     // this is common when removing insert of a fact that is later updated - not interesting
-                    logger.debug("    Can't remove insert: {}", (Object) reproducedException);
+                    logger.debug("    Can't remove insert: {}", reproducedException.toString());
                 } else if (reproducedException.getMessage() != null
                         && reproducedException.getMessage().startsWith("Error evaluating constraint '")) {
                     // this is common after pruning setup code, which can lead to NPE during rule evaluation
-                    logger.debug("    Can't drop field setup: {}", (Object) reproducedException);
+                    logger.debug("    Can't drop field setup: {}", reproducedException.toString());
                 } else {
                     logger.info("Unexpected exception", reproducedException);
                 }


### PR DESCRIPTION
It appears that there is a difference in behavior of the "log4j12"
backend that causes the stack trace of exceptions to be printed, which
is not desired.

See kiegroup/optaplanner#325