### PR TITLE
PLANNER-1689 Make Drools the default backend for Constraint Streams

### DIFF
--- a/optaplanner-core/src/build/revapi-config.json
+++ b/optaplanner-core/src/build/revapi-config.json
@@ -82,6 +82,138 @@
           "methodName": "getClassLoader",
           "elementKind": "method",
           "justification": "Replaced by SolverConfig.getClassLoader(). SolverConfigContext isn't public API."
+        },
+        {
+          "code": "java.method.removed",
+          "old": "method <A, B, Property_> org.optaplanner.core.api.score.stream.bi.BiJoiner<A, B> org.optaplanner.core.api.score.stream.Joiners::containing(java.util.function.Function<A, ? extends java.util.Collection<Property_>>, java.util.function.Function<B, Property_>)",
+          "package": "org.optaplanner.core.api.score.stream",
+          "classSimpleName": "Joiners",
+          "methodName": "containing",
+          "elementKind": "method",
+          "justification": "Temporarily removed until actually implemented."
+        },
+        {
+          "code": "java.method.removed",
+          "old": "method <A, Property_> org.optaplanner.core.api.score.stream.bi.BiJoiner<A, A> org.optaplanner.core.api.score.stream.Joiners::disjoint(java.util.function.Function<A, ? extends java.util.Collection<Property_>>)",
+          "package": "org.optaplanner.core.api.score.stream",
+          "classSimpleName": "Joiners",
+          "methodName": "disjoint",
+          "elementKind": "method",
+          "justification": "Temporarily removed until actually implemented."
+        },
+        {
+          "code": "java.method.removed",
+          "old": "method <A, B, Property_> org.optaplanner.core.api.score.stream.bi.BiJoiner<A, B> org.optaplanner.core.api.score.stream.Joiners::disjoint(java.util.function.Function<A, ? extends java.util.Collection<Property_>>, java.util.function.Function<B, ? extends java.util.Collection<Property_>>)",
+          "package": "org.optaplanner.core.api.score.stream",
+          "classSimpleName": "Joiners",
+          "methodName": "disjoint",
+          "elementKind": "method",
+          "justification": "Temporarily removed until actually implemented."
+        },
+        {
+          "code": "java.method.removed",
+          "old": "method <A, Property_> org.optaplanner.core.api.score.stream.bi.BiJoiner<A, A> org.optaplanner.core.api.score.stream.Joiners::intersecting(java.util.function.Function<A, ? extends java.util.Collection<Property_>>)",
+          "package": "org.optaplanner.core.api.score.stream",
+          "classSimpleName": "Joiners",
+          "methodName": "intersecting",
+          "elementKind": "method",
+          "justification": "Temporarily removed until actually implemented."
+        },
+        {
+          "code": "java.method.removed",
+          "old": "method <A, B, Property_> org.optaplanner.core.api.score.stream.bi.BiJoiner<A, B> org.optaplanner.core.api.score.stream.Joiners::intersecting(java.util.function.Function<A, ? extends java.util.Collection<Property_>>, java.util.function.Function<B, ? extends java.util.Collection<Property_>>)",
+          "package": "org.optaplanner.core.api.score.stream",
+          "classSimpleName": "Joiners",
+          "methodName": "intersecting",
+          "elementKind": "method",
+          "justification": "Temporarily removed until actually implemented."
+        },
+        {
+          "code": "java.method.removed",
+          "old": "method <GroupKey_> org.optaplanner.core.api.score.stream.uni.UniConstraintStream<GroupKey_> org.optaplanner.core.api.score.stream.bi.BiConstraintStream<A, B>::groupBy(java.util.function.BiFunction<A, B, GroupKey_>)",
+          "package": "org.optaplanner.core.api.score.stream.bi",
+          "classSimpleName": "BiConstraintStream",
+          "methodName": "groupBy",
+          "elementKind": "method",
+          "justification": "Temporarily removed until actually implemented."
+        },
+        {
+          "code": "java.method.removed",
+          "old": "method <GroupKeyA_, GroupKeyB_> org.optaplanner.core.api.score.stream.bi.BiConstraintStream<GroupKeyA_, GroupKeyB_> org.optaplanner.core.api.score.stream.bi.BiConstraintStream<A, B>::groupBy(java.util.function.BiFunction<A, B, GroupKeyA_>, java.util.function.BiFunction<A, B, GroupKeyB_>)",
+          "package": "org.optaplanner.core.api.score.stream.bi",
+          "classSimpleName": "BiConstraintStream",
+          "methodName": "groupBy",
+          "elementKind": "method",
+          "justification": "Temporarily removed until actually implemented."
+        },
+        {
+          "code": "java.method.removed",
+          "old": "method <GroupKeyA_, GroupKeyB_, ResultContainer_, Result_> org.optaplanner.core.api.score.stream.tri.TriConstraintStream<GroupKeyA_, GroupKeyB_, Result_> org.optaplanner.core.api.score.stream.bi.BiConstraintStream<A, B>::groupBy(java.util.function.BiFunction<A, B, GroupKeyA_>, java.util.function.BiFunction<A, B, GroupKeyB_>, org.optaplanner.core.api.score.stream.bi.BiConstraintCollector<A, B, ResultContainer_, Result_>)",
+          "package": "org.optaplanner.core.api.score.stream.bi",
+          "classSimpleName": "BiConstraintStream",
+          "methodName": "groupBy",
+          "elementKind": "method",
+          "justification": "Temporarily removed until actually implemented."
+        },
+        {
+          "code": "java.method.removed",
+          "old": "method <GroupKey_, ResultContainer_, Result_> org.optaplanner.core.api.score.stream.bi.BiConstraintStream<GroupKey_, Result_> org.optaplanner.core.api.score.stream.bi.BiConstraintStream<A, B>::groupBy(java.util.function.BiFunction<A, B, GroupKey_>, org.optaplanner.core.api.score.stream.bi.BiConstraintCollector<A, B, ResultContainer_, Result_>)",
+          "package": "org.optaplanner.core.api.score.stream.bi",
+          "classSimpleName": "BiConstraintStream",
+          "methodName": "groupBy",
+          "elementKind": "method",
+          "justification": "Temporarily removed until actually implemented."
+        },
+        {
+          "code": "java.method.numberOfParametersChanged",
+          "old": "method <GroupKeyA_, GroupKeyB_, ResultContainer_, Result_> org.optaplanner.core.api.score.stream.tri.TriConstraintStream<GroupKeyA_, GroupKeyB_, Result_> org.optaplanner.core.api.score.stream.uni.UniConstraintStream<A>::groupBy(java.util.function.Function<A, GroupKeyA_>, java.util.function.Function<A, GroupKeyB_>, org.optaplanner.core.api.score.stream.uni.UniConstraintCollector<A, ResultContainer_, Result_>)",
+          "new": "method <ResultContainer_, Result_> org.optaplanner.core.api.score.stream.uni.UniConstraintStream<Result_> org.optaplanner.core.api.score.stream.uni.UniConstraintStream<A>::groupBy(org.optaplanner.core.api.score.stream.uni.UniConstraintCollector<A, ResultContainer_, Result_>)",
+          "package": "org.optaplanner.core.api.score.stream.uni",
+          "classSimpleName": "UniConstraintStream",
+          "methodName": "groupBy",
+          "elementKind": "method",
+          "justification": "Temporarily removed until actually implemented."
+        },
+        {
+          "code": "java.method.returnTypeChanged",
+          "old": "method <GroupKeyA_, GroupKeyB_, ResultContainer_, Result_> org.optaplanner.core.api.score.stream.tri.TriConstraintStream<GroupKeyA_, GroupKeyB_, Result_> org.optaplanner.core.api.score.stream.uni.UniConstraintStream<A>::groupBy(java.util.function.Function<A, GroupKeyA_>, java.util.function.Function<A, GroupKeyB_>, org.optaplanner.core.api.score.stream.uni.UniConstraintCollector<A, ResultContainer_, Result_>)",
+          "new": "method <ResultContainer_, Result_> org.optaplanner.core.api.score.stream.uni.UniConstraintStream<Result_> org.optaplanner.core.api.score.stream.uni.UniConstraintStream<A>::groupBy(org.optaplanner.core.api.score.stream.uni.UniConstraintCollector<A, ResultContainer_, Result_>)",
+          "oldType": "org.optaplanner.core.api.score.stream.tri.TriConstraintStream<GroupKeyA_ extends java.lang.Object, GroupKeyB_ extends java.lang.Object, Result_ extends java.lang.Object>",
+          "newType": "org.optaplanner.core.api.score.stream.uni.UniConstraintStream<Result_ extends java.lang.Object>",
+          "package": "org.optaplanner.core.api.score.stream.uni",
+          "classSimpleName": "UniConstraintStream",
+          "methodName": "groupBy",
+          "elementKind": "method",
+          "justification": "Temporarily removed until actually implemented."
+        },
+        {
+          "code": "java.generics.formalTypeParameterRemoved",
+          "old": "method <GroupKeyA_, GroupKeyB_, ResultContainer_, Result_> org.optaplanner.core.api.score.stream.tri.TriConstraintStream<GroupKeyA_, GroupKeyB_, Result_> org.optaplanner.core.api.score.stream.uni.UniConstraintStream<A>::groupBy(java.util.function.Function<A, GroupKeyA_>, java.util.function.Function<A, GroupKeyB_>, org.optaplanner.core.api.score.stream.uni.UniConstraintCollector<A, ResultContainer_, Result_>)",
+          "new": "method <ResultContainer_, Result_> org.optaplanner.core.api.score.stream.uni.UniConstraintStream<Result_> org.optaplanner.core.api.score.stream.uni.UniConstraintStream<A>::groupBy(org.optaplanner.core.api.score.stream.uni.UniConstraintCollector<A, ResultContainer_, Result_>)",
+          "package": "org.optaplanner.core.api.score.stream.uni",
+          "classSimpleName": "UniConstraintStream",
+          "methodName": "groupBy",
+          "elementKind": "method",
+          "justification": "Temporarily removed until actually implemented."
+        },
+        {
+          "code": "java.generics.formalTypeParameterRemoved",
+          "old": "method <GroupKeyA_, GroupKeyB_, ResultContainer_, Result_> org.optaplanner.core.api.score.stream.tri.TriConstraintStream<GroupKeyA_, GroupKeyB_, Result_> org.optaplanner.core.api.score.stream.uni.UniConstraintStream<A>::groupBy(java.util.function.Function<A, GroupKeyA_>, java.util.function.Function<A, GroupKeyB_>, org.optaplanner.core.api.score.stream.uni.UniConstraintCollector<A, ResultContainer_, Result_>)",
+          "new": "method <ResultContainer_, Result_> org.optaplanner.core.api.score.stream.uni.UniConstraintStream<Result_> org.optaplanner.core.api.score.stream.uni.UniConstraintStream<A>::groupBy(org.optaplanner.core.api.score.stream.uni.UniConstraintCollector<A, ResultContainer_, Result_>)",
+          "package": "org.optaplanner.core.api.score.stream.uni",
+          "classSimpleName": "UniConstraintStream",
+          "methodName": "groupBy",
+          "elementKind": "method",
+          "justification": "Temporarily removed until actually implemented."
+        },
+        {
+          "code": "java.method.removed",
+          "old": "method <GroupKeyA_, GroupKeyB_> org.optaplanner.core.api.score.stream.bi.BiConstraintStream<GroupKeyA_, GroupKeyB_> org.optaplanner.core.api.score.stream.uni.UniConstraintStream<A>::groupBy(java.util.function.Function<A, GroupKeyA_>, java.util.function.Function<A, GroupKeyB_>)",
+          "package": "org.optaplanner.core.api.score.stream.uni",
+          "classSimpleName": "UniConstraintStream",
+          "methodName": "groupBy",
+          "elementKind": "method",
+          "justification": "Temporarily removed until actually implemented."
         }
       ]
     }

