### PR TITLE
PLANNER-1674 Change values to cover more branches and add comments to AndCompositeTerminationTest

### DIFF
--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/solver/termination/AndCompositeTerminationTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/solver/termination/AndCompositeTerminationTest.java
@@ -89,17 +89,17 @@ public class AndCompositeTerminationTest {
 
         when(termination1.calculateSolverTimeGradient(solverScope)).thenReturn(-1.0);
         when(termination2.calculateSolverTimeGradient(solverScope)).thenReturn(-1.0);
-        // Negative number are unsupported and ignored, min(unsupported,unsupported) = 1.0 (default)
+        // Negative time gradient values are unsupported and ignored, min(unsupported,unsupported) = 1.0 (default)
         assertEquals(1.0, compositeTermination.calculateSolverTimeGradient(solverScope), 0.0);
 
         when(termination1.calculateSolverTimeGradient(solverScope)).thenReturn(0.5);
         when(termination2.calculateSolverTimeGradient(solverScope)).thenReturn(-1.0);
-        // Negative number are unsupported and ignored, min(0.5,unsupported) = 0.5
+        // Negative time gradient values are unsupported and ignored, min(0.5,unsupported) = 0.5
         assertEquals(0.5, compositeTermination.calculateSolverTimeGradient(solverScope), 0.0);
 
         when(termination1.calculateSolverTimeGradient(solverScope)).thenReturn(-1.0);
         when(termination2.calculateSolverTimeGradient(solverScope)).thenReturn(0.5);
-        // Negative number are unsupported and ignored, min(unsupported,0.5) = 0.5
+        // Negative time gradient values are unsupported and ignored, min(unsupported,0.5) = 0.5
         assertEquals(0.5, compositeTermination.calculateSolverTimeGradient(solverScope), 0.0);
     }
 
@@ -129,17 +129,17 @@ public class AndCompositeTerminationTest {
 
         when(termination1.calculatePhaseTimeGradient(phaseScope)).thenReturn(-1.0);
         when(termination2.calculatePhaseTimeGradient(phaseScope)).thenReturn(-1.0);
-        // Negative number are unsupported and ignored, min(unsupported,unsupported) = 1.0 (default)
+        // Negative time gradient values are unsupported and ignored, min(unsupported,unsupported) = 1.0 (default)
         assertEquals(1.0, compositeTermination.calculatePhaseTimeGradient(phaseScope), 0.0);
 
         when(termination1.calculatePhaseTimeGradient(phaseScope)).thenReturn(0.5);
         when(termination2.calculatePhaseTimeGradient(phaseScope)).thenReturn(-1.0);
-        // Negative number are unsupported and ignored, min(0.5,unsupported) = 0.5
+        // Negative time numbersgradient values are unsupported and ignored, min(0.5,unsupported) = 0.5
         assertEquals(0.5, compositeTermination.calculatePhaseTimeGradient(phaseScope), 0.0);
 
         when(termination1.calculatePhaseTimeGradient(phaseScope)).thenReturn(-1.0);
         when(termination2.calculatePhaseTimeGradient(phaseScope)).thenReturn(0.5);
-        // Negative number are unsupported and ignored, min(unsupported,0.5) = 0.5
+        // Negative time gradient values are unsupported and ignored, min(unsupported,0.5) = 0.5
         assertEquals(0.5, compositeTermination.calculatePhaseTimeGradient(phaseScope), 0.0);
     }
 }

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/solver/termination/AndCompositeTerminationTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/solver/termination/AndCompositeTerminationTest.java
@@ -74,32 +74,32 @@ public class AndCompositeTerminationTest {
 
         when(termination1.calculateSolverTimeGradient(solverScope)).thenReturn(0.0);
         when(termination2.calculateSolverTimeGradient(solverScope)).thenReturn(0.0);
-        //min(0.0,0.0) = 0.0
+        // min(0.0,0.0) = 0.0
         assertEquals(0.0, compositeTermination.calculateSolverTimeGradient(solverScope), 0.0);
 
         when(termination1.calculateSolverTimeGradient(solverScope)).thenReturn(0.5);
         when(termination2.calculateSolverTimeGradient(solverScope)).thenReturn(0.0);
-        //min(0.5,0.0) = 0.0
+        // min(0.5,0.0) = 0.0
         assertEquals(0.0, compositeTermination.calculateSolverTimeGradient(solverScope), 0.0);
 
         when(termination1.calculateSolverTimeGradient(solverScope)).thenReturn(0.0);
         when(termination2.calculateSolverTimeGradient(solverScope)).thenReturn(0.5);
-        //min(0.0,0.5) = 0.0
+        // min(0.0,0.5) = 0.0
         assertEquals(0.0, compositeTermination.calculateSolverTimeGradient(solverScope), 0.0);
 
         when(termination1.calculateSolverTimeGradient(solverScope)).thenReturn(-1.0);
         when(termination2.calculateSolverTimeGradient(solverScope)).thenReturn(-1.0);
-        //negative number are unsupported and ignored, min(unsupported,unsupported) = 1.0 (default)
+        // Negative number are unsupported and ignored, min(unsupported,unsupported) = 1.0 (default)
         assertEquals(1.0, compositeTermination.calculateSolverTimeGradient(solverScope), 0.0);
 
         when(termination1.calculateSolverTimeGradient(solverScope)).thenReturn(0.5);
         when(termination2.calculateSolverTimeGradient(solverScope)).thenReturn(-1.0);
-        //negative number are unsupported and ignored, min(0.5,unsupported) = 0.5
+        // Negative number are unsupported and ignored, min(0.5,unsupported) = 0.5
         assertEquals(0.5, compositeTermination.calculateSolverTimeGradient(solverScope), 0.0);
 
         when(termination1.calculateSolverTimeGradient(solverScope)).thenReturn(-1.0);
         when(termination2.calculateSolverTimeGradient(solverScope)).thenReturn(0.5);
-        //negative number are unsupported and ignored, min(unsupported,0.5) = 0.5
+        // Negative number are unsupported and ignored, min(unsupported,0.5) = 0.5
         assertEquals(0.5, compositeTermination.calculateSolverTimeGradient(solverScope), 0.0);
     }
 
