### PR TITLE
PLANNER-1530 Fix AIOOBE when deserializnig score levels

### DIFF
--- a/optaplanner-persistence/optaplanner-persistence-jpa/src/main/java/org/optaplanner/persistence/jpa/impl/score/AbstractScoreHibernateType.java
+++ b/optaplanner-persistence/optaplanner-persistence-jpa/src/main/java/org/optaplanner/persistence/jpa/impl/score/AbstractScoreHibernateType.java
@@ -105,7 +105,7 @@ public abstract class AbstractScoreHibernateType implements CompositeUserType {
                     + ") must be lower than the levelsSize for score (" + score + ").");
         }
         Number[] levelNumbers = score.toLevelNumbers();
-        return levelNumbers[propertyIndex];
+        return levelNumbers[propertyIndex - 1];
     }
 
     @Override

--- a/optaplanner-persistence/optaplanner-persistence-jpa/src/test/java/org/optaplanner/persistence/jpa/impl/score/buildin/bendable/BendableScoreHibernateTypeTest.java
+++ b/optaplanner-persistence/optaplanner-persistence-jpa/src/test/java/org/optaplanner/persistence/jpa/impl/score/buildin/bendable/BendableScoreHibernateTypeTest.java
@@ -30,25 +30,9 @@ public class BendableScoreHibernateTypeTest extends AbstractScoreHibernateTypeTe
 
     @Test
     public void persistAndMerge() {
-        persistAndMerge(new TestJpaEntity(null),
+        persistAndMerge(new TestJpaEntity(BendableScore.zero(3, 2)),
                 BendableScore.of(new int[]{10000, 2000, 300}, new int[]{40, 5}),
                 BendableScore.ofUninitialized(-7, new int[]{10000, 2000, 300}, new int[]{40, 5}));
-    }
-
-    @Test
-    public void persistUninitializedScoreThenFind() {
-        BendableScore uninitializedScore = BendableScore.ofUninitialized(-7, new int[]{10000, 2000, 300}, new int[]{40, 5});
-        TestJpaEntity uninitializedScoreEntity = new TestJpaEntity(uninitializedScore);
-        Long uninitializedId = persistAndAssert(uninitializedScoreEntity);
-        findAndAssert(TestJpaEntity.class, uninitializedId, uninitializedScore);
-    }
-
-    @Test
-    public void persistInitializedScoreThenFind() {
-        BendableScore initializedScore = BendableScore.of(new int[]{10000, 2000, 300}, new int[]{40, 5});
-        TestJpaEntity initializedScoreEntity = new TestJpaEntity(initializedScore);
-        Long initializedScoreId = persistAndAssert(initializedScoreEntity);
-        findAndAssert(TestJpaEntity.class, initializedScoreId, initializedScore);
     }
 
     @Entity
@@ -77,7 +61,5 @@ public class BendableScoreHibernateTypeTest extends AbstractScoreHibernateTypeTe
         public void setScore(BendableScore score) {
             this.score = score;
         }
-
     }
-
 }

--- a/optaplanner-persistence/optaplanner-persistence-jpa/src/test/java/org/optaplanner/persistence/jpa/impl/score/buildin/bendable/BendableScoreHibernateTypeTest.java
+++ b/optaplanner-persistence/optaplanner-persistence-jpa/src/test/java/org/optaplanner/persistence/jpa/impl/score/buildin/bendable/BendableScoreHibernateTypeTest.java
@@ -35,6 +35,22 @@ public class BendableScoreHibernateTypeTest extends AbstractScoreHibernateTypeTe
                 BendableScore.ofUninitialized(-7, new int[]{10000, 2000, 300}, new int[]{40, 5}));
     }
 
+    @Test
+    public void persistUninitializedScoreThenFind() {
+        BendableScore uninitializedScore = BendableScore.ofUninitialized(-7, new int[]{10000, 2000, 300}, new int[]{40, 5});
+        TestJpaEntity uninitializedScoreEntity = new TestJpaEntity(uninitializedScore);
+        Long uninitializedId = persistAndAssert(uninitializedScoreEntity);
+        findAndAssert(TestJpaEntity.class, uninitializedId, uninitializedScore);
+    }
+
+    @Test
+    public void persistInitializedScoreThenFind() {
+        BendableScore initializedScore = BendableScore.of(new int[]{10000, 2000, 300}, new int[]{40, 5});
+        TestJpaEntity initializedScoreEntity = new TestJpaEntity(initializedScore);
+        Long initializedScoreId = persistAndAssert(initializedScoreEntity);
+        findAndAssert(TestJpaEntity.class, initializedScoreId, initializedScore);
+    }
+
     @Entity
     @TypeDef(defaultForType = BendableScore.class, typeClass = BendableScoreHibernateType.class,
             parameters = {@Parameter(name = "hardLevelsSize", value = "3"), @Parameter(name = "softLevelsSize", value = "2")})

