### PR TITLE
PLANNER-1666 Add min() and max() UniCollector

### DIFF
--- a/optaplanner-core/src/main/java/org/optaplanner/core/api/score/stream/ConstraintCollectors.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/api/score/stream/ConstraintCollectors.java
@@ -196,22 +196,38 @@ public final class ConstraintCollectors {
     }
 
     // ************************************************************************
-    // max
+    // min
     // ************************************************************************
 
-    public static <A> UniConstraintCollector<A, SortedMap<A, Long>, A> max(Comparator<A> comparator) {
+    private static <A> UniConstraintCollector<A, SortedMap<A, Long>, A> minOrMax(Comparator<A> comparator,
+            boolean min) {
+        Function<SortedMap<A, Long>, A> keySupplier = min ? SortedMap::firstKey : SortedMap::lastKey;
         return new DefaultUniConstraintCollector<>(
                 () -> new TreeMap<>(comparator),
                 (resultContainer, a) -> {
                     resultContainer.compute(a, (key, value) -> value == null ? 1 : value + 1);
-                    return (() -> {
-                        resultContainer.compute(a, (key, value) -> value == 1 ? null : value - 1);
-                    });
+                    return (() -> resultContainer.compute(a, (key, value) -> value == 1 ? null : value - 1));
                 },
-                (resultContainer) -> resultContainer.size() == 0 ? null : resultContainer.lastKey());
+                (resultContainer) -> resultContainer.size() == 0 ? null : keySupplier.apply(resultContainer));
     }
 
