### PR TITLE
PLANNER-1777 bugfix when using java generics or kotlin open classes

### DIFF
--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/valuerange/descriptor/AbstractFromPropertyValueRangeDescriptor.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/valuerange/descriptor/AbstractFromPropertyValueRangeDescriptor.java
@@ -18,6 +18,7 @@ package org.optaplanner.core.impl.domain.valuerange.descriptor;
 
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
+import java.lang.reflect.WildcardType;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -103,6 +104,11 @@ public abstract class AbstractFromPropertyValueRangeDescriptor<Solution_>
                         + ") with an unsupported number of generic parameters (" + typeArguments.length + ").");
             }
             Type typeArgument = typeArguments[0];
+
+            if (typeArgument instanceof WildcardType) {
+                typeArgument = ((WildcardType) typeArgument).getUpperBounds()[0];
+            }
+
             if (typeArgument instanceof ParameterizedType) {
                 // TODO fail fast if the type arguments don't match
                 // with the variableDescriptor's generic type's type arguments

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/domain/solution/descriptor/SolutionDescriptorTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/domain/solution/descriptor/SolutionDescriptorTest.java
@@ -30,6 +30,7 @@ import org.optaplanner.core.impl.testdata.domain.extended.TestdataUnannotatedExt
 import org.optaplanner.core.impl.testdata.domain.extended.abstractsolution.TestdataExtendedAbstractSolution;
 import org.optaplanner.core.impl.testdata.domain.extended.abstractsolution.TestdataScoreGetterOverrideExtendedAbstractSolution;
 import org.optaplanner.core.impl.testdata.domain.extended.legacysolution.TestdataLegacySolution;
+import org.optaplanner.core.impl.testdata.domain.reflect.generic.TestdataGenericEntity;
 import org.optaplanner.core.impl.testdata.domain.reflect.generic.TestdataGenericSolution;
 import org.optaplanner.core.impl.testdata.domain.solutionproperties.TestdataNoProblemFactPropertySolution;
 import org.optaplanner.core.impl.testdata.domain.solutionproperties.TestdataProblemFactPropertySolution;
@@ -158,6 +159,12 @@ public class SolutionDescriptorTest {
     public void generic() {
         SolutionDescriptor<TestdataGenericSolution> solutionDescriptor
                 = TestdataGenericSolution.buildSolutionDescriptor();
+
+        assertMapContainsKeysExactly(solutionDescriptor.getProblemFactCollectionMemberAccessorMap(), "valueList", "complexGenericValueList", "subTypeValueList");
+        assertMapContainsKeysExactly(solutionDescriptor.getEntityCollectionMemberAccessorMap(),"entityList");
+
+        assertMapContainsKeysExactly(solutionDescriptor.findEntityDescriptor( TestdataGenericEntity.class ).getVariableDescriptorMap(), "value", "subTypeValue", "complexGenericValue"  );
+
     }
 
     // ************************************************************************

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/testdata/domain/reflect/generic/TestdataGenericEntity.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/testdata/domain/reflect/generic/TestdataGenericEntity.java
@@ -40,6 +40,7 @@ public class TestdataGenericEntity<T> extends TestdataObject {
     }
 
     private TestdataGenericValue<T> value;
+    private TestdataGenericValue<T> subTypeValue;
     private TestdataGenericValue<Map<T, TestdataGenericValue<T>>> complexGenericValue;
 
     public TestdataGenericEntity() {
@@ -59,8 +60,17 @@ public class TestdataGenericEntity<T> extends TestdataObject {
         return value;
     }
 
+    @PlanningVariable(valueRangeProviderRefs = "subTypeValueRange")
+    public TestdataGenericValue<T> getSubTypeValue() {
+        return subTypeValue;
+    }
+
     public void setValue(TestdataGenericValue<T> value) {
         this.value = value;
+    }
+
+    public void setSubTypeValue(TestdataGenericValue<T> subTypeValue) {
+        this.subTypeValue = subTypeValue;
     }
 
     @PlanningVariable(valueRangeProviderRefs = "complexGenericValueRange")

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/testdata/domain/reflect/generic/TestdataGenericSolution.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/testdata/domain/reflect/generic/TestdataGenericSolution.java
@@ -36,6 +36,7 @@ public class TestdataGenericSolution<T> extends TestdataObject {
     }
 
     private List<TestdataGenericValue<T>> valueList;
+    private List<? extends TestdataGenericValue<T>> subTypeValueList;
     private List<TestdataGenericValue<Map<T, TestdataGenericValue<T>>>> complexGenericValueList;
     private List<TestdataGenericEntity<T>> entityList;
 
@@ -67,6 +68,12 @@ public class TestdataGenericSolution<T> extends TestdataObject {
     @ProblemFactCollectionProperty
     public List<TestdataGenericValue<Map<T, TestdataGenericValue<T>>>> getComplexGenericValueList() {
         return complexGenericValueList;
+    }
+
+    @ValueRangeProvider(id = "subTypeValueRange")
+    @ProblemFactCollectionProperty
+    public List<? extends TestdataGenericValue<T>> getSubTypeValueList() {
+        return subTypeValueList;
     }
 
     @PlanningEntityCollectionProperty


### PR DESCRIPTION
I am getting following error when using kotlin data classes as PlanningEntity having a PlanningVariable with valueRangeProviderRefs to a collection of kotlin data classes. Following is the stacktrace of the error. I was able to reproduce this issue on master branch of optaplanner.

> java.lang.IllegalArgumentException: The entityClass (class org.divy.resource.planning.domain.allocation.IterationAllocation) has a PlanningVariable annotated property (employee) that refers to a ValueRangeProvider annotated member (field private java.util.List org.divy.resource.planning.domain.iteration.IterationAllocations.employeeList) that returns a parameterized Collection with an unsupported type arguments (? extends org.divy.resource.planning.domain.employee.Employee).
```
	at org.optaplanner.core.impl.domain.valuerange.descriptor.AbstractFromPropertyValueRangeDescriptor.processValueRangeProviderAnnotation(AbstractFromPropertyValueRangeDescriptor.java:117)
	at org.optaplanner.core.impl.domain.valuerange.descriptor.AbstractFromPropertyValueRangeDescriptor.<init>(AbstractFromPropertyValueRangeDescriptor.java:57)
	at org.optaplanner.core.impl.domain.valuerange.descriptor.FromSolutionPropertyValueRangeDescriptor.<init>(FromSolutionPropertyValueRangeDescriptor.java:34)
	at org.optaplanner.core.impl.domain.variable.descriptor.GenuineVariableDescriptor.buildValueRangeDescriptor(GenuineVariableDescriptor.java:152)
	at org.optaplanner.core.impl.domain.variable.descriptor.GenuineVariableDescriptor.processValueRangeRefs(GenuineVariableDescriptor.java:139)
	at org.optaplanner.core.impl.domain.variable.descriptor.GenuineVariableDescriptor.processPropertyAnnotations(GenuineVariableDescriptor.java:84)
	at org.optaplanner.core.impl.domain.variable.descriptor.GenuineVariableDescriptor.processAnnotations(GenuineVariableDescriptor.java:77)
```