### PR TITLE
Remove useless property override

### DIFF
--- a/optaplanner-webexamples/pom.xml
+++ b/optaplanner-webexamples/pom.xml
@@ -22,9 +22,6 @@
   </description>
   <url>https://www.optaplanner.org</url>
 
-  <properties>
-    <version.org.wildfly>14.0.1.Final</version.org.wildfly>
-  </properties>
   <build>
     <testResources>
       <testResource>


### PR DESCRIPTION
optaplanner-webexamples overrides 'version.org.wildfly' defined in kie-parent from '14.0.1.Final' to the same version '14.0.1.Final'
This override is unnecessary and will require changes in more places when we update wildfly in the future (or will be forgotten and will cause inconsistencies).

@ge0ffrey please check and consider merging.