### PR TITLE
Make exception message more meaningful

### DIFF
--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/nurserostering/solver/move/EmployeeMultipleChangeMove.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/nurserostering/solver/move/EmployeeMultipleChangeMove.java
@@ -57,7 +57,7 @@ public class EmployeeMultipleChangeMove extends AbstractMove<NurseRoster> {
         for (ShiftAssignment shiftAssignment : shiftAssignmentList) {
             if (!shiftAssignment.getEmployee().equals(fromEmployee)) {
                 throw new IllegalStateException("The shiftAssignment (" + shiftAssignment + ") should have the same employee ("
-                        + fromEmployee + ") as the fromEmployee (" + fromEmployee + ").");
+                        + shiftAssignment.getEmployee() + ") as the fromEmployee (" + fromEmployee + ").");
             }
             NurseRosteringMoveHelper.moveEmployee(scoreDirector, shiftAssignment, toEmployee);
         }


### PR DESCRIPTION
Currently exception message shows the same employee twice, which makes no sense, because it should compare `shiftAssignment` employee and `fromEmployee`.