### PR TITLE
AF-593: Migrate project-datamodel-* from UberFire.

### DIFF
--- a/optaplanner-integration/optaplanner-workbench-models/optaplanner-workbench-models-datamodel-api/src/main/java/org/optaplanner/workbench/models/datamodel/util/TemplateUtils.java
+++ b/optaplanner-integration/optaplanner-workbench-models/optaplanner-workbench-models-datamodel-api/src/main/java/org/optaplanner/workbench/models/datamodel/util/TemplateUtils.java
@@ -22,8 +22,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.function.Function;
 
-import org.appformer.project.datamodel.oracle.DataType;
 import org.drools.workbench.models.datamodel.rule.InterpolationVariable;
+import org.kie.soup.project.datamodel.oracle.DataType;
 
 public final class TemplateUtils {
 

--- a/optaplanner-integration/optaplanner-workbench-models/optaplanner-workbench-models-datamodel-api/src/test/java/org/optaplanner/workbench/models/datamodel/rule/ActionConstraintMatchTest.java
+++ b/optaplanner-integration/optaplanner-workbench-models/optaplanner-workbench-models-datamodel-api/src/test/java/org/optaplanner/workbench/models/datamodel/rule/ActionConstraintMatchTest.java
@@ -16,10 +16,10 @@
 
 package org.optaplanner.workbench.models.datamodel.rule;
 
-import org.appformer.project.datamodel.oracle.DataType;
 import org.drools.workbench.models.datamodel.rule.IAction;
 import org.drools.workbench.models.datamodel.rule.InterpolationVariable;
 import org.junit.Test;
+import org.kie.soup.project.datamodel.oracle.DataType;
 
 import java.util.Arrays;
 import java.util.Collection;

--- a/optaplanner-integration/optaplanner-workbench-models/optaplanner-workbench-models-datamodel-api/src/test/java/org/optaplanner/workbench/models/datamodel/util/TemplateUtilsTest.java
+++ b/optaplanner-integration/optaplanner-workbench-models/optaplanner-workbench-models-datamodel-api/src/test/java/org/optaplanner/workbench/models/datamodel/util/TemplateUtilsTest.java
@@ -19,9 +19,9 @@ package org.optaplanner.workbench.models.datamodel.util;
 import java.util.Collection;
 import java.util.function.Function;
 
-import org.appformer.project.datamodel.oracle.DataType;
 import org.drools.workbench.models.datamodel.rule.InterpolationVariable;
 import org.junit.Test;
+import org.kie.soup.project.datamodel.oracle.DataType;
 
 import static org.junit.Assert.*;
 


### PR DESCRIPTION
Related:
https://github.com/kiegroup/guvnor/pull/519
https://github.com/dashbuilder/dashbuilder/pull/372
https://github.com/kiegroup/kie-soup/pull/3
https://github.com/kiegroup/kie-wb-distributions/pull/621
https://github.com/kiegroup/droolsjbpm-tools/pull/82
https://github.com/kiegroup/optaplanner-wb/pull/218
https://github.com/kiegroup/jbpm-wb/pull/864
https://github.com/kiegroup/jbpm-designer/pull/654
https://github.com/kiegroup/drools-wb/pull/596
https://github.com/kiegroup/kie-wb-common/pull/1133
https://github.com/kiegroup/droolsjbpm-integration/pull/1163
https://github.com/kiegroup/droolsjbpm-integration/pull/1163
https://github.com/kiegroup/jbpm/pull/973
https://github.com/kiegroup/drools/pull/1444
https://github.com/kiegroup/droolsjbpm-knowledge/pull/263
https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/541
https://github.com/AppFormer/uberfire/pull/822