### PR TITLE
PLANNER-1089 Use a java.util.Supplier instead of a Class for ScoreDirectorFactoryConfig

### DIFF
--- a/optaplanner-core/src/main/java/org/optaplanner/core/config/score/director/ScoreDirectorFactoryConfig.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/config/score/director/ScoreDirectorFactoryConfig.java
@@ -108,7 +108,7 @@ public class ScoreDirectorFactoryConfig extends AbstractConfig<ScoreDirectorFact
     protected ScoreDirectorFactoryConfig assertionScoreDirectorFactory = null;
 
     protected Boolean generateDroolsTestOnError = null;
-    protected Supplier<? extends EasyScoreCalculator> easyScoreCalculatorSupplier;
+    protected Supplier<? extends EasyScoreCalculator> easyScoreCalculatorSupplier = null;
 
     /**
      * @return sometimes null

--- a/optaplanner-core/src/main/java/org/optaplanner/core/config/score/director/ScoreDirectorFactoryConfig.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/config/score/director/ScoreDirectorFactoryConfig.java
@@ -87,6 +87,8 @@ public class ScoreDirectorFactoryConfig extends AbstractConfig<ScoreDirectorFact
     @Deprecated protected Integer bendableSoftLevelsSize = null;
 
     protected Class<? extends EasyScoreCalculator> easyScoreCalculatorClass = null;
+    @XStreamConverter(KeyAsElementMapConverter.class)
+    protected Map<String, String> easyScoreCalculatorCustomProperties = null;
 
     protected Class<? extends IncrementalScoreCalculator> incrementalScoreCalculatorClass = null;
 
@@ -417,6 +419,8 @@ public class ScoreDirectorFactoryConfig extends AbstractConfig<ScoreDirectorFact
     protected <Solution_> AbstractScoreDirectorFactory<Solution_> buildEasyScoreDirectorFactory() {
         if (getEasyScoreCalculatorSupplier() != null) {
             final EasyScoreCalculator easyScoreCalculator = getEasyScoreCalculatorSupplier().get();
+            ConfigUtils.applyCustomProperties(easyScoreCalculator, "easyScoreCalculatorClass",
+                easyScoreCalculatorCustomProperties);
             return new EasyScoreDirectorFactory<>(easyScoreCalculator);
         } else {
             return null;

--- a/optaplanner-core/src/main/java/org/optaplanner/core/config/score/director/ScoreDirectorFactoryConfig.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/config/score/director/ScoreDirectorFactoryConfig.java
@@ -86,7 +86,7 @@ public class ScoreDirectorFactoryConfig extends AbstractConfig<ScoreDirectorFact
     @Deprecated protected Integer bendableHardLevelsSize = null;
     @Deprecated protected Integer bendableSoftLevelsSize = null;
 
-    @Deprecated protected Class<? extends EasyScoreCalculator> easyScoreCalculatorClass = null;
+    protected Class<? extends EasyScoreCalculator> easyScoreCalculatorClass = null;
 
     protected Class<? extends IncrementalScoreCalculator> incrementalScoreCalculatorClass = null;
 
@@ -173,7 +173,7 @@ public class ScoreDirectorFactoryConfig extends AbstractConfig<ScoreDirectorFact
     }
 
     public Class<? extends EasyScoreCalculator> getEasyScoreCalculatorClass() {
-        return getEasyScoreCalculatorSupplier().get().getClass();
+        return easyScoreCalculatorClass;
     }
 
     public Supplier<? extends EasyScoreCalculator> getEasyScoreCalculatorSupplier() {
@@ -183,10 +183,6 @@ public class ScoreDirectorFactoryConfig extends AbstractConfig<ScoreDirectorFact
         return easyScoreCalculatorSupplier;
     }
 
-    /**
-     * @deprecated Use {@link #setEasyScoreCalculatorSupplier(Supplier)} instead
-     */
-    @Deprecated
     public void setEasyScoreCalculatorClass(Class<? extends EasyScoreCalculator> easyScoreCalculatorClass) {
         if (easyScoreCalculatorClass == null) {
             this.easyScoreCalculatorSupplier = null;
@@ -568,8 +564,10 @@ public class ScoreDirectorFactoryConfig extends AbstractConfig<ScoreDirectorFact
             bendableHardLevelsSize = inheritedConfig.getBendableHardLevelsSize();
             bendableSoftLevelsSize = inheritedConfig.getBendableSoftLevelsSize();
         }
+        easyScoreCalculatorClass = ConfigUtils.inheritOverwritableProperty(
+                easyScoreCalculatorClass, inheritedConfig.getEasyScoreCalculatorClass());
         easyScoreCalculatorSupplier = ConfigUtils.inheritOverwritableProperty(
-                 getEasyScoreCalculatorSupplier(), inheritedConfig.getEasyScoreCalculatorSupplier());
+                easyScoreCalculatorSupplier, inheritedConfig.getEasyScoreCalculatorSupplier());
         incrementalScoreCalculatorClass = ConfigUtils.inheritOverwritableProperty(
                 incrementalScoreCalculatorClass, inheritedConfig.getIncrementalScoreCalculatorClass());
         ksessionName = ConfigUtils.inheritOverwritableProperty(

--- a/optaplanner-docs/src/main/asciidoc/ScoreCalculation/ScoreCalculation-chapter.adoc
+++ b/optaplanner-docs/src/main/asciidoc/ScoreCalculation/ScoreCalculation-chapter.adoc
@@ -492,13 +492,34 @@ Configure it in your solver configuration:
   </scoreDirectorFactory>
 ----
 
-Alternatively, build a `EasyScoreCalculator` instance at runtime and set it with the programmatic API:
+Alternatively, describe a way to construct an `EasyScoreCalculator` instance at runtime and set it with the programmatic API:
 
 [source,java,options="nowrap"]
 ----
-    solverFactory.getSolverConfig().getScoreDirectorFactoryConfig().setEasyScoreCalculator(easyScoreCalculator);
+    Supplier<EasyScoreCalculator> easyScoreCalculatorSupplier = () -> new MyEasyScoreCalculator(1, 2);
+    solverFactory.getSolverConfig().getScoreDirectorFactoryConfig().setEasyScoreCalculatorSupplier(easyScoreCalculatorSupplier);
 ----
 
+An additional way to configure parameters of an `EasyScoreCalculator` dynamically is to add a `customProperties` element:
+
+[source,xml,options="nowrap"]
+----
+  <scoreDirectorFactory>
+    <easyScoreCalculatorClass>com.example.Example</easyScoreCalculatorClass>
+    <easyScoreCalculatorCustomProperties>
+      <myCustomParam>5</myCustomParam>
+    </easyScoreCalculatorCustomProperties>
+  </scoreDirectorFactory>
+----
+
+The setter for the parameter must be public. For instance, for the above example, the corresponding `EasyScoreCalculator` should have a method
+
+[source,java,options="nowrap"]
+----
+    public void setMyCustomParam(int paramValue) {
+        this.myCustomParam = paramValue;
+    }
+----
 
 [[incrementalJavaScoreCalculation]]
 === Incremental Java Score Calculation


### PR DESCRIPTION
A `Class` was used since it allowed instantiating multiple instances of
the `ScoreCalculator` to supply to calculating threads, etc.

Using a `Supplier` instead allows building `EasyScoreCalculator`s at
run-time while retaining the desired ability to instantiate multiple
`EasyScoreCalculator`s. This permits varying parameters in the same
process in a simple fashion.

For example:

```
scoreDirectorFactoryConfig.setEasyScoreCalculatorSupplier(
  () -> new ScoreCalculator(4.3, 2.1)
);
```

See: https://stackoverflow.com/a/49748882/3858681