--- a/optaplanner-persistence/optaplanner-persistence-jpa/src/test/java/org/optaplanner/persistence/jpa/impl/score/buildin/bendablebigdecimal/BendableBigDecimalScoreHibernateTypeTest.java
+++ b/optaplanner-persistence/optaplanner-persistence-jpa/src/test/java/org/optaplanner/persistence/jpa/impl/score/buildin/bendablebigdecimal/BendableBigDecimalScoreHibernateTypeTest.java
@@ -31,7 +31,7 @@ public class BendableBigDecimalScoreHibernateTypeTest extends AbstractScoreHiber
 
     @Test
     public void persistAndMerge() {
-        persistAndMerge(new TestJpaEntity(null),
+        persistAndMerge(new TestJpaEntity(BendableBigDecimalScore.zero(3, 2)),
                 BendableBigDecimalScore.of(
                         new BigDecimal[]{new BigDecimal("10000.00001"), new BigDecimal("2000.00020"), new BigDecimal("300.00300")},
                         new BigDecimal[]{new BigDecimal("40.04000"), new BigDecimal("5.50000")}),

--- a/optaplanner-persistence/optaplanner-persistence-jpa/src/test/java/org/optaplanner/persistence/jpa/impl/score/buildin/bendablelong/BendableLongScoreHibernateTypeTest.java
+++ b/optaplanner-persistence/optaplanner-persistence-jpa/src/test/java/org/optaplanner/persistence/jpa/impl/score/buildin/bendablelong/BendableLongScoreHibernateTypeTest.java
@@ -30,7 +30,7 @@ public class BendableLongScoreHibernateTypeTest extends AbstractScoreHibernateTy
 
     @Test
     public void persistAndMerge() {
-        persistAndMerge(new TestJpaEntity(null),
+        persistAndMerge(new TestJpaEntity(BendableLongScore.zero(3, 2)),
                 BendableLongScore.of(new long[]{10000L, 2000L, 300L}, new long[]{40L, 5L}),
                 BendableLongScore.ofUninitialized(-7, new long[]{10000L, 2000L, 300L}, new long[]{40L, 5L}));
     }

--- a/optaplanner-persistence/optaplanner-persistence-jpa/src/test/java/org/optaplanner/persistence/jpa/impl/score/buildin/hardmediumsoft/HardMediumSoftScoreHibernateTypeTest.java
+++ b/optaplanner-persistence/optaplanner-persistence-jpa/src/test/java/org/optaplanner/persistence/jpa/impl/score/buildin/hardmediumsoft/HardMediumSoftScoreHibernateTypeTest.java
@@ -29,7 +29,7 @@ public class HardMediumSoftScoreHibernateTypeTest extends AbstractScoreHibernate
 
     @Test
     public void persistAndMerge() {
-        persistAndMerge(new TestJpaEntity(null),
+        persistAndMerge(new TestJpaEntity(HardMediumSoftScore.ZERO),
                 HardMediumSoftScore.of(-100, -20, -3),
                 HardMediumSoftScore.ofUninitialized(-7, -100, -20, -3));
     }

--- a/optaplanner-persistence/optaplanner-persistence-jpa/src/test/java/org/optaplanner/persistence/jpa/impl/score/buildin/hardmediumsoftbigdecimal/HardMediumSoftBigDecimalScoreHibernateTypeTest.java
+++ b/optaplanner-persistence/optaplanner-persistence-jpa/src/test/java/org/optaplanner/persistence/jpa/impl/score/buildin/hardmediumsoftbigdecimal/HardMediumSoftBigDecimalScoreHibernateTypeTest.java
@@ -30,7 +30,7 @@ public class HardMediumSoftBigDecimalScoreHibernateTypeTest extends AbstractScor
 
     @Test
     public void persistAndMerge() {
-        persistAndMerge(new TestJpaEntity(null),
+        persistAndMerge(new TestJpaEntity(HardMediumSoftBigDecimalScore.ZERO),
                 HardMediumSoftBigDecimalScore.of(new BigDecimal("-10.01000"), new BigDecimal("-4.32100"), new BigDecimal("-2.20000")),
                 HardMediumSoftBigDecimalScore.ofUninitialized(-7, new BigDecimal("-10.01000"), new BigDecimal("-4.32100"), new BigDecimal("-2.20000")));
     }

--- a/optaplanner-persistence/optaplanner-persistence-jpa/src/test/java/org/optaplanner/persistence/jpa/impl/score/buildin/hardmediumsoftlong/HardMediumSoftLongScoreHibernateTypeTest.java
+++ b/optaplanner-persistence/optaplanner-persistence-jpa/src/test/java/org/optaplanner/persistence/jpa/impl/score/buildin/hardmediumsoftlong/HardMediumSoftLongScoreHibernateTypeTest.java
@@ -29,7 +29,7 @@ public class HardMediumSoftLongScoreHibernateTypeTest extends AbstractScoreHiber
 
     @Test
     public void persistAndMerge() {
-        persistAndMerge(new TestJpaEntity(null),
+        persistAndMerge(new TestJpaEntity(HardMediumSoftLongScore.ZERO),
                 HardMediumSoftLongScore.of(-100L, -20L, -3L),
                 HardMediumSoftLongScore.ofUninitialized(-7, -100L, -20L, -3L));
     }

--- a/optaplanner-persistence/optaplanner-persistence-jpa/src/test/java/org/optaplanner/persistence/jpa/impl/score/buildin/hardsoft/HardSoftScoreHibernateTypeTest.java
+++ b/optaplanner-persistence/optaplanner-persistence-jpa/src/test/java/org/optaplanner/persistence/jpa/impl/score/buildin/hardsoft/HardSoftScoreHibernateTypeTest.java
@@ -29,7 +29,7 @@ public class HardSoftScoreHibernateTypeTest extends AbstractScoreHibernateTypeTe
 
     @Test
     public void persistAndMerge() {
-        persistAndMerge(new TestJpaEntity(null),
+        persistAndMerge(new TestJpaEntity(HardSoftScore.ZERO),
                 HardSoftScore.of(-10, -2),
                 HardSoftScore.ofUninitialized(-7, -10, -2));
     }

--- a/optaplanner-persistence/optaplanner-persistence-jpa/src/test/java/org/optaplanner/persistence/jpa/impl/score/buildin/hardsoftbigdecimal/HardSoftBigDecimalScoreHibernateTypeTest.java
+++ b/optaplanner-persistence/optaplanner-persistence-jpa/src/test/java/org/optaplanner/persistence/jpa/impl/score/buildin/hardsoftbigdecimal/HardSoftBigDecimalScoreHibernateTypeTest.java
@@ -30,7 +30,7 @@ public class HardSoftBigDecimalScoreHibernateTypeTest extends AbstractScoreHiber
 
     @Test
     public void persistAndMerge() {
-        persistAndMerge(new TestJpaEntity(null),
+        persistAndMerge(new TestJpaEntity(HardSoftBigDecimalScore.ZERO),
                 HardSoftBigDecimalScore.of(new BigDecimal("-10.01000"), new BigDecimal("-2.20000")),
                 HardSoftBigDecimalScore.ofUninitialized(-7, new BigDecimal("-10.01000"), new BigDecimal("-2.20000")));
     }

--- a/optaplanner-persistence/optaplanner-persistence-jpa/src/test/java/org/optaplanner/persistence/jpa/impl/score/buildin/hardsoftdouble/HardSoftDoubleScoreHibernateTypeTest.java
+++ b/optaplanner-persistence/optaplanner-persistence-jpa/src/test/java/org/optaplanner/persistence/jpa/impl/score/buildin/hardsoftdouble/HardSoftDoubleScoreHibernateTypeTest.java
@@ -29,7 +29,7 @@ public class HardSoftDoubleScoreHibernateTypeTest extends AbstractScoreHibernate
 
     @Test
     public void persistAndMerge() {
-        persistAndMerge(new TestJpaEntity(null),
+        persistAndMerge(new TestJpaEntity(HardSoftDoubleScore.ZERO),
                 HardSoftDoubleScore.of(-10.01, -2.20),
                 HardSoftDoubleScore.ofUninitialized(-7, -10.01, -2.20));
     }

--- a/optaplanner-persistence/optaplanner-persistence-jpa/src/test/java/org/optaplanner/persistence/jpa/impl/score/buildin/hardsoftlong/HardSoftLongScoreHibernateTypeTest.java
+++ b/optaplanner-persistence/optaplanner-persistence-jpa/src/test/java/org/optaplanner/persistence/jpa/impl/score/buildin/hardsoftlong/HardSoftLongScoreHibernateTypeTest.java
@@ -29,7 +29,7 @@ public class HardSoftLongScoreHibernateTypeTest extends AbstractScoreHibernateTy
 
     @Test
     public void persistAndMerge() {
-        persistAndMerge(new TestJpaEntity(null),
+        persistAndMerge(new TestJpaEntity(HardSoftLongScore.ZERO),
                 HardSoftLongScore.of(-10L, -2L),
                 HardSoftLongScore.ofUninitialized(-7, -10L, -2L));
     }

--- a/optaplanner-persistence/optaplanner-persistence-jpa/src/test/java/org/optaplanner/persistence/jpa/impl/score/buildin/simple/SimpleScoreHibernateTypeTest.java
+++ b/optaplanner-persistence/optaplanner-persistence-jpa/src/test/java/org/optaplanner/persistence/jpa/impl/score/buildin/simple/SimpleScoreHibernateTypeTest.java
@@ -29,7 +29,7 @@ public class SimpleScoreHibernateTypeTest extends AbstractScoreHibernateTypeTest
 
     @Test
     public void persistAndMerge() {
-        persistAndMerge(new TestJpaEntity(null),
+        persistAndMerge(new TestJpaEntity(SimpleScore.ZERO),
                 SimpleScore.of(-10),
                 SimpleScore.ofUninitialized(-7, -10));
     }

--- a/optaplanner-persistence/optaplanner-persistence-jpa/src/test/java/org/optaplanner/persistence/jpa/impl/score/buildin/simplebigdecimal/SimpleBigDecimalScoreHibernateTypeTest.java
+++ b/optaplanner-persistence/optaplanner-persistence-jpa/src/test/java/org/optaplanner/persistence/jpa/impl/score/buildin/simplebigdecimal/SimpleBigDecimalScoreHibernateTypeTest.java
@@ -30,7 +30,7 @@ public class SimpleBigDecimalScoreHibernateTypeTest extends AbstractScoreHiberna
 
     @Test
     public void persistAndMerge() {
-        persistAndMerge(new TestJpaEntity(null),
+        persistAndMerge(new TestJpaEntity(SimpleBigDecimalScore.ZERO),
                 SimpleBigDecimalScore.of(new BigDecimal("-10.01000")),
                 SimpleBigDecimalScore.ofUninitialized(-7, new BigDecimal("-10.01000")));
     }

--- a/optaplanner-persistence/optaplanner-persistence-jpa/src/test/java/org/optaplanner/persistence/jpa/impl/score/buildin/simpledouble/SimpleDoubleScoreHibernateTypeTest.java
+++ b/optaplanner-persistence/optaplanner-persistence-jpa/src/test/java/org/optaplanner/persistence/jpa/impl/score/buildin/simpledouble/SimpleDoubleScoreHibernateTypeTest.java
@@ -29,7 +29,7 @@ public class SimpleDoubleScoreHibernateTypeTest extends AbstractScoreHibernateTy
 
     @Test
     public void persistAndMerge() {
-        persistAndMerge(new TestJpaEntity(null),
+        persistAndMerge(new TestJpaEntity(SimpleDoubleScore.ZERO),
                 SimpleDoubleScore.of(-10.01),
                 SimpleDoubleScore.ofUninitialized(-7, -10.01));
     }

--- a/optaplanner-persistence/optaplanner-persistence-jpa/src/test/java/org/optaplanner/persistence/jpa/impl/score/buildin/simplelong/SimpleLongScoreHibernateTypeTest.java
+++ b/optaplanner-persistence/optaplanner-persistence-jpa/src/test/java/org/optaplanner/persistence/jpa/impl/score/buildin/simplelong/SimpleLongScoreHibernateTypeTest.java
@@ -29,7 +29,7 @@ public class SimpleLongScoreHibernateTypeTest extends AbstractScoreHibernateType
 
     @Test
     public void persistAndMerge() {
-        persistAndMerge(new TestJpaEntity(null),
+        persistAndMerge(new TestJpaEntity(SimpleLongScore.ZERO),
                 SimpleLongScore.of(-10L),
                 SimpleLongScore.ofUninitialized(-7, -10L));
     }


### PR DESCRIPTION
Accessing hard/soft score levels in Hibernate starts from 1 (0 is for initScore), this results in an ArrayIndexOutOfBoundsException when accessing the last score level.