### PR TITLE
PLANNER-1170 Remove unnecessary hibernate properties

### DIFF
--- a/optaplanner-persistence/optaplanner-persistence-jpa/src/test/filtered-resources/META-INF/persistence.xml
+++ b/optaplanner-persistence/optaplanner-persistence-jpa/src/test/filtered-resources/META-INF/persistence.xml
@@ -30,11 +30,6 @@
       <property name="hibernate.dialect" value="${maven.hibernate.dialect}"/>
       <property name="hibernate.default_schema" value="${maven.jdbc.schema}"/>
 
-      <property name="hibernate.connection.driver_class" value="${maven.jdbc.driver.class}" />
-      <property name="hibernate.connection.url" value="${maven.jdbc.url}" />
-      <property name="hibernate.connection.username" value="${maven.jdbc.username}" />
-      <property name="hibernate.connection.password" value="${maven.jdbc.password}" />
-
       <!-- The following line is what's used in Hibernate 4 instead of a TransactionManagerLookup class -->
       <property name="hibernate.transaction.jta.platform" value="org.hibernate.service.jta.platform.internal.JBossStandAloneJtaPlatform" />
     </properties>


### PR DESCRIPTION
Relates to Narayana+DBCP integration, OptaPlanner persistence tests depend on changes introduced by https://github.com/kiegroup/drools/pull/1939.

