### PR TITLE
PLANNER-1764 groupBy on TriStreams

### DIFF
--- a/optaplanner-core/src/build/revapi-config.json
+++ b/optaplanner-core/src/build/revapi-config.json
@@ -351,6 +351,60 @@
           "methodName": "groupBy",
           "elementKind": "method",
           "justification": "Introduce groupBy() for BiStreams."
+        },
+        {
+          "code": "java.method.addedToInterface",
+          "new": "method <ResultContainer_, Result_> org.optaplanner.core.api.score.stream.uni.UniConstraintStream<Result_> org.optaplanner.core.api.score.stream.bi.BiConstraintStream<A, B>::groupBy(org.optaplanner.core.api.score.stream.bi.BiConstraintCollector<A, B, ResultContainer_, Result_>)",
+          "package": "org.optaplanner.core.api.score.stream.bi",
+          "classSimpleName": "BiConstraintStream",
+          "methodName": "groupBy",
+          "elementKind": "method",
+          "justification": "Introduce groupBy() for TriStreams."
+        },
+        {
+          "code": "java.method.addedToInterface",
+          "new": "method <GroupKey_> org.optaplanner.core.api.score.stream.uni.UniConstraintStream<GroupKey_> org.optaplanner.core.api.score.stream.tri.TriConstraintStream<A, B, C>::groupBy(org.optaplanner.core.api.function.TriFunction<A, B, C, GroupKey_>)",
+          "package": "org.optaplanner.core.api.score.stream.tri",
+          "classSimpleName": "TriConstraintStream",
+          "methodName": "groupBy",
+          "elementKind": "method",
+          "justification": "Introduce groupBy() for TriStreams."
+        },
+        {
+          "code": "java.method.addedToInterface",
+          "new": "method <GroupKeyA_, GroupKeyB_> org.optaplanner.core.api.score.stream.bi.BiConstraintStream<GroupKeyA_, GroupKeyB_> org.optaplanner.core.api.score.stream.tri.TriConstraintStream<A, B, C>::groupBy(org.optaplanner.core.api.function.TriFunction<A, B, C, GroupKeyA_>, org.optaplanner.core.api.function.TriFunction<A, B, C, GroupKeyB_>)",
+          "package": "org.optaplanner.core.api.score.stream.tri",
+          "classSimpleName": "TriConstraintStream",
+          "methodName": "groupBy",
+          "elementKind": "method",
+          "justification": "Introduce groupBy() for TriStreams."
+        },
+        {
+          "code": "java.method.addedToInterface",
+          "new": "method <GroupKeyA_, GroupKeyB_, ResultContainer_, Result_> org.optaplanner.core.api.score.stream.tri.TriConstraintStream<GroupKeyA_, GroupKeyB_, Result_> org.optaplanner.core.api.score.stream.tri.TriConstraintStream<A, B, C>::groupBy(org.optaplanner.core.api.function.TriFunction<A, B, C, GroupKeyA_>, org.optaplanner.core.api.function.TriFunction<A, B, C, GroupKeyB_>, org.optaplanner.core.api.score.stream.tri.TriConstraintCollector<A, B, C, ResultContainer_, Result_>)",
+          "package": "org.optaplanner.core.api.score.stream.tri",
+          "classSimpleName": "TriConstraintStream",
+          "methodName": "groupBy",
+          "elementKind": "method",
+          "justification": "Introduce groupBy() for TriStreams."
+        },
+        {
+          "code": "java.method.addedToInterface",
+          "new": "method <GroupKey_, ResultContainer_, Result_> org.optaplanner.core.api.score.stream.bi.BiConstraintStream<GroupKey_, Result_> org.optaplanner.core.api.score.stream.tri.TriConstraintStream<A, B, C>::groupBy(org.optaplanner.core.api.function.TriFunction<A, B, C, GroupKey_>, org.optaplanner.core.api.score.stream.tri.TriConstraintCollector<A, B, C, ResultContainer_, Result_>)",
+          "package": "org.optaplanner.core.api.score.stream.tri",
+          "classSimpleName": "TriConstraintStream",
+          "methodName": "groupBy",
+          "elementKind": "method",
+          "justification": "Introduce groupBy() for TriStreams."
+        },
+        {
+          "code": "java.method.addedToInterface",
+          "new": "method <ResultContainer_, Result_> org.optaplanner.core.api.score.stream.uni.UniConstraintStream<Result_> org.optaplanner.core.api.score.stream.tri.TriConstraintStream<A, B, C>::groupBy(org.optaplanner.core.api.score.stream.tri.TriConstraintCollector<A, B, C, ResultContainer_, Result_>)",
+          "package": "org.optaplanner.core.api.score.stream.tri",
+          "classSimpleName": "TriConstraintStream",
+          "methodName": "groupBy",
+          "elementKind": "method",
+          "justification": "Introduce groupBy() for TriStreams."
         }
       ]
     }

--- a/optaplanner-core/src/main/java/org/optaplanner/core/api/score/stream/ConstraintCollectors.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/api/score/stream/ConstraintCollectors.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,10 +32,15 @@ import java.util.function.ToIntFunction;
 import java.util.function.ToLongBiFunction;
 import java.util.function.ToLongFunction;
 
+import org.optaplanner.core.api.function.ToIntTriFunction;
+import org.optaplanner.core.api.function.ToLongTriFunction;
+import org.optaplanner.core.api.function.TriFunction;
 import org.optaplanner.core.api.score.stream.bi.BiConstraintCollector;
+import org.optaplanner.core.api.score.stream.tri.TriConstraintCollector;
 import org.optaplanner.core.api.score.stream.uni.UniConstraintCollector;
 import org.optaplanner.core.api.score.stream.uni.UniConstraintStream;
 import org.optaplanner.core.impl.score.stream.bi.DefaultBiConstraintCollector;
+import org.optaplanner.core.impl.score.stream.tri.DefaultTriConstraintCollector;
 import org.optaplanner.core.impl.score.stream.uni.DefaultUniConstraintCollector;
 
 /**
@@ -82,6 +87,26 @@ public final class ConstraintCollectors {
         return new DefaultBiConstraintCollector<>(
                 () -> new long[1],
                 (resultContainer, a, b) -> {
+                    resultContainer[0]++;
+                    return (() -> resultContainer[0]--);
+                },
+                resultContainer -> resultContainer[0]);
+    }
+
+    public static <A, B, C> TriConstraintCollector<A, B, C, ?, Integer> countTri() {
+        return new DefaultTriConstraintCollector<>(
+                () -> new int[1],
+                (resultContainer, a, b, c) -> {
+                    resultContainer[0]++;
+                    return (() -> resultContainer[0]--);
+                },
+                resultContainer -> resultContainer[0]);
+    }
+
+    public static <A, B, C> TriConstraintCollector<A, B, C, ?, Long> countLongTri() {
+        return new DefaultTriConstraintCollector<>(
+                () -> new long[1],
+                (resultContainer, a, b, c) -> {
                     resultContainer[0]++;
                     return (() -> resultContainer[0]--);
                 },
@@ -290,6 +315,78 @@ public final class ConstraintCollectors {
                 () -> new Period[] { Period.ZERO },
                 (resultContainer, a, b) -> {
                     Period value = groupValueMapping.apply(a, b);
+                    resultContainer[0] = resultContainer[0].plus(value);
+                    return (() -> resultContainer[0] = resultContainer[0].minus(value));
+                },
+                resultContainer -> resultContainer[0]);
+    }
+
+    public static <A, B, C> TriConstraintCollector<A, B, C, ?, Integer> sum(
+            ToIntTriFunction<? super A, ? super B, ? super C> groupValueMapping) {
+        return new DefaultTriConstraintCollector<>(
+                () -> new int[1],
+                (resultContainer, a, b, c) -> {
+                    int value = groupValueMapping.applyAsInt(a, b, c);
+                    resultContainer[0] += value;
+                    return (() -> resultContainer[0] -= value);
+                },
+                resultContainer -> resultContainer[0]);
+    }
+
+    public static <A, B, C> TriConstraintCollector<A, B, C, ?, Long> sumLong(
+            ToLongTriFunction<? super A, ? super B, ? super C> groupValueMapping) {
+        return new DefaultTriConstraintCollector<>(
+                () -> new long[1],
+                (resultContainer, a, b, c) -> {
+                    long value = groupValueMapping.applyAsLong(a, b, c);
+                    resultContainer[0] += value;
+                    return (() -> resultContainer[0] -= value);
+                },
+                resultContainer -> resultContainer[0]);
+    }
+
+    public static <A, B, C> TriConstraintCollector<A, B, C, ?, BigDecimal> sumBigDecimal(
+            TriFunction<? super A, ? super B, ? super C, BigDecimal> groupValueMapping) {
+        return new DefaultTriConstraintCollector<>(
+                () -> new BigDecimal[] { BigDecimal.ZERO },
+                (resultContainer, a, b, c) -> {
+                    BigDecimal value = groupValueMapping.apply(a, b, c);
+                    resultContainer[0] = resultContainer[0].add(value);
+                    return (() -> resultContainer[0] = resultContainer[0].subtract(value));
+                },
+                resultContainer -> resultContainer[0]);
+    }
+
+    public static <A, B, C> TriConstraintCollector<A, B, C, ?, BigInteger> sumBigInteger(
+            TriFunction<? super A, ? super B, ? super C, BigInteger> groupValueMapping) {
+        return new DefaultTriConstraintCollector<>(
+                () -> new BigInteger[] { BigInteger.ZERO },
+                (resultContainer, a, b, c) -> {
+                    BigInteger value = groupValueMapping.apply(a, b, c);
+                    resultContainer[0] = resultContainer[0].add(value);
+                    return (() -> resultContainer[0] = resultContainer[0].subtract(value));
+                },
+                resultContainer -> resultContainer[0]);
+    }
+
+    public static <A, B, C> TriConstraintCollector<A, B, C, ?, Duration> sumDuration(
+            TriFunction<? super A, ? super B, ? super C, Duration> groupValueMapping) {
+        return new DefaultTriConstraintCollector<>(
+                () -> new Duration[] { Duration.ZERO },
+                (resultContainer, a, b, c) -> {
+                    Duration value = groupValueMapping.apply(a, b, c);
+                    resultContainer[0] = resultContainer[0].plus(value);
+                    return (() -> resultContainer[0] = resultContainer[0].minus(value));
+                },
+                resultContainer -> resultContainer[0]);
+    }
+
+    public static <A, B, C> TriConstraintCollector<A, B, C, ?, Period> sumPeriod(
+            TriFunction<? super A, ? super B, ? super C, Period> groupValueMapping) {
+        return new DefaultTriConstraintCollector<>(
+                () -> new Period[] { Period.ZERO },
+                (resultContainer, a, b, c) -> {
+                    Period value = groupValueMapping.apply(a, b, c);
                     resultContainer[0] = resultContainer[0].plus(value);
                     return (() -> resultContainer[0] = resultContainer[0].minus(value));
                 },

--- a/optaplanner-core/src/main/java/org/optaplanner/core/api/score/stream/bi/BiConstraintStream.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/api/score/stream/bi/BiConstraintStream.java
@@ -251,14 +251,23 @@ public interface BiConstraintStream<A, B> extends ConstraintStream {
     <GroupKeyA_, GroupKeyB_> BiConstraintStream<GroupKeyA_, GroupKeyB_> groupBy(
             BiFunction<A, B, GroupKeyA_> groupKeyAMapping, BiFunction<A, B, GroupKeyB_> groupKeyBMapping);
 
-    /*
-    // TODO implement this
-    <GroupKeyA_, GroupKeyB_, ResultContainer_, Result_>
-    TriConstraintStream<GroupKeyA_, GroupKeyB_, Result_> groupBy(
-            BiFunction<A, B, GroupKeyA_> groupKeyAMapping,
-            BiFunction<A, B, GroupKeyB_> groupKeyBMapping,
-            BiConstraintCollector<A, B, ResultContainer_, Result_> collector);
+    /**
+     * Combines the semantics of {@link #groupBy(BiFunction, BiFunction)} and {@link #groupBy(BiConstraintCollector)}.
+     * That is, the first and second facts in the tuple follow the {@link #groupBy(BiFunction, BiFunction)} semantics,
+     * and the third fact is the result of applying {@link BiConstraintCollector#finisher()} on all the tuples of the
+     * original {@link UniConstraintStream} that fall in the group.
+     * @param groupKeyAMapping never null, function to convert first fact in the original tuple to a different fact
+     * @param groupKeyBMapping never null, function to convert second fact in the original tuple to a different fact
+     * @param collector never null, the collector to perform the grouping operation with
+     * @param <GroupKeyA_> the type of the first fact in the destination {@link TriConstraintStream}'s tuple
+     * @param <GroupKeyB_> the type of the second fact in the destination {@link TriConstraintStream}'s tuple
+     * @param <ResultContainer_> the mutable accumulation type (often hidden as an implementation detail)
+     * @param <Result_> the type of the third fact in the destination {@link TriConstraintStream}'s tuple
+     * @return never null
      */
+    <GroupKeyA_, GroupKeyB_, ResultContainer_, Result_> TriConstraintStream<GroupKeyA_, GroupKeyB_, Result_> groupBy(
+            BiFunction<A, B, GroupKeyA_> groupKeyAMapping, BiFunction<A, B, GroupKeyB_> groupKeyBMapping,
+            BiConstraintCollector<A, B, ResultContainer_, Result_> collector);
 
     // ************************************************************************
     // Penalize/reward

--- a/optaplanner-core/src/main/java/org/optaplanner/core/api/score/stream/tri/TriConstraintCollector.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/api/score/stream/tri/TriConstraintCollector.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.core.api.score.stream.tri;
+
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.stream.Collector;
+
+import org.optaplanner.core.api.function.QuadFunction;
+import org.optaplanner.core.api.function.TriFunction;
+import org.optaplanner.core.api.score.stream.ConstraintCollectors;
+import org.optaplanner.core.api.score.stream.ConstraintStream;
+
+/**
+ * Usually created with {@link ConstraintCollectors}.
+ * Used by {@link TriConstraintStream#groupBy(TriFunction, TriConstraintCollector)}, ...
+ * <p>
+ * Loosely based on JDK's {@link Collector}, but it returns an undo operation for each accumulation
+ * to enable incremental score calculation in {@link ConstraintStream constraint streams}.
+ * @param <A> the type of the first fact of the tuple in the source {@link TriConstraintStream}
+ * @param <B> the type of the second fact of the tuple in the source {@link TriConstraintStream}
+ * @param <ResultContainer_> the mutable accumulation type (often hidden as an implementation detail)
+ * @param <Result_> the type of the fact of the tuple in the destination {@link ConstraintStream}
+ * @see ConstraintCollectors
+ */
+public interface TriConstraintCollector<A, B, C, ResultContainer_, Result_> {
+
+    /**
+     * A lambda that creates the result container, one for each group key combination.
+     * @return never null
+     */
+    Supplier<ResultContainer_> supplier();
+
+    /**
+     * A lambda that extracts data from the matched facts,
+     * accumulates it in the result container
+     * and returns an undo operation for that accumulation.
+     * @return never null, the undo operation. This lamdba is called when the facts no longer matches.
+     */
+    QuadFunction<ResultContainer_, A, B, C, Runnable> accumulator();
+
+    /**
+     * A lambda that converts the result container into the result.
+     * @return never null
+     */
+    Function<ResultContainer_, Result_> finisher();
+
+}

--- a/optaplanner-core/src/main/java/org/optaplanner/core/api/score/stream/uni/UniConstraintStream.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/api/score/stream/uni/UniConstraintStream.java
@@ -31,6 +31,7 @@ import org.optaplanner.core.api.score.stream.Constraint;
 import org.optaplanner.core.api.score.stream.ConstraintStream;
 import org.optaplanner.core.api.score.stream.bi.BiConstraintStream;
 import org.optaplanner.core.api.score.stream.bi.BiJoiner;
+import org.optaplanner.core.api.score.stream.tri.TriConstraintStream;
 import org.optaplanner.core.impl.score.stream.bi.AbstractBiJoiner;
 import org.optaplanner.core.impl.score.stream.bi.NoneBiJoiner;
 
@@ -239,7 +240,6 @@ public interface UniConstraintStream<A> extends ConstraintStream {
     <GroupKeyA_, GroupKeyB_> BiConstraintStream<GroupKeyA_, GroupKeyB_> groupBy(
             Function<A, GroupKeyA_> groupKeyAMapping, Function<A, GroupKeyB_> groupKeyBMapping);
 
-    /*
     /**
      * Combines the semantics of {@link #groupBy(Function, Function)} and {@link #groupBy(UniConstraintCollector)}.
      * That is, the first and second facts in the tuple follow the {@link #groupBy(Function, Function)} semantics, and
@@ -254,11 +254,9 @@ public interface UniConstraintStream<A> extends ConstraintStream {
      * @param <Result_> the type of the third fact in the destination {@link TriConstraintStream}'s tuple
      * @return never null
      */
-    // TODO implement this
-    //<GroupKeyA_, GroupKeyB_, ResultContainer_, Result_> TriConstraintStream<GroupKeyA_, GroupKeyB_, Result_> groupBy(
-    //        Function<A, GroupKeyA_> groupKeyAMapping,
-    //        Function<A, GroupKeyB_> groupKeyBMapping,
-    //        UniConstraintCollector<A, ResultContainer_, Result_> collector);
+    <GroupKeyA_, GroupKeyB_, ResultContainer_, Result_> TriConstraintStream<GroupKeyA_, GroupKeyB_, Result_> groupBy(
+            Function<A, GroupKeyA_> groupKeyAMapping, Function<A, GroupKeyB_> groupKeyBMapping,
+            UniConstraintCollector<A, ResultContainer_, Result_> collector);
 
     // ************************************************************************
     // Penalize/reward

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/bavet/bi/BavetAbstractBiConstraintStream.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/bavet/bi/BavetAbstractBiConstraintStream.java
@@ -131,6 +131,11 @@ public abstract class BavetAbstractBiConstraintStream<Solution_, A, B> extends B
         throw new UnsupportedOperationException();
     }
 
+    @Override
+    public <GroupKeyA_, GroupKeyB_, ResultContainer_, Result_> TriConstraintStream<GroupKeyA_, GroupKeyB_, Result_> groupBy(BiFunction<A, B, GroupKeyA_> groupKeyAMapping, BiFunction<A, B, GroupKeyB_> groupKeyBMapping, BiConstraintCollector<A, B, ResultContainer_, Result_> collector) {
+        throw new UnsupportedOperationException();
+    }
+
     // ************************************************************************
     // Penalize/reward
     // ************************************************************************

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/bavet/tri/BavetAbstractTriConstraintStream.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/bavet/tri/BavetAbstractTriConstraintStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,8 +26,11 @@ import org.optaplanner.core.api.function.TriFunction;
 import org.optaplanner.core.api.function.TriPredicate;
 import org.optaplanner.core.api.score.Score;
 import org.optaplanner.core.api.score.stream.Constraint;
+import org.optaplanner.core.api.score.stream.bi.BiConstraintStream;
 import org.optaplanner.core.api.score.stream.quad.QuadConstraintStream;
 import org.optaplanner.core.api.score.stream.quad.QuadJoiner;
+import org.optaplanner.core.api.score.stream.tri.TriConstraintCollector;
+import org.optaplanner.core.api.score.stream.tri.TriConstraintStream;
 import org.optaplanner.core.api.score.stream.uni.UniConstraintStream;
 import org.optaplanner.core.impl.score.stream.bavet.BavetConstraint;
 import org.optaplanner.core.impl.score.stream.bavet.BavetConstraintFactory;
@@ -69,6 +72,35 @@ public abstract class BavetAbstractTriConstraintStream<Solution_, A, B, C> exten
 
     @Override
     public <D> QuadConstraintStream<A, B, C, D> join(UniConstraintStream<D> otherStream, QuadJoiner<A, B, C, D> joiner) {
+        throw new UnsupportedOperationException();
+    }
+
+    // ************************************************************************
+    // Group by
+    // ************************************************************************
+
+    @Override
+    public <ResultContainer_, Result_> UniConstraintStream<Result_> groupBy(TriConstraintCollector<A, B, C, ResultContainer_, Result_> collector) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public <GroupKey_> UniConstraintStream<GroupKey_> groupBy(TriFunction<A, B, C, GroupKey_> groupKeyMapping) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public <GroupKey_, ResultContainer_, Result_> BiConstraintStream<GroupKey_, Result_> groupBy(TriFunction<A, B, C, GroupKey_> groupKeyMapping, TriConstraintCollector<A, B, C, ResultContainer_, Result_> collector) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public <GroupKeyA_, GroupKeyB_> BiConstraintStream<GroupKeyA_, GroupKeyB_> groupBy(TriFunction<A, B, C, GroupKeyA_> groupKeyAMapping, TriFunction<A, B, C, GroupKeyB_> groupKeyBMapping) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public <GroupKeyA_, GroupKeyB_, ResultContainer_, Result_> TriConstraintStream<GroupKeyA_, GroupKeyB_, Result_> groupBy(TriFunction<A, B, C, GroupKeyA_> groupKeyAMapping, TriFunction<A, B, C, GroupKeyB_> groupKeyBMapping, TriConstraintCollector<A, B, C, ResultContainer_, Result_> collector) {
         throw new UnsupportedOperationException();
     }
 

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/bavet/uni/BavetAbstractUniConstraintStream.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/bavet/uni/BavetAbstractUniConstraintStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,6 +29,7 @@ import org.optaplanner.core.api.score.stream.Constraint;
 import org.optaplanner.core.api.score.stream.ConstraintFactory;
 import org.optaplanner.core.api.score.stream.bi.BiConstraintStream;
 import org.optaplanner.core.api.score.stream.bi.BiJoiner;
+import org.optaplanner.core.api.score.stream.tri.TriConstraintStream;
 import org.optaplanner.core.api.score.stream.uni.UniConstraintCollector;
 import org.optaplanner.core.api.score.stream.uni.UniConstraintStream;
 import org.optaplanner.core.impl.score.stream.bavet.BavetConstraint;
@@ -135,6 +136,11 @@ public abstract class BavetAbstractUniConstraintStream<Solution_, A> extends Bav
                 = new BavetGroupBiConstraintStream<>(constraintFactory, bridge, collector.finisher());
         bridge.setGroupStream(groupStream);
         return groupStream;
+    }
+
+    @Override
+    public <GroupKeyA_, GroupKeyB_, ResultContainer_, Result_> TriConstraintStream<GroupKeyA_, GroupKeyB_, Result_> groupBy(Function<A, GroupKeyA_> groupKeyAMapping, Function<A, GroupKeyB_> groupKeyBMapping, UniConstraintCollector<A, ResultContainer_, Result_> collector) {
+        throw new UnsupportedOperationException(); // TODO
     }
 
     // ************************************************************************

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/DroolsConstraintSessionFactory.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/DroolsConstraintSessionFactory.java
@@ -82,10 +82,10 @@ public class DroolsConstraintSessionFactory<Solution_> implements ConstraintSess
                      */
                     if (item instanceof BiTuple) {
                         BiTuple<?, ?> pair = (BiTuple<?, ?>) item;
-                        return Stream.of(pair._1, pair._2);
+                        return Stream.of(pair.a, pair.b);
                     } else if (item instanceof TriTuple) {
                         TriTuple<?, ?, ?> pair = (TriTuple<?, ?, ?>) item;
-                        return Stream.of(pair._1, pair._2, pair._3);
+                        return Stream.of(pair.a, pair.b, pair.c);
                     } else {
                         return Stream.of(item);
                     }

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/DroolsConstraintSessionFactory.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/DroolsConstraintSessionFactory.java
@@ -33,6 +33,7 @@ import org.optaplanner.core.impl.score.director.drools.OptaPlannerRuleEventListe
 import org.optaplanner.core.impl.score.stream.ConstraintSession;
 import org.optaplanner.core.impl.score.stream.ConstraintSessionFactory;
 import org.optaplanner.core.impl.score.stream.drools.common.BiTuple;
