### PR TITLE
Preparation for multithreaded solving

### DIFF
--- a/optaplanner-core/src/build/revapi-config.json
+++ b/optaplanner-core/src/build/revapi-config.json
@@ -115,6 +115,31 @@
           "classSimpleName": "MemberAccessorType",
           "elementKind": "enum",
           "justification": "Internal utility enum moved to MemberAccessorFactory"
+        },
+        {
+          "code": "java.method.returnTypeTypeParametersChanged",
+          "old": "method java.lang.Class<? extends org.optaplanner.core.impl.localsearch.decider.forager.Forager> org.optaplanner.core.config.localsearch.decider.forager.LocalSearchForagerConfig::getForagerClass()",
+          "new": "method java.lang.Class<? extends org.optaplanner.core.impl.localsearch.decider.forager.LocalSearchForager> org.optaplanner.core.config.localsearch.decider.forager.LocalSearchForagerConfig::getForagerClass()",
+          "oldType": "java.lang.Class<? extends org.optaplanner.core.impl.localsearch.decider.forager.Forager>",
+          "newType": "java.lang.Class<? extends org.optaplanner.core.impl.localsearch.decider.forager.LocalSearchForager>",
+          "package": "org.optaplanner.core.config.localsearch.decider.forager",
+          "classSimpleName": "LocalSearchForagerConfig",
+          "methodName": "getForagerClass",
+          "elementKind": "method",
+          "justification": "Non-api class changed name. The exposure of this class in the API is now deprecated and will be removed in 8.0."
+        },
+        {
+          "code": "java.method.parameterTypeParameterChanged",
+          "old": "parameter void org.optaplanner.core.config.localsearch.decider.forager.LocalSearchForagerConfig::setForagerClass(===java.lang.Class<? extends org.optaplanner.core.impl.localsearch.decider.forager.Forager>===)",
+          "new": "parameter void org.optaplanner.core.config.localsearch.decider.forager.LocalSearchForagerConfig::setForagerClass(===java.lang.Class<? extends org.optaplanner.core.impl.localsearch.decider.forager.LocalSearchForager>===)",
+          "oldType": "java.lang.Class<? extends org.optaplanner.core.impl.localsearch.decider.forager.Forager>",
+          "newType": "java.lang.Class<? extends org.optaplanner.core.impl.localsearch.decider.forager.LocalSearchForager>",
+          "package": "org.optaplanner.core.config.localsearch.decider.forager",
+          "classSimpleName": "LocalSearchForagerConfig",
+          "methodName": "setForagerClass",
+          "parameterIndex": "0",
+          "elementKind": "parameter",
+          "justification": "Non-api class changed name. The exposure of this class in the API is now deprecated and will be removed in 8.0."
         }
       ]
     }

--- a/optaplanner-core/src/main/java/org/optaplanner/core/config/localsearch/LocalSearchPhaseConfig.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/config/localsearch/LocalSearchPhaseConfig.java
@@ -42,7 +42,7 @@ import org.optaplanner.core.impl.localsearch.DefaultLocalSearchPhase;
 import org.optaplanner.core.impl.localsearch.LocalSearchPhase;
 import org.optaplanner.core.impl.localsearch.decider.LocalSearchDecider;
 import org.optaplanner.core.impl.localsearch.decider.acceptor.Acceptor;
-import org.optaplanner.core.impl.localsearch.decider.forager.Forager;
+import org.optaplanner.core.impl.localsearch.decider.forager.LocalSearchForager;
 import org.optaplanner.core.impl.solver.recaller.BestSolutionRecaller;
 import org.optaplanner.core.impl.solver.termination.Termination;
 
