### PR TITLE
PLANNER-1329 Links to ICON challenge in documentation do not work

### DIFF
--- a/optaplanner-docs/src/main/asciidoc/UseCasesAndExamples/CheapTime/CheapTime-section.adoc
+++ b/optaplanner-docs/src/main/asciidoc/UseCasesAndExamples/CheapTime/CheapTime-section.adoc
@@ -27,7 +27,7 @@ Soft constraints (addendum to the original problem definition):
 
 * Start early: prefer starting a task sooner rather than later.
 
-The problem is defined by the ICON challenge.
+The problem is defined by the ICON challenge 2014.
 
 
 [[cheapTimeSchedulingProblemSize]]

--- a/optaplanner-docs/src/main/asciidoc/UseCasesAndExamples/CheapTime/CheapTime-section.adoc
+++ b/optaplanner-docs/src/main/asciidoc/UseCasesAndExamples/CheapTime/CheapTime-section.adoc
@@ -27,7 +27,7 @@ Soft constraints (addendum to the original problem definition):
 
 * Start early: prefer starting a task sooner rather than later.
 
-The problem is defined by http://iconchallenge.insight-centre.org/[the ICON challenge].
+The problem is defined by the ICON challenge.
 
 
 [[cheapTimeSchedulingProblemSize]]

--- a/optaplanner-docs/src/main/asciidoc/UseCasesAndExamples/ExamplesOverview/ExamplesOverview-section.adoc
+++ b/optaplanner-docs/src/main/asciidoc/UseCasesAndExamples/ExamplesOverview/ExamplesOverview-section.adoc
@@ -204,7 +204,7 @@ and also in git under [path]_optaplanner/optaplanner-examples_.
 * Value <= `100` and <= `288`
 * Search space <= `10^20078`
 |* Nearly realistic
-* http://iconchallenge.insight-centre.org/challenge-energy[ICON Energy]
+* ICON Energy
 |* <<annotationAlternatives,Field annotations>>
 * <<valueRangeFactory,ValueRangeFactory>>
 

--- a/optaplanner-docs/src/main/asciidoc/UseCasesAndExamples/ExamplesOverview/ExamplesOverview-section.adoc
+++ b/optaplanner-docs/src/main/asciidoc/UseCasesAndExamples/ExamplesOverview/ExamplesOverview-section.adoc
@@ -204,7 +204,7 @@ and also in git under [path]_optaplanner/optaplanner-examples_.
 * Value <= `100` and <= `288`
 * Search space <= `10^20078`
 |* Nearly realistic
-* ICON Energy
+* ICON challenge 2014
 |* <<annotationAlternatives,Field annotations>>
 * <<valueRangeFactory,ValueRangeFactory>>
 


### PR DESCRIPTION
That page simply doesn't exist any more, but bad links are forbidden, even if we loose the URL information because of this.