### PR TITLE
JDK 9 fixes

### DIFF
--- a/optaplanner-distribution/pom.xml
+++ b/optaplanner-distribution/pom.xml
@@ -44,6 +44,18 @@
                 <dependencySourceInclude>org.optaplanner:optaplanner-test</dependencySourceInclude>
                 <!-- TODO apparently optaplanner-examples gets included too somehow? -->
               </dependencySourceIncludes>
+              <additionalDependencies>
+                <additionalDependency>
+                  <groupId>org.hibernate</groupId>
+                  <artifactId>hibernate-core</artifactId>
+                  <version>${version.org.hibernate}</version>
+                </additionalDependency>
+                <additionalDependency>
+                  <groupId>junit</groupId>
+                  <artifactId>junit</artifactId>
+                  <version>${version.junit}</version>
+                </additionalDependency>
+              </additionalDependencies>
             </configuration>
           </execution>
         </executions>

--- a/optaplanner-persistence/optaplanner-persistence-jpa/pom.xml
+++ b/optaplanner-persistence/optaplanner-persistence-jpa/pom.xml
@@ -58,6 +58,10 @@
       <scope>runtime</scope>
       <optional>true</optional>
     </dependency>
+    <dependency>
+      <groupId>org.jboss.spec.javax.xml.bind</groupId>
+      <artifactId>jboss-jaxb-api_2.2_spec</artifactId>
+    </dependency>
 
     <!-- Test -->
     <dependency>


### PR DESCRIPTION
These should be last pieces to make the default `mvn clean install -Dfull` build work on JDK9.