### PR TITLE
PLANNER-1270 Provide tests and fix for unimproved time spent score diff termination

### DIFF
--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/solver/termination/UnimprovedTimeMillisSpentScoreDifferenceThresholdTermination.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/solver/termination/UnimprovedTimeMillisSpentScoreDifferenceThresholdTermination.java
@@ -16,6 +16,7 @@
 
 package org.optaplanner.core.impl.solver.termination;
 
+import java.time.Clock;
 import java.util.ArrayDeque;
 import java.util.Iterator;
 import java.util.Queue;
@@ -31,6 +32,7 @@ public class UnimprovedTimeMillisSpentScoreDifferenceThresholdTermination extend
 
     private final long unimprovedTimeMillisSpentLimit;
     private final Score unimprovedScoreDifferenceThreshold;
+    private final Clock clock;
 
     private Queue<Pair<Long, Score>> bestScoreImprovementHistoryQueue;
     // safeTimeMillis is until when we're safe from termination
@@ -38,13 +40,20 @@ public class UnimprovedTimeMillisSpentScoreDifferenceThresholdTermination extend
     private long phaseSafeTimeMillis = -1L;
 
     public UnimprovedTimeMillisSpentScoreDifferenceThresholdTermination(long unimprovedTimeMillisSpentLimit,
-            Score unimprovedScoreDifferenceThreshold) {
+                                                                        Score unimprovedScoreDifferenceThreshold) {
+        this(unimprovedTimeMillisSpentLimit, unimprovedScoreDifferenceThreshold, Clock.systemUTC());
+    }
+
+    protected UnimprovedTimeMillisSpentScoreDifferenceThresholdTermination(long unimprovedTimeMillisSpentLimit,
+                                                                           Score unimprovedScoreDifferenceThreshold,
+                                                                           Clock clock) {
         this.unimprovedTimeMillisSpentLimit = unimprovedTimeMillisSpentLimit;
         this.unimprovedScoreDifferenceThreshold = unimprovedScoreDifferenceThreshold;
         if (unimprovedTimeMillisSpentLimit <= 0L) {
             throw new IllegalArgumentException("The unimprovedTimeMillisSpentLimit (" + unimprovedTimeMillisSpentLimit
-                    + ") cannot be negative.");
+                                                       + ") cannot be negative.");
         }
