### PR TITLE
Revert "Remove migrated optaplanner-integration module"

### DIFF
--- a/optaplanner-integration/optaplanner-workbench-models/.gitignore
+++ b/optaplanner-integration/optaplanner-workbench-models/.gitignore
@@ -1,0 +1,10 @@
+/target
+/local
+
+# Eclipse, Netbeans and IntelliJ files
+/.*
+!.gitignore
+/nbproject
+/*.ipr
+/*.iws
+/*.iml

--- a/optaplanner-integration/optaplanner-workbench-models/optaplanner-workbench-models-core/.gitignore
+++ b/optaplanner-integration/optaplanner-workbench-models/optaplanner-workbench-models-core/.gitignore
@@ -1,0 +1,11 @@
+/target
+/local
+
+# Eclipse, Netbeans and IntelliJ files
+/.*
+/**/.*
+!.gitignore
+/nbproject
+/*.ipr
+/*.iws
+/*.iml

--- a/optaplanner-integration/optaplanner-workbench-models/optaplanner-workbench-models-core/pom.xml
+++ b/optaplanner-integration/optaplanner-workbench-models/optaplanner-workbench-models-core/pom.xml
@@ -1,0 +1,118 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.optaplanner</groupId>
+    <artifactId>optaplanner-workbench-models</artifactId>
+    <version>7.32.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>optaplanner-workbench-models-core</artifactId>
+  <packaging>jar</packaging>
+
+  <name>OptaPlanner core GWT wrapper for OptaPlanner Workbench</name>
+  <description>
+    OptaPlanner solves planning problems.
+    This lightweight, embeddable planning engine implements powerful and scalable algorithms
+    to optimize business resource scheduling and planning.
+
+    This module wraps OptaPlanner core classes used by OptaPlanner Workbench.
+  </description>
+
+  <properties>
+    <java.module.name>org.optaplanner.workbench.models.core</java.module.name>
+  </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.jboss.errai.bom</groupId>
+        <artifactId>errai-internal-bom</artifactId>
+        <version>${version.org.jboss.errai}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <dependencies>
+    <!-- Transitive dependencies -->
+    <dependency>
+      <groupId>org.jboss.errai</groupId>
+      <artifactId>errai-codegen</artifactId>
+    </dependency>
+    <!-- Regular dependencies -->
+    <dependency>
+      <groupId>org.optaplanner</groupId>
+      <artifactId>optaplanner-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.errai</groupId>
+      <artifactId>errai-marshalling</artifactId>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>unpack</id>
+            <phase>generate-resources</phase>
+            <goals>
+              <goal>unpack-dependencies</goal>
+            </goals>
+            <configuration>
+              <includeGroupIds>org.optaplanner</includeGroupIds>
+              <includeArtifactIds>optaplanner-core</includeArtifactIds>
+              <classifier>sources</classifier>
+              <outputDirectory>${project.build.directory}/core-dependencies</outputDirectory>
+              <overWriteReleases>true</overWriteReleases>
+              <overWriteSnapshots>true</overWriteSnapshots>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+
+    <!--Include classes and resources reused by client-side of the workbench -->
+    <resources>
+      <resource>
+        <directory>${project.build.directory}/core-dependencies</directory>
+        <includes>
+          <include>org/optaplanner/core/api/score/AbstractScore.java</include>
+          <include>org/optaplanner/core/api/score/AbstractBendableScore.java</include>
+          <include>org/optaplanner/core/api/score/FeasibilityScore.java</include>
+          <include>org/optaplanner/core/api/score/Score.java</include>
+          <include>org/optaplanner/core/api/score/buildin/bendable/BendableScore.java</include>
+          <include>org/optaplanner/core/api/score/buildin/bendablebigdecimal/BendableBigDecimalScore.java</include>
+          <include>org/optaplanner/core/api/score/buildin/bendablelong/BendableLongScore.java</include>
+          <include>org/optaplanner/core/api/score/buildin/hardmediumsoft/HardMediumSoftScore.java</include>
+          <include>org/optaplanner/core/api/score/buildin/hardmediumsoftbigdecimal/HardMediumSoftBigDecimalScore.java</include>
+          <include>org/optaplanner/core/api/score/buildin/hardmediumsoftlong/HardMediumSoftLongScore.java</include>
+          <include>org/optaplanner/core/api/score/buildin/hardsoft/HardSoftScore.java</include>
+          <include>org/optaplanner/core/api/score/buildin/hardsoftbigdecimal/HardSoftBigDecimalScore.java</include>
+          <include>org/optaplanner/core/api/score/buildin/hardsoftdouble/HardSoftDoubleScore.java</include>
+          <include>org/optaplanner/core/api/score/buildin/hardsoftlong/HardSoftLongScore.java</include>
+          <include>org/optaplanner/core/api/score/buildin/simple/SimpleScore.java</include>
+          <include>org/optaplanner/core/api/score/buildin/simplebigdecimal/SimpleBigDecimalScore.java</include>
+          <include>org/optaplanner/core/api/score/buildin/simpledouble/SimpleDoubleScore.java</include>
+          <include>org/optaplanner/core/api/score/buildin/simplelong/SimpleLongScore.java</include>
+          <include>org/optaplanner/core/config/constructionheuristic/ConstructionHeuristicType.java</include>
+          <include>org/optaplanner/core/config/heuristic/selector/entity/EntitySorterManner.java</include>
+          <include>org/optaplanner/core/config/heuristic/selector/value/ValueSorterManner.java</include>
+          <include>org/optaplanner/core/config/localsearch/LocalSearchType.java</include>
+        </includes>
+      </resource>
+      <resource>
+        <directory>src/main/resources</directory>
+      </resource>
+    </resources>
+  </build>
+
+</project>

--- a/optaplanner-integration/optaplanner-workbench-models/optaplanner-workbench-models-core/src/main/java/org/optaplanner/workbench/models/core/marshalling/BendableBigDecimalScoreMapper.java
+++ b/optaplanner-integration/optaplanner-workbench-models/optaplanner-workbench-models-core/src/main/java/org/optaplanner/workbench/models/core/marshalling/BendableBigDecimalScoreMapper.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.workbench.models.core.marshalling;
+
+import java.math.BigDecimal;
+
+import org.jboss.errai.codegen.meta.impl.java.JavaReflectionMethod;
+import org.jboss.errai.marshalling.rebind.api.CustomMapping;
+import org.jboss.errai.marshalling.rebind.api.model.MappingDefinition;
+import org.jboss.errai.marshalling.rebind.api.model.impl.ReadMapping;
+import org.jboss.errai.marshalling.rebind.api.model.impl.SimpleFactoryMapping;
+import org.optaplanner.core.api.score.buildin.bendablebigdecimal.BendableBigDecimalScore;
+
+@CustomMapping(BendableBigDecimalScore.class)
+public class BendableBigDecimalScoreMapper extends MappingDefinition {
+
+    public BendableBigDecimalScoreMapper() throws NoSuchMethodException {
+        super(BendableBigDecimalScore.class);
+
+        SimpleFactoryMapping factoryMapping = new SimpleFactoryMapping();
+        factoryMapping.setMethod(new JavaReflectionMethod(BendableBigDecimalScore.class.getMethod("valueOfUninitialized",
+                                                                                                  int.class,
+                                                                                                  BigDecimal[].class,
+                                                                                                  BigDecimal[].class)));
+        factoryMapping.mapParmToIndex("initScore",
+                                      0,
+                                      int.class);
+        factoryMapping.mapParmToIndex("hardScores",
+                                      1,
+                                      BigDecimal[].class);
+        factoryMapping.mapParmToIndex("softScores",
+                                      2,
+                                      BigDecimal[].class);
+
+        setInstantiationMapping(factoryMapping);
+
+        addMemberMapping(new ReadMapping("initScore",
+                                         int.class,
+                                         "getInitScore"));
+        addMemberMapping(new ReadMapping("hardScores",
+                                         BigDecimal[].class,
+                                         "getHardScores"));
+        addMemberMapping(new ReadMapping("softScores",
+                                         BigDecimal[].class,
+                                         "getSoftScores"));
+    }
+}

--- a/optaplanner-integration/optaplanner-workbench-models/optaplanner-workbench-models-core/src/main/java/org/optaplanner/workbench/models/core/marshalling/BendableLongScoreMapper.java
+++ b/optaplanner-integration/optaplanner-workbench-models/optaplanner-workbench-models-core/src/main/java/org/optaplanner/workbench/models/core/marshalling/BendableLongScoreMapper.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.workbench.models.core.marshalling;
+
+import org.jboss.errai.codegen.meta.impl.java.JavaReflectionMethod;
+import org.jboss.errai.marshalling.rebind.api.CustomMapping;
+import org.jboss.errai.marshalling.rebind.api.model.MappingDefinition;
+import org.jboss.errai.marshalling.rebind.api.model.impl.ReadMapping;
+import org.jboss.errai.marshalling.rebind.api.model.impl.SimpleFactoryMapping;
+import org.optaplanner.core.api.score.buildin.bendablelong.BendableLongScore;
+
+@CustomMapping(BendableLongScore.class)
+public class BendableLongScoreMapper extends MappingDefinition {
+
+    public BendableLongScoreMapper() throws NoSuchMethodException {
+        super(BendableLongScore.class);
+
+        SimpleFactoryMapping factoryMapping = new SimpleFactoryMapping();
+        factoryMapping.setMethod(new JavaReflectionMethod(BendableLongScore.class.getMethod("valueOfUninitialized",
+                                                                                            int.class,
+                                                                                            long[].class,
+                                                                                            long[].class)));
+        factoryMapping.mapParmToIndex("initScore",
+                                      0,
+                                      int.class);
+        factoryMapping.mapParmToIndex("hardScores",
+                                      1,
+                                      long[].class);
+        factoryMapping.mapParmToIndex("softScores",
+                                      2,
+                                      long[].class);
+
+        setInstantiationMapping(factoryMapping);
+
+        addMemberMapping(new ReadMapping("initScore",
+                                         int.class,
+                                         "getInitScore"));
+        addMemberMapping(new ReadMapping("hardScores",
+                                         long[].class,
+                                         "getHardScores"));
+        addMemberMapping(new ReadMapping("softScores",
+                                         long[].class,
+                                         "getSoftScores"));
+    }
+}

--- a/optaplanner-integration/optaplanner-workbench-models/optaplanner-workbench-models-core/src/main/java/org/optaplanner/workbench/models/core/marshalling/BendableScoreMapper.java
+++ b/optaplanner-integration/optaplanner-workbench-models/optaplanner-workbench-models-core/src/main/java/org/optaplanner/workbench/models/core/marshalling/BendableScoreMapper.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.workbench.models.core.marshalling;
+
+import org.jboss.errai.codegen.meta.impl.java.JavaReflectionMethod;
+import org.jboss.errai.marshalling.rebind.api.CustomMapping;
+import org.jboss.errai.marshalling.rebind.api.model.MappingDefinition;
+import org.jboss.errai.marshalling.rebind.api.model.impl.ReadMapping;
+import org.jboss.errai.marshalling.rebind.api.model.impl.SimpleFactoryMapping;
+import org.optaplanner.core.api.score.buildin.bendable.BendableScore;
+
+@CustomMapping(BendableScore.class)
+public class BendableScoreMapper extends MappingDefinition {
+
+    public BendableScoreMapper() throws NoSuchMethodException {
+        super(BendableScore.class);
+
+        SimpleFactoryMapping factoryMapping = new SimpleFactoryMapping();
+        factoryMapping.setMethod(new JavaReflectionMethod(BendableScore.class.getMethod("valueOfUninitialized",
+                                                                                        int.class,
+                                                                                        int[].class,
+                                                                                        int[].class)));
+        factoryMapping.mapParmToIndex("initScore",
+                                      0,
+                                      int.class);
+        factoryMapping.mapParmToIndex("hardScores",
+                                      1,
+                                      int[].class);
+        factoryMapping.mapParmToIndex("softScores",
+                                      2,
+                                      int[].class);
+
+        setInstantiationMapping(factoryMapping);
+
+        addMemberMapping(new ReadMapping("initScore",
+                                         int.class,
+                                         "getInitScore"));
+        addMemberMapping(new ReadMapping("hardScores",
+                                         int[].class,
+                                         "getHardScores"));
+        addMemberMapping(new ReadMapping("softScores",
+                                         int[].class,
+                                         "getSoftScores"));
+    }
+}

--- a/optaplanner-integration/optaplanner-workbench-models/optaplanner-workbench-models-core/src/main/java/org/optaplanner/workbench/models/core/marshalling/HardMediumSoftBigDecimalScoreMapper.java
+++ b/optaplanner-integration/optaplanner-workbench-models/optaplanner-workbench-models-core/src/main/java/org/optaplanner/workbench/models/core/marshalling/HardMediumSoftBigDecimalScoreMapper.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2017 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.workbench.models.core.marshalling;
+
+import java.math.BigDecimal;
+
+import org.jboss.errai.codegen.meta.impl.java.JavaReflectionMethod;
+import org.jboss.errai.marshalling.rebind.api.CustomMapping;
+import org.jboss.errai.marshalling.rebind.api.model.MappingDefinition;
+import org.jboss.errai.marshalling.rebind.api.model.impl.ReadMapping;
+import org.jboss.errai.marshalling.rebind.api.model.impl.SimpleFactoryMapping;
+import org.optaplanner.core.api.score.buildin.hardmediumsoftbigdecimal.HardMediumSoftBigDecimalScore;
+
+@CustomMapping(HardMediumSoftBigDecimalScore.class)
+public class HardMediumSoftBigDecimalScoreMapper extends MappingDefinition {
+
+    public HardMediumSoftBigDecimalScoreMapper() throws NoSuchMethodException {
+        super(HardMediumSoftBigDecimalScore.class);
+
+        SimpleFactoryMapping factoryMapping = new SimpleFactoryMapping();
+        factoryMapping.setMethod(new JavaReflectionMethod(HardMediumSoftBigDecimalScore.class.getMethod("valueOfUninitialized",
+                                                                                                        int.class,
+                                                                                                        BigDecimal.class,
+                                                                                                        BigDecimal.class,
+                                                                                                        BigDecimal.class)));
+        factoryMapping.mapParmToIndex("initScore",
+                                      0,
+                                      int.class);
+        factoryMapping.mapParmToIndex("hardScore",
+                                      1,
+                                      BigDecimal.class);
+        factoryMapping.mapParmToIndex("mediumScore",
+                                      2,
+                                      BigDecimal.class);
+        factoryMapping.mapParmToIndex("softScore",
+                                      3,
+                                      BigDecimal.class);
+
+        setInstantiationMapping(factoryMapping);
+
+        addMemberMapping(new ReadMapping("initScore",
+                                         int.class,
+                                         "getInitScore"));
+        addMemberMapping(new ReadMapping("hardScore",
+                                         BigDecimal.class,
+                                         "getHardScore"));
+        addMemberMapping(new ReadMapping("mediumScore",
+                                         BigDecimal.class,
+                                         "getMediumScore"));
+        addMemberMapping(new ReadMapping("softScore",
+                                         BigDecimal.class,
+                                         "getSoftScore"));
+    }
+}

--- a/optaplanner-integration/optaplanner-workbench-models/optaplanner-workbench-models-core/src/main/java/org/optaplanner/workbench/models/core/marshalling/HardMediumSoftLongScoreMapper.java
+++ b/optaplanner-integration/optaplanner-workbench-models/optaplanner-workbench-models-core/src/main/java/org/optaplanner/workbench/models/core/marshalling/HardMediumSoftLongScoreMapper.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.workbench.models.core.marshalling;
+
+import org.jboss.errai.codegen.meta.impl.java.JavaReflectionMethod;
+import org.jboss.errai.marshalling.rebind.api.CustomMapping;
+import org.jboss.errai.marshalling.rebind.api.model.MappingDefinition;
+import org.jboss.errai.marshalling.rebind.api.model.impl.ReadMapping;
+import org.jboss.errai.marshalling.rebind.api.model.impl.SimpleFactoryMapping;
+import org.optaplanner.core.api.score.buildin.hardmediumsoftlong.HardMediumSoftLongScore;
+
+@CustomMapping(HardMediumSoftLongScore.class)
+public class HardMediumSoftLongScoreMapper extends MappingDefinition {
+
+    public HardMediumSoftLongScoreMapper() throws NoSuchMethodException {
+        super(HardMediumSoftLongScore.class);
+
+        SimpleFactoryMapping factoryMapping = new SimpleFactoryMapping();
+        factoryMapping.setMethod(new JavaReflectionMethod(HardMediumSoftLongScore.class.getMethod("valueOfUninitialized",
+                                                                                                  int.class,
+                                                                                                  long.class,
+                                                                                                  long.class,
+                                                                                                  long.class)));
+        factoryMapping.mapParmToIndex("initScore",
+                                      0,
+                                      int.class);
+        factoryMapping.mapParmToIndex("hardScore",
+                                      1,
+                                      long.class);
+        factoryMapping.mapParmToIndex("mediumScore",
+                                      2,
+                                      long.class);
+        factoryMapping.mapParmToIndex("softScore",
+                                      3,
+                                      long.class);
+
+        setInstantiationMapping(factoryMapping);
+
+        addMemberMapping(new ReadMapping("initScore",
+                                         int.class,
+                                         "getInitScore"));
+        addMemberMapping(new ReadMapping("hardScore",
+                                         long.class,
+                                         "getHardScore"));
+        addMemberMapping(new ReadMapping("mediumScore",
+                                         long.class,
+                                         "getMediumScore"));
+        addMemberMapping(new ReadMapping("softScore",
+                                         long.class,
+                                         "getSoftScore"));
+    }
+}

--- a/optaplanner-integration/optaplanner-workbench-models/optaplanner-workbench-models-core/src/main/java/org/optaplanner/workbench/models/core/marshalling/HardMediumSoftScoreMapper.java
+++ b/optaplanner-integration/optaplanner-workbench-models/optaplanner-workbench-models-core/src/main/java/org/optaplanner/workbench/models/core/marshalling/HardMediumSoftScoreMapper.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.workbench.models.core.marshalling;
+
+import org.jboss.errai.codegen.meta.impl.java.JavaReflectionMethod;
+import org.jboss.errai.marshalling.rebind.api.CustomMapping;
+import org.jboss.errai.marshalling.rebind.api.model.MappingDefinition;
+import org.jboss.errai.marshalling.rebind.api.model.impl.ReadMapping;
+import org.jboss.errai.marshalling.rebind.api.model.impl.SimpleFactoryMapping;
+import org.optaplanner.core.api.score.buildin.hardmediumsoft.HardMediumSoftScore;
+
+@CustomMapping(HardMediumSoftScore.class)
+public class HardMediumSoftScoreMapper extends MappingDefinition {
+
+    public HardMediumSoftScoreMapper() throws NoSuchMethodException {
+        super(HardMediumSoftScore.class);
+
+        SimpleFactoryMapping factoryMapping = new SimpleFactoryMapping();
+        factoryMapping.setMethod(new JavaReflectionMethod(HardMediumSoftScore.class.getMethod("valueOfUninitialized",
+                                                                                              int.class,
+                                                                                              int.class,
+                                                                                              int.class,
+                                                                                              int.class)));
+        factoryMapping.mapParmToIndex("initScore",
+                                      0,
+                                      int.class);
+        factoryMapping.mapParmToIndex("hardScore",
+                                      1,
+                                      int.class);
+        factoryMapping.mapParmToIndex("mediumScore",
+                                      2,
+                                      int.class);
+        factoryMapping.mapParmToIndex("softScore",
+                                      3,
+                                      int.class);
+
+        setInstantiationMapping(factoryMapping);
+
+        addMemberMapping(new ReadMapping("initScore",
+                                         int.class,
+                                         "getInitScore"));
+        addMemberMapping(new ReadMapping("hardScore",
+                                         int.class,
+                                         "getHardScore"));
+        addMemberMapping(new ReadMapping("mediumScore",
+                                         int.class,
+                                         "getMediumScore"));
+        addMemberMapping(new ReadMapping("softScore",
+                                         int.class,
+                                         "getSoftScore"));
+    }
+}

--- a/optaplanner-integration/optaplanner-workbench-models/optaplanner-workbench-models-core/src/main/java/org/optaplanner/workbench/models/core/marshalling/HardSoftBigDecimalScoreMapper.java
+++ b/optaplanner-integration/optaplanner-workbench-models/optaplanner-workbench-models-core/src/main/java/org/optaplanner/workbench/models/core/marshalling/HardSoftBigDecimalScoreMapper.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.workbench.models.core.marshalling;
+
+import java.math.BigDecimal;
+
+import org.jboss.errai.codegen.meta.impl.java.JavaReflectionMethod;
+import org.jboss.errai.marshalling.rebind.api.CustomMapping;
+import org.jboss.errai.marshalling.rebind.api.model.MappingDefinition;
+import org.jboss.errai.marshalling.rebind.api.model.impl.ReadMapping;
+import org.jboss.errai.marshalling.rebind.api.model.impl.SimpleFactoryMapping;
+import org.optaplanner.core.api.score.buildin.hardsoftbigdecimal.HardSoftBigDecimalScore;
+
+@CustomMapping(HardSoftBigDecimalScore.class)
+public class HardSoftBigDecimalScoreMapper extends MappingDefinition {
+
+    public HardSoftBigDecimalScoreMapper() throws NoSuchMethodException {
+        super(HardSoftBigDecimalScore.class);
+
+        SimpleFactoryMapping factoryMapping = new SimpleFactoryMapping();
+        factoryMapping.setMethod(new JavaReflectionMethod(HardSoftBigDecimalScore.class.getMethod("valueOfUninitialized",
+                                                                                                  int.class,
+                                                                                                  BigDecimal.class,
+                                                                                                  BigDecimal.class)));
+        factoryMapping.mapParmToIndex("initScore",
+                                      0,
+                                      int.class);
+        factoryMapping.mapParmToIndex("hardScore",
+                                      1,
+                                      BigDecimal.class);
+        factoryMapping.mapParmToIndex("softScore",
+                                      2,
+                                      BigDecimal.class);
+
+        setInstantiationMapping(factoryMapping);
+
+        addMemberMapping(new ReadMapping("initScore",
+                                         int.class,
+                                         "getInitScore"));
+        addMemberMapping(new ReadMapping("hardScore",
+                                         BigDecimal.class,
+                                         "getHardScore"));
+        addMemberMapping(new ReadMapping("softScore",
+                                         BigDecimal.class,
+                                         "getSoftScore"));
+    }
+}

--- a/optaplanner-integration/optaplanner-workbench-models/optaplanner-workbench-models-core/src/main/java/org/optaplanner/workbench/models/core/marshalling/HardSoftDoubleScoreMapper.java
+++ b/optaplanner-integration/optaplanner-workbench-models/optaplanner-workbench-models-core/src/main/java/org/optaplanner/workbench/models/core/marshalling/HardSoftDoubleScoreMapper.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.workbench.models.core.marshalling;
+
+import org.jboss.errai.codegen.meta.impl.java.JavaReflectionMethod;
+import org.jboss.errai.marshalling.rebind.api.CustomMapping;
+import org.jboss.errai.marshalling.rebind.api.model.MappingDefinition;
+import org.jboss.errai.marshalling.rebind.api.model.impl.ReadMapping;
+import org.jboss.errai.marshalling.rebind.api.model.impl.SimpleFactoryMapping;
+import org.optaplanner.core.api.score.buildin.hardsoftdouble.HardSoftDoubleScore;
+
+@CustomMapping(HardSoftDoubleScore.class)
+public class HardSoftDoubleScoreMapper extends MappingDefinition {
+
+    public HardSoftDoubleScoreMapper() throws NoSuchMethodException {
+        super(HardSoftDoubleScore.class);
+
+        SimpleFactoryMapping factoryMapping = new SimpleFactoryMapping();
+        factoryMapping.setMethod(new JavaReflectionMethod(HardSoftDoubleScore.class.getMethod("valueOfUninitialized",
+                                                                                              int.class,
+                                                                                              double.class,
+                                                                                              double.class)));
+        factoryMapping.mapParmToIndex("initScore",
+                                      0,
+                                      int.class);
+        factoryMapping.mapParmToIndex("hardScore",
+                                      1,
+                                      double.class);
+        factoryMapping.mapParmToIndex("softScore",
+                                      2,
+                                      double.class);
+
+        setInstantiationMapping(factoryMapping);
+
+        addMemberMapping(new ReadMapping("initScore",
+                                         int.class,
+                                         "getInitScore"));
+        addMemberMapping(new ReadMapping("hardScore",
+                                         double.class,
+                                         "getHardScore"));
+        addMemberMapping(new ReadMapping("softScore",
+                                         double.class,
+                                         "getSoftScore"));
+    }
+}

--- a/optaplanner-integration/optaplanner-workbench-models/optaplanner-workbench-models-core/src/main/java/org/optaplanner/workbench/models/core/marshalling/HardSoftLongScoreMapper.java
+++ b/optaplanner-integration/optaplanner-workbench-models/optaplanner-workbench-models-core/src/main/java/org/optaplanner/workbench/models/core/marshalling/HardSoftLongScoreMapper.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.workbench.models.core.marshalling;
+
+import org.jboss.errai.codegen.meta.impl.java.JavaReflectionMethod;
+import org.jboss.errai.marshalling.rebind.api.CustomMapping;
+import org.jboss.errai.marshalling.rebind.api.model.MappingDefinition;
+import org.jboss.errai.marshalling.rebind.api.model.impl.ReadMapping;
+import org.jboss.errai.marshalling.rebind.api.model.impl.SimpleFactoryMapping;
+import org.optaplanner.core.api.score.buildin.hardsoftlong.HardSoftLongScore;
+
+@CustomMapping(HardSoftLongScore.class)
+public class HardSoftLongScoreMapper extends MappingDefinition {
+
+    public HardSoftLongScoreMapper() throws NoSuchMethodException {
+        super(HardSoftLongScore.class);
+
+        SimpleFactoryMapping factoryMapping = new SimpleFactoryMapping();
+        factoryMapping.setMethod(new JavaReflectionMethod(HardSoftLongScore.class.getMethod("valueOfUninitialized",
+                                                                                            int.class,
+                                                                                            long.class,
+                                                                                            long.class)));
+        factoryMapping.mapParmToIndex("initScore",
+                                      0,
+                                      int.class);
+        factoryMapping.mapParmToIndex("hardScore",
+                                      1,
+                                      long.class);
+        factoryMapping.mapParmToIndex("softScore",
+                                      2,
+                                      long.class);
+
+        setInstantiationMapping(factoryMapping);
+
+        addMemberMapping(new ReadMapping("initScore",
+                                         int.class,
+                                         "getInitScore"));
+        addMemberMapping(new ReadMapping("hardScore",
+                                         long.class,
+                                         "getHardScore"));
+        addMemberMapping(new ReadMapping("softScore",
+                                         long.class,
+                                         "getSoftScore"));
+    }
+}

--- a/optaplanner-integration/optaplanner-workbench-models/optaplanner-workbench-models-core/src/main/java/org/optaplanner/workbench/models/core/marshalling/HardSoftScoreMapper.java
+++ b/optaplanner-integration/optaplanner-workbench-models/optaplanner-workbench-models-core/src/main/java/org/optaplanner/workbench/models/core/marshalling/HardSoftScoreMapper.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.workbench.models.core.marshalling;
+
+import org.jboss.errai.codegen.meta.impl.java.JavaReflectionMethod;
+import org.jboss.errai.marshalling.rebind.api.CustomMapping;
+import org.jboss.errai.marshalling.rebind.api.model.MappingDefinition;
+import org.jboss.errai.marshalling.rebind.api.model.impl.ReadMapping;
+import org.jboss.errai.marshalling.rebind.api.model.impl.SimpleFactoryMapping;
+import org.optaplanner.core.api.score.buildin.hardsoft.HardSoftScore;
+
+@CustomMapping(HardSoftScore.class)
+public class HardSoftScoreMapper extends MappingDefinition {
+
+    public HardSoftScoreMapper() throws NoSuchMethodException {
+        super(HardSoftScore.class);
+
+        SimpleFactoryMapping factoryMapping = new SimpleFactoryMapping();
+        factoryMapping.setMethod(new JavaReflectionMethod(HardSoftScore.class.getMethod("valueOfUninitialized",
+                                                                                        int.class,
+                                                                                        int.class,
+                                                                                        int.class)));
+        factoryMapping.mapParmToIndex("initScore",
+                                      0,
+                                      int.class);
+        factoryMapping.mapParmToIndex("hardScore",
+                                      1,
+                                      int.class);
+        factoryMapping.mapParmToIndex("softScore",
+                                      2,
+                                      int.class);
+
+        setInstantiationMapping(factoryMapping);
+
+        addMemberMapping(new ReadMapping("initScore",
+                                         int.class,
+                                         "getInitScore"));
+        addMemberMapping(new ReadMapping("hardScore",
+                                         int.class,
+                                         "getHardScore"));
+        addMemberMapping(new ReadMapping("softScore",
+                                         int.class,
+                                         "getSoftScore"));
+    }
+}

--- a/optaplanner-integration/optaplanner-workbench-models/optaplanner-workbench-models-core/src/main/java/org/optaplanner/workbench/models/core/marshalling/SimpleBigDecimalScoreMapper.java
+++ b/optaplanner-integration/optaplanner-workbench-models/optaplanner-workbench-models-core/src/main/java/org/optaplanner/workbench/models/core/marshalling/SimpleBigDecimalScoreMapper.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.workbench.models.core.marshalling;
+
+import java.math.BigDecimal;
+
+import org.jboss.errai.codegen.meta.impl.java.JavaReflectionMethod;
+import org.jboss.errai.marshalling.rebind.api.CustomMapping;
+import org.jboss.errai.marshalling.rebind.api.model.MappingDefinition;
+import org.jboss.errai.marshalling.rebind.api.model.impl.ReadMapping;
+import org.jboss.errai.marshalling.rebind.api.model.impl.SimpleFactoryMapping;
+import org.optaplanner.core.api.score.buildin.simplebigdecimal.SimpleBigDecimalScore;
+
+@CustomMapping(SimpleBigDecimalScore.class)
+public class SimpleBigDecimalScoreMapper extends MappingDefinition {
+
+    public SimpleBigDecimalScoreMapper() throws NoSuchMethodException {
+        super(SimpleBigDecimalScore.class);
+
+        SimpleFactoryMapping factoryMapping = new SimpleFactoryMapping();
+        factoryMapping.setMethod(new JavaReflectionMethod(SimpleBigDecimalScore.class.getMethod("valueOfUninitialized",
+                                                                                                int.class,
+                                                                                                BigDecimal.class)));
+        factoryMapping.mapParmToIndex("initScore",
+                                      0,
+                                      int.class);
+        factoryMapping.mapParmToIndex("score",
+                                      1,
+                                      BigDecimal.class);
+
+        setInstantiationMapping(factoryMapping);
+
+        addMemberMapping(new ReadMapping("initScore",
+                                         int.class,
+                                         "getInitScore"));
+        addMemberMapping(new ReadMapping("score",
+                                         BigDecimal.class,
+                                         "getScore"));
+    }
+}

--- a/optaplanner-integration/optaplanner-workbench-models/optaplanner-workbench-models-core/src/main/java/org/optaplanner/workbench/models/core/marshalling/SimpleDoubleScoreMapper.java
+++ b/optaplanner-integration/optaplanner-workbench-models/optaplanner-workbench-models-core/src/main/java/org/optaplanner/workbench/models/core/marshalling/SimpleDoubleScoreMapper.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.workbench.models.core.marshalling;
+
+import org.jboss.errai.codegen.meta.impl.java.JavaReflectionMethod;
+import org.jboss.errai.marshalling.rebind.api.CustomMapping;
+import org.jboss.errai.marshalling.rebind.api.model.MappingDefinition;
+import org.jboss.errai.marshalling.rebind.api.model.impl.ReadMapping;
+import org.jboss.errai.marshalling.rebind.api.model.impl.SimpleFactoryMapping;
+import org.optaplanner.core.api.score.buildin.simpledouble.SimpleDoubleScore;
+
+@CustomMapping(SimpleDoubleScore.class)
+public class SimpleDoubleScoreMapper extends MappingDefinition {
+
+    public SimpleDoubleScoreMapper() throws NoSuchMethodException {
+        super(SimpleDoubleScore.class);
+
+        SimpleFactoryMapping factoryMapping = new SimpleFactoryMapping();
+        factoryMapping.setMethod(new JavaReflectionMethod(SimpleDoubleScore.class.getMethod("valueOfUninitialized",
+                                                                                            int.class,
+                                                                                            double.class)));
+        factoryMapping.mapParmToIndex("initScore",
+                                      0,
+                                      int.class);
+        factoryMapping.mapParmToIndex("score",
+                                      1,
+                                      double.class);
+
+        setInstantiationMapping(factoryMapping);
+
+        addMemberMapping(new ReadMapping("initScore",
+                                         int.class,
+                                         "getInitScore"));
+        addMemberMapping(new ReadMapping("score",
+                                         double.class,
+                                         "getScore"));
+    }
+}

--- a/optaplanner-integration/optaplanner-workbench-models/optaplanner-workbench-models-core/src/main/java/org/optaplanner/workbench/models/core/marshalling/SimpleLongScoreMapper.java
+++ b/optaplanner-integration/optaplanner-workbench-models/optaplanner-workbench-models-core/src/main/java/org/optaplanner/workbench/models/core/marshalling/SimpleLongScoreMapper.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.workbench.models.core.marshalling;
+
+import org.jboss.errai.codegen.meta.impl.java.JavaReflectionMethod;
+import org.jboss.errai.marshalling.rebind.api.CustomMapping;
+import org.jboss.errai.marshalling.rebind.api.model.MappingDefinition;
+import org.jboss.errai.marshalling.rebind.api.model.impl.ReadMapping;
+import org.jboss.errai.marshalling.rebind.api.model.impl.SimpleFactoryMapping;
+import org.optaplanner.core.api.score.buildin.simplelong.SimpleLongScore;
+
+@CustomMapping(SimpleLongScore.class)
+public class SimpleLongScoreMapper extends MappingDefinition {
+
+    public SimpleLongScoreMapper() throws NoSuchMethodException {
+        super(SimpleLongScore.class);
+
+        SimpleFactoryMapping factoryMapping = new SimpleFactoryMapping();
+        factoryMapping.setMethod(new JavaReflectionMethod(SimpleLongScore.class.getMethod("valueOfUninitialized",
+                                                                                          int.class,
+                                                                                          long.class)));
+        factoryMapping.mapParmToIndex("initScore",
+                                      0,
+                                      int.class);
+        factoryMapping.mapParmToIndex("score",
+                                      1,
+                                      long.class);
+
+        setInstantiationMapping(factoryMapping);
+
+        addMemberMapping(new ReadMapping("initScore",
+                                         int.class,
+                                         "getInitScore"));
+        addMemberMapping(new ReadMapping("score",
+                                         long.class,
+                                         "getScore"));
+    }
+}

--- a/optaplanner-integration/optaplanner-workbench-models/optaplanner-workbench-models-core/src/main/java/org/optaplanner/workbench/models/core/marshalling/SimpleScoreMapper.java
+++ b/optaplanner-integration/optaplanner-workbench-models/optaplanner-workbench-models-core/src/main/java/org/optaplanner/workbench/models/core/marshalling/SimpleScoreMapper.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.workbench.models.core.marshalling;
+
+import org.jboss.errai.codegen.meta.impl.java.JavaReflectionMethod;
+import org.jboss.errai.marshalling.rebind.api.CustomMapping;
+import org.jboss.errai.marshalling.rebind.api.model.MappingDefinition;
+import org.jboss.errai.marshalling.rebind.api.model.impl.ReadMapping;
+import org.jboss.errai.marshalling.rebind.api.model.impl.SimpleFactoryMapping;
+import org.optaplanner.core.api.score.buildin.simple.SimpleScore;
+
+@CustomMapping(SimpleScore.class)
+public class SimpleScoreMapper extends MappingDefinition {
+
+    public SimpleScoreMapper() throws NoSuchMethodException {
+        super(SimpleScore.class);
+
+        SimpleFactoryMapping factoryMapping = new SimpleFactoryMapping();
+        factoryMapping.setMethod(new JavaReflectionMethod(SimpleScore.class.getMethod("valueOfUninitialized",
+                                                                                      int.class,
+                                                                                      int.class)));
+        factoryMapping.mapParmToIndex("initScore",
+                                      0,
+                                      int.class);
+        factoryMapping.mapParmToIndex("score",
+                                      1,
+                                      int.class);
+
+        setInstantiationMapping(factoryMapping);
+
+        addMemberMapping(new ReadMapping("initScore",
+                                         int.class,
+                                         "getInitScore"));
+        addMemberMapping(new ReadMapping("score",
+                                         int.class,
+                                         "getScore"));
+    }
+}

--- a/optaplanner-integration/optaplanner-workbench-models/optaplanner-workbench-models-core/src/main/resources/META-INF/ErraiApp.properties
+++ b/optaplanner-integration/optaplanner-workbench-models/optaplanner-workbench-models-core/src/main/resources/META-INF/ErraiApp.properties
@@ -1,0 +1,50 @@
+#
+# Copyright 2016 Red Hat, Inc. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# ErraiApp.properties
+#
+# Do not remove, even if empty!
+#
+
+# This is a marker file. When it is detected inside a JAR or at the
+# top of any classpath, the subdirectories are scanned for deployable
+# components. As such, all Errai application modules in a project
+# should contain an ErraiApp.properties at the root of all classpaths
+# that you wish to be scanned.
+#
+# There are also some configuration options that can be set in this
+# file, although it is rarely necessary. See the documentation at
+# https://docs.jboss.org/author/display/ERRAI/ErraiApp.properties
+# for details.
+
+errai.marshalling.serializableTypes=org.optaplanner.core.api.score.buildin.bendable.BendableScore \
+    org.optaplanner.core.api.score.buildin.bendablebigdecimal.BendableBigDecimalScore \
+    org.optaplanner.core.api.score.buildin.bendablelong.BendableLongScore \
+    org.optaplanner.core.api.score.buildin.hardmediumsoft.HardMediumSoftScore \
+    org.optaplanner.core.api.score.buildin.hardmediumsoftbigdecimal.HardMediumSoftBigDecimalScore \
+    org.optaplanner.core.api.score.buildin.hardmediumsoftlong.HardMediumSoftLongScore \
+    org.optaplanner.core.api.score.buildin.hardsoft.HardSoftScore \
+    org.optaplanner.core.api.score.buildin.hardsoftbigdecimal.HardSoftBigDecimalScore \
+    org.optaplanner.core.api.score.buildin.hardsoftdouble.HardSoftDoubleScore \
+    org.optaplanner.core.api.score.buildin.hardsoftlong.HardSoftLongScore \
+    org.optaplanner.core.api.score.buildin.simple.SimpleScore \
+    org.optaplanner.core.api.score.buildin.simplebigdecimal.SimpleBigDecimalScore \
+    org.optaplanner.core.api.score.buildin.simpledouble.SimpleDoubleScore \
+    org.optaplanner.core.api.score.buildin.simplelong.SimpleLongScore \
+    org.optaplanner.core.config.constructionheuristic.ConstructionHeuristicType \
+    org.optaplanner.core.config.heuristic.selector.entity.EntitySorterManner \
+    org.optaplanner.core.config.heuristic.selector.value.ValueSorterManner \
+    org.optaplanner.core.config.localsearch.LocalSearchType

--- a/optaplanner-integration/optaplanner-workbench-models/optaplanner-workbench-models-core/src/main/resources/OptaPlannerWorkbenchCoreAPISourcePaths.gwt.xml
+++ b/optaplanner-integration/optaplanner-workbench-models/optaplanner-workbench-models-core/src/main/resources/OptaPlannerWorkbenchCoreAPISourcePaths.gwt.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright 2017 Red Hat, Inc. and/or its affiliates.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~       http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit 2.8.0//EN"
+    "http://gwtproject.org/doctype/2.8.0/gwt-module.dtd">
+<module>
+
+  <source path="org/optaplanner/core/api/score" includes="AbstractScore.java"/>
+  <source path="org/optaplanner/core/api/score" includes="AbstractBendableScore.java"/>
+  <source path="org/optaplanner/core/api/score" includes="FeasibilityScore.java"/>
+  <source path="org/optaplanner/core/api/score" includes="Score.java"/>
+  <source path="org/optaplanner/core/api/score/buildin/bendable" includes="BendableScore.java"/>
+  <source path="org/optaplanner/core/api/score/buildin/bendablebigdecimal" includes="BendableBigDecimalScore.java"/>
+  <source path="org/optaplanner/core/api/score/buildin/bendablelong" includes="BendableLongScore.java"/>
+  <source path="org/optaplanner/core/api/score/buildin/hardmediumsoft" includes="HardMediumSoftScore.java"/>
+  <source path="org/optaplanner/core/api/score/buildin/hardmediumsoftbigdecimal" includes="HardMediumSoftBigDecimalScore.java"/>
+  <source path="org/optaplanner/core/api/score/buildin/hardmediumsoftlong" includes="HardMediumSoftLongScore.java"/>
+  <source path="org/optaplanner/core/api/score/buildin/hardsoft" includes="HardSoftScore.java"/>
+  <source path="org/optaplanner/core/api/score/buildin/hardsoftbigdecimal" includes="HardSoftBigDecimalScore.java"/>
+  <source path="org/optaplanner/core/api/score/buildin/hardsoftdouble" includes="HardSoftDoubleScore.java"/>
+  <source path="org/optaplanner/core/api/score/buildin/hardsoftlong" includes="HardSoftLongScore.java"/>
+  <source path="org/optaplanner/core/api/score/buildin/simple" includes="SimpleScore.java"/>
+  <source path="org/optaplanner/core/api/score/buildin/simplebigdecimal" includes="SimpleBigDecimalScore.java"/>
+  <source path="org/optaplanner/core/api/score/buildin/simpledouble" includes="SimpleDoubleScore.java"/>
+  <source path="org/optaplanner/core/api/score/buildin/simplelong" includes="SimpleLongScore.java"/>
+  <source path="org/optaplanner/core/config/constructionheuristic" includes="ConstructionHeuristicType.java"/>
+  <source path="org/optaplanner/core/config/heuristic/selector/entity" includes="EntitySorterManner.java"/>
+  <source path="org/optaplanner/core/config/heuristic/selector/value" includes="ValueSorterManner.java"/>
+  <source path="org/optaplanner/core/config/localsearch" includes="LocalSearchType.java"/>
+
+</module>

--- a/optaplanner-integration/optaplanner-workbench-models/optaplanner-workbench-models-core/src/main/resources/org/optaplanner/workbench/models/core/OptaPlannerWorkbenchCoreAPI.gwt.xml
+++ b/optaplanner-integration/optaplanner-workbench-models/optaplanner-workbench-models-core/src/main/resources/org/optaplanner/workbench/models/core/OptaPlannerWorkbenchCoreAPI.gwt.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright 2017 Red Hat, Inc. and/or its affiliates.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~       http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit 2.8.0//EN"
+    "http://gwtproject.org/doctype/2.8.0/gwt-module.dtd">
+<module>
+
+  <inherits name="OptaPlannerWorkbenchCoreAPISourcePaths"/>
+
+</module>

--- a/optaplanner-integration/optaplanner-workbench-models/optaplanner-workbench-models-datamodel-api/.gitignore
+++ b/optaplanner-integration/optaplanner-workbench-models/optaplanner-workbench-models-datamodel-api/.gitignore
@@ -1,0 +1,10 @@
+/target
+/local
+
+# Eclipse, Netbeans and IntelliJ files
+/.*
+!.gitignore
+/nbproject
+/*.ipr
+/*.iws
+/*.iml

--- a/optaplanner-integration/optaplanner-workbench-models/optaplanner-workbench-models-datamodel-api/pom.xml
+++ b/optaplanner-integration/optaplanner-workbench-models/optaplanner-workbench-models-datamodel-api/pom.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.optaplanner</groupId>
+    <artifactId>optaplanner-workbench-models</artifactId>
+    <version>7.32.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>optaplanner-workbench-models-datamodel-api</artifactId>
+  <packaging>jar</packaging>
+
+  <name>Drools data model API implementations for OptaPlanner Workbench</name>
+  <description>
+    OptaPlanner solves planning problems.
+    This lightweight, embeddable planning engine implements powerful and scalable algorithms
+    to optimize business resource scheduling and planning.
+
+    This module provides OptaPlanner implementations of Drools data model interfaces used by OptaPlanner Workbench.
+  </description>
+
+  <properties>
+    <java.module.name>org.optaplanner.workbench.models.datamodel</java.module.name>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.drools</groupId>
+      <artifactId>drools-workbench-models-datamodel-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.kie.soup</groupId>
+      <artifactId>kie-soup-project-datamodel-api</artifactId>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/optaplanner-integration/optaplanner-workbench-models/optaplanner-workbench-models-datamodel-api/src/main/java/org/optaplanner/workbench/models/datamodel/rule/AbstractActionBendableConstraintMatch.java
+++ b/optaplanner-integration/optaplanner-workbench-models/optaplanner-workbench-models-datamodel-api/src/main/java/org/optaplanner/workbench/models/datamodel/rule/AbstractActionBendableConstraintMatch.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.workbench.models.datamodel.rule;
+
+public abstract class AbstractActionBendableConstraintMatch extends AbstractActionConstraintMatch {
+
+    protected int position;
+
+    public AbstractActionBendableConstraintMatch() {
+    }
+
+    public AbstractActionBendableConstraintMatch(final String constraintMatch,
+                                                 final int position) {
+        super(constraintMatch);
+        this.position = position;
+    }
+
+    public int getPosition() {
+        return position;
+    }
+
+    public void setPosition(int position) {
+        this.position = position;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
+
+        AbstractActionBendableConstraintMatch that = (AbstractActionBendableConstraintMatch) o;
+
+        return position == that.position;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result = ~~result;
+        result = 31 * result + position;
+        result = ~~result;
+        return result;
+    }
+}

--- a/optaplanner-integration/optaplanner-workbench-models/optaplanner-workbench-models-datamodel-api/src/main/java/org/optaplanner/workbench/models/datamodel/rule/AbstractActionConstraintMatch.java
+++ b/optaplanner-integration/optaplanner-workbench-models/optaplanner-workbench-models-datamodel-api/src/main/java/org/optaplanner/workbench/models/datamodel/rule/AbstractActionConstraintMatch.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.workbench.models.datamodel.rule;
+
+import java.util.Collection;
+import java.util.function.Function;
+
+import org.drools.workbench.models.datamodel.rule.InterpolationVariable;
+import org.drools.workbench.models.datamodel.rule.TemplateAware;
+import org.optaplanner.workbench.models.datamodel.util.TemplateUtils;
+
+public abstract class AbstractActionConstraintMatch implements ActionConstraintMatch,
+                                                               TemplateAware {
+
+    private String constraintMatch;
+
+    public AbstractActionConstraintMatch() {
+    }
+
+    public AbstractActionConstraintMatch(final String constraintMatch) {
+        this.constraintMatch = constraintMatch;
+    }
+
+    public String getConstraintMatch() {
+        return constraintMatch;
+    }
+
+    public void setConstraintMatch(String constraintMatch) {
+        this.constraintMatch = constraintMatch;
+    }
+
+    @Override
+    public Collection<InterpolationVariable> extractInterpolationVariables() {
+        return TemplateUtils.extractInterpolationVariables(getConstraintMatch());
+    }
+
+    @Override
+    public void substituteTemplateVariables(Function<String, String> keyToValueFunction) {
+        setConstraintMatch(TemplateUtils.substituteTemplateVariable(getConstraintMatch(),
+                                                                    keyToValueFunction));
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        AbstractActionConstraintMatch that = (AbstractActionConstraintMatch) o;
+
+        return constraintMatch != null ? constraintMatch.equals(that.constraintMatch) : that.constraintMatch == null;
+    }
+
+    @Override
+    public int hashCode() {
+        return constraintMatch != null ? constraintMatch.hashCode() : 0;
+    }
+}

--- a/optaplanner-integration/optaplanner-workbench-models/optaplanner-workbench-models-datamodel-api/src/main/java/org/optaplanner/workbench/models/datamodel/rule/AbstractActionMultiConstraintBendableMatch.java
+++ b/optaplanner-integration/optaplanner-workbench-models/optaplanner-workbench-models-datamodel-api/src/main/java/org/optaplanner/workbench/models/datamodel/rule/AbstractActionMultiConstraintBendableMatch.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.workbench.models.datamodel.rule;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.function.Function;
+
+import org.drools.workbench.models.datamodel.rule.InterpolationVariable;
+import org.drools.workbench.models.datamodel.rule.TemplateAware;
+import org.optaplanner.workbench.models.datamodel.util.TemplateUtils;
+
+public abstract class AbstractActionMultiConstraintBendableMatch implements ActionConstraintMatch,
+                                                                            TemplateAware {
+
+    private List<ActionBendableHardConstraintMatch> actionBendableHardConstraintMatches;
+
+    private List<ActionBendableSoftConstraintMatch> actionBendableSoftConstraintMatches;
+
+    public AbstractActionMultiConstraintBendableMatch() {
+    }
+
+    public AbstractActionMultiConstraintBendableMatch(final List<ActionBendableHardConstraintMatch> actionBendableHardConstraintMatches,
+                                                      final List<ActionBendableSoftConstraintMatch> actionBendableSoftConstraintMatches) {
+        this.actionBendableHardConstraintMatches = actionBendableHardConstraintMatches;
+        this.actionBendableSoftConstraintMatches = actionBendableSoftConstraintMatches;
+    }
+
+    public List<ActionBendableHardConstraintMatch> getActionBendableHardConstraintMatches() {
+        return actionBendableHardConstraintMatches;
+    }
+
+    public void setActionBendableHardConstraintMatches(List<ActionBendableHardConstraintMatch> actionBendableHardConstraintMatches) {
+        this.actionBendableHardConstraintMatches = actionBendableHardConstraintMatches;
+    }
+
+    public List<ActionBendableSoftConstraintMatch> getActionBendableSoftConstraintMatches() {
+        return actionBendableSoftConstraintMatches;
+    }
+
+    public void setActionBendableSoftConstraintMatches(List<ActionBendableSoftConstraintMatch> actionBendableSoftConstraintMatches) {
+        this.actionBendableSoftConstraintMatches = actionBendableSoftConstraintMatches;
+    }
+
+    @Override
+    public Collection<InterpolationVariable> extractInterpolationVariables() {
+        List<InterpolationVariable> interpolationVariableList = new ArrayList<>();
+        if (getActionBendableHardConstraintMatches() != null) {
+            for (ActionBendableHardConstraintMatch hardConstraintMatch : getActionBendableHardConstraintMatches()) {
+                interpolationVariableList.addAll(TemplateUtils.extractInterpolationVariables(hardConstraintMatch.getConstraintMatch()));
+            }
+        }
+        if (getActionBendableSoftConstraintMatches() != null) {
+            for (ActionBendableSoftConstraintMatch softConstraintMatch : getActionBendableSoftConstraintMatches()) {
+                interpolationVariableList.addAll(TemplateUtils.extractInterpolationVariables(softConstraintMatch.getConstraintMatch()));
+            }
+        }
+        return interpolationVariableList;
+    }
+
+    @Override
+    public void substituteTemplateVariables(Function<String, String> keyToValueFunction) {
+        if (getActionBendableHardConstraintMatches() != null) {
+            for (ActionBendableHardConstraintMatch hardConstraintMatch : getActionBendableHardConstraintMatches()) {
+                hardConstraintMatch.substituteTemplateVariables(keyToValueFunction);
+            }
+        }
+        if (getActionBendableSoftConstraintMatches() != null) {
+            for (ActionBendableSoftConstraintMatch softConstraintMatch : getActionBendableSoftConstraintMatches()) {
+                softConstraintMatch.substituteTemplateVariables(keyToValueFunction);
+            }
+        }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        AbstractActionMultiConstraintBendableMatch that = (AbstractActionMultiConstraintBendableMatch) o;
+
+        if (actionBendableHardConstraintMatches != null ? !actionBendableHardConstraintMatches.equals(that.actionBendableHardConstraintMatches) : that.actionBendableHardConstraintMatches != null) {
+            return false;
+        }
+        return actionBendableSoftConstraintMatches != null ? actionBendableSoftConstraintMatches.equals(that.actionBendableSoftConstraintMatches) : that.actionBendableSoftConstraintMatches == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = actionBendableHardConstraintMatches != null ? actionBendableHardConstraintMatches.hashCode() : 0;
+        result = ~~result;
+        result = 31 * result + (actionBendableSoftConstraintMatches != null ? actionBendableSoftConstraintMatches.hashCode() : 0);
+        result = ~~result;
+        return result;
+    }
+}

--- a/optaplanner-integration/optaplanner-workbench-models/optaplanner-workbench-models-datamodel-api/src/main/java/org/optaplanner/workbench/models/datamodel/rule/ActionBendableHardConstraintMatch.java
+++ b/optaplanner-integration/optaplanner-workbench-models/optaplanner-workbench-models-datamodel-api/src/main/java/org/optaplanner/workbench/models/datamodel/rule/ActionBendableHardConstraintMatch.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.workbench.models.datamodel.rule;
+
+import org.drools.workbench.models.datamodel.rule.TemplateAware;
+
+public class ActionBendableHardConstraintMatch extends AbstractActionBendableConstraintMatch {
+
+    public ActionBendableHardConstraintMatch() {
+    }
+
+    public ActionBendableHardConstraintMatch(final int position,
+                                             final String constraintMatch) {
+        super(constraintMatch,
+              position);
+    }
+
+    @Override
+    public TemplateAware cloneTemplateAware() {
+        return new ActionBendableHardConstraintMatch(getPosition(),
+                                                     getConstraintMatch());
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
+
+        ActionBendableHardConstraintMatch that = (ActionBendableHardConstraintMatch) o;
+
+        return position == that.position;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result = ~~result;
+        result = 31 * result + position;
+        result = ~~result;
+        return result;
+    }
+
+    @Override
+    public String getStringRepresentation() {
+        return new StringBuilder()
+                .append("scoreHolder.addHardConstraintMatch(kcontext, ")
+                .append(getPosition())
+                .append(", ")
+                .append(getConstraintMatch())
+                .append(")").toString();
+    }
+}

--- a/optaplanner-integration/optaplanner-workbench-models/optaplanner-workbench-models-datamodel-api/src/main/java/org/optaplanner/workbench/models/datamodel/rule/ActionBendableSoftConstraintMatch.java
+++ b/optaplanner-integration/optaplanner-workbench-models/optaplanner-workbench-models-datamodel-api/src/main/java/org/optaplanner/workbench/models/datamodel/rule/ActionBendableSoftConstraintMatch.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.workbench.models.datamodel.rule;
+
+import org.drools.workbench.models.datamodel.rule.TemplateAware;
+
+public class ActionBendableSoftConstraintMatch extends AbstractActionBendableConstraintMatch {
+
+    public ActionBendableSoftConstraintMatch() {
+    }
+
+    public ActionBendableSoftConstraintMatch(final int position,
+                                             final String constraintMatch) {
+        super(constraintMatch,
+              position);
+    }
+
+    @Override
+    public TemplateAware cloneTemplateAware() {
+        return new ActionBendableSoftConstraintMatch(getPosition(),
+                                                     getConstraintMatch());
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
+
+        ActionBendableSoftConstraintMatch that = (ActionBendableSoftConstraintMatch) o;
+
+        return position == that.position;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result = ~~result;
+        result = 31 * result + position;
+        result = ~~result;
+        return result;
+    }
+
+    @Override
+    public String getStringRepresentation() {
+        return new StringBuilder()
+                .append("scoreHolder.addSoftConstraintMatch(kcontext, ")
+                .append(getPosition())
+                .append(", ")
+                .append(getConstraintMatch())
+                .append(")").toString();
+    }
+}

--- a/optaplanner-integration/optaplanner-workbench-models/optaplanner-workbench-models-datamodel-api/src/main/java/org/optaplanner/workbench/models/datamodel/rule/ActionConstraintMatch.java
+++ b/optaplanner-integration/optaplanner-workbench-models/optaplanner-workbench-models-datamodel-api/src/main/java/org/optaplanner/workbench/models/datamodel/rule/ActionConstraintMatch.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.workbench.models.datamodel.rule;
+
+import org.drools.workbench.models.datamodel.rule.PluggableIAction;
+
+public interface ActionConstraintMatch extends PluggableIAction {
+
+}

--- a/optaplanner-integration/optaplanner-workbench-models/optaplanner-workbench-models-datamodel-api/src/main/java/org/optaplanner/workbench/models/datamodel/rule/ActionHardConstraintMatch.java
+++ b/optaplanner-integration/optaplanner-workbench-models/optaplanner-workbench-models-datamodel-api/src/main/java/org/optaplanner/workbench/models/datamodel/rule/ActionHardConstraintMatch.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.optaplanner.workbench.models.datamodel.rule;
+
+import org.drools.workbench.models.datamodel.rule.TemplateAware;
+
+public class ActionHardConstraintMatch extends AbstractActionConstraintMatch {
+
+    public ActionHardConstraintMatch() {
+    }
+
+    public ActionHardConstraintMatch(final String constraintMatch) {
+        super(constraintMatch);
+    }
+
+    @Override
+    public TemplateAware cloneTemplateAware() {
+        return new ActionHardConstraintMatch(getConstraintMatch());
+    }
+
+    @Override
+    public String getStringRepresentation() {
+        return new StringBuilder()
+                .append("scoreHolder.addHardConstraintMatch(kcontext, ")
+                .append(getConstraintMatch())
+                .append(")").toString();
+    }
+}

--- a/optaplanner-integration/optaplanner-workbench-models/optaplanner-workbench-models-datamodel-api/src/main/java/org/optaplanner/workbench/models/datamodel/rule/ActionMediumConstraintMatch.java
+++ b/optaplanner-integration/optaplanner-workbench-models/optaplanner-workbench-models-datamodel-api/src/main/java/org/optaplanner/workbench/models/datamodel/rule/ActionMediumConstraintMatch.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.workbench.models.datamodel.rule;
+
+import org.drools.workbench.models.datamodel.rule.TemplateAware;
+
+public class ActionMediumConstraintMatch extends AbstractActionConstraintMatch {
+
+    public ActionMediumConstraintMatch() {
+    }
+
+    public ActionMediumConstraintMatch(final String constraintMatch) {
+        super(constraintMatch);
+    }
+
+    @Override
+    public TemplateAware cloneTemplateAware() {
+        return new ActionMediumConstraintMatch(getConstraintMatch());
+    }
+
+    @Override
+    public String getStringRepresentation() {
+        return new StringBuilder()
+                .append("scoreHolder.addMediumConstraintMatch(kcontext, ")
+                .append(getConstraintMatch())
+                .append(")").toString();
+    }
+}

--- a/optaplanner-integration/optaplanner-workbench-models/optaplanner-workbench-models-datamodel-api/src/main/java/org/optaplanner/workbench/models/datamodel/rule/ActionMultiConstraintBendableBigDecimalMatch.java
+++ b/optaplanner-integration/optaplanner-workbench-models/optaplanner-workbench-models-datamodel-api/src/main/java/org/optaplanner/workbench/models/datamodel/rule/ActionMultiConstraintBendableBigDecimalMatch.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.workbench.models.datamodel.rule;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.drools.workbench.models.datamodel.rule.TemplateAware;
+
+public class ActionMultiConstraintBendableBigDecimalMatch extends AbstractActionMultiConstraintBendableMatch {
+
+    public ActionMultiConstraintBendableBigDecimalMatch() {
+    }
+
+    public ActionMultiConstraintBendableBigDecimalMatch(final List<ActionBendableHardConstraintMatch> actionBendableHardConstraintMatches,
+                                                        final List<ActionBendableSoftConstraintMatch> actionBendableSoftConstraintMatches) {
+        super(actionBendableHardConstraintMatches,
+              actionBendableSoftConstraintMatches);
+    }
+
+    @Override
+    public TemplateAware cloneTemplateAware() {
+        return new ActionMultiConstraintBendableBigDecimalMatch(getActionBendableHardConstraintMatches().stream().map(m -> (ActionBendableHardConstraintMatch) m.cloneTemplateAware()).collect(Collectors.toList()),
+                                                                getActionBendableSoftConstraintMatches().stream().map(m -> (ActionBendableSoftConstraintMatch) m.cloneTemplateAware()).collect(Collectors.toList()));
+    }
+
+    @Override
+    public String getStringRepresentation() {
+        return new StringBuilder()
+                .append("scoreHolder.addMultiConstraintMatch(kcontext, new java.math.BigDecimal[] {")
+                .append(getActionBendableHardConstraintMatches().stream().map(m -> m.getConstraintMatch()).collect(Collectors.joining(", ")))
+                .append("}, new java.math.BigDecimal[] {")
+                .append(getActionBendableSoftConstraintMatches().stream().map(m -> m.getConstraintMatch()).collect(Collectors.joining(", ")))
+                .append("})").toString();
+    }
+}

--- a/optaplanner-integration/optaplanner-workbench-models/optaplanner-workbench-models-datamodel-api/src/main/java/org/optaplanner/workbench/models/datamodel/rule/ActionMultiConstraintBendableLongMatch.java
+++ b/optaplanner-integration/optaplanner-workbench-models/optaplanner-workbench-models-datamodel-api/src/main/java/org/optaplanner/workbench/models/datamodel/rule/ActionMultiConstraintBendableLongMatch.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.workbench.models.datamodel.rule;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.drools.workbench.models.datamodel.rule.TemplateAware;
+
+public class ActionMultiConstraintBendableLongMatch extends AbstractActionMultiConstraintBendableMatch {
+
+    public ActionMultiConstraintBendableLongMatch() {
+    }
+
+    public ActionMultiConstraintBendableLongMatch(final List<ActionBendableHardConstraintMatch> actionBendableHardConstraintMatches,
+                                                  final List<ActionBendableSoftConstraintMatch> actionBendableSoftConstraintMatches) {
+        super(actionBendableHardConstraintMatches,
+              actionBendableSoftConstraintMatches);
+    }
+
+    @Override
+    public TemplateAware cloneTemplateAware() {
+        return new ActionMultiConstraintBendableLongMatch(getActionBendableHardConstraintMatches().stream().map(m -> (ActionBendableHardConstraintMatch) m.cloneTemplateAware()).collect(Collectors.toList()),
+                                                          getActionBendableSoftConstraintMatches().stream().map(m -> (ActionBendableSoftConstraintMatch) m.cloneTemplateAware()).collect(Collectors.toList()));
+    }
+
+    @Override
+    public String getStringRepresentation() {
+        return new StringBuilder()
+                .append("scoreHolder.addMultiConstraintMatch(kcontext, new long[] {")
+                .append(getActionBendableHardConstraintMatches().stream().map(m -> m.getConstraintMatch()).collect(Collectors.joining(", ")))
+                .append("}, new long[] {")
+                .append(getActionBendableSoftConstraintMatches().stream().map(m -> m.getConstraintMatch()).collect(Collectors.joining(", ")))
+                .append("})").toString();
+    }
+}

--- a/optaplanner-integration/optaplanner-workbench-models/optaplanner-workbench-models-datamodel-api/src/main/java/org/optaplanner/workbench/models/datamodel/rule/ActionMultiConstraintBendableMatch.java
+++ b/optaplanner-integration/optaplanner-workbench-models/optaplanner-workbench-models-datamodel-api/src/main/java/org/optaplanner/workbench/models/datamodel/rule/ActionMultiConstraintBendableMatch.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.workbench.models.datamodel.rule;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.drools.workbench.models.datamodel.rule.TemplateAware;
+
+public class ActionMultiConstraintBendableMatch extends AbstractActionMultiConstraintBendableMatch {
+
+    public ActionMultiConstraintBendableMatch() {
+    }
+
+    public ActionMultiConstraintBendableMatch(final List<ActionBendableHardConstraintMatch> actionBendableHardConstraintMatches,
+                                              final List<ActionBendableSoftConstraintMatch> actionBendableSoftConstraintMatches) {
+        super(actionBendableHardConstraintMatches,
+              actionBendableSoftConstraintMatches);
+    }
+
+    @Override
+    public TemplateAware cloneTemplateAware() {
+        return new ActionMultiConstraintBendableMatch(getActionBendableHardConstraintMatches().stream().map(m -> (ActionBendableHardConstraintMatch) m.cloneTemplateAware()).collect(Collectors.toList()),
+                                                      getActionBendableSoftConstraintMatches().stream().map(m -> (ActionBendableSoftConstraintMatch) m.cloneTemplateAware()).collect(Collectors.toList()));
+    }
+
+    @Override
+    public String getStringRepresentation() {
+        return new StringBuilder()
+                .append("scoreHolder.addMultiConstraintMatch(kcontext, new int[] {")
+                .append(getActionBendableHardConstraintMatches().stream().map(m -> m.getConstraintMatch()).collect(Collectors.joining(", ")))
+                .append("}, new int[] {")
+                .append(getActionBendableSoftConstraintMatches().stream().map(m -> m.getConstraintMatch()).collect(Collectors.joining(", ")))
+                .append("})").toString();
+    }
+}

--- a/optaplanner-integration/optaplanner-workbench-models/optaplanner-workbench-models-datamodel-api/src/main/java/org/optaplanner/workbench/models/datamodel/rule/ActionMultiConstraintHardMediumSoftMatch.java
+++ b/optaplanner-integration/optaplanner-workbench-models/optaplanner-workbench-models-datamodel-api/src/main/java/org/optaplanner/workbench/models/datamodel/rule/ActionMultiConstraintHardMediumSoftMatch.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.workbench.models.datamodel.rule;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.function.Function;
+
+import org.drools.workbench.models.datamodel.rule.InterpolationVariable;
+import org.drools.workbench.models.datamodel.rule.TemplateAware;
+import org.optaplanner.workbench.models.datamodel.util.TemplateUtils;
+
+public class ActionMultiConstraintHardMediumSoftMatch implements ActionConstraintMatch,
+                                                                 TemplateAware {
+
+    private ActionHardConstraintMatch actionHardConstraintMatch;
+
+    private ActionMediumConstraintMatch actionMediumConstraintMatch;
+
+    private ActionSoftConstraintMatch actionSoftConstraintMatch;
+
+    public ActionMultiConstraintHardMediumSoftMatch() {
+    }
+
+    public ActionMultiConstraintHardMediumSoftMatch(final ActionHardConstraintMatch actionHardConstraintMatch,
+                                                    final ActionMediumConstraintMatch actionMediumConstraintMatch,
+                                                    final ActionSoftConstraintMatch actionSoftConstraintMatch) {
+        this.actionHardConstraintMatch = actionHardConstraintMatch;
+        this.actionMediumConstraintMatch = actionMediumConstraintMatch;
+        this.actionSoftConstraintMatch = actionSoftConstraintMatch;
+    }
+
+    public ActionHardConstraintMatch getActionHardConstraintMatch() {
+        return actionHardConstraintMatch;
+    }
+
+    public void setActionHardConstraintMatch(ActionHardConstraintMatch actionHardConstraintMatch) {
+        this.actionHardConstraintMatch = actionHardConstraintMatch;
+    }
+
+    public ActionMediumConstraintMatch getActionMediumConstraintMatch() {
+        return actionMediumConstraintMatch;
+    }
+
+    public void setActionMediumConstraintMatch(ActionMediumConstraintMatch actionMediumConstraintMatch) {
+        this.actionMediumConstraintMatch = actionMediumConstraintMatch;
+    }
+
+    public ActionSoftConstraintMatch getActionSoftConstraintMatch() {
+        return actionSoftConstraintMatch;
+    }
+
+    public void setActionSoftConstraintMatch(ActionSoftConstraintMatch actionSoftConstraintMatch) {
+        this.actionSoftConstraintMatch = actionSoftConstraintMatch;
+    }
+
+    @Override
+    public Collection<InterpolationVariable> extractInterpolationVariables() {
+        List<InterpolationVariable> interpolationVariableList = new ArrayList<>();
+        interpolationVariableList.addAll(TemplateUtils.extractInterpolationVariables(getActionHardConstraintMatch().getConstraintMatch()));
+        interpolationVariableList.addAll(TemplateUtils.extractInterpolationVariables(getActionMediumConstraintMatch().getConstraintMatch()));
+        interpolationVariableList.addAll(TemplateUtils.extractInterpolationVariables(getActionSoftConstraintMatch().getConstraintMatch()));
+        return interpolationVariableList;
+    }
+
+    @Override
+    public void substituteTemplateVariables(final Function<String, String> keyToValueFunction) {
+        getActionHardConstraintMatch().substituteTemplateVariables(keyToValueFunction);
+        getActionMediumConstraintMatch().substituteTemplateVariables(keyToValueFunction);
+        getActionSoftConstraintMatch().substituteTemplateVariables(keyToValueFunction);
+    }
+
+    @Override
+    public TemplateAware cloneTemplateAware() {
+        return new ActionMultiConstraintHardMediumSoftMatch(new ActionHardConstraintMatch(getActionHardConstraintMatch().getConstraintMatch()),
+                                                            new ActionMediumConstraintMatch(getActionMediumConstraintMatch().getConstraintMatch()),
+                                                            new ActionSoftConstraintMatch(getActionSoftConstraintMatch().getConstraintMatch()));
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        ActionMultiConstraintHardMediumSoftMatch that = (ActionMultiConstraintHardMediumSoftMatch) o;
+
+        if (actionHardConstraintMatch != null ? !actionHardConstraintMatch.equals(that.actionHardConstraintMatch) : that.actionHardConstraintMatch != null) {
+            return false;
+        }
+        if (actionMediumConstraintMatch != null ? !actionMediumConstraintMatch.equals(that.actionMediumConstraintMatch) : that.actionMediumConstraintMatch != null) {
+            return false;
+        }
+        return actionSoftConstraintMatch != null ? actionSoftConstraintMatch.equals(that.actionSoftConstraintMatch) : that.actionSoftConstraintMatch == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = actionHardConstraintMatch != null ? actionHardConstraintMatch.hashCode() : 0;
+        result = ~~result;
+        result = 31 * result + (actionMediumConstraintMatch != null ? actionMediumConstraintMatch.hashCode() : 0);
+        result = ~~result;
+        result = 31 * result + (actionSoftConstraintMatch != null ? actionSoftConstraintMatch.hashCode() : 0);
+        result = ~~result;
+        return result;
+    }
+
+    @Override
+    public String getStringRepresentation() {
+        return new StringBuilder()
+                .append("scoreHolder.addMultiConstraintMatch(kcontext, ")
+                .append(getActionHardConstraintMatch().getConstraintMatch())
+                .append(", ")
+                .append(getActionMediumConstraintMatch().getConstraintMatch())
+                .append(", ")
+                .append(getActionSoftConstraintMatch().getConstraintMatch())
+                .append(")").toString();
+    }
+}

--- a/optaplanner-integration/optaplanner-workbench-models/optaplanner-workbench-models-datamodel-api/src/main/java/org/optaplanner/workbench/models/datamodel/rule/ActionMultiConstraintHardSoftMatch.java
+++ b/optaplanner-integration/optaplanner-workbench-models/optaplanner-workbench-models-datamodel-api/src/main/java/org/optaplanner/workbench/models/datamodel/rule/ActionMultiConstraintHardSoftMatch.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.workbench.models.datamodel.rule;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.function.Function;
+
+import org.drools.workbench.models.datamodel.rule.InterpolationVariable;
+import org.drools.workbench.models.datamodel.rule.TemplateAware;
+import org.optaplanner.workbench.models.datamodel.util.TemplateUtils;
+
+public class ActionMultiConstraintHardSoftMatch implements ActionConstraintMatch,
+                                                           TemplateAware {
+
+    private ActionHardConstraintMatch actionHardConstraintMatch;
+
+    private ActionSoftConstraintMatch actionSoftConstraintMatch;
+
+    public ActionMultiConstraintHardSoftMatch() {
+    }
+
+    public ActionMultiConstraintHardSoftMatch(final ActionHardConstraintMatch actionHardConstraintMatch,
+                                              final ActionSoftConstraintMatch actionSoftConstraintMatch) {
+        this.actionHardConstraintMatch = actionHardConstraintMatch;
+        this.actionSoftConstraintMatch = actionSoftConstraintMatch;
+    }
+
+    public ActionHardConstraintMatch getActionHardConstraintMatch() {
+        return actionHardConstraintMatch;
+    }
+
+    public ActionSoftConstraintMatch getActionSoftConstraintMatch() {
+        return actionSoftConstraintMatch;
+    }
+
+    @Override
+    public Collection<InterpolationVariable> extractInterpolationVariables() {
+        List<InterpolationVariable> interpolationVariableList = new ArrayList<>();
+        interpolationVariableList.addAll(TemplateUtils.extractInterpolationVariables(getActionHardConstraintMatch().getConstraintMatch()));
+        interpolationVariableList.addAll(TemplateUtils.extractInterpolationVariables(getActionSoftConstraintMatch().getConstraintMatch()));
+        return interpolationVariableList;
+    }
+
+    @Override
+    public void substituteTemplateVariables(final Function<String, String> keyToValueFunction) {
+        getActionHardConstraintMatch().substituteTemplateVariables(keyToValueFunction);
+        getActionSoftConstraintMatch().substituteTemplateVariables(keyToValueFunction);
+    }
+
+    @Override
+    public TemplateAware cloneTemplateAware() {
+        return new ActionMultiConstraintHardSoftMatch(new ActionHardConstraintMatch(getActionHardConstraintMatch().getConstraintMatch()),
+                                                      new ActionSoftConstraintMatch(getActionSoftConstraintMatch().getConstraintMatch()));
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        ActionMultiConstraintHardSoftMatch that = (ActionMultiConstraintHardSoftMatch) o;
+
+        if (actionHardConstraintMatch != null ? !actionHardConstraintMatch.equals(that.actionHardConstraintMatch) : that.actionHardConstraintMatch != null) {
+            return false;
+        }
+        return actionSoftConstraintMatch != null ? actionSoftConstraintMatch.equals(that.actionSoftConstraintMatch) : that.actionSoftConstraintMatch == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = actionHardConstraintMatch != null ? actionHardConstraintMatch.hashCode() : 0;
+        result = ~~result;
+        result = 31 * result + (actionSoftConstraintMatch != null ? actionSoftConstraintMatch.hashCode() : 0);
+        result = ~~result;
+        return result;
+    }
+
+    @Override
+    public String getStringRepresentation() {
+        return new StringBuilder()
+                .append("scoreHolder.addMultiConstraintMatch(kcontext, ")
+                .append(getActionHardConstraintMatch().getConstraintMatch())
+                .append(", ")
+                .append(getActionSoftConstraintMatch().getConstraintMatch())
+                .append(")").toString();
+    }
+}

--- a/optaplanner-integration/optaplanner-workbench-models/optaplanner-workbench-models-datamodel-api/src/main/java/org/optaplanner/workbench/models/datamodel/rule/ActionSimpleConstraintMatch.java
+++ b/optaplanner-integration/optaplanner-workbench-models/optaplanner-workbench-models-datamodel-api/src/main/java/org/optaplanner/workbench/models/datamodel/rule/ActionSimpleConstraintMatch.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.workbench.models.datamodel.rule;
+
+import org.drools.workbench.models.datamodel.rule.TemplateAware;
+
+public class ActionSimpleConstraintMatch extends AbstractActionConstraintMatch {
+
+    public ActionSimpleConstraintMatch() {
+    }
+
+    public ActionSimpleConstraintMatch(final String constraintMatch) {
+        super(constraintMatch);
+    }
+
+    @Override
+    public TemplateAware cloneTemplateAware() {
+        return new ActionSimpleConstraintMatch(getConstraintMatch());
+    }
+
+    @Override
+    public String getStringRepresentation() {
+        return new StringBuilder()
+                .append("scoreHolder.addConstraintMatch(kcontext, ")
+                .append(getConstraintMatch())
+                .append(")").toString();
+    }
+}

--- a/optaplanner-integration/optaplanner-workbench-models/optaplanner-workbench-models-datamodel-api/src/main/java/org/optaplanner/workbench/models/datamodel/rule/ActionSoftConstraintMatch.java
+++ b/optaplanner-integration/optaplanner-workbench-models/optaplanner-workbench-models-datamodel-api/src/main/java/org/optaplanner/workbench/models/datamodel/rule/ActionSoftConstraintMatch.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.workbench.models.datamodel.rule;
+
+import org.drools.workbench.models.datamodel.rule.TemplateAware;
+
+public class ActionSoftConstraintMatch extends AbstractActionConstraintMatch {
+
+    public ActionSoftConstraintMatch() {
+    }
+
+    public ActionSoftConstraintMatch(final String constraintMatch) {
+        super(constraintMatch);
+    }
+
+    @Override
+    public TemplateAware cloneTemplateAware() {
+        return new ActionSoftConstraintMatch(getConstraintMatch());
+    }
+
+    @Override
+    public String getStringRepresentation() {
+        return new StringBuilder()
+                .append("scoreHolder.addSoftConstraintMatch(kcontext, ")
+                .append(getConstraintMatch())
+                .append(")").toString();
+    }
+}

--- a/optaplanner-integration/optaplanner-workbench-models/optaplanner-workbench-models-datamodel-api/src/main/java/org/optaplanner/workbench/models/datamodel/util/TemplateUtils.java
+++ b/optaplanner-integration/optaplanner-workbench-models/optaplanner-workbench-models-datamodel-api/src/main/java/org/optaplanner/workbench/models/datamodel/util/TemplateUtils.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.workbench.models.datamodel.util;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Function;
+
+import org.drools.workbench.models.datamodel.rule.InterpolationVariable;
+import org.kie.soup.project.datamodel.oracle.DataType;
+
+public final class TemplateUtils {
+
+    private TemplateUtils() {
+    }
+
+    public static Collection<InterpolationVariable> extractInterpolationVariables(final String text) {
+        if (text == null || text.length() == 0) {
+            return Collections.emptyList();
+        }
+        List<InterpolationVariable> interpolationVariableList = new ArrayList<>();
+        int pos = 0;
+        while ((pos = text.indexOf("@{",
+                                   pos)) != -1) {
+            int end = text.indexOf('}',
+                                   pos + 2);
+            if (end != -1) {
+                String varName = text.substring(pos + 2,
+                                                end);
+                pos = end + 1;
+                InterpolationVariable var = new InterpolationVariable(varName,
+                                                                      DataType.TYPE_OBJECT);
+                interpolationVariableList.add(var);
+            } else {
+                break;
+            }
+        }
+        return interpolationVariableList;
+    }
+
+    public static String substituteTemplateVariable(final String text,
+                                                    final Function<String, String> keyToValueFunction) {
+        if (text == null || text.isEmpty()) {
+            return text;
+        }
+
+        StringBuilder resultBuilder = new StringBuilder(text);
+
+        int pos;
+        while ((pos = resultBuilder.indexOf("@{")) != -1) {
+            int end = resultBuilder.indexOf("}",
+                                            pos + 2);
+            if (end != -1) {
+                final String varName = resultBuilder.substring(pos + 2,
+                                                               end);
+                final String value = keyToValueFunction.apply(varName);
+                if (value == null) {
+                    return text;
+                }
+                resultBuilder.replace(pos,
+                                      end + 1,
+                                      value);
+            } else {
+                break;
+            }
+        }
+
+        return resultBuilder.toString();
+    }
+}

--- a/optaplanner-integration/optaplanner-workbench-models/optaplanner-workbench-models-datamodel-api/src/main/resources/META-INF/ErraiApp.properties
+++ b/optaplanner-integration/optaplanner-workbench-models/optaplanner-workbench-models-datamodel-api/src/main/resources/META-INF/ErraiApp.properties
@@ -1,0 +1,42 @@
+#
+# Copyright 2017 Red Hat, Inc. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# ErraiApp.properties
+#
+# Do not remove, even if empty!
+#
+
+# This is a marker file. When it is detected inside a JAR or at the
+# top of any classpath, the subdirectories are scanned for deployable
+# components. As such, all Errai application modules in a project
+# should contain an ErraiApp.properties at the root of all classpaths
+# that you wish to be scanned.
+#
+# There are also some configuration options that can be set in this
+# file, although it is rarely necessary. See the documentation at
+# https://docs.jboss.org/author/display/ERRAI/ErraiApp.properties
+# for details.
+errai.marshalling.serializableTypes=org.optaplanner.workbench.models.datamodel.rule.ActionBendableHardConstraintMatch \
+  org.optaplanner.workbench.models.datamodel.rule.ActionBendableSoftConstraintMatch \
+  org.optaplanner.workbench.models.datamodel.rule.ActionHardConstraintMatch \
+  org.optaplanner.workbench.models.datamodel.rule.ActionMediumConstraintMatch \
+  org.optaplanner.workbench.models.datamodel.rule.ActionMultiConstraintBendableBigDecimalMatch \
+  org.optaplanner.workbench.models.datamodel.rule.ActionMultiConstraintBendableLongMatch \
+  org.optaplanner.workbench.models.datamodel.rule.ActionMultiConstraintBendableMatch \
+  org.optaplanner.workbench.models.datamodel.rule.ActionMultiConstraintHardMediumSoftMatch \
+  org.optaplanner.workbench.models.datamodel.rule.ActionMultiConstraintHardSoftMatch \
+  org.optaplanner.workbench.models.datamodel.rule.ActionSimpleConstraintMatch \
+  org.optaplanner.workbench.models.datamodel.rule.ActionSoftConstraintMatch

--- a/optaplanner-integration/optaplanner-workbench-models/optaplanner-workbench-models-datamodel-api/src/main/resources/org/optaplanner/workbench/models/datamodel/OptaplannerWorkbenchDataModelAPI.gwt.xml
+++ b/optaplanner-integration/optaplanner-workbench-models/optaplanner-workbench-models-datamodel-api/src/main/resources/org/optaplanner/workbench/models/datamodel/OptaplannerWorkbenchDataModelAPI.gwt.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright 2017 Red Hat, Inc. and/or its affiliates.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~       http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit 2.8.0//EN"
+    "http://www.gwtproject.org/doctype/2.8.0/gwt-module.dtd">
+<module>
+  <inherits name="org.drools.workbench.models.datamodel.DroolsWorkbenchDataModelAPI"/>
+  <source path="rule"/>
+  <source path="util"/>
+</module>

--- a/optaplanner-integration/optaplanner-workbench-models/optaplanner-workbench-models-datamodel-api/src/test/java/org/optaplanner/workbench/models/datamodel/rule/ActionConstraintMatchTest.java
+++ b/optaplanner-integration/optaplanner-workbench-models/optaplanner-workbench-models-datamodel-api/src/test/java/org/optaplanner/workbench/models/datamodel/rule/ActionConstraintMatchTest.java
@@ -1,0 +1,625 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.workbench.models.datamodel.rule;
+
+import org.drools.workbench.models.datamodel.rule.IAction;
+import org.drools.workbench.models.datamodel.rule.InterpolationVariable;
+import org.junit.Test;
+import org.kie.soup.project.datamodel.oracle.DataType;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.function.Function;
+
+import static org.junit.Assert.*;
+
+public class ActionConstraintMatchTest {
+
+    @Test
+    public void extractInterpolationVariablesActionHardConstraintMatch() {
+        ActionHardConstraintMatch constraintMatch = new ActionHardConstraintMatch("foo bar @{var1}");
+
+        extractInterpolationVariablesAbstractActionConstraintMatch(constraintMatch);
+    }
+
+    @Test
+    public void extractInterpolationVariablesActionSoftConstraintMatch() {
+        ActionSoftConstraintMatch constraintMatch = new ActionSoftConstraintMatch("foo bar @{var1}");
+
+        extractInterpolationVariablesAbstractActionConstraintMatch(constraintMatch);
+    }
+
+    @Test
+    public void extractInterpolationVariablesActionMediumConstraintMatch() {
+        ActionMediumConstraintMatch constraintMatch = new ActionMediumConstraintMatch("foo bar @{var1}");
+
+        extractInterpolationVariablesAbstractActionConstraintMatch(constraintMatch);
+    }
+
+    @Test
+    public void extractInterpolationVariablesActionSimpleConstraintMatch() {
+        ActionSimpleConstraintMatch constraintMatch = new ActionSimpleConstraintMatch("foo bar @{var1}");
+
+        extractInterpolationVariablesAbstractActionConstraintMatch(constraintMatch);
+    }
+
+    @Test
+    public void extractInterpolationVariablesActionBendableHardConstraintMatch() {
+        ActionBendableHardConstraintMatch constraintMatch = new ActionBendableHardConstraintMatch(0,
+                                                                                                  "foo bar @{var1}");
+
+        extractInterpolationVariablesAbstractActionConstraintMatch(constraintMatch);
+    }
+
+    @Test
+    public void extractInterpolationVariablesActionBendableSoftConstraintMatch() {
+        ActionBendableSoftConstraintMatch constraintMatch = new ActionBendableSoftConstraintMatch(0,
+                                                                                                  "foo bar @{var1}");
+
+        extractInterpolationVariablesAbstractActionConstraintMatch(constraintMatch);
+    }
+
+    private void extractInterpolationVariablesAbstractActionConstraintMatch(final AbstractActionConstraintMatch constraintMatch) {
+        Collection<InterpolationVariable> interpolationVariables = constraintMatch.extractInterpolationVariables();
+
+        assertEquals(1,
+                     interpolationVariables.size());
+        assertTrue(interpolationVariables.contains(new InterpolationVariable("var1",
+                                                                             DataType.TYPE_OBJECT)));
+    }
+
+    @Test
+    public void extractInterpolationVariablesActionMultiConstraintHardSoftMatch() {
+        ActionHardConstraintMatch hardConstraintMatch = new ActionHardConstraintMatch("foo bar @{var1}");
+        ActionSoftConstraintMatch softConstraintMatch = new ActionSoftConstraintMatch("foo bar @{var2}");
+
+        ActionMultiConstraintHardSoftMatch multiConstraintHardSoftMatch = new ActionMultiConstraintHardSoftMatch(hardConstraintMatch,
+                                                                                                                 softConstraintMatch);
+
+        Collection<InterpolationVariable> interpolationVariables = multiConstraintHardSoftMatch.extractInterpolationVariables();
+
+        assertEquals(2,
+                     interpolationVariables.size());
+        assertTrue(interpolationVariables.contains(new InterpolationVariable("var1",
+                                                                             DataType.TYPE_OBJECT)));
+        assertTrue(interpolationVariables.contains(new InterpolationVariable("var2",
+                                                                             DataType.TYPE_OBJECT)));
+    }
+
+    @Test
+    public void extractInterpolationVariablesActionMultiConstraintHardMediumSoftMatch() {
+        ActionHardConstraintMatch hardConstraintMatch = new ActionHardConstraintMatch("foo bar @{var1}");
+        ActionMediumConstraintMatch mediumConstraintMatch = new ActionMediumConstraintMatch("foo bar @{var2}");
+        ActionSoftConstraintMatch softConstraintMatch = new ActionSoftConstraintMatch("foo bar @{var3}");
+
+        ActionMultiConstraintHardMediumSoftMatch multiConstraintHardSoftMatch = new ActionMultiConstraintHardMediumSoftMatch(hardConstraintMatch,
+                                                                                                                             mediumConstraintMatch,
+                                                                                                                             softConstraintMatch);
+
+        Collection<InterpolationVariable> interpolationVariables = multiConstraintHardSoftMatch.extractInterpolationVariables();
+
+        assertEquals(3,
+                     interpolationVariables.size());
+        assertTrue(interpolationVariables.contains(new InterpolationVariable("var1",
+                                                                             DataType.TYPE_OBJECT)));
+        assertTrue(interpolationVariables.contains(new InterpolationVariable("var2",
+                                                                             DataType.TYPE_OBJECT)));
+        assertTrue(interpolationVariables.contains(new InterpolationVariable("var3",
+                                                                             DataType.TYPE_OBJECT)));
+    }
+
+    @Test
+    public void extractInterpolationVariablesActionMultiConstraintBendableMatch() {
+        ActionBendableHardConstraintMatch bendableHardConstraintMatch = new ActionBendableHardConstraintMatch(0,
+                                                                                                              "foo bar @{var1}");
+        ActionBendableSoftConstraintMatch bendableSoftConstraintMatch = new ActionBendableSoftConstraintMatch(0,
+                                                                                                              "foo bar @{var2}");
+
+        ActionMultiConstraintBendableMatch multiConstraintBendableMatch = new ActionMultiConstraintBendableMatch(Arrays.asList(bendableHardConstraintMatch),
+                                                                                                                 Arrays.asList(bendableSoftConstraintMatch));
+
+        extractInterpolationVariablesAbstractActionMultiConstraintBendableMatch(multiConstraintBendableMatch);
+    }
+
+    @Test
+    public void extractInterpolationVariablesActionMultiConstraintBendableLongMatch() {
+        ActionBendableHardConstraintMatch bendableHardConstraintMatch = new ActionBendableHardConstraintMatch(0,
+                                                                                                              "foo bar @{var1}");
+        ActionBendableSoftConstraintMatch bendableSoftConstraintMatch = new ActionBendableSoftConstraintMatch(0,
+                                                                                                              "foo bar @{var2}");
+
+        ActionMultiConstraintBendableLongMatch multiConstraintBendableMatch = new ActionMultiConstraintBendableLongMatch(Arrays.asList(bendableHardConstraintMatch),
+                                                                                                                         Arrays.asList(bendableSoftConstraintMatch));
+
+        extractInterpolationVariablesAbstractActionMultiConstraintBendableMatch(multiConstraintBendableMatch);
+    }
+
+    @Test
+    public void extractInterpolationVariablesActionMultiConstraintBendableBigDecimalMatch() {
+        ActionBendableHardConstraintMatch bendableHardConstraintMatch = new ActionBendableHardConstraintMatch(0,
+                                                                                                              "foo bar @{var1}");
+        ActionBendableSoftConstraintMatch bendableSoftConstraintMatch = new ActionBendableSoftConstraintMatch(0,
+                                                                                                              "foo bar @{var2}");
+
+        ActionMultiConstraintBendableBigDecimalMatch multiConstraintBendableMatch = new ActionMultiConstraintBendableBigDecimalMatch(Arrays.asList(bendableHardConstraintMatch),
+                                                                                                                                     Arrays.asList(bendableSoftConstraintMatch));
+
+        extractInterpolationVariablesAbstractActionMultiConstraintBendableMatch(multiConstraintBendableMatch);
+    }
+
+    private void extractInterpolationVariablesAbstractActionMultiConstraintBendableMatch(final AbstractActionMultiConstraintBendableMatch constraintMatch) {
+        Collection<InterpolationVariable> interpolationVariables = constraintMatch.extractInterpolationVariables();
+
+        assertEquals(2,
+                     interpolationVariables.size());
+        assertTrue(interpolationVariables.contains(new InterpolationVariable("var1",
+                                                                             DataType.TYPE_OBJECT)));
+        assertTrue(interpolationVariables.contains(new InterpolationVariable("var2",
+                                                                             DataType.TYPE_OBJECT)));
+    }
+
+    @Test
+    public void substituteTemplateVariablesActionHardConstraintMatch() {
+        ActionHardConstraintMatch constraintMatch = new ActionHardConstraintMatch("foo bar @{var1}");
+
+        substituteTemplateVariablesAbstractActionConstraintMatch(constraintMatch);
+    }
+
+    @Test
+    public void substituteTemplateVariablesActionSoftConstraintMatch() {
+        ActionSoftConstraintMatch constraintMatch = new ActionSoftConstraintMatch("foo bar @{var1}");
+
+        substituteTemplateVariablesAbstractActionConstraintMatch(constraintMatch);
+    }
+
+    @Test
+    public void substituteTemplateVariablesActionMediumConstraintMatch() {
+        ActionMediumConstraintMatch constraintMatch = new ActionMediumConstraintMatch("foo bar @{var1}");
+
+        substituteTemplateVariablesAbstractActionConstraintMatch(constraintMatch);
+    }
+
+    @Test
+    public void substituteTemplateVariablesActionSimpleConstraintMatch() {
+        ActionSimpleConstraintMatch constraintMatch = new ActionSimpleConstraintMatch("foo bar @{var1}");
+
+        constraintMatch.substituteTemplateVariables(getKeyToValueFunction());
+
+        substituteTemplateVariablesAbstractActionConstraintMatch(constraintMatch);
+    }
+
+    @Test
+    public void substituteTemplateVariablesActionBendableHardConstraintMatch() {
+        ActionBendableHardConstraintMatch constraintMatch = new ActionBendableHardConstraintMatch(0,
+                                                                                                  "foo bar @{var1}");
+
+        substituteTemplateVariablesAbstractActionConstraintMatch(constraintMatch);
+    }
+
+    @Test
+    public void substituteTemplateVariablesActionBendableSoftConstraintMatch() {
+        ActionBendableSoftConstraintMatch constraintMatch = new ActionBendableSoftConstraintMatch(0,
+                                                                                                  "foo bar @{var1}");
+
+        substituteTemplateVariablesAbstractActionConstraintMatch(constraintMatch);
+    }
+
+    private void substituteTemplateVariablesAbstractActionConstraintMatch(final AbstractActionConstraintMatch constraintMatch) {
+        constraintMatch.substituteTemplateVariables(getKeyToValueFunction());
+
+        assertEquals("foo bar val1",
+                     constraintMatch.getConstraintMatch());
+    }
+
+    @Test
+    public void substituteTemplateVariablesActionMultiConstraintHardSoftMatch() {
+        ActionHardConstraintMatch hardConstraintMatch = new ActionHardConstraintMatch("foo bar @{var1}");
+        ActionSoftConstraintMatch softConstraintMatch = new ActionSoftConstraintMatch("foo bar @{var2}");
+
+        ActionMultiConstraintHardSoftMatch multiConstraintHardSoftMatch = new ActionMultiConstraintHardSoftMatch(hardConstraintMatch,
+                                                                                                                 softConstraintMatch);
+
+        multiConstraintHardSoftMatch.substituteTemplateVariables(getKeyToValueFunction());
+
+        assertEquals("foo bar val1",
+                     multiConstraintHardSoftMatch.getActionHardConstraintMatch().getConstraintMatch());
+        assertEquals("foo bar val2",
+                     multiConstraintHardSoftMatch.getActionSoftConstraintMatch().getConstraintMatch());
+    }
+
+    @Test
+    public void substituteTemplateVariablesActionMultiConstraintHardMediumSoftMatch() {
+        ActionHardConstraintMatch hardConstraintMatch = new ActionHardConstraintMatch("foo bar @{var1}");
+        ActionMediumConstraintMatch mediumConstraintMatch = new ActionMediumConstraintMatch("foo bar @{var2}");
+        ActionSoftConstraintMatch softConstraintMatch = new ActionSoftConstraintMatch("foo bar @{var3}");
+
+        ActionMultiConstraintHardMediumSoftMatch multiConstraintHardSoftMatch = new ActionMultiConstraintHardMediumSoftMatch(hardConstraintMatch,
+                                                                                                                             mediumConstraintMatch,
+                                                                                                                             softConstraintMatch);
+
+        multiConstraintHardSoftMatch.substituteTemplateVariables(getKeyToValueFunction());
+
+        assertEquals("foo bar val1",
+                     multiConstraintHardSoftMatch.getActionHardConstraintMatch().getConstraintMatch());
+        assertEquals("foo bar val2",
+                     multiConstraintHardSoftMatch.getActionMediumConstraintMatch().getConstraintMatch());
+        assertEquals("foo bar val3",
+                     multiConstraintHardSoftMatch.getActionSoftConstraintMatch().getConstraintMatch());
+    }
+
+    @Test
+    public void substituteTemplateVariablesActionMultiConstraintBendableMatch() {
+        ActionBendableHardConstraintMatch bendableHardConstraintMatch = new ActionBendableHardConstraintMatch(0,
+                                                                                                              "foo bar @{var1}");
+        ActionBendableSoftConstraintMatch bendableSoftConstraintMatch = new ActionBendableSoftConstraintMatch(0,
+                                                                                                              "foo bar @{var2}");
+
+        ActionMultiConstraintBendableMatch multiConstraintBendableMatch = new ActionMultiConstraintBendableMatch(Arrays.asList(bendableHardConstraintMatch),
+                                                                                                                 Arrays.asList(bendableSoftConstraintMatch));
+
+        substituteTemplateVariablesAbstractActionMultiConstraintBendableMatch(multiConstraintBendableMatch);
+    }
+
+    @Test
+    public void substituteTemplateVariablesActionMultiConstraintBendableLongMatch() {
+        ActionBendableHardConstraintMatch bendableHardConstraintMatch = new ActionBendableHardConstraintMatch(0,
+                                                                                                              "foo bar @{var1}");
+        ActionBendableSoftConstraintMatch bendableSoftConstraintMatch = new ActionBendableSoftConstraintMatch(0,
+                                                                                                              "foo bar @{var2}");
+
+        ActionMultiConstraintBendableLongMatch multiConstraintBendableMatch = new ActionMultiConstraintBendableLongMatch(Arrays.asList(bendableHardConstraintMatch),
+                                                                                                                         Arrays.asList(bendableSoftConstraintMatch));
+
+        substituteTemplateVariablesAbstractActionMultiConstraintBendableMatch(multiConstraintBendableMatch);
+    }
+
+    @Test
+    public void substituteTemplateVariablesActionMultiConstraintBendableBigDecimalMatch() {
+        ActionBendableHardConstraintMatch bendableHardConstraintMatch = new ActionBendableHardConstraintMatch(0,
+                                                                                                              "foo bar @{var1}");
+        ActionBendableSoftConstraintMatch bendableSoftConstraintMatch = new ActionBendableSoftConstraintMatch(0,
+                                                                                                              "foo bar @{var2}");
+
+        ActionMultiConstraintBendableBigDecimalMatch multiConstraintBendableMatch = new ActionMultiConstraintBendableBigDecimalMatch(Arrays.asList(bendableHardConstraintMatch),
+                                                                                                                                     Arrays.asList(bendableSoftConstraintMatch));
+
+        substituteTemplateVariablesAbstractActionMultiConstraintBendableMatch(multiConstraintBendableMatch);
+    }
+
+    private void substituteTemplateVariablesAbstractActionMultiConstraintBendableMatch(final AbstractActionMultiConstraintBendableMatch constraintMatch) {
+        constraintMatch.substituteTemplateVariables(getKeyToValueFunction());
+
+        assertNotNull(constraintMatch.getActionBendableHardConstraintMatches());
+        assertEquals("foo bar val1",
+                     constraintMatch.getActionBendableHardConstraintMatches().get(0).getConstraintMatch());
+
+        assertNotNull(constraintMatch.getActionBendableSoftConstraintMatches());
+        assertEquals("foo bar val2",
+                     constraintMatch.getActionBendableSoftConstraintMatches().get(0).getConstraintMatch());
+    }
+
+    private Function<String, String> getKeyToValueFunction() {
+        return s -> {
+            switch (s) {
+                case "var1":
+                    return "val1";
+                case "var2":
+                    return "val2";
+                case "var3":
+                    return "val3";
+                default:
+                    throw new IllegalArgumentException("Undefined variable " + s);
+            }
+        };
+    }
+
+    @Test
+    public void cloneIActionBendableHardConstraintMatchPlugin() {
+        ActionBendableHardConstraintMatch constraintMatch = new ActionBendableHardConstraintMatch(0,
+                                                                                                  "test");
+
+        cloneIActionAbstractActionConstraintMatch(constraintMatch);
+    }
+
+    @Test
+    public void cloneIActionBendableSoftConstraintMatchPlugin() {
+        ActionBendableSoftConstraintMatch constraintMatch = new ActionBendableSoftConstraintMatch(0,
+                                                                                                  "test");
+        cloneIActionAbstractActionConstraintMatch(constraintMatch);
+    }
+
+    @Test
+    public void cloneIActionHardConstraintMatchPlugin() {
+        ActionHardConstraintMatch constraintMatch = new ActionHardConstraintMatch("test");
+
+        cloneIActionAbstractActionConstraintMatch(constraintMatch);
+    }
+
+    @Test
+    public void cloneIActionSoftConstraintMatchPlugin() {
+        ActionSoftConstraintMatch constraintMatch = new ActionSoftConstraintMatch("test");
+
+        cloneIActionAbstractActionConstraintMatch(constraintMatch);
+    }
+
+    @Test
+    public void cloneIActionMediumConstraintMatchPlugin() {
+        ActionMediumConstraintMatch constraintMatch = new ActionMediumConstraintMatch("test");
+
+        cloneIActionAbstractActionConstraintMatch(constraintMatch);
+    }
+
+    @Test
+    public void cloneIActionSimpleConstraintMatchPlugin() {
+        ActionSimpleConstraintMatch constraintMatch = new ActionSimpleConstraintMatch("test");
+
+        cloneIActionAbstractActionConstraintMatch(constraintMatch);
+    }
+
+    private void cloneIActionAbstractActionConstraintMatch(final AbstractActionConstraintMatch constraintMatch) {
+        IAction constraintMatchClone = (IAction) constraintMatch.cloneTemplateAware();
+
+        assertNotNull(constraintMatchClone);
+        assertNotSame(constraintMatchClone,
+                      constraintMatch);
+
+        assertEquals("test",
+                     constraintMatch.getConstraintMatch());
+    }
+
+    @Test
+    public void cloneIActionMultiConstraintBendableBigDecimalMatch() {
+        ActionBendableHardConstraintMatch bendableHardConstraintMatch = new ActionBendableHardConstraintMatch(0,
+                                                                                                              "hard");
+        ActionBendableSoftConstraintMatch bendableSoftConstraintMatch = new ActionBendableSoftConstraintMatch(0,
+                                                                                                              "soft");
+
+        ActionMultiConstraintBendableBigDecimalMatch constraintMatch = new ActionMultiConstraintBendableBigDecimalMatch(Arrays.asList(bendableHardConstraintMatch),
+                                                                                                                        Arrays.asList(bendableSoftConstraintMatch));
+
+        cloneIActionAbstractActionMultiConstraintBendableMatch(constraintMatch);
+    }
+
+    @Test
+    public void cloneIActionMultiConstraintBendableLongMatch() {
+        ActionBendableHardConstraintMatch bendableHardConstraintMatch = new ActionBendableHardConstraintMatch(0,
+                                                                                                              "hard");
+        ActionBendableSoftConstraintMatch bendableSoftConstraintMatch = new ActionBendableSoftConstraintMatch(0,
+                                                                                                              "soft");
+
+        ActionMultiConstraintBendableLongMatch constraintMatch = new ActionMultiConstraintBendableLongMatch(Arrays.asList(bendableHardConstraintMatch),
+                                                                                                            Arrays.asList(bendableSoftConstraintMatch));
+
+        cloneIActionAbstractActionMultiConstraintBendableMatch(constraintMatch);
+    }
+
+    @Test
+    public void cloneIActionMultiConstraintBendableMatch() {
+        ActionBendableHardConstraintMatch bendableHardConstraintMatch = new ActionBendableHardConstraintMatch(0,
+                                                                                                              "hard");
+        ActionBendableSoftConstraintMatch bendableSoftConstraintMatch = new ActionBendableSoftConstraintMatch(0,
+                                                                                                              "soft");
+
+        ActionMultiConstraintBendableMatch constraintMatch = new ActionMultiConstraintBendableMatch(Arrays.asList(bendableHardConstraintMatch),
+                                                                                                    Arrays.asList(bendableSoftConstraintMatch));
+
+        cloneIActionAbstractActionMultiConstraintBendableMatch(constraintMatch);
+    }
+
+    private void cloneIActionAbstractActionMultiConstraintBendableMatch(final AbstractActionMultiConstraintBendableMatch constraintMatch) {
+        IAction constraintMatchClone = (IAction) constraintMatch.cloneTemplateAware();
+
+        assertNotNull(constraintMatchClone);
+        assertNotSame(constraintMatchClone,
+                      constraintMatch);
+
+        assertNotNull(constraintMatch.getActionBendableHardConstraintMatches());
+        assertNotNull(constraintMatch.getActionBendableSoftConstraintMatches());
+
+        assertEquals("hard",
+                     constraintMatch.getActionBendableHardConstraintMatches().get(0).getConstraintMatch());
+        assertEquals("soft",
+                     constraintMatch.getActionBendableSoftConstraintMatches().get(0).getConstraintMatch());
+    }
+
+    @Test
+    public void cloneIActionMultiConstraintHardMediumSoftMatch() {
+        ActionHardConstraintMatch hardConstraintMatch = new ActionHardConstraintMatch("hard");
+        ActionMediumConstraintMatch mediumConstraintMatch = new ActionMediumConstraintMatch("medium");
+        ActionSoftConstraintMatch softConstraintMatch = new ActionSoftConstraintMatch("soft");
+
+        ActionMultiConstraintHardMediumSoftMatch constraintMatch = new ActionMultiConstraintHardMediumSoftMatch(hardConstraintMatch,
+                                                                                                                mediumConstraintMatch,
+                                                                                                                softConstraintMatch);
+
+        IAction constraintMatchClone = (IAction) constraintMatch.cloneTemplateAware();
+
+        assertNotNull(constraintMatchClone);
+        assertNotSame(constraintMatchClone,
+                      constraintMatch);
+
+        assertNotNull(constraintMatch.getActionHardConstraintMatch());
+        assertNotNull(constraintMatch.getActionMediumConstraintMatch());
+        assertNotNull(constraintMatch.getActionSoftConstraintMatch());
+
+        assertEquals("hard",
+                     constraintMatch.getActionHardConstraintMatch().getConstraintMatch());
+        assertEquals("medium",
+                     constraintMatch.getActionMediumConstraintMatch().getConstraintMatch());
+        assertEquals("soft",
+                     constraintMatch.getActionSoftConstraintMatch().getConstraintMatch());
+    }
+
+    @Test
+    public void cloneIActionMultiConstraintHardSoftMatch() {
+        ActionHardConstraintMatch hardConstraintMatch = new ActionHardConstraintMatch("hard");
+        ActionSoftConstraintMatch softConstraintMatch = new ActionSoftConstraintMatch("soft");
+
+        ActionMultiConstraintHardSoftMatch constraintMatch = new ActionMultiConstraintHardSoftMatch(hardConstraintMatch,
+                                                                                                    softConstraintMatch);
+
+        IAction constraintMatchClone = (IAction) constraintMatch.cloneTemplateAware();
+
+        assertNotNull(constraintMatchClone);
+        assertNotSame(constraintMatchClone,
+                      constraintMatch);
+
+        assertNotNull(constraintMatch.getActionHardConstraintMatch());
+        assertNotNull(constraintMatch.getActionSoftConstraintMatch());
+
+        assertEquals("hard",
+                     constraintMatch.getActionHardConstraintMatch().getConstraintMatch());
+        assertEquals("soft",
+                     constraintMatch.getActionSoftConstraintMatch().getConstraintMatch());
+    }
+
+    @Test
+    public void marshalActionSoftConstraintMatch() {
+        ActionSoftConstraintMatch action = new ActionSoftConstraintMatch("-1");
+
+        String marshaledAction = action.getStringRepresentation();
+
+        assertEquals("scoreHolder.addSoftConstraintMatch(kcontext, -1)",
+                     marshaledAction);
+    }
+
+    @Test
+    public void marshalActionBendableSoftConstraintMatch() {
+        ActionBendableSoftConstraintMatch action = new ActionBendableSoftConstraintMatch(1,
+                                                                                         "-1");
+
+        String marshaledAction = action.getStringRepresentation();
+
+        assertEquals("scoreHolder.addSoftConstraintMatch(kcontext, 1, -1)",
+                     marshaledAction);
+    }
+
+    @Test
+    public void marshalActionMediumConstraintMatch() {
+        ActionMediumConstraintMatch action = new ActionMediumConstraintMatch("-1");
+
+        String marshaledAction = action.getStringRepresentation();
+
+        assertEquals("scoreHolder.addMediumConstraintMatch(kcontext, -1)",
+                     marshaledAction);
+    }
+
+    @Test
+    public void marshalActionMultiConstraintHardSoftMatch() {
+        ActionMultiConstraintHardSoftMatch action = new ActionMultiConstraintHardSoftMatch(new ActionHardConstraintMatch("-1"),
+                                                                                           new ActionSoftConstraintMatch("-2"));
+
+        String marshaledAction = action.getStringRepresentation();
+
+        assertEquals("scoreHolder.addMultiConstraintMatch(kcontext, -1, -2)",
+                     marshaledAction);
+    }
+
+    @Test
+    public void marshalActionMultiConstraintHardMediumSoftMatch() {
+        ActionMultiConstraintHardMediumSoftMatch action = new ActionMultiConstraintHardMediumSoftMatch(new ActionHardConstraintMatch("-1"),
+                                                                                                       new ActionMediumConstraintMatch("-2"),
+                                                                                                       new ActionSoftConstraintMatch("-3"));
+
+        String marshaledAction = action.getStringRepresentation();
+
+        assertEquals("scoreHolder.addMultiConstraintMatch(kcontext, -1, -2, -3)",
+                     marshaledAction);
+    }
+
+    @Test
+    public void marshalActionMultiConstraintBendableMatch() {
+        ActionMultiConstraintBendableMatch action = new ActionMultiConstraintBendableMatch(Arrays.asList(new ActionBendableHardConstraintMatch(0,
+                                                                                                                                               "-1"),
+                                                                                                         new ActionBendableHardConstraintMatch(1,
+                                                                                                                                               "-2")),
+                                                                                           Arrays.asList(new ActionBendableSoftConstraintMatch(0,
+                                                                                                                                               "-3"),
+                                                                                                         new ActionBendableSoftConstraintMatch(1,
+                                                                                                                                               "-4")));
+
+        String marshaledAction = action.getStringRepresentation();
+
+        assertEquals("scoreHolder.addMultiConstraintMatch(kcontext, new int[] {-1, -2}, new int[] {-3, -4})",
+                     marshaledAction);
+    }
+
+    @Test
+    public void marshalActionMultiConstraintBendableLongMatch() {
+        ActionMultiConstraintBendableLongMatch action = new ActionMultiConstraintBendableLongMatch(Arrays.asList(new ActionBendableHardConstraintMatch(0,
+                                                                                                                                                       "-1l"),
+                                                                                                                 new ActionBendableHardConstraintMatch(1,
+                                                                                                                                                       "-2l")),
+                                                                                                   Arrays.asList(new ActionBendableSoftConstraintMatch(0,
+                                                                                                                                                       "-3l"),
+                                                                                                                 new ActionBendableSoftConstraintMatch(1,
+                                                                                                                                                       "-4l")));
+
+        String marshaledAction = action.getStringRepresentation();
+
+        assertEquals("scoreHolder.addMultiConstraintMatch(kcontext, new long[] {-1l, -2l}, new long[] {-3l, -4l})",
+                     marshaledAction);
+    }
+
+    @Test
+    public void marshalActionMultiConstraintBendableBigDecimalMatch() {
+        ActionMultiConstraintBendableBigDecimalMatch action = new ActionMultiConstraintBendableBigDecimalMatch(Arrays.asList(new ActionBendableHardConstraintMatch(0,
+                                                                                                                                                                   "new java.math.BigDecimal(-1)"),
+                                                                                                                             new ActionBendableHardConstraintMatch(1,
+                                                                                                                                                                   "new java.math.BigDecimal(-2)")),
+                                                                                                               Arrays.asList(new ActionBendableSoftConstraintMatch(0,
+                                                                                                                                                                   "new java.math.BigDecimal(-3)"),
+                                                                                                                             new ActionBendableSoftConstraintMatch(1,
+                                                                                                                                                                   "new java.math.BigDecimal(-4)")));
+
+        String marshaledAction = action.getStringRepresentation();
+
+        assertEquals("scoreHolder.addMultiConstraintMatch(kcontext, new java.math.BigDecimal[] {new java.math.BigDecimal(-1), new java.math.BigDecimal(-2)}, new java.math.BigDecimal[] {new java.math.BigDecimal(-3), new java.math.BigDecimal(-4)})",
+                     marshaledAction);
+    }
+
+    @Test
+    public void marshalActionSimpleConstraintMatch() {
+        ActionSimpleConstraintMatch action = new ActionSimpleConstraintMatch("-1");
+
+        String marshaledAction = action.getStringRepresentation();
+
+        assertEquals("scoreHolder.addConstraintMatch(kcontext, -1)",
+                     marshaledAction);
+    }
+
+    @Test
+    public void marshalActionHardConstraintMatch() {
+        ActionHardConstraintMatch action = new ActionHardConstraintMatch("-1");
+
+        String marshaledAction = action.getStringRepresentation();
+
+        assertEquals("scoreHolder.addHardConstraintMatch(kcontext, -1)",
+                     marshaledAction);
+    }
+
+    @Test
+    public void marshalActionBendableHardConstraintMatch() {
+        ActionBendableHardConstraintMatch action = new ActionBendableHardConstraintMatch(1,
+                                                                                         "-1");
+
+        String marshaledAction = action.getStringRepresentation();
+
+        assertEquals("scoreHolder.addHardConstraintMatch(kcontext, 1, -1)",
+                     marshaledAction);
+    }
+}

--- a/optaplanner-integration/optaplanner-workbench-models/optaplanner-workbench-models-datamodel-api/src/test/java/org/optaplanner/workbench/models/datamodel/util/TemplateUtilsTest.java
+++ b/optaplanner-integration/optaplanner-workbench-models/optaplanner-workbench-models-datamodel-api/src/test/java/org/optaplanner/workbench/models/datamodel/util/TemplateUtilsTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.workbench.models.datamodel.util;
+
+import java.util.Collection;
+import java.util.function.Function;
+
+import org.drools.workbench.models.datamodel.rule.InterpolationVariable;
+import org.junit.Test;
+import org.kie.soup.project.datamodel.oracle.DataType;
+
+import static org.junit.Assert.*;
+
+public class TemplateUtilsTest {
+
+    @Test
+    public void extractInterpolationVariablesContainsVariables() {
+        String string = "foo bar @{var1} baz @{var2}";
+
+        Collection<InterpolationVariable> interpolationVariables = TemplateUtils.extractInterpolationVariables(string);
+
+        assertEquals(2,
+                     interpolationVariables.size());
+        assertTrue(interpolationVariables.contains(new InterpolationVariable("var1",
+                                                                             DataType.TYPE_OBJECT)));
+        assertTrue(interpolationVariables.contains(new InterpolationVariable("var2",
+                                                                             DataType.TYPE_OBJECT)));
+    }
+
+    @Test
+    public void extractInterpolationVariablesBrokenPattern() {
+        String string = "foo @{zzz bar baz @";
+
+        Collection<InterpolationVariable> interpolationVariables = TemplateUtils.extractInterpolationVariables(string);
+
+        assertTrue(interpolationVariables.isEmpty());
+    }
+
+    @Test
+    public void extractInterpolationVariablesNoVariables() {
+        String string = "foo bar baz";
+
+        Collection<InterpolationVariable> interpolationVariables = TemplateUtils.extractInterpolationVariables(string);
+
+        assertTrue(interpolationVariables.isEmpty());
+    }
+
+    @Test
+    public void substituteTemplateKey() {
+        String string = "foo bar @{var1} baz @{var2}";
+
+        Function<String, String> keyToValueFunction = s -> {
+            switch (s) {
+                case "var1":
+                    return "val1";
+                case "var2":
+                    return "val2";
+                default:
+                    throw new IllegalArgumentException("Undefined variable " + s);
+            }
+        };
+
+        String result = TemplateUtils.substituteTemplateVariable(string,
+                                                                 keyToValueFunction);
+
+        assertEquals("foo bar val1 baz val2",
+                     result);
+    }
+}

--- a/optaplanner-integration/optaplanner-workbench-models/pom.xml
+++ b/optaplanner-integration/optaplanner-workbench-models/pom.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.optaplanner</groupId>
+    <artifactId>optaplanner-integration</artifactId>
+    <version>7.32.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>optaplanner-workbench-models</artifactId>
+  <packaging>pom</packaging>
+
+  <name>OptaPlanner Workbench models</name>
+  <description>This module contains OptaPlanner Workbench integration modules.</description>
+
+  <modules>
+    <module>optaplanner-workbench-models-core</module>
+    <module>optaplanner-workbench-models-datamodel-api</module>
+  </modules>
+
+</project>

--- a/optaplanner-integration/pom.xml
+++ b/optaplanner-integration/pom.xml
@@ -25,6 +25,7 @@
   <modules>
     <module>optaplanner-spring-boot-autoconfigure</module>
     <module>optaplanner-spring-boot-starter</module>
+    <module>optaplanner-workbench-models</module>
   </modules>
 
   <dependencyManagement>


### PR DESCRIPTION
Reverts kiegroup/optaplanner#639

Can't simply move the models to `optaplanner-wb` repository because that is being built *after* `droolsjbpm-integration` where there is a dependency from `kie-maven-plugin` to the model.

Discussion will continue on internal BSIG mailing list.

![dep-tree dot](https://user-images.githubusercontent.com/673386/71085907-d9244580-2198-11ea-99c1-6d757873234f.png)

CC @ge0ffrey, @cuijulian 