### PR TITLE
Add ability to import timeslots from /slots endpoint

### DIFF
--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/conferencescheduling/swingui/ConferenceCFPImportAction.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/conferencescheduling/swingui/ConferenceCFPImportAction.java
@@ -19,6 +19,7 @@ package org.optaplanner.examples.conferencescheduling.swingui;
 import java.awt.BorderLayout;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
+import java.util.Arrays;
 import java.util.concurrent.ExecutionException;
 import java.util.function.BiConsumer;
 
@@ -54,17 +55,18 @@ public class ConferenceCFPImportAction implements CommonApp.ExtraAction<Conferen
             String[] cfpArray = {"cfp-devoxx"};
             JComboBox<String> cfpConferenceBox = new JComboBox<>(cfpArray);
             JTextField cfpRestUrlTextField = new JTextField("https://dvbe18.confinabox.com/api/conferences/DVBE18");
-            JTextField timeslotsEndpointTextField = new JTextField("/slots");
+            String[] timeslotsEndpointArray = {"/slots", "/schedules/"};
+            JComboBox<String> timeslotsEndpointBox = new JComboBox<>(timeslotsEndpointArray);
             Object[] dialogue = {
                     "Choose conference:", cfpConferenceBox,
                     "Enter CFP REST Url:", cfpRestUrlTextField,
-                    "Enter timeslots endpoint:", timeslotsEndpointTextField
+                    "Choose timeslots endpoint", timeslotsEndpointBox,
             };
 
             int option = JOptionPane.showConfirmDialog(solutionPanel, dialogue, "Import", JOptionPane.OK_CANCEL_OPTION);
             if (option == JOptionPane.OK_OPTION) {
                 String conferenceBaseUrl = cfpRestUrlTextField.getText();
-                String timeslotsEndpoint = timeslotsEndpointTextField.getText();
+                String timeslotsEndpoint = timeslotsEndpointBox.getSelectedItem().toString();
                 new ConferenceCFPImportWorker(solutionBusiness, solutionPanel, conferenceBaseUrl, timeslotsEndpoint)
                         .executeAndShowDialog();
             }

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/conferencescheduling/swingui/ConferenceCFPImportAction.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/conferencescheduling/swingui/ConferenceCFPImportAction.java
@@ -54,15 +54,19 @@ public class ConferenceCFPImportAction implements CommonApp.ExtraAction<Conferen
             String[] cfpArray = {"cfp-devoxx"};
             JComboBox<String> cfpConferenceBox = new JComboBox<>(cfpArray);
             JTextField cfpRestUrlTextField = new JTextField("https://dvbe18.confinabox.com/api/conferences/DVBE18");
+            JTextField timeslotsEndpointTextField = new JTextField("/slots");
             Object[] dialogue = {
                     "Choose conference:", cfpConferenceBox,
-                    "Enter CFP REST Url:", cfpRestUrlTextField
+                    "Enter CFP REST Url:", cfpRestUrlTextField,
+                    "Enter timeslots endpoint:", timeslotsEndpointTextField
             };
 
             int option = JOptionPane.showConfirmDialog(solutionPanel, dialogue, "Import", JOptionPane.OK_CANCEL_OPTION);
             if (option == JOptionPane.OK_OPTION) {
                 String conferenceBaseUrl = cfpRestUrlTextField.getText();
-                new ConferenceCFPImportWorker(solutionBusiness, solutionPanel, conferenceBaseUrl).executeAndShowDialog();
+                String timeslotsEndpoint = timeslotsEndpointTextField.getText();
+                new ConferenceCFPImportWorker(solutionBusiness, solutionPanel, conferenceBaseUrl, timeslotsEndpoint)
+                        .executeAndShowDialog();
             }
         };
     }
@@ -71,15 +75,17 @@ public class ConferenceCFPImportAction implements CommonApp.ExtraAction<Conferen
 
         private final SolutionBusiness<ConferenceSolution> solutionBusiness;
         private final SolutionPanel<ConferenceSolution> solutionPanel;
-        private final String conferenceBaseUrl;
+        private String conferenceBaseUrl;
+        private String timeslotsEndpoint;
 
         private final JDialog dialog;
 