--- a/optaplanner-core/src/main/java/org/optaplanner/core/api/score/stream/Joiners.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/api/score/stream/Joiners.java
@@ -16,7 +16,6 @@
 
 package org.optaplanner.core.api.score.stream;
 
-import java.util.Collection;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 
@@ -91,6 +90,8 @@ public final class Joiners {
         return new SingleBiJoiner<>(leftMapping, JoinerType.GREATER_THAN_OR_EQUAL, rightMapping);
     }
 
+    /*
+    // TODO implement these joiners
     public static <A, B, Property_> BiJoiner<A, B> containing(
             Function<A, ? extends Collection<Property_>> leftMapping, Function <B, Property_> rightMapping) {
         return new SingleBiJoiner<>(leftMapping, JoinerType.CONTAINING, rightMapping);
@@ -117,6 +118,7 @@ public final class Joiners {
             Function<A, ? extends Collection<Property_>> leftMapping, Function <B, ? extends Collection<Property_>> rightMapping) {
         return new SingleBiJoiner<>(leftMapping, JoinerType.DISJOINT, rightMapping);
     }
+    */
 
     // TODO
     // join(..., planningVariableContainsCached(Talk::getPeriod, (Period a, Period b) -> a.overlaps(b)))

--- a/optaplanner-core/src/main/java/org/optaplanner/core/api/score/stream/bi/BiConstraintStream.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/api/score/stream/bi/BiConstraintStream.java
@@ -190,9 +190,10 @@ public interface BiConstraintStream<A, B> extends ConstraintStream {
     }
 
     // ************************************************************************
-    // Group by
+    // Group by (TODO implement these)
     // ************************************************************************
 
+    /*
     <GroupKey_> UniConstraintStream<GroupKey_> groupBy(
             BiFunction<A, B, GroupKey_> groupKeyMapping);
 
@@ -209,6 +210,7 @@ public interface BiConstraintStream<A, B> extends ConstraintStream {
             BiFunction<A, B, GroupKeyA_> groupKeyAMapping,
             BiFunction<A, B, GroupKeyB_> groupKeyBMapping,
             BiConstraintCollector<A, B, ResultContainer_, Result_> collector);
+     */
 
     // ************************************************************************
     // Penalize/reward

--- a/optaplanner-core/src/main/java/org/optaplanner/core/api/score/stream/uni/UniConstraintStream.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/api/score/stream/uni/UniConstraintStream.java
@@ -31,7 +31,6 @@ import org.optaplanner.core.api.score.stream.Constraint;
 import org.optaplanner.core.api.score.stream.ConstraintStream;
 import org.optaplanner.core.api.score.stream.bi.BiConstraintStream;
 import org.optaplanner.core.api.score.stream.bi.BiJoiner;
-import org.optaplanner.core.api.score.stream.tri.TriConstraintStream;
 import org.optaplanner.core.impl.score.stream.bi.AbstractBiJoiner;
 import org.optaplanner.core.impl.score.stream.bi.NoneBiJoiner;
 
@@ -227,6 +226,7 @@ public interface UniConstraintStream<A> extends ConstraintStream {
             Function<A, GroupKey_> groupKeyMapping,
             UniConstraintCollector<A, ResultContainer_, Result_> collector);
 
+    /*
     /**
      * Convert the {@link UniConstraintStream} to a {@link BiConstraintStream}, consisting of tuples which have:
      *
@@ -244,10 +244,12 @@ public interface UniConstraintStream<A> extends ConstraintStream {
      * @param <GroupKeyB_> the type of the second fact in the destination {@link BiConstraintStream}'s tuple
      * @return never null
      */
-    <GroupKeyA_, GroupKeyB_> BiConstraintStream<GroupKeyA_, GroupKeyB_> groupBy(
-            Function<A, GroupKeyA_> groupKeyAMapping,
-            Function<A, GroupKeyB_> groupKeyBMapping);
+    // TODO implement this
+    //<GroupKeyA_, GroupKeyB_> BiConstraintStream<GroupKeyA_, GroupKeyB_> groupBy(
+    //        Function<A, GroupKeyA_> groupKeyAMapping,
+    //        Function<A, GroupKeyB_> groupKeyBMapping);
 
+    /*
     /**
      * Combines the semantics of {@link #groupBy(Function, Function)} and {@link #groupBy(UniConstraintCollector)}.
      * That is, the first and second facts in the tuple follow the {@link #groupBy(Function, Function)} semantics, and
@@ -262,10 +264,11 @@ public interface UniConstraintStream<A> extends ConstraintStream {
      * @param <Result_> the type of the third fact in the destination {@link TriConstraintStream}'s tuple
      * @return never null
      */
-    <GroupKeyA_, GroupKeyB_, ResultContainer_, Result_> TriConstraintStream<GroupKeyA_, GroupKeyB_, Result_> groupBy(
-            Function<A, GroupKeyA_> groupKeyAMapping,
-            Function<A, GroupKeyB_> groupKeyBMapping,
-            UniConstraintCollector<A, ResultContainer_, Result_> collector);
+    // TODO implement this
+    //<GroupKeyA_, GroupKeyB_, ResultContainer_, Result_> TriConstraintStream<GroupKeyA_, GroupKeyB_, Result_> groupBy(
+    //        Function<A, GroupKeyA_> groupKeyAMapping,
+    //        Function<A, GroupKeyB_> groupKeyBMapping,
+    //        UniConstraintCollector<A, ResultContainer_, Result_> collector);
 
     // ************************************************************************
     // Penalize/reward

--- a/optaplanner-core/src/main/java/org/optaplanner/core/config/score/director/ScoreDirectorFactoryConfig.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/config/score/director/ScoreDirectorFactoryConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -558,7 +558,8 @@ public class ScoreDirectorFactoryConfig extends AbstractConfig<ScoreDirectorFact
                     "constraintProviderClass", this.constraintProviderClass);
             ConfigUtils.applyCustomProperties(constraintProvider, "constraintProviderClass",
                     constraintProviderCustomProperties, "constraintProviderCustomProperties");
