### PR TITLE
PLANNER-1716 Reduce scope of the junit-vintage-engine to test

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -103,6 +103,7 @@
     <dependency>
       <groupId>org.junit.vintage</groupId>
       <artifactId>junit-vintage-engine</artifactId>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
junit-vintage-engine currently leaks into e.g. drools-wb as the project depends on kie-server-api, which depends on optaplanner-core. Reducing the dependency scope to test is sufficient and prevents the vintage engine from leaking into other repositories.

The fact that kie-server-api depends on optaplanner-core is an issue on its own; maybe we could move the optaplanner API into a separate module in the future?