+        this.clock = clock;
     }
 
     public long getUnimprovedTimeMillisSpentLimit() {
@@ -86,9 +95,13 @@ public class UnimprovedTimeMillisSpentScoreDifferenceThresholdTermination extend
             for (Iterator<Pair<Long, Score>> it = bestScoreImprovementHistoryQueue.iterator(); it.hasNext(); ) {
                 Pair<Long, Score> bestScoreImprovement = it.next();
                 Score scoreDifference = bestScore.subtract(bestScoreImprovement.getValue());
-                if (scoreDifference.compareTo(unimprovedScoreDifferenceThreshold) >= 0) {
+                final boolean timeLimitNotYetReached =
+                        bestScoreImprovement.getKey() + unimprovedTimeMillisSpentLimit >= bestSolutionTimeMillis;
+                final boolean scoreImprovedOverThreshold =
+                        scoreDifference.compareTo(unimprovedScoreDifferenceThreshold) >= 0;
+                if (scoreImprovedOverThreshold && timeLimitNotYetReached) {
                     it.remove();
-                    long safeTimeMillis = bestScoreImprovement.getKey() + unimprovedTimeMillisSpentLimit;
+                    long safeTimeMillis = bestSolutionTimeMillis + unimprovedTimeMillisSpentLimit;
                     solverSafeTimeMillis = safeTimeMillis;
                     phaseSafeTimeMillis = safeTimeMillis;
                 } else {
@@ -118,7 +131,7 @@ public class UnimprovedTimeMillisSpentScoreDifferenceThresholdTermination extend
         // that will end up pushing the safeTimeMillis further
         // but that doesn't change the fact that the best score didn't improve enough in the specified time interval.
         // It just looks weird because it terminates even though the final step is a high enough score improvement.
-        long now = System.currentTimeMillis();
+        long now = clock.millis();
         return now > safeTimeMillis;
     }
 
@@ -137,7 +150,7 @@ public class UnimprovedTimeMillisSpentScoreDifferenceThresholdTermination extend
     }
 
     protected double calculateTimeGradient(long safeTimeMillis) {
-        long now = System.currentTimeMillis();
+        long now = clock.millis();
         long unimprovedTimeMillisSpent = now - (safeTimeMillis - unimprovedTimeMillisSpentLimit);
         double timeGradient = ((double) unimprovedTimeMillisSpent) / ((double) unimprovedTimeMillisSpentLimit);
         return Math.min(timeGradient, 1.0);
@@ -158,5 +171,4 @@ public class UnimprovedTimeMillisSpentScoreDifferenceThresholdTermination extend
     public String toString() {
         return "UnimprovedTimeMillisSpent(" + unimprovedTimeMillisSpentLimit + ")";
     }
-
 }

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/solver/termination/UnimprovedTimeMillisSpentScoreDifferenceThresholdTermination.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/solver/termination/UnimprovedTimeMillisSpentScoreDifferenceThresholdTermination.java
@@ -39,17 +39,19 @@ public class UnimprovedTimeMillisSpentScoreDifferenceThresholdTermination extend
     private long solverSafeTimeMillis = -1L;
     private long phaseSafeTimeMillis = -1L;
 
-    public UnimprovedTimeMillisSpentScoreDifferenceThresholdTermination(long unimprovedTimeMillisSpentLimit,
-                                                                        Score unimprovedScoreDifferenceThreshold) {
+    public UnimprovedTimeMillisSpentScoreDifferenceThresholdTermination(
+            long unimprovedTimeMillisSpentLimit,
+            Score unimprovedScoreDifferenceThreshold) {
         this(unimprovedTimeMillisSpentLimit, unimprovedScoreDifferenceThreshold, Clock.systemUTC());
     }
 
-    protected UnimprovedTimeMillisSpentScoreDifferenceThresholdTermination(long unimprovedTimeMillisSpentLimit,
-                                                                           Score unimprovedScoreDifferenceThreshold,
-                                                                           Clock clock) {
+    protected UnimprovedTimeMillisSpentScoreDifferenceThresholdTermination(
+            long unimprovedTimeMillisSpentLimit,
+            Score unimprovedScoreDifferenceThreshold,
+            Clock clock) {
         this.unimprovedTimeMillisSpentLimit = unimprovedTimeMillisSpentLimit;
         this.unimprovedScoreDifferenceThreshold = unimprovedScoreDifferenceThreshold;
-        if (unimprovedTimeMillisSpentLimit <= 0L) {
+        if (unimprovedTimeMillisSpentLimit < 0L) {
             throw new IllegalArgumentException("The unimprovedTimeMillisSpentLimit (" + unimprovedTimeMillisSpentLimit
                                                        + ") cannot be negative.");
         }
@@ -95,10 +97,9 @@ public class UnimprovedTimeMillisSpentScoreDifferenceThresholdTermination extend
             for (Iterator<Pair<Long, Score>> it = bestScoreImprovementHistoryQueue.iterator(); it.hasNext(); ) {
                 Pair<Long, Score> bestScoreImprovement = it.next();
                 Score scoreDifference = bestScore.subtract(bestScoreImprovement.getValue());
-                final boolean timeLimitNotYetReached =
+                boolean timeLimitNotYetReached =
                         bestScoreImprovement.getKey() + unimprovedTimeMillisSpentLimit >= bestSolutionTimeMillis;
-                final boolean scoreImprovedOverThreshold =
-                        scoreDifference.compareTo(unimprovedScoreDifferenceThreshold) >= 0;
+                boolean scoreImprovedOverThreshold = scoreDifference.compareTo(unimprovedScoreDifferenceThreshold) >= 0;
                 if (scoreImprovedOverThreshold && timeLimitNotYetReached) {
                     it.remove();
                     long safeTimeMillis = bestSolutionTimeMillis + unimprovedTimeMillisSpentLimit;

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/solver/termination/UnimprovedTimeMillisSpentTermination.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/solver/termination/UnimprovedTimeMillisSpentTermination.java
@@ -16,6 +16,8 @@
 
 package org.optaplanner.core.impl.solver.termination;
 
+import java.time.Clock;
+
 import org.optaplanner.core.impl.phase.scope.AbstractPhaseScope;
 import org.optaplanner.core.impl.solver.ChildThreadType;
 import org.optaplanner.core.impl.solver.scope.DefaultSolverScope;
@@ -24,12 +26,19 @@ public class UnimprovedTimeMillisSpentTermination extends AbstractTermination {
 
     private final long unimprovedTimeMillisSpentLimit;
 
+    private final Clock clock;
+
     public UnimprovedTimeMillisSpentTermination(long unimprovedTimeMillisSpentLimit) {
+        this(unimprovedTimeMillisSpentLimit, Clock.systemUTC());
+    }
+
+    protected UnimprovedTimeMillisSpentTermination(long unimprovedTimeMillisSpentLimit, Clock clock) {
         this.unimprovedTimeMillisSpentLimit = unimprovedTimeMillisSpentLimit;
         if (unimprovedTimeMillisSpentLimit <= 0L) {
             throw new IllegalArgumentException("The unimprovedTimeMillisSpentLimit (" + unimprovedTimeMillisSpentLimit
-                    + ") cannot be negative.");
+                                                       + ") cannot be negative.");
         }
+        this.clock = clock;
     }
 
     public long getUnimprovedTimeMillisSpentLimit() {
@@ -53,7 +62,7 @@ public class UnimprovedTimeMillisSpentTermination extends AbstractTermination {
     }
 
     protected boolean isTerminated(long bestSolutionTimeMillis) {
-        long now = System.currentTimeMillis();
+        long now = clock.millis();
         long unimprovedTimeMillisSpent = now - bestSolutionTimeMillis;
         return unimprovedTimeMillisSpent >= unimprovedTimeMillisSpentLimit;
     }
@@ -75,7 +84,7 @@ public class UnimprovedTimeMillisSpentTermination extends AbstractTermination {
     }
 
     protected double calculateTimeGradient(long bestSolutionTimeMillis) {
-        long now = System.currentTimeMillis();
+        long now = clock.millis();
         long unimprovedTimeMillisSpent = now - bestSolutionTimeMillis;
         double timeGradient = ((double) unimprovedTimeMillisSpent) / ((double) unimprovedTimeMillisSpentLimit);
         return Math.min(timeGradient, 1.0);

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/solver/termination/UnimprovedTimeMillisSpentTermination.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/solver/termination/UnimprovedTimeMillisSpentTermination.java
@@ -34,7 +34,7 @@ public class UnimprovedTimeMillisSpentTermination extends AbstractTermination {
 
     protected UnimprovedTimeMillisSpentTermination(long unimprovedTimeMillisSpentLimit, Clock clock) {
         this.unimprovedTimeMillisSpentLimit = unimprovedTimeMillisSpentLimit;
-        if (unimprovedTimeMillisSpentLimit <= 0L) {
+        if (unimprovedTimeMillisSpentLimit < 0L) {
             throw new IllegalArgumentException("The unimprovedTimeMillisSpentLimit (" + unimprovedTimeMillisSpentLimit
                                                        + ") cannot be negative.");
         }
@@ -104,5 +104,4 @@ public class UnimprovedTimeMillisSpentTermination extends AbstractTermination {
     public String toString() {
         return "UnimprovedTimeMillisSpent(" + unimprovedTimeMillisSpentLimit + ")";
     }
-
 }

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/solver/termination/UnimprovedTimeMillisSpentScoreDifferenceThresholdTerminationTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/solver/termination/UnimprovedTimeMillisSpentScoreDifferenceThresholdTerminationTest.java
@@ -38,9 +38,11 @@ public class UnimprovedTimeMillisSpentScoreDifferenceThresholdTerminationTest {
     private static final long START_TIME_MILLIS = 0L;
 
     @Test
-    public void forZeroUnimprovedTimeMillis_exceptionIsThrown() {
+    public void forNegativeUnimprovedTimeMillis_exceptionIsThrown() {
         assertThatIllegalArgumentException()
-                .isThrownBy(() -> new UnimprovedTimeMillisSpentTermination(0L))
+                .isThrownBy(() -> new UnimprovedTimeMillisSpentScoreDifferenceThresholdTermination(
+                        -1L,
+                        SimpleScore.of(0)))
                 .withMessageContaining("cannot be negative");
     }
 
@@ -51,9 +53,10 @@ public class UnimprovedTimeMillisSpentScoreDifferenceThresholdTerminationTest {
         AbstractStepScope<?> stepScope = mock(LocalSearchStepScope.class);
         Clock clock = mock(Clock.class);
 
-        Termination termination = new UnimprovedTimeMillisSpentScoreDifferenceThresholdTermination(1000L,
-                                                                                                   SimpleScore.of(7),
-                                                                                                   clock);
+        Termination termination = new UnimprovedTimeMillisSpentScoreDifferenceThresholdTermination(
+                1000L,
+                SimpleScore.of(7),
+                clock);
         doReturn(solverScope).when(phaseScope).getSolverScope();
         doReturn(phaseScope).when(stepScope).getPhaseScope();
 
@@ -103,9 +106,10 @@ public class UnimprovedTimeMillisSpentScoreDifferenceThresholdTerminationTest {
         AbstractStepScope<?> stepScope = mock(LocalSearchStepScope.class);
         Clock clock = mock(Clock.class);
 
-        Termination termination = new UnimprovedTimeMillisSpentScoreDifferenceThresholdTermination(1000L,
-                                                                                                   SimpleScore.of(7),
-                                                                                                   clock);
+        Termination termination = new UnimprovedTimeMillisSpentScoreDifferenceThresholdTermination(
+                1000L,
+                SimpleScore.of(7),
+                clock);
         doReturn(solverScope).when(phaseScope).getSolverScope();
         doReturn(phaseScope).when(stepScope).getPhaseScope();
 

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/solver/termination/UnimprovedTimeMillisSpentScoreDifferenceThresholdTerminationTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/solver/termination/UnimprovedTimeMillisSpentScoreDifferenceThresholdTerminationTest.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.core.impl.solver.termination;
+
+import java.time.Clock;
+
+import org.junit.Test;
+import org.optaplanner.core.api.score.buildin.simple.SimpleScore;
+import org.optaplanner.core.impl.localsearch.scope.LocalSearchPhaseScope;
+import org.optaplanner.core.impl.localsearch.scope.LocalSearchStepScope;
+import org.optaplanner.core.impl.phase.scope.AbstractPhaseScope;
+import org.optaplanner.core.impl.phase.scope.AbstractStepScope;
+import org.optaplanner.core.impl.solver.scope.DefaultSolverScope;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.assertj.core.api.Assertions.withPrecision;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class UnimprovedTimeMillisSpentScoreDifferenceThresholdTerminationTest {
+
+    private static final long START_TIME_MILLIS = 0L;
+
+    @Test
+    public void forZeroUnimprovedTimeMillis_exceptionIsThrown() {
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> new UnimprovedTimeMillisSpentTermination(0L))
+                .withMessageContaining("cannot be negative");
+    }
+
+    @Test
+    public void scoreImproves_terminationIsPostponed() {
+        DefaultSolverScope<?> solverScope = mock(DefaultSolverScope.class);
+        AbstractPhaseScope<?> phaseScope = mock(LocalSearchPhaseScope.class);
+        AbstractStepScope<?> stepScope = mock(LocalSearchStepScope.class);
+        Clock clock = mock(Clock.class);
+
+        Termination termination = new UnimprovedTimeMillisSpentScoreDifferenceThresholdTermination(1000L,
+                                                                                                   SimpleScore.of(7),
+                                                                                                   clock);
+        doReturn(solverScope).when(phaseScope).getSolverScope();
+        doReturn(phaseScope).when(stepScope).getPhaseScope();
+
+        // first step
+        when(clock.millis()).thenReturn(START_TIME_MILLIS);
+        when(phaseScope.getStartingSystemTimeMillis()).thenReturn(START_TIME_MILLIS);
+        when(solverScope.getBestSolutionTimeMillis()).thenReturn(START_TIME_MILLIS);
+        when(stepScope.getBestScoreImproved()).thenReturn(Boolean.TRUE);
+        when(solverScope.getBestScore()).thenReturn(SimpleScore.of(0));
+
+        termination.solvingStarted(solverScope);
+        termination.phaseStarted(phaseScope);
+        termination.stepEnded(stepScope);
+
+        // time has not yet run out
+        when(clock.millis()).thenReturn(START_TIME_MILLIS + 500L);
+        assertThat(termination.isPhaseTerminated(phaseScope)).isFalse();
+        assertThat(termination.calculatePhaseTimeGradient(phaseScope)).isEqualTo(0.5, withPrecision(0.0));
+        assertThat(termination.isSolverTerminated(solverScope)).isFalse();
+        assertThat(termination.calculateSolverTimeGradient(solverScope)).isEqualTo(0.5, withPrecision(0.0));
+
+        // second step - score has improved beyond the threshold => termination is postponed by another second
+        when(solverScope.getBestSolutionTimeMillis()).thenReturn(START_TIME_MILLIS + 500L);
+        when(stepScope.getBestScoreImproved()).thenReturn(Boolean.TRUE);
+        when(solverScope.getBestScore()).thenReturn(SimpleScore.of(10));
+
+        termination.stepEnded(stepScope);
+
+        assertThat(termination.calculatePhaseTimeGradient(phaseScope)).isEqualTo(0.0, withPrecision(0.0));
+        assertThat(termination.calculateSolverTimeGradient(solverScope)).isEqualTo(0.0, withPrecision(0.0));
+
+        when(clock.millis()).thenReturn(START_TIME_MILLIS + 1500L);
+        assertThat(termination.isPhaseTerminated(phaseScope)).isFalse();
+        assertThat(termination.calculatePhaseTimeGradient(phaseScope)).isEqualTo(1.0, withPrecision(0.0));
+        assertThat(termination.isSolverTerminated(solverScope)).isFalse();
+        assertThat(termination.calculateSolverTimeGradient(solverScope)).isEqualTo(1.0, withPrecision(0.0));
+
+        when(clock.millis()).thenReturn(START_TIME_MILLIS + 1501L);
+        assertThat(termination.isPhaseTerminated(phaseScope)).isTrue();
+        assertThat(termination.isSolverTerminated(solverScope)).isTrue();
+    }
+
+    @Test
+    public void scoreImprovesTooLate_terminates() {
+        DefaultSolverScope<?> solverScope = mock(DefaultSolverScope.class);
+        AbstractPhaseScope<?> phaseScope = mock(LocalSearchPhaseScope.class);
+        AbstractStepScope<?> stepScope = mock(LocalSearchStepScope.class);
+        Clock clock = mock(Clock.class);
+
+        Termination termination = new UnimprovedTimeMillisSpentScoreDifferenceThresholdTermination(1000L,
+                                                                                                   SimpleScore.of(7),
+                                                                                                   clock);
+        doReturn(solverScope).when(phaseScope).getSolverScope();
+        doReturn(phaseScope).when(stepScope).getPhaseScope();
+
+        // first step
+        when(clock.millis()).thenReturn(START_TIME_MILLIS);
+        when(phaseScope.getStartingSystemTimeMillis()).thenReturn(START_TIME_MILLIS);
+        when(solverScope.getBestSolutionTimeMillis()).thenReturn(START_TIME_MILLIS);
+        when(stepScope.getBestScoreImproved()).thenReturn(Boolean.TRUE);
+        when(solverScope.getBestScore()).thenReturn(SimpleScore.of(0));
+
+        termination.solvingStarted(solverScope);
+        termination.phaseStarted(phaseScope);
+        termination.stepEnded(stepScope);
+
+        // time has not yet run out
+        when(clock.millis()).thenReturn(START_TIME_MILLIS + 500L);
+        assertThat(termination.isPhaseTerminated(phaseScope)).isFalse();
+        assertThat(termination.calculatePhaseTimeGradient(phaseScope)).isEqualTo(0.5, withPrecision(0.0));
+        assertThat(termination.isSolverTerminated(solverScope)).isFalse();
+        assertThat(termination.calculateSolverTimeGradient(solverScope)).isEqualTo(0.5, withPrecision(0.0));
+
+        // second step - score has improved, but not beyond the threshold
+        when(clock.millis()).thenReturn(START_TIME_MILLIS + 1000L);
+        when(solverScope.getBestSolutionTimeMillis()).thenReturn(START_TIME_MILLIS + 1000L);
+        when(stepScope.getBestScoreImproved()).thenReturn(Boolean.TRUE);
+        when(solverScope.getBestScore()).thenReturn(SimpleScore.of(5));
+        termination.stepEnded(stepScope);
+
+        assertThat(termination.isPhaseTerminated(phaseScope)).isFalse();
+        assertThat(termination.calculatePhaseTimeGradient(phaseScope)).isEqualTo(1.0, withPrecision(0.0));
+        assertThat(termination.isSolverTerminated(solverScope)).isFalse();
+        assertThat(termination.calculateSolverTimeGradient(solverScope)).isEqualTo(1.0, withPrecision(0.0));
+
+        // third step - score has improved beyond the threshold, but too late
+        when(clock.millis()).thenReturn(START_TIME_MILLIS + 1001L);
+        when(solverScope.getBestSolutionTimeMillis()).thenReturn(START_TIME_MILLIS + 1001L);
+        when(stepScope.getBestScoreImproved()).thenReturn(Boolean.TRUE);
+        when(solverScope.getBestScore()).thenReturn(SimpleScore.of(10));
+        termination.stepEnded(stepScope);
+
+        assertThat(termination.isPhaseTerminated(phaseScope)).isTrue();
+        assertThat(termination.isSolverTerminated(solverScope)).isTrue();
+    }
+}

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/solver/termination/UnimprovedTimeMillisSpentTerminationTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/solver/termination/UnimprovedTimeMillisSpentTerminationTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.core.impl.solver.termination;
+
+import java.time.Clock;
+
+import org.junit.Test;
+import org.optaplanner.core.impl.phase.scope.AbstractPhaseScope;
+import org.optaplanner.core.impl.solver.scope.DefaultSolverScope;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.assertj.core.api.Assertions.withPrecision;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class UnimprovedTimeMillisSpentTerminationTest {
+
+    @Test
+    public void forZeroUnimprovedTimeMillis_exceptionIsThrown() {
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> new UnimprovedTimeMillisSpentTermination(0L))
+                .withMessageContaining("cannot be negative");
+    }
+
+    @Test
+    public void solverTermination() {
+        DefaultSolverScope<?> solverScope = mock(DefaultSolverScope.class);
+        Clock clock = mock(Clock.class);
+
+        Termination termination = new UnimprovedTimeMillisSpentTermination(1000L, clock);
+
+        when(clock.millis()).thenReturn(1000L);
+        when(solverScope.getBestSolutionTimeMillis()).thenReturn(500L);
+        assertThat(termination.isSolverTerminated(solverScope)).isFalse();
+        assertThat(termination.calculateSolverTimeGradient(solverScope)).isEqualTo(0.5, withPrecision(0.0));
+
+        when(clock.millis()).thenReturn(2000L);
+        when(solverScope.getBestSolutionTimeMillis()).thenReturn(1000L);
+        assertThat(termination.isSolverTerminated(solverScope)).isTrue();
+        assertThat(termination.calculateSolverTimeGradient(solverScope)).isEqualTo(1.0, withPrecision(0.0));
+    }
+
+    @Test
+    public void phaseTermination() {
+        AbstractPhaseScope<?> phaseScope = mock(AbstractPhaseScope.class);
+        Clock clock = mock(Clock.class);
+
+        Termination termination = new UnimprovedTimeMillisSpentTermination(1000L, clock);
+
+        when(clock.millis()).thenReturn(1000L);
+        when(phaseScope.getPhaseBestSolutionTimeMillis()).thenReturn(500L);
+        assertThat(termination.isPhaseTerminated(phaseScope)).isFalse();
+        assertThat(termination.calculatePhaseTimeGradient(phaseScope)).isEqualTo(0.5, withPrecision(0.0));
+
+        when(clock.millis()).thenReturn(2000L);
+        when(phaseScope.getPhaseBestSolutionTimeMillis()).thenReturn(1000L);
+        assertThat(termination.isPhaseTerminated(phaseScope)).isTrue();
+        assertThat(termination.calculatePhaseTimeGradient(phaseScope)).isEqualTo(1.0, withPrecision(0.0));
+    }
+}

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/solver/termination/UnimprovedTimeMillisSpentTerminationTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/solver/termination/UnimprovedTimeMillisSpentTerminationTest.java
@@ -31,9 +31,9 @@ import static org.mockito.Mockito.when;
 public class UnimprovedTimeMillisSpentTerminationTest {
 
     @Test
-    public void forZeroUnimprovedTimeMillis_exceptionIsThrown() {
+    public void forNegativeUnimprovedTimeMillis_exceptionIsThrown() {
         assertThatIllegalArgumentException()
-                .isThrownBy(() -> new UnimprovedTimeMillisSpentTermination(0L))
+                .isThrownBy(() -> new UnimprovedTimeMillisSpentTermination(-1L))
                 .withMessageContaining("cannot be negative");
     }
 


### PR DESCRIPTION
- adds a new constructor taking a `Clock` instance as a parameter to enable testing
- provides unit coverage for both the `UnimprovedTimeMillisSpentTermination` and `UnimprovedTimeMillisSpentScoreDifferenceThresholdTermination`
- fixes a bug that solving terminates despite the fact that score improved within a time limit over a given threshold