### PR TITLE
PLANNER-896 Benchmark aggregator fails due to XStream security exception

### DIFF
--- a/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/impl/result/BenchmarkResultIO.java
+++ b/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/impl/result/BenchmarkResultIO.java
@@ -53,6 +53,8 @@ public class BenchmarkResultIO {
     public BenchmarkResultIO() {
         xStream = XStreamXmlSolverFactory.buildXStream();
         xStream.processAnnotations(PlannerBenchmarkResult.class);
+        xStream.allowTypesByRegExp(new String[]{"org\\.optaplanner\\.\\w+\\.api\\..*"});
+        xStream.allowTypesByRegExp(new String[]{"org\\.optaplanner\\.\\w+\\.impl\\..*"});
         AbstractScoreXStreamConverter.registerScoreConverters(xStream);
     }
 


### PR DESCRIPTION
I'm working on performance report for 7.5.0.Final and I'm hitting various issues (wrong maven-exec-plugin configuration, benchmarker backward compatibility). One of them is this problem with XStream security configuration which prevents unmarshalling benchmarker reports. The fix has been backported to 7.4.x but not to 7.3.x, which is also affected.