### PR TITLE
docs: fix typo JAXB -> Jackson

### DIFF
--- a/optaplanner-docs/src/main/asciidoc/Integration/Integration-chapter.adoc
+++ b/optaplanner-docs/src/main/asciidoc/Integration/Integration-chapter.adoc
@@ -336,7 +336,7 @@ objectMapper.registerModule(OptaPlannerJacksonModule.createModule());
 
 
 [[jacksonMarshallingAScore]]
-==== JAXB: Marshalling a `Score`
+==== Jackson: Marshalling a `Score`
 
 When a `Score` is marshalled to/from JSON by the default Jackson configuration, it fails.
 The `OptaPlannerJacksonModule` fixes that, by using `HardSoftScoreJacksonJsonSerializer`,


### PR DESCRIPTION
I just stumbled upon the Header "16.2.4.1. JAXB: Marshalling a Score" which is a subheader of "16.2.4. JSON: Jackson" and think, it might be a typo.