### PR TITLE
Support java.util.Date in TestGen

### DIFF
--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/fact/TestGenDateValueProvider.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/fact/TestGenDateValueProvider.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.core.impl.score.director.drools.testgen.fact;
+
+import java.util.Date;
+
+public class TestGenDateValueProvider extends TestGenAbstractValueProvider<Date> {
+
+    public TestGenDateValueProvider(Date value) {
+        super(value);
+    }
+
+    @Override
+    public String toString() {
+        return '"' + value.toString() + '"';
+    }
+}

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/fact/TestGenDateValueProvider.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/fact/TestGenDateValueProvider.java
@@ -18,7 +18,7 @@ package org.optaplanner.core.impl.score.director.drools.testgen.fact;
 
 import java.util.Date;
 
-public class TestGenDateValueProvider extends TestGenAbstractValueProvider<Date> {
+class TestGenDateValueProvider extends TestGenAbstractValueProvider<Date> {
 
     public TestGenDateValueProvider(Date value) {
         super(value);

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/fact/TestGenValueFact.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/fact/TestGenValueFact.java
@@ -22,6 +22,7 @@ import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -94,6 +95,9 @@ public class TestGenValueFact implements TestGenFact {
                     TestGenMapValueProvider mapValueProvider = new TestGenMapValueProvider(
                             (Map) value, id, typeArgs, existingInstances);
                     fields.add(new TestGenFactField(this, fieldName, mapValueProvider));
+                } else if (field.getType().equals(Date.class)) {
+                    TestGenDateValueProvider dateValueProvider = new TestGenDateValueProvider((Date) value);
+                    fields.add(new TestGenFactField(this, fieldName, dateValueProvider));
                 } else {
                     Method parseMethod = getParseMethod(field);
                     if (parseMethod != null) {


### PR DESCRIPTION
This modification was necessary for me to proceed in isolation of NPE in Drools.