-            ConstraintStreamImplType constraintStreamImplType_ = defaultIfNull(constraintStreamImplType, ConstraintStreamImplType.BAVET);
+            ConstraintStreamImplType constraintStreamImplType_ = defaultIfNull(constraintStreamImplType,
+                    ConstraintStreamImplType.DROOLS);
             return new ConstraintStreamScoreDirectorFactory<>(solutionDescriptor, constraintProvider, constraintStreamImplType_);
         } else {
             if (constraintProviderCustomProperties != null) {

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/bavet/bi/BavetAbstractBiConstraintStream.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/bavet/bi/BavetAbstractBiConstraintStream.java
@@ -27,8 +27,6 @@ import java.util.function.ToLongBiFunction;
 import org.optaplanner.core.api.score.Score;
 import org.optaplanner.core.api.score.stream.Constraint;
 import org.optaplanner.core.api.score.stream.ConstraintFactory;
-import org.optaplanner.core.api.score.stream.bi.BiConstraintCollector;
-import org.optaplanner.core.api.score.stream.bi.BiConstraintStream;
 import org.optaplanner.core.api.score.stream.tri.TriConstraintStream;
 import org.optaplanner.core.api.score.stream.tri.TriJoiner;
 import org.optaplanner.core.api.score.stream.uni.UniConstraintStream;
@@ -102,35 +100,6 @@ public abstract class BavetAbstractBiConstraintStream<Solution_, A, B> extends B
         leftBridge.setJoinStream(joinStream);
         rightBridge.setJoinStream(joinStream);
         return joinStream;
-    }
-
-    // ************************************************************************
-    // Group by
-    // ************************************************************************
-
-    @Override
-    public <GroupKey_> UniConstraintStream<GroupKey_> groupBy(BiFunction<A, B, GroupKey_> groupKeyMapping) {
-        throw new UnsupportedOperationException(); // TODO
-    }
-
-    @Override
-    public <GroupKey_, ResultContainer_, Result_> BiConstraintStream<GroupKey_, Result_>
-    groupBy(BiFunction<A, B, GroupKey_> groupKeyMapping,
-            BiConstraintCollector<A, B, ResultContainer_, Result_> collector) {
-        throw new UnsupportedOperationException(); // TODO
-    }
-
-    @Override
-    public <GroupKeyA_, GroupKeyB_> BiConstraintStream<GroupKeyA_, GroupKeyB_> groupBy(BiFunction<A, B, GroupKeyA_> groupKeyAMapping, BiFunction<A, B, GroupKeyB_> groupKeyBMapping) {
-        throw new UnsupportedOperationException(); // TODO
-    }
-
-    @Override
-    public <GroupKeyA_, GroupKeyB_, ResultContainer_, Result_>
-    TriConstraintStream<GroupKeyA_, GroupKeyB_, Result_> groupBy(BiFunction<A, B, GroupKeyA_> groupKeyAMapping,
-            BiFunction<A, B, GroupKeyB_> groupKeyBMapping,
-            BiConstraintCollector<A, B, ResultContainer_, Result_> collector) {
-        throw new UnsupportedOperationException(); // TODO
     }
 
     // ************************************************************************

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/bavet/uni/BavetAbstractUniConstraintStream.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/bavet/uni/BavetAbstractUniConstraintStream.java
@@ -29,7 +29,6 @@ import org.optaplanner.core.api.score.stream.Constraint;
 import org.optaplanner.core.api.score.stream.ConstraintFactory;
 import org.optaplanner.core.api.score.stream.bi.BiConstraintStream;
 import org.optaplanner.core.api.score.stream.bi.BiJoiner;
-import org.optaplanner.core.api.score.stream.tri.TriConstraintStream;
 import org.optaplanner.core.api.score.stream.uni.UniConstraintCollector;
 import org.optaplanner.core.api.score.stream.uni.UniConstraintStream;
 import org.optaplanner.core.impl.score.stream.bavet.BavetConstraint;
@@ -130,20 +129,6 @@ public abstract class BavetAbstractUniConstraintStream<Solution_, A> extends Bav
                 = new BavetGroupBiConstraintStream<>(constraintFactory, bridge, collector.finisher());
         bridge.setGroupStream(groupStream);
         return groupStream;
-    }
-
-    @Override
-    public <GroupKeyA_, GroupKeyB_> BiConstraintStream<GroupKeyA_, GroupKeyB_> groupBy(
-            Function<A, GroupKeyA_> groupKeyAMapping, Function<A, GroupKeyB_> groupKeyBMapping) {
-        throw new UnsupportedOperationException(); // TODO
-    }
-
-    @Override
-    public <GroupKeyA_, GroupKeyB_, ResultContainer_, Result_>
-    TriConstraintStream<GroupKeyA_, GroupKeyB_, Result_> groupBy(Function<A, GroupKeyA_> groupKeyAMapping,
-            Function<A, GroupKeyB_> groupKeyBMapping,
-            UniConstraintCollector<A, ResultContainer_, Result_> collector) {
-        throw new UnsupportedOperationException(); // TODO
     }
 
     // ************************************************************************

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/bi/DroolsAbstractBiConstraintStream.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/bi/DroolsAbstractBiConstraintStream.java
@@ -26,7 +26,6 @@ import java.util.stream.Stream;
 
 import org.optaplanner.core.api.score.Score;
 import org.optaplanner.core.api.score.stream.Constraint;
-import org.optaplanner.core.api.score.stream.bi.BiConstraintCollector;
 import org.optaplanner.core.api.score.stream.bi.BiConstraintStream;
 import org.optaplanner.core.api.score.stream.tri.TriConstraintStream;
 import org.optaplanner.core.api.score.stream.tri.TriJoiner;
@@ -62,32 +61,6 @@ public abstract class DroolsAbstractBiConstraintStream<Solution_, A, B>
                         (DroolsAbstractUniConstraintStream<Solution_, C>) otherStream, joiner);
         addChildStream(stream);
         return stream;
