### PR TITLE
PLANNER-910 Improve logging related to Partitioned Search

### DIFF
--- a/optaplanner-core/src/main/java/org/optaplanner/core/config/heuristic/policy/HeuristicConfigPolicy.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/config/heuristic/policy/HeuristicConfigPolicy.java
@@ -130,7 +130,7 @@ public class HeuristicConfigPolicy {
     // ************************************************************************
 
     public HeuristicConfigPolicy createPhaseConfigPolicy() {
-        return new HeuristicConfigPolicy(environmentMode, scoreDirectorFactory);
+        return new HeuristicConfigPolicy(environmentMode, logIndentation, scoreDirectorFactory);
     }
 
     public HeuristicConfigPolicy createChildThreadConfigPolicy(ChildThreadType childThreadType) {

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/partitionedsearch/DefaultPartitionedSearchPhase.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/partitionedsearch/DefaultPartitionedSearchPhase.java
@@ -116,7 +116,7 @@ public class DefaultPartitionedSearchPhase<Solution_> extends AbstractPhase<Solu
                         childThreadPlumbingTermination, runnablePartThreadSemaphore, solverScope);
                 partitionSolver.addEventListener(event -> {
                     InnerScoreDirector<Solution_> childScoreDirector = partitionSolver.solverScope.getScoreDirector();
-                    PartitionChangeMove<Solution_> move = PartitionChangeMove.createMove(childScoreDirector);
+                    PartitionChangeMove<Solution_> move = PartitionChangeMove.createMove(childScoreDirector, partIndex);
                     InnerScoreDirector<Solution_> parentScoreDirector = solverScope.getScoreDirector();
                     move = move.rebase(parentScoreDirector);
                     partitionQueue.addMove(partIndex, move);

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/partitionedsearch/scope/PartitionChangeMove.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/partitionedsearch/scope/PartitionChangeMove.java
@@ -38,7 +38,8 @@ import org.optaplanner.core.impl.score.director.ScoreDirector;
  */
 public final class PartitionChangeMove<Solution_> extends AbstractMove<Solution_> {
 
-    public static <Solution_> PartitionChangeMove<Solution_> createMove(InnerScoreDirector<Solution_> scoreDirector) {
+    public static <Solution_> PartitionChangeMove<Solution_> createMove(InnerScoreDirector<Solution_> scoreDirector,
+                                                                        int partIndex) {
         SolutionDescriptor<Solution_> solutionDescriptor = scoreDirector.getSolutionDescriptor();
         Solution_ workingSolution = scoreDirector.getWorkingSolution();
 
@@ -63,13 +64,16 @@ public final class PartitionChangeMove<Solution_> extends AbstractMove<Solution_
                 }
             }
         }
-        return new PartitionChangeMove<>(changeMap);
+        return new PartitionChangeMove<>(changeMap, partIndex);
     }
 
     private final Map<GenuineVariableDescriptor<Solution_>, List<Pair<Object, Object>>> changeMap;
+    private final int partIndex;
 
-    public PartitionChangeMove(Map<GenuineVariableDescriptor<Solution_>, List<Pair<Object, Object>>> changeMap) {
+    public PartitionChangeMove(Map<GenuineVariableDescriptor<Solution_>, List<Pair<Object, Object>>> changeMap,
+                               int partIndex) {
         this.changeMap = changeMap;
+        this.partIndex = partIndex;
     }
 
     @Override
@@ -134,8 +138,12 @@ public final class PartitionChangeMove<Solution_> extends AbstractMove<Solution_
             }
             destinationChangeMap.put(variableDescriptor, destinationPairList);
         }
-        return new PartitionChangeMove<>(destinationChangeMap);
+        return new PartitionChangeMove<>(destinationChangeMap, partIndex);
     }
 
-    // TODO implement toString()
+    @Override
+    public String toString() {
+        return "partIndex=" + partIndex;
+    }
+
 }

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/partitionedsearch/queue/PartitionQueueTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/partitionedsearch/queue/PartitionQueueTest.java
@@ -147,7 +147,7 @@ public class PartitionQueueTest {
     }
 
     public PartitionChangeMove<TestdataSolution> buildMove() {
-        return new PartitionChangeMove<>(null);
+        return new PartitionChangeMove<>(null, -1);
     }
 
 }

--- a/optaplanner-core/src/test/resources/logback-test.xml
+++ b/optaplanner-core/src/test/resources/logback-test.xml
@@ -5,7 +5,7 @@
     <encoder>
       <!-- %L lowers performance -->
       <!--<pattern>%d{HH:mm:ss.SSS} [%t] %-5p %L%n  %m%n</pattern>-->
-      <pattern>%d{HH:mm:ss.SSS} [%t] %-5p %m%n</pattern>
+      <pattern>%d{HH:mm:ss.SSS} [%-4.4t] %-5p %m%n</pattern>
     </encoder>
   </appender>
 


### PR DESCRIPTION
* Bugfix: propagate logIndentation when creating phase config policy.
* Store partIndex in PartitionChangeMove and use it in toString().
* Truncate part thread name when logging to have a consistent
  indentation in test logs.