-    public static <A extends Comparable<A>> UniConstraintCollector<A, SortedMap<A, Long>, A> max() {
+    public static <A> UniConstraintCollector<A, ?, A> min(Comparator<A> comparator) {
+        return minOrMax(comparator, true);
+    }
+
+    public static <A extends Comparable<A>> UniConstraintCollector<A, ?, A> min() {
+        return min(Comparable::compareTo);
+    }
+
+    // ************************************************************************
+    // max
+    // ************************************************************************
+
+    public static <A> UniConstraintCollector<A, ?, A> max(Comparator<A> comparator) {
+        return minOrMax(comparator, false);
+    }
+
+    public static <A extends Comparable<A>> UniConstraintCollector<A, ?, A> max() {
         return max(Comparable::compareTo);
     }
 

--- a/optaplanner-core/src/main/java/org/optaplanner/core/api/score/stream/ConstraintCollectors.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/api/score/stream/ConstraintCollectors.java
@@ -199,18 +199,6 @@ public final class ConstraintCollectors {
     // min
     // ************************************************************************
 
-    private static <A> UniConstraintCollector<A, SortedMap<A, Long>, A> minOrMax(Comparator<A> comparator,
-            boolean min) {
-        Function<SortedMap<A, Long>, A> keySupplier = min ? SortedMap::firstKey : SortedMap::lastKey;
-        return new DefaultUniConstraintCollector<>(
-                () -> new TreeMap<>(comparator),
-                (resultContainer, a) -> {
-                    resultContainer.compute(a, (key, value) -> value == null ? 1 : value + 1);
-                    return (() -> resultContainer.compute(a, (key, value) -> value == 1 ? null : value - 1));
-                },
-                (resultContainer) -> resultContainer.size() == 0 ? null : keySupplier.apply(resultContainer));
-    }
-
     public static <A> UniConstraintCollector<A, ?, A> min(Comparator<A> comparator) {
         return minOrMax(comparator, true);
     }
@@ -229,6 +217,18 @@ public final class ConstraintCollectors {
 
     public static <A extends Comparable<A>> UniConstraintCollector<A, ?, A> max() {
         return max(Comparable::compareTo);
+    }
+
+    private static <A> UniConstraintCollector<A, SortedMap<A, Long>, A> minOrMax(Comparator<A> comparator,
+            boolean min) {
+        Function<SortedMap<A, Long>, A> keySupplier = min ? SortedMap::firstKey : SortedMap::lastKey;
+        return new DefaultUniConstraintCollector<>(
+                () -> new TreeMap<>(comparator),
+                (resultContainer, a) -> {
+                    resultContainer.compute(a, (key, value) -> value == null ? 1 : value + 1);
+                    return (() -> resultContainer.compute(a, (key, value) -> value == 1 ? null : value - 1));
+                },
+                (resultContainer) -> resultContainer.size() == 0 ? null : keySupplier.apply(resultContainer));
     }
 
     private ConstraintCollectors() {

--- a/optaplanner-core/src/main/java/org/optaplanner/core/api/score/stream/ConstraintCollectors.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/api/score/stream/ConstraintCollectors.java
@@ -16,8 +16,11 @@
 
 package org.optaplanner.core.api.score.stream;
 
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.SortedMap;
+import java.util.TreeMap;
 import java.util.function.Function;
 import java.util.function.ToIntBiFunction;
 import java.util.function.ToIntFunction;
@@ -190,6 +193,26 @@ public final class ConstraintCollectors {
                     return (() -> resultContainer[0] -= value);
                 },
                 resultContainer -> resultContainer[0]);
+    }
+
+    // ************************************************************************
+    // max
+    // ************************************************************************
+
+    public static <A> UniConstraintCollector<A, SortedMap<A, Long>, A> max(Comparator<A> comparator) {
+        return new DefaultUniConstraintCollector<>(
+                () -> new TreeMap<>(comparator),
+                (resultContainer, a) -> {
+                    resultContainer.compute(a, (key, value) -> value == null ? 1 : value + 1);
+                    return (() -> {
+                        resultContainer.compute(a, (key, value) -> value == 1 ? null : value - 1);
+                    });
+                },
+                (resultContainer) -> resultContainer.size() == 0 ? null : resultContainer.lastKey());
+    }
+
+    public static <A extends Comparable<A>> UniConstraintCollector<A, SortedMap<A, Long>, A> max() {
+        return max(Comparable::compareTo);
     }
 
     private ConstraintCollectors() {

--- a/optaplanner-core/src/main/java/org/optaplanner/core/api/score/stream/uni/UniConstraintCollector.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/api/score/stream/uni/UniConstraintCollector.java
@@ -53,7 +53,7 @@ public interface UniConstraintCollector<A, ResultContainer_, Result_> {
 
     /**
      * A lambda that converts the result container into the result.
-     * @return never null
+     * @return null when the result would be invalid, such as maximum value from an empty container.
      */
     Function<ResultContainer_, Result_> finisher();
 

--- a/optaplanner-core/src/test/java/org/optaplanner/core/api/score/stream/ConstraintCollectorsTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/api/score/stream/ConstraintCollectorsTest.java
@@ -1,7 +1,6 @@
 package org.optaplanner.core.api.score.stream;
 
 import java.util.Comparator;
-import java.util.SortedMap;
 
 import org.junit.Test;
 import org.optaplanner.core.api.score.stream.uni.UniConstraintCollector;
@@ -10,19 +9,19 @@ import static org.junit.Assert.assertEquals;
 
 public class ConstraintCollectorsTest {
 
-    private <A, B, C> Runnable accumulate(UniConstraintCollector<A, B, C> collector, B container, A value) {
-        return collector.accumulator().apply(container, value);
+    private <A, B, C> Runnable accumulate(UniConstraintCollector<A, B, C> collector, Object container, A value) {
+        return collector.accumulator().apply((B) container, value);
     }
 
-    private <A, B, C> void assertResult(UniConstraintCollector<A, B, C> collector, B container, C expectedResult) {
-        C actualResult = collector.finisher().apply(container);
+    private <A, B, C> void assertResult(UniConstraintCollector<A, B, C> collector, Object container, C expectedResult) {
+        C actualResult = collector.finisher().apply((B) container);
         assertEquals("Collector (" + collector + ") did not produced expected result.", expectedResult, actualResult);
     }
 
     @Test
     public void maxComparable() {
-        UniConstraintCollector<Integer, SortedMap<Integer, Long>, Integer> collector = ConstraintCollectors.max();
-        SortedMap<Integer, Long> container = collector.supplier().get();
+        UniConstraintCollector<Integer, ?, Integer> collector = ConstraintCollectors.max();
+        Object container = collector.supplier().get();
         // add first value, which becomes the max
         int firstValue = 2;
         Runnable firstRetractor = accumulate(collector, container, firstValue);
@@ -47,9 +46,9 @@ public class ConstraintCollectorsTest {
 
     @Test
     public void maxNotComparable() {
-        UniConstraintCollector<Class, SortedMap<Class, Long>, Class> collector =
+        UniConstraintCollector<Class, ?, Class> collector =
                 ConstraintCollectors.max(Comparator.comparing(Class::getCanonicalName));
-        SortedMap<Class, Long> container = collector.supplier().get();
+        Object container = collector.supplier().get();
         // add first value, which becomes the max
         Class firstValue = ConstraintCollectorsTest.class;
         Runnable firstRetractor = accumulate(collector, container, firstValue);
@@ -69,6 +68,59 @@ public class ConstraintCollectorsTest {
         assertResult(collector, container, secondValue);
         // retract last value; there are no values now
         secondRetractor.run();
+        assertResult(collector, container, null);
+    }
+
+    @Test
+    public void minComparable() {
+        UniConstraintCollector<Integer, ?, Integer> collector = ConstraintCollectors.min();
+        Object container = collector.supplier().get();
+        // add first value, which becomes the min
+        int firstValue = 2;
+        Runnable firstRetractor = accumulate(collector, container, firstValue);
+        assertResult(collector, container, firstValue);
+        // add second value, lesser than the first, becomes the new min
+        int secondValue = 1;
+        Runnable secondRetractor = accumulate(collector, container, secondValue);
+        assertResult(collector, container, secondValue);
+        // add third value, same as the second, result does not change
+        Runnable thirdRetractor = accumulate(collector, container, secondValue);
+        assertResult(collector, container, secondValue);
+        // retract one instance of the second value; second value is still the min value, nothing should change
+        secondRetractor.run();
+        assertResult(collector, container, secondValue);
+        // retract final instance of the second value; first value is now the min value
+        thirdRetractor.run();
+        assertResult(collector, container, firstValue);
+        // retract last value; there are no values now
+        firstRetractor.run();
+        assertResult(collector, container, null);
+    }
+
+    @Test
+    public void minNotComparable() {
+        UniConstraintCollector<Class, ?, Class> collector =
+                ConstraintCollectors.min(Comparator.comparing(Class::getCanonicalName));
+        Object container = collector.supplier().get();
+        // add first value, which becomes the min
+        Class firstValue = ConstraintCollectorsTest.class;
+        Runnable firstRetractor = accumulate(collector, container, firstValue);
+        assertResult(collector, container, firstValue);
+        // add second value, lesser than the first, becomes the new min
+        Class secondValue = ConstraintCollectors.class;
+        Runnable secondRetractor = accumulate(collector, container, secondValue);
+        assertResult(collector, container, secondValue);
+        // add third value, same as the second, result does not change
+        Runnable thirdRetractor = accumulate(collector, container, secondValue);
+        assertResult(collector, container, secondValue);
+        // retract one instance of the second value; second value is still the min value, nothing should change
+        secondRetractor.run();
+        assertResult(collector, container, secondValue);
+        // retract final instance of the second value; first value is now the min value
+        thirdRetractor.run();
+        assertResult(collector, container, firstValue);
+        // retract last value; there are no values now
+        firstRetractor.run();
         assertResult(collector, container, null);
     }
 

--- a/optaplanner-core/src/test/java/org/optaplanner/core/api/score/stream/ConstraintCollectorsTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/api/score/stream/ConstraintCollectorsTest.java
@@ -9,14 +9,66 @@ import static org.junit.Assert.assertEquals;
 
 public class ConstraintCollectorsTest {
 
-    private <A, B, C> Runnable accumulate(UniConstraintCollector<A, B, C> collector, Object container, A value) {
-        return collector.accumulator().apply((B) container, value);
+    // ************************************************************************
+    // min
+    // ************************************************************************
+
+    @Test
+    public void minComparable() {
+        UniConstraintCollector<Integer, ?, Integer> collector = ConstraintCollectors.min();
+        Object container = collector.supplier().get();
+        // add first value, which becomes the min
+        int firstValue = 2;
+        Runnable firstRetractor = accumulate(collector, container, firstValue);
+        assertResult(collector, container, firstValue);
+        // add second value, lesser than the first, becomes the new min
+        int secondValue = 1;
+        Runnable secondRetractor = accumulate(collector, container, secondValue);
+        assertResult(collector, container, secondValue);
+        // add third value, same as the second, result does not change
+        Runnable thirdRetractor = accumulate(collector, container, secondValue);
+        assertResult(collector, container, secondValue);
+        // retract one instance of the second value; second value is still the min value, nothing should change
+        secondRetractor.run();
+        assertResult(collector, container, secondValue);
+        // retract final instance of the second value; first value is now the min value
+        thirdRetractor.run();
+        assertResult(collector, container, firstValue);
+        // retract last value; there are no values now
+        firstRetractor.run();
+        assertResult(collector, container, null);
     }
 
-    private <A, B, C> void assertResult(UniConstraintCollector<A, B, C> collector, Object container, C expectedResult) {
-        C actualResult = collector.finisher().apply((B) container);
-        assertEquals("Collector (" + collector + ") did not produced expected result.", expectedResult, actualResult);
+    @Test
+    public void minNotComparable() {
+        UniConstraintCollector<Class, ?, Class> collector =
+                ConstraintCollectors.min(Comparator.comparing(Class::getCanonicalName));
+        Object container = collector.supplier().get();
+        // add first value, which becomes the min
+        Class firstValue = ConstraintCollectorsTest.class;
+        Runnable firstRetractor = accumulate(collector, container, firstValue);
+        assertResult(collector, container, firstValue);
+        // add second value, lesser than the first, becomes the new min
+        Class secondValue = ConstraintCollectors.class;
+        Runnable secondRetractor = accumulate(collector, container, secondValue);
+        assertResult(collector, container, secondValue);
+        // add third value, same as the second, result does not change
+        Runnable thirdRetractor = accumulate(collector, container, secondValue);
+        assertResult(collector, container, secondValue);
+        // retract one instance of the second value; second value is still the min value, nothing should change
+        secondRetractor.run();
+        assertResult(collector, container, secondValue);
+        // retract final instance of the second value; first value is now the min value
+        thirdRetractor.run();
+        assertResult(collector, container, firstValue);
+        // retract last value; there are no values now
+        firstRetractor.run();
+        assertResult(collector, container, null);
     }
+
+    // ************************************************************************
+    // max
+    // ************************************************************************
 
     @Test
     public void maxComparable() {
@@ -71,57 +123,13 @@ public class ConstraintCollectorsTest {
         assertResult(collector, container, null);
     }
 
-    @Test
-    public void minComparable() {
-        UniConstraintCollector<Integer, ?, Integer> collector = ConstraintCollectors.min();
-        Object container = collector.supplier().get();
-        // add first value, which becomes the min
-        int firstValue = 2;
-        Runnable firstRetractor = accumulate(collector, container, firstValue);
-        assertResult(collector, container, firstValue);
-        // add second value, lesser than the first, becomes the new min
-        int secondValue = 1;
-        Runnable secondRetractor = accumulate(collector, container, secondValue);
-        assertResult(collector, container, secondValue);
-        // add third value, same as the second, result does not change
-        Runnable thirdRetractor = accumulate(collector, container, secondValue);
-        assertResult(collector, container, secondValue);
-        // retract one instance of the second value; second value is still the min value, nothing should change
-        secondRetractor.run();
-        assertResult(collector, container, secondValue);
-        // retract final instance of the second value; first value is now the min value
-        thirdRetractor.run();
-        assertResult(collector, container, firstValue);
-        // retract last value; there are no values now
-        firstRetractor.run();
-        assertResult(collector, container, null);
+    private <A, B, C> Runnable accumulate(UniConstraintCollector<A, B, C> collector, Object container, A value) {
+        return collector.accumulator().apply((B) container, value);
     }
 
-    @Test
-    public void minNotComparable() {
-        UniConstraintCollector<Class, ?, Class> collector =
-                ConstraintCollectors.min(Comparator.comparing(Class::getCanonicalName));
-        Object container = collector.supplier().get();
-        // add first value, which becomes the min
-        Class firstValue = ConstraintCollectorsTest.class;
-        Runnable firstRetractor = accumulate(collector, container, firstValue);
-        assertResult(collector, container, firstValue);
-        // add second value, lesser than the first, becomes the new min
-        Class secondValue = ConstraintCollectors.class;
-        Runnable secondRetractor = accumulate(collector, container, secondValue);
-        assertResult(collector, container, secondValue);
-        // add third value, same as the second, result does not change
-        Runnable thirdRetractor = accumulate(collector, container, secondValue);
-        assertResult(collector, container, secondValue);
-        // retract one instance of the second value; second value is still the min value, nothing should change
-        secondRetractor.run();
-        assertResult(collector, container, secondValue);
-        // retract final instance of the second value; first value is now the min value
-        thirdRetractor.run();
-        assertResult(collector, container, firstValue);
-        // retract last value; there are no values now
-        firstRetractor.run();
-        assertResult(collector, container, null);
+    private <A, B, C> void assertResult(UniConstraintCollector<A, B, C> collector, Object container, C expectedResult) {
+        C actualResult = collector.finisher().apply((B) container);
+        assertEquals("Collector (" + collector + ") did not produced expected result.", expectedResult, actualResult);
     }
 
 }

--- a/optaplanner-core/src/test/java/org/optaplanner/core/api/score/stream/ConstraintCollectorsTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/api/score/stream/ConstraintCollectorsTest.java
@@ -1,0 +1,75 @@
+package org.optaplanner.core.api.score.stream;
+
+import java.util.Comparator;
+import java.util.SortedMap;
+
+import org.junit.Test;
+import org.optaplanner.core.api.score.stream.uni.UniConstraintCollector;
+
+import static org.junit.Assert.assertEquals;
+
+public class ConstraintCollectorsTest {
+
+    private <A, B, C> Runnable accumulate(UniConstraintCollector<A, B, C> collector, B container, A value) {
+        return collector.accumulator().apply(container, value);
+    }
+
+    private <A, B, C> void assertResult(UniConstraintCollector<A, B, C> collector, B container, C expectedResult) {
+        C actualResult = collector.finisher().apply(container);
+        assertEquals("Collector (" + collector + ") did not produced expected result.", expectedResult, actualResult);
+    }
+
+    @Test
+    public void maxComparable() {
+        UniConstraintCollector<Integer, SortedMap<Integer, Long>, Integer> collector = ConstraintCollectors.max();
+        SortedMap<Integer, Long> container = collector.supplier().get();
+        // add first value, which becomes the max
+        int firstValue = 2;
+        Runnable firstRetractor = accumulate(collector, container, firstValue);
+        assertResult(collector, container, firstValue);
+        // add second value, lesser than the first, result does not change
+        int secondValue = 1;
+        Runnable secondRetractor = accumulate(collector, container, secondValue);
+        assertResult(collector, container, firstValue);
+        // add third value, same as the first, result does not change
+        Runnable thirdRetractor = accumulate(collector, container, firstValue);
+        assertResult(collector, container, firstValue);
+        // retract one instance of the first value; first value is still the max value, nothing should change
+        firstRetractor.run();
+        assertResult(collector, container, firstValue);
+        // retract final instance of the first value; second value is now the max value
+        thirdRetractor.run();
+        assertResult(collector, container, secondValue);
+        // retract last value; there are no values now
+        secondRetractor.run();
+        assertResult(collector, container, null);
+    }
+
+    @Test
+    public void maxNotComparable() {
+        UniConstraintCollector<Class, SortedMap<Class, Long>, Class> collector =
+                ConstraintCollectors.max(Comparator.comparing(Class::getCanonicalName));
+        SortedMap<Class, Long> container = collector.supplier().get();
+        // add first value, which becomes the max
+        Class firstValue = ConstraintCollectorsTest.class;
+        Runnable firstRetractor = accumulate(collector, container, firstValue);
+        assertResult(collector, container, firstValue);
+        // add second value, lesser than the first, result does not change
+        Class secondValue = ConstraintCollectors.class;
+        Runnable secondRetractor = accumulate(collector, container, secondValue);
+        assertResult(collector, container, firstValue);
+        // add third value, same as the first, result does not change
+        Runnable thirdRetractor = accumulate(collector, container, firstValue);
+        assertResult(collector, container, firstValue);
+        // retract one instance of the first value; first value is still the max value, nothing should change
+        firstRetractor.run();
+        assertResult(collector, container, firstValue);
+        // retract final instance of the first value; second value is now the max value
+        thirdRetractor.run();
+        assertResult(collector, container, secondValue);
+        // retract last value; there are no values now
+        secondRetractor.run();
+        assertResult(collector, container, null);
+    }
+
+}

--- a/optaplanner-core/src/test/java/org/optaplanner/core/api/score/stream/uni/UniConstraintStreamTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/api/score/stream/uni/UniConstraintStreamTest.java
@@ -415,7 +415,7 @@ public class UniConstraintStreamTest extends AbstractConstraintStreamTest {
                 assertMatchWithScore(-1_000_000, entityGroup1, entity1),
                 assertMatchWithScore(-1, firstEntity.getEntityGroup(), firstEntity));
 
-        // Now remove all entities and see that the score is zero. (= all matches removed)
+        // Now remove all entities and see that the score is zero (= all matches removed).
         solution.setEntityList(Collections.emptyList());
         scoreDirector.setWorkingSolution(solution);
         assertScore(scoreDirector);
@@ -444,7 +444,7 @@ public class UniConstraintStreamTest extends AbstractConstraintStreamTest {
                 assertMatchWithScore(-1_000_000, entityGroup1, entity1),
                 assertMatchWithScore(-1, lastEntity.getEntityGroup(), lastEntity));
 
-        // Now remove all entities and see that the score is zero. (= all matches removed)
+        // Now remove all entities and see that the score is zero (= all matches removed).
         solution.setEntityList(Collections.emptyList());
         scoreDirector.setWorkingSolution(solution);
         assertScore(scoreDirector);


### PR DESCRIPTION
Some questions to answer:

- Is this kind of `min` or `max` valid on bi-streams and higher? What would it do there?
- The collectors return null when the result makes no sense. (Such as "minimum of empty stream.") My assumption is that we would never get to see those situations, since an empty stream would never call the collector in the first place. Is the assumption correct?
- Does this help to address some of the feature gaps we have in the implementation currently? If so, what examples could we improve with this?