-    }
-
-    @Override
-    public <GroupKey_> UniConstraintStream<GroupKey_> groupBy(BiFunction<A, B, GroupKey_> groupKeyMapping) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public <GroupKey_, ResultContainer_, Result_> BiConstraintStream<GroupKey_, Result_> groupBy(
-            BiFunction<A, B, GroupKey_> groupKeyMapping,
-            BiConstraintCollector<A, B, ResultContainer_, Result_> collector) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public <GroupKeyA_, GroupKeyB_> BiConstraintStream<GroupKeyA_, GroupKeyB_> groupBy
-            (BiFunction<A, B, GroupKeyA_> groupKeyAMapping, BiFunction<A, B, GroupKeyB_> groupKeyBMapping) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public <GroupKeyA_, GroupKeyB_, ResultContainer_, Result_>
-    TriConstraintStream<GroupKeyA_, GroupKeyB_, Result_> groupBy(BiFunction<A, B, GroupKeyA_> groupKeyAMapping,
-            BiFunction<A, B, GroupKeyB_> groupKeyBMapping,
-            BiConstraintCollector<A, B, ResultContainer_, Result_> collector) {
-        throw new UnsupportedOperationException();
     }
 
     @Override

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/common/DroolsLogicalTuple.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/common/DroolsLogicalTuple.java
@@ -73,15 +73,10 @@ public final class DroolsLogicalTuple {
      * Return a fact on n-th position in the tuple.
      * @param index required position in the tuple. Must be between 0 (incl.) and {@link #getCardinality()} (excl.)
      * @param <T> type that we're expecting to see. Method may throw an exception if the cast can not be made.
-     * @throws IllegalArgumentException When index out of range.
+     * @throws ArrayIndexOutOfBoundsException when index not between 0 (incl.) and {@link #getCardinality()} (excl.)
      * @return never null.
      */
     public <T> T getItem(final int index) {
-        int cardinality = getCardinality();
-        if (index < 0 || index >= cardinality) {
-            throw new IllegalArgumentException("Logical tuple of cardinality (" + cardinality + ") has no element no. ("
-                    + index + ").");
-        }
         return (T) items[index];
     }
 

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/uni/DroolsAbstractUniConstraintStream.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/uni/DroolsAbstractUniConstraintStream.java
@@ -26,7 +26,6 @@ import org.optaplanner.core.api.score.Score;
 import org.optaplanner.core.api.score.stream.Constraint;
 import org.optaplanner.core.api.score.stream.bi.BiConstraintStream;
 import org.optaplanner.core.api.score.stream.bi.BiJoiner;
-import org.optaplanner.core.api.score.stream.tri.TriConstraintStream;
 import org.optaplanner.core.api.score.stream.uni.UniConstraintCollector;
 import org.optaplanner.core.api.score.stream.uni.UniConstraintStream;
 import org.optaplanner.core.impl.score.stream.drools.DroolsConstraintFactory;
@@ -97,20 +96,6 @@ public abstract class DroolsAbstractUniConstraintStream<Solution_, A> extends Dr
                 new DroolsGroupingBiConstraintStream<>(constraintFactory, this, groupKeyMapping, collector);
         addChildStream(stream);
         return stream;
-    }
-
-    @Override
-    public <GroupKeyA_, GroupKeyB_> BiConstraintStream<GroupKeyA_, GroupKeyB_> groupBy(
-            Function<A, GroupKeyA_> groupKeyAMapping, Function<A, GroupKeyB_> groupKeyBMapping) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public <GroupKeyA_, GroupKeyB_, ResultContainer_, Result_>
-    TriConstraintStream<GroupKeyA_, GroupKeyB_, Result_> groupBy(Function<A, GroupKeyA_> groupKeyAMapping,
-            Function<A, GroupKeyB_> groupKeyBMapping,
-            UniConstraintCollector<A, ResultContainer_, Result_> collector) {
-        throw new UnsupportedOperationException();
     }
 
     // ************************************************************************

--- a/optaplanner-core/src/test/java/org/optaplanner/core/api/score/stream/uni/UniConstraintStreamTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/api/score/stream/uni/UniConstraintStreamTest.java
@@ -647,10 +647,12 @@ public class UniConstraintStreamTest extends AbstractConstraintStreamTest {
         TestdataLavishEntity entity3 = new TestdataLavishEntity("MyEntity 3", entityGroup1, value1);
         solution.getEntityList().add(entity3);
 
+
         InnerScoreDirector<TestdataLavishSolution> scoreDirector = buildScoreDirector((factory) -> {
-            return factory.from(TestdataLavishEntity.class)
-                    .groupBy(TestdataLavishEntity::getEntityGroup, TestdataLavishEntity::getValue, count())
-                    .penalize(TEST_CONSTRAINT_NAME, SimpleScore.ONE, (entityGroup, value, count) -> count);
+            throw new UnsupportedOperationException("Not yet implemented.");
+            //return factory.from(TestdataLavishEntity.class)
+            //        .groupBy(TestdataLavishEntity::getEntityGroup, TestdataLavishEntity::getValue, count())
+            //        .penalize(TEST_CONSTRAINT_NAME, SimpleScore.ONE, (entityGroup, value, count) -> count);
         });
 
         // From scratch

--- a/optaplanner-core/src/test/java/org/optaplanner/core/api/score/stream/uni/UniConstraintStreamTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/api/score/stream/uni/UniConstraintStreamTest.java
@@ -155,7 +155,6 @@ public class UniConstraintStreamTest extends AbstractConstraintStreamTest {
         TestdataLavishEntityGroup entityGroup = new TestdataLavishEntityGroup("MyEntityGroup");
         solution.getEntityGroupList().add(entityGroup);
 
-
         InnerScoreDirector<TestdataLavishSolution> scoreDirector = buildScoreDirector((factory) -> {
             return factory.from(TestdataLavishValueGroup.class)
                     .join(TestdataLavishEntityGroup.class)

--- a/optaplanner-docs/src/main/asciidoc/ConstraintStreams/ConstraintStreams-chapter.adoc
+++ b/optaplanner-docs/src/main/asciidoc/ConstraintStreams/ConstraintStreams-chapter.adoc
@@ -8,16 +8,30 @@
 :experimental:
 
 
-Constraint streams are an Functional Programming form of incremental score calculation in plain Java 8+
-that is fast, scalable and debuggable.
+Constraint streams are a Functional Programming form of incremental score calculation in plain Java that is easy to
+read, write and debug.
 The API should feel familiar if you've worked with Java 8 Streams or SQL.
 
 [WARNING]
 ====
-The ConstraintStreams/ConstraintProvider API is TECH PREVIEW.
+The ConstraintStreams/ConstraintProvider API is an ongoing project.
 It works but it has many API gaps.
 Therefore, it is not rich enough yet to handle complex constraints.
 ====
+
+To use constraint streams in your project, implement the `ConstraintProvider` interface and use the following in your
+solver config:
+
+[source,xml,options="nowrap"]
+----
+    <solver>
+      <scoreDirectorFactory>
+        <constraintProviderClass>com.example.MyConstraintProvider</constraintProviderClass>
+      </scoreDirectorFactory>
+      ...
+    </solver>
+----
+
 
 [[constraintStreamsIntroduction]]
 == Introduction
@@ -57,6 +71,7 @@ and supports <<explainingTheScore,justifications>>:
                         Talk::getDurationInMinutes);
     }
 ----
+
 
 [[constraintStreamsGroupingAndCollectors]]
 == Grouping and Collectors
@@ -174,3 +189,27 @@ The following example finds a computer which runs the most power-demanding proce
     }
 ----
 
+
+[[constraintStreamsImplementations]]
+== Variant implementation types
+
+Constraint streams come in two flavours, a default implementation using Drools as a backend and a pure Java-based
+implementation called "Bavet".
+Drools-based implementation is more feature-complete and it is our primary focus. It will be seeing further improvements
+in future releases.
+
+Bavet is an experimental implementation focusing on raw speed, which often significantly outperforms the Drools
+implementation, or even Drools itself.
+However, it lacks features and will not be extended in the near future.
+To try it out, implement the `ConstraintProvider` interface and use the following in your solver config:
+
+[source,xml,options="nowrap"]
+----
+    <solver>
+      <scoreDirectorFactory>
+        <constraintStreamImplType>BAVET</constraintStreamImplType>
+        <constraintProviderClass>com.example.MyConstraintProvider</constraintProviderClass>
+      </scoreDirectorFactory>
+      ...
+    </solver>
+----

--- a/optaplanner-docs/src/main/asciidoc/ConstraintStreams/ConstraintStreams-chapter.adoc
+++ b/optaplanner-docs/src/main/asciidoc/ConstraintStreams/ConstraintStreams-chapter.adoc
@@ -193,14 +193,12 @@ The following example finds a computer which runs the most power-demanding proce
 [[constraintStreamsImplementations]]
 == Variant implementation types
 
-Constraint streams come in two flavours, a default implementation using Drools as a backend and a pure Java-based
-implementation called "Bavet".
-Drools-based implementation is more feature-complete and it is our primary focus. It will be seeing further improvements
-in future releases.
+Constraint streams come in two flavours, a default implementation using Drools under the hood and a pure Java-based
+implementation called _Bavet_. Drools-based implementation is more feature-complete.
 
 Bavet is an experimental implementation focusing on raw speed, which often significantly outperforms the Drools
 implementation, or even Drools itself.
-However, it lacks features and will not be extended in the near future.
+However, it lacks features.
 To try it out, implement the `ConstraintProvider` interface and use the following in your solver config:
 
 [source,xml,options="nowrap"]

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/cloudbalancing/optional/score/CloudBalancingConstraintProvider.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/cloudbalancing/optional/score/CloudBalancingConstraintProvider.java
@@ -26,10 +26,6 @@ import static org.optaplanner.core.api.score.stream.ConstraintCollectors.*;
 
 public class CloudBalancingConstraintProvider implements ConstraintProvider {
 
-    // WARNING: The ConstraintStreams/ConstraintProvider API is TECH PREVIEW.
-    // It works but it has many API gaps.
-    // Therefore, it is not rich enough yet to handle complex constraints.
-
     @Override
     public Constraint[] defineConstraints(ConstraintFactory constraintFactory) {
         return new Constraint[]{

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/conferencescheduling/optional/score/ConferenceSchedulingConstraintProvider.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/conferencescheduling/optional/score/ConferenceSchedulingConstraintProvider.java
@@ -52,10 +52,6 @@ import static org.optaplanner.examples.conferencescheduling.domain.ConferenceCon
 
 public class ConferenceSchedulingConstraintProvider implements ConstraintProvider {
 
-    // WARNING: The ConstraintStreams/ConstraintProvider API is TECH PREVIEW.
-    // It works but it has many API gaps.
-    // Therefore, it is not rich enough yet to handle complex constraints.
-
     @Override
     public Constraint[] defineConstraints(ConstraintFactory factory) {
         return new Constraint[]{

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/conferencescheduling/optional/score/ConferenceSchedulingConstraintProvider.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/conferencescheduling/optional/score/ConferenceSchedulingConstraintProvider.java
@@ -16,16 +16,39 @@
 
 package org.optaplanner.examples.conferencescheduling.optional.score;
 
-import java.util.function.Function;
-
 import org.optaplanner.core.api.score.stream.Constraint;
 import org.optaplanner.core.api.score.stream.ConstraintFactory;
 import org.optaplanner.core.api.score.stream.ConstraintProvider;
 import org.optaplanner.examples.conferencescheduling.domain.Talk;
 
-import static org.optaplanner.core.api.score.stream.ConstraintCollectors.*;
-import static org.optaplanner.core.api.score.stream.Joiners.*;
-import static org.optaplanner.examples.conferencescheduling.domain.ConferenceConstraintConfiguration.*;
+import static org.optaplanner.core.api.score.stream.Joiners.equal;
+import static org.optaplanner.core.api.score.stream.Joiners.greaterThan;
+import static org.optaplanner.core.api.score.stream.Joiners.lessThan;
+import static org.optaplanner.examples.conferencescheduling.domain.ConferenceConstraintConfiguration.AUDIENCE_LEVEL_DIVERSITY;
+import static org.optaplanner.examples.conferencescheduling.domain.ConferenceConstraintConfiguration.LANGUAGE_DIVERSITY;
+import static org.optaplanner.examples.conferencescheduling.domain.ConferenceConstraintConfiguration.POPULAR_TALKS;
+import static org.optaplanner.examples.conferencescheduling.domain.ConferenceConstraintConfiguration.PUBLISHED_ROOM;
+import static org.optaplanner.examples.conferencescheduling.domain.ConferenceConstraintConfiguration.PUBLISHED_TIMESLOT;
+import static org.optaplanner.examples.conferencescheduling.domain.ConferenceConstraintConfiguration.ROOM_CONFLICT;
+import static org.optaplanner.examples.conferencescheduling.domain.ConferenceConstraintConfiguration.ROOM_UNAVAILABLE_TIMESLOT;
+import static org.optaplanner.examples.conferencescheduling.domain.ConferenceConstraintConfiguration.SAME_DAY_TALKS;
+import static org.optaplanner.examples.conferencescheduling.domain.ConferenceConstraintConfiguration.SPEAKER_PREFERRED_ROOM_TAGS;
+import static org.optaplanner.examples.conferencescheduling.domain.ConferenceConstraintConfiguration.SPEAKER_PREFERRED_TIMESLOT_TAGS;
+import static org.optaplanner.examples.conferencescheduling.domain.ConferenceConstraintConfiguration.SPEAKER_PROHIBITED_ROOM_TAGS;
+import static org.optaplanner.examples.conferencescheduling.domain.ConferenceConstraintConfiguration.SPEAKER_PROHIBITED_TIMESLOT_TAGS;
+import static org.optaplanner.examples.conferencescheduling.domain.ConferenceConstraintConfiguration.SPEAKER_REQUIRED_ROOM_TAGS;
+import static org.optaplanner.examples.conferencescheduling.domain.ConferenceConstraintConfiguration.SPEAKER_REQUIRED_TIMESLOT_TAGS;
+import static org.optaplanner.examples.conferencescheduling.domain.ConferenceConstraintConfiguration.SPEAKER_UNAVAILABLE_TIMESLOT;
+import static org.optaplanner.examples.conferencescheduling.domain.ConferenceConstraintConfiguration.SPEAKER_UNDESIRED_ROOM_TAGS;
+import static org.optaplanner.examples.conferencescheduling.domain.ConferenceConstraintConfiguration.SPEAKER_UNDESIRED_TIMESLOT_TAGS;
+import static org.optaplanner.examples.conferencescheduling.domain.ConferenceConstraintConfiguration.TALK_PREFERRED_ROOM_TAGS;
+import static org.optaplanner.examples.conferencescheduling.domain.ConferenceConstraintConfiguration.TALK_PREFERRED_TIMESLOT_TAGS;
+import static org.optaplanner.examples.conferencescheduling.domain.ConferenceConstraintConfiguration.TALK_PROHIBITED_ROOM_TAGS;
+import static org.optaplanner.examples.conferencescheduling.domain.ConferenceConstraintConfiguration.TALK_PROHIBITED_TIMESLOT_TAGS;
+import static org.optaplanner.examples.conferencescheduling.domain.ConferenceConstraintConfiguration.TALK_REQUIRED_ROOM_TAGS;
+import static org.optaplanner.examples.conferencescheduling.domain.ConferenceConstraintConfiguration.TALK_REQUIRED_TIMESLOT_TAGS;
+import static org.optaplanner.examples.conferencescheduling.domain.ConferenceConstraintConfiguration.TALK_UNDESIRED_ROOM_TAGS;
+import static org.optaplanner.examples.conferencescheduling.domain.ConferenceConstraintConfiguration.TALK_UNDESIRED_TIMESLOT_TAGS;
 
 public class ConferenceSchedulingConstraintProvider implements ConstraintProvider {
 
@@ -112,35 +135,37 @@ public class ConferenceSchedulingConstraintProvider implements ConstraintProvide
     }
 
     private Constraint speakerConflict(ConstraintFactory factory) {
-        return factory.fromUniquePair(Talk.class, intersecting(Talk::getSpeakerList))
-                // TODO Support joiner for time overlap
-                .filter(Talk::overlapsTime)
-                .penalizeConfigurable(SPEAKER_CONFLICT,
-                        Talk::overlappingDurationInMinutes);
+        throw new UnsupportedOperationException("Not yet implemented due to missing support for advanced joiners.");
+//        return factory.fromUniquePair(Talk.class, intersecting(Talk::getSpeakerList))
+//                // TODO Support joiner for time overlap
+//                .filter(Talk::overlapsTime)
+//                .penalizeConfigurable(SPEAKER_CONFLICT,
+//                        Talk::overlappingDurationInMinutes);
     }
 
     private Constraint talkPrerequisiteTalks(ConstraintFactory factory) {
-        return factory.from(Talk.class)
-                .join(Talk.class,
-                        containing(Talk::getPrerequisiteTalkSet, Function.identity()),
-                        lessThan(talk1 -> talk1.getTimeslot().getStartDateTime(),
-                                talk2 -> talk2.getTimeslot().getEndDateTime()))
-                .penalizeConfigurable(TALK_PREREQUISITE_TALKS,
-                        Talk::combinedDurationInMinutes);
+        throw new UnsupportedOperationException("Not yet implemented due to missing support for advanced joiners.");
+//        return factory.from(Talk.class)
+//                .join(Talk.class,
+//                        containing(Talk::getPrerequisiteTalkSet, Function.identity()),
+//                        lessThan(talk1 -> talk1.getTimeslot().getStartDateTime(),
+//                                talk2 -> talk2.getTimeslot().getEndDateTime()))
+//                .penalizeConfigurable(TALK_PREREQUISITE_TALKS,
+//                        Talk::combinedDurationInMinutes);
     }
 
     private Constraint talkMutuallyExclusiveTalksTags(ConstraintFactory factory) {
-        return factory.fromUniquePair(Talk.class, intersecting(Talk::getMutuallyExclusiveTalksTagSet))
-                // TODO Support joiner for time overlap
-                .filter(Talk::overlapsTime)
-                .penalizeConfigurable(TALK_MUTUALLY_EXCLUSIVE_TALKS_TAGS,
-                        (talk1, talk2) -> talk1.overlappingMutuallyExclusiveTalksTagCount(talk2)
-                        * talk1.overlappingDurationInMinutes(talk2));
+        throw new UnsupportedOperationException("Not yet implemented due to missing support for advanced joiners.");
+//        return factory.fromUniquePair(Talk.class, intersecting(Talk::getMutuallyExclusiveTalksTagSet))
+//                // TODO Support joiner for time overlap
+//                .filter(Talk::overlapsTime)
+//                .penalizeConfigurable(TALK_MUTUALLY_EXCLUSIVE_TALKS_TAGS,
+//                        (talk1, talk2) -> talk1.overlappingMutuallyExclusiveTalksTagCount(talk2)
+//                        * talk1.overlappingDurationInMinutes(talk2));
     }
 
     private Constraint consecutiveTalksPause(ConstraintFactory factory) {
-        throw new UnsupportedOperationException();
-//
+        throw new UnsupportedOperationException("Not yet implemented due to missing support for advanced joiners.");
 //        return factory.fromUniquePair((Talk.class, intersecting(Talk::getSpeakerList))
 //                .filter((talk1, talk2) -> !talk1.getTimeslot().pauseExists(talk2.getTimeslot(), $minimumPause))
 //                .penalizeConfigurable(CONSECUTIVE_TALKS_PAUSE,
@@ -148,15 +173,16 @@ public class ConferenceSchedulingConstraintProvider implements ConstraintProvide
     }
 
     private Constraint crowdControl(ConstraintFactory factory) {
-        return factory.from(Talk.class)
-                .filter(talk -> talk.getCrowdControlRisk() > 0)
-                // No fromUniquePair() because we want both [A, B] and [B, A].
-                .join(Talk.class, equal(Talk::getTimeslot))
-                .filter((talk1, talk2) -> talk1 != talk2)
-                .groupBy((talk1, talk2) -> talk1, countBi())
-                .filter((talk, count) -> count != 1)
-                .penalizeConfigurable(CROWD_CONTROL,
-                        (talk, count) -> talk.getDurationInMinutes());
+        throw new UnsupportedOperationException("Not yet implemented due to missing support for bi-joins.");
+//        return factory.from(Talk.class)
+//                .filter(talk -> talk.getCrowdControlRisk() > 0)
+//                // No fromUniquePair() because we want both [A, B] and [B, A].
+//                .join(Talk.class, equal(Talk::getTimeslot))
+//                .filter((talk1, talk2) -> talk1 != talk2)
+//                .groupBy((talk1, talk2) -> talk1, countBi())
+//                .filter((talk, count) -> count != 1)
+//                .penalizeConfigurable(CROWD_CONTROL,
+//                        (talk, count) -> talk.getDurationInMinutes());
     }
 
     private Constraint speakerRequiredTimeslotTags(ConstraintFactory factory) {
@@ -237,55 +263,60 @@ public class ConferenceSchedulingConstraintProvider implements ConstraintProvide
     }
 
     private Constraint themeTrackConflict(ConstraintFactory factory) {
-        return factory.fromUniquePair(Talk.class, intersecting(Talk::getThemeTrackTagSet))
-                // TODO Support joiner for time overlap
-                .filter(Talk::overlapsTime)
-                .penalizeConfigurable(THEME_TRACK_CONFLICT,
-                        (talk1, talk2) -> talk1.overlappingThemeTrackCount(talk2)
-                        * talk1.overlappingDurationInMinutes(talk2));
+        throw new UnsupportedOperationException("Not yet implemented due to missing support for advanced joiners.");
+//        return factory.fromUniquePair(Talk.class, intersecting(Talk::getThemeTrackTagSet))
+//                // TODO Support joiner for time overlap
+//                .filter(Talk::overlapsTime)
+//                .penalizeConfigurable(THEME_TRACK_CONFLICT,
+//                        (talk1, talk2) -> talk1.overlappingThemeTrackCount(talk2)
+//                        * talk1.overlappingDurationInMinutes(talk2));
     }
 
     private Constraint themeTrackRoomStability(ConstraintFactory factory) {
-        return factory.fromUniquePair(Talk.class,
-                equal(talk -> talk.getTimeslot().getStartDateTime().toLocalDate()),
-                intersecting(Talk::getThemeTrackTagSet))
-                // TODO Support joiner for time overlap
-                .filter(Talk::overlapsTime)
-                .filter((talk1, talk2) -> talk1.getRoom() != talk2.getRoom())
-                .penalizeConfigurable(THEME_TRACK_ROOM_STABILITY,
-                        (talk1, talk2) -> talk1.overlappingThemeTrackCount(talk2)
-                        * talk1.combinedDurationInMinutes(talk2));
+        throw new UnsupportedOperationException("Not yet implemented due to missing support for advanced joiners.");
+//        return factory.fromUniquePair(Talk.class,
+//                equal(talk -> talk.getTimeslot().getStartDateTime().toLocalDate()),
+//                intersecting(Talk::getThemeTrackTagSet))
+//                // TODO Support joiner for time overlap
+//                .filter(Talk::overlapsTime)
+//                .filter((talk1, talk2) -> talk1.getRoom() != talk2.getRoom())
+//                .penalizeConfigurable(THEME_TRACK_ROOM_STABILITY,
+//                        (talk1, talk2) -> talk1.overlappingThemeTrackCount(talk2)
+//                        * talk1.combinedDurationInMinutes(talk2));
     }
 
     private Constraint sectorConflict(ConstraintFactory factory) {
-        return factory.fromUniquePair(Talk.class, intersecting(Talk::getSectorTagSet))
-                // TODO Support joiner for time overlap
-                .filter(Talk::overlapsTime)
-                .penalizeConfigurable(SECTOR_CONFLICT,
-                        (talk1, talk2) -> talk1.overlappingSectorCount(talk2)
-                        * talk1.overlappingDurationInMinutes(talk2));
+        throw new UnsupportedOperationException("Not yet implemented due to missing support for advanced joiners.");
+//        return factory.fromUniquePair(Talk.class, intersecting(Talk::getSectorTagSet))
+//                // TODO Support joiner for time overlap
+//                .filter(Talk::overlapsTime)
+//                .penalizeConfigurable(SECTOR_CONFLICT,
+//                        (talk1, talk2) -> talk1.overlappingSectorCount(talk2)
+//                        * talk1.overlappingDurationInMinutes(talk2));
     }
 
     private Constraint audienceTypeDiversity(ConstraintFactory factory) {
-        return factory.fromUniquePair(Talk.class,
-                // Timeslot.overlaps() is deliberately not used
-                equal(Talk::getTimeslot),
-                intersecting(Talk::getAudienceTypeSet))
-                .rewardConfigurable(AUDIENCE_TYPE_DIVERSITY,
-                        (talk1, talk2) -> talk1.overlappingAudienceTypeCount(talk2)
-                        * talk1.getTimeslot().getDurationInMinutes());
+        throw new UnsupportedOperationException("Not yet implemented due to missing support for advanced joiners.");
+//        return factory.fromUniquePair(Talk.class,
+//                // Timeslot.overlaps() is deliberately not used
+//                equal(Talk::getTimeslot),
+//                intersecting(Talk::getAudienceTypeSet))
+//                .rewardConfigurable(AUDIENCE_TYPE_DIVERSITY,
+//                        (talk1, talk2) -> talk1.overlappingAudienceTypeCount(talk2)
+//                        * talk1.getTimeslot().getDurationInMinutes());
     }
 
     private Constraint audienceTypeThemeTrackConflict(ConstraintFactory factory) {
-        return factory.fromUniquePair(Talk.class,
-                intersecting(Talk::getThemeTrackTagSet),
-                intersecting(Talk::getAudienceTypeSet))
-                // TODO Support joiner for time overlap
-                .filter(Talk::overlapsTime)
-                .penalizeConfigurable(AUDIENCE_TYPE_THEME_TRACK_CONFLICT,
-                        (talk1, talk2) -> talk1.overlappingThemeTrackCount(talk2)
-                        * talk1.overlappingAudienceTypeCount(talk2)
-                        * talk1.overlappingDurationInMinutes(talk2));
+        throw new UnsupportedOperationException("Not yet implemented due to missing support for advanced joiners.");
+//        return factory.fromUniquePair(Talk.class,
+//                intersecting(Talk::getThemeTrackTagSet),
+//                intersecting(Talk::getAudienceTypeSet))
+//                // TODO Support joiner for time overlap
+//                .filter(Talk::overlapsTime)
+//                .penalizeConfigurable(AUDIENCE_TYPE_THEME_TRACK_CONFLICT,
+//                        (talk1, talk2) -> talk1.overlappingThemeTrackCount(talk2)
+//                        * talk1.overlappingAudienceTypeCount(talk2)
+//                        * talk1.overlappingDurationInMinutes(talk2));
     }
 
     private Constraint audienceLevelDiversity(ConstraintFactory factory) {
@@ -298,25 +329,27 @@ public class ConferenceSchedulingConstraintProvider implements ConstraintProvide
     }
 
     private Constraint contentAudienceLevelFlowViolation(ConstraintFactory factory) {
-        return factory.from(Talk.class)
-                // fromUniquePair() not wanted due to lessThan(Talk::getAudienceLevel)
-                .join(Talk.class,
-                        intersecting(Talk::getContentTagSet),
-                        lessThan(Talk::getAudienceLevel),
-                        greaterThan(talk1 -> talk1.getTimeslot().getEndDateTime(),
-                                talk2 -> talk2.getTimeslot().getStartDateTime()))
-                .penalizeConfigurable(CONTENT_AUDIENCE_LEVEL_FLOW_VIOLATION,
-                        (talk1, talk2) -> talk1.overlappingContentCount(talk2)
-                        * talk1.combinedDurationInMinutes(talk2));
+        throw new UnsupportedOperationException();
+//        return factory.from(Talk.class)
+//                // fromUniquePair() not wanted due to lessThan(Talk::getAudienceLevel)
+//                .join(Talk.class,
+//                        intersecting(Talk::getContentTagSet),
+//                        lessThan(Talk::getAudienceLevel),
+//                        greaterThan(talk1 -> talk1.getTimeslot().getEndDateTime(),
+//                                talk2 -> talk2.getTimeslot().getStartDateTime()))
+//                .penalizeConfigurable(CONTENT_AUDIENCE_LEVEL_FLOW_VIOLATION,
+//                        (talk1, talk2) -> talk1.overlappingContentCount(talk2)
+//                        * talk1.combinedDurationInMinutes(talk2));
     }
 
     private Constraint contentConflict(ConstraintFactory factory) {
-        return factory.fromUniquePair(Talk.class, intersecting(Talk::getContentTagSet))
-                // TODO Support joiner for time overlap
-                .filter(Talk::overlapsTime)
-                .penalizeConfigurable(CONTENT_CONFLICT,
-                        (talk1, talk2) -> talk1.overlappingContentCount(talk2)
-                        * talk1.overlappingDurationInMinutes(talk2));
+        throw new UnsupportedOperationException("Not yet implemented due to missing support for advanced joiners.");
+//        return factory.fromUniquePair(Talk.class, intersecting(Talk::getContentTagSet))
+//                // TODO Support joiner for time overlap
+//                .filter(Talk::overlapsTime)
+//                .penalizeConfigurable(CONTENT_CONFLICT,
+//                        (talk1, talk2) -> talk1.overlappingContentCount(talk2)
+//                        * talk1.overlappingDurationInMinutes(talk2));
     }
 
     private Constraint languageDiversity(ConstraintFactory factory) {

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/curriculumcourse/optional/score/CourseScheduleConstraintProvider.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/curriculumcourse/optional/score/CourseScheduleConstraintProvider.java
@@ -103,12 +103,13 @@ public class CourseScheduleConstraintProvider implements ConstraintProvider {
     }
 
     private Constraint roomOccupancy(ConstraintFactory factory) {
-        return factory.from(Lecture.class)
-                .groupBy(Lecture::getPeriod, Lecture::getRoom, count())
-                .filter((period, room, count) -> count > 1)
-                .penalize("roomOccupancy",
-                        HardSoftScore.ofHard(1),
-                        (period, room, count) -> count - 1);
+        throw new UnsupportedOperationException("Not yet implemented due to missing support for tri-grouping.");
+//        return factory.from(Lecture.class)
+//                .groupBy(Lecture::getPeriod, Lecture::getRoom, count())
+//                .filter((period, room, count) -> count > 1)
+//                .penalize("roomOccupancy",
+//                        HardSoftScore.ofHard(1),
+//                        (period, room, count) -> count - 1);
     }
 
     private Constraint unavailablePeriodPenalty(ConstraintFactory factory) {
@@ -142,6 +143,7 @@ public class CourseScheduleConstraintProvider implements ConstraintProvider {
     }
 
     private Constraint curriculumCompactness(ConstraintFactory factory) {
+        throw new UnsupportedOperationException("Not yet implemented due to missing support for bi-grouping.");
 //        return factory.from(Curriculum.class)
 //                .join(Lecture.class)
 //                .filter((curriculum, lecture) -> lecture.getCurriculumList().contains(curriculum));
@@ -149,7 +151,6 @@ public class CourseScheduleConstraintProvider implements ConstraintProvider {
 //                .flatten()
 //                .penalize("curriculumCompactness",
 //                        HardSoftScore.ofSoft(2));
-        throw new UnsupportedOperationException();
     }
 
     private Constraint roomStability(ConstraintFactory factory) {

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/curriculumcourse/optional/score/CourseScheduleConstraintProvider.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/curriculumcourse/optional/score/CourseScheduleConstraintProvider.java
@@ -29,10 +29,6 @@ import static org.optaplanner.core.api.score.stream.Joiners.*;
 
 public class CourseScheduleConstraintProvider implements ConstraintProvider {
 
-    // WARNING: The ConstraintStreams/ConstraintProvider API is TECH PREVIEW.
-    // It works but it has many API gaps.
-    // Therefore, it is not rich enough yet to handle complex constraints.
-
     @Override
     public Constraint[] defineConstraints(ConstraintFactory factory) {
         return new Constraint[]{

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/machinereassignment/solver/score/MachineReassignmentConstraintProvider.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/machinereassignment/solver/score/MachineReassignmentConstraintProvider.java
@@ -28,10 +28,6 @@ import static org.optaplanner.core.api.score.stream.Joiners.equal;
 
 public class MachineReassignmentConstraintProvider implements ConstraintProvider {
 
-    // WARNING: The ConstraintStreams/ConstraintProvider API is TECH PREVIEW.
-    // It works but it has many API gaps.
-    // Therefore, it is not rich enough yet to handle complex constraints.
-
     @Override
     public Constraint[] defineConstraints(ConstraintFactory factory) {
         return new Constraint[]{

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/machinereassignment/solver/score/MachineReassignmentConstraintProvider.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/machinereassignment/solver/score/MachineReassignmentConstraintProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,15 +18,13 @@ package org.optaplanner.examples.machinereassignment.solver.score;
 
 import org.optaplanner.core.api.score.buildin.hardsoftlong.HardSoftLongScore;
 import org.optaplanner.core.api.score.stream.Constraint;
+import org.optaplanner.core.api.score.stream.ConstraintCollectors;
 import org.optaplanner.core.api.score.stream.ConstraintFactory;
 import org.optaplanner.core.api.score.stream.ConstraintProvider;
-import org.optaplanner.core.api.score.stream.ConstraintCollectors;
-import org.optaplanner.examples.machinereassignment.domain.MrMachineCapacity;
 import org.optaplanner.examples.machinereassignment.domain.MrProcessAssignment;
 import org.optaplanner.examples.machinereassignment.domain.solver.MrServiceDependency;
 
-import static org.optaplanner.core.api.score.stream.ConstraintCollectors.*;
-import static org.optaplanner.core.api.score.stream.Joiners.*;
+import static org.optaplanner.core.api.score.stream.Joiners.equal;
 
 public class MachineReassignmentConstraintProvider implements ConstraintProvider {
 
@@ -59,19 +57,20 @@ public class MachineReassignmentConstraintProvider implements ConstraintProvider
      * Maximum capacity: The maximum capacity for each resource for each machine must not be exceeded.
      */
     private Constraint maximumCapacity(ConstraintFactory factory) {
-        return factory.from(MrMachineCapacity.class)
-                .join(MrProcessAssignment.class,
-                        equal(MrMachineCapacity::getMachine, MrProcessAssignment::getMachine)
-                )
-                .groupBy(
-                        (machineCapacity, processAssignment) -> machineCapacity, sumLong(
-                                (machineCapacity, processAssignment) -> processAssignment.getUsage(machineCapacity.getResource())
-                        )
-                )
-                .filter(((machineCapacity, usage) -> machineCapacity.getMaximumCapacity() < usage))
-                .penalizeLong(MrConstraints.MAXIMUM_CAPACITY,
-                        HardSoftLongScore.ofHard(1L),
-                        (machineCapacity, usage) -> machineCapacity.getMaximumCapacity() - usage);
+        throw new UnsupportedOperationException("Not yet implemented due to missing support for bi-grouping.");
+//        return factory.from(MrMachineCapacity.class)
+//                .join(MrProcessAssignment.class,
+//                        equal(MrMachineCapacity::getMachine, MrProcessAssignment::getMachine)
+//                )
+//                .groupBy(
+//                        (machineCapacity, processAssignment) -> machineCapacity, sumLong(
+//                                (machineCapacity, processAssignment) -> processAssignment.getUsage(machineCapacity.getResource())
+//                        )
+//                )
+//                .filter(((machineCapacity, usage) -> machineCapacity.getMaximumCapacity() < usage))
+//                .penalizeLong(MrConstraints.MAXIMUM_CAPACITY,
+//                        HardSoftLongScore.ofHard(1L),
+//                        (machineCapacity, usage) -> machineCapacity.getMaximumCapacity() - usage);
     }
 
     /**
@@ -119,20 +118,21 @@ public class MachineReassignmentConstraintProvider implements ConstraintProvider
      * machine as the newly assigned machine.
      */
     private Constraint transientUsage(ConstraintFactory factory) {
-        return factory.from(MrMachineCapacity.class)
-                .filter(MrMachineCapacity::isTransientlyConsumed)
-                .join(factory.from(MrProcessAssignment.class).filter(MrProcessAssignment::isMoved),
-                        equal(MrMachineCapacity::getMachine, MrProcessAssignment::getOriginalMachine)
-                )
-                .groupBy((machineCapacity, processAssignment) -> machineCapacity,
-                        sumLong((machineCapacity, processAssignment)
-                                -> processAssignment.getUsage(machineCapacity.getResource())
-                        )
-                )
-                .filter(((machineCapacity, usage) -> machineCapacity.getMaximumCapacity() < usage))
-                .penalizeLong(MrConstraints.TRANSIENT_USAGE,
-                        HardSoftLongScore.ofHard(1L),
-                        (machineCapacity, usage) -> machineCapacity.getMaximumCapacity() - usage);
+        throw new UnsupportedOperationException("Not yet implemented due to missing support for bi-grouping.");
+//        return factory.from(MrMachineCapacity.class)
+//                .filter(MrMachineCapacity::isTransientlyConsumed)
+//                .join(factory.from(MrProcessAssignment.class).filter(MrProcessAssignment::isMoved),
+//                        equal(MrMachineCapacity::getMachine, MrProcessAssignment::getOriginalMachine)
+//                )
+//                .groupBy((machineCapacity, processAssignment) -> machineCapacity,
+//                        sumLong((machineCapacity, processAssignment)
+//                                -> processAssignment.getUsage(machineCapacity.getResource())
+//                        )
+//                )
+//                .filter(((machineCapacity, usage) -> machineCapacity.getMaximumCapacity() < usage))
+//                .penalizeLong(MrConstraints.TRANSIENT_USAGE,
+//                        HardSoftLongScore.ofHard(1L),
+//                        (machineCapacity, usage) -> machineCapacity.getMaximumCapacity() - usage);
     }
 
     // ************************************************************************
@@ -143,19 +143,20 @@ public class MachineReassignmentConstraintProvider implements ConstraintProvider
      * Load: The safety capacity for each resource for each machine should not be exceeded.
      */
     private Constraint loadCost(ConstraintFactory factory) {
-        return factory.from(MrMachineCapacity.class)
-                .join(MrProcessAssignment.class,
-                        equal(MrMachineCapacity::getMachine, MrProcessAssignment::getMachine)
-                )
-                .groupBy(
-                        (machineCapacity, processAssignment) -> machineCapacity, sumLong(
-                                (machineCapacity, processAssignment) -> processAssignment.getUsage(machineCapacity.getResource())
-                        )
-                )
-                .filter(((machineCapacity, usage) -> machineCapacity.getSafetyCapacity() < usage))
-                .penalizeLong(MrConstraints.LOAD_COST,
-                        HardSoftLongScore.ofSoft(1L),
-                        (machineCapacity, usage) -> machineCapacity.getSafetyCapacity() - usage);
+        throw new UnsupportedOperationException("Not yet implemented due to missing support for bi-grouping.");
+//        return factory.from(MrMachineCapacity.class)
+//                .join(MrProcessAssignment.class,
+//                        equal(MrMachineCapacity::getMachine, MrProcessAssignment::getMachine)
+//                )
+//                .groupBy(
+//                        (machineCapacity, processAssignment) -> machineCapacity, sumLong(
+//                                (machineCapacity, processAssignment) -> processAssignment.getUsage(machineCapacity.getResource())
+//                        )
+//                )
+//                .filter(((machineCapacity, usage) -> machineCapacity.getSafetyCapacity() < usage))
+//                .penalizeLong(MrConstraints.LOAD_COST,
+//                        HardSoftLongScore.ofSoft(1L),
+//                        (machineCapacity, usage) -> machineCapacity.getSafetyCapacity() - usage);
     }
 
     /**

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/nqueens/solver/score/NQueensConstraintProvider.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/nqueens/solver/score/NQueensConstraintProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,10 +25,6 @@ import org.optaplanner.examples.nqueens.domain.Queen;
 import static org.optaplanner.core.api.score.stream.Joiners.*;
 
 public class NQueensConstraintProvider implements ConstraintProvider {
-
-    // WARNING: The ConstraintStreams/ConstraintProvider API is TECH PREVIEW.
-    // It works but it has many API gaps.
-    // Therefore, it is not rich enough yet to handle complex constraints.
 
     @Override
     public Constraint[] defineConstraints(ConstraintFactory factory) {

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/vehiclerouting/optional/score/VehicleRoutingConstraintProvider.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/vehiclerouting/optional/score/VehicleRoutingConstraintProvider.java
@@ -27,10 +27,6 @@ import static org.optaplanner.core.api.score.stream.ConstraintCollectors.*;
 
 public class VehicleRoutingConstraintProvider implements ConstraintProvider {
 
-    // WARNING: The ConstraintStreams/ConstraintProvider API is TECH PREVIEW.
-    // It works but it has many API gaps.
-    // Therefore, it is not rich enough yet to handle complex constraints.
-
     @Override
     public Constraint[] defineConstraints(ConstraintFactory factory) {
         return new Constraint[]{

--- a/optaplanner-examples/src/main/resources/org/optaplanner/examples/cloudbalancing/optional/benchmark/cloudBalancingScoreDirectorBenchmarkConfig.xml
+++ b/optaplanner-examples/src/main/resources/org/optaplanner/examples/cloudbalancing/optional/benchmark/cloudBalancingScoreDirectorBenchmarkConfig.xml
@@ -1,20 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
-  ~ Copyright 2019 Red Hat, Inc. and/or its affiliates.
-  ~
-  ~ Licensed under the Apache License, Version 2.0 (the "License");
-  ~ you may not use this file except in compliance with the License.
-  ~ You may obtain a copy of the License at
-  ~
-  ~      http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing, software
-  ~ distributed under the License is distributed on an "AS IS" BASIS,
-  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~ See the License for the specific language governing permissions and
-  ~ limitations under the License.
-  -->
-
 <plannerBenchmark>
   <benchmarkDirectory>local/data/cloudbalancing/scoreDirector</benchmarkDirectory>
   <warmUpSecondsSpentLimit>30</warmUpSecondsSpentLimit>

--- a/optaplanner-examples/src/main/resources/org/optaplanner/examples/cloudbalancing/optional/benchmark/cloudBalancingScoreDirectorBenchmarkConfig.xml
+++ b/optaplanner-examples/src/main/resources/org/optaplanner/examples/cloudbalancing/optional/benchmark/cloudBalancingScoreDirectorBenchmarkConfig.xml
@@ -1,4 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2019 Red Hat, Inc. and/or its affiliates.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
 <plannerBenchmark>
   <benchmarkDirectory>local/data/cloudbalancing/scoreDirector</benchmarkDirectory>
   <warmUpSecondsSpentLimit>30</warmUpSecondsSpentLimit>
@@ -49,9 +65,18 @@
     </solver>
   </solverBenchmark>
   <solverBenchmark>
+    <name>ConstraintStreams (Drools)</name>
+    <solver>
+      <scoreDirectorFactory>
+        <constraintProviderClass>org.optaplanner.examples.cloudbalancing.optional.score.CloudBalancingConstraintProvider</constraintProviderClass>
+      </scoreDirectorFactory>
+    </solver>
+  </solverBenchmark>
+  <solverBenchmark>
     <name>ConstraintStreams (Bavet)</name>
     <solver>
       <scoreDirectorFactory>
+        <constraintStreamImplType>BAVET</constraintStreamImplType>
         <constraintProviderClass>org.optaplanner.examples.cloudbalancing.optional.score.CloudBalancingConstraintProvider</constraintProviderClass>
       </scoreDirectorFactory>
     </solver>

--- a/optaplanner-examples/src/main/resources/org/optaplanner/examples/nqueens/benchmark/nqueensScoreDirectorBenchmarkConfig.xml
+++ b/optaplanner-examples/src/main/resources/org/optaplanner/examples/nqueens/benchmark/nqueensScoreDirectorBenchmarkConfig.xml
@@ -1,20 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
-  ~ Copyright 2019 Red Hat, Inc. and/or its affiliates.
-  ~
-  ~ Licensed under the Apache License, Version 2.0 (the "License");
-  ~ you may not use this file except in compliance with the License.
-  ~ You may obtain a copy of the License at
-  ~
-  ~      http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing, software
-  ~ distributed under the License is distributed on an "AS IS" BASIS,
-  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~ See the License for the specific language governing permissions and
-  ~ limitations under the License.
-  -->
-
 <plannerBenchmark>
   <benchmarkDirectory>local/data/nqueens/scoreDirector</benchmarkDirectory>
   <warmUpSecondsSpentLimit>30</warmUpSecondsSpentLimit>

--- a/optaplanner-examples/src/main/resources/org/optaplanner/examples/nqueens/benchmark/nqueensScoreDirectorBenchmarkConfig.xml
+++ b/optaplanner-examples/src/main/resources/org/optaplanner/examples/nqueens/benchmark/nqueensScoreDirectorBenchmarkConfig.xml
@@ -1,4 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2019 Red Hat, Inc. and/or its affiliates.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
 <plannerBenchmark>
   <benchmarkDirectory>local/data/nqueens/scoreDirector</benchmarkDirectory>
   <warmUpSecondsSpentLimit>30</warmUpSecondsSpentLimit>
@@ -68,9 +84,18 @@
     </solver>
   </solverBenchmark>
   <solverBenchmark>
+    <name>ConstraintStreams (Drools)</name>
+    <solver>
+      <scoreDirectorFactory>
+        <constraintProviderClass>org.optaplanner.examples.nqueens.solver.score.NQueensConstraintProvider</constraintProviderClass>
+      </scoreDirectorFactory>
+    </solver>
+  </solverBenchmark>
+  <solverBenchmark>
     <name>ConstraintStreams (Bavet)</name>
     <solver>
       <scoreDirectorFactory>
+        <constraintStreamImplType>BAVET</constraintStreamImplType>
         <constraintProviderClass>org.optaplanner.examples.nqueens.solver.score.NQueensConstraintProvider</constraintProviderClass>
       </scoreDirectorFactory>
     </solver>

--- a/optaplanner-examples/src/main/resources/org/optaplanner/examples/taskassigning/benchmark/taskAssigningScoreDirectorBenchmarkConfig.xml
+++ b/optaplanner-examples/src/main/resources/org/optaplanner/examples/taskassigning/benchmark/taskAssigningScoreDirectorBenchmarkConfig.xml
@@ -1,20 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
-  ~ Copyright 2019 Red Hat, Inc. and/or its affiliates.
-  ~
-  ~ Licensed under the Apache License, Version 2.0 (the "License");
-  ~ you may not use this file except in compliance with the License.
-  ~ You may obtain a copy of the License at
-  ~
-  ~      http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing, software
-  ~ distributed under the License is distributed on an "AS IS" BASIS,
-  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~ See the License for the specific language governing permissions and
-  ~ limitations under the License.
-  -->
-
 <plannerBenchmark>
   <benchmarkDirectory>local/data/taskassigning</benchmarkDirectory>
   <parallelBenchmarkCount>AUTO</parallelBenchmarkCount>

--- a/optaplanner-examples/src/main/resources/org/optaplanner/examples/taskassigning/benchmark/taskAssigningScoreDirectorBenchmarkConfig.xml
+++ b/optaplanner-examples/src/main/resources/org/optaplanner/examples/taskassigning/benchmark/taskAssigningScoreDirectorBenchmarkConfig.xml
@@ -1,4 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2019 Red Hat, Inc. and/or its affiliates.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
 <plannerBenchmark>
   <benchmarkDirectory>local/data/taskassigning</benchmarkDirectory>
   <parallelBenchmarkCount>AUTO</parallelBenchmarkCount>
@@ -25,9 +41,18 @@
   </inheritedSolverBenchmark>
 
   <solverBenchmark>
+    <name>ConstraintStreams (Drools)</name>
+    <solver>
+      <scoreDirectorFactory>
+        <constraintProviderClass>org.optaplanner.examples.taskassigning.solver.score.TaskAssigningConstraintProvider</constraintProviderClass>
+      </scoreDirectorFactory>
+    </solver>
+  </solverBenchmark>
+  <solverBenchmark>
     <name>ConstraintStreams (Bavet)</name>
     <solver>
       <scoreDirectorFactory>
+        <constraintStreamImplType>BAVET</constraintStreamImplType>
         <constraintProviderClass>org.optaplanner.examples.taskassigning.solver.score.TaskAssigningConstraintProvider</constraintProviderClass>
       </scoreDirectorFactory>
     </solver>

--- a/optaplanner-examples/src/main/resources/org/optaplanner/examples/vehiclerouting/benchmark/vehicleRoutingScoreDirectorBenchmarkConfig.xml
+++ b/optaplanner-examples/src/main/resources/org/optaplanner/examples/vehiclerouting/benchmark/vehicleRoutingScoreDirectorBenchmarkConfig.xml
@@ -1,20 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
-  ~ Copyright 2019 Red Hat, Inc. and/or its affiliates.
-  ~
-  ~ Licensed under the Apache License, Version 2.0 (the "License");
-  ~ you may not use this file except in compliance with the License.
-  ~ You may obtain a copy of the License at
-  ~
-  ~      http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing, software
-  ~ distributed under the License is distributed on an "AS IS" BASIS,
-  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~ See the License for the specific language governing permissions and
-  ~ limitations under the License.
-  -->
-
 <plannerBenchmark>
   <benchmarkDirectory>local/data/vehiclerouting</benchmarkDirectory>
   <warmUpSecondsSpentLimit>30</warmUpSecondsSpentLimit>

--- a/optaplanner-examples/src/main/resources/org/optaplanner/examples/vehiclerouting/benchmark/vehicleRoutingScoreDirectorBenchmarkConfig.xml
+++ b/optaplanner-examples/src/main/resources/org/optaplanner/examples/vehiclerouting/benchmark/vehicleRoutingScoreDirectorBenchmarkConfig.xml
@@ -1,4 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2019 Red Hat, Inc. and/or its affiliates.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
 <plannerBenchmark>
   <benchmarkDirectory>local/data/vehiclerouting</benchmarkDirectory>
   <warmUpSecondsSpentLimit>30</warmUpSecondsSpentLimit>
@@ -46,9 +62,18 @@
     </solver>
   </solverBenchmark>
   <solverBenchmark>
+    <name>ConstraintStreams (Drools)</name>
+    <solver>
+      <scoreDirectorFactory>
+        <constraintProviderClass>org.optaplanner.examples.vehiclerouting.optional.score.VehicleRoutingConstraintProvider</constraintProviderClass>
+      </scoreDirectorFactory>
+    </solver>
+  </solverBenchmark>
+  <solverBenchmark>
     <name>ConstraintStreams (Bavet)</name>
     <solver>
       <scoreDirectorFactory>
+        <constraintStreamImplType>BAVET</constraintStreamImplType>
         <constraintProviderClass>org.optaplanner.examples.vehiclerouting.optional.score.VehicleRoutingConstraintProvider</constraintProviderClass>
       </scoreDirectorFactory>
     </solver>


### PR DESCRIPTION
The changes I've made:

- [Improved performance](https://docs.google.com/spreadsheets/d/1SP1QzVkGSiPah4WzLtlZD7Y3bk9FWcx5H0J3BY7-4ag/edit#gid=1301881863). The "friendly" examples are no longer horribly slow.
- Removed from the API methods that would throw `UnsupportedOperationException` with the Drools backend. They will be added in the future.
- Added a section of documentation discussing the two implementations.
- Removed all notions of "tech preview".

We have a meeting on Tuesday 29th to discuss if this is enough.