+import org.optaplanner.core.impl.score.stream.drools.common.TriTuple;
 
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toMap;
@@ -75,13 +76,16 @@ public class DroolsConstraintSessionFactory<Solution_> implements ConstraintSess
     private static List<Object> unpair(List<Object> justificationList, int expectedJustificationCount) {
         return justificationList.stream()
                 .flatMap(item -> {
+                    /*
+                     * In the case of Drools-based CS, the justification may be both in the form of (A, B, ...) and
+                     * Tuple<A, B, ...>. In the latter case, we adapt to the former.
+                     */
                     if (item instanceof BiTuple) {
-                        /*
-                         * In the case of Drools-based CS, the justification may be both in the form of (A, B) and
-                         * Pair<A, B>. In the latter case, we adapt to the former.
-                         */
                         BiTuple<?, ?> pair = (BiTuple<?, ?>) item;
-                        return Stream.of(pair.key, pair.value);
+                        return Stream.of(pair._1, pair._2);
+                    } else if (item instanceof TriTuple) {
+                        TriTuple<?, ?, ?> pair = (TriTuple<?, ?, ?>) item;
+                        return Stream.of(pair._1, pair._2, pair._3);
                     } else {
                         return Stream.of(item);
                     }

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/bi/DroolsAbstractBiConstraintStream.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/bi/DroolsAbstractBiConstraintStream.java
@@ -74,7 +74,7 @@ public abstract class DroolsAbstractBiConstraintStream<Solution_, A, B>
     public <ResultContainer_, Result_> UniConstraintStream<Result_> groupBy(
             BiConstraintCollector<A, B, ResultContainer_, Result_> collector) {
         throwWhenGroupByNotAllowed();
-        DroolsGroupingUniConstraintStream<Solution_, A, Result_> stream =
+        DroolsGroupingUniConstraintStream<Solution_, Result_> stream =
                 new DroolsGroupingUniConstraintStream<>(constraintFactory, this, collector);
         addChildStream(stream);
         return stream;
@@ -83,7 +83,7 @@ public abstract class DroolsAbstractBiConstraintStream<Solution_, A, B>
     @Override
     public <GroupKey_> UniConstraintStream<GroupKey_> groupBy(BiFunction<A, B, GroupKey_> groupKeyMapping) {
         throwWhenGroupByNotAllowed();
-        DroolsGroupingUniConstraintStream<Solution_, A, GroupKey_> stream =
+        DroolsGroupingUniConstraintStream<Solution_, GroupKey_> stream =
                 new DroolsGroupingUniConstraintStream<>(constraintFactory, this, groupKeyMapping);
         addChildStream(stream);
         return stream;

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/bi/DroolsAbstractBiConstraintStream.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/bi/DroolsAbstractBiConstraintStream.java
@@ -108,6 +108,11 @@ public abstract class DroolsAbstractBiConstraintStream<Solution_, A, B>
         return stream;
     }
 
+    @Override
+    public <GroupKeyA_, GroupKeyB_, ResultContainer_, Result_> TriConstraintStream<GroupKeyA_, GroupKeyB_, Result_> groupBy(BiFunction<A, B, GroupKeyA_> groupKeyAMapping, BiFunction<A, B, GroupKeyB_> groupKeyBMapping, BiConstraintCollector<A, B, ResultContainer_, Result_> collector) {
+        throw new UnsupportedOperationException();
+    }
+
     // ************************************************************************
     // Penalize/reward
     // ************************************************************************

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/bi/DroolsAbstractBiConstraintStream.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/bi/DroolsAbstractBiConstraintStream.java
@@ -35,6 +35,7 @@ import org.optaplanner.core.impl.score.stream.bi.InnerBiConstraintStream;
 import org.optaplanner.core.impl.score.stream.drools.DroolsConstraintFactory;
 import org.optaplanner.core.impl.score.stream.drools.common.DroolsAbstractConstraintStream;
 import org.optaplanner.core.impl.score.stream.drools.tri.DroolsAbstractTriConstraintStream;
+import org.optaplanner.core.impl.score.stream.drools.tri.DroolsGroupingTriConstraintStream;
 import org.optaplanner.core.impl.score.stream.drools.tri.DroolsJoinTriConstraintStream;
 import org.optaplanner.core.impl.score.stream.drools.uni.DroolsAbstractUniConstraintStream;
 import org.optaplanner.core.impl.score.stream.drools.uni.DroolsFromUniConstraintStream;
@@ -110,7 +111,12 @@ public abstract class DroolsAbstractBiConstraintStream<Solution_, A, B>
 
     @Override
     public <GroupKeyA_, GroupKeyB_, ResultContainer_, Result_> TriConstraintStream<GroupKeyA_, GroupKeyB_, Result_> groupBy(BiFunction<A, B, GroupKeyA_> groupKeyAMapping, BiFunction<A, B, GroupKeyB_> groupKeyBMapping, BiConstraintCollector<A, B, ResultContainer_, Result_> collector) {
-        throw new UnsupportedOperationException();
+        throwWhenGroupByNotAllowed();
+        DroolsGroupingTriConstraintStream<Solution_, GroupKeyA_, GroupKeyB_, Result_> stream =
+                new DroolsGroupingTriConstraintStream<>(constraintFactory, this, groupKeyAMapping,
+                        groupKeyBMapping, collector);
+        addChildStream(stream);
+        return stream;
     }
 
     // ************************************************************************

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/bi/DroolsBiAccumulateFunctionBridge.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/bi/DroolsBiAccumulateFunctionBridge.java
@@ -48,7 +48,7 @@ final class DroolsBiAccumulateFunctionBridge<A, B, ResultContainer_, NewA>
 
     @Override
     protected Runnable accumulate(ResultContainer_ container, BiTuple<A, B> tuple) {
-        return accumulator.apply(container, tuple._1, tuple._2);
+        return accumulator.apply(container, tuple.a, tuple.b);
     }
 
     @Override

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/bi/DroolsBiAccumulateFunctionBridge.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/bi/DroolsBiAccumulateFunctionBridge.java
@@ -69,7 +69,7 @@ final class DroolsBiAccumulateFunctionBridge<A, B, ResultContainer_, NewA>
             throw new IllegalStateException("Undo for (" + value +  ") already exists.");
         }
         BiTuple<A, B> values = (BiTuple<A, B>) value;
-        Runnable undo = accumulator.apply(context.getContainer(), values.key, values.value);
+        Runnable undo = accumulator.apply(context.getContainer(), values._1, values._2);
         undoMap.put(value, undo);
     }
 

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/bi/DroolsBiCondition.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/bi/DroolsBiCondition.java
@@ -38,12 +38,10 @@ import org.drools.model.functions.Block4;
 import org.drools.model.functions.Predicate3;
 import org.drools.model.view.ExprViewItem;
 import org.drools.model.view.ViewItem;
-import org.kie.api.runtime.rule.AccumulateFunction;
 import org.optaplanner.core.api.score.holder.AbstractScoreHolder;
 import org.optaplanner.core.api.score.stream.bi.BiConstraintCollector;
 import org.optaplanner.core.impl.score.stream.common.JoinerType;
 import org.optaplanner.core.impl.score.stream.drools.common.BiTuple;
-import org.optaplanner.core.impl.score.stream.drools.common.DroolsAccumulateContext;
 import org.optaplanner.core.impl.score.stream.drools.common.DroolsCondition;
 import org.optaplanner.core.impl.score.stream.drools.common.DroolsPatternBuilder;
 import org.optaplanner.core.impl.score.stream.drools.common.TriTuple;
@@ -54,7 +52,6 @@ import org.optaplanner.core.impl.score.stream.drools.uni.DroolsUniRuleStructure;
 import org.optaplanner.core.impl.score.stream.tri.AbstractTriJoiner;
 
 import static org.drools.model.DSL.accFunction;
-import static org.drools.model.DSL.declarationOf;
 import static org.drools.model.DSL.from;
 import static org.drools.model.DSL.on;
 import static org.drools.model.PatternDSL.alphaIndexedBy;
@@ -79,20 +76,10 @@ public final class DroolsBiCondition<A, B> extends DroolsCondition<DroolsBiRuleS
     }
 
     public <NewA, __> DroolsUniCondition<NewA> andCollect(BiConstraintCollector<A, B, __, NewA> collector) {
-        Variable<BiTuple<A, B>> pairVariable = ruleStructure.createVariable("pair");
-        PatternDSL.PatternDef<Object> mainAccumulatePattern = ruleStructure.getPrimaryPattern()
-                .expand(p -> p.bind(pairVariable, ruleStructure.getA(), (b, a) -> {
-                    return new BiTuple<>((A) a, (B) b);
-                }))
-                .build();
-        ViewItem<?> innerAccumulatePattern = getInnerAccumulatePattern(mainAccumulatePattern);
-        AccumulateFunction<DroolsAccumulateContext<__>> accumulateFunction =
-                new DroolsBiAccumulateFunctionBridge<>(collector);
-        Variable<NewA> outputVariable = (Variable<NewA>) declarationOf(Object.class, "collected");
-        ViewItem<?> outerAccumulatePattern = DSL.accumulate(innerAccumulatePattern,
-                accFunction(() -> accumulateFunction, pairVariable).as(outputVariable));
-        DroolsUniRuleStructure<NewA> newRuleStructure = ruleStructure.recollect(outputVariable, outerAccumulatePattern);
-        return new DroolsUniCondition<>(newRuleStructure);
+        DroolsBiAccumulateFunctionBridge<A, B, __, NewA> bridge = new DroolsBiAccumulateFunctionBridge<>(collector);
+        return super.andCollect(bridge,
+                (pattern, ruleStructure, carrier) -> pattern.bind(carrier, ruleStructure.getA(),
+                        (b, a) -> new BiTuple<>((A) a, (B) b)));
     }
 
     public <NewA> DroolsUniCondition<NewA> andGroup(BiFunction<A, B, NewA> groupKeyMapping) {

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/bi/DroolsBiCondition.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/bi/DroolsBiCondition.java
@@ -39,7 +39,6 @@ import org.optaplanner.core.impl.score.stream.drools.common.BiTuple;
 import org.optaplanner.core.impl.score.stream.drools.common.DroolsCondition;
 import org.optaplanner.core.impl.score.stream.drools.common.DroolsPatternBuilder;
 import org.optaplanner.core.impl.score.stream.drools.tri.DroolsTriCondition;
-import org.optaplanner.core.impl.score.stream.drools.tri.DroolsTriGroupByInvoker;
 import org.optaplanner.core.impl.score.stream.drools.tri.DroolsTriRuleStructure;
 import org.optaplanner.core.impl.score.stream.drools.uni.DroolsUniCondition;
 import org.optaplanner.core.impl.score.stream.drools.uni.DroolsUniRuleStructure;
@@ -80,12 +79,12 @@ public final class DroolsBiCondition<A, B> extends DroolsCondition<DroolsBiRuleS
 
     public <NewA, __> DroolsUniCondition<NewA> andCollect(BiConstraintCollector<A, B, __, NewA> collector) {
         DroolsBiAccumulateFunctionBridge<A, B, __, NewA> bridge = new DroolsBiAccumulateFunctionBridge<>(collector);
-        return collect(bridge, (pattern, carrier) -> pattern.bind(carrier, ruleStructure.getA(),
+        return collect(bridge, (pattern, tuple) -> pattern.bind(tuple, ruleStructure.getA(),
                 (b, a) -> new BiTuple<>((A) a, (B) b)));
     }
 
     public <NewA> DroolsUniCondition<NewA> andGroup(BiFunction<A, B, NewA> groupKeyMapping) {
-        return group((pattern, carrier) -> pattern.bind(carrier, ruleStructure.getA(),
+        return group((pattern, tuple) -> pattern.bind(tuple, ruleStructure.getA(),
                 (b, a) -> groupKeyMapping.apply(a, (B) b)));
     }
 

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/bi/DroolsBiCondition.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/bi/DroolsBiCondition.java
@@ -51,7 +51,6 @@ import org.optaplanner.core.impl.score.stream.drools.tri.DroolsTriCondition;
 import org.optaplanner.core.impl.score.stream.drools.tri.DroolsTriRuleStructure;
 import org.optaplanner.core.impl.score.stream.drools.uni.DroolsUniCondition;
 import org.optaplanner.core.impl.score.stream.drools.uni.DroolsUniRuleStructure;
-import org.optaplanner.core.impl.score.stream.drools.uni.DroolsUniToTriGroupByInvoker;
 import org.optaplanner.core.impl.score.stream.tri.AbstractTriJoiner;
 
 import static org.drools.model.DSL.accFunction;
@@ -181,8 +180,6 @@ public final class DroolsBiCondition<A, B> extends DroolsCondition<DroolsBiRuleS
                 accumulate);
         return new DroolsTriCondition<>(newRuleStructure);
     }
-
-
 
     public <C> DroolsTriCondition<A, B, C> andJoin(DroolsUniCondition<C> cCondition,
             AbstractTriJoiner<A, B, C> triJoiner) {

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/bi/DroolsBiCondition.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/bi/DroolsBiCondition.java
@@ -88,23 +88,8 @@ public final class DroolsBiCondition<A, B> extends DroolsCondition<DroolsBiRuleS
 
     public <NewA, NewB, __> DroolsBiCondition<NewA, NewB> andGroupWithCollect(BiFunction<A, B, NewA> groupKeyMapping,
             BiConstraintCollector<A, B, __, NewB> collector) {
-        Variable<Set<BiTuple<NewA, NewB>>> setOfPairsVar =
-                (Variable<Set<BiTuple<NewA, NewB>>>) ruleStructure.createVariable(Set.class, "setOfPairs");
-        PatternDSL.PatternDef<Set<BiTuple<NewA, NewB>>> pattern = pattern(setOfPairsVar)
-                .expr("Set of resulting pairs", set -> !set.isEmpty(),
-                        alphaIndexedBy(Integer.class, Index.ConstraintType.GREATER_THAN, -1, Set::size, 0));
-        // Prepare the list of pairs.
-        PatternDSL.PatternDef<Object> innerNewACollectingPattern = ruleStructure.getPrimaryPattern().build();
-        ViewItem<?> innerAccumulatePattern = getInnerAccumulatePattern(innerNewACollectingPattern);
-        ViewItem<?> accumulate = DSL.accumulate(innerAccumulatePattern,
-                accFunction(() -> new DroolsBiGroupByInvoker<>(groupKeyMapping, collector, getRuleStructure().getA(),
-                        getRuleStructure().getB()))
-                        .as(setOfPairsVar));
-        // Load one pair from the list.
-        Variable<BiTuple<NewA, NewB>> onePairVar =
-                (Variable<BiTuple<NewA, NewB>>) ruleStructure.createVariable(BiTuple.class, "pair", from(setOfPairsVar));
-        DroolsBiRuleStructure<NewA, NewB> newRuleStructure = ruleStructure.regroupBi(onePairVar, pattern, accumulate);
-        return new DroolsBiCondition<>(newRuleStructure);
+        return groupWithCollect(() -> new DroolsBiGroupByInvoker<>(groupKeyMapping, collector,
+                getRuleStructure().getA(), getRuleStructure().getB()));
     }
 
     public <NewA, NewB> DroolsBiCondition<NewA, NewB> andGroupBi(BiFunction<A, B, NewA> groupKeyAMapping,

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/bi/DroolsBiCondition.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/bi/DroolsBiCondition.java
@@ -77,26 +77,13 @@ public final class DroolsBiCondition<A, B> extends DroolsCondition<DroolsBiRuleS
 
     public <NewA, __> DroolsUniCondition<NewA> andCollect(BiConstraintCollector<A, B, __, NewA> collector) {
         DroolsBiAccumulateFunctionBridge<A, B, __, NewA> bridge = new DroolsBiAccumulateFunctionBridge<>(collector);
-        return super.andCollect(bridge,
-                (pattern, ruleStructure, carrier) -> pattern.bind(carrier, ruleStructure.getA(),
-                        (b, a) -> new BiTuple<>((A) a, (B) b)));
+        return collect(bridge, (pattern, carrier) -> pattern.bind(carrier, ruleStructure.getA(),
+                (b, a) -> new BiTuple<>((A) a, (B) b)));
     }
 
     public <NewA> DroolsUniCondition<NewA> andGroup(BiFunction<A, B, NewA> groupKeyMapping) {
-        Variable<NewA> mappedVariable = ruleStructure.createVariable("biMapped");
-        PatternDSL.PatternDef<Object> mainAccumulatePattern = ruleStructure.getPrimaryPattern()
-                        .expand(p -> p.bind(mappedVariable, ruleStructure.getA(), (b, a) -> groupKeyMapping.apply((A) a, (B) b)))
-                        .build();
-        ViewItem<?> innerAccumulatePattern = getInnerAccumulatePattern(mainAccumulatePattern);
-        Variable<Set<NewA>> setOfMappings =
-                (Variable<Set<NewA>>) ruleStructure.createVariable(Set.class, "setOfGroupKey");
-        PatternDSL.PatternDef<Set<NewA>> pattern = pattern(setOfMappings)
-                .expr("Set of " + mappedVariable.getName(), set -> !set.isEmpty(),
-                        alphaIndexedBy(Integer.class, Index.ConstraintType.GREATER_THAN, -1, Set::size, 0));
-        ExprViewItem<Object> accumulate = DSL.accumulate(innerAccumulatePattern,
-                accFunction(CollectSetAccumulateFunction.class, mappedVariable).as(setOfMappings));
-        DroolsUniRuleStructure<NewA> newRuleStructure = ruleStructure.regroup(setOfMappings, pattern, accumulate);
-        return new DroolsUniCondition<>(newRuleStructure);
+        return group((pattern, carrier) -> pattern.bind(carrier, ruleStructure.getA(),
+                (b, a) -> groupKeyMapping.apply(a, (B) b)));
     }
 
     public <NewA, NewB, __> DroolsBiCondition<NewA, NewB> andGroupWithCollect(BiFunction<A, B, NewA> groupKeyMapping,

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/bi/DroolsBiCondition.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/bi/DroolsBiCondition.java
@@ -18,42 +18,34 @@ package org.optaplanner.core.impl.score.stream.drools.bi;
 
 import java.math.BigDecimal;
 import java.util.List;
-import java.util.Set;
 import java.util.function.BiFunction;
 import java.util.function.BiPredicate;
 import java.util.function.ToIntBiFunction;
 import java.util.function.ToLongBiFunction;
 import java.util.function.UnaryOperator;
 
-import org.drools.model.DSL;
 import org.drools.model.Drools;
 import org.drools.model.Global;
-import org.drools.model.Index;
 import org.drools.model.PatternDSL;
 import org.drools.model.RuleItemBuilder;
 import org.drools.model.Variable;
 import org.drools.model.consequences.ConsequenceBuilder;
 import org.drools.model.functions.Block4;
 import org.drools.model.functions.Predicate3;
-import org.drools.model.view.ViewItem;
 import org.optaplanner.core.api.score.holder.AbstractScoreHolder;
 import org.optaplanner.core.api.score.stream.bi.BiConstraintCollector;
 import org.optaplanner.core.impl.score.stream.common.JoinerType;
 import org.optaplanner.core.impl.score.stream.drools.common.BiTuple;
 import org.optaplanner.core.impl.score.stream.drools.common.DroolsCondition;
 import org.optaplanner.core.impl.score.stream.drools.common.DroolsPatternBuilder;
-import org.optaplanner.core.impl.score.stream.drools.common.TriTuple;
 import org.optaplanner.core.impl.score.stream.drools.tri.DroolsTriCondition;
+import org.optaplanner.core.impl.score.stream.drools.tri.DroolsTriGroupByInvoker;
 import org.optaplanner.core.impl.score.stream.drools.tri.DroolsTriRuleStructure;
 import org.optaplanner.core.impl.score.stream.drools.uni.DroolsUniCondition;
 import org.optaplanner.core.impl.score.stream.drools.uni.DroolsUniRuleStructure;
 import org.optaplanner.core.impl.score.stream.tri.AbstractTriJoiner;
 
-import static org.drools.model.DSL.accFunction;
-import static org.drools.model.DSL.from;
 import static org.drools.model.DSL.on;
-import static org.drools.model.PatternDSL.alphaIndexedBy;
-import static org.drools.model.PatternDSL.pattern;
 
 public final class DroolsBiCondition<A, B> extends DroolsCondition<DroolsBiRuleStructure<A, B>> {
 
@@ -115,25 +107,8 @@ public final class DroolsBiCondition<A, B> extends DroolsCondition<DroolsBiRuleS
     public <ResultContainer, NewA, NewB, NewC> DroolsTriCondition<NewA, NewB, NewC> andGroupBiWithCollect(
             BiFunction<A, B, NewA> groupKeyAMapping, BiFunction<A, B, NewB> groupKeyBMapping,
             BiConstraintCollector<A, B, ResultContainer, NewC> collector) {
-        Variable<Set<TriTuple<NewA, NewB, NewC>>> setOfPairsVar =
-                (Variable<Set<TriTuple<NewA, NewB, NewC>>>) ruleStructure.createVariable(Set.class, "setOfTuples");
-        PatternDSL.PatternDef<Set<TriTuple<NewA, NewB, NewC>>> pattern = pattern(setOfPairsVar)
-                .expr("Set of resulting tuples", set -> !set.isEmpty(),
-                        alphaIndexedBy(Integer.class, Index.ConstraintType.GREATER_THAN, -1, Set::size, 0));
-        // Prepare the list of pairs.
-        PatternDSL.PatternDef<Object> innerCollectingPattern = ruleStructure.getPrimaryPattern().build();
-        ViewItem<?> innerAccumulatePattern = getInnerAccumulatePattern(innerCollectingPattern);
-        ViewItem<?> accumulate = DSL.accumulate(innerAccumulatePattern,
-                accFunction(() -> new DroolsBiToTriGroupByInvoker<>(groupKeyAMapping, groupKeyBMapping, collector,
-                        getRuleStructure().getA(), getRuleStructure().getB()))
-                        .as(setOfPairsVar));
-        // Load one pair from the list.
-        Variable<TriTuple<NewA, NewB, NewC>> oneTupleVar =
-                (Variable<TriTuple<NewA, NewB, NewC>>) ruleStructure.createVariable(TriTuple.class, "tuple",
-                        from(setOfPairsVar));
-        DroolsTriRuleStructure<NewA, NewB, NewC> newRuleStructure = ruleStructure.regroupBiToTri(oneTupleVar, pattern,
-                accumulate);
-        return new DroolsTriCondition<>(newRuleStructure);
+        return groupBiWithCollect(() -> new DroolsBiToTriGroupByInvoker<>(groupKeyAMapping, groupKeyBMapping, collector,
+                getRuleStructure().getA(), getRuleStructure().getB()));
     }
 
     public <C> DroolsTriCondition<A, B, C> andJoin(DroolsUniCondition<C> cCondition,

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/bi/DroolsBiGroupBy.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/bi/DroolsBiGroupBy.java
@@ -46,7 +46,7 @@ final class DroolsBiGroupBy<A, B, ResultContainer, NewA, NewB> implements Serial
     }
 
     public void accumulate(InternalFactHandle handle, A a, B b) {
-        Runnable undo = acc.accumulate(a, b);
+        Runnable undo = acc.accumulate(new BiTuple<>(a, b));
         Runnable oldUndo = this.undoMap.put(handle.getId(), undo);
         if (oldUndo != null) {
             throw new IllegalStateException("Undo for fact handle (" + handle.getId() + ") already exists.");

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/bi/DroolsBiGroupByAccumulator.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/bi/DroolsBiGroupByAccumulator.java
@@ -43,7 +43,7 @@ final class DroolsBiGroupByAccumulator<A, B, ResultContainer, NewA, NewB>
 
     @Override
     protected NewA toKey(BiTuple<A, B> tuple) {
-        return groupKeyMapping.apply(tuple._1, tuple._2);
+        return groupKeyMapping.apply(tuple.a, tuple.b);
     }
 
     @Override
@@ -53,7 +53,7 @@ final class DroolsBiGroupByAccumulator<A, B, ResultContainer, NewA, NewB>
 
     @Override
     protected Runnable process(BiTuple<A, B> tuple, ResultContainer container) {
-        return accumulator.apply(container, tuple._1, tuple._2);
+        return accumulator.apply(container, tuple.a, tuple.b);
     }
 
     @Override

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/bi/DroolsBiGroupByInvoker.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/bi/DroolsBiGroupByInvoker.java
@@ -32,6 +32,7 @@ import org.drools.core.spi.CompiledInvoker;
 import org.drools.core.spi.Tuple;
 import org.drools.model.Variable;
 import org.optaplanner.core.api.score.stream.bi.BiConstraintCollector;
+import org.optaplanner.core.impl.score.stream.drools.common.BiTuple;
 
 public class DroolsBiGroupByInvoker<A, B, ResultContainer, NewA, NewB> implements Accumulator, CompiledInvoker {
 
@@ -67,7 +68,7 @@ public class DroolsBiGroupByInvoker<A, B, ResultContainer, NewA, NewB> implement
         Object handleObject = handle.getObject();
         final A groupKey = getValue(aVariable, internalWorkingMemory, handleObject, innerDeclarations);
         final B toCollect = getValue(bVariable, internalWorkingMemory, handleObject, innerDeclarations);
-        castContext(context).accumulate(handle, groupKey, toCollect);
+        castContext(context).accumulate(handle, new BiTuple<>(groupKey, toCollect));
     }
 
     private static <X> X getValue(Variable<X> var, InternalWorkingMemory internalWorkingMemory, Object handleObject,

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/bi/DroolsBiGroupByInvoker.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/bi/DroolsBiGroupByInvoker.java
@@ -16,25 +16,17 @@
 
 package org.optaplanner.core.impl.score.stream.drools.bi;
 
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.Serializable;
 import java.util.function.BiFunction;
+import java.util.function.Function;
 
-import org.drools.core.WorkingMemory;
-import org.drools.core.common.InternalFactHandle;
-import org.drools.core.common.InternalWorkingMemory;
-import org.drools.core.reteoo.SubnetworkTuple;
-import org.drools.core.rule.Declaration;
-import org.drools.core.spi.Accumulator;
-import org.drools.core.spi.CompiledInvoker;
-import org.drools.core.spi.Tuple;
 import org.drools.model.Variable;
 import org.optaplanner.core.api.score.stream.bi.BiConstraintCollector;
 import org.optaplanner.core.impl.score.stream.drools.common.BiTuple;
+import org.optaplanner.core.impl.score.stream.drools.common.DroolsAbstractGroupBy;
+import org.optaplanner.core.impl.score.stream.drools.common.DroolsAbstractGroupByInvoker;
 
-public class DroolsBiGroupByInvoker<A, B, ResultContainer, NewA, NewB> implements Accumulator, CompiledInvoker {
+public class DroolsBiGroupByInvoker<A, B, ResultContainer, NewA, NewB>
+        extends DroolsAbstractGroupByInvoker<ResultContainer, BiTuple<A, B>> {
 
     private final BiConstraintCollector<A, B, ResultContainer, NewB> collector;
     private final BiFunction<A, B, NewA> groupKeyMapping;
@@ -51,92 +43,15 @@ public class DroolsBiGroupByInvoker<A, B, ResultContainer, NewA, NewB> implement
     }
 
     @Override
-    public Serializable createContext() {
+    protected DroolsAbstractGroupBy<ResultContainer, BiTuple<A, B>, ?> newContext() {
         return new DroolsBiGroupBy<>(groupKeyMapping, collector);
     }
 
     @Override
-    public void init(Object workingMemoryContext, Object context, Tuple tuple, Declaration[] declarations,
-            WorkingMemory workingMemory) {
-        castContext(context).init();
-    }
-
-    @Override
-    public void accumulate(Object workingMemoryContext, Object context, Tuple tuple, InternalFactHandle handle,
-            Declaration[] declarations, Declaration[] innerDeclarations, final WorkingMemory workingMemory) {
-        InternalWorkingMemory internalWorkingMemory = (InternalWorkingMemory) workingMemory;
-        Object handleObject = handle.getObject();
-        final A groupKey = getValue(aVariable, internalWorkingMemory, handleObject, innerDeclarations);
-        final B toCollect = getValue(bVariable, internalWorkingMemory, handleObject, innerDeclarations);
-        castContext(context).accumulate(handle, new BiTuple<>(groupKey, toCollect));
-    }
-
-    private static <X> X getValue(Variable<X> var, InternalWorkingMemory internalWorkingMemory, Object handleObject,
-            Declaration... innerDeclarations) {
-        Declaration declaration = getDeclarationForVariable(var, innerDeclarations);
-        Object actualHandleObject = handleObject instanceof SubnetworkTuple ?
-                ((SubnetworkTuple)handleObject).getObject(declaration) :
-                handleObject;
-        return (X) declaration.getValue(internalWorkingMemory, actualHandleObject);
-    }
-
-    private DroolsBiGroupBy<A, B, ResultContainer, NewA, NewB> castContext(Object context) {
-        return (DroolsBiGroupBy<A, B, ResultContainer, NewA, NewB>) context;
-    }
-
-    /**
-     * Declarations in Drools appear to show up in random order. Therefore, we need to match the proper declaration
-     * not by directly addressing within the array, but by looking it up based on the associated variable.
-     * @param variable
-     * @param declarations
-     * @return
-     */
-    private static Declaration getDeclarationForVariable(Variable<?> variable, Declaration... declarations) {
-        for (Declaration declaration: declarations) {
-            if (declaration.getIdentifier().equals(variable.getName())) {
-                return declaration;
-            }
-        }
-        throw new IllegalStateException("Could not find declaration for variable (" + variable + ").");
-    }
-
-    @Override
-    public void reverse(Object workingMemoryContext, Object context, Tuple tuple, InternalFactHandle handle,
-            Declaration[] declarations, Declaration[] innerDeclarations, WorkingMemory workingMemory) {
-        castContext(context).reverse(handle);
-    }
-
-    @Override
-    public Object getResult(Object workingMemoryContext, Object context, Tuple tuple, Declaration[] declarations,
-            WorkingMemory workingMemory) {
-        return castContext(context).getResult();
-    }
-
-    @Override
-    public boolean supportsReverse() {
-        return true;
-    }
-
-    @Override
-    public Object createWorkingMemoryContext() {
-        return null;
-    }
-
-    @Override
-    public String getMethodBytecode() {
-        Class<?> accumulateClass = DroolsBiGroupBy.class;
-        String classFileName = accumulateClass.getCanonicalName().replace('.', '/') + ".class";
-        try (InputStream is = getClass().getClassLoader().getResourceAsStream(classFileName)) {
-            final byte[] data = new byte[1024];
-            int byteCount;
-            ByteArrayOutputStream bos = new ByteArrayOutputStream();
-            while ((byteCount = is.read(data, 0, 1024)) > -1) {
-                bos.write(data, 0, byteCount);
-            }
-            return bos.toString();
-        } catch (final IOException e) {
-            throw new RuntimeException("Unable to getResourceAsStream for " + accumulateClass);
-        }
+    protected <X> BiTuple<A, B> createInput(Function<Variable<X>, X> valueFinder) {
+        final A a = materialize(aVariable, valueFinder);
+        final B b = materialize(bVariable, valueFinder);
+        return new BiTuple<>(a, b);
     }
 
 }

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/bi/DroolsBiToTriGroupBy.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/bi/DroolsBiToTriGroupBy.java
@@ -24,6 +24,7 @@ import java.util.function.BiFunction;
 
 import org.drools.core.common.InternalFactHandle;
 import org.optaplanner.core.api.score.stream.bi.BiConstraintCollector;
+import org.optaplanner.core.impl.score.stream.drools.common.BiTuple;
 import org.optaplanner.core.impl.score.stream.drools.common.TriTuple;
 
 final class DroolsBiToTriGroupBy<A, B, ResultContainer, NewA, NewB, NewC> implements Serializable {
@@ -48,7 +49,7 @@ final class DroolsBiToTriGroupBy<A, B, ResultContainer, NewA, NewB, NewC> implem
     }
 
     public void accumulate(InternalFactHandle handle, A a, B b) {
-        Runnable undo = acc.accumulate(a, b);
+        Runnable undo = acc.accumulate(new BiTuple<>(a, b));
         Runnable oldUndo = this.undoMap.put(handle.getId(), undo);
         if (oldUndo != null) {
             throw new IllegalStateException("Undo for fact handle (" + handle.getId() + ") already exists.");

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/bi/DroolsBiToTriGroupBy.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/bi/DroolsBiToTriGroupBy.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.core.impl.score.stream.drools.bi;
+
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.BiFunction;
+
+import org.drools.core.common.InternalFactHandle;
+import org.optaplanner.core.api.score.stream.bi.BiConstraintCollector;
+import org.optaplanner.core.impl.score.stream.drools.common.TriTuple;
+
+final class DroolsBiToTriGroupBy<A, B, ResultContainer, NewA, NewB, NewC> implements Serializable {
+
+    private static final long serialVersionUID = 510l;
+    private final Map<Long, Runnable> undoMap = new HashMap<>(0);
+    private final BiFunction<A, B, NewA> groupKeyAMapping;
+    private final BiFunction<A, B, NewB> groupKeyBMapping;
+    private final BiConstraintCollector<A, B, ResultContainer, NewC> collector;
+    private DroolsBiToTriGroupByAccumulator<A, B, ResultContainer, NewA, NewB, NewC> acc;
+
+    public DroolsBiToTriGroupBy(BiFunction<A, B, NewA> groupKeyAMapping, BiFunction<A, B, NewB> groupKeyBMapping,
+            BiConstraintCollector<A, B, ResultContainer, NewC> collector) {
+        this.groupKeyAMapping = groupKeyAMapping;
+        this.groupKeyBMapping = groupKeyBMapping;
+        this.collector = collector;
+    }
+
+    public void init() {
+        acc = new DroolsBiToTriGroupByAccumulator<>(groupKeyAMapping, groupKeyBMapping, collector);
+        undoMap.clear();
+    }
+
+    public void accumulate(InternalFactHandle handle, A a, B b) {
+        Runnable undo = acc.accumulate(a, b);
+        Runnable oldUndo = this.undoMap.put(handle.getId(), undo);
+        if (oldUndo != null) {
+            throw new IllegalStateException("Undo for fact handle (" + handle.getId() + ") already exists.");
+        }
+    }
+
+    public void reverse(InternalFactHandle handle) {
+        final Runnable undo = this.undoMap.remove(handle.getId());
+        if (undo == null) {
+            throw new IllegalStateException("No undo for fact handle (" + handle.getId() + ")");
+        }
+        undo.run();
+    }
+
+    public Set<TriTuple<NewA, NewB, NewC>> getResult() {
+        return acc.finish();
+    }
+
+}

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/bi/DroolsBiToTriGroupByAccumulator.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/bi/DroolsBiToTriGroupByAccumulator.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.core.impl.score.stream.drools.bi;
+
+import java.io.Serializable;
+import java.util.IdentityHashMap;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+import org.optaplanner.core.api.function.TriFunction;
+import org.optaplanner.core.api.score.stream.bi.BiConstraintCollector;
+import org.optaplanner.core.impl.score.stream.drools.common.BiTuple;
+import org.optaplanner.core.impl.score.stream.drools.common.TriTuple;
+
+final class DroolsBiToTriGroupByAccumulator<A, B, ResultContainer, NewA, NewB, NewC> implements Serializable {
+
+    // Containers may be identical in type and contents, yet they should still not count as the same container.
+    private final Map<ResultContainer, Long> containersInUseMap = new IdentityHashMap<>(0);
+    // LinkedHashMap to maintain a consistent iteration order of resulting pairs.
+    private final Map<BiTuple<NewA, NewB>, ResultContainer> containersMap = new LinkedHashMap<>(0);
+    private final BiFunction<A, B, NewA> groupKeyAMapping;
+    private final BiFunction<A, B, NewB> groupKeyBMapping;
+    private final Supplier<ResultContainer> supplier;
+    private final TriFunction<ResultContainer, A, B, Runnable> accumulator;
+    private final Function<ResultContainer, NewC> finisher;
+    // Transient as Spotbugs complains otherwise ("non-transient non-serializable instance field").
+    // It doesn't make sense to serialize this anyway, as it is recreated every time.
+    private final transient Set<TriTuple<NewA, NewB, NewC>> resultSet = new LinkedHashSet<>(0);
+
+    public DroolsBiToTriGroupByAccumulator(BiFunction<A, B, NewA> groupKeyAMapping,
+            BiFunction<A, B, NewB> groupKeyBMapping, BiConstraintCollector<A, B, ResultContainer, NewC> collector) {
+        this.groupKeyAMapping = groupKeyAMapping;
+        this.groupKeyBMapping = groupKeyBMapping;
+        this.supplier = collector.supplier();
+        this.accumulator = collector.accumulator();
+        this.finisher = collector.finisher();
+    }
+
+    private static Long increment(Long count) {
+        return count == null ? 1L : count + 1L;
+    }
+
+    private static Long decrement(Long count) {
+        return count == 1L ? null : count - 1L;
+    }
+
+    public Runnable accumulate(A a, B b) {
+        BiTuple<NewA, NewB> key = new BiTuple<>(groupKeyAMapping.apply(a, b), groupKeyBMapping.apply(a, b));
+        ResultContainer container = containersMap.computeIfAbsent(key, __ -> supplier.get());
+        Runnable undo = accumulator.apply(container, a, b);
+        containersInUseMap.compute(container, (__, count) -> increment(count)); // Increment use counter.
+        return () -> {
+            undo.run();
+            // Decrement use counter. If 0, container is ignored during finishing. Removes empty groups from results.
+            Long currentCount = containersInUseMap.compute(container, (__, count) -> decrement(count));
+            if (currentCount == null) {
+                containersMap.remove(key);
+            }
+        };
+    }
+
+    public Set<TriTuple<NewA, NewB, NewC>> finish() {
+        resultSet.clear();
+        for (Map.Entry<BiTuple<NewA, NewB>, ResultContainer> entry : containersMap.entrySet()) {
+            BiTuple<NewA, NewB> key = entry.getKey();
+            ResultContainer container = entry.getValue();
+            TriTuple<NewA, NewB, NewC> result = new TriTuple<>(key._1, key._2, finisher.apply(container));
+            resultSet.add(result);
+        }
+        return resultSet;
+    }
+}

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/bi/DroolsBiToTriGroupByAccumulator.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/bi/DroolsBiToTriGroupByAccumulator.java
@@ -46,8 +46,8 @@ final class DroolsBiToTriGroupByAccumulator<A, B, ResultContainer, NewA, NewB, N
 
     @Override
     protected BiTuple<NewA, NewB> toKey(BiTuple<A, B> abBiTuple) {
-        return new BiTuple<>(groupKeyAMapping.apply(abBiTuple._1, abBiTuple._2),
-                groupKeyBMapping.apply(abBiTuple._1, abBiTuple._2));
+        return new BiTuple<>(groupKeyAMapping.apply(abBiTuple.a, abBiTuple.b),
+                groupKeyBMapping.apply(abBiTuple.a, abBiTuple.b));
     }
 
     @Override
@@ -57,12 +57,12 @@ final class DroolsBiToTriGroupByAccumulator<A, B, ResultContainer, NewA, NewB, N
 
     @Override
     protected Runnable process(BiTuple<A, B> abBiTuple, ResultContainer container) {
-        return accumulator.apply(container, abBiTuple._1, abBiTuple._2);
+        return accumulator.apply(container, abBiTuple.a, abBiTuple.b);
     }
 
     @Override
     protected TriTuple<NewA, NewB, NewC> toResult(BiTuple<NewA, NewB> key, ResultContainer container) {
-        return new TriTuple<>(key._1, key._2, finisher.apply(container));
+        return new TriTuple<>(key.a, key.b, finisher.apply(container));
     }
 
 }

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/bi/DroolsBiToTriGroupByInvoker.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/bi/DroolsBiToTriGroupByInvoker.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.core.impl.score.stream.drools.bi;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.Serializable;
+import java.util.function.BiFunction;
+
+import org.drools.core.WorkingMemory;
+import org.drools.core.common.InternalFactHandle;
+import org.drools.core.common.InternalWorkingMemory;
+import org.drools.core.reteoo.SubnetworkTuple;
+import org.drools.core.rule.Declaration;
+import org.drools.core.spi.Accumulator;
+import org.drools.core.spi.CompiledInvoker;
+import org.drools.core.spi.Tuple;
+import org.drools.model.Variable;
+import org.optaplanner.core.api.score.stream.bi.BiConstraintCollector;
+
+public class DroolsBiToTriGroupByInvoker<A, B, ResultContainer, NewA, NewB, NewC> implements Accumulator, CompiledInvoker {
+
+    private final BiConstraintCollector<A, B, ResultContainer, NewC> collector;
+    private final BiFunction<A, B, NewA> groupKeyAMapping;
+    private final BiFunction<A, B, NewB> groupKeyBMapping;
+    private final Variable<A> aVariable;
+    private final Variable<B> bVariable;
+
+    public DroolsBiToTriGroupByInvoker(BiFunction<A, B, NewA> groupKeyAMapping, BiFunction<A, B, NewB> groupKeyBMapping,
+            BiConstraintCollector<A, B, ResultContainer, NewC> collector, Variable<A> aVariable, Variable<B> bVariable) {
+        this.collector = collector;
+        this.groupKeyAMapping = groupKeyAMapping;
+        this.groupKeyBMapping = groupKeyBMapping;
+        this.aVariable = aVariable;
+        this.bVariable = bVariable;
+    }
+
+    @Override
+    public Serializable createContext() {
+        return new DroolsBiToTriGroupBy<>(groupKeyAMapping, groupKeyBMapping, collector);
+    }
+
+    @Override
+    public void init(Object workingMemoryContext, Object context, Tuple tuple, Declaration[] declarations,
+            WorkingMemory workingMemory) {
+        castContext(context).init();
+    }
+
+    @Override
+    public void accumulate(Object workingMemoryContext, Object context, Tuple tuple, InternalFactHandle handle,
+            Declaration[] declarations, Declaration[] innerDeclarations, final WorkingMemory workingMemory) {
+        InternalWorkingMemory internalWorkingMemory = (InternalWorkingMemory) workingMemory;
+        Object handleObject = handle.getObject();
+        final A groupKeyA = getValue(aVariable, internalWorkingMemory, handleObject, innerDeclarations);
+        final B groupKeyB = getValue(bVariable, internalWorkingMemory, handleObject, innerDeclarations);
+        castContext(context).accumulate(handle, groupKeyA, groupKeyB);
+    }
+
+    private static <X> X getValue(Variable<X> var, InternalWorkingMemory internalWorkingMemory, Object handleObject,
+            Declaration... innerDeclarations) {
+        Declaration declaration = getDeclarationForVariable(var, innerDeclarations);
+        Object actualHandleObject = handleObject instanceof SubnetworkTuple ?
+                ((SubnetworkTuple)handleObject).getObject(declaration) :
+                handleObject;
+        return (X) declaration.getValue(internalWorkingMemory, actualHandleObject);
+    }
+
+    private DroolsBiToTriGroupBy<A, B, ResultContainer, NewA, NewB, NewC> castContext(Object context) {
+        return (DroolsBiToTriGroupBy<A, B, ResultContainer, NewA, NewB, NewC>) context;
+    }
+
+    /**
+     * Declarations in Drools appear to show up in random order. Therefore, we need to match the proper declaration
+     * not by directly addressing within the array, but by looking it up based on the associated variable.
+     * @param variable
+     * @param declarations
+     * @return
+     */
+    private static Declaration getDeclarationForVariable(Variable<?> variable, Declaration... declarations) {
+        for (Declaration declaration: declarations) {
+            if (declaration.getIdentifier().equals(variable.getName())) {
+                return declaration;
+            }
+        }
+        throw new IllegalStateException("Could not find declaration for variable (" + variable + ").");
+    }
+
+    @Override
+    public void reverse(Object workingMemoryContext, Object context, Tuple tuple, InternalFactHandle handle,
+            Declaration[] declarations, Declaration[] innerDeclarations, WorkingMemory workingMemory) {
+        castContext(context).reverse(handle);
+    }
+
+    @Override
+    public Object getResult(Object workingMemoryContext, Object context, Tuple tuple, Declaration[] declarations,
+            WorkingMemory workingMemory) {
+        return castContext(context).getResult();
+    }
+
+    @Override
+    public boolean supportsReverse() {
+        return true;
+    }
+
+    @Override
+    public Object createWorkingMemoryContext() {
+        return null;
+    }
+
+    @Override
+    public String getMethodBytecode() {
+        Class<?> accumulateClass = DroolsBiToTriGroupBy.class;
+        String classFileName = accumulateClass.getCanonicalName().replace('.', '/') + ".class";
+        try (InputStream is = getClass().getClassLoader().getResourceAsStream(classFileName)) {
+            final byte[] data = new byte[1024];
+            int byteCount;
+            ByteArrayOutputStream bos = new ByteArrayOutputStream();
+            while ((byteCount = is.read(data, 0, 1024)) > -1) {
+                bos.write(data, 0, byteCount);
+            }
+            return bos.toString();
+        } catch (final IOException e) {
+            throw new RuntimeException("Unable to getResourceAsStream for " + accumulateClass);
+        }
+    }
+
+}

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/bi/DroolsBiToTriGroupByInvoker.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/bi/DroolsBiToTriGroupByInvoker.java
@@ -16,25 +16,17 @@
 
 package org.optaplanner.core.impl.score.stream.drools.bi;
 
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.Serializable;
 import java.util.function.BiFunction;
+import java.util.function.Function;
 
-import org.drools.core.WorkingMemory;
-import org.drools.core.common.InternalFactHandle;
-import org.drools.core.common.InternalWorkingMemory;
-import org.drools.core.reteoo.SubnetworkTuple;
-import org.drools.core.rule.Declaration;
-import org.drools.core.spi.Accumulator;
-import org.drools.core.spi.CompiledInvoker;
-import org.drools.core.spi.Tuple;
 import org.drools.model.Variable;
 import org.optaplanner.core.api.score.stream.bi.BiConstraintCollector;
 import org.optaplanner.core.impl.score.stream.drools.common.BiTuple;
+import org.optaplanner.core.impl.score.stream.drools.common.DroolsAbstractGroupBy;
+import org.optaplanner.core.impl.score.stream.drools.common.DroolsAbstractGroupByInvoker;
 
-public class DroolsBiToTriGroupByInvoker<A, B, ResultContainer, NewA, NewB, NewC> implements Accumulator, CompiledInvoker {
+public class DroolsBiToTriGroupByInvoker<A, B, ResultContainer, NewA, NewB, NewC>
+        extends DroolsAbstractGroupByInvoker<ResultContainer, BiTuple<A, B>> {
 
     private final BiConstraintCollector<A, B, ResultContainer, NewC> collector;
     private final BiFunction<A, B, NewA> groupKeyAMapping;
@@ -52,92 +44,15 @@ public class DroolsBiToTriGroupByInvoker<A, B, ResultContainer, NewA, NewB, NewC
     }
 
     @Override
-    public Serializable createContext() {
+    protected DroolsAbstractGroupBy<ResultContainer, BiTuple<A, B>, ?> newContext() {
         return new DroolsBiToTriGroupBy<>(groupKeyAMapping, groupKeyBMapping, collector);
     }
 
     @Override
-    public void init(Object workingMemoryContext, Object context, Tuple tuple, Declaration[] declarations,
-            WorkingMemory workingMemory) {
-        castContext(context).init();
-    }
-
-    @Override
-    public void accumulate(Object workingMemoryContext, Object context, Tuple tuple, InternalFactHandle handle,
-            Declaration[] declarations, Declaration[] innerDeclarations, final WorkingMemory workingMemory) {
-        InternalWorkingMemory internalWorkingMemory = (InternalWorkingMemory) workingMemory;
-        Object handleObject = handle.getObject();
-        final A groupKeyA = getValue(aVariable, internalWorkingMemory, handleObject, innerDeclarations);
-        final B groupKeyB = getValue(bVariable, internalWorkingMemory, handleObject, innerDeclarations);
-        castContext(context).accumulate(handle, new BiTuple<>(groupKeyA, groupKeyB));
-    }
-
-    private static <X> X getValue(Variable<X> var, InternalWorkingMemory internalWorkingMemory, Object handleObject,
-            Declaration... innerDeclarations) {
-        Declaration declaration = getDeclarationForVariable(var, innerDeclarations);
-        Object actualHandleObject = handleObject instanceof SubnetworkTuple ?
-                ((SubnetworkTuple)handleObject).getObject(declaration) :
-                handleObject;
-        return (X) declaration.getValue(internalWorkingMemory, actualHandleObject);
-    }
-
-    private DroolsBiToTriGroupBy<A, B, ResultContainer, NewA, NewB, NewC> castContext(Object context) {
-        return (DroolsBiToTriGroupBy<A, B, ResultContainer, NewA, NewB, NewC>) context;
-    }
-
-    /**
-     * Declarations in Drools appear to show up in random order. Therefore, we need to match the proper declaration
-     * not by directly addressing within the array, but by looking it up based on the associated variable.
-     * @param variable
-     * @param declarations
-     * @return
-     */
-    private static Declaration getDeclarationForVariable(Variable<?> variable, Declaration... declarations) {
-        for (Declaration declaration: declarations) {
-            if (declaration.getIdentifier().equals(variable.getName())) {
-                return declaration;
-            }
-        }
-        throw new IllegalStateException("Could not find declaration for variable (" + variable + ").");
-    }
-
-    @Override
-    public void reverse(Object workingMemoryContext, Object context, Tuple tuple, InternalFactHandle handle,
-            Declaration[] declarations, Declaration[] innerDeclarations, WorkingMemory workingMemory) {
-        castContext(context).reverse(handle);
-    }
-
-    @Override
-    public Object getResult(Object workingMemoryContext, Object context, Tuple tuple, Declaration[] declarations,
-            WorkingMemory workingMemory) {
-        return castContext(context).getResult();
-    }
-
-    @Override
-    public boolean supportsReverse() {
-        return true;
-    }
-
-    @Override
-    public Object createWorkingMemoryContext() {
-        return null;
-    }
-
-    @Override
-    public String getMethodBytecode() {
-        Class<?> accumulateClass = DroolsBiToTriGroupBy.class;
-        String classFileName = accumulateClass.getCanonicalName().replace('.', '/') + ".class";
-        try (InputStream is = getClass().getClassLoader().getResourceAsStream(classFileName)) {
-            final byte[] data = new byte[1024];
-            int byteCount;
-            ByteArrayOutputStream bos = new ByteArrayOutputStream();
-            while ((byteCount = is.read(data, 0, 1024)) > -1) {
-                bos.write(data, 0, byteCount);
-            }
-            return bos.toString();
-        } catch (final IOException e) {
-            throw new RuntimeException("Unable to getResourceAsStream for " + accumulateClass);
-        }
+    protected <X> BiTuple<A, B> createInput(Function<Variable<X>, X> valueFinder) {
+        final A a = materialize(aVariable, valueFinder);
+        final B b = materialize(bVariable, valueFinder);
+        return new BiTuple<>(a, b);
     }
 
 }

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/bi/DroolsBiToTriGroupByInvoker.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/bi/DroolsBiToTriGroupByInvoker.java
@@ -32,6 +32,7 @@ import org.drools.core.spi.CompiledInvoker;
 import org.drools.core.spi.Tuple;
 import org.drools.model.Variable;
 import org.optaplanner.core.api.score.stream.bi.BiConstraintCollector;
+import org.optaplanner.core.impl.score.stream.drools.common.BiTuple;
 
 public class DroolsBiToTriGroupByInvoker<A, B, ResultContainer, NewA, NewB, NewC> implements Accumulator, CompiledInvoker {
 
@@ -68,7 +69,7 @@ public class DroolsBiToTriGroupByInvoker<A, B, ResultContainer, NewA, NewB, NewC
         Object handleObject = handle.getObject();
         final A groupKeyA = getValue(aVariable, internalWorkingMemory, handleObject, innerDeclarations);
         final B groupKeyB = getValue(bVariable, internalWorkingMemory, handleObject, innerDeclarations);
-        castContext(context).accumulate(handle, groupKeyA, groupKeyB);
+        castContext(context).accumulate(handle, new BiTuple<>(groupKeyA, groupKeyB));
     }
 
     private static <X> X getValue(Variable<X> var, InternalWorkingMemory internalWorkingMemory, Object handleObject,

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/bi/DroolsGroupingBiConstraintStream.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/bi/DroolsGroupingBiConstraintStream.java
@@ -19,10 +19,12 @@ package org.optaplanner.core.impl.score.stream.drools.bi;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 
+import org.optaplanner.core.api.function.TriFunction;
 import org.optaplanner.core.api.score.stream.bi.BiConstraintCollector;
 import org.optaplanner.core.api.score.stream.uni.UniConstraintCollector;
 import org.optaplanner.core.impl.score.stream.drools.DroolsConstraintFactory;
 import org.optaplanner.core.impl.score.stream.drools.common.DroolsAbstractConstraintStream;
+import org.optaplanner.core.impl.score.stream.drools.tri.DroolsAbstractTriConstraintStream;
 import org.optaplanner.core.impl.score.stream.drools.uni.DroolsAbstractUniConstraintStream;
 
 public class DroolsGroupingBiConstraintStream<Solution_, NewA, NewB>
@@ -58,6 +60,14 @@ public class DroolsGroupingBiConstraintStream<Solution_, NewA, NewB>
     public <A, B, __> DroolsGroupingBiConstraintStream(DroolsConstraintFactory<Solution_> constraintFactory,
             DroolsAbstractBiConstraintStream<Solution_, A, B> parent, BiFunction<A, B, NewA> groupKeyAMapping,
             BiFunction<A, B, NewB> groupKeyBMapping) {
+        super(constraintFactory);
+        this.parent = parent;
+        this.condition = parent.getCondition().andGroupBi(groupKeyAMapping, groupKeyBMapping);
+    }
+
+    public <A, B, C, __> DroolsGroupingBiConstraintStream(DroolsConstraintFactory<Solution_> constraintFactory,
+            DroolsAbstractTriConstraintStream<Solution_, A, B, C> parent, TriFunction<A, B, C, NewA> groupKeyAMapping,
+            TriFunction<A, B, C, NewB> groupKeyBMapping) {
         super(constraintFactory);
         this.parent = parent;
         this.condition = parent.getCondition().andGroupBi(groupKeyAMapping, groupKeyBMapping);

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/bi/DroolsGroupingBiConstraintStream.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/bi/DroolsGroupingBiConstraintStream.java
@@ -21,6 +21,7 @@ import java.util.function.Function;
 
 import org.optaplanner.core.api.function.TriFunction;
 import org.optaplanner.core.api.score.stream.bi.BiConstraintCollector;
+import org.optaplanner.core.api.score.stream.tri.TriConstraintCollector;
 import org.optaplanner.core.api.score.stream.uni.UniConstraintCollector;
 import org.optaplanner.core.impl.score.stream.drools.DroolsConstraintFactory;
 import org.optaplanner.core.impl.score.stream.drools.common.DroolsAbstractConstraintStream;
@@ -64,6 +65,15 @@ public class DroolsGroupingBiConstraintStream<Solution_, NewA, NewB>
         this.parent = parent;
         this.condition = parent.getCondition().andGroupBi(groupKeyAMapping, groupKeyBMapping);
     }
+
+    public <A, B, C, __> DroolsGroupingBiConstraintStream(DroolsConstraintFactory<Solution_> constraintFactory,
+            DroolsAbstractTriConstraintStream<Solution_, A, B, C> parent, TriFunction<A, B, C, NewA> groupKeyMapping,
+            TriConstraintCollector<A, B, C,__, NewB> collector) {
+        super(constraintFactory);
+        this.parent = parent;
+        this.condition = parent.getCondition().andGroupWithCollect(groupKeyMapping, collector);
+    }
+
 
     public <A, B, C, __> DroolsGroupingBiConstraintStream(DroolsConstraintFactory<Solution_> constraintFactory,
             DroolsAbstractTriConstraintStream<Solution_, A, B, C> parent, TriFunction<A, B, C, NewA> groupKeyAMapping,

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/common/BiTuple.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/common/BiTuple.java
@@ -19,14 +19,14 @@ package org.optaplanner.core.impl.score.stream.drools.common;
 import java.util.Objects;
 
 public final class BiTuple<A, B> {
-    public final A _1;
-    public final B _2;
+    public final A a;
+    public final B b;
     private final int hashCode;
 
-    public BiTuple(A _1, B _2) {
-        this._1 = _1;
-        this._2 = _2;
-        this.hashCode = Objects.hash(_1, _2);
+    public BiTuple(A a, B b) {
+        this.a = a;
+        this.b = b;
+        this.hashCode = Objects.hash(a, b);
     }
 
     @Override
@@ -38,8 +38,8 @@ public final class BiTuple<A, B> {
             return false;
         }
         final BiTuple<?, ?> other = (BiTuple<?, ?>) o;
-        return Objects.equals(_1, other._1) &&
-                Objects.equals(_2, other._2);
+        return Objects.equals(a, other.a) &&
+                Objects.equals(b, other.b);
     }
 
     @Override
@@ -49,6 +49,6 @@ public final class BiTuple<A, B> {
 
     @Override
     public String toString() {
-        return "BiTuple(" + _1 + ", " + _2 + ")";
+        return "BiTuple(" + a + ", " + b + ")";
     }
 }

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/common/DroolsAbstractAccumulateFunctionBridge.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/common/DroolsAbstractAccumulateFunctionBridge.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.core.impl.score.stream.drools.common;
+
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+import java.util.Map;
+
+import org.kie.api.runtime.rule.AccumulateFunction;
+
+public abstract class DroolsAbstractAccumulateFunctionBridge<ResultContainer_, InTuple, OutTuple>
+        implements AccumulateFunction<DroolsAccumulateContext<ResultContainer_>> {
+
+    @Override
+    public DroolsAccumulateContext<ResultContainer_> createContext() {
+        return new DroolsAccumulateContext<>(newContainer());
+    }
+
+    @Override
+    public void init(DroolsAccumulateContext<ResultContainer_> context) {
+        context.getUndoMap().clear();
+    }
+
+    @Override
+    public void accumulate(DroolsAccumulateContext<ResultContainer_> context, Object value) {
+        Map<Object, Runnable> undoMap = context.getUndoMap();
+        if (undoMap.containsKey(value)) {
+            throw new IllegalStateException("Undo for (" + value +  ") already exists.");
+        }
+        Runnable undo = accumulate(context.getContainer(), (InTuple) value);
+        undoMap.put(value, undo);
+    }
+
+    @Override
+    public void reverse(DroolsAccumulateContext<ResultContainer_> context, Object value) {
+        Runnable undo = context.getUndoMap().remove(value);
+        if (undo == null) {
+            throw new IllegalStateException("Undo for (" + value +  ") does not exist.");
+        }
+        undo.run();
+    }
+
+    @Override
+    public Object getResult(DroolsAccumulateContext<ResultContainer_> context) {
+        return getResult(context.getContainer());
+    }
+
+    @Override
+    public boolean supportsReverse() {
+        return true;
+    }
+
+    @Override
+    public Class<?> getResultType() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void writeExternal(ObjectOutput out) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void readExternal(ObjectInput in) {
+        throw new UnsupportedOperationException();
+    }
+
+    protected abstract ResultContainer_ newContainer();
+
+    protected abstract Runnable accumulate(ResultContainer_ container, InTuple tuple);
+
+    protected abstract OutTuple getResult(ResultContainer_ container);
+
+}

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/common/DroolsAbstractGroupBy.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/common/DroolsAbstractGroupBy.java
@@ -29,8 +29,6 @@ public abstract class DroolsAbstractGroupBy<ResultContainer, InTuple, OutTuple> 
     private final Map<Long, Runnable> undoMap = new HashMap<>(0);
     private DroolsAbstractGroupByAccumulator<ResultContainer, InTuple, ?, OutTuple> acc;
 
-    protected abstract DroolsAbstractGroupByAccumulator<ResultContainer, InTuple, ?, OutTuple> newAccumulator();
-
     public void init() {
         acc = newAccumulator();
         undoMap.clear();
@@ -55,5 +53,7 @@ public abstract class DroolsAbstractGroupBy<ResultContainer, InTuple, OutTuple> 
     public Set<OutTuple> getResult() {
         return acc.finish();
     }
+
+    protected abstract DroolsAbstractGroupByAccumulator<ResultContainer, InTuple, ?, OutTuple> newAccumulator();
 
 }

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/common/DroolsAbstractGroupBy.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/common/DroolsAbstractGroupBy.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.core.impl.score.stream.drools.common;
+
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import org.drools.core.common.InternalFactHandle;
+
+public abstract class DroolsAbstractGroupBy<ResultContainer, InTuple, OutTuple> implements Serializable {
+
+    private static final long serialVersionUID = 510l;
+    private final Map<Long, Runnable> undoMap = new HashMap<>(0);
+    private DroolsAbstractGroupByAccumulator<ResultContainer, InTuple, ?, OutTuple> acc;
+
+    protected abstract DroolsAbstractGroupByAccumulator<ResultContainer, InTuple, ?, OutTuple> newAccumulator();
+
+    public void init() {
+        acc = newAccumulator();
+        undoMap.clear();
+    }
+
+    public void accumulate(InternalFactHandle handle, InTuple input) {
+        Runnable undo = acc.accumulate(input);
+        Runnable oldUndo = this.undoMap.put(handle.getId(), undo);
+        if (oldUndo != null) {
+            throw new IllegalStateException("Undo for fact handle (" + handle.getId() + ") already exists.");
+        }
+    }
+
+    public void reverse(InternalFactHandle handle) {
+        final Runnable undo = this.undoMap.remove(handle.getId());
+        if (undo == null) {
+            throw new IllegalStateException("No undo for fact handle (" + handle.getId() + ")");
+        }
+        undo.run();
+    }
+
+    public Set<OutTuple> getResult() {
+        return acc.finish();
+    }
+
+}

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/common/DroolsAbstractGroupByAccumulator.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/common/DroolsAbstractGroupByAccumulator.java
@@ -33,22 +33,6 @@ public abstract class DroolsAbstractGroupByAccumulator<ResultContainer, InTuple,
     // It doesn't make sense to serialize this anyway, as it is recreated every time.
     private final transient Set<OutTuple> resultSet = new LinkedHashSet<>(0);
 
-    private static Long increment(Long count) {
-        return count == null ? 1L : count + 1L;
-    }
-
-    private static Long decrement(Long count) {
-        return count == 1L ? null : count - 1L;
-    }
-
-    protected abstract KeyTuple toKey(InTuple tuple);
-
-    protected abstract ResultContainer newContainer();
-
-    protected abstract Runnable process(InTuple tuple, ResultContainer container);
-
-    protected abstract OutTuple toResult(KeyTuple key, ResultContainer container);
-
     public Runnable accumulate(InTuple input) {
         KeyTuple key = toKey(input);
         ResultContainer container = containersMap.computeIfAbsent(key, __ -> newContainer());
@@ -64,6 +48,14 @@ public abstract class DroolsAbstractGroupByAccumulator<ResultContainer, InTuple,
         };
     }
 
+    private static Long increment(Long count) {
+        return count == null ? 1L : count + 1L;
+    }
+
+    private static Long decrement(Long count) {
+        return count == 1L ? null : count - 1L;
+    }
+
     public Set<OutTuple> finish() {
         resultSet.clear();
         for (Map.Entry<KeyTuple, ResultContainer> entry : containersMap.entrySet()) {
@@ -71,4 +63,13 @@ public abstract class DroolsAbstractGroupByAccumulator<ResultContainer, InTuple,
         }
         return resultSet;
     }
+
+    protected abstract KeyTuple toKey(InTuple tuple);
+
+    protected abstract ResultContainer newContainer();
+
+    protected abstract Runnable process(InTuple tuple, ResultContainer container);
+
+    protected abstract OutTuple toResult(KeyTuple key, ResultContainer container);
+
 }

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/common/DroolsAbstractGroupByAccumulator.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/common/DroolsAbstractGroupByAccumulator.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.core.impl.score.stream.drools.common;
+
+import java.io.Serializable;
+import java.util.IdentityHashMap;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+
+public abstract class DroolsAbstractGroupByAccumulator<ResultContainer, InTuple, KeyTuple, OutTuple> implements Serializable {
+
+    // Containers may be identical in type and contents, yet they should still not count as the same container.
+    private final Map<ResultContainer, Long> containersInUseMap = new IdentityHashMap<>(0);
+    // LinkedHashMap to maintain a consistent iteration order of resulting pairs.
+    private final Map<KeyTuple, ResultContainer> containersMap = new LinkedHashMap<>(0);
+    // Transient as Spotbugs complains otherwise ("non-transient non-serializable instance field").
+    // It doesn't make sense to serialize this anyway, as it is recreated every time.
+    private final transient Set<OutTuple> resultSet = new LinkedHashSet<>(0);
+
+    private static Long increment(Long count) {
+        return count == null ? 1L : count + 1L;
+    }
+
+    private static Long decrement(Long count) {
+        return count == 1L ? null : count - 1L;
+    }
+
+    protected abstract KeyTuple toKey(InTuple tuple);
+
+    protected abstract ResultContainer newContainer();
+
+    protected abstract Runnable process(InTuple tuple, ResultContainer container);
+
+    protected abstract OutTuple toResult(KeyTuple key, ResultContainer container);
+
+    public Runnable accumulate(InTuple input) {
+        KeyTuple key = toKey(input);
+        ResultContainer container = containersMap.computeIfAbsent(key, __ -> newContainer());
+        Runnable undo = process(input, container);
+        containersInUseMap.compute(container, (__, count) -> increment(count)); // Increment use counter.
+        return () -> {
+            undo.run();
+            // Decrement use counter. If 0, container is ignored during finishing. Removes empty groups from results.
+            Long currentCount = containersInUseMap.compute(container, (__, count) -> decrement(count));
+            if (currentCount == null) {
+                containersMap.remove(key);
+            }
+        };
+    }
+
+    public Set<OutTuple> finish() {
+        resultSet.clear();
+        for (Map.Entry<KeyTuple, ResultContainer> entry : containersMap.entrySet()) {
+            resultSet.add(toResult(entry.getKey(), entry.getValue()));
+        }
+        return resultSet;
+    }
+}

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/common/DroolsAbstractGroupByInvoker.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/common/DroolsAbstractGroupByInvoker.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.core.impl.score.stream.drools.common;
+
+import java.io.Serializable;
+import java.util.function.Function;
+
+import org.drools.core.WorkingMemory;
+import org.drools.core.common.InternalFactHandle;
+import org.drools.core.common.InternalWorkingMemory;
+import org.drools.core.reteoo.SubnetworkTuple;
+import org.drools.core.rule.Declaration;
+import org.drools.core.spi.Accumulator;
+import org.drools.core.spi.Tuple;
+import org.drools.model.Variable;
+
+public abstract class DroolsAbstractGroupByInvoker<ResultContainer, InTuple> implements Accumulator {
+
+    protected static <X> X getValue(Variable<X> var, InternalWorkingMemory internalWorkingMemory, Object handleObject,
+            Declaration... innerDeclarations) {
+        Declaration declaration = getDeclarationForVariable(var, innerDeclarations);
+        Object actualHandleObject = handleObject instanceof SubnetworkTuple ?
+                ((SubnetworkTuple) handleObject).getObject(declaration) :
+                handleObject;
+        return (X) declaration.getValue(internalWorkingMemory, actualHandleObject);
+    }
+
+    /**
+     * Declarations in Drools appear to show up in random order. Therefore, we need to match the proper declaration
+     * not by directly addressing within the array, but by looking it up based on the associated variable.
+     * @param variable
+     * @param declarations
+     * @return
+     */
+    private static Declaration getDeclarationForVariable(Variable<?> variable, Declaration... declarations) {
+        for (Declaration declaration : declarations) {
+            if (declaration.getIdentifier().equals(variable.getName())) {
+                return declaration;
+            }
+        }
+        throw new IllegalStateException("Could not find declaration for variable (" + variable + ").");
+    }
+
+    protected static <X, X2> X materialize(Variable<X> var, Function<Variable<X2>, X2> valueFinder) {
+        return (X) valueFinder.apply((Variable<X2>) var);
+    }
+
+    @Override
+    public Serializable createContext() {
+        return newContext();
+    }
+
+    @Override
+    public void init(Object workingMemoryContext, Object context, Tuple tuple, Declaration[] declarations,
+            WorkingMemory workingMemory) {
+        castContext(context).init();
+    }
+
+    @Override
+    public void accumulate(Object workingMemoryContext, Object context, Tuple tuple, InternalFactHandle handle,
+            Declaration[] declarations, Declaration[] innerDeclarations, final WorkingMemory workingMemory) {
+        InternalWorkingMemory internalWorkingMemory = (InternalWorkingMemory) workingMemory;
+        Object handleObject = handle.getObject();
+        InTuple input = createInput(var -> getValue(var, internalWorkingMemory, handleObject, innerDeclarations));
+        castContext(context).accumulate(handle, input);
+    }
+
+    private DroolsAbstractGroupBy<ResultContainer, InTuple, ?> castContext(Object context) {
+        return (DroolsAbstractGroupBy<ResultContainer, InTuple, ?>) context;
+    }
+
+    @Override
+    public void reverse(Object workingMemoryContext, Object context, Tuple tuple, InternalFactHandle handle,
+            Declaration[] declarations, Declaration[] innerDeclarations, WorkingMemory workingMemory) {
+        castContext(context).reverse(handle);
+    }
+
+    @Override
+    public Object getResult(Object workingMemoryContext, Object context, Tuple tuple, Declaration[] declarations,
+            WorkingMemory workingMemory) {
+        return castContext(context).getResult();
+    }
+
+    @Override
+    public boolean supportsReverse() {
+        return true;
+    }
+
+    @Override
+    public Object createWorkingMemoryContext() {
+        return null;
+    }
+
+    protected abstract DroolsAbstractGroupBy<ResultContainer, InTuple, ?> newContext();
+
+    protected abstract <X> InTuple createInput(Function<Variable<X>, X> valueFinder);
+
+}

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/common/DroolsCondition.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/common/DroolsCondition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,12 +20,21 @@ import java.math.BigDecimal;
 import java.util.Arrays;
 import java.util.stream.Stream;
 
+import org.drools.model.DSL;
 import org.drools.model.Drools;
 import org.drools.model.PatternDSL;
+import org.drools.model.PatternDSL.PatternDef;
+import org.drools.model.Variable;
 import org.drools.model.view.ViewItem;
 import org.kie.api.runtime.rule.RuleContext;
+import org.optaplanner.core.api.function.TriFunction;
 import org.optaplanner.core.api.score.Score;
 import org.optaplanner.core.api.score.holder.AbstractScoreHolder;
+import org.optaplanner.core.impl.score.stream.drools.uni.DroolsUniCondition;
+import org.optaplanner.core.impl.score.stream.drools.uni.DroolsUniRuleStructure;
+
+import static org.drools.model.DSL.accFunction;
+import static org.drools.model.DSL.declarationOf;
 
 /**
  * Encapsulates the low-level rule creation and manipulation operations via the Drools executable model DSL
@@ -68,12 +77,26 @@ public abstract class DroolsCondition<T extends DroolsRuleStructure> {
         scoreHolder.impactScore(kcontext, impact);
     }
 
-    protected ViewItem<?> getInnerAccumulatePattern(PatternDSL.PatternDef<Object> mainAccumulatePattern) {
+    protected ViewItem<?> getInnerAccumulatePattern(PatternDef<Object> mainAccumulatePattern) {
         ViewItem[] items = Stream.concat(ruleStructure.getOpenRuleItems().stream(), Stream.of(mainAccumulatePattern))
                 .toArray(ViewItem[]::new);
         return PatternDSL.and(items[0], Arrays.copyOfRange(items, 1, items.length));
     }
 
+    protected <NewA, CarrierTuple, OutTuple, __> DroolsUniCondition<NewA> andCollect(
+            DroolsAbstractAccumulateFunctionBridge<__, CarrierTuple, OutTuple> accumulateFunctionBridge,
+            TriFunction<PatternDef<Object>, T, Variable<CarrierTuple>, PatternDef<Object>> bindFunction) {
+        Variable<CarrierTuple> tupleVariable = ruleStructure.createVariable("tuple");
+        PatternDef<Object> mainAccumulatePattern = ruleStructure.getPrimaryPattern()
+                .expand(p -> bindFunction.apply(p, ruleStructure, tupleVariable))
+                .build();
+        ViewItem<?> innerAccumulatePattern = getInnerAccumulatePattern(mainAccumulatePattern);
+        Variable<NewA> outputVariable = (Variable<NewA>) declarationOf(Object.class, "collected");
+        ViewItem<?> outerAccumulatePattern = DSL.accumulate(innerAccumulatePattern,
+                accFunction(() -> accumulateFunctionBridge, tupleVariable).as(outputVariable));
+        DroolsUniRuleStructure<NewA> newRuleStructure = ruleStructure.recollect(outputVariable, outerAccumulatePattern);
+        return new DroolsUniCondition<>(newRuleStructure);
+    }
 
 
 }

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/common/DroolsCondition.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/common/DroolsCondition.java
@@ -44,7 +44,6 @@ import org.optaplanner.core.impl.score.stream.drools.uni.DroolsUniCondition;
 import org.optaplanner.core.impl.score.stream.drools.uni.DroolsUniRuleStructure;
 
 import static org.drools.model.DSL.accFunction;
-import static org.drools.model.DSL.declarationOf;
 import static org.drools.model.PatternDSL.alphaIndexedBy;
 import static org.drools.model.PatternDSL.pattern;
 
@@ -70,7 +69,7 @@ public abstract class DroolsCondition<T extends DroolsRuleStructure> {
                 .expand(p -> bindFunction.apply(p, tupleVariable))
                 .build();
         ViewItem<?> innerAccumulatePattern = getInnerAccumulatePattern(mainAccumulatePattern);
-        Variable<NewA> outputVariable = (Variable<NewA>) declarationOf(Object.class, "collected");
+        Variable<NewA> outputVariable = ruleStructure.createVariable("collected");
         ViewItem<?> outerAccumulatePattern = DSL.accumulate(innerAccumulatePattern,
                 accFunction(() -> accumulateFunctionBridge, tupleVariable).as(outputVariable));
         DroolsUniRuleStructure<NewA> newRuleStructure = ruleStructure.recollect(outputVariable, outerAccumulatePattern);

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/common/DroolsCondition.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/common/DroolsCondition.java
@@ -18,16 +18,20 @@ package org.optaplanner.core.impl.score.stream.drools.common;
 
 import java.math.BigDecimal;
 import java.util.Arrays;
+import java.util.Set;
+import java.util.function.BiFunction;
 import java.util.stream.Stream;
 
+import org.drools.core.base.accumulators.CollectSetAccumulateFunction;
 import org.drools.model.DSL;
 import org.drools.model.Drools;
+import org.drools.model.Index;
 import org.drools.model.PatternDSL;
 import org.drools.model.PatternDSL.PatternDef;
 import org.drools.model.Variable;
+import org.drools.model.view.ExprViewItem;
 import org.drools.model.view.ViewItem;
 import org.kie.api.runtime.rule.RuleContext;
-import org.optaplanner.core.api.function.TriFunction;
 import org.optaplanner.core.api.score.Score;
 import org.optaplanner.core.api.score.holder.AbstractScoreHolder;
 import org.optaplanner.core.impl.score.stream.drools.uni.DroolsUniCondition;
@@ -35,6 +39,8 @@ import org.optaplanner.core.impl.score.stream.drools.uni.DroolsUniRuleStructure;
 
 import static org.drools.model.DSL.accFunction;
 import static org.drools.model.DSL.declarationOf;
+import static org.drools.model.PatternDSL.alphaIndexedBy;
+import static org.drools.model.PatternDSL.pattern;
 
 /**
  * Encapsulates the low-level rule creation and manipulation operations via the Drools executable model DSL
@@ -83,18 +89,36 @@ public abstract class DroolsCondition<T extends DroolsRuleStructure> {
         return PatternDSL.and(items[0], Arrays.copyOfRange(items, 1, items.length));
     }
 
-    protected <NewA, CarrierTuple, OutTuple, __> DroolsUniCondition<NewA> andCollect(
+    protected <NewA, CarrierTuple, OutTuple, __> DroolsUniCondition<NewA> collect(
             DroolsAbstractAccumulateFunctionBridge<__, CarrierTuple, OutTuple> accumulateFunctionBridge,
-            TriFunction<PatternDef<Object>, T, Variable<CarrierTuple>, PatternDef<Object>> bindFunction) {
+            BiFunction<PatternDef<Object>, Variable<CarrierTuple>, PatternDef<Object>> bindFunction) {
         Variable<CarrierTuple> tupleVariable = ruleStructure.createVariable("tuple");
         PatternDef<Object> mainAccumulatePattern = ruleStructure.getPrimaryPattern()
-                .expand(p -> bindFunction.apply(p, ruleStructure, tupleVariable))
+                .expand(p -> bindFunction.apply(p, tupleVariable))
                 .build();
         ViewItem<?> innerAccumulatePattern = getInnerAccumulatePattern(mainAccumulatePattern);
         Variable<NewA> outputVariable = (Variable<NewA>) declarationOf(Object.class, "collected");
         ViewItem<?> outerAccumulatePattern = DSL.accumulate(innerAccumulatePattern,
                 accFunction(() -> accumulateFunctionBridge, tupleVariable).as(outputVariable));
         DroolsUniRuleStructure<NewA> newRuleStructure = ruleStructure.recollect(outputVariable, outerAccumulatePattern);
+        return new DroolsUniCondition<>(newRuleStructure);
+    }
+
+    protected <NewA> DroolsUniCondition<NewA> group(
+            BiFunction<PatternDef<Object>, Variable<NewA>, PatternDef<Object>> bindFunction) {
+        Variable<NewA> mappedVariable = ruleStructure.createVariable("biMapped");
+        PatternDSL.PatternDef<Object> mainAccumulatePattern = ruleStructure.getPrimaryPattern()
+                .expand(p -> bindFunction.apply(p, mappedVariable))
+                .build();
+        ViewItem<?> innerAccumulatePattern = getInnerAccumulatePattern(mainAccumulatePattern);
+        Variable<Set<NewA>> setOfMappings =
+                (Variable<Set<NewA>>) ruleStructure.createVariable(Set.class, "setOfGroupKey");
+        PatternDSL.PatternDef<Set<NewA>> pattern = pattern(setOfMappings)
+                .expr("Set of " + mappedVariable.getName(), set -> !set.isEmpty(),
+                        alphaIndexedBy(Integer.class, Index.ConstraintType.GREATER_THAN, -1, Set::size, 0));
+        ExprViewItem<Object> accumulate = DSL.accumulate(innerAccumulatePattern,
+                accFunction(CollectSetAccumulateFunction.class, mappedVariable).as(setOfMappings));
+        DroolsUniRuleStructure<NewA> newRuleStructure = ruleStructure.regroup(setOfMappings, pattern, accumulate);
         return new DroolsUniCondition<>(newRuleStructure);
     }
 

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/common/DroolsRuleStructure.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/common/DroolsRuleStructure.java
@@ -172,11 +172,12 @@ public abstract class DroolsRuleStructure {
                 mergeClosedItems(accumulatePattern), getVariableIdSupplier());
     }
 
-    public <NewA, NewB> DroolsBiRuleStructure<NewA, NewB> regroupBi(Variable<BiTuple<NewA, NewB>> newSource,
+    public <NewA, NewB> DroolsBiRuleStructure<NewA, NewB> regroupBi(Variable<Set<BiTuple<NewA, NewB>>> newSource,
             PatternDSL.PatternDef<Set<BiTuple<NewA, NewB>>> collectPattern, ViewItem<?> accumulatePattern) {
+        Variable<BiTuple<NewA, NewB>> newTuple = createVariable("groupKey", from(newSource));
         Variable<NewA> newA = createVariable("newA");
         Variable<NewB> newB = createVariable("newB");
-        DroolsPatternBuilder<BiTuple<NewA, NewB>> newPrimaryPattern = new DroolsPatternBuilder<>(newSource)
+        DroolsPatternBuilder<BiTuple<NewA, NewB>> newPrimaryPattern = new DroolsPatternBuilder<>(newTuple)
                 .expand(p -> p.bind(newA, pair -> (NewA) pair._1))
                 .expand(p -> p.bind(newB, pair -> (NewB) pair._2));
         return new DroolsBiRuleStructure<>(newA, newB, newPrimaryPattern, Arrays.asList(collectPattern),

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/common/DroolsRuleStructure.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/common/DroolsRuleStructure.java
@@ -179,8 +179,8 @@ public abstract class DroolsRuleStructure {
         Variable<NewA> newA = createVariable("newA");
         Variable<NewB> newB = createVariable("newB");
         DroolsPatternBuilder<BiTuple<NewA, NewB>> newPrimaryPattern = new DroolsPatternBuilder<>(newTuple)
-                .expand(p -> p.bind(newA, pair -> (NewA) pair._1))
-                .expand(p -> p.bind(newB, pair -> (NewB) pair._2));
+                .expand(p -> p.bind(newA, pair -> (NewA) pair.a))
+                .expand(p -> p.bind(newB, pair -> (NewB) pair.b));
         return new DroolsBiRuleStructure<>(newA, newB, newPrimaryPattern, Arrays.asList(collectPattern),
                 mergeClosedItems(accumulatePattern), getVariableIdSupplier());
     }
@@ -194,9 +194,9 @@ public abstract class DroolsRuleStructure {
         Variable<NewB> newB = createVariable("newB");
         Variable<NewC> newC = createVariable("newC");
         DroolsPatternBuilder<TriTuple<NewA, NewB, NewC>> newPrimaryPattern = new DroolsPatternBuilder<>(newTuple)
-                .expand(p -> p.bind(newA, pair -> (NewA) pair._1))
-                .expand(p -> p.bind(newB, pair -> (NewB) pair._2))
-                .expand(p -> p.bind(newC, pair -> (NewC) pair._3));
+                .expand(p -> p.bind(newA, pair -> (NewA) pair.a))
+                .expand(p -> p.bind(newB, pair -> (NewB) pair.b))
+                .expand(p -> p.bind(newC, pair -> (NewC) pair.c));
         return new DroolsTriRuleStructure<>(newA, newB, newC, newPrimaryPattern, Arrays.asList(collectPattern),
                 mergeClosedItems(accumulatePattern), getVariableIdSupplier());
     }

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/common/DroolsRuleStructure.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/common/DroolsRuleStructure.java
@@ -34,6 +34,7 @@ import org.drools.model.consequences.ConsequenceBuilder;
 import org.drools.model.view.ViewItem;
 import org.optaplanner.core.impl.score.stream.drools.DroolsConstraintFactory;
 import org.optaplanner.core.impl.score.stream.drools.bi.DroolsBiRuleStructure;
+import org.optaplanner.core.impl.score.stream.drools.tri.DroolsTriRuleStructure;
 import org.optaplanner.core.impl.score.stream.drools.uni.DroolsUniRuleStructure;
 
 import static org.drools.model.DSL.from;
@@ -176,9 +177,22 @@ public abstract class DroolsRuleStructure {
         Variable<NewA> newA = createVariable("newA");
         Variable<NewB> newB = createVariable("newB");
         DroolsPatternBuilder<BiTuple<NewA, NewB>> newPrimaryPattern = new DroolsPatternBuilder<>(newSource)
-                .expand(p -> p.bind(newA, pair -> (NewA) pair.key))
-                .expand(p -> p.bind(newB, pair -> (NewB) pair.value));
+                .expand(p -> p.bind(newA, pair -> (NewA) pair._1))
+                .expand(p -> p.bind(newB, pair -> (NewB) pair._2));
         return new DroolsBiRuleStructure<>(newA, newB, newPrimaryPattern, Arrays.asList(collectPattern),
+                mergeClosedItems(accumulatePattern), getVariableIdSupplier());
+    }
+
+    public <NewA, NewB, NewC> DroolsTriRuleStructure<NewA, NewB, NewC> regroupBiToTri(Variable<TriTuple<NewA, NewB, NewC>> newSource,
+            PatternDSL.PatternDef<Set<TriTuple<NewA, NewB, NewC>>> collectPattern, ViewItem<?> accumulatePattern) {
+        Variable<NewA> newA = createVariable("newA");
+        Variable<NewB> newB = createVariable("newB");
+        Variable<NewC> newC = createVariable("newC");
+        DroolsPatternBuilder<TriTuple<NewA, NewB, NewC>> newPrimaryPattern = new DroolsPatternBuilder<>(newSource)
+                .expand(p -> p.bind(newA, pair -> (NewA) pair._1))
+                .expand(p -> p.bind(newB, pair -> (NewB) pair._2))
+                .expand(p -> p.bind(newC, pair -> (NewC) pair._3));
+        return new DroolsTriRuleStructure<>(newA, newB, newC, newPrimaryPattern, Arrays.asList(collectPattern),
                 mergeClosedItems(accumulatePattern), getVariableIdSupplier());
     }
 

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/common/DroolsRuleStructure.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/common/DroolsRuleStructure.java
@@ -174,7 +174,8 @@ public abstract class DroolsRuleStructure {
 
     public <NewA, NewB> DroolsBiRuleStructure<NewA, NewB> regroupBi(Variable<Set<BiTuple<NewA, NewB>>> newSource,
             PatternDSL.PatternDef<Set<BiTuple<NewA, NewB>>> collectPattern, ViewItem<?> accumulatePattern) {
-        Variable<BiTuple<NewA, NewB>> newTuple = createVariable("groupKey", from(newSource));
+        Variable<BiTuple<NewA, NewB>> newTuple =
+                (Variable<BiTuple<NewA, NewB>>) createVariable(BiTuple.class,"groupKey", from(newSource));
         Variable<NewA> newA = createVariable("newA");
         Variable<NewB> newB = createVariable("newB");
         DroolsPatternBuilder<BiTuple<NewA, NewB>> newPrimaryPattern = new DroolsPatternBuilder<>(newTuple)
@@ -187,7 +188,8 @@ public abstract class DroolsRuleStructure {
     public <NewA, NewB, NewC> DroolsTriRuleStructure<NewA, NewB, NewC> regroupBiToTri(
             Variable<Set<TriTuple<NewA, NewB, NewC>>> newSource,
             PatternDSL.PatternDef<Set<TriTuple<NewA, NewB, NewC>>> collectPattern, ViewItem<?> accumulatePattern) {
-        Variable<TriTuple<NewA, NewB, NewC>> newTuple = createVariable("groupKey", from(newSource));
+        Variable<TriTuple<NewA, NewB, NewC>> newTuple =
+                (Variable<TriTuple<NewA, NewB, NewC>>) createVariable(TriTuple.class, "groupKey", from(newSource));
         Variable<NewA> newA = createVariable("newA");
         Variable<NewB> newB = createVariable("newB");
         Variable<NewC> newC = createVariable("newC");

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/common/DroolsRuleStructure.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/common/DroolsRuleStructure.java
@@ -183,7 +183,8 @@ public abstract class DroolsRuleStructure {
                 mergeClosedItems(accumulatePattern), getVariableIdSupplier());
     }
 
-    public <NewA, NewB, NewC> DroolsTriRuleStructure<NewA, NewB, NewC> regroupBiToTri(Variable<TriTuple<NewA, NewB, NewC>> newSource,
+    public <NewA, NewB, NewC> DroolsTriRuleStructure<NewA, NewB, NewC> regroupBiToTri(
+            Variable<TriTuple<NewA, NewB, NewC>> newSource,
             PatternDSL.PatternDef<Set<TriTuple<NewA, NewB, NewC>>> collectPattern, ViewItem<?> accumulatePattern) {
         Variable<NewA> newA = createVariable("newA");
         Variable<NewB> newB = createVariable("newB");

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/common/DroolsRuleStructure.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/common/DroolsRuleStructure.java
@@ -185,12 +185,13 @@ public abstract class DroolsRuleStructure {
     }
 
     public <NewA, NewB, NewC> DroolsTriRuleStructure<NewA, NewB, NewC> regroupBiToTri(
-            Variable<TriTuple<NewA, NewB, NewC>> newSource,
+            Variable<Set<TriTuple<NewA, NewB, NewC>>> newSource,
             PatternDSL.PatternDef<Set<TriTuple<NewA, NewB, NewC>>> collectPattern, ViewItem<?> accumulatePattern) {
+        Variable<TriTuple<NewA, NewB, NewC>> newTuple = createVariable("groupKey", from(newSource));
         Variable<NewA> newA = createVariable("newA");
         Variable<NewB> newB = createVariable("newB");
         Variable<NewC> newC = createVariable("newC");
-        DroolsPatternBuilder<TriTuple<NewA, NewB, NewC>> newPrimaryPattern = new DroolsPatternBuilder<>(newSource)
+        DroolsPatternBuilder<TriTuple<NewA, NewB, NewC>> newPrimaryPattern = new DroolsPatternBuilder<>(newTuple)
                 .expand(p -> p.bind(newA, pair -> (NewA) pair._1))
                 .expand(p -> p.bind(newB, pair -> (NewB) pair._2))
                 .expand(p -> p.bind(newC, pair -> (NewC) pair._3));

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/common/Memoizer.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/common/Memoizer.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.core.impl.score.stream.drools.common;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Function;
+
+final class Memoizer<In, Out> {
+
+    private final Map<In, Out> cache = new ConcurrentHashMap<>(0);
+
+    private Memoizer() {
+        // No external instances.
+    }
+
+    public static <T, U> Function<T, U> memoize(Function<T, U> function) {
+        return new Memoizer<T, U>().doMemoize(function);
+    }
+
+    private Function<In, Out> doMemoize(Function<In, Out> function) {
+        return in -> cache.computeIfAbsent(in, function);
+    }
+
+}

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/common/TriTuple.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/common/TriTuple.java
@@ -19,16 +19,16 @@ package org.optaplanner.core.impl.score.stream.drools.common;
 import java.util.Objects;
 
 public final class TriTuple<A, B, C> {
-    public final A _1;
-    public final B _2;
-    public final C _3;
+    public final A a;
+    public final B b;
+    public final C c;
     private final int hashCode;
 
-    public TriTuple(A _1, B _2, C _3) {
-        this._1 = _1;
-        this._2 = _2;
-        this._3 = _3;
-        this.hashCode = Objects.hash(_1, _2, _3);
+    public TriTuple(A a, B b, C c) {
+        this.a = a;
+        this.b = b;
+        this.c = c;
+        this.hashCode = Objects.hash(a, b, c);
     }
 
     @Override
@@ -40,9 +40,9 @@ public final class TriTuple<A, B, C> {
             return false;
         }
         final TriTuple<?, ?, ?> other = (TriTuple<?, ?, ?>) o;
-        return Objects.equals(_1, other._1) &&
-                Objects.equals(_2, other._2) &&
-                Objects.equals(_3, other._3);
+        return Objects.equals(a, other.a) &&
+                Objects.equals(b, other.b) &&
+                Objects.equals(c, other.c);
     }
 
     @Override
@@ -52,6 +52,6 @@ public final class TriTuple<A, B, C> {
 
     @Override
     public String toString() {
-        return "TriTuple(" + _1 + ", " + _2  + ", " + _3 + ")";
+        return "TriTuple(" + a + ", " + b + ", " + c + ")";
     }
 }

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/common/TriTuple.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/common/TriTuple.java
@@ -18,15 +18,17 @@ package org.optaplanner.core.impl.score.stream.drools.common;
 
 import java.util.Objects;
 
-public final class BiTuple<A, B> {
+public final class TriTuple<A, B, C> {
     public final A _1;
     public final B _2;
+    public final C _3;
     private final int hashCode;
 
-    public BiTuple(A _1, B _2) {
+    public TriTuple(A _1, B _2, C _3) {
         this._1 = _1;
         this._2 = _2;
-        this.hashCode = Objects.hash(_1, _2);
+        this._3 = _3;
+        this.hashCode = Objects.hash(_1, _2, _3);
     }
 
     @Override
@@ -37,9 +39,10 @@ public final class BiTuple<A, B> {
         if (o == null || !Objects.equals(getClass(), o.getClass())) {
             return false;
         }
-        final BiTuple<?, ?> other = (BiTuple<?, ?>) o;
+        final TriTuple<?, ?, ?> other = (TriTuple<?, ?, ?>) o;
         return Objects.equals(_1, other._1) &&
-                Objects.equals(_2, other._2);
+                Objects.equals(_2, other._2) &&
+                Objects.equals(_3, other._3);
     }
 
     @Override
@@ -49,6 +52,6 @@ public final class BiTuple<A, B> {
 
     @Override
     public String toString() {
-        return "BiTuple(" + _1 + ", " + _2 + ")";
+        return "TriTuple(" + _1 + ", " + _2  + ", " + _3 + ")";
     }
 }

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/tri/DroolsAbstractTriConstraintStream.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/tri/DroolsAbstractTriConstraintStream.java
@@ -34,6 +34,7 @@ import org.optaplanner.core.api.score.stream.tri.TriConstraintCollector;
 import org.optaplanner.core.api.score.stream.tri.TriConstraintStream;
 import org.optaplanner.core.api.score.stream.uni.UniConstraintStream;
 import org.optaplanner.core.impl.score.stream.drools.DroolsConstraintFactory;
+import org.optaplanner.core.impl.score.stream.drools.bi.DroolsGroupingBiConstraintStream;
 import org.optaplanner.core.impl.score.stream.drools.common.DroolsAbstractConstraintStream;
 import org.optaplanner.core.impl.score.stream.drools.quad.DroolsAbstractQuadConstraintStream;
 import org.optaplanner.core.impl.score.stream.drools.quad.DroolsJoinQuadConstraintStream;
@@ -170,7 +171,12 @@ public abstract class DroolsAbstractTriConstraintStream<Solution_, A, B, C>
     @Override
     public <GroupKeyA_, GroupKeyB_> BiConstraintStream<GroupKeyA_, GroupKeyB_> groupBy(
             TriFunction<A, B, C, GroupKeyA_> groupKeyAMapping, TriFunction<A, B, C, GroupKeyB_> groupKeyBMapping) {
-        throw new UnsupportedOperationException();
+        throwWhenGroupByNotAllowed();
+        DroolsGroupingBiConstraintStream<Solution_, GroupKeyA_, GroupKeyB_> stream =
+                new DroolsGroupingBiConstraintStream<>(constraintFactory, this, groupKeyAMapping,
+                        groupKeyBMapping);
+        addChildStream(stream);
+        return stream;
     }
 
     @Override

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/tri/DroolsAbstractTriConstraintStream.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/tri/DroolsAbstractTriConstraintStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,8 +27,10 @@ import org.optaplanner.core.api.function.TriFunction;
 import org.optaplanner.core.api.function.TriPredicate;
 import org.optaplanner.core.api.score.Score;
 import org.optaplanner.core.api.score.stream.Constraint;
+import org.optaplanner.core.api.score.stream.bi.BiConstraintStream;
 import org.optaplanner.core.api.score.stream.quad.QuadConstraintStream;
 import org.optaplanner.core.api.score.stream.quad.QuadJoiner;
+import org.optaplanner.core.api.score.stream.tri.TriConstraintCollector;
 import org.optaplanner.core.api.score.stream.tri.TriConstraintStream;
 import org.optaplanner.core.api.score.stream.uni.UniConstraintStream;
 import org.optaplanner.core.impl.score.stream.drools.DroolsConstraintFactory;
@@ -141,6 +143,35 @@ public abstract class DroolsAbstractTriConstraintStream<Solution_, A, B, C>
                 new DroolsScoringTriConstraintStream<>(constraintFactory, this, matchWeigher);
         addChildStream(stream);
         return buildConstraintConfigurable(constraintPackage, constraintName, positive, stream);
+    }
+
+    // ************************************************************************
+    // Group by
+    // ************************************************************************
+
+    @Override
+    public <ResultContainer_, Result_> UniConstraintStream<Result_> groupBy(TriConstraintCollector<A, B, C, ResultContainer_, Result_> collector) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public <GroupKey_> UniConstraintStream<GroupKey_> groupBy(TriFunction<A, B, C, GroupKey_> groupKeyMapping) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public <GroupKey_, ResultContainer_, Result_> BiConstraintStream<GroupKey_, Result_> groupBy(TriFunction<A, B, C, GroupKey_> groupKeyMapping, TriConstraintCollector<A, B, C, ResultContainer_, Result_> collector) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public <GroupKeyA_, GroupKeyB_> BiConstraintStream<GroupKeyA_, GroupKeyB_> groupBy(TriFunction<A, B, C, GroupKeyA_> groupKeyAMapping, TriFunction<A, B, C, GroupKeyB_> groupKeyBMapping) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public <GroupKeyA_, GroupKeyB_, ResultContainer_, Result_> TriConstraintStream<GroupKeyA_, GroupKeyB_, Result_> groupBy(TriFunction<A, B, C, GroupKeyA_> groupKeyAMapping, TriFunction<A, B, C, GroupKeyB_> groupKeyBMapping, TriConstraintCollector<A, B, C, ResultContainer_, Result_> collector) {
+        throw new UnsupportedOperationException();
     }
 
     // ************************************************************************

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/tri/DroolsAbstractTriConstraintStream.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/tri/DroolsAbstractTriConstraintStream.java
@@ -44,10 +44,10 @@ import org.optaplanner.core.impl.score.stream.tri.InnerTriConstraintStream;
 public abstract class DroolsAbstractTriConstraintStream<Solution_, A, B, C>
         extends DroolsAbstractConstraintStream<Solution_> implements InnerTriConstraintStream<A, B, C> {
 
-    protected final DroolsAbstractTriConstraintStream<Solution_, A, B, C> parent;
+    protected final DroolsAbstractConstraintStream<Solution_> parent;
 
     public DroolsAbstractTriConstraintStream(DroolsConstraintFactory<Solution_> constraintFactory,
-            DroolsAbstractTriConstraintStream<Solution_, A, B, C> parent) {
+            DroolsAbstractConstraintStream<Solution_> parent) {
         super(constraintFactory);
         if (parent == null && !(this instanceof DroolsJoinTriConstraintStream)) {
             throw new IllegalArgumentException("The stream (" + this + ") must have a parent (null), " +

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/tri/DroolsAbstractTriConstraintStream.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/tri/DroolsAbstractTriConstraintStream.java
@@ -150,7 +150,8 @@ public abstract class DroolsAbstractTriConstraintStream<Solution_, A, B, C>
     // ************************************************************************
 
     @Override
-    public <ResultContainer_, Result_> UniConstraintStream<Result_> groupBy(TriConstraintCollector<A, B, C, ResultContainer_, Result_> collector) {
+    public <ResultContainer_, Result_> UniConstraintStream<Result_> groupBy(
+            TriConstraintCollector<A, B, C, ResultContainer_, Result_> collector) {
         throw new UnsupportedOperationException();
     }
 
@@ -160,18 +161,28 @@ public abstract class DroolsAbstractTriConstraintStream<Solution_, A, B, C>
     }
 
     @Override
-    public <GroupKey_, ResultContainer_, Result_> BiConstraintStream<GroupKey_, Result_> groupBy(TriFunction<A, B, C, GroupKey_> groupKeyMapping, TriConstraintCollector<A, B, C, ResultContainer_, Result_> collector) {
+    public <GroupKey_, ResultContainer_, Result_> BiConstraintStream<GroupKey_, Result_> groupBy(
+            TriFunction<A, B, C, GroupKey_> groupKeyMapping,
+            TriConstraintCollector<A, B, C, ResultContainer_, Result_> collector) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public <GroupKeyA_, GroupKeyB_> BiConstraintStream<GroupKeyA_, GroupKeyB_> groupBy(TriFunction<A, B, C, GroupKeyA_> groupKeyAMapping, TriFunction<A, B, C, GroupKeyB_> groupKeyBMapping) {
+    public <GroupKeyA_, GroupKeyB_> BiConstraintStream<GroupKeyA_, GroupKeyB_> groupBy(
+            TriFunction<A, B, C, GroupKeyA_> groupKeyAMapping, TriFunction<A, B, C, GroupKeyB_> groupKeyBMapping) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public <GroupKeyA_, GroupKeyB_, ResultContainer_, Result_> TriConstraintStream<GroupKeyA_, GroupKeyB_, Result_> groupBy(TriFunction<A, B, C, GroupKeyA_> groupKeyAMapping, TriFunction<A, B, C, GroupKeyB_> groupKeyBMapping, TriConstraintCollector<A, B, C, ResultContainer_, Result_> collector) {
-        throw new UnsupportedOperationException();
+    public <GroupKeyA_, GroupKeyB_, ResultContainer_, Result_> TriConstraintStream<GroupKeyA_, GroupKeyB_, Result_>
+    groupBy(TriFunction<A, B, C, GroupKeyA_> groupKeyAMapping, TriFunction<A, B, C, GroupKeyB_> groupKeyBMapping,
+            TriConstraintCollector<A, B, C, ResultContainer_, Result_> collector) {
+        throwWhenGroupByNotAllowed();
+        DroolsGroupingTriConstraintStream<Solution_, GroupKeyA_, GroupKeyB_, Result_> stream =
+                new DroolsGroupingTriConstraintStream<>(constraintFactory, this, groupKeyAMapping,
+                        groupKeyBMapping, collector);
+        addChildStream(stream);
+        return stream;
     }
 
     // ************************************************************************

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/tri/DroolsAbstractTriConstraintStream.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/tri/DroolsAbstractTriConstraintStream.java
@@ -154,7 +154,11 @@ public abstract class DroolsAbstractTriConstraintStream<Solution_, A, B, C>
     @Override
     public <ResultContainer_, Result_> UniConstraintStream<Result_> groupBy(
             TriConstraintCollector<A, B, C, ResultContainer_, Result_> collector) {
-        throw new UnsupportedOperationException();
+        throwWhenGroupByNotAllowed();
+        DroolsGroupingUniConstraintStream<Solution_, Result_> stream =
+                new DroolsGroupingUniConstraintStream<>(constraintFactory, this, collector);
+        addChildStream(stream);
+        return stream;
     }
 
     @Override

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/tri/DroolsAbstractTriConstraintStream.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/tri/DroolsAbstractTriConstraintStream.java
@@ -165,7 +165,11 @@ public abstract class DroolsAbstractTriConstraintStream<Solution_, A, B, C>
     public <GroupKey_, ResultContainer_, Result_> BiConstraintStream<GroupKey_, Result_> groupBy(
             TriFunction<A, B, C, GroupKey_> groupKeyMapping,
             TriConstraintCollector<A, B, C, ResultContainer_, Result_> collector) {
-        throw new UnsupportedOperationException();
+        throwWhenGroupByNotAllowed();
+        DroolsGroupingBiConstraintStream<Solution_, GroupKey_, Result_> stream =
+                new DroolsGroupingBiConstraintStream<>(constraintFactory, this, groupKeyMapping, collector);
+        addChildStream(stream);
+        return stream;
     }
 
     @Override

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/tri/DroolsAbstractTriConstraintStream.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/tri/DroolsAbstractTriConstraintStream.java
@@ -40,6 +40,7 @@ import org.optaplanner.core.impl.score.stream.drools.quad.DroolsAbstractQuadCons
 import org.optaplanner.core.impl.score.stream.drools.quad.DroolsJoinQuadConstraintStream;
 import org.optaplanner.core.impl.score.stream.drools.uni.DroolsAbstractUniConstraintStream;
 import org.optaplanner.core.impl.score.stream.drools.uni.DroolsFromUniConstraintStream;
+import org.optaplanner.core.impl.score.stream.drools.uni.DroolsGroupingUniConstraintStream;
 import org.optaplanner.core.impl.score.stream.tri.InnerTriConstraintStream;
 
 public abstract class DroolsAbstractTriConstraintStream<Solution_, A, B, C>
@@ -158,7 +159,11 @@ public abstract class DroolsAbstractTriConstraintStream<Solution_, A, B, C>
 
     @Override
     public <GroupKey_> UniConstraintStream<GroupKey_> groupBy(TriFunction<A, B, C, GroupKey_> groupKeyMapping) {
-        throw new UnsupportedOperationException();
+        throwWhenGroupByNotAllowed();
+        DroolsGroupingUniConstraintStream<Solution_, GroupKey_> stream =
+                new DroolsGroupingUniConstraintStream<>(constraintFactory, this, groupKeyMapping);
+        addChildStream(stream);
+        return stream;
     }
 
     @Override

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/tri/DroolsGroupingTriConstraintStream.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/tri/DroolsGroupingTriConstraintStream.java
@@ -19,7 +19,9 @@ package org.optaplanner.core.impl.score.stream.drools.tri;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 
+import org.optaplanner.core.api.function.TriFunction;
 import org.optaplanner.core.api.score.stream.bi.BiConstraintCollector;
+import org.optaplanner.core.api.score.stream.tri.TriConstraintCollector;
 import org.optaplanner.core.api.score.stream.uni.UniConstraintCollector;
 import org.optaplanner.core.impl.score.stream.drools.DroolsConstraintFactory;
 import org.optaplanner.core.impl.score.stream.drools.bi.DroolsAbstractBiConstraintStream;
@@ -37,9 +39,19 @@ public class DroolsGroupingTriConstraintStream<Solution_, NewA, NewB, NewC>
         this.condition = parent.getCondition().andGroupBiWithCollect(groupKeyAMapping, groupKeyBMapping, collector);
     }
 
-    public <A, B, ResultContainer_> DroolsGroupingTriConstraintStream(DroolsConstraintFactory<Solution_> constraintFactory,
+    public <A, B, ResultContainer_> DroolsGroupingTriConstraintStream(
+            DroolsConstraintFactory<Solution_> constraintFactory,
             DroolsAbstractBiConstraintStream<Solution_, A, B> parent, BiFunction<A, B, NewA> groupKeyAMapping,
             BiFunction<A, B, NewB> groupKeyBMapping, BiConstraintCollector<A, B, ResultContainer_, NewC> collector) {
+        super(constraintFactory, parent);
+        this.condition = parent.getCondition().andGroupBiWithCollect(groupKeyAMapping, groupKeyBMapping, collector);
+    }
+
+    public <A, B, C, ResultContainer_> DroolsGroupingTriConstraintStream(
+            DroolsConstraintFactory<Solution_> constraintFactory,
+            DroolsAbstractTriConstraintStream<Solution_, A, B, C> parent, TriFunction<A, B, C, NewA> groupKeyAMapping,
+            TriFunction<A, B, C, NewB> groupKeyBMapping,
+            TriConstraintCollector<A, B, C, ResultContainer_, NewC> collector) {
         super(constraintFactory, parent);
         this.condition = parent.getCondition().andGroupBiWithCollect(groupKeyAMapping, groupKeyBMapping, collector);
     }

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/tri/DroolsGroupingTriConstraintStream.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/tri/DroolsGroupingTriConstraintStream.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.core.impl.score.stream.drools.tri;
+
+import java.util.function.Function;
+
+import org.optaplanner.core.api.score.stream.uni.UniConstraintCollector;
+import org.optaplanner.core.impl.score.stream.drools.DroolsConstraintFactory;
+import org.optaplanner.core.impl.score.stream.drools.uni.DroolsAbstractUniConstraintStream;
+
+public class DroolsGroupingTriConstraintStream<Solution_, NewA, NewB, NewC>
+        extends DroolsAbstractTriConstraintStream<Solution_, NewA, NewB, NewC> {
+
+    private final DroolsTriCondition<NewA, NewB, NewC> condition;
+
+    public <A, ResultContainer_> DroolsGroupingTriConstraintStream(DroolsConstraintFactory<Solution_> constraintFactory,
+            DroolsAbstractUniConstraintStream<Solution_, A> parent, Function<A, NewA> groupKeyAMapping,
+            Function<A, NewB> groupKeyBMapping, UniConstraintCollector<A, ResultContainer_, NewC> collector) {
+        super(constraintFactory, parent);
+        this.condition = parent.getCondition().andGroupBiWithCollect(groupKeyAMapping, groupKeyBMapping, collector);
+    }
+
+    @Override
+    public DroolsTriCondition<NewA, NewB, NewC> getCondition() {
+        return condition;
+    }
+
+    @Override
+    public boolean isGroupByAllowed() {
+        return false;
+    }
+
+    @Override
+    public String toString() {
+        return "TriGroup() with " + getChildStreams().size() + " children";
+    }
+}

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/tri/DroolsGroupingTriConstraintStream.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/tri/DroolsGroupingTriConstraintStream.java
@@ -16,10 +16,13 @@
 
 package org.optaplanner.core.impl.score.stream.drools.tri;
 
+import java.util.function.BiFunction;
 import java.util.function.Function;
 
+import org.optaplanner.core.api.score.stream.bi.BiConstraintCollector;
 import org.optaplanner.core.api.score.stream.uni.UniConstraintCollector;
 import org.optaplanner.core.impl.score.stream.drools.DroolsConstraintFactory;
+import org.optaplanner.core.impl.score.stream.drools.bi.DroolsAbstractBiConstraintStream;
 import org.optaplanner.core.impl.score.stream.drools.uni.DroolsAbstractUniConstraintStream;
 
 public class DroolsGroupingTriConstraintStream<Solution_, NewA, NewB, NewC>
@@ -30,6 +33,13 @@ public class DroolsGroupingTriConstraintStream<Solution_, NewA, NewB, NewC>
     public <A, ResultContainer_> DroolsGroupingTriConstraintStream(DroolsConstraintFactory<Solution_> constraintFactory,
             DroolsAbstractUniConstraintStream<Solution_, A> parent, Function<A, NewA> groupKeyAMapping,
             Function<A, NewB> groupKeyBMapping, UniConstraintCollector<A, ResultContainer_, NewC> collector) {
+        super(constraintFactory, parent);
+        this.condition = parent.getCondition().andGroupBiWithCollect(groupKeyAMapping, groupKeyBMapping, collector);
+    }
+
+    public <A, B, ResultContainer_> DroolsGroupingTriConstraintStream(DroolsConstraintFactory<Solution_> constraintFactory,
+            DroolsAbstractBiConstraintStream<Solution_, A, B> parent, BiFunction<A, B, NewA> groupKeyAMapping,
+            BiFunction<A, B, NewB> groupKeyBMapping, BiConstraintCollector<A, B, ResultContainer_, NewC> collector) {
         super(constraintFactory, parent);
         this.condition = parent.getCondition().andGroupBiWithCollect(groupKeyAMapping, groupKeyBMapping, collector);
     }

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/tri/DroolsScoringTriConstraintStream.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/tri/DroolsScoringTriConstraintStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -82,7 +82,9 @@ public final class DroolsScoringTriConstraintStream<Solution_, A, B, C>
 
     @Override
     public List<RuleItemBuilder<?>> createRuleItemBuilders(Global<? extends AbstractScoreHolder<?>> scoreHolderGlobal) {
-        DroolsTriCondition<A, B, C> condition = parent.getCondition();
+        DroolsAbstractTriConstraintStream<Solution_, A, B, C> actualParent =
+                (DroolsAbstractTriConstraintStream<Solution_, A, B, C>) parent;
+        DroolsTriCondition<A, B, C> condition = actualParent.getCondition();
         if (intMatchWeigher != null) {
             return condition.completeWithScoring(scoreHolderGlobal, intMatchWeigher);
         } else if (longMatchWeigher != null) {

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/tri/DroolsTriAccumulateFunctionBridge.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/tri/DroolsTriAccumulateFunctionBridge.java
@@ -48,7 +48,7 @@ final class DroolsTriAccumulateFunctionBridge<A, B, C, ResultContainer_, NewA>
 
     @Override
     protected Runnable accumulate(ResultContainer_ container, TriTuple<A, B, C> tuple) {
-        return accumulator.apply(container, tuple._1, tuple._2, tuple._3);
+        return accumulator.apply(container, tuple.a, tuple.b, tuple.c);
     }
 
     @Override

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/tri/DroolsTriAccumulateFunctionBridge.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/tri/DroolsTriAccumulateFunctionBridge.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.optaplanner.core.impl.score.stream.drools.bi;
+package org.optaplanner.core.impl.score.stream.drools.tri;
 
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
@@ -23,25 +23,25 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 
 import org.kie.api.runtime.rule.AccumulateFunction;
-import org.optaplanner.core.api.function.TriFunction;
-import org.optaplanner.core.api.score.stream.bi.BiConstraintCollector;
-import org.optaplanner.core.impl.score.stream.drools.common.BiTuple;
+import org.optaplanner.core.api.function.QuadFunction;
+import org.optaplanner.core.api.score.stream.tri.TriConstraintCollector;
 import org.optaplanner.core.impl.score.stream.drools.common.DroolsAccumulateContext;
+import org.optaplanner.core.impl.score.stream.drools.common.TriTuple;
 
-final class DroolsBiAccumulateFunctionBridge<A, B, ResultContainer_, NewA>
+final class DroolsTriAccumulateFunctionBridge<A, B, C, ResultContainer_, NewA>
         implements AccumulateFunction<DroolsAccumulateContext<ResultContainer_>> {
 
     private final Supplier<ResultContainer_> supplier;
-    private final TriFunction<ResultContainer_, A, B, Runnable> accumulator;
+    private final QuadFunction<ResultContainer_, A, B, C, Runnable> accumulator;
     private final Function<ResultContainer_, NewA> finisher;
 
-    public DroolsBiAccumulateFunctionBridge(BiConstraintCollector<A, B, ResultContainer_, NewA> collector) {
+    public DroolsTriAccumulateFunctionBridge(TriConstraintCollector<A, B, C, ResultContainer_, NewA> collector) {
         this.supplier = collector.supplier();
         this.accumulator = collector.accumulator();
         this.finisher = collector.finisher();
     }
 
-    public DroolsBiAccumulateFunctionBridge() {
+    public DroolsTriAccumulateFunctionBridge() {
         throw new UnsupportedOperationException("Serialization is not supported.");
     }
 
@@ -61,8 +61,8 @@ final class DroolsBiAccumulateFunctionBridge<A, B, ResultContainer_, NewA>
         if (undoMap.containsKey(value)) {
             throw new IllegalStateException("Undo for (" + value +  ") already exists.");
         }
-        BiTuple<A, B> values = (BiTuple<A, B>) value;
-        Runnable undo = accumulator.apply(context.getContainer(), values._1, values._2);
+        TriTuple<A, B, C> values = (TriTuple<A, B, C>) value;
+        Runnable undo = accumulator.apply(context.getContainer(), values._1, values._2, values._3);
         undoMap.put(value, undo);
     }
 

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/tri/DroolsTriCondition.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/tri/DroolsTriCondition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -58,7 +58,8 @@ public final class DroolsTriCondition<A, B, C> extends DroolsCondition<DroolsTri
         DroolsPatternBuilder<Object> newTargetPattern = ruleStructure.getPrimaryPattern()
                 .expand(p -> p.expr("Filter using " + predicate, aVariable, bVariable, cVariable, filter));
         DroolsTriRuleStructure<A, B, C> newRuleStructure = new DroolsTriRuleStructure<>(aVariable, bVariable, cVariable,
-                newTargetPattern, ruleStructure.getOpenRuleItems(), ruleStructure.getVariableIdSupplier());
+                newTargetPattern, ruleStructure.getOpenRuleItems(), ruleStructure.getClosedRuleItems(),
+                ruleStructure.getVariableIdSupplier());
         return new DroolsTriCondition<>(newRuleStructure);
     }
 

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/tri/DroolsTriCondition.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/tri/DroolsTriCondition.java
@@ -34,7 +34,6 @@ import org.drools.model.functions.Block5;
 import org.drools.model.functions.Predicate4;
 import org.drools.model.view.ExprViewItem;
 import org.drools.model.view.ViewItem;
-import org.kie.api.runtime.rule.AccumulateFunction;
 import org.optaplanner.core.api.function.ToIntTriFunction;
 import org.optaplanner.core.api.function.ToLongTriFunction;
 import org.optaplanner.core.api.function.TriFunction;
@@ -45,7 +44,6 @@ import org.optaplanner.core.impl.score.stream.common.JoinerType;
 import org.optaplanner.core.impl.score.stream.drools.bi.DroolsBiCondition;
 import org.optaplanner.core.impl.score.stream.drools.bi.DroolsBiRuleStructure;
 import org.optaplanner.core.impl.score.stream.drools.common.BiTuple;
-import org.optaplanner.core.impl.score.stream.drools.common.DroolsAccumulateContext;
 import org.optaplanner.core.impl.score.stream.drools.common.DroolsCondition;
 import org.optaplanner.core.impl.score.stream.drools.common.DroolsPatternBuilder;
 import org.optaplanner.core.impl.score.stream.drools.common.TriTuple;
@@ -56,7 +54,6 @@ import org.optaplanner.core.impl.score.stream.drools.uni.DroolsUniRuleStructure;
 import org.optaplanner.core.impl.score.stream.quad.AbstractQuadJoiner;
 
 import static org.drools.model.DSL.accFunction;
-import static org.drools.model.DSL.declarationOf;
 import static org.drools.model.DSL.from;
 import static org.drools.model.DSL.on;
 import static org.drools.model.PatternDSL.alphaIndexedBy;
@@ -94,20 +91,11 @@ public final class DroolsTriCondition<A, B, C> extends DroolsCondition<DroolsTri
     }
 
     public <NewA, __> DroolsUniCondition<NewA> andCollect(TriConstraintCollector<A, B, C, __, NewA> collector) {
-        Variable<TriTuple<A, B, C>> tupleVariable = ruleStructure.createVariable("tuple");
-        PatternDSL.PatternDef<Object> mainAccumulatePattern = ruleStructure.getPrimaryPattern()
-                .expand(p -> p.bind(tupleVariable, ruleStructure.getA(), ruleStructure.getB(), (c, a, b) -> {
-                    return new TriTuple<>((A) a, (B) b, (C) c);
-                }))
-                .build();
-        ViewItem<?> innerAccumulatePattern = getInnerAccumulatePattern(mainAccumulatePattern);
-        AccumulateFunction<DroolsAccumulateContext<__>> accumulateFunction =
+        DroolsTriAccumulateFunctionBridge<A, B, C, __, NewA> bridge =
                 new DroolsTriAccumulateFunctionBridge<>(collector);
-        Variable<NewA> outputVariable = (Variable<NewA>) declarationOf(Object.class, "collected");
-        ViewItem<?> outerAccumulatePattern = DSL.accumulate(innerAccumulatePattern,
-                accFunction(() -> accumulateFunction, tupleVariable).as(outputVariable));
-        DroolsUniRuleStructure<NewA> newRuleStructure = ruleStructure.recollect(outputVariable, outerAccumulatePattern);
-        return new DroolsUniCondition<>(newRuleStructure);
+        return super.andCollect(bridge,
+                (pattern, ruleStructure, carrier) -> pattern.bind(carrier, ruleStructure.getA(), ruleStructure.getB(),
+                        (c, a, b) -> new TriTuple<>((A) a, (B) b, (C) c)));
     }
 
     public <NewA> DroolsUniCondition<NewA> andGroup(TriFunction<A, B, C, NewA> groupKeyMapping) {

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/tri/DroolsTriCondition.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/tri/DroolsTriCondition.java
@@ -104,23 +104,8 @@ public final class DroolsTriCondition<A, B, C> extends DroolsCondition<DroolsTri
 
     public <NewA, NewB, __> DroolsBiCondition<NewA, NewB> andGroupWithCollect(TriFunction<A, B, C, NewA> groupKeyMapping,
             TriConstraintCollector<A, B, C, __, NewB> collector) {
-        Variable<Set<BiTuple<NewA, NewB>>> setOfPairsVar =
-                (Variable<Set<BiTuple<NewA, NewB>>>) ruleStructure.createVariable(Set.class, "setOfPairs");
-        PatternDSL.PatternDef<Set<BiTuple<NewA, NewB>>> pattern = pattern(setOfPairsVar)
-                .expr("Set of resulting pairs", set -> !set.isEmpty(),
-                        alphaIndexedBy(Integer.class, Index.ConstraintType.GREATER_THAN, -1, Set::size, 0));
-        // Prepare the list of pairs.
-        PatternDSL.PatternDef<Object> innerNewACollectingPattern = ruleStructure.getPrimaryPattern().build();
-        ViewItem<?> innerAccumulatePattern = getInnerAccumulatePattern(innerNewACollectingPattern);
-        ViewItem<?> accumulate = DSL.accumulate(innerAccumulatePattern,
-                accFunction(() -> new DroolsTriToBiGroupByInvoker<>(groupKeyMapping, collector, getRuleStructure().getA(),
-                        getRuleStructure().getB(), getRuleStructure().getC()))
-                        .as(setOfPairsVar));
-        // Load one pair from the list.
-        Variable<BiTuple<NewA, NewB>> onePairVar =
-                (Variable<BiTuple<NewA, NewB>>) ruleStructure.createVariable(BiTuple.class, "pair", from(setOfPairsVar));
-        DroolsBiRuleStructure<NewA, NewB> newRuleStructure = ruleStructure.regroupBi(onePairVar, pattern, accumulate);
-        return new DroolsBiCondition<>(newRuleStructure);
+        return groupWithCollect(() -> new DroolsTriToBiGroupByInvoker<>(groupKeyMapping, collector, getRuleStructure().getA(),
+                        getRuleStructure().getB(), getRuleStructure().getC()));
     }
 
     public <NewA, NewB> DroolsBiCondition<NewA, NewB> andGroupBi(TriFunction<A, B, C, NewA> groupKeyAMapping,

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/tri/DroolsTriCondition.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/tri/DroolsTriCondition.java
@@ -93,27 +93,13 @@ public final class DroolsTriCondition<A, B, C> extends DroolsCondition<DroolsTri
     public <NewA, __> DroolsUniCondition<NewA> andCollect(TriConstraintCollector<A, B, C, __, NewA> collector) {
         DroolsTriAccumulateFunctionBridge<A, B, C, __, NewA> bridge =
                 new DroolsTriAccumulateFunctionBridge<>(collector);
-        return super.andCollect(bridge,
-                (pattern, ruleStructure, carrier) -> pattern.bind(carrier, ruleStructure.getA(), ruleStructure.getB(),
-                        (c, a, b) -> new TriTuple<>((A) a, (B) b, (C) c)));
+        return collect(bridge, (pattern, carrier) -> pattern.bind(carrier, ruleStructure.getA(),
+                ruleStructure.getB(), (c, a, b) -> new TriTuple<>((A) a, (B) b, (C) c)));
     }
 
     public <NewA> DroolsUniCondition<NewA> andGroup(TriFunction<A, B, C, NewA> groupKeyMapping) {
-        Variable<NewA> mappedVariable = ruleStructure.createVariable("biMapped");
-        PatternDSL.PatternDef<Object> mainAccumulatePattern = ruleStructure.getPrimaryPattern()
-                .expand(p -> p.bind(mappedVariable, ruleStructure.getA(), ruleStructure.getB(),
-                        (c, a, b) -> groupKeyMapping.apply(a, b, (C) c)))
-                .build();
-        ViewItem<?> innerAccumulatePattern = getInnerAccumulatePattern(mainAccumulatePattern);
-        Variable<Set<NewA>> setOfMappings =
-                (Variable<Set<NewA>>) ruleStructure.createVariable(Set.class, "setOfGroupKey");
-        PatternDSL.PatternDef<Set<NewA>> pattern = pattern(setOfMappings)
-                .expr("Set of " + mappedVariable.getName(), set -> !set.isEmpty(),
-                        alphaIndexedBy(Integer.class, Index.ConstraintType.GREATER_THAN, -1, Set::size, 0));
-        ExprViewItem<Object> accumulate = DSL.accumulate(innerAccumulatePattern,
-                accFunction(CollectSetAccumulateFunction.class, mappedVariable).as(setOfMappings));
-        DroolsUniRuleStructure<NewA> newRuleStructure = ruleStructure.regroup(setOfMappings, pattern, accumulate);
-        return new DroolsUniCondition<>(newRuleStructure);
+        return super.group((pattern, carrier) -> pattern.bind(carrier, ruleStructure.getA(), ruleStructure.getB(),
+                (c, a, b) -> groupKeyMapping.apply(a, b, (C) c)));
     }
 
     public <NewA, NewB, __> DroolsBiCondition<NewA, NewB> andGroupWithCollect(TriFunction<A, B, C, NewA> groupKeyMapping,

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/tri/DroolsTriCondition.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/tri/DroolsTriCondition.java
@@ -18,31 +18,41 @@ package org.optaplanner.core.impl.score.stream.drools.tri;
 
 import java.math.BigDecimal;
 import java.util.List;
+import java.util.Set;
 import java.util.function.UnaryOperator;
 
+import org.drools.model.DSL;
 import org.drools.model.Drools;
 import org.drools.model.Global;
+import org.drools.model.Index;
 import org.drools.model.PatternDSL;
 import org.drools.model.RuleItemBuilder;
 import org.drools.model.Variable;
 import org.drools.model.consequences.ConsequenceBuilder;
 import org.drools.model.functions.Block5;
 import org.drools.model.functions.Predicate4;
+import org.drools.model.view.ViewItem;
 import org.optaplanner.core.api.function.ToIntTriFunction;
 import org.optaplanner.core.api.function.ToLongTriFunction;
 import org.optaplanner.core.api.function.TriFunction;
 import org.optaplanner.core.api.function.TriPredicate;
 import org.optaplanner.core.api.score.holder.AbstractScoreHolder;
+import org.optaplanner.core.api.score.stream.tri.TriConstraintCollector;
 import org.optaplanner.core.impl.score.stream.common.JoinerType;
 import org.optaplanner.core.impl.score.stream.drools.common.DroolsCondition;
 import org.optaplanner.core.impl.score.stream.drools.common.DroolsPatternBuilder;
+import org.optaplanner.core.impl.score.stream.drools.common.TriTuple;
 import org.optaplanner.core.impl.score.stream.drools.quad.DroolsQuadCondition;
 import org.optaplanner.core.impl.score.stream.drools.quad.DroolsQuadRuleStructure;
 import org.optaplanner.core.impl.score.stream.drools.uni.DroolsUniCondition;
 import org.optaplanner.core.impl.score.stream.drools.uni.DroolsUniRuleStructure;
 import org.optaplanner.core.impl.score.stream.quad.AbstractQuadJoiner;
 
+import static org.drools.model.DSL.accFunction;
+import static org.drools.model.DSL.from;
 import static org.drools.model.DSL.on;
+import static org.drools.model.PatternDSL.alphaIndexedBy;
+import static org.drools.model.PatternDSL.pattern;
 
 public final class DroolsTriCondition<A, B, C> extends DroolsCondition<DroolsTriRuleStructure<A, B, C>> {
 
@@ -74,6 +84,31 @@ public final class DroolsTriCondition<A, B, C> extends DroolsCondition<DroolsTri
         return new DroolsQuadCondition<>(new DroolsQuadRuleStructure<>(ruleStructure, newDRuleStructure,
                 ruleStructure.getVariableIdSupplier()));
     }
+
+    public <ResultContainer, NewA, NewB, NewC> DroolsTriCondition<NewA, NewB, NewC> andGroupBiWithCollect(
+            TriFunction<A, B, C, NewA> groupKeyAMapping, TriFunction<A, B, C, NewB> groupKeyBMapping,
+            TriConstraintCollector<A, B, C, ResultContainer, NewC> collector) {
+        Variable<Set<TriTuple<NewA, NewB, NewC>>> setOfPairsVar =
+                (Variable<Set<TriTuple<NewA, NewB, NewC>>>) ruleStructure.createVariable(Set.class, "setOfTuples");
+        PatternDSL.PatternDef<Set<TriTuple<NewA, NewB, NewC>>> pattern = pattern(setOfPairsVar)
+                .expr("Set of resulting tuples", set -> !set.isEmpty(),
+                        alphaIndexedBy(Integer.class, Index.ConstraintType.GREATER_THAN, -1, Set::size, 0));
+        // Prepare the list of pairs.
+        PatternDSL.PatternDef<Object> innerCollectingPattern = ruleStructure.getPrimaryPattern().build();
+        ViewItem<?> innerAccumulatePattern = getInnerAccumulatePattern(innerCollectingPattern);
+        ViewItem<?> accumulate = DSL.accumulate(innerAccumulatePattern,
+                accFunction(() -> new DroolsTriGroupByInvoker<>(groupKeyAMapping, groupKeyBMapping, collector,
+                        getRuleStructure().getA(), getRuleStructure().getB(), getRuleStructure().getC()))
+                        .as(setOfPairsVar));
+        // Load one pair from the list.
+        Variable<TriTuple<NewA, NewB, NewC>> oneTupleVar =
+                (Variable<TriTuple<NewA, NewB, NewC>>) ruleStructure.createVariable(TriTuple.class, "tuple",
+                        from(setOfPairsVar));
+        DroolsTriRuleStructure<NewA, NewB, NewC> newRuleStructure = ruleStructure.regroupBiToTri(oneTupleVar, pattern,
+                accumulate);
+        return new DroolsTriCondition<>(newRuleStructure);
+    }
+
 
     public List<RuleItemBuilder<?>> completeWithScoring(Global<? extends AbstractScoreHolder<?>> scoreHolderGlobal) {
         return completeWithScoring(scoreHolderGlobal,

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/tri/DroolsTriCondition.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/tri/DroolsTriCondition.java
@@ -21,7 +21,6 @@ import java.util.List;
 import java.util.Set;
 import java.util.function.UnaryOperator;
 
-import org.drools.core.base.accumulators.CollectSetAccumulateFunction;
 import org.drools.model.DSL;
 import org.drools.model.Drools;
 import org.drools.model.Global;
@@ -32,7 +31,6 @@ import org.drools.model.Variable;
 import org.drools.model.consequences.ConsequenceBuilder;
 import org.drools.model.functions.Block5;
 import org.drools.model.functions.Predicate4;
-import org.drools.model.view.ExprViewItem;
 import org.drools.model.view.ViewItem;
 import org.optaplanner.core.api.function.ToIntTriFunction;
 import org.optaplanner.core.api.function.ToLongTriFunction;
@@ -42,7 +40,6 @@ import org.optaplanner.core.api.score.holder.AbstractScoreHolder;
 import org.optaplanner.core.api.score.stream.tri.TriConstraintCollector;
 import org.optaplanner.core.impl.score.stream.common.JoinerType;
 import org.optaplanner.core.impl.score.stream.drools.bi.DroolsBiCondition;
-import org.optaplanner.core.impl.score.stream.drools.bi.DroolsBiRuleStructure;
 import org.optaplanner.core.impl.score.stream.drools.common.BiTuple;
 import org.optaplanner.core.impl.score.stream.drools.common.DroolsCondition;
 import org.optaplanner.core.impl.score.stream.drools.common.DroolsPatternBuilder;
@@ -110,27 +107,12 @@ public final class DroolsTriCondition<A, B, C> extends DroolsCondition<DroolsTri
 
     public <NewA, NewB> DroolsBiCondition<NewA, NewB> andGroupBi(TriFunction<A, B, C, NewA> groupKeyAMapping,
             TriFunction<A, B, C, NewB> groupKeyBMapping) {
-        Variable<BiTuple<NewA, NewB>> mappedVariable = ruleStructure.createVariable("biMapped");
-        PatternDSL.PatternDef<Object> mainAccumulatePattern = ruleStructure.getPrimaryPattern()
-                .expand(p -> p.bind(mappedVariable, ruleStructure.getA(), ruleStructure.getB(),
-                        (c, a, b) -> {
-                            final NewA newA = groupKeyAMapping.apply(a, b, (C) c);
-                            final NewB newB = groupKeyBMapping.apply(a, b, (C) c);
-                            return new BiTuple<>(newA, newB);
-                        }))
-                .build();
-        ViewItem<?> innerAccumulatePattern = getInnerAccumulatePattern(mainAccumulatePattern);
-        Variable<Set<BiTuple<NewA, NewB>>> setOfPairs =
-                (Variable<Set<BiTuple<NewA, NewB>>>) ruleStructure.createVariable(Set.class, "setOfPairs");
-        PatternDSL.PatternDef<Set<BiTuple<NewA, NewB>>> pattern = pattern(setOfPairs)
-                .expr("Set of " + mappedVariable.getName(), set -> !set.isEmpty(),
-                        alphaIndexedBy(Integer.class, Index.ConstraintType.GREATER_THAN, -1, Set::size, 0));
-        ExprViewItem<Object> accumulate = DSL.accumulate(innerAccumulatePattern,
-                accFunction(CollectSetAccumulateFunction.class, mappedVariable).as(setOfPairs));
-        Variable<BiTuple<NewA, NewB>> onePairVar =
-                (Variable<BiTuple<NewA, NewB>>) ruleStructure.createVariable(BiTuple.class, "pair", from(setOfPairs));
-        DroolsBiRuleStructure<NewA, NewB> newRuleStructure = ruleStructure.regroupBi(onePairVar, pattern, accumulate);
-        return new DroolsBiCondition<>(newRuleStructure);
+        return groupBi((pattern, tuple) -> pattern.bind(tuple, ruleStructure.getA(), ruleStructure.getB(),
+                (c, a, b) -> {
+                    final NewA newA = groupKeyAMapping.apply(a, b, (C) c);
+                    final NewB newB = groupKeyBMapping.apply(a, b, (C) c);
+                    return new BiTuple<>(newA, newB);
+                }));
     }
 
     public <ResultContainer, NewA, NewB, NewC> DroolsTriCondition<NewA, NewB, NewC> andGroupBiWithCollect(

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/tri/DroolsTriCondition.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/tri/DroolsTriCondition.java
@@ -90,6 +90,27 @@ public final class DroolsTriCondition<A, B, C> extends DroolsCondition<DroolsTri
                 ruleStructure.getVariableIdSupplier()));
     }
 
+    public <NewA, NewB, __> DroolsBiCondition<NewA, NewB> andGroupWithCollect(TriFunction<A, B, C, NewA> groupKeyMapping,
+            TriConstraintCollector<A, B, C, __, NewB> collector) {
+        Variable<Set<BiTuple<NewA, NewB>>> setOfPairsVar =
+                (Variable<Set<BiTuple<NewA, NewB>>>) ruleStructure.createVariable(Set.class, "setOfPairs");
+        PatternDSL.PatternDef<Set<BiTuple<NewA, NewB>>> pattern = pattern(setOfPairsVar)
+                .expr("Set of resulting pairs", set -> !set.isEmpty(),
+                        alphaIndexedBy(Integer.class, Index.ConstraintType.GREATER_THAN, -1, Set::size, 0));
+        // Prepare the list of pairs.
+        PatternDSL.PatternDef<Object> innerNewACollectingPattern = ruleStructure.getPrimaryPattern().build();
+        ViewItem<?> innerAccumulatePattern = getInnerAccumulatePattern(innerNewACollectingPattern);
+        ViewItem<?> accumulate = DSL.accumulate(innerAccumulatePattern,
+                accFunction(() -> new DroolsTriToBiGroupByInvoker<>(groupKeyMapping, collector, getRuleStructure().getA(),
+                        getRuleStructure().getB(), getRuleStructure().getC()))
+                        .as(setOfPairsVar));
+        // Load one pair from the list.
+        Variable<BiTuple<NewA, NewB>> onePairVar =
+                (Variable<BiTuple<NewA, NewB>>) ruleStructure.createVariable(BiTuple.class, "pair", from(setOfPairsVar));
+        DroolsBiRuleStructure<NewA, NewB> newRuleStructure = ruleStructure.regroupBi(onePairVar, pattern, accumulate);
+        return new DroolsBiCondition<>(newRuleStructure);
+    }
+
     public <NewA, NewB> DroolsBiCondition<NewA, NewB> andGroupBi(TriFunction<A, B, C, NewA> groupKeyAMapping,
             TriFunction<A, B, C, NewB> groupKeyBMapping) {
         Variable<BiTuple<NewA, NewB>> mappedVariable = ruleStructure.createVariable("biMapped");

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/tri/DroolsTriCondition.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/tri/DroolsTriCondition.java
@@ -82,12 +82,12 @@ public final class DroolsTriCondition<A, B, C> extends DroolsCondition<DroolsTri
     public <NewA, __> DroolsUniCondition<NewA> andCollect(TriConstraintCollector<A, B, C, __, NewA> collector) {
         DroolsTriAccumulateFunctionBridge<A, B, C, __, NewA> bridge =
                 new DroolsTriAccumulateFunctionBridge<>(collector);
-        return collect(bridge, (pattern, carrier) -> pattern.bind(carrier, ruleStructure.getA(),
+        return collect(bridge, (pattern, tuple) -> pattern.bind(tuple, ruleStructure.getA(),
                 ruleStructure.getB(), (c, a, b) -> new TriTuple<>((A) a, (B) b, (C) c)));
     }
 
     public <NewA> DroolsUniCondition<NewA> andGroup(TriFunction<A, B, C, NewA> groupKeyMapping) {
-        return super.group((pattern, carrier) -> pattern.bind(carrier, ruleStructure.getA(), ruleStructure.getB(),
+        return super.group((pattern, tuple) -> pattern.bind(tuple, ruleStructure.getA(), ruleStructure.getB(),
                 (c, a, b) -> groupKeyMapping.apply(a, b, (C) c)));
     }
 
@@ -107,9 +107,9 @@ public final class DroolsTriCondition<A, B, C> extends DroolsCondition<DroolsTri
                 }));
     }
 
-    public <ResultContainer, NewA, NewB, NewC> DroolsTriCondition<NewA, NewB, NewC> andGroupBiWithCollect(
+    public <NewA, NewB, NewC, __> DroolsTriCondition<NewA, NewB, NewC> andGroupBiWithCollect(
             TriFunction<A, B, C, NewA> groupKeyAMapping, TriFunction<A, B, C, NewB> groupKeyBMapping,
-            TriConstraintCollector<A, B, C, ResultContainer, NewC> collector) {
+            TriConstraintCollector<A, B, C, __, NewC> collector) {
         return groupBiWithCollect(() -> new DroolsTriGroupByInvoker<>(groupKeyAMapping, groupKeyBMapping, collector,
                 getRuleStructure().getA(), getRuleStructure().getB(), getRuleStructure().getC()));
     }

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/tri/DroolsTriGroupBy.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/tri/DroolsTriGroupBy.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.core.impl.score.stream.drools.tri;
+
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import org.drools.core.common.InternalFactHandle;
+import org.optaplanner.core.api.function.TriFunction;
+import org.optaplanner.core.api.score.stream.tri.TriConstraintCollector;
+import org.optaplanner.core.impl.score.stream.drools.common.TriTuple;
+
+final class DroolsTriGroupBy<A, B, C, ResultContainer, NewA, NewB, NewC> implements Serializable {
+
+    private static final long serialVersionUID = 510l;
+    private final Map<Long, Runnable> undoMap = new HashMap<>(0);
+    private final TriFunction<A, B, C, NewA> groupKeyAMapping;
+    private final TriFunction<A, B, C, NewB> groupKeyBMapping;
+    private final TriConstraintCollector<A, B, C, ResultContainer, NewC> collector;
+    private DroolsTriGroupByAccumulator<A, B, C, ResultContainer, NewA, NewB, NewC> acc;
+
+    public DroolsTriGroupBy(TriFunction<A, B, C, NewA> groupKeyAMapping, TriFunction<A, B, C, NewB> groupKeyBMapping,
+            TriConstraintCollector<A, B, C, ResultContainer, NewC> collector) {
+        this.groupKeyAMapping = groupKeyAMapping;
+        this.groupKeyBMapping = groupKeyBMapping;
+        this.collector = collector;
+    }
+
+    public void init() {
+        acc = new DroolsTriGroupByAccumulator<>(groupKeyAMapping, groupKeyBMapping, collector);
+        undoMap.clear();
+    }
+
+    public void accumulate(InternalFactHandle handle, A a, B b, C c) {
+        Runnable undo = acc.accumulate(a, b, c);
+        Runnable oldUndo = this.undoMap.put(handle.getId(), undo);
+        if (oldUndo != null) {
+            throw new IllegalStateException("Undo for fact handle (" + handle.getId() + ") already exists.");
+        }
+    }
+
+    public void reverse(InternalFactHandle handle) {
+        final Runnable undo = this.undoMap.remove(handle.getId());
+        if (undo == null) {
+            throw new IllegalStateException("No undo for fact handle (" + handle.getId() + ")");
+        }
+        undo.run();
+    }
+
+    public Set<TriTuple<NewA, NewB, NewC>> getResult() {
+        return acc.finish();
+    }
+
+}

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/tri/DroolsTriGroupBy.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/tri/DroolsTriGroupBy.java
@@ -48,7 +48,7 @@ final class DroolsTriGroupBy<A, B, C, ResultContainer, NewA, NewB, NewC> impleme
     }
 
     public void accumulate(InternalFactHandle handle, A a, B b, C c) {
-        Runnable undo = acc.accumulate(a, b, c);
+        Runnable undo = acc.accumulate(new TriTuple<>(a, b, c));
         Runnable oldUndo = this.undoMap.put(handle.getId(), undo);
         if (oldUndo != null) {
             throw new IllegalStateException("Undo for fact handle (" + handle.getId() + ") already exists.");

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/tri/DroolsTriGroupByAccumulator.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/tri/DroolsTriGroupByAccumulator.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.core.impl.score.stream.drools.tri;
+
+import java.io.Serializable;
+import java.util.IdentityHashMap;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+import org.optaplanner.core.api.function.QuadFunction;
+import org.optaplanner.core.api.function.TriFunction;
+import org.optaplanner.core.api.score.stream.tri.TriConstraintCollector;
+import org.optaplanner.core.impl.score.stream.drools.common.BiTuple;
+import org.optaplanner.core.impl.score.stream.drools.common.TriTuple;
+
+final class DroolsTriGroupByAccumulator<A, B, C, ResultContainer, NewA, NewB, NewC> implements Serializable {
+
+    // Containers may be identical in type and contents, yet they should still not count as the same container.
+    private final Map<ResultContainer, Long> containersInUseMap = new IdentityHashMap<>(0);
+    // LinkedHashMap to maintain a consistent iteration order of resulting pairs.
+    private final Map<BiTuple<NewA, NewB>, ResultContainer> containersMap = new LinkedHashMap<>(0);
+    private final TriFunction<A, B, C, NewA> groupKeyAMapping;
+    private final TriFunction<A, B, C, NewB> groupKeyBMapping;
+    private final Supplier<ResultContainer> supplier;
+    private final QuadFunction<ResultContainer, A, B, C, Runnable> accumulator;
+    private final Function<ResultContainer, NewC> finisher;
+    // Transient as Spotbugs complains otherwise ("non-transient non-serializable instance field").
+    // It doesn't make sense to serialize this anyway, as it is recreated every time.
+    private final transient Set<TriTuple<NewA, NewB, NewC>> resultSet = new LinkedHashSet<>(0);
+
+    public DroolsTriGroupByAccumulator(TriFunction<A, B, C, NewA> groupKeyAMapping,
+            TriFunction<A, B, C, NewB> groupKeyBMapping,
+            TriConstraintCollector<A, B, C, ResultContainer, NewC> collector) {
+        this.groupKeyAMapping = groupKeyAMapping;
+        this.groupKeyBMapping = groupKeyBMapping;
+        this.supplier = collector.supplier();
+        this.accumulator = collector.accumulator();
+        this.finisher = collector.finisher();
+    }
+
+    private static Long increment(Long count) {
+        return count == null ? 1L : count + 1L;
+    }
+
+    private static Long decrement(Long count) {
+        return count == 1L ? null : count - 1L;
+    }
+
+    public Runnable accumulate(A a, B b, C c) {
+        BiTuple<NewA, NewB> key = new BiTuple<>(groupKeyAMapping.apply(a, b, c), groupKeyBMapping.apply(a, b, c));
+        ResultContainer container = containersMap.computeIfAbsent(key, __ -> supplier.get());
+        Runnable undo = accumulator.apply(container, a, b, c);
+        containersInUseMap.compute(container, (__, count) -> increment(count)); // Increment use counter.
+        return () -> {
+            undo.run();
+            // Decrement use counter. If 0, container is ignored during finishing. Removes empty groups from results.
+            Long currentCount = containersInUseMap.compute(container, (__, count) -> decrement(count));
+            if (currentCount == null) {
+                containersMap.remove(key);
+            }
+        };
+    }
+
+    public Set<TriTuple<NewA, NewB, NewC>> finish() {
+        resultSet.clear();
+        for (Map.Entry<BiTuple<NewA, NewB>, ResultContainer> entry : containersMap.entrySet()) {
+            BiTuple<NewA, NewB> key = entry.getKey();
+            ResultContainer container = entry.getValue();
+            TriTuple<NewA, NewB, NewC> result = new TriTuple<>(key._1, key._2, finisher.apply(container));
+            resultSet.add(result);
+        }
+        return resultSet;
+    }
+}

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/tri/DroolsTriGroupByAccumulator.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/tri/DroolsTriGroupByAccumulator.java
@@ -47,8 +47,8 @@ final class DroolsTriGroupByAccumulator<A, B, C, ResultContainer, NewA, NewB, Ne
 
     @Override
     protected BiTuple<NewA, NewB> toKey(TriTuple<A, B, C> abcTriTuple) {
-        return new BiTuple<>(groupKeyAMapping.apply(abcTriTuple._1, abcTriTuple._2, abcTriTuple._3),
-                groupKeyBMapping.apply(abcTriTuple._1, abcTriTuple._2, abcTriTuple._3));
+        return new BiTuple<>(groupKeyAMapping.apply(abcTriTuple.a, abcTriTuple.b, abcTriTuple.c),
+                groupKeyBMapping.apply(abcTriTuple.a, abcTriTuple.b, abcTriTuple.c));
     }
 
     @Override
@@ -58,12 +58,12 @@ final class DroolsTriGroupByAccumulator<A, B, C, ResultContainer, NewA, NewB, Ne
 
     @Override
     protected Runnable process(TriTuple<A, B, C> abcTriTuple, ResultContainer container) {
-        return accumulator.apply(container, abcTriTuple._1, abcTriTuple._2, abcTriTuple._3);
+        return accumulator.apply(container, abcTriTuple.a, abcTriTuple.b, abcTriTuple.c);
     }
 
     @Override
     protected TriTuple<NewA, NewB, NewC> toResult(BiTuple<NewA, NewB> key, ResultContainer container) {
-        return new TriTuple<>(key._1, key._2, finisher.apply(container));
+        return new TriTuple<>(key.a, key.b, finisher.apply(container));
     }
 
 }

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/tri/DroolsTriGroupByInvoker.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/tri/DroolsTriGroupByInvoker.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.core.impl.score.stream.drools.tri;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.Serializable;
+import java.util.function.BiFunction;
+
+import org.drools.core.WorkingMemory;
+import org.drools.core.common.InternalFactHandle;
+import org.drools.core.common.InternalWorkingMemory;
+import org.drools.core.reteoo.SubnetworkTuple;
+import org.drools.core.rule.Declaration;
+import org.drools.core.spi.Accumulator;
+import org.drools.core.spi.CompiledInvoker;
+import org.drools.core.spi.Tuple;
+import org.drools.model.Variable;
+import org.optaplanner.core.api.function.TriFunction;
+import org.optaplanner.core.api.score.stream.bi.BiConstraintCollector;
+import org.optaplanner.core.api.score.stream.tri.TriConstraintCollector;
+
+public class DroolsTriGroupByInvoker<A, B, C, ResultContainer, NewA, NewB, NewC> implements Accumulator,
+        CompiledInvoker {
+
+    private final TriConstraintCollector<A, B, C, ResultContainer, NewC> collector;
+    private final TriFunction<A, B, C, NewA> groupKeyAMapping;
+    private final TriFunction<A, B, C, NewB> groupKeyBMapping;
+    private final Variable<A> aVariable;
+    private final Variable<B> bVariable;
+    private final Variable<C> cVariable;
+
+    public DroolsTriGroupByInvoker(TriFunction<A, B, C, NewA> groupKeyAMapping,
+            TriFunction<A, B, C, NewB> groupKeyBMapping,
+            TriConstraintCollector<A, B, C, ResultContainer, NewC> collector, Variable<A> aVariable,
+            Variable<B> bVariable, Variable<C> cVariable) {
+        this.collector = collector;
+        this.groupKeyAMapping = groupKeyAMapping;
+        this.groupKeyBMapping = groupKeyBMapping;
+        this.aVariable = aVariable;
+        this.bVariable = bVariable;
+        this.cVariable = cVariable;
+    }
+
+    @Override
+    public Serializable createContext() {
+        return new DroolsTriGroupBy<>(groupKeyAMapping, groupKeyBMapping, collector);
+    }
+
+    @Override
+    public void init(Object workingMemoryContext, Object context, Tuple tuple, Declaration[] declarations,
+            WorkingMemory workingMemory) {
+        castContext(context).init();
+    }
+
+    @Override
+    public void accumulate(Object workingMemoryContext, Object context, Tuple tuple, InternalFactHandle handle,
+            Declaration[] declarations, Declaration[] innerDeclarations, final WorkingMemory workingMemory) {
+        InternalWorkingMemory internalWorkingMemory = (InternalWorkingMemory) workingMemory;
+        Object handleObject = handle.getObject();
+        final A groupKeyA = getValue(aVariable, internalWorkingMemory, handleObject, innerDeclarations);
+        final B groupKeyB = getValue(bVariable, internalWorkingMemory, handleObject, innerDeclarations);
+        final C groupKeyC = getValue(cVariable, internalWorkingMemory, handleObject, innerDeclarations);
+        castContext(context).accumulate(handle, groupKeyA, groupKeyB, groupKeyC);
+    }
+
+    private static <X> X getValue(Variable<X> var, InternalWorkingMemory internalWorkingMemory, Object handleObject,
+            Declaration... innerDeclarations) {
+        Declaration declaration = getDeclarationForVariable(var, innerDeclarations);
+        Object actualHandleObject = handleObject instanceof SubnetworkTuple ?
+                ((SubnetworkTuple)handleObject).getObject(declaration) :
+                handleObject;
+        return (X) declaration.getValue(internalWorkingMemory, actualHandleObject);
+    }
+
+    private DroolsTriGroupBy<A, B, C, ResultContainer, NewA, NewB, NewC> castContext(Object context) {
+        return (DroolsTriGroupBy<A, B, C, ResultContainer, NewA, NewB, NewC>) context;
+    }
+
+    /**
+     * Declarations in Drools appear to show up in random order. Therefore, we need to match the proper declaration
+     * not by directly addressing within the array, but by looking it up based on the associated variable.
+     * @param variable
+     * @param declarations
+     * @return
+     */
+    private static Declaration getDeclarationForVariable(Variable<?> variable, Declaration... declarations) {
+        for (Declaration declaration: declarations) {
+            if (declaration.getIdentifier().equals(variable.getName())) {
+                return declaration;
+            }
+        }
+        throw new IllegalStateException("Could not find declaration for variable (" + variable + ").");
+    }
+
+    @Override
+    public void reverse(Object workingMemoryContext, Object context, Tuple tuple, InternalFactHandle handle,
+            Declaration[] declarations, Declaration[] innerDeclarations, WorkingMemory workingMemory) {
+        castContext(context).reverse(handle);
+    }
+
+    @Override
+    public Object getResult(Object workingMemoryContext, Object context, Tuple tuple, Declaration[] declarations,
+            WorkingMemory workingMemory) {
+        return castContext(context).getResult();
+    }
+
+    @Override
+    public boolean supportsReverse() {
+        return true;
+    }
+
+    @Override
+    public Object createWorkingMemoryContext() {
+        return null;
+    }
+
+    @Override
+    public String getMethodBytecode() {
+        Class<?> accumulateClass = DroolsTriGroupBy.class;
+        String classFileName = accumulateClass.getCanonicalName().replace('.', '/') + ".class";
+        try (InputStream is = getClass().getClassLoader().getResourceAsStream(classFileName)) {
+            final byte[] data = new byte[1024];
+            int byteCount;
+            ByteArrayOutputStream bos = new ByteArrayOutputStream();
+            while ((byteCount = is.read(data, 0, 1024)) > -1) {
+                bos.write(data, 0, byteCount);
+            }
+            return bos.toString();
+        } catch (final IOException e) {
+            throw new RuntimeException("Unable to getResourceAsStream for " + accumulateClass);
+        }
+    }
+
+}

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/tri/DroolsTriGroupByInvoker.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/tri/DroolsTriGroupByInvoker.java
@@ -20,7 +20,6 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.Serializable;
-import java.util.function.BiFunction;
 
 import org.drools.core.WorkingMemory;
 import org.drools.core.common.InternalFactHandle;
@@ -32,8 +31,8 @@ import org.drools.core.spi.CompiledInvoker;
 import org.drools.core.spi.Tuple;
 import org.drools.model.Variable;
 import org.optaplanner.core.api.function.TriFunction;
-import org.optaplanner.core.api.score.stream.bi.BiConstraintCollector;
 import org.optaplanner.core.api.score.stream.tri.TriConstraintCollector;
+import org.optaplanner.core.impl.score.stream.drools.common.TriTuple;
 
 public class DroolsTriGroupByInvoker<A, B, C, ResultContainer, NewA, NewB, NewC> implements Accumulator,
         CompiledInvoker {
@@ -76,7 +75,7 @@ public class DroolsTriGroupByInvoker<A, B, C, ResultContainer, NewA, NewB, NewC>
         final A groupKeyA = getValue(aVariable, internalWorkingMemory, handleObject, innerDeclarations);
         final B groupKeyB = getValue(bVariable, internalWorkingMemory, handleObject, innerDeclarations);
         final C groupKeyC = getValue(cVariable, internalWorkingMemory, handleObject, innerDeclarations);
-        castContext(context).accumulate(handle, groupKeyA, groupKeyB, groupKeyC);
+        castContext(context).accumulate(handle, new TriTuple<>(groupKeyA, groupKeyB, groupKeyC));
     }
 
     private static <X> X getValue(Variable<X> var, InternalWorkingMemory internalWorkingMemory, Object handleObject,

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/tri/DroolsTriRuleStructure.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/tri/DroolsTriRuleStructure.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -64,14 +64,14 @@ public class DroolsTriRuleStructure<A, B, C> extends DroolsRuleStructure {
 
     public DroolsTriRuleStructure(Variable<A> aVariable, Variable<B> bVariable, Variable<C> cVariable,
             DroolsPatternBuilder<?> primaryPattern, List<RuleItemBuilder<?>> openRuleItems,
-            LongSupplier variableIdSupplier) {
+            List<RuleItemBuilder<?>> closedRuleItems, LongSupplier variableIdSupplier) {
         super(variableIdSupplier);
         this.a = aVariable;
         this.b = bVariable;
         this.c = cVariable;
         this.primaryPattern = primaryPattern;
         this.openRuleItems = Collections.unmodifiableList(openRuleItems);
-        this.closedRuleItems = Collections.emptyList();
+        this.closedRuleItems = Collections.unmodifiableList(closedRuleItems);
     }
 
     public Variable<A> getA() {

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/tri/DroolsTriToBiGroupBy.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/tri/DroolsTriToBiGroupBy.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.core.impl.score.stream.drools.tri;
+
+import org.optaplanner.core.api.function.TriFunction;
+import org.optaplanner.core.api.score.stream.tri.TriConstraintCollector;
+import org.optaplanner.core.impl.score.stream.drools.common.BiTuple;
+import org.optaplanner.core.impl.score.stream.drools.common.DroolsAbstractGroupBy;
+import org.optaplanner.core.impl.score.stream.drools.common.DroolsAbstractGroupByAccumulator;
+import org.optaplanner.core.impl.score.stream.drools.common.TriTuple;
+
+final class DroolsTriToBiGroupBy<A, B, C, ResultContainer, NewA, NewB>
+    extends DroolsAbstractGroupBy<ResultContainer, TriTuple<A, B, C>, BiTuple<NewA, NewB>> {
+
+    private final TriFunction<A, B, C, NewA> groupKeyMapping;
+    private final TriConstraintCollector<A, B, C, ResultContainer, NewB> collector;
+
+    public DroolsTriToBiGroupBy(TriFunction<A, B, C, NewA> groupKeyMapping,
+            TriConstraintCollector<A, B, C, ResultContainer, NewB> collector) {
+        this.groupKeyMapping = groupKeyMapping;
+        this.collector = collector;
+    }
+
+    @Override
+    protected DroolsAbstractGroupByAccumulator<ResultContainer, TriTuple<A, B, C>, ?, BiTuple<NewA, NewB>> newAccumulator() {
+        return new DroolsTriToBiGroupByAccumulator<>(groupKeyMapping, collector);
+    }
+
+}

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/tri/DroolsTriToBiGroupByAccumulator.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/tri/DroolsTriToBiGroupByAccumulator.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.core.impl.score.stream.drools.tri;
+
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+import org.optaplanner.core.api.function.QuadFunction;
+import org.optaplanner.core.api.function.TriFunction;
+import org.optaplanner.core.api.score.stream.tri.TriConstraintCollector;
+import org.optaplanner.core.impl.score.stream.drools.common.BiTuple;
+import org.optaplanner.core.impl.score.stream.drools.common.DroolsAbstractGroupByAccumulator;
+import org.optaplanner.core.impl.score.stream.drools.common.TriTuple;
+
+final class DroolsTriToBiGroupByAccumulator<A, B, C, ResultContainer, NewA, NewB>
+    extends DroolsAbstractGroupByAccumulator<ResultContainer, TriTuple<A, B, C>, NewA, BiTuple<NewA, NewB>> {
+
+    private final TriFunction<A, B, C, NewA> groupKeyMapping;
+    private final Supplier<ResultContainer> supplier;
+    private final QuadFunction<ResultContainer, A, B, C, Runnable> accumulator;
+    private final Function<ResultContainer, NewB> finisher;
+
+    public DroolsTriToBiGroupByAccumulator(TriFunction<A, B, C, NewA> groupKeyMapping,
+            TriConstraintCollector<A, B, C, ResultContainer, NewB> collector) {
+        this.groupKeyMapping = groupKeyMapping;
+        this.supplier = collector.supplier();
+        this.accumulator = collector.accumulator();
+        this.finisher = collector.finisher();
+    }
+
+    @Override
+    protected NewA toKey(TriTuple<A, B, C> abcTriTuple) {
+        return groupKeyMapping.apply(abcTriTuple._1, abcTriTuple._2, abcTriTuple._3);
+    }
+
+    @Override
+    protected ResultContainer newContainer() {
+        return supplier.get();
+    }
+
+    @Override
+    protected Runnable process(TriTuple<A, B, C> abcTriTuple, ResultContainer container) {
+        return accumulator.apply(container, abcTriTuple._1, abcTriTuple._2, abcTriTuple._3);
+    }
+
+    @Override
+    protected BiTuple<NewA, NewB> toResult(NewA key, ResultContainer container) {
+        return new BiTuple<>(key, finisher.apply(container));
+    }
+
+}

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/tri/DroolsTriToBiGroupByAccumulator.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/tri/DroolsTriToBiGroupByAccumulator.java
@@ -44,7 +44,7 @@ final class DroolsTriToBiGroupByAccumulator<A, B, C, ResultContainer, NewA, NewB
 
     @Override
     protected NewA toKey(TriTuple<A, B, C> abcTriTuple) {
-        return groupKeyMapping.apply(abcTriTuple._1, abcTriTuple._2, abcTriTuple._3);
+        return groupKeyMapping.apply(abcTriTuple.a, abcTriTuple.b, abcTriTuple.c);
     }
 
     @Override
@@ -54,7 +54,7 @@ final class DroolsTriToBiGroupByAccumulator<A, B, C, ResultContainer, NewA, NewB
 
     @Override
     protected Runnable process(TriTuple<A, B, C> abcTriTuple, ResultContainer container) {
-        return accumulator.apply(container, abcTriTuple._1, abcTriTuple._2, abcTriTuple._3);
+        return accumulator.apply(container, abcTriTuple.a, abcTriTuple.b, abcTriTuple.c);
     }
 
     @Override

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/tri/DroolsTriToBiGroupByInvoker.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/tri/DroolsTriToBiGroupByInvoker.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.core.impl.score.stream.drools.tri;
+
+import java.util.function.Function;
+
+import org.drools.model.Variable;
+import org.optaplanner.core.api.function.TriFunction;
+import org.optaplanner.core.api.score.stream.tri.TriConstraintCollector;
+import org.optaplanner.core.impl.score.stream.drools.common.DroolsAbstractGroupBy;
+import org.optaplanner.core.impl.score.stream.drools.common.DroolsAbstractGroupByInvoker;
+import org.optaplanner.core.impl.score.stream.drools.common.TriTuple;
+
+public class DroolsTriToBiGroupByInvoker<A, B, C, ResultContainer, NewA, NewB>
+        extends DroolsAbstractGroupByInvoker<ResultContainer, TriTuple<A, B, C>> {
+
+    private final TriConstraintCollector<A, B, C, ResultContainer, NewB> collector;
+    private final TriFunction<A, B, C, NewA> groupKeyMapping;
+    private final Variable<A> aVariable;
+    private final Variable<B> bVariable;
+    private final Variable<C> cVariable;
+
+    public DroolsTriToBiGroupByInvoker(TriFunction<A, B, C, NewA> groupKeyMapping,
+            TriConstraintCollector<A, B, C, ResultContainer, NewB> collector, Variable<A> aVariable,
+            Variable<B> bVariable, Variable<C> cVariable) {
+        this.collector = collector;
+        this.groupKeyMapping = groupKeyMapping;
+        this.aVariable = aVariable;
+        this.bVariable = bVariable;
+        this.cVariable = cVariable;
+    }
+
+    @Override
+    protected DroolsAbstractGroupBy<ResultContainer, TriTuple<A, B, C>, ?> newContext() {
+        return new DroolsTriToBiGroupBy<>(groupKeyMapping, collector);
+    }
+
+    @Override
+    protected <X> TriTuple<A, B, C> createInput(Function<Variable<X>, X> valueFinder) {
+        final A a = materialize(aVariable, valueFinder);
+        final B b = materialize(bVariable, valueFinder);
+        final C c = materialize(cVariable, valueFinder);
+        return new TriTuple<>(a, b, c);
+    }
+
+}

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/uni/DroolsAbstractUniConstraintStream.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/uni/DroolsAbstractUniConstraintStream.java
@@ -26,6 +26,7 @@ import org.optaplanner.core.api.score.Score;
 import org.optaplanner.core.api.score.stream.Constraint;
 import org.optaplanner.core.api.score.stream.bi.BiConstraintStream;
 import org.optaplanner.core.api.score.stream.bi.BiJoiner;
+import org.optaplanner.core.api.score.stream.tri.TriConstraintStream;
 import org.optaplanner.core.api.score.stream.uni.UniConstraintCollector;
 import org.optaplanner.core.api.score.stream.uni.UniConstraintStream;
 import org.optaplanner.core.impl.score.stream.drools.DroolsConstraintFactory;
@@ -111,6 +112,12 @@ public abstract class DroolsAbstractUniConstraintStream<Solution_, A> extends Dr
         addChildStream(stream);
         return stream;
     }
+
+    @Override
+    public <GroupKeyA_, GroupKeyB_, ResultContainer_, Result_> TriConstraintStream<GroupKeyA_, GroupKeyB_, Result_> groupBy(Function<A, GroupKeyA_> groupKeyAMapping, Function<A, GroupKeyB_> groupKeyBMapping, UniConstraintCollector<A, ResultContainer_, Result_> collector) {
+        throw new UnsupportedOperationException();
+    }
+
     // ************************************************************************
     // Penalize/reward
     // ************************************************************************

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/uni/DroolsAbstractUniConstraintStream.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/uni/DroolsAbstractUniConstraintStream.java
@@ -78,7 +78,7 @@ public abstract class DroolsAbstractUniConstraintStream<Solution_, A> extends Dr
     public <ResultContainer_, Result_> UniConstraintStream<Result_> groupBy(
             UniConstraintCollector<A, ResultContainer_, Result_> collector) {
         throwWhenGroupByNotAllowed();
-        DroolsGroupingUniConstraintStream<Solution_, A, Result_> stream =
+        DroolsGroupingUniConstraintStream<Solution_, Result_> stream =
                 new DroolsGroupingUniConstraintStream<>(constraintFactory, this, collector);
         addChildStream(stream);
         return stream;
@@ -87,7 +87,7 @@ public abstract class DroolsAbstractUniConstraintStream<Solution_, A> extends Dr
     @Override
     public <GroupKey_> UniConstraintStream<GroupKey_> groupBy(Function<A, GroupKey_> groupKeyMapping) {
         throwWhenGroupByNotAllowed();
-        DroolsGroupingUniConstraintStream<Solution_, A, GroupKey_> stream =
+        DroolsGroupingUniConstraintStream<Solution_, GroupKey_> stream =
                 new DroolsGroupingUniConstraintStream<>(constraintFactory, this, groupKeyMapping);
         addChildStream(stream);
         return stream;

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/uni/DroolsAbstractUniConstraintStream.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/uni/DroolsAbstractUniConstraintStream.java
@@ -34,6 +34,7 @@ import org.optaplanner.core.impl.score.stream.drools.bi.DroolsAbstractBiConstrai
 import org.optaplanner.core.impl.score.stream.drools.bi.DroolsGroupingBiConstraintStream;
 import org.optaplanner.core.impl.score.stream.drools.bi.DroolsJoinBiConstraintStream;
 import org.optaplanner.core.impl.score.stream.drools.common.DroolsAbstractConstraintStream;
+import org.optaplanner.core.impl.score.stream.drools.tri.DroolsGroupingTriConstraintStream;
 import org.optaplanner.core.impl.score.stream.uni.InnerUniConstraintStream;
 
 public abstract class DroolsAbstractUniConstraintStream<Solution_, A> extends DroolsAbstractConstraintStream<Solution_>
@@ -114,8 +115,15 @@ public abstract class DroolsAbstractUniConstraintStream<Solution_, A> extends Dr
     }
 
     @Override
-    public <GroupKeyA_, GroupKeyB_, ResultContainer_, Result_> TriConstraintStream<GroupKeyA_, GroupKeyB_, Result_> groupBy(Function<A, GroupKeyA_> groupKeyAMapping, Function<A, GroupKeyB_> groupKeyBMapping, UniConstraintCollector<A, ResultContainer_, Result_> collector) {
-        throw new UnsupportedOperationException();
+    public <GroupKeyA_, GroupKeyB_, ResultContainer_, Result_> TriConstraintStream<GroupKeyA_, GroupKeyB_, Result_>
+    groupBy(Function<A, GroupKeyA_> groupKeyAMapping,
+            Function<A, GroupKeyB_> groupKeyBMapping, UniConstraintCollector<A, ResultContainer_, Result_> collector) {
+        throwWhenGroupByNotAllowed();
+        DroolsGroupingTriConstraintStream<Solution_, GroupKeyA_, GroupKeyB_, Result_> stream =
+                new DroolsGroupingTriConstraintStream<>(constraintFactory, this, groupKeyAMapping, groupKeyBMapping,
+                        collector);
+        addChildStream(stream);
+        return stream;
     }
 
     // ************************************************************************

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/uni/DroolsGroupingUniConstraintStream.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/uni/DroolsGroupingUniConstraintStream.java
@@ -20,26 +20,28 @@ import java.util.List;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 
+import org.optaplanner.core.api.function.TriFunction;
 import org.optaplanner.core.api.score.stream.bi.BiConstraintCollector;
 import org.optaplanner.core.api.score.stream.uni.UniConstraintCollector;
 import org.optaplanner.core.impl.score.stream.drools.DroolsConstraintFactory;
 import org.optaplanner.core.impl.score.stream.drools.bi.DroolsAbstractBiConstraintStream;
 import org.optaplanner.core.impl.score.stream.drools.common.DroolsAbstractConstraintStream;
+import org.optaplanner.core.impl.score.stream.drools.tri.DroolsAbstractTriConstraintStream;
 
-public final class DroolsGroupingUniConstraintStream<Solution_, A, NewA>
+public final class DroolsGroupingUniConstraintStream<Solution_, NewA>
         extends DroolsAbstractUniConstraintStream<Solution_, NewA> {
 
     private final DroolsAbstractConstraintStream<Solution_> parent;
     private final DroolsUniCondition<NewA> condition;
 
-    public DroolsGroupingUniConstraintStream(DroolsConstraintFactory<Solution_> constraintFactory,
+    public <A> DroolsGroupingUniConstraintStream(DroolsConstraintFactory<Solution_> constraintFactory,
             DroolsAbstractUniConstraintStream<Solution_, A> parent, Function<A, NewA> groupKeyMapping) {
         super(constraintFactory);
         this.parent = parent;
         this.condition = parent.getCondition().andGroup(groupKeyMapping);
     }
 
-    public <ResultContainer_> DroolsGroupingUniConstraintStream(DroolsConstraintFactory<Solution_> constraintFactory,
+    public <A, ResultContainer_> DroolsGroupingUniConstraintStream(DroolsConstraintFactory<Solution_> constraintFactory,
             DroolsAbstractUniConstraintStream<Solution_, A> parent,
             UniConstraintCollector<A, ResultContainer_, NewA> collector) {
         super(constraintFactory);
@@ -47,19 +49,26 @@ public final class DroolsGroupingUniConstraintStream<Solution_, A, NewA>
         this.condition = parent.getCondition().andCollect(collector);
     }
 
-    public <B> DroolsGroupingUniConstraintStream(DroolsConstraintFactory<Solution_> constraintFactory,
+    public <A, B> DroolsGroupingUniConstraintStream(DroolsConstraintFactory<Solution_> constraintFactory,
             DroolsAbstractBiConstraintStream<Solution_, A, B> parent, BiFunction<A, B, NewA> groupKeyMapping) {
         super(constraintFactory);
         this.parent = parent;
         this.condition = parent.getCondition().andGroup(groupKeyMapping);
     }
 
-    public <B, ResultContainer_> DroolsGroupingUniConstraintStream(DroolsConstraintFactory<Solution_> constraintFactory,
+    public <A, B, ResultContainer_> DroolsGroupingUniConstraintStream(DroolsConstraintFactory<Solution_> constraintFactory,
             DroolsAbstractBiConstraintStream<Solution_, A, B> parent,
             BiConstraintCollector<A, B, ResultContainer_, NewA> collector) {
         super(constraintFactory);
         this.parent = parent;
         this.condition = parent.getCondition().andCollect(collector);
+    }
+
+    public <A, B, C> DroolsGroupingUniConstraintStream(DroolsConstraintFactory<Solution_> constraintFactory,
+            DroolsAbstractTriConstraintStream<Solution_, A, B, C> parent, TriFunction<A, B, C, NewA> groupKeyMapping) {
+        super(constraintFactory);
+        this.parent = parent;
+        this.condition = parent.getCondition().andGroup(groupKeyMapping);
     }
 
     @Override

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/uni/DroolsGroupingUniConstraintStream.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/uni/DroolsGroupingUniConstraintStream.java
@@ -22,6 +22,7 @@ import java.util.function.Function;
 
 import org.optaplanner.core.api.function.TriFunction;
 import org.optaplanner.core.api.score.stream.bi.BiConstraintCollector;
+import org.optaplanner.core.api.score.stream.tri.TriConstraintCollector;
 import org.optaplanner.core.api.score.stream.uni.UniConstraintCollector;
 import org.optaplanner.core.impl.score.stream.drools.DroolsConstraintFactory;
 import org.optaplanner.core.impl.score.stream.drools.bi.DroolsAbstractBiConstraintStream;
@@ -59,6 +60,15 @@ public final class DroolsGroupingUniConstraintStream<Solution_, NewA>
     public <A, B, ResultContainer_> DroolsGroupingUniConstraintStream(DroolsConstraintFactory<Solution_> constraintFactory,
             DroolsAbstractBiConstraintStream<Solution_, A, B> parent,
             BiConstraintCollector<A, B, ResultContainer_, NewA> collector) {
+        super(constraintFactory);
+        this.parent = parent;
+        this.condition = parent.getCondition().andCollect(collector);
+    }
+
+    public <A, B, C, ResultContainer_> DroolsGroupingUniConstraintStream(
+            DroolsConstraintFactory<Solution_> constraintFactory,
+            DroolsAbstractTriConstraintStream<Solution_, A, B, C> parent,
+            TriConstraintCollector<A, B, C, ResultContainer_, NewA> collector) {
         super(constraintFactory);
         this.parent = parent;
         this.condition = parent.getCondition().andCollect(collector);

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/uni/DroolsUniAccumulateFunctionBridge.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/uni/DroolsUniAccumulateFunctionBridge.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,12 +27,6 @@ import org.kie.api.runtime.rule.AccumulateFunction;
 import org.optaplanner.core.api.score.stream.uni.UniConstraintCollector;
 import org.optaplanner.core.impl.score.stream.drools.common.DroolsAccumulateContext;
 
-/**
- * Drools {@link AccumulateFunction} that calls {@link UniConstraintCollector} underneath.
- * @param <A> input to accumulate
- * @param <ResultContainer_> implementation detail
- * @param <NewA> result of accumulation
- */
 final class DroolsUniAccumulateFunctionBridge<A, ResultContainer_, NewA>
         implements AccumulateFunction<DroolsAccumulateContext<ResultContainer_>> {
 

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/uni/DroolsUniCondition.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/uni/DroolsUniCondition.java
@@ -108,24 +108,10 @@ public final class DroolsUniCondition<A> extends DroolsCondition<DroolsUniRuleSt
         return group((pattern, carrier) -> pattern.bind(carrier, a -> groupKeyMapping.apply((A) a)));
     }
 
-    public <ResultContainer, NewA, NewB> DroolsBiCondition<NewA, NewB> andGroupWithCollect(
-            Function<A, NewA> groupKeyMapping, UniConstraintCollector<A, ResultContainer, NewB> collector) {
-        Variable<Set<BiTuple<NewA, NewB>>> setOfPairsVar =
-                (Variable<Set<BiTuple<NewA, NewB>>>) ruleStructure.createVariable(Set.class, "setOfPairs");
-        PatternDSL.PatternDef<Set<BiTuple<NewA, NewB>>> pattern = pattern(setOfPairsVar)
-                .expr("Set of resulting pairs", set -> !set.isEmpty(),
-                        alphaIndexedBy(Integer.class, Index.ConstraintType.GREATER_THAN, -1, Set::size, 0));
-        // Prepare the list of pairs.
-        PatternDSL.PatternDef<Object> innerNewACollectingPattern = ruleStructure.getPrimaryPattern().build();
-        ViewItem<?> innerAccumulatePattern = getInnerAccumulatePattern(innerNewACollectingPattern);
-        ViewItem<?> accumulate = DSL.accumulate(innerAccumulatePattern,
-                accFunction(() -> new DroolsUniToBiGroupByInvoker<>(groupKeyMapping, collector, getRuleStructure().getA()))
-                        .as(setOfPairsVar));
-        // Load one pair from the list.
-        Variable<BiTuple<NewA, NewB>> onePairVar =
-                (Variable<BiTuple<NewA, NewB>>) ruleStructure.createVariable(BiTuple.class, "pair", from(setOfPairsVar));
-        DroolsBiRuleStructure<NewA, NewB> newRuleStructure = ruleStructure.regroupBi(onePairVar, pattern, accumulate);
-        return new DroolsBiCondition<>(newRuleStructure);
+    public <__, NewA, NewB> DroolsBiCondition<NewA, NewB> andGroupWithCollect(
+            Function<A, NewA> groupKeyMapping, UniConstraintCollector<A, __, NewB> collector) {
+        return groupWithCollect(() -> new DroolsUniToBiGroupByInvoker<>(groupKeyMapping, collector,
+                getRuleStructure().getA()));
     }
 
     /**

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/uni/DroolsUniCondition.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/uni/DroolsUniCondition.java
@@ -91,11 +91,11 @@ public final class DroolsUniCondition<A> extends DroolsCondition<DroolsUniRuleSt
 
     public <NewA, __> DroolsUniCondition<NewA> andCollect(UniConstraintCollector<A, __, NewA> collector) {
         DroolsUniAccumulateFunctionBridge<A, __, NewA> bridge = new DroolsUniAccumulateFunctionBridge<>(collector);
-        return collect(bridge, (pattern, carrier) -> pattern.bind(carrier, a -> (A) a));
+        return collect(bridge, (pattern, tuple) -> pattern.bind(tuple, a -> (A) a));
     }
 
     public <NewA> DroolsUniCondition<NewA> andGroup(Function<A, NewA> groupKeyMapping) {
-        return group((pattern, carrier) -> pattern.bind(carrier, a -> groupKeyMapping.apply((A) a)));
+        return group((pattern, tuple) -> pattern.bind(tuple, a -> groupKeyMapping.apply((A) a)));
     }
 
     public <__, NewA, NewB> DroolsBiCondition<NewA, NewB> andGroupWithCollect(

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/uni/DroolsUniGroupBy.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/uni/DroolsUniGroupBy.java
@@ -42,7 +42,7 @@ final class DroolsUniGroupBy<A, B, ResultContainer, NewB> implements Serializabl
     }
 
     public void accumulate(InternalFactHandle handle, A groupKey, B collected) {
-        Runnable undo = acc.accumulate(groupKey, collected);
+        Runnable undo = acc.accumulate(new BiTuple<>(groupKey, collected));
         Runnable oldUndo = this.undoMap.put(handle.getId(), undo);
         if (oldUndo != null) {
             throw new IllegalStateException("Undo for fact handle (" + handle.getId() + ") already exists.");

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/uni/DroolsUniGroupByInvoker.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/uni/DroolsUniGroupByInvoker.java
@@ -31,6 +31,7 @@ import org.drools.core.spi.CompiledInvoker;
 import org.drools.core.spi.Tuple;
 import org.drools.model.Variable;
 import org.optaplanner.core.api.score.stream.uni.UniConstraintCollector;
+import org.optaplanner.core.impl.score.stream.drools.common.BiTuple;
 
 public class DroolsUniGroupByInvoker<A, B, ResultContainer, NewB> implements Accumulator, CompiledInvoker {
 
@@ -63,7 +64,8 @@ public class DroolsUniGroupByInvoker<A, B, ResultContainer, NewB> implements Acc
         Object handleObject = handle.getObject();
         final A groupKey = getValue(groupKeyVar, internalWorkingMemory, handleObject, innerDeclarations);
         final B toCollect = getValue(collectingVar, internalWorkingMemory, handleObject, innerDeclarations);
-        ((DroolsUniGroupBy<A, B, ResultContainer, NewB>) context).accumulate(handle, groupKey, toCollect);
+        ((DroolsUniGroupBy<A, B, ResultContainer, NewB>) context).accumulate(handle,
+                new BiTuple<>(groupKey, toCollect));
     }
 
     private static <X> X getValue(Variable<X> var, InternalWorkingMemory internalWorkingMemory, Object handleObject,

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/uni/DroolsUniGroupByInvoker.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/uni/DroolsUniGroupByInvoker.java
@@ -16,120 +16,38 @@
 
 package org.optaplanner.core.impl.score.stream.drools.uni;
 
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.Serializable;
+import java.util.function.Function;
 
-import org.drools.core.WorkingMemory;
-import org.drools.core.common.InternalFactHandle;
-import org.drools.core.common.InternalWorkingMemory;
-import org.drools.core.reteoo.SubnetworkTuple;
-import org.drools.core.rule.Declaration;
-import org.drools.core.spi.Accumulator;
-import org.drools.core.spi.CompiledInvoker;
-import org.drools.core.spi.Tuple;
 import org.drools.model.Variable;
 import org.optaplanner.core.api.score.stream.uni.UniConstraintCollector;
 import org.optaplanner.core.impl.score.stream.drools.common.BiTuple;
+import org.optaplanner.core.impl.score.stream.drools.common.DroolsAbstractGroupBy;
+import org.optaplanner.core.impl.score.stream.drools.common.DroolsAbstractGroupByInvoker;
 
-public class DroolsUniGroupByInvoker<A, B, ResultContainer, NewB> implements Accumulator, CompiledInvoker {
+public class DroolsUniGroupByInvoker<A, B, ResultContainer, NewB>
+        extends DroolsAbstractGroupByInvoker<ResultContainer, BiTuple<A, B>> {
 
     private final UniConstraintCollector<B, ResultContainer, NewB> collector;
-    private final Variable<A> groupKeyVar;
-    private final Variable<B> collectingVar;
+    private final Variable<A> aVariable;
+    private final Variable<B> bVariable;
 
-    public DroolsUniGroupByInvoker(UniConstraintCollector<B, ResultContainer, NewB> collector, Variable<A> groupKeyVar,
-            Variable<B> collectingVar) {
+    public DroolsUniGroupByInvoker(UniConstraintCollector<B, ResultContainer, NewB> collector, Variable<A> aVariable,
+            Variable<B> bVariable) {
         this.collector = collector;
-        this.groupKeyVar = groupKeyVar;
-        this.collectingVar = collectingVar;
+        this.aVariable = aVariable;
+        this.bVariable = bVariable;
     }
 
     @Override
-    public Serializable createContext() {
+    protected DroolsAbstractGroupBy<ResultContainer, BiTuple<A, B>, ?> newContext() {
         return new DroolsUniGroupBy<>(collector);
     }
 
     @Override
-    public void init(Object workingMemoryContext, Object context, Tuple tuple, Declaration[] declarations,
-            WorkingMemory workingMemory) {
-        ((DroolsUniGroupBy<A, B, ResultContainer, NewB>) context).init();
-    }
-
-    @Override
-    public void accumulate(Object workingMemoryContext, Object context, Tuple tuple, InternalFactHandle handle,
-            Declaration[] declarations, Declaration[] innerDeclarations, final WorkingMemory workingMemory) {
-        InternalWorkingMemory internalWorkingMemory = (InternalWorkingMemory) workingMemory;
-        Object handleObject = handle.getObject();
-        final A groupKey = getValue(groupKeyVar, internalWorkingMemory, handleObject, innerDeclarations);
-        final B toCollect = getValue(collectingVar, internalWorkingMemory, handleObject, innerDeclarations);
-        ((DroolsUniGroupBy<A, B, ResultContainer, NewB>) context).accumulate(handle,
-                new BiTuple<>(groupKey, toCollect));
-    }
-
-    private static <X> X getValue(Variable<X> var, InternalWorkingMemory internalWorkingMemory, Object handleObject,
-            Declaration... innerDeclarations) {
-        Declaration declaration = getDeclarationForVariable(var, innerDeclarations);
-        Object actualHandleObject = handleObject instanceof SubnetworkTuple ?
-                ((SubnetworkTuple)handleObject).getObject(declaration) :
-                handleObject;
-        return (X) declaration.getValue(internalWorkingMemory, actualHandleObject);
-    }
-
-    /**
-     * Declarations in Drools appear to show up in random order. Therefore, we need to match the proper declaration
-     * not by directly addressing within the array, but by looking it up based on the associated variable.
-     * @param variable
-     * @param declarations
-     * @return
-     */
-    private static Declaration getDeclarationForVariable(Variable<?> variable, Declaration... declarations) {
-        for (Declaration declaration: declarations) {
-            if (declaration.getIdentifier().equals(variable.getName())) {
-                return declaration;
-            }
-        }
-        throw new IllegalStateException("Could not find declaration for variable (" + variable + ").");
-    }
-
-    @Override
-    public void reverse(Object workingMemoryContext, Object context, Tuple tuple, InternalFactHandle handle,
-            Declaration[] declarations, Declaration[] innerDeclarations, WorkingMemory workingMemory) {
-        ((DroolsUniGroupBy<A, B, ResultContainer, NewB>) context).reverse(handle);
-    }
-
-    @Override
-    public Object getResult(Object workingMemoryContext, Object context, Tuple tuple, Declaration[] declarations,
-            WorkingMemory workingMemory) {
-        return ((DroolsUniGroupBy<A, B, ResultContainer, NewB>) context).getResult();
-    }
-
-    @Override
-    public boolean supportsReverse() {
-        return true;
-    }
-
-    @Override
-    public Object createWorkingMemoryContext() {
-        return null;
-    }
-
-    @Override
-    public String getMethodBytecode() {
-        Class<?> accumulateClass = DroolsUniGroupBy.class;
-        String classFileName = accumulateClass.getCanonicalName().replace('.', '/') + ".class";
-        try (InputStream is = getClass().getClassLoader().getResourceAsStream(classFileName)) {
-            final byte[] data = new byte[1024];
-            int byteCount;
-            ByteArrayOutputStream bos = new ByteArrayOutputStream();
-            while ((byteCount = is.read(data, 0, 1024)) > -1) {
-                bos.write(data, 0, byteCount);
-            }
-            return bos.toString();
-        } catch (final IOException e) {
-            throw new RuntimeException("Unable to getResourceAsStream for " + accumulateClass);
-        }
+    protected <X> BiTuple<A, B> createInput(Function<Variable<X>, X> valueFinder) {
+        final A a = materialize(aVariable, valueFinder);
+        final B b = materialize(bVariable, valueFinder);
+        return new BiTuple<>(a, b);
     }
 
 }

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/uni/DroolsUniToBiGroupBy.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/uni/DroolsUniToBiGroupBy.java
@@ -16,23 +16,28 @@
 
 package org.optaplanner.core.impl.score.stream.drools.uni;
 
+import java.util.function.Function;
+
 import org.optaplanner.core.api.score.stream.uni.UniConstraintCollector;
 import org.optaplanner.core.impl.score.stream.drools.common.BiTuple;
 import org.optaplanner.core.impl.score.stream.drools.common.DroolsAbstractGroupBy;
 import org.optaplanner.core.impl.score.stream.drools.common.DroolsAbstractGroupByAccumulator;
 
-final class DroolsUniGroupBy<A, B, ResultContainer, NewB>
-        extends DroolsAbstractGroupBy<ResultContainer, BiTuple<A, B>, BiTuple<A, NewB>> {
+final class DroolsUniToBiGroupBy<A, ResultContainer, NewA, NewB>
+        extends DroolsAbstractGroupBy<ResultContainer, A, BiTuple<NewA, NewB>> {
 
-    private final UniConstraintCollector<B, ResultContainer, NewB> collector;
+    private final Function<A, NewA> groupKeyMapping;
+    private final UniConstraintCollector<A, ResultContainer, NewB> collector;
 
-    public DroolsUniGroupBy(UniConstraintCollector<B, ResultContainer, NewB> collector) {
+    public DroolsUniToBiGroupBy(Function<A, NewA> groupKeyMapping,
+            UniConstraintCollector<A, ResultContainer, NewB> collector) {
+        this.groupKeyMapping = groupKeyMapping;
         this.collector = collector;
     }
 
     @Override
-    protected DroolsAbstractGroupByAccumulator<ResultContainer, BiTuple<A, B>, ?, BiTuple<A, NewB>> newAccumulator() {
-        return new DroolsUniGroupByAccumulator<>(collector);
+    protected DroolsAbstractGroupByAccumulator<ResultContainer, A, ?, BiTuple<NewA, NewB>> newAccumulator() {
+        return new DroolsUniToBiGroupByAccumulator<>(groupKeyMapping, collector);
     }
 
 }

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/uni/DroolsUniToBiGroupByInvoker.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/uni/DroolsUniToBiGroupByInvoker.java
@@ -20,34 +20,31 @@ import java.util.function.Function;
 
 import org.drools.model.Variable;
 import org.optaplanner.core.api.score.stream.uni.UniConstraintCollector;
-import org.optaplanner.core.impl.score.stream.drools.common.BiTuple;
 import org.optaplanner.core.impl.score.stream.drools.common.DroolsAbstractGroupBy;
 import org.optaplanner.core.impl.score.stream.drools.common.DroolsAbstractGroupByInvoker;
 
-public class DroolsUniGroupByInvoker<A, B, ResultContainer, NewB>
-        extends DroolsAbstractGroupByInvoker<ResultContainer, BiTuple<A, B>> {
+public class DroolsUniToBiGroupByInvoker<A, ResultContainer, NewA, NewB>
+    extends DroolsAbstractGroupByInvoker<ResultContainer, A> {
 
-    private final UniConstraintCollector<B, ResultContainer, NewB> collector;
+    private final UniConstraintCollector<A, ResultContainer, NewB> collector;
+    private final Function<A, NewA> groupKeyMapping;
     private final Variable<A> aVariable;
-    private final Variable<B> bVariable;
 
-    public DroolsUniGroupByInvoker(UniConstraintCollector<B, ResultContainer, NewB> collector, Variable<A> aVariable,
-            Variable<B> bVariable) {
+    public DroolsUniToBiGroupByInvoker(Function<A, NewA> groupKeyMapping,
+            UniConstraintCollector<A, ResultContainer, NewB> collector, Variable<A> aVariable) {
         this.collector = collector;
+        this.groupKeyMapping = groupKeyMapping;
         this.aVariable = aVariable;
-        this.bVariable = bVariable;
     }
 
     @Override
-    protected DroolsAbstractGroupBy<ResultContainer, BiTuple<A, B>, ?> newContext() {
-        return new DroolsUniGroupBy<>(collector);
+    protected DroolsAbstractGroupBy<ResultContainer, A, ?> newContext() {
+        return new DroolsUniToBiGroupBy<>(groupKeyMapping, collector);
     }
 
     @Override
-    protected <X> BiTuple<A, B> createInput(Function<Variable<X>, X> valueFinder) {
-        final A a = materialize(aVariable, valueFinder);
-        final B b = materialize(bVariable, valueFinder);
-        return new BiTuple<>(a, b);
+    protected <X> A createInput(Function<Variable<X>, X> valueFinder) {
+        return materialize(aVariable, valueFinder);
     }
 
 }

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/uni/DroolsUniToTriGroupBy.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/uni/DroolsUniToTriGroupBy.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.core.impl.score.stream.drools.uni;
+
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+
+import org.drools.core.common.InternalFactHandle;
+import org.optaplanner.core.api.score.stream.uni.UniConstraintCollector;
+import org.optaplanner.core.impl.score.stream.drools.common.TriTuple;
+
+final class DroolsUniToTriGroupBy<A, ResultContainer, NewA, NewB, NewC> implements Serializable {
+
+    private static final long serialVersionUID = 510l;
+    private final Map<Long, Runnable> undoMap = new HashMap<>(0);
+    private final Function<A, NewA> groupKeyAMapping;
+    private final Function<A, NewB> groupKeyBMapping;
+    private final UniConstraintCollector<A, ResultContainer, NewC> collector;
+    private DroolsUniToTriGroupByAccumulator<A, ResultContainer, NewA, NewB, NewC> acc;
+
+    public DroolsUniToTriGroupBy(Function<A, NewA> groupKeyAMapping, Function<A, NewB> groupKeyBMapping,
+            UniConstraintCollector<A, ResultContainer, NewC> collector) {
+        this.groupKeyAMapping = groupKeyAMapping;
+        this.groupKeyBMapping = groupKeyBMapping;
+        this.collector = collector;
+    }
+
+    public void init() {
+        acc = new DroolsUniToTriGroupByAccumulator<>(groupKeyAMapping, groupKeyBMapping, collector);
+        undoMap.clear();
+    }
+
+    public void accumulate(InternalFactHandle handle, A a) {
+        Runnable undo = acc.accumulate(a);
+        Runnable oldUndo = this.undoMap.put(handle.getId(), undo);
+        if (oldUndo != null) {
+            throw new IllegalStateException("Undo for fact handle (" + handle.getId() + ") already exists.");
+        }
+    }
+
+    public void reverse(InternalFactHandle handle) {
+        final Runnable undo = this.undoMap.remove(handle.getId());
+        if (undo == null) {
+            throw new IllegalStateException("No undo for fact handle (" + handle.getId() + ")");
+        }
+        undo.run();
+    }
+
+    public Set<TriTuple<NewA, NewB, NewC>> getResult() {
+        return acc.finish();
+    }
+
+}

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/uni/DroolsUniToTriGroupByAccumulator.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/uni/DroolsUniToTriGroupByAccumulator.java
@@ -60,7 +60,7 @@ final class DroolsUniToTriGroupByAccumulator<A, ResultContainer, NewA, NewB, New
 
     @Override
     protected TriTuple<NewA, NewB, NewC> toResult(BiTuple<NewA, NewB> key, ResultContainer container) {
-        return new TriTuple<>(key._1, key._2, finisher.apply(container));
+        return new TriTuple<>(key.a, key.b, finisher.apply(container));
     }
 
 }

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/uni/DroolsUniToTriGroupByAccumulator.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/uni/DroolsUniToTriGroupByAccumulator.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.core.impl.score.stream.drools.uni;
+
+import java.io.Serializable;
+import java.util.IdentityHashMap;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+import org.optaplanner.core.api.score.stream.uni.UniConstraintCollector;
+import org.optaplanner.core.impl.score.stream.drools.common.BiTuple;
+import org.optaplanner.core.impl.score.stream.drools.common.TriTuple;
+
+final class DroolsUniToTriGroupByAccumulator<A, ResultContainer, NewA, NewB, NewC> implements Serializable {
+
+    // Containers may be identical in type and contents, yet they should still not count as the same container.
+    private final Map<ResultContainer, Long> containersInUseMap = new IdentityHashMap<>(0);
+    // LinkedHashMap to maintain a consistent iteration order of resulting pairs.
+    private final Map<BiTuple<NewA, NewB>, ResultContainer> containersMap = new LinkedHashMap<>(0);
+    private final Function<A, NewA> groupKeyAMapping;
+    private final Function<A, NewB> groupKeyBMapping;
+    private final Supplier<ResultContainer> supplier;
+    private final BiFunction<ResultContainer, A, Runnable> accumulator;
+    private final Function<ResultContainer, NewC> finisher;
+    // Transient as Spotbugs complains otherwise ("non-transient non-serializable instance field").
+    // It doesn't make sense to serialize this anyway, as it is recreated every time.
+    private final transient Set<TriTuple<NewA, NewB, NewC>> resultSet = new LinkedHashSet<>(0);
+
+    public DroolsUniToTriGroupByAccumulator(Function<A, NewA> groupKeyAMapping, Function<A, NewB> groupKeyBMapping,
+            UniConstraintCollector<A, ResultContainer, NewC> collector) {
+        this.groupKeyAMapping = groupKeyAMapping;
+        this.groupKeyBMapping = groupKeyBMapping;
+        this.supplier = collector.supplier();
+        this.accumulator = collector.accumulator();
+        this.finisher = collector.finisher();
+    }
+
+    private static Long increment(Long count) {
+        return count == null ? 1L : count + 1L;
+    }
+
+    private static Long decrement(Long count) {
+        return count == 1L ? null : count - 1L;
+    }
+
+    public Runnable accumulate(A a) {
+        BiTuple<NewA, NewB> key = new BiTuple<>(groupKeyAMapping.apply(a), groupKeyBMapping.apply(a));
+        ResultContainer container = containersMap.computeIfAbsent(key, __ -> supplier.get());
+        Runnable undo = accumulator.apply(container, a);
+        containersInUseMap.compute(container, (__, count) -> increment(count)); // Increment use counter.
+        return () -> {
+            undo.run();
+            // Decrement use counter. If 0, container is ignored during finishing. Removes empty groups from results.
+            Long currentCount = containersInUseMap.compute(container, (__, count) -> decrement(count));
+            if (currentCount == null) {
+                containersMap.remove(key);
+            }
+        };
+    }
+
+    public Set<TriTuple<NewA, NewB, NewC>> finish() {
+        resultSet.clear();
+        for (Map.Entry<BiTuple<NewA, NewB>, ResultContainer> entry : containersMap.entrySet()) {
+            BiTuple<NewA, NewB> key = entry.getKey();
+            ResultContainer container = entry.getValue();
+            TriTuple<NewA, NewB, NewC> result = new TriTuple<>(key._1, key._2, finisher.apply(container));
+            resultSet.add(result);
+        }
+        return resultSet;
+    }
+}

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/uni/DroolsUniToTriGroupByAccumulator.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/uni/DroolsUniToTriGroupByAccumulator.java
@@ -16,11 +16,6 @@
 
 package org.optaplanner.core.impl.score.stream.drools.uni;
 
-import java.util.IdentityHashMap;
-import java.util.LinkedHashMap;
-import java.util.LinkedHashSet;
-import java.util.Map;
-import java.util.Set;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -33,18 +28,11 @@ import org.optaplanner.core.impl.score.stream.drools.common.TriTuple;
 final class DroolsUniToTriGroupByAccumulator<A, ResultContainer, NewA, NewB, NewC>
     extends DroolsAbstractGroupByAccumulator<ResultContainer, A, BiTuple<NewA, NewB>, TriTuple<NewA, NewB, NewC>> {
 
-    // Containers may be identical in type and contents, yet they should still not count as the same container.
-    private final Map<ResultContainer, Long> containersInUseMap = new IdentityHashMap<>(0);
-    // LinkedHashMap to maintain a consistent iteration order of resulting pairs.
-    private final Map<BiTuple<NewA, NewB>, ResultContainer> containersMap = new LinkedHashMap<>(0);
     private final Function<A, NewA> groupKeyAMapping;
     private final Function<A, NewB> groupKeyBMapping;
     private final Supplier<ResultContainer> supplier;
     private final BiFunction<ResultContainer, A, Runnable> accumulator;
     private final Function<ResultContainer, NewC> finisher;
-    // Transient as Spotbugs complains otherwise ("non-transient non-serializable instance field").
-    // It doesn't make sense to serialize this anyway, as it is recreated every time.
-    private final transient Set<TriTuple<NewA, NewB, NewC>> resultSet = new LinkedHashSet<>(0);
 
     public DroolsUniToTriGroupByAccumulator(Function<A, NewA> groupKeyAMapping, Function<A, NewB> groupKeyBMapping,
             UniConstraintCollector<A, ResultContainer, NewC> collector) {

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/uni/DroolsUniToTriGroupByInvoker.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/uni/DroolsUniToTriGroupByInvoker.java
@@ -16,24 +16,15 @@
 
 package org.optaplanner.core.impl.score.stream.drools.uni;
 
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.Serializable;
 import java.util.function.Function;
 
-import org.drools.core.WorkingMemory;
-import org.drools.core.common.InternalFactHandle;
-import org.drools.core.common.InternalWorkingMemory;
-import org.drools.core.reteoo.SubnetworkTuple;
-import org.drools.core.rule.Declaration;
-import org.drools.core.spi.Accumulator;
-import org.drools.core.spi.CompiledInvoker;
-import org.drools.core.spi.Tuple;
 import org.drools.model.Variable;
 import org.optaplanner.core.api.score.stream.uni.UniConstraintCollector;
+import org.optaplanner.core.impl.score.stream.drools.common.DroolsAbstractGroupBy;
+import org.optaplanner.core.impl.score.stream.drools.common.DroolsAbstractGroupByInvoker;
 
-public class DroolsUniToTriGroupByInvoker<A, ResultContainer, NewA, NewB, NewC> implements Accumulator, CompiledInvoker {
+public class DroolsUniToTriGroupByInvoker<A, ResultContainer, NewA, NewB, NewC>
+    extends DroolsAbstractGroupByInvoker<ResultContainer, A> {
 
     private final UniConstraintCollector<A, ResultContainer, NewC> collector;
     private final Function<A, NewA> groupKeyAMapping;
@@ -49,91 +40,13 @@ public class DroolsUniToTriGroupByInvoker<A, ResultContainer, NewA, NewB, NewC> 
     }
 
     @Override
-    public Serializable createContext() {
+    protected DroolsAbstractGroupBy<ResultContainer, A, ?> newContext() {
         return new DroolsUniToTriGroupBy<>(groupKeyAMapping, groupKeyBMapping, collector);
     }
 
     @Override
-    public void init(Object workingMemoryContext, Object context, Tuple tuple, Declaration[] declarations,
-            WorkingMemory workingMemory) {
-        castContext(context).init();
-    }
-
-    @Override
-    public void accumulate(Object workingMemoryContext, Object context, Tuple tuple, InternalFactHandle handle,
-            Declaration[] declarations, Declaration[] innerDeclarations, final WorkingMemory workingMemory) {
-        InternalWorkingMemory internalWorkingMemory = (InternalWorkingMemory) workingMemory;
-        Object handleObject = handle.getObject();
-        final A groupKey = getValue(aVariable, internalWorkingMemory, handleObject, innerDeclarations);
-        castContext(context).accumulate(handle, groupKey);
-    }
-
-    private static <X> X getValue(Variable<X> var, InternalWorkingMemory internalWorkingMemory, Object handleObject,
-            Declaration... innerDeclarations) {
-        Declaration declaration = getDeclarationForVariable(var, innerDeclarations);
-        Object actualHandleObject = handleObject instanceof SubnetworkTuple ?
-                ((SubnetworkTuple)handleObject).getObject(declaration) :
-                handleObject;
-        return (X) declaration.getValue(internalWorkingMemory, actualHandleObject);
-    }
-
-    private DroolsUniToTriGroupBy<A, ResultContainer, NewA, NewB, NewC> castContext(Object context) {
-        return (DroolsUniToTriGroupBy<A, ResultContainer, NewA, NewB, NewC>) context;
-    }
-
-    /**
-     * Declarations in Drools appear to show up in random order. Therefore, we need to match the proper declaration
-     * not by directly addressing within the array, but by looking it up based on the associated variable.
-     * @param variable
-     * @param declarations
-     * @return
-     */
-    private static Declaration getDeclarationForVariable(Variable<?> variable, Declaration... declarations) {
-        for (Declaration declaration: declarations) {
-            if (declaration.getIdentifier().equals(variable.getName())) {
-                return declaration;
-            }
-        }
-        throw new IllegalStateException("Could not find declaration for variable (" + variable + ").");
-    }
-
-    @Override
-    public void reverse(Object workingMemoryContext, Object context, Tuple tuple, InternalFactHandle handle,
-            Declaration[] declarations, Declaration[] innerDeclarations, WorkingMemory workingMemory) {
-        castContext(context).reverse(handle);
-    }
-
-    @Override
-    public Object getResult(Object workingMemoryContext, Object context, Tuple tuple, Declaration[] declarations,
-            WorkingMemory workingMemory) {
-        return castContext(context).getResult();
-    }
-
-    @Override
-    public boolean supportsReverse() {
-        return true;
-    }
-
-    @Override
-    public Object createWorkingMemoryContext() {
-        return null;
-    }
-
-    @Override
-    public String getMethodBytecode() {
-        Class<?> accumulateClass = DroolsUniToTriGroupBy.class;
-        String classFileName = accumulateClass.getCanonicalName().replace('.', '/') + ".class";
-        try (InputStream is = getClass().getClassLoader().getResourceAsStream(classFileName)) {
-            final byte[] data = new byte[1024];
-            int byteCount;
-            ByteArrayOutputStream bos = new ByteArrayOutputStream();
-            while ((byteCount = is.read(data, 0, 1024)) > -1) {
-                bos.write(data, 0, byteCount);
-            }
-            return bos.toString();
-        } catch (final IOException e) {
-            throw new RuntimeException("Unable to getResourceAsStream for " + accumulateClass);
-        }
+    protected <X> A createInput(Function<Variable<X>, X> valueFinder) {
+        return materialize(aVariable, valueFinder);
     }
 
 }

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/uni/DroolsUniToTriGroupByInvoker.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/uni/DroolsUniToTriGroupByInvoker.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.core.impl.score.stream.drools.uni;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.Serializable;
+import java.util.function.Function;
+
+import org.drools.core.WorkingMemory;
+import org.drools.core.common.InternalFactHandle;
+import org.drools.core.common.InternalWorkingMemory;
+import org.drools.core.reteoo.SubnetworkTuple;
+import org.drools.core.rule.Declaration;
+import org.drools.core.spi.Accumulator;
+import org.drools.core.spi.CompiledInvoker;
+import org.drools.core.spi.Tuple;
+import org.drools.model.Variable;
+import org.optaplanner.core.api.score.stream.uni.UniConstraintCollector;
+
+public class DroolsUniToTriGroupByInvoker<A, ResultContainer, NewA, NewB, NewC> implements Accumulator, CompiledInvoker {
+
+    private final UniConstraintCollector<A, ResultContainer, NewC> collector;
+    private final Function<A, NewA> groupKeyAMapping;
+    private final Function<A, NewB> groupKeyBMapping;
+    private final Variable<A> aVariable;
+
+    public DroolsUniToTriGroupByInvoker(Function<A, NewA> groupKeyAMapping, Function<A, NewB> groupKeyBMapping,
+            UniConstraintCollector<A, ResultContainer, NewC> collector, Variable<A> aVariable) {
+        this.collector = collector;
+        this.groupKeyAMapping = groupKeyAMapping;
+        this.groupKeyBMapping = groupKeyBMapping;
+        this.aVariable = aVariable;
+    }
+
+    @Override
+    public Serializable createContext() {
+        return new DroolsUniToTriGroupBy<>(groupKeyAMapping, groupKeyBMapping, collector);
+    }
+
+    @Override
+    public void init(Object workingMemoryContext, Object context, Tuple tuple, Declaration[] declarations,
+            WorkingMemory workingMemory) {
+        castContext(context).init();
+    }
+
+    @Override
+    public void accumulate(Object workingMemoryContext, Object context, Tuple tuple, InternalFactHandle handle,
+            Declaration[] declarations, Declaration[] innerDeclarations, final WorkingMemory workingMemory) {
+        InternalWorkingMemory internalWorkingMemory = (InternalWorkingMemory) workingMemory;
+        Object handleObject = handle.getObject();
+        final A groupKey = getValue(aVariable, internalWorkingMemory, handleObject, innerDeclarations);
+        castContext(context).accumulate(handle, groupKey);
+    }
+
+    private static <X> X getValue(Variable<X> var, InternalWorkingMemory internalWorkingMemory, Object handleObject,
+            Declaration... innerDeclarations) {
+        Declaration declaration = getDeclarationForVariable(var, innerDeclarations);
+        Object actualHandleObject = handleObject instanceof SubnetworkTuple ?
+                ((SubnetworkTuple)handleObject).getObject(declaration) :
+                handleObject;
+        return (X) declaration.getValue(internalWorkingMemory, actualHandleObject);
+    }
+
+    private DroolsUniToTriGroupBy<A, ResultContainer, NewA, NewB, NewC> castContext(Object context) {
+        return (DroolsUniToTriGroupBy<A, ResultContainer, NewA, NewB, NewC>) context;
+    }
+
+    /**
+     * Declarations in Drools appear to show up in random order. Therefore, we need to match the proper declaration
+     * not by directly addressing within the array, but by looking it up based on the associated variable.
+     * @param variable
+     * @param declarations
+     * @return
+     */
+    private static Declaration getDeclarationForVariable(Variable<?> variable, Declaration... declarations) {
+        for (Declaration declaration: declarations) {
+            if (declaration.getIdentifier().equals(variable.getName())) {
+                return declaration;
+            }
+        }
+        throw new IllegalStateException("Could not find declaration for variable (" + variable + ").");
+    }
+
+    @Override
+    public void reverse(Object workingMemoryContext, Object context, Tuple tuple, InternalFactHandle handle,
+            Declaration[] declarations, Declaration[] innerDeclarations, WorkingMemory workingMemory) {
+        castContext(context).reverse(handle);
+    }
+
+    @Override
+    public Object getResult(Object workingMemoryContext, Object context, Tuple tuple, Declaration[] declarations,
+            WorkingMemory workingMemory) {
+        return castContext(context).getResult();
+    }
+
+    @Override
+    public boolean supportsReverse() {
+        return true;
+    }
+
+    @Override
+    public Object createWorkingMemoryContext() {
+        return null;
+    }
+
+    @Override
+    public String getMethodBytecode() {
+        Class<?> accumulateClass = DroolsUniToTriGroupBy.class;
+        String classFileName = accumulateClass.getCanonicalName().replace('.', '/') + ".class";
+        try (InputStream is = getClass().getClassLoader().getResourceAsStream(classFileName)) {
+            final byte[] data = new byte[1024];
+            int byteCount;
+            ByteArrayOutputStream bos = new ByteArrayOutputStream();
+            while ((byteCount = is.read(data, 0, 1024)) > -1) {
+                bos.write(data, 0, byteCount);
+            }
+            return bos.toString();
+        } catch (final IOException e) {
+            throw new RuntimeException("Unable to getResourceAsStream for " + accumulateClass);
+        }
+    }
+
+}

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/tri/DefaultTriConstraintCollector.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/tri/DefaultTriConstraintCollector.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.core.impl.score.stream.tri;
+
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+import org.optaplanner.core.api.function.QuadFunction;
+import org.optaplanner.core.api.score.stream.tri.TriConstraintCollector;
+
+public final class DefaultTriConstraintCollector<A, B, C, ResultContainer_, Result_>
+        implements TriConstraintCollector<A, B, C, ResultContainer_, Result_> {
+
+    private final Supplier<ResultContainer_> supplier;
+    private final QuadFunction<ResultContainer_, A, B, C, Runnable> accumulator;
+    private final Function<ResultContainer_, Result_> finisher;
+
+    public DefaultTriConstraintCollector(Supplier<ResultContainer_> supplier,
+            QuadFunction<ResultContainer_, A, B, C, Runnable> accumulator,
+            Function<ResultContainer_, Result_> finisher) {
+        this.supplier = supplier;
+        this.accumulator = accumulator;
+        this.finisher = finisher;
+    }
+
+    @Override
+    public Supplier<ResultContainer_> supplier() {
+        return supplier;
+    }
+
+    @Override
+    public QuadFunction<ResultContainer_, A, B, C, Runnable> accumulator() {
+        return accumulator;
+    }
+
+    @Override
+    public Function<ResultContainer_, Result_> finisher() {
+        return finisher;
+    }
+
+}

--- a/optaplanner-core/src/test/java/org/optaplanner/core/api/score/stream/tri/TriConstraintStreamTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/api/score/stream/tri/TriConstraintStreamTest.java
@@ -276,6 +276,28 @@ public class TriConstraintStreamTest extends AbstractConstraintStreamTest {
     // ************************************************************************
 
     @Test
+    public void groupBy_1Mapping0Collector() {
+        assumeDrools();
+        TestdataLavishSolution solution = TestdataLavishSolution.generateSolution(1, 2, 2, 3);
+
+        InnerScoreDirector<TestdataLavishSolution> scoreDirector = buildScoreDirector((factory) -> {
+            return factory.from(TestdataLavishEntity.class)
+                    .join(TestdataLavishEntityGroup.class, equal(TestdataLavishEntity::getEntityGroup, Function.identity()))
+                    .join(TestdataLavishValue.class, equal((entity, group) -> entity.getValue(), Function.identity()))
+                    .groupBy((entity, group, value) -> value)
+                    .penalize(TEST_CONSTRAINT_NAME, SimpleScore.ONE);
+        });
+
+        TestdataLavishValue value1 = solution.getFirstValue();
+        TestdataLavishValue value2 = solution.getValueList().get(1);
+
+        scoreDirector.setWorkingSolution(solution);
+        assertScore(scoreDirector,
+                assertMatchWithScore(-1, value2),
+                assertMatchWithScore(-1, value1));
+    }
+
+    @Test
     public void groupBy_1Mapping1Collector_count() {
         assumeDrools();
         TestdataLavishSolution solution = TestdataLavishSolution.generateSolution(1, 2, 2, 3);

--- a/optaplanner-core/src/test/java/org/optaplanner/core/api/score/stream/tri/TriConstraintStreamTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/api/score/stream/tri/TriConstraintStreamTest.java
@@ -276,6 +276,39 @@ public class TriConstraintStreamTest extends AbstractConstraintStreamTest {
     // ************************************************************************
 
     @Test
+    public void groupBy_2Mapping0Collector() {
+        assumeDrools();
+        TestdataLavishSolution solution = TestdataLavishSolution.generateSolution(1, 2, 2, 3);
+        InnerScoreDirector<TestdataLavishSolution> scoreDirector = buildScoreDirector((factory) -> {
+            return factory.from(TestdataLavishEntity.class)
+                    .join(TestdataLavishEntityGroup.class, equal(TestdataLavishEntity::getEntityGroup, Function.identity()))
+                    .join(TestdataLavishValue.class, equal((entity, group) -> entity.getValue(), Function.identity()))
+                    .groupBy((entity, group, value) -> group, (entity, group, value) -> value)
+                    .penalize(TEST_CONSTRAINT_NAME, SimpleScore.ONE);
+        });
+
+        TestdataLavishEntityGroup group1 = solution.getFirstEntityGroup();
+        TestdataLavishEntityGroup group2 = solution.getEntityGroupList().get(1);
+        TestdataLavishValue value1 = solution.getFirstValue();
+        TestdataLavishValue value2 = solution.getValueList().get(1);
+
+        // From scratch
+        scoreDirector.setWorkingSolution(solution);
+        assertScore(scoreDirector,
+                assertMatchWithScore(-1, group2, value2),
+                assertMatchWithScore(-1, group1, value1));
+
+        // Incremental
+        TestdataLavishEntity entity = solution.getFirstEntity();
+        scoreDirector.beforeEntityRemoved(entity);
+        solution.getEntityList().remove(entity);
+        scoreDirector.afterEntityRemoved(entity);
+        assertScore(scoreDirector,
+                assertMatchWithScore(-1, group2, value2),
+                assertMatchWithScore(-1, group1, value1));
+    }
+
+    @Test
     public void groupBy_2Mapping1Collector_count() {
         assumeDrools();
         TestdataLavishSolution solution = TestdataLavishSolution.generateSolution(1, 2, 2, 3);

--- a/optaplanner-core/src/test/java/org/optaplanner/core/api/score/stream/uni/UniConstraintStreamTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/api/score/stream/uni/UniConstraintStreamTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +25,6 @@ import java.util.function.Predicate;
 import java.util.stream.Stream;
 
 import com.google.common.base.Functions;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.optaplanner.core.api.score.buildin.simple.SimpleScore;
 import org.optaplanner.core.api.score.buildin.simplebigdecimal.SimpleBigDecimalScore;
@@ -741,8 +740,9 @@ public class UniConstraintStreamTest extends AbstractConstraintStreamTest {
                 assertMatchWithScore(-1, solution.getFirstEntityGroup(), solution.getValueList().get(4)));
     }
 
-    @Test @Ignore("TODO implement it") // TODO
+    @Test
     public void groupBy_2Mapping1Collector_count() {
+        assumeDrools();
         TestdataLavishSolution solution = TestdataLavishSolution.generateSolution(1, 1, 1, 7);
         TestdataLavishEntityGroup entityGroup1 = new TestdataLavishEntityGroup("MyEntityGroup");
         solution.getEntityGroupList().add(entityGroup1);
@@ -755,12 +755,10 @@ public class UniConstraintStreamTest extends AbstractConstraintStreamTest {
         TestdataLavishEntity entity3 = new TestdataLavishEntity("MyEntity 3", entityGroup1, value1);
         solution.getEntityList().add(entity3);
 
-
         InnerScoreDirector<TestdataLavishSolution> scoreDirector = buildScoreDirector((factory) -> {
-            throw new UnsupportedOperationException("Not yet implemented.");
-            //return factory.from(TestdataLavishEntity.class)
-            //        .groupBy(TestdataLavishEntity::getEntityGroup, TestdataLavishEntity::getValue, count())
-            //        .penalize(TEST_CONSTRAINT_NAME, SimpleScore.ONE, (entityGroup, value, count) -> count);
+            return factory.from(TestdataLavishEntity.class)
+                    .groupBy(TestdataLavishEntity::getEntityGroup, TestdataLavishEntity::getValue, count())
+                    .penalize(TEST_CONSTRAINT_NAME, SimpleScore.ONE, (entityGroup, value, count) -> count);
         });
 
         // From scratch


### PR DESCRIPTION
Introduces all `groupBy()` operations for Drools-based `TriConstraintStream`.
Since the amount of code was getting out of hand, this PR also spends considerable number of lines on unifying existing `groupBy` implementations and refactoring towards much more code reuse.