### PR TITLE
Configure sonarcloud and travis-ci

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 /.*
 !.gitignore
 !.gitattributes
+!.travis.yml
 /nbproject
 /*.ipr
 /*.iws

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ install: true
 jdk:
 - oraclejdk8
 script:
-- mvn --quiet clean install -Prun-code-coverage
+- mvn -e --quiet clean install -Prun-code-coverage
 - mvn --quiet jacoco:report jacoco:merge sonar:sonar -Preport-code-coverage -Dsonar.host.url=https://sonarcloud.io -Dsonar.organization=kiegroup -Dsonar.login=$SONARCLOUD_TOKEN -Dsonar.projectKey=org.optaplanner:optaplanner
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: java
+sudo: false
+install: true
+
+jdk:
+- oraclejdk8
+script:
+- mvn --quiet clean install -Prun-code-coverage
+- mvn --quiet jacoco:report jacoco:merge sonar:sonar -Preport-code-coverage -Dsonar.host.url=https://sonarcloud.io -Dsonar.organization=kiegroup -Dsonar.login=$SONARCLOUD_TOKEN -Dsonar.projectKey=org.optaplanner:optaplanner
+cache:
+  directories:
+  - "$HOME/.m2/repository"
+  - "$HOME/.sonar/cache"

--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,12 @@
 
   <properties>
     <findbugs.failOnViolation>true</findbugs.failOnViolation>
+    <jacoco.agent.line/>
+    <surefire.argLine>
+      -Dfile.encoding=${project.build.sourceEncoding}
+      ${jacoco.agent.line}
+    </surefire.argLine>
+    <version.jacoco.plugin>0.8.2</version.jacoco.plugin>
   </properties>
 
   <repositories>
@@ -90,6 +96,11 @@
         <!-- Old version until this issue is resolved: https://github.com/ImmobilienScout24/illegal-transitive-dependency-check/issues/30 -->
         <version>1.0.4</version>
       </dependency>
+      <dependency>
+        <groupId>org.jacoco</groupId>
+        <artifactId>org.jacoco.agent</artifactId>
+        <version>${version.jacoco.plugin}</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 
@@ -105,6 +116,84 @@
         <module>optaplanner-docs</module>
         <module>optaplanner-distribution</module>
       </modules>
+    </profile>
+
+    <profile>
+      <id>run-code-coverage</id>
+      <properties>
+        <jacoco.exec.file>${project.build.directory}/jacoco.exec</jacoco.exec.file>
+        <jacoco.excludes>*Lexer:org.optaplanner.core.impl.testdata.domain.*:*TestdataAbstractSolutionBasedSolution</jacoco.excludes>
+        <jacoco.agent.line>-javaagent:${settings.localRepository}/org/jacoco/org.jacoco.agent/${version.jacoco.plugin}/org.jacoco.agent-${version.jacoco.plugin}-runtime.jar=destfile=${jacoco.exec.file},append=true,excludes=${jacoco.excludes}</jacoco.agent.line>
+      </properties>
+      <dependencies>
+        <dependency>
+          <groupId>org.jacoco</groupId>
+          <artifactId>org.jacoco.agent</artifactId>
+        </dependency>
+      </dependencies>
+      <build>
+        <pluginManagement>
+          <plugins>
+            <plugin>
+              <groupId>org.codehaus.cargo</groupId>
+              <artifactId>cargo-maven2-plugin</artifactId>
+              <configuration>
+                <configuration>
+                  <properties>
+                    <cargo.start.jvmargs>${jacoco.agent.line}</cargo.start.jvmargs>
+                  </properties>
+                </configuration>
+              </configuration>
+            </plugin>
+            <plugin>
+              <groupId>net.ltgt.gwt.maven</groupId>
+              <artifactId>gwt-maven-plugin</artifactId>
+              <configuration>
+                <skipCompilation>true</skipCompilation>
+              </configuration>
+            </plugin>
+            <plugin>
+              <artifactId>maven-surefire-plugin</artifactId>
+              <configuration>
+                <argLine>${surefire.argLine}</argLine>
+              </configuration>
+            </plugin>
+          </plugins>
+        </pluginManagement>
+      </build>
+    </profile>
+
+    <profile>
+      <!--
+        See .travis.yml for how to run the coverage report
+      -->
+      <id>report-code-coverage</id>
+      <properties>
+        <jacoco.master.exec.file>${maven.multiModuleProjectDirectory}/target/jacoco.exec</jacoco.master.exec.file>
+        <sonar.jacoco.reportPaths>${jacoco.master.exec.file}</sonar.jacoco.reportPaths>
+      </properties>
+      <build>
+        <pluginManagement>
+          <plugins>
+            <plugin>
+              <groupId>org.jacoco</groupId>
+              <artifactId>jacoco-maven-plugin</artifactId>
+              <version>${version.jacoco.plugin}</version>
+              <configuration>
+                <fileSets>
+                  <fileSet>
+                    <directory>${project.build.directory}</directory>
+                    <includes>
+                      <include>*.exec</include>
+                    </includes>
+                  </fileSet>
+                </fileSets>
+                <destFile>${jacoco.master.exec.file}</destFile>
+              </configuration>
+            </plugin>
+          </plugins>
+        </pluginManagement>
+      </build>
     </profile>
   </profiles>
 

--- a/pom.xml
+++ b/pom.xml
@@ -28,12 +28,6 @@
 
   <properties>
     <findbugs.failOnViolation>true</findbugs.failOnViolation>
-    <jacoco.agent.line/>
-    <surefire.argLine>
-      -Dfile.encoding=${project.build.sourceEncoding}
-      ${jacoco.agent.line}
-    </surefire.argLine>
-    <version.jacoco.plugin>0.8.2</version.jacoco.plugin>
   </properties>
 
   <repositories>
@@ -96,11 +90,6 @@
         <!-- Old version until this issue is resolved: https://github.com/ImmobilienScout24/illegal-transitive-dependency-check/issues/30 -->
         <version>1.0.4</version>
       </dependency>
-      <dependency>
-        <groupId>org.jacoco</groupId>
-        <artifactId>org.jacoco.agent</artifactId>
-        <version>${version.jacoco.plugin}</version>
-      </dependency>
     </dependencies>
   </dependencyManagement>
 
@@ -124,13 +113,11 @@
         <jacoco.exec.file>${project.build.directory}/jacoco.exec</jacoco.exec.file>
         <jacoco.excludes>*Lexer:org.optaplanner.core.impl.testdata.domain.*:*TestdataAbstractSolutionBasedSolution</jacoco.excludes>
         <jacoco.agent.line>-javaagent:${settings.localRepository}/org/jacoco/org.jacoco.agent/${version.jacoco.plugin}/org.jacoco.agent-${version.jacoco.plugin}-runtime.jar=destfile=${jacoco.exec.file},append=true,excludes=${jacoco.excludes}</jacoco.agent.line>
+        <surefire.argLine>
+          -Dfile.encoding=${project.build.sourceEncoding}
+          ${jacoco.agent.line}
+        </surefire.argLine>
       </properties>
-      <dependencies>
-        <dependency>
-          <groupId>org.jacoco</groupId>
-          <artifactId>org.jacoco.agent</artifactId>
-        </dependency>
-      </dependencies>
       <build>
         <pluginManagement>
           <plugins>
@@ -157,6 +144,13 @@
               <configuration>
                 <argLine>${surefire.argLine}</argLine>
               </configuration>
+              <dependencies>
+                <dependency>
+                  <groupId>org.jacoco</groupId>
+                  <artifactId>org.jacoco.agent</artifactId>
+                  <version>${version.jacoco.plugin}</version>
+                </dependency>
+              </dependencies>
             </plugin>
           </plugins>
         </pluginManagement>


### PR DESCRIPTION
- configures jacoco code coverage and reporting to sonarcloud.io
- enables travis-ci to update the sonarcloud.io with every PR