### PR TITLE
Complement JPMS requirements

### DIFF
--- a/optaplanner-docs/src/main/asciidoc/Integration/Integration-chapter.adoc
+++ b/optaplanner-docs/src/main/asciidoc/Integration/Integration-chapter.adoc
@@ -540,7 +540,7 @@ provide the `ClassLoader` of your classes <<solverConfigurationByXML,during the 
 
 When using Planner from code on the modulepath (Java 9 and higher),
 _open_ your packages that contain your domain objects, DRL files and solver configuration
-in your `module-info.java` file:
+_to all modules_ in your `module-info.java` file:
 
 [source,java,options="nowrap"]
 ----
@@ -556,6 +556,26 @@ module org.optaplanner.cloudbalancing {
 
 Otherwise Planner can't reach those classes or files, even if they are exported.
 
+The package `org.xmlpull.v1` is split between dependencies of XStream.
+A workaround is to patch the `xmlpull` module with the `xpp3_min-1.1.4c.jar` artifact.
+
+Since OptaPlanner has no `module-info.java`, it is required to add its `java.scripting` dependency manually to the modulepath with this JVM argument:
+
+[source,bash,options="nowrap"]
+----
+--add-modules java.scripting
+----
+
+Drools and XStream require illegal reflective access to some internal Java packages. This can be achieved with the following JVM arguments:
+
+[source,bash,options="nowrap"]
+----
+--add-opens java.base/java.lang=org.drools.core \
+--add-opens java.base/java.util=xstream \
+--add-opens java.base/java.lang.reflect=xstream \
+--add-opens java.base/java.text=xstream \
+--add-opens java.desktop/java.awt.font=xstream
+----
 
 [[integrationWithOSGi]]
 === OSGi


### PR DESCRIPTION
These steps are based on https://github.com/mwkroening/optaplanner-modulepath-example/commit/e8f909250a6664b368f55b6dd503bd2cc3240824
and https://github.com/psiroky/optaplanner-cloudbalancing-jdk9

The requirement to open up the two packages to all modules is really bothering me.
When opening the domain package only to `org.optaplanner.core`, I get this message:
```bash
Exception in thread "main" java.lang.IllegalAccessError: class org.drools.base.io.github.mwkroening.optaplannermodulepathexample.domain.CloudProcess520162288$getComputer (in unnamed module @0x4d68b571) cannot access class io.github.mwkroening.optaplannermodulepathexample.domain.CloudProcess (in module io.github.mwkroening.optaplannermodulepathexample) because module io.github.mwkroening.optaplannermodulepathexample does not export io.github.mwkroening.optaplannermodulepathexample.domain to unnamed module @0x4d68b571
	at org.drools.base.io.github.mwkroening.optaplannermodulepathexample.domain.CloudProcess520162288$getComputer.getValue(Unknown Source)
	at org.drools.core@7.18.0.Final/org.drools.core.base.extractors.BaseObjectClassFieldReader.getHashCode(BaseObjectClassFieldReader.java:180)
	at org.drools.core@7.18.0.Final/org.drools.core.base.ClassFieldReader.getHashCode(ClassFieldReader.java:224)
	at org.drools.core@7.18.0.Final/org.drools.core.util.AbstractHashTable$FieldIndex.hashCodeOf(AbstractHashTable.java:344)
	at org.drools.core@7.18.0.Final/org.drools.core.util.AbstractHashTable$SingleIndex.hashCodeOf(AbstractHashTable.java:409)
	at org.drools.core@7.18.0.Final/org.drools.core.util.index.TupleIndexHashTable.getOrCreate(TupleIndexHashTable.java:392)
	at org.drools.core@7.18.0.Final/org.drools.core.util.index.TupleIndexHashTable.add(TupleIndexHashTable.java:358)
	at org.drools.core@7.18.0.Final/org.drools.core.phreak.PhreakAccumulateNode.doRightInserts(PhreakAccumulateNode.java:217)
	at org.drools.core@7.18.0.Final/org.drools.core.phreak.PhreakAccumulateNode.doNode(PhreakAccumulateNode.java:85)
	at org.drools.core@7.18.0.Final/org.drools.core.phreak.RuleNetworkEvaluator.switchOnDoBetaNode(RuleNetworkEvaluator.java:581)
	at org.drools.core@7.18.0.Final/org.drools.core.phreak.RuleNetworkEvaluator.evalBetaNode(RuleNetworkEvaluator.java:552)
	at org.drools.core@7.18.0.Final/org.drools.core.phreak.RuleNetworkEvaluator.evalNode(RuleNetworkEvaluator.java:379)
	at org.drools.core@7.18.0.Final/org.drools.core.phreak.RuleNetworkEvaluator.innerEval(RuleNetworkEvaluator.java:339)
	at org.drools.core@7.18.0.Final/org.drools.core.phreak.RuleNetworkEvaluator.outerEval(RuleNetworkEvaluator.java:175)
	at org.drools.core@7.18.0.Final/org.drools.core.phreak.RuleNetworkEvaluator.evaluateNetwork(RuleNetworkEvaluator.java:133)
	at org.drools.core@7.18.0.Final/org.drools.core.phreak.RuleExecutor.reEvaluateNetwork(RuleExecutor.java:213)
	at org.drools.core@7.18.0.Final/org.drools.core.phreak.RuleExecutor.evaluateNetworkAndFire(RuleExecutor.java:88)
	at org.drools.core@7.18.0.Final/org.drools.core.concurrent.AbstractRuleEvaluator.internalEvaluateAndFire(AbstractRuleEvaluator.java:34)
	at org.drools.core@7.18.0.Final/org.drools.core.concurrent.SequentialRuleEvaluator.evaluateAndFire(SequentialRuleEvaluator.java:43)
	at org.drools.core@7.18.0.Final/org.drools.core.common.DefaultAgenda.fireLoop(DefaultAgenda.java:1062)
	at org.drools.core@7.18.0.Final/org.drools.core.common.DefaultAgenda.internalFireAllRules(DefaultAgenda.java:1009)
	at org.drools.core@7.18.0.Final/org.drools.core.common.DefaultAgenda.fireAllRules(DefaultAgenda.java:1001)
	at org.drools.core@7.18.0.Final/org.drools.core.impl.StatefulKnowledgeSessionImpl.internalFireAllRules(StatefulKnowledgeSessionImpl.java:1330)
	at org.drools.core@7.18.0.Final/org.drools.core.impl.StatefulKnowledgeSessionImpl.fireAllRules(StatefulKnowledgeSessionImpl.java:1321)
	at org.drools.core@7.18.0.Final/org.drools.core.impl.StatefulKnowledgeSessionImpl.fireAllRules(StatefulKnowledgeSessionImpl.java:1305)
	at org.optaplanner.core@7.18.0.Final/org.optaplanner.core.impl.score.director.drools.DroolsScoreDirector.calculateScore(DroolsScoreDirector.java:171)
	at org.optaplanner.core@7.18.0.Final/org.optaplanner.core.impl.solver.recaller.BestSolutionRecaller.solvingStarted(BestSolutionRecaller.java:69)
	at org.optaplanner.core@7.18.0.Final/org.optaplanner.core.impl.solver.AbstractSolver.solvingStarted(AbstractSolver.java:76)
	at org.optaplanner.core@7.18.0.Final/org.optaplanner.core.impl.solver.DefaultSolver.solvingStarted(DefaultSolver.java:210)
	at org.optaplanner.core@7.18.0.Final/org.optaplanner.core.impl.solver.DefaultSolver.solve(DefaultSolver.java:190)
	at io.github.mwkroening.optaplannermodulepathexample/io.github.mwkroening.optaplannermodulepathexample.App.main(App.java:22)
```
I dont't know if there is any way for Drools to make this call come from a named package.

The issue with the split package (https://github.com/x-stream/xstream/issues/120) seems to be dormant, although there has been some work to provide a combined artifact: https://github.com/xmlpull-xpp3/xmlpull-xpp3

I think the issue with the missing `java.scripting` module could be resolved by adding an `module-info.java` to OptaPlanner itself, so it can properly declare its dependency as per the java-contract:
https://twitter.com/johanvos/status/1094631555983728640

The only illegal reflective access of Drools in my test was this one:
```bash
WARNING: Illegal reflective access by org.drools.core.rule.builder.dialect.asm.ClassGenerator (file:/home/mkroening/.gradle/caches/modules-2/files-2.1/org.drools/drools-core/7.18.0.Final/ba6d99bb107cab6a9d798682f6487fdedba78dc/drools-core-7.18.0.Final.jar) to method protected final java.lang.Class java.lang.ClassLoader.defineClass(java.lang.String,byte[],int,int) throws java.lang.ClassFormatError
```
I don't know if it would be possible to make Drools use the public API instead.

XStreams issue with illegal reflective acces (https://github.com/x-stream/xstream/issues/101) does not seem to make any progress. In my project I migrated from XStream to JAXB, which is supported on the modulepath.

Thanks for your help!