### PR TITLE
PLANNER-1586 Mention classloader in reflection-related exceptions

### DIFF
--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/common/accessor/LambdaBeanPropertyMemberAccessor.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/common/accessor/LambdaBeanPropertyMemberAccessor.java
@@ -102,10 +102,7 @@ public final class LambdaBeanPropertyMemberAccessor implements MemberAccessor {
                     MethodType.methodType(void.class, Object.class, Object.class),
                     lookup.findVirtual(declaringClass, setterMethod.getName(), MethodType.methodType(void.class, propertyType)),
                     MethodType.methodType(void.class, declaringClass, propertyType));
-        } catch (IllegalAccessException e) {
-            throw new IllegalStateException("Lambda creation failed for setterMethod (" + setterMethod + "). You may " +
-                    "consider supplying a ClassLoader parameter to your SolverFactory.create...() method call.", e);
-        } catch (LambdaConversionException | NoSuchMethodException e) {
+        } catch (LambdaConversionException | NoSuchMethodException | IllegalAccessException e) {
             throw new IllegalArgumentException("Lambda creation failed for setterMethod (" + setterMethod + ").", e);
         }
         try {

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/common/accessor/LambdaBeanPropertyMemberAccessor.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/common/accessor/LambdaBeanPropertyMemberAccessor.java
@@ -77,8 +77,8 @@ public final class LambdaBeanPropertyMemberAccessor implements MemberAccessor {
                     lookup.findVirtual(declaringClass, getterMethod.getName(), MethodType.methodType(propertyType)),
                     MethodType.methodType(propertyType, declaringClass));
         } catch (IllegalAccessException e) {
-            throw new IllegalStateException("Lambda creation failed for getterMethod (" + getterMethod + "). You may " +
-                    " consider supplying a ClassLoader parameter to your SolverFactory.create...() method call.", e);
+            throw new IllegalStateException("Lambda creation failed for getterMethod (" + getterMethod + ").\n" +
+                    MemberAccessorFactory.CLASSLOADER_NUDGE_MESSAGE, e);
         } catch (LambdaConversionException | NoSuchMethodException e) {
             throw new IllegalArgumentException("Lambda creation failed for getterMethod (" + getterMethod + ").", e);
         }

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/common/accessor/LambdaBeanPropertyMemberAccessor.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/common/accessor/LambdaBeanPropertyMemberAccessor.java
@@ -76,7 +76,10 @@ public final class LambdaBeanPropertyMemberAccessor implements MemberAccessor {
                     MethodType.methodType(Object.class, Object.class),
                     lookup.findVirtual(declaringClass, getterMethod.getName(), MethodType.methodType(propertyType)),
                     MethodType.methodType(propertyType, declaringClass));
