### PR TITLE
Fixes related to Mockito upgrade

### DIFF
--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/domain/valuerange/buildin/bigdecimal/BigDecimalValueRangeTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/domain/valuerange/buildin/bigdecimal/BigDecimalValueRangeTest.java
@@ -22,7 +22,6 @@ import java.util.Random;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Matchers.anyInt;
 import static org.mockito.Mockito.*;
 import static org.optaplanner.core.impl.testdata.util.PlannerAssert.*;
 

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/domain/valuerange/buildin/biginteger/BigIntegerValueRangeTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/domain/valuerange/buildin/biginteger/BigIntegerValueRangeTest.java
@@ -23,7 +23,6 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Matchers.anyInt;
 import static org.mockito.Mockito.*;
 import static org.optaplanner.core.impl.testdata.util.PlannerAssert.*;
 

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/domain/valuerange/buildin/composite/CompositeCountableValueRangeTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/domain/valuerange/buildin/composite/CompositeCountableValueRangeTest.java
@@ -26,7 +26,6 @@ import org.junit.Test;
 import org.optaplanner.core.impl.domain.valuerange.buildin.collection.ListValueRange;
 
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Matchers.anyInt;
 import static org.mockito.Mockito.*;
 import static org.optaplanner.core.impl.testdata.util.PlannerAssert.*;
 

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/domain/valuerange/buildin/composite/NullableCountableValueRangeTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/domain/valuerange/buildin/composite/NullableCountableValueRangeTest.java
@@ -24,7 +24,6 @@ import org.junit.Test;
 import org.optaplanner.core.impl.domain.valuerange.buildin.collection.ListValueRange;
 
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Matchers.anyInt;
 import static org.mockito.Mockito.*;
 import static org.optaplanner.core.impl.testdata.util.PlannerAssert.*;
 

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/domain/valuerange/buildin/temporal/TemporalValueRangeTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/domain/valuerange/buildin/temporal/TemporalValueRangeTest.java
@@ -28,7 +28,6 @@ import java.util.Random;
 import org.junit.Test;
 
 import static org.junit.Assert.*;
-import static org.mockito.Matchers.*;
 import static org.mockito.Mockito.*;
 import static org.optaplanner.core.impl.testdata.util.PlannerAssert.*;
 

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/exhaustivesearch/DefaultExhaustiveSearchPhaseTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/exhaustivesearch/DefaultExhaustiveSearchPhaseTest.java
@@ -32,6 +32,7 @@ import org.optaplanner.core.impl.exhaustivesearch.scope.ExhaustiveSearchPhaseSco
 import org.optaplanner.core.impl.exhaustivesearch.scope.ExhaustiveSearchStepScope;
 import org.optaplanner.core.impl.heuristic.move.Move;
 import org.optaplanner.core.impl.heuristic.selector.entity.EntitySelector;
+import org.optaplanner.core.impl.score.director.InnerScoreDirector;
 import org.optaplanner.core.impl.score.director.ScoreDirector;
 import org.optaplanner.core.impl.testdata.domain.TestdataEntity;
 import org.optaplanner.core.impl.testdata.domain.TestdataSolution;
