### PR TITLE
PLANNER-919 Make runnablePartThreadSemaphore fair

### DIFF
--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/partitionedsearch/DefaultPartitionedSearchPhase.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/partitionedsearch/DefaultPartitionedSearchPhase.java
@@ -107,7 +107,7 @@ public class DefaultPartitionedSearchPhase<Solution_> extends AbstractPhase<Solu
         ChildThreadPlumbingTermination childThreadPlumbingTermination = new ChildThreadPlumbingTermination();
         PartitionQueue<Solution_> partitionQueue = new PartitionQueue<>(partCount);
         Semaphore runnablePartThreadSemaphore
-                = runnablePartThreadLimit == null ? null : new Semaphore(runnablePartThreadLimit);
+                = runnablePartThreadLimit == null ? null : new Semaphore(runnablePartThreadLimit, true);
         try {
             for (ListIterator<Solution_> it = partList.listIterator(); it.hasNext();) {
                 int partIndex = it.nextIndex();


### PR DESCRIPTION
After making the semaphore fair, part threads make steps at the same rate.

<details>
<summary>Log:</summary>

```
Running org.optaplanner.core.impl.partitionedsearch.DefaultPartitionedSearchPhaseTest
17:49:00.922 [test] TRACE     Model annotations parsed for Solution TestdataSolution:
17:49:00.923 [test] TRACE         Entity TestdataEntity:
17:49:00.923 [test] TRACE             Variable value (genuine)
17:49:01.251 [test] INFO  Solving started: time spent (23), best score (0), environment mode (REPRODUCIBLE), random (JDK with seed 0).
17:49:01.269 [ad-2] TRACE                 Move index (0) not doable, ignoring move (B {0 -> 0}).
17:49:01.269 [ad-1] TRACE                 Move index (0) not doable, ignoring move (A {0 -> 0}).
17:49:01.270 [ad-3] TRACE                 Move index (0) not doable, ignoring move (C {0 -> 0}).
17:49:01.270 [ad-4] TRACE                 Move index (0) not doable, ignoring move (D {0 -> 0}).
17:49:01.271 [ad-5] TRACE                 Move index (0) not doable, ignoring move (E {0 -> 0}).
17:49:01.271 [ad-2] TRACE                 Move index (1), score (1), accepted (true), move (B {0 -> 1}).
17:49:01.271 [ad-1] TRACE                 Move index (1), score (1), accepted (true), move (A {0 -> 1}).
17:49:01.274 [ad-2] DEBUG             LS step (0), time spent (46), score (1), new best score (1), accepted/selected move count (1/1), picked move (B {0 -> 1}).
17:49:01.274 [ad-1] DEBUG             LS step (0), time spent (46), score (1), new best score (1), accepted/selected move count (1/1), picked move (A {0 -> 1}).
17:49:01.274 [ad-1] TRACE                 Move index (0), score (0), accepted (false), move (A {1 -> 0}).
17:49:01.274 [ad-2] TRACE                 Move index (0), score (0), accepted (false), move (B {1 -> 0}).
17:49:01.274 [ad-4] TRACE                 Move index (1), score (1), accepted (true), move (D {0 -> 1}).
17:49:01.274 [ad-3] TRACE                 Move index (1), score (1), accepted (true), move (C {0 -> 1}).
17:49:01.274 [test] DEBUG     PS step (0), time spent (46), score (1), new best score (1), picked move (partIndex=1).
17:49:01.275 [ad-4] DEBUG             LS step (0), time spent (47), score (1), new best score (1), accepted/selected move count (1/1), picked move (D {0 -> 1}).
17:49:01.275 [ad-4] TRACE                 Move index (0), score (0), accepted (false), move (D {1 -> 0}).
17:49:01.275 [ad-5] TRACE                 Move index (1), score (1), accepted (true), move (E {0 -> 1}).
17:49:01.275 [test] DEBUG     PS step (1), time spent (47), score (2), new best score (2), picked move (partIndex=0).
17:49:01.275 [ad-3] DEBUG             LS step (0), time spent (47), score (1), new best score (1), accepted/selected move count (1/1), picked move (C {0 -> 1}).
17:49:01.275 [ad-5] DEBUG             LS step (0), time spent (47), score (1), new best score (1), accepted/selected move count (1/1), picked move (E {0 -> 1}).
17:49:01.275 [ad-5] TRACE                 Move index (0), score (0), accepted (false), move (E {1 -> 0}).
17:49:01.275 [ad-3] TRACE                 Move index (0), score (0), accepted (false), move (C {1 -> 0}).
17:49:01.275 [test] DEBUG     PS step (2), time spent (47), score (3), new best score (3), picked move (partIndex=3).
17:49:01.275 [ad-2] TRACE                 Move index (1) not doable, ignoring move (B {1 -> 1}).
17:49:01.275 [ad-1] TRACE                 Move index (1) not doable, ignoring move (A {1 -> 1}).
17:49:01.275 [ad-4] TRACE                 Move index (1) not doable, ignoring move (D {1 -> 1}).
17:49:01.275 [ad-5] TRACE                 Move index (1) not doable, ignoring move (E {1 -> 1}).
17:49:01.275 [ad-3] TRACE                 Move index (1) not doable, ignoring move (C {1 -> 1}).
17:49:01.275 [ad-2] TRACE                 Move index (2), score (2), accepted (true), move (B {1 -> 2}).
17:49:01.275 [ad-1] TRACE                 Move index (2), score (2), accepted (true), move (A {1 -> 2}).
17:49:01.275 [test] DEBUG     PS step (3), time spent (47), score (4), new best score (4), picked move (partIndex=2).
17:49:01.275 [ad-2] DEBUG             LS step (1), time spent (47), score (2), new best score (2), accepted/selected move count (1/2), picked move (B {1 -> 2}).
17:49:01.275 [ad-1] DEBUG             LS step (1), time spent (47), score (2), new best score (2), accepted/selected move count (1/2), picked move (A {1 -> 2}).
17:49:01.276 [ad-2] TRACE                 Move index (0), score (0), accepted (false), move (B {2 -> 0}).
17:49:01.276 [ad-1] TRACE                 Move index (0), score (0), accepted (false), move (A {2 -> 0}).
17:49:01.276 [test] DEBUG     PS step (4), time spent (48), score (5), new best score (5), picked move (partIndex=4).
```
</details>