### PR TITLE
PLANNER-1685: Benchmark Regression Fix

### DIFF
--- a/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/impl/report/BenchmarkReport.java
+++ b/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/impl/report/BenchmarkReport.java
@@ -76,6 +76,8 @@ import freemarker.template.Configuration;
 import freemarker.template.Template;
 import freemarker.template.TemplateException;
 
+import static java.lang.Double.isFinite;
+
 public class BenchmarkReport {
 
     protected final transient Logger logger = LoggerFactory.getLogger(getClass());
@@ -353,10 +355,12 @@ public class BenchmarkReport {
                 if (singleBenchmarkResult.hasAllSuccess()) {
                     double[] levelValues = ScoreUtils.extractLevelDoubles(singleBenchmarkResult.getAverageScore());
                     for (int i = 0; i < levelValues.length && i < CHARTED_SCORE_LEVEL_SIZE; i++) {
-                        if (i >= datasetList.size()) {
-                            datasetList.add(new DefaultCategoryDataset());
+                        if (isFinite(levelValues[i])) {
+                            if (i >= datasetList.size()) {
+                                datasetList.add(new DefaultCategoryDataset());
+                            }
+                            datasetList.get(i).addValue(levelValues[i], solverLabel, problemLabel);
                         }
-                        datasetList.get(i).addValue(levelValues[i], solverLabel, problemLabel);
                     }
                 }
             }
@@ -469,10 +473,12 @@ public class BenchmarkReport {
                 if (singleBenchmarkResult.hasAllSuccess()) {
                     double[] levelValues = ScoreUtils.extractLevelDoubles(singleBenchmarkResult.getWinningScoreDifference());
                     for (int i = 0; i < levelValues.length && i < CHARTED_SCORE_LEVEL_SIZE; i++) {
-                        if (i >= datasetList.size()) {
-                            datasetList.add(new DefaultCategoryDataset());
+                        if (isFinite(levelValues[i])) {
+                            if (i >= datasetList.size()) {
+                                datasetList.add(new DefaultCategoryDataset());
+                            }
+                            datasetList.get(i).addValue(levelValues[i], solverLabel, problemLabel);
                         }
-                        datasetList.get(i).addValue(levelValues[i], solverLabel, problemLabel);
                     }
                 }
             }
@@ -501,10 +507,12 @@ public class BenchmarkReport {
                 if (singleBenchmarkResult.hasAllSuccess()) {
                     double[] levelValues = singleBenchmarkResult.getWorstScoreDifferencePercentage().getPercentageLevels();
                     for (int i = 0; i < levelValues.length && i < CHARTED_SCORE_LEVEL_SIZE; i++) {
-                        if (i >= datasetList.size()) {
-                            datasetList.add(new DefaultCategoryDataset());
+                        if (isFinite(levelValues[i])) {
+                            if (i >= datasetList.size()) {
+                                datasetList.add(new DefaultCategoryDataset());
+                            }
+                            datasetList.get(i).addValue(levelValues[i], solverLabel, problemLabel);
                         }
-                        datasetList.get(i).addValue(levelValues[i], solverLabel, problemLabel);
                     }
                 }
             }


### PR DESCRIPTION
Fixes regression caused by upgrading `JFreeChart` from `1.0.19` to `1.5.0` in #576 
