### PR TITLE
PLANNER-683 Add exception propagation test for Partitioned Search

### DIFF
--- a/optaplanner-core/pom.xml
+++ b/optaplanner-core/pom.xml
@@ -89,6 +89,11 @@
       <groupId>com.thoughtworks.xstream</groupId>
       <artifactId>xstream</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/partitionedsearch/DefaultPartitionedSearchPhase.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/partitionedsearch/DefaultPartitionedSearchPhase.java
@@ -20,8 +20,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.Semaphore;
-import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
@@ -174,11 +174,8 @@ public class DefaultPartitionedSearchPhase<Solution_> extends AbstractPhase<Solu
     }
 
     private ExecutorService createThreadPoolExecutor(int partCount) {
-        // Based on Executors.newCachedThreadPool(...)
-        ThreadPoolExecutor threadPoolExecutor = new ThreadPoolExecutor(0, Integer.MAX_VALUE,
-                60L, TimeUnit.SECONDS,
-                new SynchronousQueue<>(),
-                threadFactory);
+        ThreadPoolExecutor threadPoolExecutor
+                = (ThreadPoolExecutor) Executors.newFixedThreadPool(partCount, threadFactory);
 
         if (threadPoolExecutor.getMaximumPoolSize() < partCount) {
             throw new IllegalStateException(

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/partitionedsearch/DefaultPartitionedSearchPhase.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/partitionedsearch/DefaultPartitionedSearchPhase.java
@@ -159,7 +159,8 @@ public class DefaultPartitionedSearchPhase<Solution_> extends AbstractPhase<Solu
             // but the other partition threads are not aware of the failure and may continue solving for a long time,
             // so we need to ask them to terminate. In case no exception was thrown, this does nothing.
             if (!childThreadPlumbingTermination.terminateChildren()) {
-                logger.info("Termination of children wasn't sucessful.");
+                // This may happen as a result of the abrupt shutdown in step 1a.
+                logger.info("Children have already been interrupted.");
             }
 
             // 3. Finally, wait until the executor finishes shutting down

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/solver/termination/AbstractCompositeTermination.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/solver/termination/AbstractCompositeTermination.java
@@ -30,7 +30,7 @@ import org.optaplanner.core.impl.solver.scope.DefaultSolverScope;
  * @see AndCompositeTermination
  * @see OrCompositeTermination
  */
-public abstract class AbstractCompositeTermination extends AbstractTermination implements Termination {
+public abstract class AbstractCompositeTermination extends AbstractTermination {
 
     protected final List<Termination> terminationList;
 

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/solver/termination/ChildThreadPlumbingTermination.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/solver/termination/ChildThreadPlumbingTermination.java
@@ -38,13 +38,6 @@ public class ChildThreadPlumbingTermination extends AbstractTermination {
         return terminationEarlySuccessful;
     }
 
-    /**
-     * This method is thread-safe.
-     */
-    public synchronized boolean isTerminateChildren() {
-        return terminateChildren;
-    }
-
     // ************************************************************************
     // Termination worker methods
     // ************************************************************************

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/solver/termination/ChildThreadPlumbingTermination.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/solver/termination/ChildThreadPlumbingTermination.java
@@ -30,7 +30,7 @@ public class ChildThreadPlumbingTermination extends AbstractTermination {
 
     /**
      * This method is thread-safe.
-     * @return true if successful
+     * @return true if termination hasn't been requested previously
      */
     public synchronized boolean terminateChildren() {
         boolean terminationEarlySuccessful = !terminateChildren;

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/partitionedsearch/DefaultPartitionedSearchPhaseTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/partitionedsearch/DefaultPartitionedSearchPhaseTest.java
@@ -141,7 +141,7 @@ public class DefaultPartitionedSearchPhaseTest {
         final int partCount = 3;
 
         TestdataSolution solution = createSolution(partCount * partSize - 1, 100);
-        solution.getEntityList().add(new FaultyEntity("XYZ"));
+        solution.getEntityList().add(new TestdataFaultyEntity("XYZ"));
         assertEquals(partSize * partCount, solution.getEntityList().size());
 
         SolverFactory<TestdataSolution> solverFactory = createSolverFactory(false);
@@ -193,7 +193,7 @@ public class DefaultPartitionedSearchPhaseTest {
 
         TestdataSolution solution = createSolution(partCount * partSize - 1, 10);
         CountDownLatch latch = new CountDownLatch(1);
-        solution.getEntityList().add(new BusyEntity("XYZ", latch));
+        solution.getEntityList().add(new TestdataBusyEntity("XYZ", latch));
 
         SolverFactory<TestdataSolution> solverFactory = createSolverFactory(true);
         setPartSize(solverFactory.getSolverConfig(), partSize);
@@ -223,65 +223,4 @@ public class DefaultPartitionedSearchPhaseTest {
         }
     }
 
-    public static class BusyEntity extends TestdataEntity {
-
-        private static final Logger logger = LoggerFactory.getLogger(BusyEntity.class);
-        private CountDownLatch latch;
-
-        public BusyEntity() {
-            // needed for cloning
-        }
-
-        public BusyEntity(String code, CountDownLatch cdl) {
-            super(code);
-            this.latch = cdl;
-        }
-
-        public CountDownLatch getLatch() {
-            return latch;
-        }
-
-        public void setLatch(CountDownLatch latch) {
-            this.latch = latch;
-        }
-
-        @Override
-        public void setValue(TestdataValue value) {
-            super.setValue(value);
-            if (latch.getCount() == 0) {
-                logger.debug("This entity was already interrupted in the past. Not going to busy wait again.");
-                return;
-            }
-            latch.countDown();
-            long start = System.currentTimeMillis();
-            logger.info("{}.setValue() started.", BusyEntity.class.getSimpleName());
-            while (!Thread.currentThread().isInterrupted()) {
-                // busy wait
-            }
-            logger.info("{}.setValue() interrupted after {}ms.",
-                        BusyEntity.class.getSimpleName(),
-                        System.currentTimeMillis() - start);
-        }
-    }
-
-    public static class FaultyEntity extends TestdataEntity {
-
-        private static final Logger logger = LoggerFactory.getLogger(FaultyEntity.class);
-
-        public FaultyEntity() {
-            // needed for cloning
-        }
-
-        public FaultyEntity(String code) {
-            super(code);
-        }
-
-        @Override
-        public void setValue(TestdataValue value) {
-            super.setValue(value);
-            logger.info("Going to divide by zero.");
-            int zero = 0;
-            logger.info("{}", 1 / zero);
-        }
-    }
 }

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/partitionedsearch/TestdataBusyEntity.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/partitionedsearch/TestdataBusyEntity.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.optaplanner.core.impl.partitionedsearch;
+
+import java.util.concurrent.CountDownLatch;
+
+import org.optaplanner.core.impl.testdata.domain.TestdataEntity;
+import org.optaplanner.core.impl.testdata.domain.TestdataValue;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class TestdataBusyEntity extends TestdataEntity {
+
+    private static final Logger logger = LoggerFactory.getLogger(TestdataBusyEntity.class);
+    private CountDownLatch latch;
+
+    public TestdataBusyEntity() {
+    }
+
+    public TestdataBusyEntity(String code, CountDownLatch cdl) {
+        super(code);
+        this.latch = cdl;
+    }
+
+    public CountDownLatch getLatch() {
+        return latch;
+    }
+
+    public void setLatch(CountDownLatch latch) {
+        this.latch = latch;
+    }
+
+    @Override
+    public void setValue(TestdataValue value) {
+        super.setValue(value);
+        if (latch.getCount() == 0) {
+            logger.debug("This entity was already interrupted in the past. Not going to busy wait again.");
+            return;
+        }
+        latch.countDown();
+        long start = System.currentTimeMillis();
+        logger.info("{}.setValue() started.", TestdataBusyEntity.class.getSimpleName());
+        while (!Thread.currentThread().isInterrupted()) {
+            // busy wait
+        }
+        logger.info("{}.setValue() interrupted after {}ms.",
+                    TestdataBusyEntity.class.getSimpleName(),
+                    System.currentTimeMillis() - start);
+    }
+
+}

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/partitionedsearch/TestdataFaultyEntity.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/partitionedsearch/TestdataFaultyEntity.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.optaplanner.core.impl.partitionedsearch;
+
+import org.optaplanner.core.impl.testdata.domain.TestdataEntity;
+import org.optaplanner.core.impl.testdata.domain.TestdataValue;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class TestdataFaultyEntity extends TestdataEntity {
+
+    private static final Logger logger = LoggerFactory.getLogger(TestdataFaultyEntity.class);
+
+    public TestdataFaultyEntity() {
+    }
+
+    public TestdataFaultyEntity(String code) {
+        super(code);
+    }
+
+    @Override
+    public void setValue(TestdataValue value) {
+        super.setValue(value);
+        logger.info("Going to divide by zero.");
+        int zero = 0;
+        logger.info("{}", 1 / zero);
+    }
+
+}

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/partitionedsearch/TestdataFaultyEntity.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/partitionedsearch/TestdataFaultyEntity.java
@@ -34,9 +34,16 @@ public class TestdataFaultyEntity extends TestdataEntity {
     @Override
     public void setValue(TestdataValue value) {
         super.setValue(value);
-        logger.info("Going to divide by zero.");
-        int zero = 0;
-        logger.info("{}", 1 / zero);
+        if (Thread.currentThread().getName().matches("OptaPool-\\d+-PartThread-\\d+")) {
+            logger.info("Throwing exception on a partition thread.");
+            throw new TestException();
+        }
     }
 
+    public static class TestException extends RuntimeException {
+
+        public TestException() {
+            super("Unexpected solver failure.");
+        }
+    }
 }

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/partitionedsearch/TestdataSleepingEntity.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/partitionedsearch/TestdataSleepingEntity.java
@@ -22,15 +22,15 @@ import org.optaplanner.core.impl.testdata.domain.TestdataValue;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class TestdataBusyEntity extends TestdataEntity {
+public class TestdataSleepingEntity extends TestdataEntity {
 
-    private static final Logger logger = LoggerFactory.getLogger(TestdataBusyEntity.class);
+    private static final Logger logger = LoggerFactory.getLogger(TestdataSleepingEntity.class);
     private CountDownLatch latch;
 
-    public TestdataBusyEntity() {
+    public TestdataSleepingEntity() {
     }
 
-    public TestdataBusyEntity(String code, CountDownLatch cdl) {
+    public TestdataSleepingEntity(String code, CountDownLatch cdl) {
         super(code);
         this.latch = cdl;
     }
@@ -47,17 +47,20 @@ public class TestdataBusyEntity extends TestdataEntity {
     public void setValue(TestdataValue value) {
         super.setValue(value);
         if (latch.getCount() == 0) {
-            logger.debug("This entity was already interrupted in the past. Not going to busy wait again.");
+            logger.debug("This entity was already interrupted in the past. Not going to sleep again.");
             return;
         }
         latch.countDown();
         long start = System.currentTimeMillis();
-        logger.info("{}.setValue() started.", TestdataBusyEntity.class.getSimpleName());
-        while (!Thread.currentThread().isInterrupted()) {
-            // busy wait
+        logger.info("{}.setValue() started and going to sleep.", TestdataSleepingEntity.class.getSimpleName());
+        try {
+            Thread.sleep(Long.MAX_VALUE);
+        } catch (InterruptedException ex) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException("Interrupted while sleeping", ex);
         }
         logger.info("{}.setValue() interrupted after {}ms.",
-                    TestdataBusyEntity.class.getSimpleName(),
+                    TestdataSleepingEntity.class.getSimpleName(),
                     System.currentTimeMillis() - start);
     }
 

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/partitionedsearch/TestdataSolutionPartitioner.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/partitionedsearch/TestdataSolutionPartitioner.java
@@ -40,7 +40,9 @@ public class TestdataSolutionPartitioner implements SolutionPartitioner<Testdata
         TestdataSolution workingSolution = scoreDirector.getWorkingSolution();
         List<TestdataEntity> allEntities = workingSolution.getEntityList();
         if (allEntities.size() % partSize > 0) {
-            throw new IllegalStateException("This partitioner can only make equally sized partitions.");
+            throw new IllegalStateException("This partitioner can only make equally sized partitions."
+                    + " This is impossible because number of allEntities (" + allEntities.size()
+                    + ") is not divisible by partSize (" + partSize + ").");
         }
         List<TestdataSolution> partitions = new ArrayList<>();
         for (int i = 0; i < allEntities.size() / partSize; i++) {

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/partitionedsearch/TestdataSolutionPartitioner.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/partitionedsearch/TestdataSolutionPartitioner.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.optaplanner.core.impl.partitionedsearch;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.optaplanner.core.impl.partitionedsearch.partitioner.SolutionPartitioner;
+import org.optaplanner.core.impl.score.director.ScoreDirector;
+import org.optaplanner.core.impl.testdata.domain.TestdataEntity;
+import org.optaplanner.core.impl.testdata.domain.TestdataSolution;
+
+public class TestdataSolutionPartitioner implements SolutionPartitioner<TestdataSolution> {
+
+    /**
+     * {@link PartitionedSearchPhaseConfig#solutionPartitionerCustomProperties Custom property}.
+     */
+    private int partSize = 1;
+
+    public void setPartSize(int partSize) {
+        this.partSize = partSize;
+    }
+
+    @Override
+    public List<TestdataSolution> splitWorkingSolution(ScoreDirector<TestdataSolution> scoreDirector,
+                                                       Integer runnablePartThreadLimit) {
+        TestdataSolution workingSolution = scoreDirector.getWorkingSolution();
+        List<TestdataEntity> allEntities = workingSolution.getEntityList();
+        if (allEntities.size() % partSize > 0) {
+            throw new IllegalStateException("This partitioner can only make equally sized partitions.");
+        }
+        List<TestdataSolution> partitions = new ArrayList<>();
+        for (int i = 0; i < allEntities.size() / partSize; i++) {
+            List<TestdataEntity> partitionEntitites
+                    = new ArrayList<>(allEntities.subList(i * partSize, (i + 1) * partSize));
+            TestdataSolution partition = new TestdataSolution();
+            partition.setEntityList(partitionEntitites);
+            partition.setValueList(workingSolution.getValueList());
+            partitions.add(partition);
+        }
+        return partitions;
+    }
+
+}


### PR DESCRIPTION
See https://issues.jboss.org/browse/PLANNER-683.

* Added test that verifies propagation of the original exception that caused one of child partition solvers to fail.
* Child thread termination is handled by `DefaultPartitionedSearchPhase`. This piece of code is hard to test but I think it's covered by `awaitTermination()` in the test. There are no thread sleeps and the tests are quick.

As a result of the small changes accompanying the new tests, optaplanner behaves nicely and terminates all children when one of them fails or when the main thread is interrupted.