### PR TITLE
PLANNER-583 Benchmarker report should mention how long it took to load a problem's inputSolutionFile

### DIFF
--- a/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/impl/result/ProblemBenchmarkResult.java
+++ b/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/impl/result/ProblemBenchmarkResult.java
@@ -76,6 +76,7 @@ public class ProblemBenchmarkResult<Solution_> {
     private Long variableCount = null;
     private Long maximumValueCount = null;
     private Long problemScale = null;
+    private Long inputSolutionLoadingTimeMillisSpent = null;
 
     @XStreamOmitField // Loaded lazily from singleBenchmarkResults
     private Integer maximumSubSingleCount = null;
@@ -163,6 +164,10 @@ public class ProblemBenchmarkResult<Solution_> {
 
     public Long getProblemScale() {
         return problemScale;
+    }
+
+    public Long getInputSolutionLoadingTimeMillisSpent() {
+        return inputSolutionLoadingTimeMillisSpent;
     }
 
     public Integer getMaximumSubSingleCount() {
@@ -293,7 +298,10 @@ public class ProblemBenchmarkResult<Solution_> {
     }
 
     public Solution_ readProblem() {
-        return problemProvider.readProblem();
+        long startTimeMillis = System.currentTimeMillis();
+        Solution_ inputSolution = problemProvider.readProblem();
+        inputSolutionLoadingTimeMillisSpent = System.currentTimeMillis() - startTimeMillis;
+        return inputSolution;
     }
 
     public void writeSolution(SubSingleBenchmarkResult subSingleBenchmarkResult, Solution_ solution) {

--- a/optaplanner-benchmark/src/main/resources/org/optaplanner/benchmark/impl/report/benchmarkReport.html.ftl
+++ b/optaplanner-benchmark/src/main/resources/org/optaplanner/benchmark/impl/report/benchmarkReport.html.ftl
@@ -548,6 +548,14 @@
                         Variable count: ${problemBenchmarkResult.variableCount!""}<br/>
                         Maximum value count: ${problemBenchmarkResult.maximumValueCount!""}<br/>
                         Problem scale: ${problemBenchmarkResult.problemScale!""}
+                        <#if problemBenchmarkResult.inputSolutionLoadingTimeMillisSpent??>
+                            <br/>Time spent to load the inputSolution:&nbsp;
+                            <#if problemBenchmarkResult.inputSolutionLoadingTimeMillisSpent lt 1>
+                                &lt; 1 ms
+                            <#else>
+                                ${problemBenchmarkResult.inputSolutionLoadingTimeMillisSpent} ms
+                            </#if>
+                        </#if>
                         <#if problemBenchmarkResult.averageUsedMemoryAfterInputSolution??>
                             <br/>Memory usage after loading the inputSolution (before creating the Solver): ${problemBenchmarkResult.averageUsedMemoryAfterInputSolution?string.number} bytes on average.
                         </#if>


### PR DESCRIPTION
The issue has been sitting in the queue for quite some time. Came across huge datasets recently, where this would have been super useful.