### PR TITLE
PLANNER-1200 subtract weekly budget from total seconds

### DIFF
--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/rocktour/domain/solver/RockShowVariableListener.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/rocktour/domain/solver/RockShowVariableListener.java
@@ -118,13 +118,15 @@ public class RockShowVariableListener implements VariableListener<RockShow> {
                 timeOfDay = RockTimeOfDay.EARLY;
             }
         }
-        hosWeekDrivingSecondsTotal += drivingSeconds;
+
+        hosWeekDrivingSecondsTotal += show.getDrivingTimeFromPreviousStandstill();
+
         // HOS driving time per week limits: add weekend rest period if driving for too many hour or too many days
         if (hosWeekDrivingSecondsTotal > hosWeekDrivingSecondsBudget
                 || hosWeekStart.getDepartureDate().until(arrivalDate, DAYS) > hosWeekConsecutiveDrivingDaysBudget) {
             arrivalDate = arrivalDate.plusDays(hosWeekRestDays);
             hosWeekStart = show;
-            hosWeekDrivingSecondsTotal = 0L;
+            hosWeekDrivingSecondsTotal -= hosWeekDrivingSecondsBudget;
             timeOfDay = RockTimeOfDay.EARLY;
         }
         if (show.getDurationInHalfDay() % 2 == 0 && timeOfDay != RockTimeOfDay.EARLY) {

--- a/optaplanner-examples/src/test/java/org/optaplanner/examples/rocktour/app/RockTourPerformanceTest.java
+++ b/optaplanner-examples/src/test/java/org/optaplanner/examples/rocktour/app/RockTourPerformanceTest.java
@@ -18,21 +18,15 @@ package org.optaplanner.examples.rocktour.app;
 
 import java.io.File;
 
-import org.junit.Assume;
 import org.junit.Test;
 import org.optaplanner.core.config.solver.EnvironmentMode;
-import org.optaplanner.core.config.solver.SolverConfig;
 import org.optaplanner.examples.common.app.SolverPerformanceTest;
 import org.optaplanner.examples.rocktour.domain.RockTourSolution;
 
 public class RockTourPerformanceTest extends SolverPerformanceTest<RockTourSolution> {
 
-    // PLANNER-1200
-    private String moveThreadCount;
-
     public RockTourPerformanceTest(String moveThreadCount) {
         super(moveThreadCount);
-        this.moveThreadCount = moveThreadCount;
     }
 
     @Override
@@ -52,13 +46,7 @@ public class RockTourPerformanceTest extends SolverPerformanceTest<RockTourSolut
 
     @Test(timeout = 600000)
     public void solveModelFastAssert() {
-        runInSolverThreadOnly();
         File unsolvedDataFile = new File("data/rocktour/unsolved/47shows.xlsx");
         runSpeedTest(unsolvedDataFile, "0hard/72725039medium/-5186309soft", EnvironmentMode.FAST_ASSERT);
-    }
-
-    // PLANNER-1200
-    private void runInSolverThreadOnly() {
-        Assume.assumeTrue(SolverConfig.MOVE_THREAD_COUNT_NONE.equals(moveThreadCount));
     }
 }


### PR DESCRIPTION
When driving seconds are over weekly budget, the budget should be
subtracted instead of putting the driving seconds to 0.

@ge0ffrey would you kindly review?