### PR TITLE
fixing links that gave a privacy error

### DIFF
--- a/optaplanner-docs/src/main/asciidoc/UseCasesAndExamples/ExamplesOverview/ExamplesOverview-section.adoc
+++ b/optaplanner-docs/src/main/asciidoc/UseCasesAndExamples/ExamplesOverview/ExamplesOverview-section.adoc
@@ -194,7 +194,7 @@ and also in git under [path]_optaplanner/optaplanner-examples_.
 * Value <= `78`
 * Search space <= `10^2301`
 |* Unrealistic
-* http://mat.gsia.cmu.edu/TOURN/[TTP]
+* http://mat.tepper.cmu.edu/TOURN/[TTP]
 |* Custom <<moveListFactory,MoveListFactory>>
 
 |<<cheapTimeScheduling,Cheap time scheduling>>

--- a/optaplanner-docs/src/main/asciidoc/UseCasesAndExamples/TravellingTournament/TravellingTournament-section.adoc
+++ b/optaplanner-docs/src/main/asciidoc/UseCasesAndExamples/TravellingTournament/TravellingTournament-section.adoc
@@ -21,7 +21,7 @@ Soft constraints:
 
 * Minimize the total distance traveled by all teams.
 
-The problem is defined on http://mat.gsia.cmu.edu/TOURN/[Michael Trick's website (which contains the world records too)].
+The problem is defined on http://mat.tepper.cmu.edu/TOURN/[Michael Trick's website (which contains the world records too)].
 
 
 [[travelingTournamentProblemSize]]


### PR DESCRIPTION
Links to mat.gsia.cmu.edu give privacy errors, the fix is to change to mat.tepper.cmu.edu, it is the same website