### PR TITLE
Make performance tests parameterized by moveThreadCount

### DIFF
--- a/optaplanner-examples/src/test/java/org/optaplanner/examples/cheaptime/app/CheapTimePerformanceTest.java
+++ b/optaplanner-examples/src/test/java/org/optaplanner/examples/cheaptime/app/CheapTimePerformanceTest.java
@@ -26,6 +26,10 @@ import org.optaplanner.examples.common.app.SolverPerformanceTest;
 
 public class CheapTimePerformanceTest extends SolverPerformanceTest<CheapTimeSolution> {
 
+    public CheapTimePerformanceTest(String moveThreadCount) {
+        super(moveThreadCount);
+    }
+
     @Override
     protected CheapTimeApp createCommonApp() {
         return new CheapTimeApp();

--- a/optaplanner-examples/src/test/java/org/optaplanner/examples/cloudbalancing/app/CloudBalancingPerformanceTest.java
+++ b/optaplanner-examples/src/test/java/org/optaplanner/examples/cloudbalancing/app/CloudBalancingPerformanceTest.java
@@ -25,6 +25,10 @@ import org.optaplanner.examples.common.app.SolverPerformanceTest;
 
 public class CloudBalancingPerformanceTest extends SolverPerformanceTest<CloudBalance> {
 
+    public CloudBalancingPerformanceTest(String moveThreadCount) {
+        super(moveThreadCount);
+    }
+
     @Override
     protected CloudBalancingApp createCommonApp() {
         return new CloudBalancingApp();

--- a/optaplanner-examples/src/test/java/org/optaplanner/examples/coachshuttlegathering/app/CoachShuttleGatheringPerformanceTest.java
+++ b/optaplanner-examples/src/test/java/org/optaplanner/examples/coachshuttlegathering/app/CoachShuttleGatheringPerformanceTest.java
@@ -25,6 +25,10 @@ import org.optaplanner.examples.common.app.SolverPerformanceTest;
 
 public class CoachShuttleGatheringPerformanceTest extends SolverPerformanceTest<CoachShuttleGatheringSolution> {
 
+    public CoachShuttleGatheringPerformanceTest(String moveThreadCount) {
+        super(moveThreadCount);
+    }
+
     @Override
     protected CoachShuttleGatheringApp createCommonApp() {
         return new CoachShuttleGatheringApp();

--- a/optaplanner-examples/src/test/java/org/optaplanner/examples/common/TestSystemProperties.java
+++ b/optaplanner-examples/src/test/java/org/optaplanner/examples/common/TestSystemProperties.java
@@ -18,6 +18,8 @@ package org.optaplanner.examples.common;
 
 public final class TestSystemProperties {
 
+    public static final String MOVE_THREAD_COUNTS = "moveThreadCounts";
+
     public static final String RUN_TURTLE_TESTS = "runTurtleTests";
     public static final String MOVE_THREAD_COUNT = "moveThreadCount";
 

--- a/optaplanner-examples/src/test/java/org/optaplanner/examples/conferencescheduling/app/ConferenceSchedulingPerformanceTest.java
+++ b/optaplanner-examples/src/test/java/org/optaplanner/examples/conferencescheduling/app/ConferenceSchedulingPerformanceTest.java
@@ -25,6 +25,10 @@ import org.optaplanner.examples.conferencescheduling.domain.ConferenceSolution;
 
 public class ConferenceSchedulingPerformanceTest extends SolverPerformanceTest<ConferenceSolution> {
 
+    public ConferenceSchedulingPerformanceTest(String moveThreadCount) {
+        super(moveThreadCount);
+    }
+
     @Override
     protected ConferenceSchedulingApp createCommonApp() {
         return new ConferenceSchedulingApp();

--- a/optaplanner-examples/src/test/java/org/optaplanner/examples/curriculumcourse/app/CurriculumCoursePerformanceTest.java
+++ b/optaplanner-examples/src/test/java/org/optaplanner/examples/curriculumcourse/app/CurriculumCoursePerformanceTest.java
@@ -25,6 +25,10 @@ import org.optaplanner.examples.curriculumcourse.domain.CourseSchedule;
 
 public class CurriculumCoursePerformanceTest extends SolverPerformanceTest<CourseSchedule> {
 
+    public CurriculumCoursePerformanceTest(String moveThreadCount) {
+        super(moveThreadCount);
+    }
+
     @Override
     protected CurriculumCourseApp createCommonApp() {
         return new CurriculumCourseApp();

--- a/optaplanner-examples/src/test/java/org/optaplanner/examples/dinnerparty/app/DinnerPartyPerformanceTest.java
+++ b/optaplanner-examples/src/test/java/org/optaplanner/examples/dinnerparty/app/DinnerPartyPerformanceTest.java
@@ -25,6 +25,10 @@ import org.optaplanner.examples.dinnerparty.domain.DinnerParty;
 
 public class DinnerPartyPerformanceTest extends SolverPerformanceTest<DinnerParty> {
 
+    public DinnerPartyPerformanceTest(String moveThreadCount) {
+        super(moveThreadCount);
+    }
+
     @Override
     protected DinnerPartyApp createCommonApp() {
         return new DinnerPartyApp();

--- a/optaplanner-examples/src/test/java/org/optaplanner/examples/examination/app/ExaminationPerformanceTest.java
+++ b/optaplanner-examples/src/test/java/org/optaplanner/examples/examination/app/ExaminationPerformanceTest.java
@@ -25,6 +25,10 @@ import org.optaplanner.examples.examination.domain.Examination;
 
 public class ExaminationPerformanceTest extends SolverPerformanceTest<Examination> {
 
+    public ExaminationPerformanceTest(String moveThreadCount) {
+        super(moveThreadCount);
+    }
+
     @Override
     protected ExaminationApp createCommonApp() {
         return new ExaminationApp();

--- a/optaplanner-examples/src/test/java/org/optaplanner/examples/investment/app/InvestmentPerformanceTest.java
+++ b/optaplanner-examples/src/test/java/org/optaplanner/examples/investment/app/InvestmentPerformanceTest.java
@@ -25,6 +25,10 @@ import org.optaplanner.examples.investment.domain.InvestmentSolution;
 
 public class InvestmentPerformanceTest extends SolverPerformanceTest<InvestmentSolution> {
 
+    public InvestmentPerformanceTest(String moveThreadCount) {
+        super(moveThreadCount);
+    }
+
     @Override
     protected InvestmentApp createCommonApp() {
         return new InvestmentApp();

--- a/optaplanner-examples/src/test/java/org/optaplanner/examples/machinereassignment/app/MachineReassignmentPerformanceTest.java
+++ b/optaplanner-examples/src/test/java/org/optaplanner/examples/machinereassignment/app/MachineReassignmentPerformanceTest.java
@@ -25,6 +25,10 @@ import org.optaplanner.examples.machinereassignment.domain.MachineReassignment;
 
 public class MachineReassignmentPerformanceTest extends SolverPerformanceTest<MachineReassignment> {
 
+    public MachineReassignmentPerformanceTest(String moveThreadCount) {
+        super(moveThreadCount);
+    }
+
     @Override
     protected MachineReassignmentApp createCommonApp() {
         return new MachineReassignmentApp();

--- a/optaplanner-examples/src/test/java/org/optaplanner/examples/meetingscheduling/app/MeetingSchedulingPerformanceTest.java
+++ b/optaplanner-examples/src/test/java/org/optaplanner/examples/meetingscheduling/app/MeetingSchedulingPerformanceTest.java
@@ -25,6 +25,10 @@ import org.optaplanner.examples.meetingscheduling.domain.MeetingSchedule;
 
 public class MeetingSchedulingPerformanceTest extends SolverPerformanceTest<MeetingSchedule> {
 
+    public MeetingSchedulingPerformanceTest(String moveThreadCount) {
+        super(moveThreadCount);
+    }
+
     @Override
     protected MeetingSchedulingApp createCommonApp() {
         return new MeetingSchedulingApp();

--- a/optaplanner-examples/src/test/java/org/optaplanner/examples/nqueens/app/NQueensPerformanceTest.java
+++ b/optaplanner-examples/src/test/java/org/optaplanner/examples/nqueens/app/NQueensPerformanceTest.java
@@ -25,6 +25,10 @@ import org.optaplanner.examples.nqueens.domain.NQueens;
 
 public class NQueensPerformanceTest extends SolverPerformanceTest<NQueens> {
 
+    public NQueensPerformanceTest(String moveThreadCount) {
+        super(moveThreadCount);
+    }
+
     @Override
     protected NQueensApp createCommonApp() {
         return new NQueensApp();

--- a/optaplanner-examples/src/test/java/org/optaplanner/examples/nurserostering/app/NurseRosteringPerformanceTest.java
+++ b/optaplanner-examples/src/test/java/org/optaplanner/examples/nurserostering/app/NurseRosteringPerformanceTest.java
@@ -25,6 +25,10 @@ import org.optaplanner.examples.nurserostering.domain.NurseRoster;
 
 public class NurseRosteringPerformanceTest extends SolverPerformanceTest<NurseRoster> {
 
+    public NurseRosteringPerformanceTest(String moveThreadCount) {
+        super(moveThreadCount);
+    }
+
     @Override
     protected NurseRosteringApp createCommonApp() {
         return new NurseRosteringApp();

--- a/optaplanner-examples/src/test/java/org/optaplanner/examples/pas/app/PatientAdmissionSchedulePerformanceTest.java
+++ b/optaplanner-examples/src/test/java/org/optaplanner/examples/pas/app/PatientAdmissionSchedulePerformanceTest.java
@@ -25,6 +25,10 @@ import org.optaplanner.examples.pas.domain.PatientAdmissionSchedule;
 
 public class PatientAdmissionSchedulePerformanceTest extends SolverPerformanceTest<PatientAdmissionSchedule> {
 
+    public PatientAdmissionSchedulePerformanceTest(String moveThreadCount) {
+        super(moveThreadCount);
+    }
+
     @Override
     protected PatientAdmissionScheduleApp createCommonApp() {
         return new PatientAdmissionScheduleApp();

--- a/optaplanner-examples/src/test/java/org/optaplanner/examples/projectjobscheduling/app/ProjectJobSchedulingPerformanceTest.java
+++ b/optaplanner-examples/src/test/java/org/optaplanner/examples/projectjobscheduling/app/ProjectJobSchedulingPerformanceTest.java
@@ -25,6 +25,10 @@ import org.optaplanner.examples.projectjobscheduling.domain.Schedule;
 
 public class ProjectJobSchedulingPerformanceTest extends SolverPerformanceTest<Schedule> {
 
+    public ProjectJobSchedulingPerformanceTest(String moveThreadCount) {
+        super(moveThreadCount);
+    }
+
     @Override
     protected ProjectJobSchedulingApp createCommonApp() {
         return new ProjectJobSchedulingApp();

--- a/optaplanner-examples/src/test/java/org/optaplanner/examples/rocktour/app/RockTourPerformanceTest.java
+++ b/optaplanner-examples/src/test/java/org/optaplanner/examples/rocktour/app/RockTourPerformanceTest.java
@@ -25,6 +25,10 @@ import org.optaplanner.examples.rocktour.domain.RockTourSolution;
 
 public class RockTourPerformanceTest extends SolverPerformanceTest<RockTourSolution> {
 
+    public RockTourPerformanceTest(String moveThreadCount) {
+        super(moveThreadCount);
+    }
+
     @Override
     protected RockTourApp createCommonApp() {
         return new RockTourApp();

--- a/optaplanner-examples/src/test/java/org/optaplanner/examples/scrabble/app/ScrabblePerformanceTest.java
+++ b/optaplanner-examples/src/test/java/org/optaplanner/examples/scrabble/app/ScrabblePerformanceTest.java
@@ -25,6 +25,10 @@ import org.optaplanner.examples.scrabble.domain.ScrabbleSolution;
 
 public class ScrabblePerformanceTest extends SolverPerformanceTest<ScrabbleSolution> {
 
+    public ScrabblePerformanceTest(String moveThreadCount) {
+        super(moveThreadCount);
+    }
+
     @Override
     protected ScrabbleApp createCommonApp() {
         return new ScrabbleApp();

--- a/optaplanner-examples/src/test/java/org/optaplanner/examples/taskassigning/app/TaskAssigningPerformanceTest.java
+++ b/optaplanner-examples/src/test/java/org/optaplanner/examples/taskassigning/app/TaskAssigningPerformanceTest.java
@@ -25,6 +25,10 @@ import org.optaplanner.examples.taskassigning.domain.TaskAssigningSolution;
 
 public class TaskAssigningPerformanceTest extends SolverPerformanceTest<TaskAssigningSolution> {
 
+    public TaskAssigningPerformanceTest(String moveThreadCount) {
+        super(moveThreadCount);
+    }
+
     @Override
     protected TaskAssigningApp createCommonApp() {
         return new TaskAssigningApp();

--- a/optaplanner-examples/src/test/java/org/optaplanner/examples/tennis/app/TennisPerformanceTest.java
+++ b/optaplanner-examples/src/test/java/org/optaplanner/examples/tennis/app/TennisPerformanceTest.java
@@ -25,6 +25,10 @@ import org.optaplanner.examples.tennis.domain.TennisSolution;
 
 public class TennisPerformanceTest extends SolverPerformanceTest<TennisSolution> {
 
+    public TennisPerformanceTest(String moveThreadCount) {
+        super(moveThreadCount);
+    }
+
     @Override
     protected TennisApp createCommonApp() {
         return new TennisApp();

--- a/optaplanner-examples/src/test/java/org/optaplanner/examples/travelingtournament/app/TravelingTournamentPerformanceTest.java
+++ b/optaplanner-examples/src/test/java/org/optaplanner/examples/travelingtournament/app/TravelingTournamentPerformanceTest.java
@@ -25,6 +25,10 @@ import org.optaplanner.examples.travelingtournament.domain.TravelingTournament;
 
 public class TravelingTournamentPerformanceTest extends SolverPerformanceTest<TravelingTournament> {
 
+    public TravelingTournamentPerformanceTest(String moveThreadCount) {
+        super(moveThreadCount);
+    }
+
     @Override
     protected TravelingTournamentApp createCommonApp() {
         return new TravelingTournamentApp();

--- a/optaplanner-examples/src/test/java/org/optaplanner/examples/tsp/app/TspPerformanceTest.java
+++ b/optaplanner-examples/src/test/java/org/optaplanner/examples/tsp/app/TspPerformanceTest.java
@@ -25,6 +25,10 @@ import org.optaplanner.examples.tsp.domain.TspSolution;
 
 public class TspPerformanceTest extends SolverPerformanceTest<TspSolution> {
 
+    public TspPerformanceTest(String moveThreadCount) {
+        super(moveThreadCount);
+    }
+
     @Override
     protected TspApp createCommonApp() {
         return new TspApp();

--- a/optaplanner-examples/src/test/java/org/optaplanner/examples/vehiclerouting/app/VehicleRoutingPerformanceTest.java
+++ b/optaplanner-examples/src/test/java/org/optaplanner/examples/vehiclerouting/app/VehicleRoutingPerformanceTest.java
@@ -25,6 +25,10 @@ import org.optaplanner.examples.vehiclerouting.domain.VehicleRoutingSolution;
 
 public class VehicleRoutingPerformanceTest extends SolverPerformanceTest<VehicleRoutingSolution> {
 
+    public VehicleRoutingPerformanceTest(String moveThreadCount) {
+        super(moveThreadCount);
+    }
+
     @Override
     protected VehicleRoutingApp createCommonApp() {
         return new VehicleRoutingApp();


### PR DESCRIPTION
- introduced a new system property moveThreadCounts taking a comma separated list of moveThreadCount values to test with
- parameterized *PerformanceTest to run with multiple moveThreadCount settings

@ge0ffrey could you please take a look?