-        } catch (LambdaConversionException | NoSuchMethodException | IllegalAccessException e) {
+        } catch (IllegalAccessException e) {
+            throw new IllegalStateException("Lambda creation failed for getterMethod (" + getterMethod + "). You may " +
+                    " consider supplying a ClassLoader parameter to your SolverFactory.create...() method call.", e);
+        } catch (LambdaConversionException | NoSuchMethodException e) {
             throw new IllegalArgumentException("Lambda creation failed for getterMethod (" + getterMethod + ").", e);
         }
         try {
@@ -99,7 +102,10 @@ public final class LambdaBeanPropertyMemberAccessor implements MemberAccessor {
                     MethodType.methodType(void.class, Object.class, Object.class),
                     lookup.findVirtual(declaringClass, setterMethod.getName(), MethodType.methodType(void.class, propertyType)),
                     MethodType.methodType(void.class, declaringClass, propertyType));
-        } catch (LambdaConversionException | NoSuchMethodException | IllegalAccessException e) {
+        } catch (IllegalAccessException e) {
+            throw new IllegalStateException("Lambda creation failed for setterMethod (" + setterMethod + "). You may " +
+                    "consider supplying a ClassLoader parameter to your SolverFactory.create...() method call.", e);
+        } catch (LambdaConversionException | NoSuchMethodException e) {
             throw new IllegalArgumentException("Lambda creation failed for setterMethod (" + setterMethod + ").", e);
         }
         try {
@@ -177,5 +183,4 @@ public final class LambdaBeanPropertyMemberAccessor implements MemberAccessor {
     public String toString() {
         return "bean property " + propertyName + " on " + getterMethod.getDeclaringClass();
     }
-
 }

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/common/accessor/MemberAccessorFactory.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/common/accessor/MemberAccessorFactory.java
@@ -22,9 +22,14 @@ import java.lang.reflect.Member;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 
+import org.optaplanner.core.api.solver.SolverFactory;
 import org.optaplanner.core.impl.domain.common.ReflectionHelper;
 
 public class MemberAccessorFactory {
+
+    // exists only so that the various member accessors can share the same text in their exception messages
+    static final String CLASSLOADER_NUDGE_MESSAGE = "Maybe add getClass().getClassLoader() as a parameter to the " +
+            SolverFactory.class.getSimpleName() + ".create...() method call.";
 
     public static MemberAccessor buildMemberAccessor(Member member, MemberAccessorType memberAccessorType,
             Class<? extends Annotation> annotationClass) {

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/common/accessor/ReflectionBeanPropertyMemberAccessor.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/common/accessor/ReflectionBeanPropertyMemberAccessor.java
@@ -82,7 +82,8 @@ public final class ReflectionBeanPropertyMemberAccessor implements MemberAccesso
             return getterMethod.invoke(bean);
         } catch (IllegalAccessException e) {
             throw new IllegalStateException("Cannot call property (" + propertyName
-                    + ") getterMethod (" + getterMethod + ") on bean of class (" + bean.getClass() + ").", e);
+                    + ") getterMethod (" + getterMethod + ") on bean of class (" + bean.getClass() + "). You may "
+                    + "consider supplying a ClassLoader parameter to your SolverFactory.create...() method call.", e);
         } catch (InvocationTargetException e) {
             throw new IllegalStateException("The property (" + propertyName
                     + ") getterMethod (" + getterMethod + ") on bean of class (" + bean.getClass()

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/common/accessor/ReflectionBeanPropertyMemberAccessor.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/common/accessor/ReflectionBeanPropertyMemberAccessor.java
@@ -82,8 +82,8 @@ public final class ReflectionBeanPropertyMemberAccessor implements MemberAccesso
             return getterMethod.invoke(bean);
         } catch (IllegalAccessException e) {
             throw new IllegalStateException("Cannot call property (" + propertyName
-                    + ") getterMethod (" + getterMethod + ") on bean of class (" + bean.getClass() + "). You may "
-                    + "consider supplying a ClassLoader parameter to your SolverFactory.create...() method call.", e);
+                    + ") getterMethod (" + getterMethod + ") on bean of class (" + bean.getClass() + ").\n" +
+                    MemberAccessorFactory.CLASSLOADER_NUDGE_MESSAGE, e);
         } catch (InvocationTargetException e) {
             throw new IllegalStateException("The property (" + propertyName
                     + ") getterMethod (" + getterMethod + ") on bean of class (" + bean.getClass()

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/common/accessor/ReflectionFieldMemberAccessor.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/common/accessor/ReflectionFieldMemberAccessor.java
@@ -59,8 +59,8 @@ public final class ReflectionFieldMemberAccessor implements MemberAccessor {
             return field.get(bean);
         } catch (IllegalAccessException e) {
             throw new IllegalStateException("Cannot get the field (" + field.getName()
-                    + ") on bean of class (" + bean.getClass() + "). You may consider supplying a ClassLoader parameter"
-                    + " to your SolverFactory.create...() method call.", e);
+                    + ") on bean of class (" + bean.getClass() + ").\n" +
+                    MemberAccessorFactory.CLASSLOADER_NUDGE_MESSAGE, e);
         }
     }
 

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/common/accessor/ReflectionFieldMemberAccessor.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/common/accessor/ReflectionFieldMemberAccessor.java
@@ -59,7 +59,8 @@ public final class ReflectionFieldMemberAccessor implements MemberAccessor {
             return field.get(bean);
         } catch (IllegalAccessException e) {
             throw new IllegalStateException("Cannot get the field (" + field.getName()
-                    + ") on bean of class (" + bean.getClass() + ").", e);
+                    + ") on bean of class (" + bean.getClass() + "). You may consider supplying a ClassLoader parameter"
+                    + " to your SolverFactory.create...() method call.", e);
         }
     }
 

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/common/accessor/ReflectionMethodMemberAccessor.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/common/accessor/ReflectionMethodMemberAccessor.java
@@ -73,8 +73,8 @@ public final class ReflectionMethodMemberAccessor implements MemberAccessor {
             return readMethod.invoke(bean);
         } catch (IllegalAccessException e) {
             throw new IllegalStateException("Cannot call property (" + methodName
-                    + ") getterMethod (" + readMethod + ") on bean of class (" + bean.getClass() + "). You may consider"
-                    + " supplying a ClassLoader parameter to your SolverFactory.create...() method call.", e);
+                    + ") getterMethod (" + readMethod + ") on bean of class (" + bean.getClass() + ").\n" +
+                    MemberAccessorFactory.CLASSLOADER_NUDGE_MESSAGE, e);
         } catch (InvocationTargetException e) {
             throw new IllegalStateException("The property (" + methodName
                     + ") getterMethod (" + readMethod + ") on bean of class (" + bean.getClass()

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/common/accessor/ReflectionMethodMemberAccessor.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/common/accessor/ReflectionMethodMemberAccessor.java
@@ -73,7 +73,8 @@ public final class ReflectionMethodMemberAccessor implements MemberAccessor {
             return readMethod.invoke(bean);
         } catch (IllegalAccessException e) {
             throw new IllegalStateException("Cannot call property (" + methodName
-                    + ") getterMethod (" + readMethod + ") on bean of class (" + bean.getClass() + ").", e);
+                    + ") getterMethod (" + readMethod + ") on bean of class (" + bean.getClass() + "). You may consider"
+                    + " supplying a ClassLoader parameter to your SolverFactory.create...() method call.", e);
         } catch (InvocationTargetException e) {
             throw new IllegalStateException("The property (" + methodName
                     + ") getterMethod (" + readMethod + ") on bean of class (" + bean.getClass()


### PR DESCRIPTION
This gives a useful hint, but that hint may not be applicable at all times. [See here](https://stackoverflow.com/questions/57711906/redhat-decision-manager-7-3-opta-cloud-solver-example-not-working) for a situation where the hint would mislead people - therefore I am not adding the same message on setters.