### PR TITLE
Address subpillar performance regression (follow-up to PLANNER-1565)

### DIFF
--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/heuristic/selector/entity/pillar/DefaultPillarSelectorTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/heuristic/selector/entity/pillar/DefaultPillarSelectorTest.java
@@ -93,7 +93,7 @@ public class DefaultPillarSelectorTest {
 
         GenuineVariableDescriptor variableDescriptor = TestdataEntity.buildVariableDescriptorForValue();
         EntitySelector entitySelector = SelectorTestUtils.mockEntitySelector(variableDescriptor.getEntityDescriptor(),
-                a, b, c, d, e, f);
+                                                                             a, b, c, d, e, f);
 
         DefaultPillarSelector pillarSelector = new DefaultPillarSelector(
                 entitySelector, Arrays.asList(variableDescriptor), false, false, 1, Integer.MAX_VALUE);
@@ -205,7 +205,7 @@ public class DefaultPillarSelectorTest {
 
         GenuineVariableDescriptor variableDescriptor = TestdataEntity.buildVariableDescriptorForValue();
         EntitySelector entitySelector = SelectorTestUtils.mockEntitySelector(variableDescriptor.getEntityDescriptor(),
-                a, b, c, d, e, f);
+                                                                             a, b, c, d, e, f);
 
         DefaultPillarSelector pillarSelector = new DefaultPillarSelector(
                 entitySelector, Arrays.asList(variableDescriptor), true, true, 1, Integer.MAX_VALUE);
@@ -227,10 +227,10 @@ public class DefaultPillarSelectorTest {
         // Expected pillar cache: [a], [b, d], [c, e, f]
         when(workingRandom.nextInt(anyInt())).thenReturn(
                 0, // [a]
-                2, 1, 0, 1, // [c, e, f]
-                1, 1, // [b, d]
+                2, 1, 0, 0, // [c, e, f]
+                1, 0, 0, // [b, d]
                 1, 0, 1); // [b, d]
-        assertCodesOfNeverEndingPillarSelector(pillarSelector, "[a]", "[c, e]", "[b, d]", "[d]");
+        assertCodesOfNeverEndingPillarSelector(pillarSelector, "[a]", "[c, e]", "[b]", "[d]");
         pillarSelector.stepEnded(stepScopeA1);
 
         b.setValue(val3);
@@ -245,7 +245,7 @@ public class DefaultPillarSelectorTest {
                 3, // [f]
                 1, 2, // [b, c, e]
                 1, 0, 0, // [b, c, e]
-                2); // [d]
+                2, 0, 0); // [d]
         assertCodesOfNeverEndingPillarSelector(pillarSelector, "[f]", "[b, c, e]", "[b]", "[d]");
         pillarSelector.stepEnded(stepScopeA2);
 
@@ -264,7 +264,7 @@ public class DefaultPillarSelectorTest {
                 3, // [f]
                 1, 2, // [b, c, e]
                 1, 0, 0, // [b, c, e]
-                2); // [d]
+                2, 0, 0); // [d]
         assertCodesOfNeverEndingPillarSelector(pillarSelector, "[f]", "[b, c, e]", "[b]", "[d]");
         pillarSelector.stepEnded(stepScopeB1);
 
@@ -291,7 +291,7 @@ public class DefaultPillarSelectorTest {
 
         GenuineVariableDescriptor variableDescriptor = TestdataEntity.buildVariableDescriptorForValue();
         EntitySelector entitySelector = SelectorTestUtils.mockEntitySelector(variableDescriptor.getEntityDescriptor(),
-                a, b, c, d, e, f);
+                                                                             a, b, c, d, e, f);
 
         DefaultPillarSelector pillarSelector = new DefaultPillarSelector(
                 entitySelector, Arrays.asList(variableDescriptor), true, true, 2, 2);
@@ -312,9 +312,9 @@ public class DefaultPillarSelectorTest {
         // nextInt pattern: pillarIndex, subPillarSize, element 0, element 1, element 2, ...
         // Expected pillar cache: [a], [b, d], [c, e, f]
         when(workingRandom.nextInt(anyInt())).thenReturn(
-                0, // [a]
-                2, 0, 0, 1, // [c, e, f]
-                1, 0); // [b, d]
+                0,// [a]
+                2, 0, 0, 0, // [c, e, f]
+                1, 0, 0); // [b, d]
         assertCodesOfNeverEndingPillarSelector(pillarSelector, "[a]", "[c, e]", "[b, d]");
         pillarSelector.stepEnded(stepScopeA1);
 


### PR DESCRIPTION
@rsynek's benchmarks have shown that subpillars have actually regressed in raw Java performance. For that reason, I have gone back and [ran the new algorithm in JMH against its old implementation](https://docs.google.com/spreadsheets/d/1Szqv2bMRZaker15v7TtU7aj2q7XQ2Gs2cXttwMNFHnY/edit#gid=0) in a very wide range of circumstances.

- The new implementation (`STREAM+SHORTCUT`) is indeed better than the original loop (`ORIGINAL`) in a lot of places.
- However, this new data also shows that it is **only better in places where the code uses the shortcuts** [1]. The stream actually sucks in places where the shortcuts are not in effect. [2]
- Therefore we take the original loop, apply the same shortcuts, and we get the best results (`LOOP+SHORTCUT`).

I am submitting this PR, which implements `LOOP+SHORTCUT`. It is **the best solution in literally every circumstance tried**. Now that we have an algorithm that performs better even at raw Java level, we **should be seeing further score improvements**.

[1] It delivers a better score, though - which was the only thing that we actually measure via the Benchmarker. We did not actually measure its raw Java performance. 

[2] The stream suffers from generating *a lot* of random numbers. The more it generates, the harder it becomes to generate new distinct ones. Therefore, the stream solution begins to suck more and more as the `subPillarSize` starts reaching `basePillarSize`. The effect eventually becomes so pronounced that even the `basePillar.toArray()` copying isn't as big of a deal.