### PR TITLE
PLANNER-1385 Enable PR code analysis by SonarCloud

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ jdk:
 - oraclejdk8
 script:
 - mvn -e --quiet clean install -Prun-code-coverage
-- mvn --quiet jacoco:report jacoco:merge sonar:sonar -Preport-code-coverage -Dsonar.host.url=https://sonarcloud.io -Dsonar.organization=kiegroup -Dsonar.login=$SONARCLOUD_TOKEN -Dsonar.projectKey=org.optaplanner:optaplanner
+- mvn --quiet jacoco:report jacoco:merge sonar:sonar -Preport-code-coverage -Dsonar.host.url=https://sonarcloud.io -Dsonar.organization=kiegroup -Dsonar.login=$SONARCLOUD_TOKEN -Dsonar.projectKey=org.optaplanner:optaplanner -Dsonar.pullrequest.base=$TRAVIS_BRANCH -Dsonar.pullrequest.branch=$TRAVIS_PULL_REQUEST_BRANCH -Dsonar.pullrequest.key=$TRAVIS_PULL_REQUEST -Dsonar.pullrequest.provider=GitHub -Dsonar.pullrequest.github.repository=$TRAVIS_PULL_REQUEST_SLUG
 cache:
   directories:
   - "$HOME/.m2/repository"


### PR DESCRIPTION
@ge0ffrey after merging this, we should be able to see analysis on PRs like that:
https://github.com/rsynek/sonarcloud-playground/pull/2

It may require some additional settings on github side, though. Since I don't have admin privilege, I cannot check it.