### PR TITLE
PLANNER-1689 Drools Model JARs no longer optional

### DIFF
--- a/optaplanner-core/pom.xml
+++ b/optaplanner-core/pom.xml
@@ -53,12 +53,10 @@
     <dependency>
       <groupId>org.drools</groupId>
       <artifactId>drools-canonical-model</artifactId>
-      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>org.drools</groupId>
       <artifactId>drools-model-compiler</artifactId>
-      <optional>true</optional>
     </dependency>
     <!-- External dependencies -->
     <!-- Common utils -->


### PR DESCRIPTION
    [lpetrovi@sagan optaplanner]$ diff 7.29.txt 7.30.txt 
    16,21c16,21
    < [INFO] +- org.drools:drools-canonical-model:jar:7.30.0-SNAPSHOT:compile (optional)
    < [INFO] +- org.drools:drools-model-compiler:jar:7.30.0-SNAPSHOT:compile (optional)
    < [INFO] |  +- com.github.javaparser:javaparser-core:jar:3.13.10:compile (optional)
    < [INFO] |  +- org.drools:drools-mvel-parser:jar:7.30.0-SNAPSHOT:compile (optional)
    < [INFO] |  |  \- org.jboss.spec.javax.annotation:jboss-annotations-api_1.2_spec:jar:1.0.0.Final:compile (optional)
    < [INFO] |  \- org.drools:drools-mvel-compiler:jar:7.30.0-SNAPSHOT:compile (optional)
    ---
    > [INFO] +- org.drools:drools-canonical-model:jar:7.30.0-SNAPSHOT:compile
    > [INFO] +- org.drools:drools-model-compiler:jar:7.30.0-SNAPSHOT:compile
    > [INFO] |  +- com.github.javaparser:javaparser-core:jar:3.13.10:compile
    > [INFO] |  +- org.drools:drools-mvel-parser:jar:7.30.0-SNAPSHOT:compile
    > [INFO] |  |  \- org.jboss.spec.javax.annotation:jboss-annotations-api_1.2_spec:jar:1.0.0.Final:compile
    > [INFO] |  \- org.drools:drools-mvel-compiler:jar:7.30.0-SNAPSHOT:compile