### PR TITLE
Deprecate forceUpdateBestSolution

### DIFF
--- a/optaplanner-core/src/main/java/org/optaplanner/core/config/phase/custom/CustomPhaseConfig.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/config/phase/custom/CustomPhaseConfig.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 import com.thoughtworks.xstream.annotations.XStreamConverter;
 import com.thoughtworks.xstream.annotations.XStreamImplicit;
+import org.optaplanner.core.api.solver.Solver;
 import org.optaplanner.core.config.heuristic.policy.HeuristicConfigPolicy;
 import org.optaplanner.core.config.phase.PhaseConfig;
 import org.optaplanner.core.config.solver.EnvironmentMode;
@@ -31,6 +32,7 @@ import org.optaplanner.core.config.util.KeyAsElementMapConverter;
 import org.optaplanner.core.impl.phase.custom.CustomPhase;
 import org.optaplanner.core.impl.phase.custom.CustomPhaseCommand;
 import org.optaplanner.core.impl.phase.custom.DefaultCustomPhase;
+import org.optaplanner.core.impl.solver.ProblemFactChange;
 import org.optaplanner.core.impl.solver.recaller.BestSolutionRecaller;
 import org.optaplanner.core.impl.solver.termination.Termination;
 
@@ -45,6 +47,8 @@ public class CustomPhaseConfig extends PhaseConfig<CustomPhaseConfig> {
 
     @XStreamConverter(KeyAsElementMapConverter.class)
     protected Map<String, String> customProperties = null;
+    /** @deprecated Use {@link Solver#addProblemFactChange(ProblemFactChange)} instead.*/
+    @Deprecated
     protected Boolean forceUpdateBestSolution = null;
 
     // ************************************************************************
@@ -67,10 +71,12 @@ public class CustomPhaseConfig extends PhaseConfig<CustomPhaseConfig> {
         this.customProperties = customProperties;
     }
 
+    @Deprecated
     public Boolean getForceUpdateBestSolution() {
         return forceUpdateBestSolution;
     }
 
+    @Deprecated
     public void setForceUpdateBestSolution(Boolean forceUpdateBestSolution) {
         this.forceUpdateBestSolution = forceUpdateBestSolution;
     }

--- a/optaplanner-docs/src/main/asciidoc/OptimizationAlgorithms/OptimizationAlgorithms-chapter.adoc
+++ b/optaplanner-docs/src/main/asciidoc/OptimizationAlgorithms/OptimizationAlgorithms-chapter.adoc
@@ -778,21 +778,12 @@ Configure multiple `customPhaseCommandClass` instances to run them in sequence.
 ====
 If the changes of a `CustomPhaseCommand` do not result in a better score, the best solution will not be changed
 (so effectively nothing will have changed for the next `Phase` or `CustomPhaseCommand`).
-To force such changes anyway, use `forceUpdateBestSolution`:
-
-[source,xml,options="nowrap"]
-----
-  <customPhase>
-    <customPhaseCommandClass>...MyCustomPhase</customPhaseCommandClass>
-    <forceUpdateBestSolution>true</forceUpdateBestSolution>
-  </customPhase>
-----
 ====
 
 [NOTE]
 ====
 If the `Solver` or a `Phase` wants to terminate while a `CustomPhaseCommand` is still running,
-it will wait to terminate until the `CustomPhaseCommand` is complete.
+it waits to terminate until the `CustomPhaseCommand` is complete.
 This may take a significant amount of time.
 The built-in solver phases do not have this issue.
 ====


### PR DESCRIPTION
Motivation: forceUpdateBestSolution was a hack, introduced before PFC probably, to use in a Santa compo once. I am not aware of anyone else actually using it.
This is not compatible with https://issues.jboss.org/browse/PLANNER-241 which allows for skipping phases if all entities are immovable.
Furthermore, it is fundamentally wrong for phases to worsen the best score.