### PR TITLE
PLANNER-1451 End solver scope before firing solving ended event

### DIFF
--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/solver/DefaultSolver.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/solver/DefaultSolver.java
@@ -220,8 +220,8 @@ public class DefaultSolver<Solution_> extends AbstractSolver<Solution_> {
 
     @Override
     public void solvingEnded(DefaultSolverScope<Solution_> solverScope) {
-        super.solvingEnded(solverScope);
         solverScope.endingNow();
+        super.solvingEnded(solverScope);
     }
 
     public void outerSolvingEnded(DefaultSolverScope<Solution_> solverScope) {


### PR DESCRIPTION
https://issues.jboss.org/browse/PLANNER-1451

Getting score calculation speed from solver scope in `PhaseLifecycleListener#solvingEnded()` shouldn't throw NPE. The fix is simple, we just need to call `solverScope.endingNow()` just before `AbstractSolver#solvingEnded()`, which fires the lifecycle event.

Unblocks gathering Prothean metrics.