### PR TITLE
PLANNER-1261 javadoc Move.getPlanningEntities() & getPlanningValues()

### DIFF
--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/heuristic/move/Move.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/heuristic/move/Move.java
@@ -133,6 +133,8 @@ public interface Move<Solution_> {
      * Returns all planning entities that are being changed by this move.
      * Required for {@link AcceptorType#ENTITY_TABU}.
      * <p>
+     * This method is only called after {@link #doMove(ScoreDirector)} (which might affect the return values).
+     * <p>
      * Duplicate entries in the returned {@link Collection} are best avoided.
      * The returned {@link Collection} is recommended to be in a stable order.
      * For example: use {@link List} or {@link LinkedHashSet}, but not {@link HashSet}.
@@ -143,6 +145,8 @@ public interface Move<Solution_> {
     /**
      * Returns all planning values that entities are being assigned to by this move.
      * Required for {@link AcceptorType#VALUE_TABU}.
+     * <p>
+     * This method is only called after {@link #doMove(ScoreDirector)} (which might affect the return values).
      * <p>
      * Duplicate entries in the returned {@link Collection} are best avoided.
      * The returned {@link Collection} is recommended to be in a stable order.


### PR DESCRIPTION
javadoc should guarantee that they are only called after doMove()