### PR TITLE
PLANNER-706 fix performance drop caused by using computeIfAbsent method

### DIFF
--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/solution/cloner/FieldAccessingSolutionCloner.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/solution/cloner/FieldAccessingSolutionCloner.java
@@ -42,9 +42,8 @@ import java.util.SortedMap;
 import java.util.SortedSet;
 import java.util.TreeMap;
 import java.util.TreeSet;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
 
+import java.util.concurrent.ConcurrentMap;
 import org.apache.commons.lang3.tuple.Pair;
 import org.optaplanner.core.api.domain.solution.PlanningSolution;
 import org.optaplanner.core.api.domain.solution.cloner.DeepPlanningClone;
@@ -52,6 +51,7 @@ import org.optaplanner.core.api.domain.solution.cloner.SolutionCloner;
 import org.optaplanner.core.impl.domain.common.ReflectionHelper;
 import org.optaplanner.core.impl.domain.common.accessor.MemberAccessor;
 import org.optaplanner.core.impl.domain.solution.descriptor.SolutionDescriptor;
+import org.optaplanner.core.impl.domain.solution.util.ConcurrentCache;
 
 /**
  * @param <Solution_> the solution type, the class with the {@link PlanningSolution} annotation
@@ -60,10 +60,10 @@ public class FieldAccessingSolutionCloner<Solution_> implements SolutionCloner<S
 
     protected final SolutionDescriptor<Solution_> solutionDescriptor;
 
-    protected final ConcurrentMap<Class<?>, Constructor<?>> constructorCache = new ConcurrentHashMap<>();
-    protected final ConcurrentMap<Class<?>, List<Field>> fieldListCache = new ConcurrentHashMap<>();
-    protected final ConcurrentMap<Pair<Field, Class<?>>, Boolean> deepCloneDecisionFieldCache = new ConcurrentHashMap<>();
-    protected final ConcurrentMap<Class<?>, Boolean> deepCloneDecisionActualValueClassCache = new ConcurrentHashMap<>();
+    protected final ConcurrentMap<Class<?>, Constructor<?>> constructorCache = new ConcurrentCache<>();
+    protected final ConcurrentMap<Class<?>, List<Field>> fieldListCache = new ConcurrentCache<>();
+    protected final ConcurrentMap<Pair<Field, Class<?>>, Boolean> deepCloneDecisionFieldCache = new ConcurrentCache<>();
+    protected final ConcurrentMap<Class<?>, Boolean> deepCloneDecisionActualValueClassCache = new ConcurrentCache<>();
 
     public FieldAccessingSolutionCloner(SolutionDescriptor<Solution_> solutionDescriptor) {
         this.solutionDescriptor = solutionDescriptor;

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/solution/descriptor/SolutionDescriptor.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/solution/descriptor/SolutionDescriptor.java
@@ -34,10 +34,9 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
 
 import com.google.common.collect.Iterators;
+import java.util.concurrent.ConcurrentMap;
 import org.apache.commons.lang3.tuple.MutablePair;
 import org.apache.commons.lang3.tuple.Pair;
 import org.optaplanner.core.api.domain.autodiscover.AutoDiscoverMemberType;
@@ -75,6 +74,7 @@ import org.optaplanner.core.impl.domain.lookup.LookUpStrategyResolver;
 import org.optaplanner.core.impl.domain.policy.DescriptorPolicy;
 import org.optaplanner.core.impl.domain.solution.AbstractSolution;
 import org.optaplanner.core.impl.domain.solution.cloner.FieldAccessingSolutionCloner;
+import org.optaplanner.core.impl.domain.solution.util.ConcurrentCache;
 import org.optaplanner.core.impl.domain.variable.descriptor.GenuineVariableDescriptor;
 import org.optaplanner.core.impl.domain.variable.descriptor.ShadowVariableDescriptor;
 import org.optaplanner.core.impl.domain.variable.descriptor.VariableDescriptor;
@@ -161,7 +161,7 @@ public class SolutionDescriptor<Solution_> {
     private final Map<Class<?>, EntityDescriptor<Solution_>> entityDescriptorMap;
     private final List<Class<?>> reversedEntityClassList;
 
-    private final ConcurrentMap<Class<?>, EntityDescriptor<Solution_>> lowestEntityDescriptorCache = new ConcurrentHashMap<>();
+    private final ConcurrentMap<Class<?>, EntityDescriptor<Solution_>> lowestEntityDescriptorCache = new ConcurrentCache<>();
     private LookUpStrategyResolver lookUpStrategyResolver = null;
 
     // ************************************************************************

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/solution/util/ConcurrentCache.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/solution/util/ConcurrentCache.java
@@ -1,0 +1,31 @@
+package org.optaplanner.core.impl.domain.solution.util;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Function;
+
+/**
+ * Thread-safe basic cache implementation.
+ *
+ * @param <K> the type of keys for the cache
+ * @param <V> the type of values stored in the cache
+ * */
+public final class ConcurrentCache<K, V> extends ConcurrentHashMap<K, V> {
+
+    /**
+     * {@link ConcurrentHashMap#computeIfAbsent(Object, Function)} should not be used to directly retrieve cached values
+     * as it incorporates locking even when the value is present and doesn't have to be computed. Thus, the value is
+     * retrieved by {@link ConcurrentHashMap#get(Object)} and if and only if the value is null,
+     * {@link ConcurrentHashMap#computeIfAbsent(Object, Function)} is used to ensure thread-safety.
+     *
+     * {@inheritDoc}
+     * */
+    @Override
+    public V computeIfAbsent(K key, Function<? super K, ? extends V> mappingFunction) {
+        V value = get(key);
+        if (value == null) {
+            value = super.computeIfAbsent(key, mappingFunction);
+        }
+        return value;
+    }
+
+}


### PR DESCRIPTION
Running the most severely impacted benchmarks locally shows improvement by ~25 %. We need to run complete benchmarks to be sure this is the right fix, but all the evidence point to the `computeIfAbsent` method.