### PR TITLE
PLANNER-1791 Add SolverManager tests

### DIFF
--- a/optaplanner-core/src/test/java/org/optaplanner/core/api/solver/SolverManagerTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/api/solver/SolverManagerTest.java
@@ -283,14 +283,14 @@ public class SolverManagerTest {
         // Use twice the amount of problems than available processors.
         int problemCount = Runtime.getRuntime().availableProcessors() * 2;
 
-        SolverManager<TestdataSolution, Integer> solverManager = createSolverManagerTestableByDifferentConsumers(problemCount);
+        SolverManager<TestdataSolution, Integer> solverManager = createSolverManagerTestableByDifferentConsumers();
 
         assertSolveWithoutConsumer(problemCount, solverManager);
         assertSolveWithBestSolutionConsumer(problemCount, solverManager);
         assertSolveWithFinalBestSolutionConsumer(problemCount, solverManager);
     }
 
-    private SolverManager<TestdataSolution, Integer> createSolverManagerTestableByDifferentConsumers(int processCount) {
+    private SolverManager<TestdataSolution, Integer> createSolverManagerTestableByDifferentConsumers() {
         final SolverConfig solverConfig = PlannerTestUtils.buildSolverConfig(TestdataSolution.class, TestdataEntity.class)
                 .withPhases(new CustomPhaseConfig().withCustomPhaseCommands(
                         (ScoreDirector<TestdataSolution> scoreDirector) -> {

--- a/optaplanner-core/src/test/java/org/optaplanner/core/api/solver/SolverManagerTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/api/solver/SolverManagerTest.java
@@ -255,7 +255,7 @@ public class SolverManagerTest {
         assertTrue(eventCount.get() < 4);
     }
 
-    @Ignore("A test that runs forever and is here to investigate a faulty thread-creating behavior.")
+    @Ignore("https://issues.redhat.com/browse/PLANNER-1837")
     @Test
     public void solveMultipleThreadedMovesWithSolverManager_allGetSolved() throws ExecutionException, InterruptedException {
         int processCount = Runtime.getRuntime().availableProcessors();

--- a/optaplanner-core/src/test/java/org/optaplanner/core/api/solver/SolverManagerTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/api/solver/SolverManagerTest.java
@@ -407,7 +407,7 @@ public class SolverManagerTest {
         assertThat(entity.getValue()).isNull();
     }
 
-    @Test(timeout = 100)
+    @Test(timeout = 1_000)
     public void runSameIdProcesses_throwsIllegalStateException() {
         SolverManagerConfig solverManagerConfig = new SolverManagerConfig();
 


### PR DESCRIPTION
Tests the following requirements:
- Test how multiple solver manager threads work together with multi-threaded solving
- Test submitting more problems than number of cpu cores.
- Submitting same problem twice