### PR TITLE
enable SORT_PROPERTIES_ALPHABETICALLY for a deterministic order

### DIFF
--- a/optaplanner-persistence/optaplanner-persistence-jackson/src/test/java/org/optaplanner/persistence/jackson/api/OptaPlannerJacksonModuleTest.java
+++ b/optaplanner-persistence/optaplanner-persistence-jackson/src/test/java/org/optaplanner/persistence/jackson/api/OptaPlannerJacksonModuleTest.java
@@ -16,6 +16,7 @@
 
 package org.optaplanner.persistence.jackson.api;
 
+import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.Test;
 import org.optaplanner.core.api.score.Score;
@@ -29,6 +30,7 @@ public class OptaPlannerJacksonModuleTest extends AbstractJacksonJsonSerializerA
     @Test
     public void polymorphicScore() {
         ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.enable(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY);
         objectMapper.registerModule(OptaPlannerJacksonModule.createModule());
 
         TestOptaPlannerJacksonModuleWrapper input = new TestOptaPlannerJacksonModuleWrapper();


### PR DESCRIPTION
Test `polymorphicScore()` uses `ObjectMapper` from `Jackson` to serialize and de-serialize a object. However, the `ObjectMapper` relies on the order of fields returned by `java.lang.Class.getDeclaredFields`. 
But there is no guarantee in the order returned by that API and test can fail for failing to de-serialize this. 
e.g., `java.lang.AssertionError: expected:<-1hard/-20soft> but was:<null>`
 
We previously send a PR for fixing some of tests in `jackson` library and realize there is also related to `polymorphicScore` test here.

In this PR, we propose to enable the `SORT_PROPERTIES_ALPHABETICALLY` feature so that the order is deterministic. 