@@ -58,6 +59,8 @@ public class DefaultExhaustiveSearchPhaseTest {
         when(stepScope.getPhaseScope()).thenReturn(phaseScope);
         TestdataSolution workingSolution = new TestdataSolution();
         when(phaseScope.getWorkingSolution()).thenReturn(workingSolution);
+        InnerScoreDirector<TestdataSolution> scoreDirector = mock(InnerScoreDirector.class);
+        when(phaseScope.getScoreDirector()).thenReturn(scoreDirector);
 
         SolutionDescriptor<TestdataSolution> solutionDescriptor = TestdataSolution.buildSolutionDescriptor();
         when(phaseScope.getSolutionDescriptor()).thenReturn(solutionDescriptor);
@@ -102,14 +105,14 @@ public class DefaultExhaustiveSearchPhaseTest {
         verify(node1.getMove(), times(0)).doMove(any(ScoreDirector.class));
         verify(node1.getUndoMove(), times(0)).doMove(any(ScoreDirector.class));
         verify(node2A.getMove(), times(0)).doMove(any(ScoreDirector.class));
-        verify(node2A.getUndoMove(), times(1)).doMove(any(ScoreDirector.class));
+        verify(node2A.getUndoMove(), times(1)).doMove(scoreDirector);
         verify(node3A.getMove(), times(0)).doMove(any(ScoreDirector.class));
-        verify(node3A.getUndoMove(), times(1)).doMove(any(ScoreDirector.class));
-        verify(node2B.getMove(), times(1)).doMove(any(ScoreDirector.class));
+        verify(node3A.getUndoMove(), times(1)).doMove(scoreDirector);
+        verify(node2B.getMove(), times(1)).doMove(scoreDirector);
         verify(node2B.getUndoMove(), times(0)).doMove(any(ScoreDirector.class));
-        verify(node3B.getMove(), times(1)).doMove(any(ScoreDirector.class));
+        verify(node3B.getMove(), times(1)).doMove(scoreDirector);
         verify(node3B.getUndoMove(), times(0)).doMove(any(ScoreDirector.class));
-        verify(node4B.getMove(), times(1)).doMove(any(ScoreDirector.class));
+        verify(node4B.getMove(), times(1)).doMove(scoreDirector);
         verify(node4B.getUndoMove(), times(0)).doMove(any(ScoreDirector.class));
         // TODO FIXME
         // verify(workingSolution).setScore(newScore);

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/localsearch/decider/acceptor/composite/CompositeAcceptorTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/localsearch/decider/acceptor/composite/CompositeAcceptorTest.java
@@ -25,7 +25,6 @@ import org.optaplanner.core.impl.localsearch.decider.acceptor.CompositeAcceptor;
 import org.optaplanner.core.impl.localsearch.scope.LocalSearchMoveScope;
 
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.*;
 import static org.optaplanner.core.impl.testdata.util.PlannerAssert.*;
 

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/localsearch/decider/acceptor/composite/CompositeAcceptorTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/localsearch/decider/acceptor/composite/CompositeAcceptorTest.java
@@ -23,31 +23,42 @@ import org.junit.Test;
 import org.optaplanner.core.impl.localsearch.decider.acceptor.Acceptor;
 import org.optaplanner.core.impl.localsearch.decider.acceptor.CompositeAcceptor;
 import org.optaplanner.core.impl.localsearch.scope.LocalSearchMoveScope;
+import org.optaplanner.core.impl.localsearch.scope.LocalSearchPhaseScope;
+import org.optaplanner.core.impl.localsearch.scope.LocalSearchStepScope;
+import org.optaplanner.core.impl.solver.scope.DefaultSolverScope;
+import org.optaplanner.core.impl.testdata.domain.TestdataSolution;
 
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.*;
-import static org.optaplanner.core.impl.testdata.util.PlannerAssert.*;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.optaplanner.core.impl.testdata.util.PlannerAssert.verifyPhaseLifecycle;
 
 public class CompositeAcceptorTest {
+
     @Test
     public void phaseLifecycle() {
+        DefaultSolverScope<TestdataSolution> solverScope = mock(DefaultSolverScope.class);
+        LocalSearchPhaseScope<TestdataSolution> phaseScope = mock(LocalSearchPhaseScope.class);
+        LocalSearchStepScope<TestdataSolution> stepScope = mock(LocalSearchStepScope.class);
+
         Acceptor acceptor1 = mock(Acceptor.class);
         Acceptor acceptor2 = mock(Acceptor.class);
         Acceptor acceptor3 = mock(Acceptor.class);
         CompositeAcceptor compositeAcceptor = new CompositeAcceptor(acceptor1, acceptor2, acceptor3);
 
-        compositeAcceptor.solvingStarted(null);
-        compositeAcceptor.phaseStarted(null);
-        compositeAcceptor.stepStarted(null);
-        compositeAcceptor.stepEnded(null);
-        compositeAcceptor.stepStarted(null);
-        compositeAcceptor.stepEnded(null);
-        compositeAcceptor.phaseEnded(null);
-        compositeAcceptor.phaseStarted(null);
-        compositeAcceptor.stepStarted(null);
-        compositeAcceptor.stepEnded(null);
-        compositeAcceptor.phaseEnded(null);
-        compositeAcceptor.solvingEnded(null);
+        compositeAcceptor.solvingStarted(solverScope);
+        compositeAcceptor.phaseStarted(phaseScope);
+        compositeAcceptor.stepStarted(stepScope);
+        compositeAcceptor.stepEnded(stepScope);
+        compositeAcceptor.stepStarted(stepScope);
+        compositeAcceptor.stepEnded(stepScope);
+        compositeAcceptor.phaseEnded(phaseScope);
+        compositeAcceptor.phaseStarted(phaseScope);
+        compositeAcceptor.stepStarted(stepScope);
+        compositeAcceptor.stepEnded(stepScope);
+        compositeAcceptor.phaseEnded(phaseScope);
+        compositeAcceptor.solvingEnded(solverScope);
 
         verifyPhaseLifecycle(acceptor1, 1, 2, 3);
         verifyPhaseLifecycle(acceptor2, 1, 2, 3);
@@ -73,5 +84,4 @@ public class CompositeAcceptorTest {
         CompositeAcceptor acceptor = new CompositeAcceptor(acceptorList);
         return acceptor.isAccepted(mock(LocalSearchMoveScope.class));
     }
-
 }

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/testdata/util/PlannerAssert.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/testdata/util/PlannerAssert.java
@@ -26,7 +26,6 @@ import java.util.NoSuchElementException;
 
 import org.junit.Assert;
 import org.junit.ComparisonFailure;
-import org.mockito.Matchers;
 import org.optaplanner.core.impl.constructionheuristic.event.ConstructionHeuristicPhaseLifecycleListener;
 import org.optaplanner.core.impl.constructionheuristic.scope.ConstructionHeuristicPhaseScope;
 import org.optaplanner.core.impl.constructionheuristic.scope.ConstructionHeuristicStepScope;
@@ -49,7 +48,9 @@ import org.optaplanner.core.impl.phase.scope.AbstractPhaseScope;
 import org.optaplanner.core.impl.phase.scope.AbstractStepScope;
 import org.optaplanner.core.impl.solver.scope.DefaultSolverScope;
 
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 /**
  * @see PlannerTestUtils
@@ -193,32 +194,32 @@ public class PlannerAssert extends Assert {
 
     public static void verifyPhaseLifecycle(PhaseLifecycleListener phaseLifecycleListener,
             int solvingCount, int phaseCount, int stepCount) {
-        verify(phaseLifecycleListener, times(solvingCount)).solvingStarted(Matchers.<DefaultSolverScope>any());
-        verify(phaseLifecycleListener, times(phaseCount)).phaseStarted(Matchers.<AbstractPhaseScope>any());
-        verify(phaseLifecycleListener, times(stepCount)).stepStarted(Matchers.<AbstractStepScope>any());
-        verify(phaseLifecycleListener, times(stepCount)).stepEnded(Matchers.<AbstractStepScope>any());
-        verify(phaseLifecycleListener, times(phaseCount)).phaseEnded(Matchers.<AbstractPhaseScope>any());
-        verify(phaseLifecycleListener, times(solvingCount)).solvingEnded(Matchers.<DefaultSolverScope>any());
+        verify(phaseLifecycleListener, times(solvingCount)).solvingStarted(any(DefaultSolverScope.class));
+        verify(phaseLifecycleListener, times(phaseCount)).phaseStarted(any(AbstractPhaseScope.class));
+        verify(phaseLifecycleListener, times(stepCount)).stepStarted(any(AbstractStepScope.class));
+        verify(phaseLifecycleListener, times(stepCount)).stepEnded(any(AbstractStepScope.class));
+        verify(phaseLifecycleListener, times(phaseCount)).phaseEnded(any(AbstractPhaseScope.class));
+        verify(phaseLifecycleListener, times(solvingCount)).solvingEnded(any(DefaultSolverScope.class));
     }
 
     public static void verifyPhaseLifecycle(ConstructionHeuristicPhaseLifecycleListener phaseLifecycleListener,
             int solvingCount, int phaseCount, int stepCount) {
-        verify(phaseLifecycleListener, times(solvingCount)).solvingStarted(Matchers.<DefaultSolverScope>any());
-        verify(phaseLifecycleListener, times(phaseCount)).phaseStarted(Matchers.<ConstructionHeuristicPhaseScope>any());
-        verify(phaseLifecycleListener, times(stepCount)).stepStarted(Matchers.<ConstructionHeuristicStepScope>any());
-        verify(phaseLifecycleListener, times(stepCount)).stepEnded(Matchers.<ConstructionHeuristicStepScope>any());
-        verify(phaseLifecycleListener, times(phaseCount)).phaseEnded(Matchers.<ConstructionHeuristicPhaseScope>any());
-        verify(phaseLifecycleListener, times(solvingCount)).solvingEnded(Matchers.<DefaultSolverScope>any());
+        verify(phaseLifecycleListener, times(solvingCount)).solvingStarted(any(DefaultSolverScope.class));
+        verify(phaseLifecycleListener, times(phaseCount)).phaseStarted(any(ConstructionHeuristicPhaseScope.class));
+        verify(phaseLifecycleListener, times(stepCount)).stepStarted(any(ConstructionHeuristicStepScope.class));
+        verify(phaseLifecycleListener, times(stepCount)).stepEnded(any(ConstructionHeuristicStepScope.class));
+        verify(phaseLifecycleListener, times(phaseCount)).phaseEnded(any(ConstructionHeuristicPhaseScope.class));
+        verify(phaseLifecycleListener, times(solvingCount)).solvingEnded(any(DefaultSolverScope.class));
     }
 
     public static void verifyPhaseLifecycle(LocalSearchPhaseLifecycleListener phaseLifecycleListener,
             int solvingCount, int phaseCount, int stepCount) {
-        verify(phaseLifecycleListener, times(solvingCount)).solvingStarted(Matchers.<DefaultSolverScope>any());
-        verify(phaseLifecycleListener, times(phaseCount)).phaseStarted(Matchers.<LocalSearchPhaseScope>any());
-        verify(phaseLifecycleListener, times(stepCount)).stepStarted(Matchers.<LocalSearchStepScope>any());
-        verify(phaseLifecycleListener, times(stepCount)).stepEnded(Matchers.<LocalSearchStepScope>any());
-        verify(phaseLifecycleListener, times(phaseCount)).phaseEnded(Matchers.<LocalSearchPhaseScope>any());
-        verify(phaseLifecycleListener, times(solvingCount)).solvingEnded(Matchers.<DefaultSolverScope>any());
+        verify(phaseLifecycleListener, times(solvingCount)).solvingStarted(any(DefaultSolverScope.class));
+        verify(phaseLifecycleListener, times(phaseCount)).phaseStarted(any(LocalSearchPhaseScope.class));
+        verify(phaseLifecycleListener, times(stepCount)).stepStarted(any(LocalSearchStepScope.class));
+        verify(phaseLifecycleListener, times(stepCount)).stepEnded(any(LocalSearchStepScope.class));
+        verify(phaseLifecycleListener, times(phaseCount)).phaseEnded(any(LocalSearchPhaseScope.class));
+        verify(phaseLifecycleListener, times(solvingCount)).solvingEnded(any(DefaultSolverScope.class));
     }
 
     @SafeVarargs


### PR DESCRIPTION
`org.mockito.Matchers` is deprecated. Matchers are now obtained by statically importing `Mockito` which extends `ArgumentMatchers`.

`any(Class)` no longer accepts `null` -> needed to set up a few additional mocks.