### PR TITLE
PLANNER-1635 Termination should support java.time.Duration

### DIFF
--- a/optaplanner-core/src/test/java/org/optaplanner/core/config/solver/termination/TerminationConfigTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/config/solver/termination/TerminationConfigTest.java
@@ -16,20 +16,35 @@
 
 package org.optaplanner.core.config.solver.termination;
 
+import java.time.Duration;
+
 import org.junit.Test;
 import org.optaplanner.core.config.heuristic.policy.HeuristicConfigPolicy;
 import org.optaplanner.core.impl.solver.termination.Termination;
 import org.optaplanner.core.impl.solver.termination.TimeMillisSpentTermination;
 import org.optaplanner.core.impl.solver.termination.UnimprovedTimeMillisSpentTermination;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 import static org.optaplanner.core.impl.testdata.util.PlannerAssert.*;
 
 public class TerminationConfigTest {
 
     @Test
-    public void spendLimit() {
+    public void spentLimit() {
+        TerminationConfig terminationConfig = new TerminationConfig();
+        terminationConfig.setSpentLimit(Duration.ofMillis(5L)
+                .plusSeconds(4L)
+                .plusMinutes(3L)
+                .plusHours(2L)
+                .plusDays(1L));
+        Termination termination = terminationConfig.buildTermination(mock(HeuristicConfigPolicy.class));
+        assertInstanceOf(TimeMillisSpentTermination.class, termination);
+        assertEquals(93784005L, ((TimeMillisSpentTermination) termination).getTimeMillisSpentLimit());
+    }
+
+    @Test
+    public void spentLimitWithoutJavaTime() {
         TerminationConfig terminationConfig = new TerminationConfig();
         terminationConfig.setMillisecondsSpentLimit(5L);
         terminationConfig.setSecondsSpentLimit(4L);
@@ -42,7 +57,20 @@ public class TerminationConfigTest {
     }
 
     @Test
-    public void unimprovedSpendLimit() {
+    public void unimprovedSpentLimit() {
+        TerminationConfig terminationConfig = new TerminationConfig();
+        terminationConfig.setUnimprovedSpentLimit(Duration.ofMillis(5L)
+                .plusSeconds(4L)
+                .plusMinutes(3L)
+                .plusHours(2L)
+                .plusDays(1L));
+        Termination termination = terminationConfig.buildTermination(mock(HeuristicConfigPolicy.class));
+        assertInstanceOf(UnimprovedTimeMillisSpentTermination.class, termination);
+        assertEquals(93784005L, ((UnimprovedTimeMillisSpentTermination) termination).getUnimprovedTimeMillisSpentLimit());
+    }
+
+    @Test
+    public void unimprovedSpentLimitWithoutJavaTime() {
         TerminationConfig terminationConfig = new TerminationConfig();
         terminationConfig.setUnimprovedMillisecondsSpentLimit(5L);
         terminationConfig.setUnimprovedSecondsSpentLimit(4L);

--- a/optaplanner-docs/src/main/asciidoc/OptimizationAlgorithms/OptimizationAlgorithms-chapter.adoc
+++ b/optaplanner-docs/src/main/asciidoc/OptimizationAlgorithms/OptimizationAlgorithms-chapter.adoc
@@ -292,11 +292,21 @@ Terminates when an amount of time has been used.
 [source,xml,options="nowrap"]
 ----
   <termination>
-    <millisecondsSpentLimit>500</millisecondsSpentLimit>
+    <!-- 2 minutes and 30 seconds in ISO 8601 format P[n]Y[n]M[n]DT[n]H[n]M[n]S -->
+    <spentLimit>PT2M30S</spentLimit>
   </termination>
 ----
 
-Besides milliseconds you can also use:
+Alternatively to a `java.util.Duration` in ISO 8601 format, you can also use:
+
+* Milliseconds
++
+[source,xml,options="nowrap"]
+----
+  <termination>
+    <millisecondsSpentLimit>500</millisecondsSpentLimit>
+  </termination>
+----
 
 * Seconds
 +
@@ -368,7 +378,22 @@ which will send time gradient-based algorithms (such as Simulated Annealing) on 
 === Unimproved Time Spent Termination
 
 Terminates when the best score has not improved in a specified amount of time.
+Each time a new best solution is found, the timer basically resets.
 
+[source,xml,options="nowrap"]
+----
+  <localSearch>
+    <termination>
+      <!-- 2 minutes and 30 seconds in ISO 8601 format P[n]Y[n]M[n]DT[n]H[n]M[n]S -->
+      <unimprovedSpentLimit>PT2M30S</unimprovedSpentLimit>
+    </termination>
+  </localSearch>
+----
+
+Alternatively to a `java.util.Duration` in ISO 8601 format, you can also use:
+
+* Milliseconds
++
 [source,xml,options="nowrap"]
 ----
   <localSearch>
@@ -377,9 +402,6 @@ Terminates when the best score has not improved in a specified amount of time.
     </termination>
   </localSearch>
 ----
-
-
-Besides milliseconds you can also use:
 
 * Seconds
 +
@@ -473,7 +495,7 @@ use a wildcard `*` for lower score levels that are allowed to deteriorate if a h
   </localSearch>
 ----
 
-This effectively implies a threshold of `1hard/-2147483648soft`.
+This effectively implies a threshold of `1hard/-2147483648soft`, because it relies on `Integer.MIN_VALUE`.
 
 
 [[bestScoreTermination]]


### PR DESCRIPTION
Needed so we can do this in quarkus/spring-boot application.properties:
optaplanner.spentLimit=PT2M30S