### PR TITLE
PLANNER-1639 Migrate BenchmarkParallelExecutionTest to upstream

### DIFF
--- a/optaplanner-benchmark/pom.xml
+++ b/optaplanner-benchmark/pom.xml
@@ -106,6 +106,11 @@
       <groupId>org.freemarker</groupId>
       <artifactId>freemarker</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/optaplanner-benchmark/src/test/java/org/optaplanner/benchmark/config/blueprint/SolverBenchmarkBluePrintConfigTest.java
+++ b/optaplanner-benchmark/src/test/java/org/optaplanner/benchmark/config/blueprint/SolverBenchmarkBluePrintConfigTest.java
@@ -9,7 +9,7 @@ public class SolverBenchmarkBluePrintConfigTest {
     @Test
     public void withoutSolverBenchmarkBluePrintType() {
         SolverBenchmarkBluePrintConfig config = new SolverBenchmarkBluePrintConfig();
-        assertThatExceptionOfType(IllegalStateException.class)
+        assertThatExceptionOfType(IllegalArgumentException.class)
                 .isThrownBy(config::validate)
                 .withMessageContaining("solverBenchmarkBluePrintType");
     }

--- a/optaplanner-benchmark/src/test/java/org/optaplanner/benchmark/config/blueprint/SolverBenchmarkBluePrintConfigTest.java
+++ b/optaplanner-benchmark/src/test/java/org/optaplanner/benchmark/config/blueprint/SolverBenchmarkBluePrintConfigTest.java
@@ -1,20 +1,16 @@
 package org.optaplanner.benchmark.config.blueprint;
 
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
+
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 public class SolverBenchmarkBluePrintConfigTest {
 
-    @Rule
-    public ExpectedException exceptionRule = ExpectedException.none();
-
     @Test
-    public void throwIllegalArgumentException_WhenValidateOnUnassignedSolverBenchmarkBluePrintType() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("The solverBenchmarkBluePrint must have a solverBenchmarkBluePrintType (");
-
+    public void withoutSolverBenchmarkBluePrintType() {
         SolverBenchmarkBluePrintConfig config = new SolverBenchmarkBluePrintConfig();
-        config.validate();
+        assertThatExceptionOfType(IllegalStateException.class)
+                .isThrownBy(config::validate)
+                .withMessageContaining("solverBenchmarkBluePrintType");
     }
 }

--- a/optaplanner-benchmark/src/test/java/org/optaplanner/benchmark/config/blueprint/SolverBenchmarkBluePrintConfigTest.java
+++ b/optaplanner-benchmark/src/test/java/org/optaplanner/benchmark/config/blueprint/SolverBenchmarkBluePrintConfigTest.java
@@ -1,0 +1,20 @@
+package org.optaplanner.benchmark.config.blueprint;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class SolverBenchmarkBluePrintConfigTest {
+
+    @Rule
+    public ExpectedException exceptionRule = ExpectedException.none();
+
+    @Test
+    public void throwIllegalArgumentException_WhenValidateOnUnassignedSolverBenchmarkBluePrintType() {
+        exceptionRule.expect(IllegalArgumentException.class);
+        exceptionRule.expectMessage("The solverBenchmarkBluePrint must have a solverBenchmarkBluePrintType (");
+
+        SolverBenchmarkBluePrintConfig config = new SolverBenchmarkBluePrintConfig();
+        config.validate();
+    }
+}

--- a/optaplanner-benchmark/src/test/java/org/optaplanner/benchmark/config/report/BenchmarkReportConfigTest.java
+++ b/optaplanner-benchmark/src/test/java/org/optaplanner/benchmark/config/report/BenchmarkReportConfigTest.java
@@ -2,21 +2,17 @@ package org.optaplanner.benchmark.config.report;
 
 import java.util.Locale;
 
-import org.junit.Assert;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.optaplanner.benchmark.config.ranking.SolverRankingType;
 import org.optaplanner.benchmark.impl.ranking.TotalRankSolverRankingWeightFactory;
 import org.optaplanner.benchmark.impl.ranking.TotalScoreSolverRankingComparator;
 import org.optaplanner.benchmark.impl.result.PlannerBenchmarkResult;
 
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
 public class BenchmarkReportConfigTest {
-
-    @Rule
-    public ExpectedException exceptionRule = ExpectedException.none();
 
     @Test
     public void inheritBenchmarkReportConfig_WhenCallingConstructorWithConfigParameter() {
@@ -28,58 +24,50 @@ public class BenchmarkReportConfigTest {
 
         BenchmarkReportConfig inheritor = new BenchmarkReportConfig(inheritance);
 
-        Assert.assertEquals(inheritance.getLocale(), inheritor.getLocale());
-        Assert.assertEquals(inheritance.getSolverRankingType(), inheritor.getSolverRankingType());
-        Assert.assertEquals(inheritance.getSolverRankingComparatorClass(), inheritor.getSolverRankingComparatorClass());
-        Assert.assertEquals(inheritance.getSolverRankingWeightFactoryClass(), inheritor.getSolverRankingWeightFactoryClass());
+        assertThat(inheritor.getLocale()).isEqualTo(inheritance.getLocale());
+        assertThat(inheritor.getSolverRankingType()).isEqualTo(inheritance.getSolverRankingType());
+        assertThat(inheritor.getSolverRankingComparatorClass()).isEqualTo(inheritance.getSolverRankingComparatorClass());
+        assertThat(inheritor.getSolverRankingWeightFactoryClass()).isEqualTo(inheritance.getSolverRankingWeightFactoryClass());
     }
 
     @Test
     public void throwIllegalStateException_WhenConfigContainsSolverRankingTypeAndSolverRankingComparatorClass() {
-        exceptionRule.expect(IllegalStateException.class);
-        exceptionRule.expectMessage("The PlannerBenchmark cannot have a solverRankingType (");
-        exceptionRule.expectMessage(") and a solverRankingComparatorClass (");
-        exceptionRule.expectMessage(") at the same time.");
-
         BenchmarkReportConfig config = new BenchmarkReportConfig();
         config.setSolverRankingType(SolverRankingType.TOTAL_RANKING);
         config.setSolverRankingComparatorClass(TotalScoreSolverRankingComparator.class);
 
         PlannerBenchmarkResult result = mock(PlannerBenchmarkResult.class);
-
-        config.buildBenchmarkReport(result);
+        assertThatExceptionOfType(IllegalStateException.class).isThrownBy(() -> config.buildBenchmarkReport(result))
+                .withMessageStartingWith("The PlannerBenchmark cannot have a solverRankingType (")
+                .withMessageContaining(") and a solverRankingComparatorClass (")
+                .withMessageEndingWith(") at the same time.");
     }
 
     @Test
     public void throwIllegalStateException_WhenConfigContainsSolverRankingTypeAndSolverRankingWeightFactoryClass() {
-        exceptionRule.expect(IllegalStateException.class);
-        exceptionRule.expectMessage("The PlannerBenchmark cannot have a solverRankingType (");
-        exceptionRule.expectMessage(") and a solverRankingWeightFactoryClass (");
-        exceptionRule.expectMessage(") at the same time.");
-
         BenchmarkReportConfig config = new BenchmarkReportConfig();
         config.setSolverRankingType(SolverRankingType.TOTAL_RANKING);
         config.setSolverRankingWeightFactoryClass(TotalRankSolverRankingWeightFactory.class);
 
         PlannerBenchmarkResult result = mock(PlannerBenchmarkResult.class);
 
-        config.buildBenchmarkReport(result);
+        assertThatExceptionOfType(IllegalStateException.class).isThrownBy(() -> config.buildBenchmarkReport(result))
+                .withMessageStartingWith("The PlannerBenchmark cannot have a solverRankingType (")
+                .withMessageContaining(") and a solverRankingWeightFactoryClass (")
+                .withMessageEndingWith(") at the same time.");
     }
 
     @Test
     public void throwIllegalStateException_WhenConfigContainsSolverRankingComparatorClassAndSolverRankingWeightFactoryClass() {
-        exceptionRule.expect(IllegalStateException.class);
-        exceptionRule.expectMessage("The PlannerBenchmark cannot have a solverRankingComparatorClass (");
-        exceptionRule.expectMessage(") and a solverRankingWeightFactoryClass (");
-        exceptionRule.expectMessage(") at the same time.");
-
         BenchmarkReportConfig config = new BenchmarkReportConfig();
         config.setSolverRankingComparatorClass(TotalScoreSolverRankingComparator.class);
         config.setSolverRankingWeightFactoryClass(TotalRankSolverRankingWeightFactory.class);
 
         PlannerBenchmarkResult result = mock(PlannerBenchmarkResult.class);
 
-        config.buildBenchmarkReport(result);
+        assertThatExceptionOfType(IllegalStateException.class).isThrownBy(() -> config.buildBenchmarkReport(result))
+                .withMessageStartingWith("The PlannerBenchmark cannot have a solverRankingComparatorClass (")
+                .withMessageContaining(") and a solverRankingWeightFactoryClass (")
+                .withMessageEndingWith(") at the same time.");
     }
-
 }

--- a/optaplanner-benchmark/src/test/java/org/optaplanner/benchmark/config/report/BenchmarkReportConfigTest.java
+++ b/optaplanner-benchmark/src/test/java/org/optaplanner/benchmark/config/report/BenchmarkReportConfigTest.java
@@ -1,0 +1,85 @@
+package org.optaplanner.benchmark.config.report;
+
+import java.util.Locale;
+
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.optaplanner.benchmark.config.ranking.SolverRankingType;
+import org.optaplanner.benchmark.impl.ranking.TotalRankSolverRankingWeightFactory;
+import org.optaplanner.benchmark.impl.ranking.TotalScoreSolverRankingComparator;
+import org.optaplanner.benchmark.impl.result.PlannerBenchmarkResult;
+
+import static org.mockito.Mockito.mock;
+
+public class BenchmarkReportConfigTest {
+
+    @Rule
+    public ExpectedException exceptionRule = ExpectedException.none();
+
+    @Test
+    public void inheritBenchmarkReportConfig_WhenCallingConstructorWithConfigParameter() {
+        BenchmarkReportConfig inheritance = new BenchmarkReportConfig();
+        inheritance.setLocale(Locale.CANADA);
+        inheritance.setSolverRankingType(SolverRankingType.TOTAL_RANKING);
+        inheritance.setSolverRankingComparatorClass(TotalScoreSolverRankingComparator.class);
+        inheritance.setSolverRankingWeightFactoryClass(TotalRankSolverRankingWeightFactory.class);
+
+        BenchmarkReportConfig inheritor = new BenchmarkReportConfig(inheritance);
+
+        Assert.assertEquals(inheritance.getLocale(), inheritor.getLocale());
+        Assert.assertEquals(inheritance.getSolverRankingType(), inheritor.getSolverRankingType());
+        Assert.assertEquals(inheritance.getSolverRankingComparatorClass(), inheritor.getSolverRankingComparatorClass());
+        Assert.assertEquals(inheritance.getSolverRankingWeightFactoryClass(), inheritor.getSolverRankingWeightFactoryClass());
+    }
+
+    @Test
+    public void throwIllegalStateException_WhenConfigContainsSolverRankingTypeAndSolverRankingComparatorClass() {
+        exceptionRule.expect(IllegalStateException.class);
+        exceptionRule.expectMessage("The PlannerBenchmark cannot have a solverRankingType (");
+        exceptionRule.expectMessage(") and a solverRankingComparatorClass (");
+        exceptionRule.expectMessage(") at the same time.");
+
+        BenchmarkReportConfig config = new BenchmarkReportConfig();
+        config.setSolverRankingType(SolverRankingType.TOTAL_RANKING);
+        config.setSolverRankingComparatorClass(TotalScoreSolverRankingComparator.class);
+
+        PlannerBenchmarkResult result = mock(PlannerBenchmarkResult.class);
+
+        config.buildBenchmarkReport(result);
+    }
+
+    @Test
+    public void throwIllegalStateException_WhenConfigContainsSolverRankingTypeAndSolverRankingWeightFactoryClass() {
+        exceptionRule.expect(IllegalStateException.class);
+        exceptionRule.expectMessage("The PlannerBenchmark cannot have a solverRankingType (");
+        exceptionRule.expectMessage(") and a solverRankingWeightFactoryClass (");
+        exceptionRule.expectMessage(") at the same time.");
+
+        BenchmarkReportConfig config = new BenchmarkReportConfig();
+        config.setSolverRankingType(SolverRankingType.TOTAL_RANKING);
+        config.setSolverRankingWeightFactoryClass(TotalRankSolverRankingWeightFactory.class);
+
+        PlannerBenchmarkResult result = mock(PlannerBenchmarkResult.class);
+
+        config.buildBenchmarkReport(result);
+    }
+
+    @Test
+    public void throwIllegalStateException_WhenConfigContainsSolverRankingComparatorClassAndSolverRankingWeightFactoryClass() {
+        exceptionRule.expect(IllegalStateException.class);
+        exceptionRule.expectMessage("The PlannerBenchmark cannot have a solverRankingComparatorClass (");
+        exceptionRule.expectMessage(") and a solverRankingWeightFactoryClass (");
+        exceptionRule.expectMessage(") at the same time.");
+
+        BenchmarkReportConfig config = new BenchmarkReportConfig();
+        config.setSolverRankingComparatorClass(TotalScoreSolverRankingComparator.class);
+        config.setSolverRankingWeightFactoryClass(TotalRankSolverRankingWeightFactory.class);
+
+        PlannerBenchmarkResult result = mock(PlannerBenchmarkResult.class);
+
+        config.buildBenchmarkReport(result);
+    }
+
+}

--- a/optaplanner-benchmark/src/test/java/org/optaplanner/benchmark/config/report/BenchmarkReportConfigTest.java
+++ b/optaplanner-benchmark/src/test/java/org/optaplanner/benchmark/config/report/BenchmarkReportConfigTest.java
@@ -15,36 +15,35 @@ import static org.mockito.Mockito.mock;
 public class BenchmarkReportConfigTest {
 
     @Test
-    public void inheritBenchmarkReportConfig_WhenCallingConstructorWithConfigParameter() {
-        BenchmarkReportConfig inheritance = new BenchmarkReportConfig();
-        inheritance.setLocale(Locale.CANADA);
-        inheritance.setSolverRankingType(SolverRankingType.TOTAL_RANKING);
-        inheritance.setSolverRankingComparatorClass(TotalScoreSolverRankingComparator.class);
-        inheritance.setSolverRankingWeightFactoryClass(TotalRankSolverRankingWeightFactory.class);
+    public void inheritBenchmarkReportConfig() {
+        BenchmarkReportConfig inheritedReportConfig = new BenchmarkReportConfig();
+        inheritedReportConfig.setLocale(Locale.CANADA);
+        inheritedReportConfig.setSolverRankingType(SolverRankingType.TOTAL_RANKING);
+        inheritedReportConfig.setSolverRankingComparatorClass(TotalScoreSolverRankingComparator.class);
+        inheritedReportConfig.setSolverRankingWeightFactoryClass(TotalRankSolverRankingWeightFactory.class);
 
-        BenchmarkReportConfig inheritor = new BenchmarkReportConfig(inheritance);
+        BenchmarkReportConfig reportConfig = new BenchmarkReportConfig(inheritedReportConfig);
 
-        assertThat(inheritor.getLocale()).isEqualTo(inheritance.getLocale());
-        assertThat(inheritor.getSolverRankingType()).isEqualTo(inheritance.getSolverRankingType());
-        assertThat(inheritor.getSolverRankingComparatorClass()).isEqualTo(inheritance.getSolverRankingComparatorClass());
-        assertThat(inheritor.getSolverRankingWeightFactoryClass()).isEqualTo(inheritance.getSolverRankingWeightFactoryClass());
+        assertThat(reportConfig.getLocale()).isEqualTo(inheritedReportConfig.getLocale());
+        assertThat(reportConfig.getSolverRankingType()).isEqualTo(inheritedReportConfig.getSolverRankingType());
+        assertThat(reportConfig.getSolverRankingComparatorClass()).isEqualTo(inheritedReportConfig.getSolverRankingComparatorClass());
+        assertThat(reportConfig.getSolverRankingWeightFactoryClass()).isEqualTo(inheritedReportConfig.getSolverRankingWeightFactoryClass());
     }
 
     @Test
-    public void throwIllegalStateException_WhenConfigContainsSolverRankingTypeAndSolverRankingComparatorClass() {
+    public void buildWithSolverRankingTypeAndSolverRankingComparatorClass() {
         BenchmarkReportConfig config = new BenchmarkReportConfig();
         config.setSolverRankingType(SolverRankingType.TOTAL_RANKING);
         config.setSolverRankingComparatorClass(TotalScoreSolverRankingComparator.class);
 
         PlannerBenchmarkResult result = mock(PlannerBenchmarkResult.class);
+
         assertThatExceptionOfType(IllegalStateException.class).isThrownBy(() -> config.buildBenchmarkReport(result))
-                .withMessageStartingWith("The PlannerBenchmark cannot have a solverRankingType (")
-                .withMessageContaining(") and a solverRankingComparatorClass (")
-                .withMessageEndingWith(") at the same time.");
+                .withMessageContaining("solverRankingType").withMessageContaining("solverRankingComparatorClass");
     }
 
     @Test
-    public void throwIllegalStateException_WhenConfigContainsSolverRankingTypeAndSolverRankingWeightFactoryClass() {
+    public void buildWithSolverRankingTypeAndSolverRankingWeightFactoryClass() {
         BenchmarkReportConfig config = new BenchmarkReportConfig();
         config.setSolverRankingType(SolverRankingType.TOTAL_RANKING);
         config.setSolverRankingWeightFactoryClass(TotalRankSolverRankingWeightFactory.class);
@@ -52,13 +51,11 @@ public class BenchmarkReportConfigTest {
         PlannerBenchmarkResult result = mock(PlannerBenchmarkResult.class);
 
         assertThatExceptionOfType(IllegalStateException.class).isThrownBy(() -> config.buildBenchmarkReport(result))
-                .withMessageStartingWith("The PlannerBenchmark cannot have a solverRankingType (")
-                .withMessageContaining(") and a solverRankingWeightFactoryClass (")
-                .withMessageEndingWith(") at the same time.");
+                .withMessageContaining("solverRankingType").withMessageContaining("solverRankingWeightFactoryClass");
     }
 
     @Test
-    public void throwIllegalStateException_WhenConfigContainsSolverRankingComparatorClassAndSolverRankingWeightFactoryClass() {
+    public void buildWithSolverRankingComparatorClassAndSolverRankingWeightFactoryClass() {
         BenchmarkReportConfig config = new BenchmarkReportConfig();
         config.setSolverRankingComparatorClass(TotalScoreSolverRankingComparator.class);
         config.setSolverRankingWeightFactoryClass(TotalRankSolverRankingWeightFactory.class);
@@ -66,8 +63,6 @@ public class BenchmarkReportConfigTest {
         PlannerBenchmarkResult result = mock(PlannerBenchmarkResult.class);
 
         assertThatExceptionOfType(IllegalStateException.class).isThrownBy(() -> config.buildBenchmarkReport(result))
-                .withMessageStartingWith("The PlannerBenchmark cannot have a solverRankingComparatorClass (")
-                .withMessageContaining(") and a solverRankingWeightFactoryClass (")
-                .withMessageEndingWith(") at the same time.");
+                .withMessageContaining("solverRankingComparatorClass").withMessageContaining("solverRankingWeightFactoryClass");
     }
 }

--- a/optaplanner-benchmark/src/test/java/org/optaplanner/benchmark/impl/DefaultPlannerBenchmarkTest.java
+++ b/optaplanner-benchmark/src/test/java/org/optaplanner/benchmark/impl/DefaultPlannerBenchmarkTest.java
@@ -45,7 +45,7 @@ public class DefaultPlannerBenchmarkTest {
         ExecutorService executorService = mock(ExecutorService.class);
         BenchmarkReport benchmarkReport = mock(BenchmarkReport.class);
 
-        //solverBenchmarkResultList is empty when instantiated by default constructor
+        // solverBenchmarkResultList is empty when instantiated by default constructor
         PlannerBenchmarkResult benchmarkResult = new PlannerBenchmarkResult();
 
         DefaultPlannerBenchmark benchmark = new DefaultPlannerBenchmark(benchmarkResult, solverConfigContext,

--- a/optaplanner-benchmark/src/test/java/org/optaplanner/benchmark/impl/DefaultPlannerBenchmarkTest.java
+++ b/optaplanner-benchmark/src/test/java/org/optaplanner/benchmark/impl/DefaultPlannerBenchmarkTest.java
@@ -26,7 +26,7 @@ public class DefaultPlannerBenchmarkTest {
     public ExpectedException exceptionRule = ExpectedException.none();
 
     @Test
-    public void throwIllegalStateExceptionWhenBenchmarkingStartedTwice() {
+    public void throwIllegalStateException_WhenBenchmarkingStartedTwice() {
         exceptionRule.expect(IllegalStateException.class);
         exceptionRule.expectMessage("This benchmark has already ran before.");
 
@@ -43,7 +43,7 @@ public class DefaultPlannerBenchmarkTest {
     }
 
     @Test
-    public void throwIllegalArgumentExceptionWhenSolverResultBenchmarkResultListIsEmpty() {
+    public void throwIllegalArgumentException_WhenSolverResultBenchmarkResultListIsEmpty() {
         exceptionRule.expect(IllegalArgumentException.class);
         exceptionRule.expectMessage("The solverBenchmarkResultList");
         exceptionRule.expectMessage("cannot be empty.");
@@ -62,7 +62,7 @@ public class DefaultPlannerBenchmarkTest {
     }
 
     @Test
-    public void throwIllegalArgumentExceptionWhenBenchmarkDirectoryIsNull() {
+    public void throwIllegalArgumentException_WhenBenchmarkDirectoryIsNull() {
         exceptionRule.expect(IllegalArgumentException.class);
         exceptionRule.expectMessage("The benchmarkDirectory");
         exceptionRule.expectMessage("must not be null.");

--- a/optaplanner-benchmark/src/test/java/org/optaplanner/benchmark/impl/DefaultPlannerBenchmarkTest.java
+++ b/optaplanner-benchmark/src/test/java/org/optaplanner/benchmark/impl/DefaultPlannerBenchmarkTest.java
@@ -5,10 +5,9 @@ import java.util.Collections;
 import java.util.concurrent.ExecutorService;
 
 import static org.mockito.Mockito.*;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.optaplanner.benchmark.api.*;
 import org.optaplanner.benchmark.config.PlannerBenchmarkConfig;
 import org.optaplanner.benchmark.impl.report.BenchmarkReport;
@@ -22,14 +21,8 @@ import org.optaplanner.core.impl.testdata.util.PlannerTestUtils;
 
 public class DefaultPlannerBenchmarkTest {
 
-    @Rule
-    public ExpectedException exceptionRule = ExpectedException.none();
-
     @Test
     public void throwIllegalStateException_WhenBenchmarkingStartedTwice() {
-        exceptionRule.expect(IllegalStateException.class);
-        exceptionRule.expectMessage("This benchmark has already ran before.");
-
         SolverConfig solverConfig = PlannerTestUtils.buildSolverConfig(
                 TestdataSolution.class, TestdataEntity.class);
         PlannerBenchmarkFactory benchmarkFactory = PlannerBenchmarkFactory.create(
@@ -39,15 +32,13 @@ public class DefaultPlannerBenchmarkTest {
 
         DefaultPlannerBenchmark benchmark = (DefaultPlannerBenchmark) benchmarkFactory.buildPlannerBenchmark(solution);
         benchmark.benchmarkingStarted();
-        benchmark.benchmarkingStarted();
+
+        assertThatExceptionOfType(IllegalStateException.class)
+                .isThrownBy(benchmark::benchmarkingStarted).withMessage("This benchmark has already ran before.");
     }
 
     @Test
     public void throwIllegalArgumentException_WhenSolverResultBenchmarkResultListIsEmpty() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("The solverBenchmarkResultList");
-        exceptionRule.expectMessage("cannot be empty.");
-
         SolverConfigContext solverConfigContext = mock(SolverConfigContext.class);
         File benchmarkDirectory = mock(File.class);
         ExecutorService executorService = mock(ExecutorService.class);
@@ -58,15 +49,13 @@ public class DefaultPlannerBenchmarkTest {
         DefaultPlannerBenchmark benchmark = new DefaultPlannerBenchmark(benchmarkResultWithEmptySolverResultList,
                                                                         solverConfigContext, benchmarkDirectory,
                                                                         executorService, executorService, benchmarkReport);
-        benchmark.benchmarkingStarted();
+
+        assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(benchmark::benchmarkingStarted)
+                .withMessageStartingWith("The solverBenchmarkResultList").withMessageEndingWith("cannot be empty.");
     }
 
     @Test
     public void throwIllegalArgumentException_WhenBenchmarkDirectoryIsNull() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("The benchmarkDirectory");
-        exceptionRule.expectMessage("must not be null.");
-
         SolverConfigContext solverConfigContext = mock(SolverConfigContext.class);
         ExecutorService executorService = mock(ExecutorService.class);
         BenchmarkReport benchmarkReport = mock(BenchmarkReport.class);
@@ -78,6 +67,7 @@ public class DefaultPlannerBenchmarkTest {
         DefaultPlannerBenchmark benchmark = new DefaultPlannerBenchmark(plannerBenchmarkResult,
                                                                         solverConfigContext, null,
                                                                         executorService, executorService, benchmarkReport);
-        benchmark.benchmarkingStarted();
+        assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(benchmark::benchmarkingStarted)
+                .withMessageStartingWith("The benchmarkDirectory").withMessageEndingWith("must not be null.");
     }
 }

--- a/optaplanner-benchmark/src/test/java/org/optaplanner/benchmark/impl/DefaultPlannerBenchmarkTest.java
+++ b/optaplanner-benchmark/src/test/java/org/optaplanner/benchmark/impl/DefaultPlannerBenchmarkTest.java
@@ -4,13 +4,13 @@ import java.io.File;
 import java.util.Collections;
 import java.util.concurrent.ExecutorService;
 
-import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 import org.junit.Test;
-import org.optaplanner.benchmark.api.*;
+import org.optaplanner.benchmark.api.PlannerBenchmarkException;
+import org.optaplanner.benchmark.api.PlannerBenchmarkFactory;
 import org.optaplanner.benchmark.config.PlannerBenchmarkConfig;
 import org.optaplanner.benchmark.impl.report.BenchmarkReport;
 import org.optaplanner.benchmark.impl.result.PlannerBenchmarkResult;
@@ -24,7 +24,7 @@ import org.optaplanner.core.impl.testdata.util.PlannerTestUtils;
 public class DefaultPlannerBenchmarkTest {
 
     @Test
-    public void throwIllegalStateException_WhenBenchmarkingStartedTwice() {
+    public void benchmarkingStartedTwice() {
         SolverConfig solverConfig = PlannerTestUtils.buildSolverConfig(
                 TestdataSolution.class, TestdataEntity.class);
         PlannerBenchmarkFactory benchmarkFactory = PlannerBenchmarkFactory.create(
@@ -35,61 +35,58 @@ public class DefaultPlannerBenchmarkTest {
         DefaultPlannerBenchmark benchmark = (DefaultPlannerBenchmark) benchmarkFactory.buildPlannerBenchmark(solution);
         benchmark.benchmarkingStarted();
 
-        assertThatExceptionOfType(IllegalStateException.class)
-                .isThrownBy(benchmark::benchmarkingStarted).withMessage("This benchmark has already ran before.");
+        assertThatExceptionOfType(IllegalStateException.class).isThrownBy(benchmark::benchmarkingStarted).withNoCause();
     }
 
     @Test
-    public void throwIllegalArgumentException_WhenSolverResultBenchmarkResultListIsEmpty() {
+    public void solverBenchmarkResultListIsEmpty() {
         SolverConfigContext solverConfigContext = mock(SolverConfigContext.class);
         File benchmarkDirectory = mock(File.class);
         ExecutorService executorService = mock(ExecutorService.class);
         BenchmarkReport benchmarkReport = mock(BenchmarkReport.class);
 
-        PlannerBenchmarkResult benchmarkResultWithEmptySolverResultList = new PlannerBenchmarkResult();
+        //solverBenchmarkResultList is empty when instantiated by default constructor
+        PlannerBenchmarkResult benchmarkResult = new PlannerBenchmarkResult();
 
-        DefaultPlannerBenchmark benchmark = new DefaultPlannerBenchmark(benchmarkResultWithEmptySolverResultList,
-                                                                        solverConfigContext, benchmarkDirectory,
-                                                                        executorService, executorService, benchmarkReport);
+        DefaultPlannerBenchmark benchmark = new DefaultPlannerBenchmark(benchmarkResult, solverConfigContext,
+                                                                        benchmarkDirectory, executorService,
+                                                                        executorService, benchmarkReport);
 
         assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(benchmark::benchmarkingStarted)
-                .withMessageStartingWith("The solverBenchmarkResultList").withMessageEndingWith("cannot be empty.");
+                .withMessageContaining("solverBenchmarkResultList").withMessageContaining("empty");
     }
 
     @Test
-    public void throwIllegalArgumentException_WhenBenchmarkDirectoryIsNull() {
+    public void benchmarkDirectoryIsNull() {
         SolverConfigContext solverConfigContext = mock(SolverConfigContext.class);
         ExecutorService executorService = mock(ExecutorService.class);
         BenchmarkReport benchmarkReport = mock(BenchmarkReport.class);
-        SolverBenchmarkResult benchMarkResult = mock(SolverBenchmarkResult.class);
+        SolverBenchmarkResult benchmarkResult = mock(SolverBenchmarkResult.class);
 
         PlannerBenchmarkResult plannerBenchmarkResult = new PlannerBenchmarkResult();
-        plannerBenchmarkResult.setSolverBenchmarkResultList(Collections.singletonList(benchMarkResult));
+        plannerBenchmarkResult.setSolverBenchmarkResultList(Collections.singletonList(benchmarkResult));
 
         DefaultPlannerBenchmark benchmark = new DefaultPlannerBenchmark(plannerBenchmarkResult,
                                                                         solverConfigContext, null,
                                                                         executorService, executorService, benchmarkReport);
         assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(benchmark::benchmarkingStarted)
-                .withMessageStartingWith("The benchmarkDirectory").withMessageEndingWith("must not be null.");
+                .withMessageContaining("benchmarkDirectory").withMessageContaining("null");
     }
 
     @Test
-    public void propagateExceptionMessage_WhenExceptionThrownDuringWarmUp() {
+    public void exceptionMessagePropagatesWhenThrownDuringWarmUp() {
         SolverConfig solverConfig = PlannerTestUtils.buildSolverConfig(
                 TestdataSolution.class, TestdataEntity.class);
         PlannerBenchmarkFactory benchmarkFactory = PlannerBenchmarkFactory.create(
                 PlannerBenchmarkConfig.createFromSolverConfig(solverConfig));
 
         TestdataSolution solution = mock(TestdataSolution.class);
-        String exceptionMessage = "Message to be received with ExecutionException call.";
-        when(solution.getEntityList()).thenThrow(new UnsupportedOperationException(exceptionMessage));
+
+        UnsupportedOperationException exception = new UnsupportedOperationException();
+        when(solution.getEntityList()).thenThrow(exception);
 
         DefaultPlannerBenchmark benchmark = (DefaultPlannerBenchmark) benchmarkFactory.buildPlannerBenchmark(solution);
 
-        try {
-            benchmark.benchmark();
-        } catch (PlannerBenchmarkException e) {
-            assertEquals(exceptionMessage, e.getCause().getMessage());
-        }
+        assertThatExceptionOfType(PlannerBenchmarkException.class).isThrownBy(benchmark::benchmark).withCause(exception);
     }
 }

--- a/optaplanner-benchmark/src/test/java/org/optaplanner/benchmark/impl/DefaultPlannerBenchmarkTest.java
+++ b/optaplanner-benchmark/src/test/java/org/optaplanner/benchmark/impl/DefaultPlannerBenchmarkTest.java
@@ -1,0 +1,83 @@
+package org.optaplanner.benchmark.impl;
+
+import java.io.File;
+import java.util.Collections;
+import java.util.concurrent.ExecutorService;
+
+import static org.mockito.Mockito.*;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.optaplanner.benchmark.api.*;
+import org.optaplanner.benchmark.config.PlannerBenchmarkConfig;
+import org.optaplanner.benchmark.impl.report.BenchmarkReport;
+import org.optaplanner.benchmark.impl.result.PlannerBenchmarkResult;
+import org.optaplanner.benchmark.impl.result.SolverBenchmarkResult;
+import org.optaplanner.core.config.SolverConfigContext;
+import org.optaplanner.core.config.solver.SolverConfig;
+import org.optaplanner.core.impl.testdata.domain.TestdataEntity;
+import org.optaplanner.core.impl.testdata.domain.TestdataSolution;
+import org.optaplanner.core.impl.testdata.util.PlannerTestUtils;
+
+public class DefaultPlannerBenchmarkTest {
+
+    @Rule
+    public ExpectedException exceptionRule = ExpectedException.none();
+
+    @Test
+    public void throwIllegalStateExceptionWhenBenchmarkingStartedTwice() {
+        exceptionRule.expect(IllegalStateException.class);
+        exceptionRule.expectMessage("This benchmark has already ran before.");
+
+        SolverConfig solverConfig = PlannerTestUtils.buildSolverConfig(
+                TestdataSolution.class, TestdataEntity.class);
+        PlannerBenchmarkFactory benchmarkFactory = PlannerBenchmarkFactory.create(
+                PlannerBenchmarkConfig.createFromSolverConfig(solverConfig));
+
+        TestdataSolution solution = mock(TestdataSolution.class);
+
+        DefaultPlannerBenchmark benchmark = (DefaultPlannerBenchmark) benchmarkFactory.buildPlannerBenchmark(solution);
+        benchmark.benchmarkingStarted();
+        benchmark.benchmarkingStarted();
+    }
+
+    @Test
+    public void throwIllegalArgumentExceptionWhenSolverResultBenchmarkResultListIsEmpty() {
+        exceptionRule.expect(IllegalArgumentException.class);
+        exceptionRule.expectMessage("The solverBenchmarkResultList");
+        exceptionRule.expectMessage("cannot be empty.");
+
+        SolverConfigContext solverConfigContext = mock(SolverConfigContext.class);
+        File benchmarkDirectory = mock(File.class);
+        ExecutorService executorService = mock(ExecutorService.class);
+        BenchmarkReport benchmarkReport = mock(BenchmarkReport.class);
+
+        PlannerBenchmarkResult benchmarkResultWithEmptySolverResultList = new PlannerBenchmarkResult();
+
+        DefaultPlannerBenchmark benchmark = new DefaultPlannerBenchmark(benchmarkResultWithEmptySolverResultList,
+                                                                        solverConfigContext, benchmarkDirectory,
+                                                                        executorService, executorService, benchmarkReport);
+        benchmark.benchmarkingStarted();
+    }
+
+    @Test
+    public void throwIllegalArgumentExceptionWhenBenchmarkDirectoryIsNull() {
+        exceptionRule.expect(IllegalArgumentException.class);
+        exceptionRule.expectMessage("The benchmarkDirectory");
+        exceptionRule.expectMessage("must not be null.");
+
+        SolverConfigContext solverConfigContext = mock(SolverConfigContext.class);
+        ExecutorService executorService = mock(ExecutorService.class);
+        BenchmarkReport benchmarkReport = mock(BenchmarkReport.class);
+        SolverBenchmarkResult benchMarkResult = mock(SolverBenchmarkResult.class);
+
+        PlannerBenchmarkResult plannerBenchmarkResult = new PlannerBenchmarkResult();
+        plannerBenchmarkResult.setSolverBenchmarkResultList(Collections.singletonList(benchMarkResult));
+
+        DefaultPlannerBenchmark benchmark = new DefaultPlannerBenchmark(plannerBenchmarkResult,
+                                                                        solverConfigContext, null,
+                                                                        executorService, executorService, benchmarkReport);
+        benchmark.benchmarkingStarted();
+    }
+}


### PR DESCRIPTION
The tests in bxms-qe-tests in BenchmarkParallelExecutionTest were covered by the example module. In the spirit of increasing test coverage in the part that is touched by the migrating tests, I have found a few untested parts, mainly inheritance in BenchmarkReportConfig and exception message propagation in DefaultPlannerBenchmarkTest.