@@ -127,7 +127,7 @@ public class LocalSearchPhaseConfig extends PhaseConfig<LocalSearchPhaseConfig> 
     private LocalSearchDecider buildDecider(HeuristicConfigPolicy configPolicy, Termination termination) {
         MoveSelector moveSelector = buildMoveSelector(configPolicy);
         Acceptor acceptor = buildAcceptor(configPolicy);
-        Forager forager = buildForager(configPolicy);
+        LocalSearchForager forager = buildForager(configPolicy);
         LocalSearchDecider decider = new LocalSearchDecider(configPolicy.getLogIndentation(),
                 termination, moveSelector, acceptor, forager);
         if (moveSelector.isNeverEnding() && !forager.supportsNeverEndingMoveSelector()) {
@@ -181,7 +181,7 @@ public class LocalSearchPhaseConfig extends PhaseConfig<LocalSearchPhaseConfig> 
         return acceptorConfig_.buildAcceptor(configPolicy);
     }
 
-    protected Forager buildForager(HeuristicConfigPolicy configPolicy) {
+    protected LocalSearchForager buildForager(HeuristicConfigPolicy configPolicy) {
         LocalSearchForagerConfig foragerConfig_;
         if (foragerConfig != null) {
             if (localSearchType != null) {

--- a/optaplanner-core/src/main/java/org/optaplanner/core/config/localsearch/decider/acceptor/AcceptorConfig.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/config/localsearch/decider/acceptor/AcceptorConfig.java
@@ -45,6 +45,7 @@ import static org.apache.commons.lang3.ObjectUtils.*;
 @XStreamAlias("acceptor")
 public class AcceptorConfig extends AbstractConfig<AcceptorConfig> {
 
+    @Deprecated // TODO remove in 8.0
     @XStreamImplicit(itemFieldName = "acceptorClass")
     private List<Class<? extends Acceptor>> acceptorClassList = null;
 
@@ -73,10 +74,12 @@ public class AcceptorConfig extends AbstractConfig<AcceptorConfig> {
     protected Integer stepCountingHillClimbingSize = null;
     protected StepCountingHillClimbingType stepCountingHillClimbingType = null;
 
+    @Deprecated
     public List<Class<? extends Acceptor>> getAcceptorClassList() {
         return acceptorClassList;
     }
 
+    @Deprecated
     public void setAcceptorClassList(List<Class<? extends Acceptor>> acceptorClassList) {
         this.acceptorClassList = acceptorClassList;
     }

--- a/optaplanner-core/src/main/java/org/optaplanner/core/config/localsearch/decider/forager/LocalSearchForagerConfig.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/config/localsearch/decider/forager/LocalSearchForagerConfig.java
@@ -97,7 +97,8 @@ public class LocalSearchForagerConfig extends AbstractConfig<LocalSearchForagerC
         FinalistPodiumType finalistPodiumType_ = defaultIfNull(finalistPodiumType, FinalistPodiumType.HIGHEST_SCORE);
         // Breaking ties randomly leads statistically to much better results
         boolean breakTieRandomly_  = defaultIfNull(breakTieRandomly, true);
-        return new AcceptedLocalSearchForager(finalistPodiumType_.buildFinalistPodium(), pickEarlyType_, acceptedCountLimit_, breakTieRandomly_);
+        return new AcceptedLocalSearchForager(finalistPodiumType_.buildFinalistPodium(), pickEarlyType_,
+                acceptedCountLimit_, breakTieRandomly_);
     }
 
     @Override

--- a/optaplanner-core/src/main/java/org/optaplanner/core/config/localsearch/decider/forager/LocalSearchForagerConfig.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/config/localsearch/decider/forager/LocalSearchForagerConfig.java
@@ -20,26 +20,29 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
 import org.optaplanner.core.config.AbstractConfig;
 import org.optaplanner.core.config.heuristic.policy.HeuristicConfigPolicy;
 import org.optaplanner.core.config.util.ConfigUtils;
-import org.optaplanner.core.impl.localsearch.decider.forager.AcceptedForager;
-import org.optaplanner.core.impl.localsearch.decider.forager.Forager;
+import org.optaplanner.core.impl.localsearch.decider.forager.AcceptedLocalSearchForager;
+import org.optaplanner.core.impl.localsearch.decider.forager.LocalSearchForager;
 
 import static org.apache.commons.lang3.ObjectUtils.*;
 
 @XStreamAlias("localSearchForagerConfig")
 public class LocalSearchForagerConfig extends AbstractConfig<LocalSearchForagerConfig> {
 
-    private Class<? extends Forager> foragerClass = null;
+    @Deprecated // TODO remove in 8.0
+    private Class<? extends LocalSearchForager> foragerClass = null;
 
     protected LocalSearchPickEarlyType pickEarlyType = null;
     protected Integer acceptedCountLimit = null;
     protected FinalistPodiumType finalistPodiumType = null;
     protected Boolean breakTieRandomly = null;
 
-    public Class<? extends Forager> getForagerClass() {
+    @Deprecated
+    public Class<? extends LocalSearchForager> getForagerClass() {
         return foragerClass;
     }
 
-    public void setForagerClass(Class<? extends Forager> foragerClass) {
+    @Deprecated
+    public void setForagerClass(Class<? extends LocalSearchForager> foragerClass) {
         this.foragerClass = foragerClass;
     }
 
@@ -79,7 +82,7 @@ public class LocalSearchForagerConfig extends AbstractConfig<LocalSearchForagerC
     // Builder methods
     // ************************************************************************
 
-    public Forager buildForager(HeuristicConfigPolicy configPolicy) {
+    public LocalSearchForager buildForager(HeuristicConfigPolicy configPolicy) {
         if (foragerClass != null) {
             if (pickEarlyType != null || acceptedCountLimit != null || finalistPodiumType != null) {
                 throw new IllegalArgumentException("The forager with foragerClass (" + foragerClass
@@ -94,7 +97,7 @@ public class LocalSearchForagerConfig extends AbstractConfig<LocalSearchForagerC
         FinalistPodiumType finalistPodiumType_ = defaultIfNull(finalistPodiumType, FinalistPodiumType.HIGHEST_SCORE);
         // Breaking ties randomly leads statistically to much better results
         boolean breakTieRandomly_  = defaultIfNull(breakTieRandomly, true);
-        return new AcceptedForager(finalistPodiumType_.buildFinalistPodium(), pickEarlyType_, acceptedCountLimit_, breakTieRandomly_);
+        return new AcceptedLocalSearchForager(finalistPodiumType_.buildFinalistPodium(), pickEarlyType_, acceptedCountLimit_, breakTieRandomly_);
     }
 
     @Override

--- a/optaplanner-core/src/main/java/org/optaplanner/core/config/partitionedsearch/PartitionedSearchPhaseConfig.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/config/partitionedsearch/PartitionedSearchPhaseConfig.java
@@ -104,8 +104,8 @@ public class PartitionedSearchPhaseConfig extends PhaseConfig<PartitionedSearchP
      * this results in a slower score calculation speed per partition {@link Solver}.
      * <p/>
      * Defaults to {@value #ACTIVE_THREAD_COUNT_AUTO} which consumes the majority
-     * but not all of the CPU cores on multi-core machines, preventing other processes (including your IDE or SSH connection)
-     * on the machine from hanging.
+     * but not all of the CPU cores on multi-core machines, to prevent a livelock that hangs other processes
+     * (such as your IDE, REST servlets threads or SSH connections) on the machine.
      * <p/>
      * Use {@value #ACTIVE_THREAD_COUNT_UNLIMITED} to give it all CPU cores.
      * This is useful if you're handling the CPU consumption on an OS level.

--- a/optaplanner-core/src/main/java/org/optaplanner/core/config/partitionedsearch/PartitionedSearchPhaseConfig.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/config/partitionedsearch/PartitionedSearchPhaseConfig.java
@@ -138,10 +138,8 @@ public class PartitionedSearchPhaseConfig extends PhaseConfig<PartitionedSearchP
         HeuristicConfigPolicy phaseConfigPolicy = solverConfigPolicy.createPhaseConfigPolicy();
         DefaultPartitionedSearchPhase phase = new DefaultPartitionedSearchPhase(
                 phaseIndex, solverConfigPolicy.getLogIndentation(), bestSolutionRecaller,
-                buildPhaseTermination(phaseConfigPolicy, solverTermination));
-        phase.setSolutionPartitioner(buildSolutionPartitioner());
-        phase.setThreadFactory(buildThreadFactory());
-        phase.setRunnablePartThreadLimit(resolvedActiveThreadCount());
+                buildPhaseTermination(phaseConfigPolicy, solverTermination),
+                buildSolutionPartitioner(), buildThreadFactory(), resolvedActiveThreadCount());
         List<PhaseConfig> phaseConfigList_ = phaseConfigList;
         if (ConfigUtils.isEmptyCollection(phaseConfigList_)) {
             phaseConfigList_ = Arrays.asList(

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/constructionheuristic/DefaultConstructionHeuristicPhase.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/constructionheuristic/DefaultConstructionHeuristicPhase.java
@@ -36,7 +36,7 @@ public class DefaultConstructionHeuristicPhase<Solution_> extends AbstractPhase<
         implements ConstructionHeuristicPhase<Solution_> {
 
     protected EntityPlacer entityPlacer;
-    protected ConstructionHeuristicDecider decider;
+    protected ConstructionHeuristicDecider<Solution_> decider;
 
     // TODO make this configurable or make it constant
     protected final boolean skipBestSolutionCloningInSteps = true;
@@ -50,7 +50,7 @@ public class DefaultConstructionHeuristicPhase<Solution_> extends AbstractPhase<
         this.entityPlacer = entityPlacer;
     }
 
-    public void setDecider(ConstructionHeuristicDecider decider) {
+    public void setDecider(ConstructionHeuristicDecider<Solution_> decider) {
         this.decider = decider;
     }
 
@@ -103,9 +103,10 @@ public class DefaultConstructionHeuristicPhase<Solution_> extends AbstractPhase<
     }
 
     private void doStep(ConstructionHeuristicStepScope<Solution_> stepScope) {
-        Move<Solution_> nextStep = stepScope.getStep();
-        nextStep.doMove(stepScope.getScoreDirector());
-        predictWorkingStepScore(stepScope, nextStep);
+        Move<Solution_> step = stepScope.getStep();
+        Move<Solution_> undoStep = step.doMove(stepScope.getScoreDirector());
+        stepScope.setUndoStep(undoStep);
+        predictWorkingStepScore(stepScope, step);
         if (!skipBestSolutionCloningInSteps) {
             // Causes a planning clone, which is expensive
             // For example, on cloud balancing 1200c-4800p this reduces performance by 18%

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/constructionheuristic/scope/ConstructionHeuristicMoveScope.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/constructionheuristic/scope/ConstructionHeuristicMoveScope.java
@@ -21,7 +21,7 @@ import java.util.Random;
 import org.optaplanner.core.api.domain.solution.PlanningSolution;
 import org.optaplanner.core.api.score.Score;
 import org.optaplanner.core.impl.heuristic.move.Move;
-import org.optaplanner.core.impl.score.director.ScoreDirector;
+import org.optaplanner.core.impl.score.director.InnerScoreDirector;
 
 /**
  * @param <Solution_> the solution type, the class with the {@link PlanningSolution} annotation
@@ -31,8 +31,7 @@ public class ConstructionHeuristicMoveScope<Solution_> {
     private final ConstructionHeuristicStepScope<Solution_> stepScope;
 
     private int moveIndex;
-    private Move move = null;
-    private Move undoMove = null;
+    private Move<Solution_> move = null;
     private Score score = null;
 
     public ConstructionHeuristicMoveScope(ConstructionHeuristicStepScope<Solution_> stepScope) {
@@ -51,20 +50,12 @@ public class ConstructionHeuristicMoveScope<Solution_> {
         this.moveIndex = moveIndex;
     }
 
-    public Move getMove() {
+    public Move<Solution_> getMove() {
         return move;
     }
 
-    public void setMove(Move move) {
+    public void setMove(Move<Solution_> move) {
         this.move = move;
-    }
-
-    public Move getUndoMove() {
-        return undoMove;
-    }
-
-    public void setUndoMove(Move undoMove) {
-        this.undoMove = undoMove;
     }
 
     public Score getScore() {
@@ -79,7 +70,7 @@ public class ConstructionHeuristicMoveScope<Solution_> {
     // Calculated methods
     // ************************************************************************
 
-    public ScoreDirector<Solution_> getScoreDirector() {
+    public InnerScoreDirector<Solution_> getScoreDirector() {
         return stepScope.getScoreDirector();
     }
 

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/constructionheuristic/scope/ConstructionHeuristicStepScope.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/constructionheuristic/scope/ConstructionHeuristicStepScope.java
@@ -28,9 +28,9 @@ public class ConstructionHeuristicStepScope<Solution_> extends AbstractStepScope
     private final ConstructionHeuristicPhaseScope<Solution_> phaseScope;
 
     private Object entity = null;
-    private Move step = null;
+    private Move<Solution_> step = null;
     private String stepString = null;
-    private Move undoStep = null;
+    private Move<Solution_> undoStep = null;
     private Long selectedMoveCount = null;
 
     public ConstructionHeuristicStepScope(ConstructionHeuristicPhaseScope<Solution_> phaseScope) {
@@ -55,11 +55,11 @@ public class ConstructionHeuristicStepScope<Solution_> extends AbstractStepScope
         this.entity = entity;
     }
 
-    public Move getStep() {
+    public Move<Solution_> getStep() {
         return step;
     }
 
-    public void setStep(Move step) {
+    public void setStep(Move<Solution_> step) {
         this.step = step;
     }
 
@@ -74,11 +74,11 @@ public class ConstructionHeuristicStepScope<Solution_> extends AbstractStepScope
         this.stepString = stepString;
     }
 
-    public Move getUndoStep() {
+    public Move<Solution_> getUndoStep() {
         return undoStep;
     }
 
-    public void setUndoStep(Move undoStep) {
+    public void setUndoStep(Move<Solution_> undoStep) {
         this.undoStep = undoStep;
     }
 

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/exhaustivesearch/decider/ExhaustiveSearchDecider.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/exhaustivesearch/decider/ExhaustiveSearchDecider.java
@@ -145,16 +145,16 @@ public class ExhaustiveSearchDecider<Solution_> implements ExhaustiveSearchPhase
 
     private void doMove(ExhaustiveSearchStepScope<Solution_> stepScope, ExhaustiveSearchNode moveNode) {
         InnerScoreDirector<Solution_> scoreDirector = stepScope.getScoreDirector();
+        // TODO reuse scoreDirector.doAndProcessMove() unless it's an expandableNode
         Move<Solution_> move = moveNode.getMove();
         Move<Solution_> undoMove = move.doMove(scoreDirector);
         moveNode.setUndoMove(undoMove);
         processMove(stepScope, moveNode);
         undoMove.doMove(scoreDirector);
         if (assertExpectedUndoMoveScore) {
-            ExhaustiveSearchPhaseScope phaseScope = stepScope.getPhaseScope();
             // In BRUTE_FORCE a stepScore can be null because it was not calculated
             if (stepScope.getStartingStepScore() != null) {
-                phaseScope.assertExpectedUndoMoveScore(move, undoMove, stepScope.getStartingStepScore());
+                scoreDirector.assertExpectedUndoMoveScore(move, stepScope.getStartingStepScore());
             }
         }
         logger.trace("{}        Move treeId ({}), score ({}), expandable ({}), move ({}).",

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/exhaustivesearch/node/ExhaustiveSearchNode.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/exhaustivesearch/node/ExhaustiveSearchNode.java
@@ -19,6 +19,7 @@ package org.optaplanner.core.impl.exhaustivesearch.node;
 import org.optaplanner.core.api.score.Score;
 import org.optaplanner.core.impl.exhaustivesearch.node.bounder.ScoreBounder;
 import org.optaplanner.core.impl.heuristic.move.Move;
+import org.optaplanner.core.impl.score.director.ScoreDirector;
 
 public class ExhaustiveSearchNode {
 

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/localsearch/DefaultLocalSearchPhase.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/localsearch/DefaultLocalSearchPhase.java
@@ -97,9 +97,10 @@ public class DefaultLocalSearchPhase<Solution_> extends AbstractPhase<Solution_>
     }
 
     protected void doStep(LocalSearchStepScope<Solution_> stepScope) {
-        Move<Solution_> nextStep = stepScope.getStep();
-        nextStep.doMove(stepScope.getScoreDirector());
-        predictWorkingStepScore(stepScope, nextStep);
+        Move<Solution_> step = stepScope.getStep();
+        Move<Solution_> undoStep = step.doMove(stepScope.getScoreDirector());
+        stepScope.setUndoStep(undoStep);
+        predictWorkingStepScore(stepScope, step);
         bestSolutionRecaller.processWorkingSolutionDuringStep(stepScope);
     }
 

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/localsearch/decider/LocalSearchDecider.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/localsearch/decider/LocalSearchDecider.java
@@ -17,16 +17,14 @@
 package org.optaplanner.core.impl.localsearch.decider;
 
 import org.optaplanner.core.api.domain.solution.PlanningSolution;
-import org.optaplanner.core.api.score.Score;
 import org.optaplanner.core.impl.heuristic.move.Move;
 import org.optaplanner.core.impl.heuristic.selector.move.MoveSelector;
 import org.optaplanner.core.impl.localsearch.decider.acceptor.Acceptor;
-import org.optaplanner.core.impl.localsearch.decider.forager.Forager;
+import org.optaplanner.core.impl.localsearch.decider.forager.LocalSearchForager;
 import org.optaplanner.core.impl.localsearch.scope.LocalSearchMoveScope;
 import org.optaplanner.core.impl.localsearch.scope.LocalSearchPhaseScope;
 import org.optaplanner.core.impl.localsearch.scope.LocalSearchStepScope;
 import org.optaplanner.core.impl.score.director.InnerScoreDirector;
-import org.optaplanner.core.impl.score.director.ScoreDirector;
 import org.optaplanner.core.impl.solver.scope.DefaultSolverScope;
 import org.optaplanner.core.impl.solver.termination.Termination;
 import org.slf4j.Logger;
@@ -43,13 +41,13 @@ public class LocalSearchDecider<Solution_> {
     protected final Termination termination;
     protected final MoveSelector moveSelector;
     protected final Acceptor acceptor;
-    protected final Forager forager;
+    protected final LocalSearchForager forager;
 
     protected boolean assertMoveScoreFromScratch = false;
     protected boolean assertExpectedUndoMoveScore = false;
 
     public LocalSearchDecider(String logIndentation,
-            Termination termination, MoveSelector moveSelector, Acceptor acceptor, Forager forager) {
+            Termination termination, MoveSelector moveSelector, Acceptor acceptor, LocalSearchForager forager) {
         this.logIndentation = logIndentation;
         this.termination = termination;
         this.moveSelector = moveSelector;
@@ -69,7 +67,7 @@ public class LocalSearchDecider<Solution_> {
         return acceptor;
     }
 
-    public Forager getForager() {
+    public LocalSearchForager getForager() {
         return forager;
     }
 
@@ -108,10 +106,8 @@ public class LocalSearchDecider<Solution_> {
         scoreDirector.setAllChangesWillBeUndoneBeforeStepEnds(true);
         int moveIndex = 0;
         for (Move<Solution_> move : moveSelector) {
-            LocalSearchMoveScope<Solution_> moveScope = new LocalSearchMoveScope<>(stepScope);
-            moveScope.setMoveIndex(moveIndex);
+            LocalSearchMoveScope<Solution_> moveScope = new LocalSearchMoveScope<>(stepScope, moveIndex, move);
             moveIndex++;
-            moveScope.setMove(move);
             // TODO use Selector filtering to filter out not doable moves
             if (!move.isMoveDoable(scoreDirector)) {
                 logger.trace("{}        Move index ({}) not doable, ignoring move ({}).",
@@ -128,28 +124,20 @@ public class LocalSearchDecider<Solution_> {
             }
         }
         scoreDirector.setAllChangesWillBeUndoneBeforeStepEnds(false);
-        LocalSearchMoveScope<Solution_> pickedMoveScope = forager.pickMove(stepScope);
-        if (pickedMoveScope != null) {
-            Move<Solution_> step = pickedMoveScope.getMove();
-            stepScope.setStep(step);
-            if (logger.isDebugEnabled()) {
-                stepScope.setStepString(step.toString());
-            }
-            stepScope.setUndoStep(pickedMoveScope.getUndoMove());
-            stepScope.setScore(pickedMoveScope.getScore());
-        }
+        pickMove(stepScope);
     }
 
-    private void doMove(LocalSearchMoveScope<Solution_> moveScope) {
-        ScoreDirector<Solution_> scoreDirector = moveScope.getScoreDirector();
-        Move<Solution_> move = moveScope.getMove();
-        Move<Solution_> undoMove = move.doMove(scoreDirector);
-        moveScope.setUndoMove(undoMove);
-        processMove(moveScope);
-        undoMove.doMove(scoreDirector);
+    protected void doMove(LocalSearchMoveScope<Solution_> moveScope) {
+        InnerScoreDirector<Solution_> scoreDirector = moveScope.getScoreDirector();
+        scoreDirector.doAndProcessMove(moveScope.getMove(), assertMoveScoreFromScratch, score -> {
+                    moveScope.setScore(score);
+                    boolean accepted = acceptor.isAccepted(moveScope);
+                    moveScope.setAccepted(accepted);
+                    forager.addMove(moveScope);
+                });
         if (assertExpectedUndoMoveScore) {
-            LocalSearchPhaseScope<Solution_> phaseScope = moveScope.getStepScope().getPhaseScope();
-            phaseScope.assertExpectedUndoMoveScore(move, undoMove, phaseScope.getLastCompletedStepScope().getScore());
+            scoreDirector.assertExpectedUndoMoveScore(moveScope.getMove(),
+                    moveScope.getStepScope().getPhaseScope().getLastCompletedStepScope().getScore());
         }
         logger.trace("{}        Move index ({}), score ({}), accepted ({}), move ({}).",
                 logIndentation,
@@ -157,15 +145,16 @@ public class LocalSearchDecider<Solution_> {
                 moveScope.getMove());
     }
 
-    private void processMove(LocalSearchMoveScope<Solution_> moveScope) {
-        Score score = moveScope.getStepScope().getPhaseScope().calculateScore();
-        if (assertMoveScoreFromScratch) {
-            moveScope.getStepScope().getPhaseScope().assertWorkingScoreFromScratch(score, moveScope.getMove());
+    protected void pickMove(LocalSearchStepScope<Solution_> stepScope) {
+        LocalSearchMoveScope<Solution_> pickedMoveScope = forager.pickMove(stepScope);
+        if (pickedMoveScope != null) {
+            Move<Solution_> step = pickedMoveScope.getMove();
+            stepScope.setStep(step);
+            if (logger.isDebugEnabled()) {
+                stepScope.setStepString(step.toString());
+            }
+            stepScope.setScore(pickedMoveScope.getScore());
         }
-        moveScope.setScore(score);
-        boolean accepted = acceptor.isAccepted(moveScope);
-        moveScope.setAccepted(accepted);
-        forager.addMove(moveScope);
     }
 
     public void stepEnded(LocalSearchStepScope<Solution_> stepScope) {

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/localsearch/decider/acceptor/Acceptor.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/localsearch/decider/acceptor/Acceptor.java
@@ -17,13 +17,13 @@
 package org.optaplanner.core.impl.localsearch.decider.acceptor;
 
 import org.optaplanner.core.impl.heuristic.move.Move;
-import org.optaplanner.core.impl.localsearch.decider.forager.Forager;
+import org.optaplanner.core.impl.localsearch.decider.forager.LocalSearchForager;
 import org.optaplanner.core.impl.localsearch.event.LocalSearchPhaseLifecycleListener;
 import org.optaplanner.core.impl.localsearch.scope.LocalSearchMoveScope;
 
 /**
  * An Acceptor accepts or rejects a selected {@link Move}.
- * Note that the {@link Forager} can still ignore the advice of the {@link Acceptor}.
+ * Note that the {@link LocalSearchForager} can still ignore the advice of the {@link Acceptor}.
  * @see AbstractAcceptor
  */
 public interface Acceptor extends LocalSearchPhaseLifecycleListener {

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/localsearch/decider/forager/AbstractLocalSearchForager.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/localsearch/decider/forager/AbstractLocalSearchForager.java
@@ -21,10 +21,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Abstract superclass for {@link Forager}.
- * @see Forager
+ * Abstract superclass for {@link LocalSearchForager}.
+ * @see LocalSearchForager
  */
-public abstract class AbstractForager extends LocalSearchPhaseLifecycleListenerAdapter implements Forager {
+public abstract class AbstractLocalSearchForager extends LocalSearchPhaseLifecycleListenerAdapter implements LocalSearchForager {
 
     protected final transient Logger logger = LoggerFactory.getLogger(getClass());
 

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/localsearch/decider/forager/AcceptedLocalSearchForager.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/localsearch/decider/forager/AcceptedLocalSearchForager.java
@@ -28,11 +28,11 @@ import org.optaplanner.core.impl.localsearch.scope.LocalSearchStepScope;
 import org.optaplanner.core.impl.solver.scope.DefaultSolverScope;
 
 /**
- * A {@link Forager} which forages accepted moves and ignores unaccepted moves.
- * @see Forager
+ * A {@link LocalSearchForager} which forages accepted moves and ignores unaccepted moves.
+ * @see LocalSearchForager
  * @see Acceptor
  */
-public class AcceptedForager extends AbstractForager {
+public class AcceptedLocalSearchForager extends AbstractLocalSearchForager {
 
     protected final FinalistPodium finalistPodium;
     protected final LocalSearchPickEarlyType pickEarlyType;
@@ -44,7 +44,7 @@ public class AcceptedForager extends AbstractForager {
 
     protected LocalSearchMoveScope earlyPickedMoveScope;
 
-    public AcceptedForager(FinalistPodium finalistPodium,
+    public AcceptedLocalSearchForager(FinalistPodium finalistPodium,
             LocalSearchPickEarlyType pickEarlyType, int acceptedCountLimit, boolean breakTieRandomly) {
         this.finalistPodium = finalistPodium;
         this.pickEarlyType = pickEarlyType;

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/localsearch/decider/forager/LocalSearchForager.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/localsearch/decider/forager/LocalSearchForager.java
@@ -23,10 +23,10 @@ import org.optaplanner.core.impl.localsearch.scope.LocalSearchMoveScope;
 import org.optaplanner.core.impl.localsearch.scope.LocalSearchStepScope;
 
 /**
- * A Forager collects the accepted moves and picks the next step from those for the {@link LocalSearchDecider}.
- * @see AbstractForager
+ * Collects the moves and picks the next step from those for the {@link LocalSearchDecider}.
+ * @see AbstractLocalSearchForager
  */
-public interface Forager extends LocalSearchPhaseLifecycleListener {
+public interface LocalSearchForager extends LocalSearchPhaseLifecycleListener {
 
     /**
      * @return true if it can be combined with a {@link MoveSelector#isNeverEnding()} that returns true.

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/localsearch/decider/forager/finalist/FinalistPodium.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/localsearch/decider/forager/finalist/FinalistPodium.java
@@ -18,7 +18,7 @@ package org.optaplanner.core.impl.localsearch.decider.forager.finalist;
 
 import java.util.List;
 
-import org.optaplanner.core.impl.localsearch.decider.forager.Forager;
+import org.optaplanner.core.impl.localsearch.decider.forager.LocalSearchForager;
 import org.optaplanner.core.impl.localsearch.event.LocalSearchPhaseLifecycleListener;
 import org.optaplanner.core.impl.localsearch.scope.LocalSearchMoveScope;
 
@@ -30,7 +30,7 @@ import org.optaplanner.core.impl.localsearch.scope.LocalSearchMoveScope;
 public interface FinalistPodium extends LocalSearchPhaseLifecycleListener {
 
     /**
-     * See {@link Forager#addMove(LocalSearchMoveScope)}.
+     * See {@link LocalSearchForager#addMove(LocalSearchMoveScope)}.
      * @param moveScope never null
      */
     void addMove(LocalSearchMoveScope moveScope);

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/phase/scope/AbstractPhaseScope.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/phase/scope/AbstractPhaseScope.java
@@ -171,7 +171,7 @@ public abstract class AbstractPhaseScope<Solution_> {
         solverScope.assertShadowVariablesAreNotStale(workingScore, completedAction);
     }
 
-    public void assertExpectedUndoMoveScore(Move move, Move undoMove, Score beforeMoveScore) {
+    public void assertExpectedUndoMoveScore(Move move, Score beforeMoveScore) {
         Score undoScore = calculateScore();
         if (!undoScore.equals(beforeMoveScore)) {
             logger.trace("        Corruption detected. Diagnosing...");

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/AbstractScoreDirector.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/AbstractScoreDirector.java
@@ -521,9 +521,9 @@ public abstract class AbstractScoreDirector<Solution_, Factory_ extends Abstract
             logger.trace("        Corruption detected. Diagnosing...");
             // TODO PLANNER-421 Avoid undoMove.toString() because it's stale (because the move is already done)
             String undoMoveString = "Undo(" + move + ")";
-            // Precondition: assert that are probably no corrupted score rules.
+            // Precondition: assert that there are probably no corrupted score rules
             assertWorkingScoreFromScratch(undoScore, undoMoveString);
-            // Precondition: assert that shadow variable after the undoMove aren't stale
+            // Precondition: assert that shadow variables aren't stale after doing the undoMove
             assertShadowVariablesAreNotStale(undoScore, undoMoveString);
             throw new IllegalStateException("UndoMove corruption: the beforeMoveScore (" + beforeMoveScore
                     + ") is not the undoScore (" + undoScore

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/InnerScoreDirector.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/InnerScoreDirector.java
@@ -17,6 +17,7 @@
 package org.optaplanner.core.impl.score.director;
 
 import java.util.List;
+import java.util.function.Consumer;
 
 import org.optaplanner.core.api.domain.solution.PlanningSolution;
 import org.optaplanner.core.api.score.Score;
@@ -24,6 +25,7 @@ import org.optaplanner.core.api.score.constraint.ConstraintMatch;
 import org.optaplanner.core.impl.domain.solution.descriptor.SolutionDescriptor;
 import org.optaplanner.core.impl.domain.variable.listener.VariableListener;
 import org.optaplanner.core.impl.domain.variable.supply.SupplyManager;
+import org.optaplanner.core.impl.heuristic.move.Move;
 import org.optaplanner.core.impl.score.definition.ScoreDefinition;
 import org.optaplanner.core.impl.solver.ChildThreadType;
 
@@ -42,6 +44,13 @@ public interface InnerScoreDirector<Solution_> extends ScoreDirector<Solution_> 
      * @return used to check {@link #isWorkingEntityListDirty(long)} later on
      */
     long getWorkingEntityListRevision();
+
+    /**
+     * @param move never null
+     * @param assertMoveScoreFromScratch true will hurt performance
+     * @param moveProcessor never null, use this to store the score as well as call the acceptor and forager
+     */
+    void doAndProcessMove(Move<Solution_> move, boolean assertMoveScoreFromScratch, Consumer<Score> moveProcessor);
 
     /**
      * @param expectedWorkingEntityListRevision an
@@ -162,5 +171,16 @@ public interface InnerScoreDirector<Solution_> extends ScoreDirector<Solution_> 
      * @see InnerScoreDirectorFactory#assertScoreFromScratch
      */
     void assertWorkingScoreFromScratch(Score workingScore, Object completedAction);
+
+    /**
+     * Asserts that if the {@link Score} is calculated for the current {@link PlanningSolution working solution}
+     * in a the current {@link ScoreDirector} (with incremental calculation residue),
+     * it is equal to the parameter {@link Score beforeMoveScore}.
+     * <p>
+     * Furthermore, if the assert fails, a score corruption analysis might be included in the exception message.
+     * @param move never null
+     * @param beforeMoveScore never null
+     */
+    void assertExpectedUndoMoveScore(Move move, Score beforeMoveScore);
 
 }

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/InnerScoreDirector.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/InnerScoreDirector.java
@@ -174,7 +174,7 @@ public interface InnerScoreDirector<Solution_> extends ScoreDirector<Solution_> 
 
     /**
      * Asserts that if the {@link Score} is calculated for the current {@link PlanningSolution working solution}
-     * in a the current {@link ScoreDirector} (with incremental calculation residue),
+     * in the current {@link ScoreDirector} (with incremental calculation residue),
      * it is equal to the parameter {@link Score beforeMoveScore}.
      * <p>
      * Furthermore, if the assert fails, a score corruption analysis might be included in the exception message.

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/localsearch/decider/acceptor/AbstractAcceptorTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/localsearch/decider/acceptor/AbstractAcceptorTest.java
@@ -27,9 +27,8 @@ public abstract class AbstractAcceptorTest {
 
     protected <Solution_> LocalSearchMoveScope<Solution_> buildMoveScope(
             LocalSearchStepScope<Solution_> stepScope, int score) {
-        LocalSearchMoveScope<Solution_> moveScope = new LocalSearchMoveScope<>(stepScope);
         Move<Solution_> move = mock(Move.class);
-        moveScope.setMove(move);
+        LocalSearchMoveScope<Solution_> moveScope = new LocalSearchMoveScope<>(stepScope, 0, move);
         moveScope.setScore(SimpleScore.valueOf(score));
         return moveScope;
     }

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/localsearch/decider/acceptor/tabu/EntityTabuAcceptorTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/localsearch/decider/acceptor/tabu/EntityTabuAcceptorTest.java
@@ -255,10 +255,9 @@ public class EntityTabuAcceptorTest {
 
     private <Solution_> LocalSearchMoveScope<Solution_> buildMoveScope(
             LocalSearchStepScope<Solution_> stepScope, int score, TestdataEntity... entities) {
-        LocalSearchMoveScope<Solution_> moveScope = new LocalSearchMoveScope<>(stepScope);
         Move move = mock(Move.class);
         when(move.getPlanningEntities()).thenReturn((Collection) Arrays.asList(entities));
-        moveScope.setMove(move);
+        LocalSearchMoveScope<Solution_> moveScope = new LocalSearchMoveScope<>(stepScope, 0, move);
         moveScope.setScore(SimpleScore.valueOf(score));
         return moveScope;
     }

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/localsearch/decider/acceptor/tabu/ValueTabuAcceptorTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/localsearch/decider/acceptor/tabu/ValueTabuAcceptorTest.java
@@ -255,10 +255,9 @@ public class ValueTabuAcceptorTest {
 
     private <Solution_> LocalSearchMoveScope<Solution_> buildMoveScope(
             LocalSearchStepScope<Solution_> stepScope, int score, TestdataValue... values) {
-        LocalSearchMoveScope<Solution_> moveScope = new LocalSearchMoveScope<>(stepScope);
         Move move = mock(Move.class);
         when(move.getPlanningValues()).thenReturn((Collection) Arrays.asList(values));
-        moveScope.setMove(move);
+        LocalSearchMoveScope<Solution_> moveScope = new LocalSearchMoveScope<>(stepScope, 0, move);
         moveScope.setScore(SimpleScore.valueOf(score));
         return moveScope;
     }

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/localsearch/decider/forager/AcceptedLocalSearchForagerTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/localsearch/decider/forager/AcceptedLocalSearchForagerTest.java
@@ -35,12 +35,12 @@ import org.optaplanner.core.impl.testdata.domain.TestdataSolution;
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
-public class AcceptedForagerTest {
+public class AcceptedLocalSearchForagerTest {
 
     @Test
     public void pickMoveMaxScoreAccepted() {
         // Setup
-        Forager forager = new AcceptedForager(new HighestScoreFinalistPodium(),
+        LocalSearchForager forager = new AcceptedLocalSearchForager(new HighestScoreFinalistPodium(),
                 LocalSearchPickEarlyType.NEVER, Integer.MAX_VALUE, true);
         LocalSearchPhaseScope<TestdataSolution> phaseScope = createPhaseScope();
         forager.phaseStarted(phaseScope);
@@ -72,7 +72,7 @@ public class AcceptedForagerTest {
     @Test
     public void pickMoveMaxScoreUnaccepted() {
         // Setup
-        Forager forager = new AcceptedForager(new HighestScoreFinalistPodium(),
+        LocalSearchForager forager = new AcceptedLocalSearchForager(new HighestScoreFinalistPodium(),
                 LocalSearchPickEarlyType.NEVER, Integer.MAX_VALUE, true);
         LocalSearchPhaseScope<TestdataSolution> phaseScope = createPhaseScope();
         forager.phaseStarted(phaseScope);
@@ -104,7 +104,7 @@ public class AcceptedForagerTest {
     @Test
     public void pickMoveFirstBestScoreImproving() {
         // Setup
-        Forager forager = new AcceptedForager(new HighestScoreFinalistPodium(),
+        LocalSearchForager forager = new AcceptedLocalSearchForager(new HighestScoreFinalistPodium(),
                 LocalSearchPickEarlyType.FIRST_BEST_SCORE_IMPROVING, Integer.MAX_VALUE, true);
         LocalSearchPhaseScope<TestdataSolution> phaseScope = createPhaseScope();
         forager.phaseStarted(phaseScope);
@@ -133,7 +133,7 @@ public class AcceptedForagerTest {
     @Test
     public void pickMoveFirstLastStepScoreImproving() {
         // Setup
-        Forager forager = new AcceptedForager(new HighestScoreFinalistPodium(),
+        LocalSearchForager forager = new AcceptedLocalSearchForager(new HighestScoreFinalistPodium(),
                 LocalSearchPickEarlyType.FIRST_LAST_STEP_SCORE_IMPROVING, Integer.MAX_VALUE, true);
         LocalSearchPhaseScope<TestdataSolution> phaseScope = createPhaseScope();
         forager.phaseStarted(phaseScope);
@@ -162,7 +162,7 @@ public class AcceptedForagerTest {
     @Test
     public void pickMoveAcceptedBreakTieRandomly() {
         // Setup
-        Forager forager = new AcceptedForager(new HighestScoreFinalistPodium(),
+        LocalSearchForager forager = new AcceptedLocalSearchForager(new HighestScoreFinalistPodium(),
                 LocalSearchPickEarlyType.NEVER, 4, true);
         LocalSearchPhaseScope<TestdataSolution> phaseScope = createPhaseScope();
         forager.phaseStarted(phaseScope);
@@ -194,7 +194,7 @@ public class AcceptedForagerTest {
     @Test
     public void pickMoveAcceptedBreakTieFirst() {
         // Setup
-        Forager forager = new AcceptedForager(new HighestScoreFinalistPodium(),
+        LocalSearchForager forager = new AcceptedLocalSearchForager(new HighestScoreFinalistPodium(),
                 LocalSearchPickEarlyType.NEVER, 4, false);
         LocalSearchPhaseScope<TestdataSolution> phaseScope = createPhaseScope();
         forager.phaseStarted(phaseScope);
@@ -242,8 +242,7 @@ public class AcceptedForagerTest {
 
     public LocalSearchMoveScope<TestdataSolution> createMoveScope(LocalSearchStepScope<TestdataSolution> stepScope,
             Score score, boolean accepted) {
-        LocalSearchMoveScope<TestdataSolution> moveScope = new LocalSearchMoveScope<>(stepScope);
-        moveScope.setMove(new DummyMove());
+        LocalSearchMoveScope<TestdataSolution> moveScope = new LocalSearchMoveScope<>(stepScope, 0, new DummyMove());
         moveScope.setScore(score);
         moveScope.setAccepted(accepted);
         return moveScope;

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/localsearch/decider/forager/finalist/StrategicOscillationByLevelFinalistPodiumTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/localsearch/decider/forager/finalist/StrategicOscillationByLevelFinalistPodiumTest.java
@@ -143,11 +143,10 @@ public class StrategicOscillationByLevelFinalistPodiumTest {
 
     protected <Solution_> LocalSearchMoveScope<Solution_> buildMoveScope(
             LocalSearchStepScope<Solution_> stepScope, int hardScore, int softScore) {
-        LocalSearchMoveScope<Solution_> moveScope = new LocalSearchMoveScope<>(stepScope);
         Move<Solution_> move = mock(Move.class);
-        moveScope.setAccepted(true);
-        moveScope.setMove(move);
+        LocalSearchMoveScope<Solution_> moveScope = new LocalSearchMoveScope<>(stepScope, 0, move);
         moveScope.setScore(HardSoftScore.valueOf(hardScore, softScore));
+        moveScope.setAccepted(true);
         return moveScope;
     }
 
@@ -206,11 +205,10 @@ public class StrategicOscillationByLevelFinalistPodiumTest {
 
     protected <Solution_> LocalSearchMoveScope<Solution_> buildMoveScope(
             LocalSearchStepScope<Solution_> stepScope, int hardScore, int mediumScore, int softScore) {
-        LocalSearchMoveScope<Solution_> moveScope = new LocalSearchMoveScope<>(stepScope);
         Move<Solution_> move = mock(Move.class);
-        moveScope.setAccepted(true);
-        moveScope.setMove(move);
+        LocalSearchMoveScope<Solution_> moveScope = new LocalSearchMoveScope<>(stepScope, 0, move);
         moveScope.setScore(HardMediumSoftScore.valueOf(hardScore, mediumScore, softScore));
+        moveScope.setAccepted(true);
         return moveScope;
     }
 


### PR DESCRIPTION
- Renamed Forager to LocalSearchForager
- extracted duplicated code into InnerScoreDirector.doAndProcessMove(), so multithreaded solving can reuse it too
- removed undoMove tracking (so we don't need to rebase undoMoves too in multithreaded solving)