@@ -114,32 +114,32 @@ public class AndCompositeTerminationTest {
 
         when(termination1.calculatePhaseTimeGradient(phaseScope)).thenReturn(0.0);
         when(termination2.calculatePhaseTimeGradient(phaseScope)).thenReturn(0.0);
-        //min(0.0,0.0) = 0.0
+        // min(0.0,0.0) = 0.0
         assertEquals(0.0, compositeTermination.calculatePhaseTimeGradient(phaseScope), 0.0);
 
         when(termination1.calculatePhaseTimeGradient(phaseScope)).thenReturn(0.5);
         when(termination2.calculatePhaseTimeGradient(phaseScope)).thenReturn(0.0);
-        //min(0.5,0.0) = 0.0
+        // min(0.5,0.0) = 0.0
         assertEquals(0.0, compositeTermination.calculatePhaseTimeGradient(phaseScope), 0.0);
 
         when(termination1.calculatePhaseTimeGradient(phaseScope)).thenReturn(0.0);
         when(termination2.calculatePhaseTimeGradient(phaseScope)).thenReturn(0.5);
-        //min(0.0,0.5) = 0.0
+        // min(0.0,0.5) = 0.0
         assertEquals(0.0, compositeTermination.calculatePhaseTimeGradient(phaseScope), 0.0);
 
         when(termination1.calculatePhaseTimeGradient(phaseScope)).thenReturn(-1.0);
         when(termination2.calculatePhaseTimeGradient(phaseScope)).thenReturn(-1.0);
-        //negative number are unsupported and ignored, min(unsupported,unsupported) = 1.0 (default)
+        // Negative number are unsupported and ignored, min(unsupported,unsupported) = 1.0 (default)
         assertEquals(1.0, compositeTermination.calculatePhaseTimeGradient(phaseScope), 0.0);
 
         when(termination1.calculatePhaseTimeGradient(phaseScope)).thenReturn(0.5);
         when(termination2.calculatePhaseTimeGradient(phaseScope)).thenReturn(-1.0);
-        //negative number are unsupported and ignored, min(0.5,unsupported) = 0.5
+        // Negative number are unsupported and ignored, min(0.5,unsupported) = 0.5
         assertEquals(0.5, compositeTermination.calculatePhaseTimeGradient(phaseScope), 0.0);
 
         when(termination1.calculatePhaseTimeGradient(phaseScope)).thenReturn(-1.0);
         when(termination2.calculatePhaseTimeGradient(phaseScope)).thenReturn(0.5);
-        //negative number are unsupported and ignored, min(unsupported,0.5) = 0.5
+        // Negative number are unsupported and ignored, min(unsupported,0.5) = 0.5
         assertEquals(0.5, compositeTermination.calculatePhaseTimeGradient(phaseScope), 0.0);
     }
 }

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/solver/termination/AndCompositeTerminationTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/solver/termination/AndCompositeTerminationTest.java
@@ -134,7 +134,7 @@ public class AndCompositeTerminationTest {
 
         when(termination1.calculatePhaseTimeGradient(phaseScope)).thenReturn(0.5);
         when(termination2.calculatePhaseTimeGradient(phaseScope)).thenReturn(-1.0);
-        // Negative time numbersgradient values are unsupported and ignored, min(0.5,unsupported) = 0.5
+        // Negative time gradient values are unsupported and ignored, min(0.5,unsupported) = 0.5
         assertEquals(0.5, compositeTermination.calculatePhaseTimeGradient(phaseScope), 0.0);
 
         when(termination1.calculatePhaseTimeGradient(phaseScope)).thenReturn(-1.0);

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/solver/termination/AndCompositeTerminationTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/solver/termination/AndCompositeTerminationTest.java
@@ -74,27 +74,33 @@ public class AndCompositeTerminationTest {
 
         when(termination1.calculateSolverTimeGradient(solverScope)).thenReturn(0.0);
         when(termination2.calculateSolverTimeGradient(solverScope)).thenReturn(0.0);
+        //min(0.0,0.0) = 0.0
         assertEquals(0.0, compositeTermination.calculateSolverTimeGradient(solverScope), 0.0);
 
         when(termination1.calculateSolverTimeGradient(solverScope)).thenReturn(0.5);
         when(termination2.calculateSolverTimeGradient(solverScope)).thenReturn(0.0);
+        //min(0.5,0.0) = 0.0
         assertEquals(0.0, compositeTermination.calculateSolverTimeGradient(solverScope), 0.0);
 
         when(termination1.calculateSolverTimeGradient(solverScope)).thenReturn(0.0);
         when(termination2.calculateSolverTimeGradient(solverScope)).thenReturn(0.5);
+        //min(0.0,0.5) = 0.0
         assertEquals(0.0, compositeTermination.calculateSolverTimeGradient(solverScope), 0.0);
 
-        when(termination1.calculateSolverTimeGradient(solverScope)).thenReturn(0.1);
-        when(termination2.calculateSolverTimeGradient(solverScope)).thenReturn(0.1);
-        assertEquals(0.1, compositeTermination.calculateSolverTimeGradient(solverScope), 0.0);
+        when(termination1.calculateSolverTimeGradient(solverScope)).thenReturn(-1.0);
+        when(termination2.calculateSolverTimeGradient(solverScope)).thenReturn(-1.0);
+        //negative number are unsupported and ignored, min(unsupported,unsupported) = 1.0 (default)
+        assertEquals(1.0, compositeTermination.calculateSolverTimeGradient(solverScope), 0.0);
 
         when(termination1.calculateSolverTimeGradient(solverScope)).thenReturn(0.5);
-        when(termination2.calculateSolverTimeGradient(solverScope)).thenReturn(0.1);
-        assertEquals(0.1, compositeTermination.calculateSolverTimeGradient(solverScope), 0.0);
+        when(termination2.calculateSolverTimeGradient(solverScope)).thenReturn(-1.0);
+        //negative number are unsupported and ignored, min(0.5,unsupported) = 0.5
+        assertEquals(0.5, compositeTermination.calculateSolverTimeGradient(solverScope), 0.0);
 
-        when(termination1.calculateSolverTimeGradient(solverScope)).thenReturn(0.1);
+        when(termination1.calculateSolverTimeGradient(solverScope)).thenReturn(-1.0);
         when(termination2.calculateSolverTimeGradient(solverScope)).thenReturn(0.5);
-        assertEquals(0.1, compositeTermination.calculateSolverTimeGradient(solverScope), 0.0);
+        //negative number are unsupported and ignored, min(unsupported,0.5) = 0.5
+        assertEquals(0.5, compositeTermination.calculateSolverTimeGradient(solverScope), 0.0);
     }
 
     @Test
@@ -108,26 +114,32 @@ public class AndCompositeTerminationTest {
 
         when(termination1.calculatePhaseTimeGradient(phaseScope)).thenReturn(0.0);
         when(termination2.calculatePhaseTimeGradient(phaseScope)).thenReturn(0.0);
+        //min(0.0,0.0) = 0.0
         assertEquals(0.0, compositeTermination.calculatePhaseTimeGradient(phaseScope), 0.0);
 
         when(termination1.calculatePhaseTimeGradient(phaseScope)).thenReturn(0.5);
         when(termination2.calculatePhaseTimeGradient(phaseScope)).thenReturn(0.0);
+        //min(0.5,0.0) = 0.0
         assertEquals(0.0, compositeTermination.calculatePhaseTimeGradient(phaseScope), 0.0);
 
         when(termination1.calculatePhaseTimeGradient(phaseScope)).thenReturn(0.0);
         when(termination2.calculatePhaseTimeGradient(phaseScope)).thenReturn(0.5);
+        //min(0.0,0.5) = 0.0
         assertEquals(0.0, compositeTermination.calculatePhaseTimeGradient(phaseScope), 0.0);
 
-        when(termination1.calculatePhaseTimeGradient(phaseScope)).thenReturn(0.1);
-        when(termination2.calculatePhaseTimeGradient(phaseScope)).thenReturn(0.1);
-        assertEquals(0.1, compositeTermination.calculatePhaseTimeGradient(phaseScope), 0.0);
+        when(termination1.calculatePhaseTimeGradient(phaseScope)).thenReturn(-1.0);
+        when(termination2.calculatePhaseTimeGradient(phaseScope)).thenReturn(-1.0);
+        //negative number are unsupported and ignored, min(unsupported,unsupported) = 1.0 (default)
+        assertEquals(1.0, compositeTermination.calculatePhaseTimeGradient(phaseScope), 0.0);
 
         when(termination1.calculatePhaseTimeGradient(phaseScope)).thenReturn(0.5);
-        when(termination2.calculatePhaseTimeGradient(phaseScope)).thenReturn(0.1);
-        assertEquals(0.1, compositeTermination.calculatePhaseTimeGradient(phaseScope), 0.0);
+        when(termination2.calculatePhaseTimeGradient(phaseScope)).thenReturn(-1.0);
+        //negative number are unsupported and ignored, min(0.5,unsupported) = 0.5
+        assertEquals(0.5, compositeTermination.calculatePhaseTimeGradient(phaseScope), 0.0);
 
-        when(termination1.calculatePhaseTimeGradient(phaseScope)).thenReturn(0.1);
+        when(termination1.calculatePhaseTimeGradient(phaseScope)).thenReturn(-1.0);
         when(termination2.calculatePhaseTimeGradient(phaseScope)).thenReturn(0.5);
-        assertEquals(0.1, compositeTermination.calculatePhaseTimeGradient(phaseScope), 0.0);
+        //negative number are unsupported and ignored, min(unsupported,0.5) = 0.5
+        assertEquals(0.5, compositeTermination.calculatePhaseTimeGradient(phaseScope), 0.0);
     }
 }


### PR DESCRIPTION
Changed test cases that were suppose to cover corner cases but after consulting SonarCloud did not. Add negative cases of time gradient. In addition, add explaining comments, so that the choice of values is more transparent.