### PR TITLE
PLANNER-1638 Migrate TerminationTest to upstream

### DIFF
--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/solver/termination/AndCompositeTerminationTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/solver/termination/AndCompositeTerminationTest.java
@@ -1,0 +1,133 @@
+package org.optaplanner.core.impl.solver.termination;
+
+import java.util.Arrays;
+
+import org.junit.Test;
+import org.optaplanner.core.impl.phase.scope.AbstractPhaseScope;
+import org.optaplanner.core.impl.solver.scope.DefaultSolverScope;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+public class AndCompositeTerminationTest {
+
+    @Test
+    public void solveTermination() {
+        Termination termination1 = mock(Termination.class);
+        Termination termination2 = mock(Termination.class);
+
+        Termination compositeTermination = new AndCompositeTermination(termination1, termination2);
+
+        DefaultSolverScope solverScope = mock(DefaultSolverScope.class);
+
+        when(termination1.isSolverTerminated(solverScope)).thenReturn(false);
+        when(termination2.isSolverTerminated(solverScope)).thenReturn(false);
+        assertFalse(compositeTermination.isSolverTerminated(solverScope));
+
+        when(termination1.isSolverTerminated(solverScope)).thenReturn(true);
+        when(termination2.isSolverTerminated(solverScope)).thenReturn(false);
+        assertFalse(compositeTermination.isSolverTerminated(solverScope));
+
+        when(termination1.isSolverTerminated(solverScope)).thenReturn(false);
+        when(termination2.isSolverTerminated(solverScope)).thenReturn(true);
+        assertFalse(compositeTermination.isSolverTerminated(solverScope));
+
+        when(termination1.isSolverTerminated(solverScope)).thenReturn(true);
+        when(termination2.isSolverTerminated(solverScope)).thenReturn(true);
+        assertTrue(compositeTermination.isSolverTerminated(solverScope));
+    }
+
+    @Test
+    public void phaseTermination() {
+        Termination termination1 = mock(Termination.class);
+        Termination termination2 = mock(Termination.class);
+
+        Termination compositeTermination = new AndCompositeTermination(Arrays.asList(termination1, termination2));
+
+        AbstractPhaseScope phaseScope = mock(AbstractPhaseScope.class);
+
+        when(termination1.isPhaseTerminated(phaseScope)).thenReturn(false);
+        when(termination2.isPhaseTerminated(phaseScope)).thenReturn(false);
+        assertFalse(compositeTermination.isPhaseTerminated(phaseScope));
+
+        when(termination1.isPhaseTerminated(phaseScope)).thenReturn(true);
+        when(termination2.isPhaseTerminated(phaseScope)).thenReturn(false);
+        assertFalse(compositeTermination.isPhaseTerminated(phaseScope));
+
+        when(termination1.isPhaseTerminated(phaseScope)).thenReturn(false);
+        when(termination2.isPhaseTerminated(phaseScope)).thenReturn(true);
+        assertFalse(compositeTermination.isPhaseTerminated(phaseScope));
+
+        when(termination1.isPhaseTerminated(phaseScope)).thenReturn(true);
+        when(termination2.isPhaseTerminated(phaseScope)).thenReturn(true);
+        assertTrue(compositeTermination.isPhaseTerminated(phaseScope));
+    }
+
+    @Test
+    public void calculateSolverTimeGradientTest() {
+        Termination termination1 = mock(Termination.class);
+        Termination termination2 = mock(Termination.class);
+
+        Termination compositeTermination = new AndCompositeTermination(Arrays.asList(termination1, termination2));
+
+        DefaultSolverScope solverScope = mock(DefaultSolverScope.class);
+
+        when(termination1.calculateSolverTimeGradient(solverScope)).thenReturn(0.0);
+        when(termination2.calculateSolverTimeGradient(solverScope)).thenReturn(0.0);
+        assertEquals(0.0, compositeTermination.calculateSolverTimeGradient(solverScope), 0.0);
+
+        when(termination1.calculateSolverTimeGradient(solverScope)).thenReturn(0.5);
+        when(termination2.calculateSolverTimeGradient(solverScope)).thenReturn(0.0);
+        assertEquals(0.0, compositeTermination.calculateSolverTimeGradient(solverScope), 0.0);
+
+        when(termination1.calculateSolverTimeGradient(solverScope)).thenReturn(0.0);
+        when(termination2.calculateSolverTimeGradient(solverScope)).thenReturn(0.5);
+        assertEquals(0.0, compositeTermination.calculateSolverTimeGradient(solverScope), 0.0);
+
+        when(termination1.calculateSolverTimeGradient(solverScope)).thenReturn(0.1);
+        when(termination2.calculateSolverTimeGradient(solverScope)).thenReturn(0.1);
+        assertEquals(0.1, compositeTermination.calculateSolverTimeGradient(solverScope), 0.0);
+
+        when(termination1.calculateSolverTimeGradient(solverScope)).thenReturn(0.5);
+        when(termination2.calculateSolverTimeGradient(solverScope)).thenReturn(0.1);
+        assertEquals(0.1, compositeTermination.calculateSolverTimeGradient(solverScope), 0.0);
+
+        when(termination1.calculateSolverTimeGradient(solverScope)).thenReturn(0.1);
+        when(termination2.calculateSolverTimeGradient(solverScope)).thenReturn(0.5);
+        assertEquals(0.1, compositeTermination.calculateSolverTimeGradient(solverScope), 0.0);
+    }
+
+    @Test
+    public void calculatePhaseTimeGradientTest() {
+        Termination termination1 = mock(Termination.class);
+        Termination termination2 = mock(Termination.class);
+
+        Termination compositeTermination = new AndCompositeTermination(Arrays.asList(termination1, termination2));
+
+        AbstractPhaseScope phaseScope = mock(AbstractPhaseScope.class);
+
+        when(termination1.calculatePhaseTimeGradient(phaseScope)).thenReturn(0.0);
+        when(termination2.calculatePhaseTimeGradient(phaseScope)).thenReturn(0.0);
+        assertEquals(0.0, compositeTermination.calculatePhaseTimeGradient(phaseScope), 0.0);
+
+        when(termination1.calculatePhaseTimeGradient(phaseScope)).thenReturn(0.5);
+        when(termination2.calculatePhaseTimeGradient(phaseScope)).thenReturn(0.0);
+        assertEquals(0.0, compositeTermination.calculatePhaseTimeGradient(phaseScope), 0.0);
+
+        when(termination1.calculatePhaseTimeGradient(phaseScope)).thenReturn(0.0);
+        when(termination2.calculatePhaseTimeGradient(phaseScope)).thenReturn(0.5);
+        assertEquals(0.0, compositeTermination.calculatePhaseTimeGradient(phaseScope), 0.0);
+
+        when(termination1.calculatePhaseTimeGradient(phaseScope)).thenReturn(0.1);
+        when(termination2.calculatePhaseTimeGradient(phaseScope)).thenReturn(0.1);
+        assertEquals(0.1, compositeTermination.calculatePhaseTimeGradient(phaseScope), 0.0);
+
+        when(termination1.calculatePhaseTimeGradient(phaseScope)).thenReturn(0.5);
+        when(termination2.calculatePhaseTimeGradient(phaseScope)).thenReturn(0.1);
+        assertEquals(0.1, compositeTermination.calculatePhaseTimeGradient(phaseScope), 0.0);
+
+        when(termination1.calculatePhaseTimeGradient(phaseScope)).thenReturn(0.1);
+        when(termination2.calculatePhaseTimeGradient(phaseScope)).thenReturn(0.5);
+        assertEquals(0.1, compositeTermination.calculatePhaseTimeGradient(phaseScope), 0.0);
+    }
+}


### PR DESCRIPTION
The only class from the TerminationTest not yet covered in the upstream was the AndCompositeTeminationTest, which is covered in this commit.