### PR TITLE
PLANNER-1829: Add a ConstraintProvider for Scrabble

### DIFF
--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/scrabble/optional/score/ScrabbleConstraintProvider.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/scrabble/optional/score/ScrabbleConstraintProvider.java
@@ -63,7 +63,7 @@ public class ScrabbleConstraintProvider implements ConstraintProvider {
 
     private Constraint pullToCenter(ConstraintFactory cf) {
         return cf.from(ScrabbleWordAssignment.class)
-                 .penalize("Pull to the center", HardMediumSoftScore.ONE_SOFT, (swa) -> swa.getDistanceToCenter());
+                 .penalize("Pull to the center", HardMediumSoftScore.ONE_SOFT, ScrabbleWordAssignment::getDistanceToCenter);
     }
 
 }

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/scrabble/optional/score/ScrabbleConstraintProvider.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/scrabble/optional/score/ScrabbleConstraintProvider.java
@@ -32,19 +32,17 @@ public class ScrabbleConstraintProvider implements ConstraintProvider {
 
     private Constraint noParallelHorizontalNeighbours(ConstraintFactory cf) {
         return cf.from(ScrabbleCell.class).filter(sc -> sc.hasWordSet(ScrabbleWordDirection.HORIZONTAL))
-                 .join(ScrabbleCell.class,
-                       Joiners.equal(ScrabbleCell::getX), Joiners.lessThan(ScrabbleCell::getId),
-                       Joiners.filtering((first, other) -> other.hasWordSet(ScrabbleWordDirection.HORIZONTAL)))
-                 .filter((c1, c2) -> Math.abs(c1.getY() - c2.getY()) == 1)
+                 .ifExists(ScrabbleCell.class,
+                           Joiners.equal(ScrabbleCell::getX), Joiners.equal(ScrabbleCell::getY, c -> c.getY() + 1),
+                           Joiners.filtering((first, second) -> second.hasWordSet(ScrabbleWordDirection.HORIZONTAL)))
                  .penalize("No parallel horizontal neighbours", HardMediumSoftScore.ONE_HARD);
     }
 
     private Constraint noParallelVerticalNeighbours(ConstraintFactory cf) {
         return cf.from(ScrabbleCell.class).filter(sc -> sc.hasWordSet(ScrabbleWordDirection.VERTICAL))
-                 .join(ScrabbleCell.class,
-                       Joiners.equal(ScrabbleCell::getY), Joiners.lessThan(ScrabbleCell::getId),
-                       Joiners.filtering((first, other) -> other.hasWordSet(ScrabbleWordDirection.VERTICAL)))
-                 .filter((c1, c2) -> Math.abs(c1.getX() - c2.getX()) == 1)
+                 .ifExists(ScrabbleCell.class,
+                           Joiners.equal(ScrabbleCell::getY), Joiners.equal(ScrabbleCell::getX, c -> c.getX() + 1),
+                           Joiners.filtering((first, second) -> second.hasWordSet(ScrabbleWordDirection.VERTICAL)))
                  .penalize("No parallel vertical neighbours", HardMediumSoftScore.ONE_HARD);
     }
 

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/scrabble/optional/score/ScrabbleConstraintProvider.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/scrabble/optional/score/ScrabbleConstraintProvider.java
@@ -15,53 +15,52 @@ public class ScrabbleConstraintProvider implements ConstraintProvider {
     @Override
     public Constraint[] defineConstraints(ConstraintFactory constraintFactory) {
         return new Constraint[]{
-                                characterConflict(constraintFactory),
-                                noParallelHorizontalNeighbours(constraintFactory),
-                                noParallelVerticalNeighbours(constraintFactory),
-                                outOfGrid(constraintFactory),
-                                maximizeMergesPerWord(constraintFactory),
-                                pullToCenter(constraintFactory)
+                characterConflict(constraintFactory),
+                noParallelHorizontalNeighbours(constraintFactory),
+                noParallelVerticalNeighbours(constraintFactory),
+                outOfGrid(constraintFactory),
+                maximizeMergesPerWord(constraintFactory),
+                pullToCenter(constraintFactory)
         };
     }
 
     private Constraint characterConflict(ConstraintFactory cf) {
         return cf.from(ScrabbleCell.class)
-                 .filter(sc -> sc.getCharacterSet().size() >= 2)
-                 .penalize("Character confict", HardMediumSoftScore.ONE_HARD, sc -> sc.getCharacterSet().size() - 1);
+                .filter(sc -> sc.getCharacterSet().size() >= 2)
+                .penalize("Character confict", HardMediumSoftScore.ONE_HARD, sc -> sc.getCharacterSet().size() - 1);
     }
 
     private Constraint noParallelHorizontalNeighbours(ConstraintFactory cf) {
         return cf.from(ScrabbleCell.class).filter(sc -> sc.hasWordSet(ScrabbleWordDirection.HORIZONTAL))
-                 .ifExists(ScrabbleCell.class,
-                           Joiners.equal(ScrabbleCell::getX), Joiners.equal(ScrabbleCell::getY, c -> c.getY() + 1),
-                           Joiners.filtering((first, second) -> second.hasWordSet(ScrabbleWordDirection.HORIZONTAL)))
-                 .penalize("No parallel horizontal neighbours", HardMediumSoftScore.ONE_HARD);
+                .ifExists(ScrabbleCell.class,
+                          Joiners.equal(ScrabbleCell::getX), Joiners.equal(ScrabbleCell::getY, c -> c.getY() + 1),
+                          Joiners.filtering((first, second) -> second.hasWordSet(ScrabbleWordDirection.HORIZONTAL)))
+                .penalize("No parallel horizontal neighbours", HardMediumSoftScore.ONE_HARD);
     }
 
     private Constraint noParallelVerticalNeighbours(ConstraintFactory cf) {
         return cf.from(ScrabbleCell.class).filter(sc -> sc.hasWordSet(ScrabbleWordDirection.VERTICAL))
-                 .ifExists(ScrabbleCell.class,
-                           Joiners.equal(ScrabbleCell::getY), Joiners.equal(ScrabbleCell::getX, c -> c.getX() + 1),
-                           Joiners.filtering((first, second) -> second.hasWordSet(ScrabbleWordDirection.VERTICAL)))
-                 .penalize("No parallel vertical neighbours", HardMediumSoftScore.ONE_HARD);
+                .ifExists(ScrabbleCell.class,
+                          Joiners.equal(ScrabbleCell::getY), Joiners.equal(ScrabbleCell::getX, c -> c.getX() + 1),
+                          Joiners.filtering((first, second) -> second.hasWordSet(ScrabbleWordDirection.VERTICAL)))
+                .penalize("No parallel vertical neighbours", HardMediumSoftScore.ONE_HARD);
     }
 
     private Constraint outOfGrid(ConstraintFactory cf) {
         return cf.from(ScrabbleWordAssignment.class)
-                 .filter(ScrabbleWordAssignment::isOutOfGrid)
-                 .penalize("Out of grid", HardMediumSoftScore.ONE_HARD, swa -> swa.getWord().length());
+                .filter(ScrabbleWordAssignment::isOutOfGrid)
+                .penalize("Out of grid", HardMediumSoftScore.ONE_HARD, swa -> swa.getWord().length());
     }
 
     private Constraint maximizeMergesPerWord(ConstraintFactory cf) {
         return cf.from(ScrabbleWordAssignment.class)
-                 .join(ScrabbleCell.class, Joiners.filtering((swa, sc) -> sc.getWordSet().contains(swa) && sc.hasMerge()))
-                 .groupBy((swa, sc) -> swa.getId(), ConstraintCollectors.countBi())
-                 .reward("Maximize merges per word", HardMediumSoftScore.ONE_MEDIUM, (id, count) -> count * count);
+                .join(ScrabbleCell.class, Joiners.filtering((swa, sc) -> sc.getWordSet().contains(swa) && sc.hasMerge()))
+                .groupBy((swa, sc) -> swa.getId(), ConstraintCollectors.countBi())
+                .reward("Maximize merges per word", HardMediumSoftScore.ONE_MEDIUM, (id, count) -> count * count);
     }
 
     private Constraint pullToCenter(ConstraintFactory cf) {
         return cf.from(ScrabbleWordAssignment.class)
-                 .penalize("Pull to the center", HardMediumSoftScore.ONE_SOFT, ScrabbleWordAssignment::getDistanceToCenter);
+                .penalize("Pull to the center", HardMediumSoftScore.ONE_SOFT, ScrabbleWordAssignment::getDistanceToCenter);
     }
-
 }

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/scrabble/optional/score/ScrabbleConstraintProvider.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/scrabble/optional/score/ScrabbleConstraintProvider.java
@@ -1,0 +1,69 @@
+package org.optaplanner.examples.scrabble.optional.score;
+
+import org.optaplanner.core.api.score.buildin.hardmediumsoft.HardMediumSoftScore;
+import org.optaplanner.core.api.score.stream.Constraint;
+import org.optaplanner.core.api.score.stream.ConstraintCollectors;
+import org.optaplanner.core.api.score.stream.ConstraintFactory;
+import org.optaplanner.core.api.score.stream.ConstraintProvider;
+import org.optaplanner.core.impl.score.stream.bi.FilteringBiJoiner;
+import org.optaplanner.examples.scrabble.domain.ScrabbleWordDirection;
+import org.optaplanner.examples.scrabble.domain.ScrabbleCell;
+import org.optaplanner.examples.scrabble.domain.ScrabbleWordAssignment;
+
+public class ScrabbleConstraintProvider implements ConstraintProvider {
+
+    @Override
+    public Constraint[] defineConstraints(ConstraintFactory constraintFactory) {
+        return new Constraint[]{
+                                characterConflict(constraintFactory),
+                                noParallelHorizontalNeighbours(constraintFactory),
+                                noParallelVerticalNeighbours(constraintFactory),
+                                outOfGrid(constraintFactory),
+                                maximizeMergesPerWord(constraintFactory),
+                                pullToCenter(constraintFactory)
+        };
+    }
+
+    private Constraint characterConflict(ConstraintFactory cf) {
+        return cf.from(ScrabbleCell.class)
+                 .filter(sc -> sc.getCharacterSet().size() >= 2)
+                 .penalize("Character confict", HardMediumSoftScore.ONE_HARD, sc -> 1 - sc.getCharacterSet().size());
+    }
+
+    private Constraint noParallelHorizontalNeighbours(ConstraintFactory cf) {
+        return cf.fromUniquePair(ScrabbleCell.class)
+                 .filter((c1, c2) -> c1.getX() == c2.getX() &&
+                                     Math.abs(c1.getY() - c2.getY()) == 1 &&
+                                     c1.hasWordSet(ScrabbleWordDirection.HORIZONTAL) &&
+                                     c2.hasWordSet(ScrabbleWordDirection.HORIZONTAL))
+                 .penalize("No parallel horizontal neighbours", HardMediumSoftScore.ONE_HARD);
+    }
+
+    private Constraint noParallelVerticalNeighbours(ConstraintFactory cf) {
+        return cf.fromUniquePair(ScrabbleCell.class)
+                 .filter((c1, c2) -> c1.getY() == c2.getY() &&
+                                     Math.abs(c1.getX() - c2.getX()) == 1 &&
+                                     c1.hasWordSet(ScrabbleWordDirection.VERTICAL) &&
+                                     c2.hasWordSet(ScrabbleWordDirection.VERTICAL))
+                 .penalize("No parallel vertical neighbours", HardMediumSoftScore.ONE_HARD);
+    }
+
+    private Constraint outOfGrid(ConstraintFactory cf) {
+        return cf.from(ScrabbleWordAssignment.class)
+                 .filter(ScrabbleWordAssignment::isOutOfGrid)
+                 .penalize("Out of grid", HardMediumSoftScore.ONE_HARD, swa -> swa.getWord().length());
+    }
+
+    private Constraint maximizeMergesPerWord(ConstraintFactory cf) {
+        return cf.from(ScrabbleWordAssignment.class)
+                 .join(ScrabbleCell.class, new FilteringBiJoiner<>((swa, sc) -> sc.getWordSet().contains(swa) && sc.hasMerge()))
+                 .groupBy((swa, sc) -> swa.getId(), ConstraintCollectors.countBi())
+                 .penalize("Maximize merges per word", HardMediumSoftScore.ONE_MEDIUM, (id, count) -> count * count);
+    }
+
+    private Constraint pullToCenter(ConstraintFactory cf) {
+        return cf.from(ScrabbleWordAssignment.class)
+                 .penalize("Pull to the center", HardMediumSoftScore.ONE_SOFT, (swa) -> swa.getDistanceToCenter());
+    }
+
+}

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/scrabble/optional/score/ScrabbleConstraintProvider.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/scrabble/optional/score/ScrabbleConstraintProvider.java
@@ -5,7 +5,7 @@ import org.optaplanner.core.api.score.stream.Constraint;
 import org.optaplanner.core.api.score.stream.ConstraintCollectors;
 import org.optaplanner.core.api.score.stream.ConstraintFactory;
 import org.optaplanner.core.api.score.stream.ConstraintProvider;
-import org.optaplanner.core.impl.score.stream.bi.FilteringBiJoiner;
+import org.optaplanner.core.api.score.stream.Joiners;
 import org.optaplanner.examples.scrabble.domain.ScrabbleWordDirection;
 import org.optaplanner.examples.scrabble.domain.ScrabbleCell;
 import org.optaplanner.examples.scrabble.domain.ScrabbleWordAssignment;
@@ -27,24 +27,24 @@ public class ScrabbleConstraintProvider implements ConstraintProvider {
     private Constraint characterConflict(ConstraintFactory cf) {
         return cf.from(ScrabbleCell.class)
                  .filter(sc -> sc.getCharacterSet().size() >= 2)
-                 .penalize("Character confict", HardMediumSoftScore.ONE_HARD, sc -> 1 - sc.getCharacterSet().size());
+                 .penalize("Character confict", HardMediumSoftScore.ONE_HARD, sc -> sc.getCharacterSet().size() - 1);
     }
 
     private Constraint noParallelHorizontalNeighbours(ConstraintFactory cf) {
-        return cf.fromUniquePair(ScrabbleCell.class)
-                 .filter((c1, c2) -> c1.getX() == c2.getX() &&
-                                     Math.abs(c1.getY() - c2.getY()) == 1 &&
-                                     c1.hasWordSet(ScrabbleWordDirection.HORIZONTAL) &&
-                                     c2.hasWordSet(ScrabbleWordDirection.HORIZONTAL))
+        return cf.from(ScrabbleCell.class).filter(sc -> sc.hasWordSet(ScrabbleWordDirection.HORIZONTAL))
+                 .join(ScrabbleCell.class,
+                       Joiners.equal(ScrabbleCell::getX), Joiners.lessThan(ScrabbleCell::getId),
+                       Joiners.filtering((first, other) -> other.hasWordSet(ScrabbleWordDirection.HORIZONTAL)))
+                 .filter((c1, c2) -> Math.abs(c1.getY() - c2.getY()) == 1)
                  .penalize("No parallel horizontal neighbours", HardMediumSoftScore.ONE_HARD);
     }
 
     private Constraint noParallelVerticalNeighbours(ConstraintFactory cf) {
-        return cf.fromUniquePair(ScrabbleCell.class)
-                 .filter((c1, c2) -> c1.getY() == c2.getY() &&
-                                     Math.abs(c1.getX() - c2.getX()) == 1 &&
-                                     c1.hasWordSet(ScrabbleWordDirection.VERTICAL) &&
-                                     c2.hasWordSet(ScrabbleWordDirection.VERTICAL))
+        return cf.from(ScrabbleCell.class).filter(sc -> sc.hasWordSet(ScrabbleWordDirection.VERTICAL))
+                 .join(ScrabbleCell.class,
+                       Joiners.equal(ScrabbleCell::getY), Joiners.lessThan(ScrabbleCell::getId),
+                       Joiners.filtering((first, other) -> other.hasWordSet(ScrabbleWordDirection.VERTICAL)))
+                 .filter((c1, c2) -> Math.abs(c1.getX() - c2.getX()) == 1)
                  .penalize("No parallel vertical neighbours", HardMediumSoftScore.ONE_HARD);
     }
 
@@ -56,9 +56,9 @@ public class ScrabbleConstraintProvider implements ConstraintProvider {
 
     private Constraint maximizeMergesPerWord(ConstraintFactory cf) {
         return cf.from(ScrabbleWordAssignment.class)
-                 .join(ScrabbleCell.class, new FilteringBiJoiner<>((swa, sc) -> sc.getWordSet().contains(swa) && sc.hasMerge()))
+                 .join(ScrabbleCell.class, Joiners.filtering((swa, sc) -> sc.getWordSet().contains(swa) && sc.hasMerge()))
                  .groupBy((swa, sc) -> swa.getId(), ConstraintCollectors.countBi())
-                 .penalize("Maximize merges per word", HardMediumSoftScore.ONE_MEDIUM, (id, count) -> count * count);
+                 .reward("Maximize merges per word", HardMediumSoftScore.ONE_MEDIUM, (id, count) -> count * count);
     }
 
     private Constraint pullToCenter(ConstraintFactory cf) {

--- a/optaplanner-examples/src/main/resources/org/optaplanner/examples/scrabble/solver/scrabbleSolverConfig.xml
+++ b/optaplanner-examples/src/main/resources/org/optaplanner/examples/scrabble/solver/scrabbleSolverConfig.xml
@@ -10,11 +10,11 @@
 
   <!-- Score configuration -->
   <scoreDirectorFactory>
-    <constraintProviderClass>org.optaplanner.examples.scrabble.optional.score.ScrabbleConstraintProvider</constraintProviderClass>
+    <!--<constraintProviderClass>org.optaplanner.examples.scrabble.optional.score.ScrabbleConstraintProvider</constraintProviderClass>-->
+    <scoreDrl>org/optaplanner/examples/scrabble/solver/scrabbleScoreRules.drl</scoreDrl>
+    <!--<assertionScoreDirectorFactory>-->
+      <!--<scoreDrl>org/optaplanner/examples/scrabble/solver/scrabbleScoreRules.drl</scoreDrl>-->
+    <!--</assertionScoreDirectorFactory> -->
     <initializingScoreTrend>ONLY_DOWN</initializingScoreTrend>
-    <assertionScoreDirectorFactory>
-      <scoreDrl>org/optaplanner/examples/scrabble/solver/scrabbleScoreRules.drl</scoreDrl>
-      <initializingScoreTrend>ONLY_DOWN</initializingScoreTrend>
-    </assertionScoreDirectorFactory>
   </scoreDirectorFactory>
 </solver>

--- a/optaplanner-examples/src/main/resources/org/optaplanner/examples/scrabble/solver/scrabbleSolverConfig.xml
+++ b/optaplanner-examples/src/main/resources/org/optaplanner/examples/scrabble/solver/scrabbleSolverConfig.xml
@@ -6,7 +6,6 @@
   <solutionClass>org.optaplanner.examples.scrabble.domain.ScrabbleSolution</solutionClass>
   <entityClass>org.optaplanner.examples.scrabble.domain.ScrabbleWordAssignment</entityClass>
   <entityClass>org.optaplanner.examples.scrabble.domain.ScrabbleCell</entityClass>
-  <environmentMode>FULL_ASSERT</environmentMode>
 
   <!-- Score configuration -->
   <scoreDirectorFactory>

--- a/optaplanner-examples/src/main/resources/org/optaplanner/examples/scrabble/solver/scrabbleSolverConfig.xml
+++ b/optaplanner-examples/src/main/resources/org/optaplanner/examples/scrabble/solver/scrabbleSolverConfig.xml
@@ -6,10 +6,15 @@
   <solutionClass>org.optaplanner.examples.scrabble.domain.ScrabbleSolution</solutionClass>
   <entityClass>org.optaplanner.examples.scrabble.domain.ScrabbleWordAssignment</entityClass>
   <entityClass>org.optaplanner.examples.scrabble.domain.ScrabbleCell</entityClass>
+  <environmentMode>FULL_ASSERT</environmentMode>
 
   <!-- Score configuration -->
   <scoreDirectorFactory>
-    <scoreDrl>org/optaplanner/examples/scrabble/solver/scrabbleScoreRules.drl</scoreDrl>
+    <constraintProviderClass>org.optaplanner.examples.scrabble.optional.score.ScrabbleConstraintProvider</constraintProviderClass>
     <initializingScoreTrend>ONLY_DOWN</initializingScoreTrend>
+    <assertionScoreDirectorFactory>
+      <scoreDrl>org/optaplanner/examples/scrabble/solver/scrabbleScoreRules.drl</scoreDrl>
+      <initializingScoreTrend>ONLY_DOWN</initializingScoreTrend>
+    </assertionScoreDirectorFactory>
   </scoreDirectorFactory>
 </solver>

--- a/optaplanner-examples/src/test/java/org/optaplanner/examples/scrabble/app/ScrabblePerformanceTest.java
+++ b/optaplanner-examples/src/test/java/org/optaplanner/examples/scrabble/app/ScrabblePerformanceTest.java
@@ -41,7 +41,7 @@ public class ScrabblePerformanceTest extends SolverPerformanceTest<ScrabbleSolut
     @Test(timeout = 600000)
     public void solveModel() {
         File unsolvedDataFile = new File("data/scrabble/unsolved/jbossProjects.xml");
-        runSpeedTest(unsolvedDataFile, "0hard/328medium/-1165soft", EnvironmentMode.FULL_ASSERT);
+        runSpeedTest(unsolvedDataFile, "0hard/328medium/-1165soft");
     }
 
     @Test(timeout = 600000)

--- a/optaplanner-examples/src/test/java/org/optaplanner/examples/scrabble/app/ScrabblePerformanceTest.java
+++ b/optaplanner-examples/src/test/java/org/optaplanner/examples/scrabble/app/ScrabblePerformanceTest.java
@@ -40,8 +40,8 @@ public class ScrabblePerformanceTest extends SolverPerformanceTest<ScrabbleSolut
 
     @Test(timeout = 600000)
     public void solveModel() {
-        File unsolvedDataFile = new File("data/scrabble/unsolved/jbossProjects.xml");
-        runSpeedTest(unsolvedDataFile, "0hard/328medium/-1165soft");
+        // File unsolvedDataFile = new File("data/scrabble/unsolved/jbossProjects.xml");
+        // runSpeedTest(unsolvedDataFile, "0hard/328medium/-1165soft", EnvironmentMode.FULL_ASSERT);
     }
 
     @Test(timeout = 600000)

--- a/optaplanner-examples/src/test/java/org/optaplanner/examples/scrabble/app/ScrabblePerformanceTest.java
+++ b/optaplanner-examples/src/test/java/org/optaplanner/examples/scrabble/app/ScrabblePerformanceTest.java
@@ -40,8 +40,8 @@ public class ScrabblePerformanceTest extends SolverPerformanceTest<ScrabbleSolut
 
     @Test(timeout = 600000)
     public void solveModel() {
-        // File unsolvedDataFile = new File("data/scrabble/unsolved/jbossProjects.xml");
-        // runSpeedTest(unsolvedDataFile, "0hard/328medium/-1165soft", EnvironmentMode.FULL_ASSERT);
+        File unsolvedDataFile = new File("data/scrabble/unsolved/jbossProjects.xml");
+        runSpeedTest(unsolvedDataFile, "0hard/328medium/-1165soft", EnvironmentMode.FULL_ASSERT);
     }
 
     @Test(timeout = 600000)


### PR DESCRIPTION
Note: FAST_ASSERT passes, but FULL_ASSERT fails

```
[ERROR] Tests run: 2, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 7.996 s <<< FAILURE! - in org.optaplanner.examples.scrabble.app.ScrabblePerformanceTest
[ERROR] solveModel[0: NONE]  Time elapsed: 7.994 s  <<< ERROR!
java.lang.IllegalStateException: 
Score corruption (4hard): the workingScore (-130init/2hard/0medium/-13soft) is not the uncorruptedScore (-130init/-2hard/0medium/-13soft) after completedAction ([ OPTAPLANNER  {HORIZONTAL -> HORIZONTAL},  OPTAPLANNER  {(1,20) -> (1,20)}]):
Score corruption analysis:
  The corrupted scoreDirector has 4 ConstraintMatch(s) which are in excess (and should not be there):
    org.optaplanner.examples.scrabble.domain/Character confict/[(12,20)]=1hard/0medium/0soft
    org.optaplanner.examples.scrabble.domain/Character confict/[(13,20)]=1hard/0medium/0soft
    org.optaplanner.examples.scrabble.domain/Pull to the center/[ MICROCONTAINER ]=0hard/0medium/0soft
    org.optaplanner.examples.scrabble.domain/Pull to the center/[ OPTAPLANNER ]=0hard/0medium/-13soft
  The corrupted scoreDirector has 136 ConstraintMatch(s) which are missing:
    org.optaplanner.examples.scrabble.solver/Character confict/[(12,20)]=-1hard/0medium/0soft
    org.optaplanner.examples.scrabble.solver/Character confict/[(13,20)]=-1hard/0medium/0soft
    org.optaplanner.examples.scrabble.solver/Maximize merges per word/[0,  AEROGEAR ]=0hard/0medium/0soft
    org.optaplanner.examples.scrabble.solver/Maximize merges per word/[0,  ACTIVEMQ ]=0hard/0medium/0soft
    org.optaplanner.examples.scrabble.solver/Maximize merges per word/[0,  CAMEL ]=0hard/0medium/0soft
    org.optaplanner.examples.scrabble.solver/Maximize merges per word/[0,  CXF ]=0hard/0medium/0soft
    org.optaplanner.examples.scrabble.solver/Maximize merges per word/[0,  KARAF ]=0hard/0medium/0soft
    org.optaplanner.examples.scrabble.solver/Maximize merges per word/[0,  SERVICEMIX ]=0hard/0medium/0soft
    ... 128 more
  Maybe there is a bug in the score constraints of those ConstraintMatch(s).
  Maybe a score constraint doesn't select all the entities it depends on, but finds some through a reference in a selected entity. This corrupts incremental score calculation, because the constraint is not re-evaluated if such a non-selected entity changes.
Shadow variable corruption in the corrupted scoreDirector:
  None
	at org.optaplanner.core.impl.score.director.AbstractScoreDirector.assertScoreFromScratch(AbstractScoreDirector.java:663)
	at org.optaplanner.core.impl.score.director.AbstractScoreDirector.assertWorkingScoreFromScratch(AbstractScoreDirector.java:641)
	at org.optaplanner.core.impl.score.director.AbstractScoreDirector.doAndProcessMove(AbstractScoreDirector.java:191)
	at org.optaplanner.core.impl.constructionheuristic.decider.ConstructionHeuristicDecider.doMove(ConstructionHeuristicDecider.java:126)
	at org.optaplanner.core.impl.constructionheuristic.decider.ConstructionHeuristicDecider.decideNextStep(ConstructionHeuristicDecider.java:100)
	at org.optaplanner.core.impl.constructionheuristic.DefaultConstructionHeuristicPhase.solve(DefaultConstructionHeuristicPhase.java:74)
	at org.optaplanner.core.impl.solver.AbstractSolver.runPhases(AbstractSolver.java:98)
	at org.optaplanner.core.impl.solver.DefaultSolver.solve(DefaultSolver.java:189)
	at org.optaplanner.examples.common.app.SolverPerformanceTest.runSpeedTest(SolverPerformanceTest.java:98)
	at org.optaplanner.examples.scrabble.app.ScrabblePerformanceTest.solveModel(ScrabblePerformanceTest.java:44)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:298)
	at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:292)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.lang.Thread.run(Thread.java:748)
```