-        public ConferenceCFPImportWorker(SolutionBusiness<ConferenceSolution> solutionBusiness,
-                                         SolutionPanel<ConferenceSolution> solutionPanel, String conferenceBaseUrl) {
+        public ConferenceCFPImportWorker(SolutionBusiness<ConferenceSolution> solutionBusiness, SolutionPanel<ConferenceSolution> solutionPanel,
+                                         String conferenceBaseUrl, String timeslotsEndpoint) {
             this.solutionBusiness = solutionBusiness;
             this.solutionPanel = solutionPanel;
             this.conferenceBaseUrl = conferenceBaseUrl;
+            this.timeslotsEndpoint = timeslotsEndpoint;
             dialog = new JDialog(solutionPanel.getSolverAndPersistenceFrame(), true);
             JPanel contentPane = new JPanel(new BorderLayout(10, 10));
             contentPane.setBorder(BorderFactory.createEmptyBorder(10, 10, 10, 10));
@@ -109,7 +115,7 @@ public class ConferenceCFPImportAction implements CommonApp.ExtraAction<Conferen
 
         @Override
         protected ConferenceSolution doInBackground() {
-            return new ConferenceSchedulingCfpDevoxxImporter(conferenceBaseUrl).importSolution();
+            return new ConferenceSchedulingCfpDevoxxImporter(conferenceBaseUrl, timeslotsEndpoint).importSolution();
         }
 
         @Override

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/conferencescheduling/swingui/ConferenceCFPImportAction.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/conferencescheduling/swingui/ConferenceCFPImportAction.java
@@ -19,7 +19,6 @@ package org.optaplanner.examples.conferencescheduling.swingui;
 import java.awt.BorderLayout;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
-import java.util.Arrays;
 import java.util.concurrent.ExecutionException;
 import java.util.function.BiConsumer;
 
@@ -55,19 +54,15 @@ public class ConferenceCFPImportAction implements CommonApp.ExtraAction<Conferen
             String[] cfpArray = {"cfp-devoxx"};
             JComboBox<String> cfpConferenceBox = new JComboBox<>(cfpArray);
             JTextField cfpRestUrlTextField = new JTextField("https://dvbe18.confinabox.com/api/conferences/DVBE18");
-            String[] timeslotsEndpointArray = {"/slots", "/schedules/"};
-            JComboBox<String> timeslotsEndpointBox = new JComboBox<>(timeslotsEndpointArray);
             Object[] dialogue = {
                     "Choose conference:", cfpConferenceBox,
                     "Enter CFP REST Url:", cfpRestUrlTextField,
-                    "Choose timeslots endpoint", timeslotsEndpointBox,
             };
 
             int option = JOptionPane.showConfirmDialog(solutionPanel, dialogue, "Import", JOptionPane.OK_CANCEL_OPTION);
             if (option == JOptionPane.OK_OPTION) {
                 String conferenceBaseUrl = cfpRestUrlTextField.getText();
-                String timeslotsEndpoint = timeslotsEndpointBox.getSelectedItem().toString();
-                new ConferenceCFPImportWorker(solutionBusiness, solutionPanel, conferenceBaseUrl, timeslotsEndpoint)
+                new ConferenceCFPImportWorker(solutionBusiness, solutionPanel, conferenceBaseUrl)
                         .executeAndShowDialog();
             }
         };
@@ -78,16 +73,14 @@ public class ConferenceCFPImportAction implements CommonApp.ExtraAction<Conferen
         private final SolutionBusiness<ConferenceSolution> solutionBusiness;
         private final SolutionPanel<ConferenceSolution> solutionPanel;
         private String conferenceBaseUrl;
-        private String timeslotsEndpoint;
 
         private final JDialog dialog;
 
         public ConferenceCFPImportWorker(SolutionBusiness<ConferenceSolution> solutionBusiness, SolutionPanel<ConferenceSolution> solutionPanel,
-                                         String conferenceBaseUrl, String timeslotsEndpoint) {
+                                         String conferenceBaseUrl) {
             this.solutionBusiness = solutionBusiness;
             this.solutionPanel = solutionPanel;
             this.conferenceBaseUrl = conferenceBaseUrl;
-            this.timeslotsEndpoint = timeslotsEndpoint;
             dialog = new JDialog(solutionPanel.getSolverAndPersistenceFrame(), true);
             JPanel contentPane = new JPanel(new BorderLayout(10, 10));
             contentPane.setBorder(BorderFactory.createEmptyBorder(10, 10, 10, 10));
@@ -117,7 +110,7 @@ public class ConferenceCFPImportAction implements CommonApp.ExtraAction<Conferen
 
         @Override
         protected ConferenceSolution doInBackground() {
-            return new ConferenceSchedulingCfpDevoxxImporter(conferenceBaseUrl, timeslotsEndpoint).importSolution();
+            return new ConferenceSchedulingCfpDevoxxImporter(conferenceBaseUrl).importSolution();
         }
 
         @Override


### PR DESCRIPTION
devoxx-cfp exposes timeslots via two endpoints:
- `/slots`: Timeslots as problem facts. It displays all available timeslots without additional data.
- `/schedules/`: The conference solution, i.e. it displays days, timeslots within each day and the talk scheduled at this timeslot.

If users choose to import data using `/slots` endpoint, they'll get an empty problem to solve from scratch, however if they choose `/schedules/`, they'll get the current schedule to either view it or continue solving.