### PR TITLE
[PLANNER-1851] Add MOXy for JAXB JSON binding in optaplanner-persistence-jaxb

### DIFF
--- a/optaplanner-persistence/optaplanner-persistence-jaxb/pom.xml
+++ b/optaplanner-persistence/optaplanner-persistence-jaxb/pom.xml
@@ -55,21 +55,26 @@
       <artifactId>jboss-jaxb-api_2.3_spec</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.sun.xml.bind</groupId>
-      <artifactId>jaxb-core</artifactId>
+      <groupId>org.glassfish.jaxb</groupId>
+      <artifactId>jaxb-runtime</artifactId>
+      <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>jakarta.xml.bind</groupId>
+          <artifactId>jakarta.xml.bind-api</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
-      <groupId>com.sun.xml.bind</groupId>
-      <artifactId>jaxb-impl</artifactId>
+      <groupId>org.glassfish</groupId>
+      <artifactId>jakarta.json</artifactId>
+      <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>javax.activation</groupId>
-      <artifactId>activation</artifactId>
-    </dependency>
-    <!-- MOXy needed for JSON -->
+    <!-- MOXy needed as JAXB JSON provider -->
     <dependency>
       <groupId>org.eclipse.persistence</groupId>
       <artifactId>org.eclipse.persistence.moxy</artifactId>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 

--- a/optaplanner-persistence/optaplanner-persistence-jaxb/pom.xml
+++ b/optaplanner-persistence/optaplanner-persistence-jaxb/pom.xml
@@ -66,6 +66,11 @@
       <groupId>javax.activation</groupId>
       <artifactId>activation</artifactId>
     </dependency>
+    <!-- MOXy needed for JSON -->
+    <dependency>
+      <groupId>org.eclipse.persistence</groupId>
+      <artifactId>org.eclipse.persistence.moxy</artifactId>
+    </dependency>
   </dependencies>
 
   <build>

--- a/optaplanner-persistence/optaplanner-persistence-jaxb/src/test/java/org/optaplanner/persistence/jaxb/api/score/AbstractScoreJaxbXmlAdapterTest.java
+++ b/optaplanner-persistence/optaplanner-persistence-jaxb/src/test/java/org/optaplanner/persistence/jaxb/api/score/AbstractScoreJaxbXmlAdapterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,11 +19,14 @@ package org.optaplanner.persistence.jaxb.api.score;
 import java.io.Serializable;
 import java.io.StringReader;
 import java.io.StringWriter;
+
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBException;
 import javax.xml.bind.Marshaller;
 import javax.xml.bind.Unmarshaller;
 
+import org.eclipse.persistence.jaxb.MarshallerProperties;
+import org.eclipse.persistence.jaxb.UnmarshallerProperties;
 import org.optaplanner.core.api.score.Score;
 
 import static org.junit.Assert.*;
@@ -35,6 +38,11 @@ public abstract class AbstractScoreJaxbXmlAdapterTest {
     // ************************************************************************
 
     protected <S extends Score, W extends TestScoreWrapper<S>> void assertSerializeAndDeserialize(S expectedScore, W input) {
+        assertSerializeAndDeserializeXML(expectedScore, input);
+        assertSerializeAndDeserializeJson(expectedScore, input);
+    }
+
+    protected <S extends Score, W extends TestScoreWrapper<S>> void assertSerializeAndDeserializeXML(S expectedScore, W input) {
         String xmlString;
         W output;
         try {
@@ -64,6 +72,53 @@ public abstract class AbstractScoreJaxbXmlAdapterTest {
         }
         if (!xmlString.matches(regex)) {
             fail("Regular expression match failed.\nExpected regular expression: " + regex + "\nActual string: " + xmlString);
+        }
+    }
+
+    protected <S extends Score, W extends TestScoreWrapper<S>> void assertSerializeAndDeserializeJson(S expectedScore, W input) {
+        System.setProperty("javax.xml.bind.context.factory", "org.eclipse.persistence.jaxb.JAXBContextFactory");
+
+        String jsonString;
+        W output;
+        try {
+            JAXBContext jaxbContext = JAXBContext.newInstance(input.getClass());
+
+            Marshaller jaxbMarshaller = jaxbContext.createMarshaller();
+            jaxbMarshaller.setProperty(MarshallerProperties.MEDIA_TYPE, "application/json");
+            jaxbMarshaller.setProperty(MarshallerProperties.JSON_INCLUDE_ROOT, true);
+            jaxbMarshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, true);
+            StringWriter writer = new StringWriter();
+            jaxbMarshaller.marshal(input, writer);
+            jsonString = writer.toString();
+
+            Unmarshaller unmarshaller = jaxbContext.createUnmarshaller();
+            unmarshaller.setProperty(UnmarshallerProperties.MEDIA_TYPE, "application/json");
+            unmarshaller.setProperty(UnmarshallerProperties.JSON_INCLUDE_ROOT, true);
+
+            StringReader reader = new StringReader(jsonString);
+            output = (W) unmarshaller.unmarshal(reader);
+
+            System.clearProperty("javax.xml.bind.context.factory");
+        } catch (JAXBException e) {
+            throw new IllegalStateException("Marshalling or unmarshalling for input (" + input + ") failed.", e);
+        }
+        assertEquals(expectedScore, output.getScore());
+        String regex;
+        if (expectedScore != null) {
+            regex = "\\{\n" // Opening bracket
+                    + "\\s*\"([\\w]+)\"\\s:\\s\\{\n" // Start of element
+                    + "\\s*\"score\"\\s:\\s\"" // Start of element
+                    + expectedScore.toString().replaceAll("\\[", "\\\\[").replaceAll("\\]", "\\\\]") // Score
+                    + "\"\\s*\\}\n" // End of element
+                    + "\\}"; // Closing bracket
+        } else {
+            regex = "\\{\n" // Opening bracket
+                    + "\\s*\"([\\w]+)\"\\s:\\s\\{\n" // Start of element
+                    + "\\s*\\}\n" // End of element
+                    + "\\}"; // Closing bracket
+        }
+        if (!jsonString.matches(regex)) {
+            fail("Regular expression match failed.\nExpected regular expression: " + regex + "\nActual string: " + jsonString);
         }
     }
 

--- a/optaplanner-persistence/optaplanner-persistence-jaxb/src/test/java/org/optaplanner/persistence/jaxb/api/score/buildin/bendable/BendableScoreJaxbXmlAdapterTest.java
+++ b/optaplanner-persistence/optaplanner-persistence-jaxb/src/test/java/org/optaplanner/persistence/jaxb/api/score/buildin/bendable/BendableScoreJaxbXmlAdapterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,8 +28,10 @@ public class BendableScoreJaxbXmlAdapterTest extends AbstractScoreJaxbXmlAdapter
     @Test
     public void serializeAndDeserialize() {
         assertSerializeAndDeserialize(null, new TestBendableScoreWrapper(null));
+
         BendableScore score = BendableScore.of(new int[]{1000, 200}, new int[]{34});
         assertSerializeAndDeserialize(score, new TestBendableScoreWrapper(score));
+
         score = BendableScore.ofUninitialized(-7, new int[]{1000, 200}, new int[]{34});
         assertSerializeAndDeserialize(score, new TestBendableScoreWrapper(score));
     }

--- a/optaplanner-persistence/optaplanner-persistence-jaxb/src/test/java/org/optaplanner/persistence/jaxb/api/score/buildin/bendablebigdecimal/BendableBigDecimalScoreJaxbXmlAdapterTest.java
+++ b/optaplanner-persistence/optaplanner-persistence-jaxb/src/test/java/org/optaplanner/persistence/jaxb/api/score/buildin/bendablebigdecimal/BendableBigDecimalScoreJaxbXmlAdapterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,9 +29,11 @@ public class BendableBigDecimalScoreJaxbXmlAdapterTest extends AbstractScoreJaxb
     @Test
     public void serializeAndDeserialize() {
         assertSerializeAndDeserialize(null, new TestBendableBigDecimalScoreWrapper(null));
+
         BendableBigDecimalScore score = BendableBigDecimalScore.of(
                 new BigDecimal[]{new BigDecimal("1000.0001"), new BigDecimal("200.0020")}, new BigDecimal[]{new BigDecimal("34.4300")});
         assertSerializeAndDeserialize(score, new TestBendableBigDecimalScoreWrapper(score));
+
         score = BendableBigDecimalScore.ofUninitialized(-7,
                 new BigDecimal[]{new BigDecimal("1000.0001"), new BigDecimal("200.0020")}, new BigDecimal[]{new BigDecimal("34.4300")});
         assertSerializeAndDeserialize(score, new TestBendableBigDecimalScoreWrapper(score));

--- a/optaplanner-persistence/optaplanner-persistence-jaxb/src/test/java/org/optaplanner/persistence/jaxb/api/score/buildin/bendablelong/BendableLongScoreJaxbXmlAdapterTest.java
+++ b/optaplanner-persistence/optaplanner-persistence-jaxb/src/test/java/org/optaplanner/persistence/jaxb/api/score/buildin/bendablelong/BendableLongScoreJaxbXmlAdapterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,8 +28,10 @@ public class BendableLongScoreJaxbXmlAdapterTest extends AbstractScoreJaxbXmlAda
     @Test
     public void serializeAndDeserialize() {
         assertSerializeAndDeserialize(null, new TestBendableLongScoreWrapper(null));
+
         BendableLongScore score = BendableLongScore.of(new long[]{1000L, 200L}, new long[]{34L});
         assertSerializeAndDeserialize(score, new TestBendableLongScoreWrapper(score));
+
         score = BendableLongScore.ofUninitialized(-7, new long[]{1000L, 200L}, new long[]{34L});
         assertSerializeAndDeserialize(score, new TestBendableLongScoreWrapper(score));
     }

--- a/optaplanner-persistence/optaplanner-persistence-jaxb/src/test/java/org/optaplanner/persistence/jaxb/api/score/buildin/hardmediumsoft/HardMediumSoftScoreJaxbXmlAdapterTest.java
+++ b/optaplanner-persistence/optaplanner-persistence-jaxb/src/test/java/org/optaplanner/persistence/jaxb/api/score/buildin/hardmediumsoft/HardMediumSoftScoreJaxbXmlAdapterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,8 +28,10 @@ public class HardMediumSoftScoreJaxbXmlAdapterTest extends AbstractScoreJaxbXmlA
     @Test
     public void serializeAndDeserialize() {
         assertSerializeAndDeserialize(null, new TestHardMediumSoftScoreWrapper(null));
+
         HardMediumSoftScore score = HardMediumSoftScore.of(1200, 30, 4);
         assertSerializeAndDeserialize(score, new TestHardMediumSoftScoreWrapper(score));
+
         score = HardMediumSoftScore.ofUninitialized(-7, 1200, 30, 4);
         assertSerializeAndDeserialize(score, new TestHardMediumSoftScoreWrapper(score));
     }

--- a/optaplanner-persistence/optaplanner-persistence-jaxb/src/test/java/org/optaplanner/persistence/jaxb/api/score/buildin/hardmediumsoftbigdecimal/HardMediumSoftBigDecimalScoreJaxbXmlAdapterTest.java
+++ b/optaplanner-persistence/optaplanner-persistence-jaxb/src/test/java/org/optaplanner/persistence/jaxb/api/score/buildin/hardmediumsoftbigdecimal/HardMediumSoftBigDecimalScoreJaxbXmlAdapterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.optaplanner.persistence.jaxb.api.score.buildin.hardmediumsoftbigdecimal;
 
 import java.math.BigDecimal;

--- a/optaplanner-persistence/optaplanner-persistence-jaxb/src/test/java/org/optaplanner/persistence/jaxb/api/score/buildin/hardmediumsoftlong/HardMediumSoftLongScoreJaxbXmlAdapterTest.java
+++ b/optaplanner-persistence/optaplanner-persistence-jaxb/src/test/java/org/optaplanner/persistence/jaxb/api/score/buildin/hardmediumsoftlong/HardMediumSoftLongScoreJaxbXmlAdapterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,8 +28,10 @@ public class HardMediumSoftLongScoreJaxbXmlAdapterTest extends AbstractScoreJaxb
     @Test
     public void serializeAndDeserialize() {
         assertSerializeAndDeserialize(null, new TestHardMediumSoftLongScoreWrapper(null));
+
         HardMediumSoftLongScore score = HardMediumSoftLongScore.of(1200L, 30L, 4L);
         assertSerializeAndDeserialize(score, new TestHardMediumSoftLongScoreWrapper(score));
+
         score = HardMediumSoftLongScore.ofUninitialized(-7, 1200L, 30L, 4L);
         assertSerializeAndDeserialize(score, new TestHardMediumSoftLongScoreWrapper(score));
     }

--- a/optaplanner-persistence/optaplanner-persistence-jaxb/src/test/java/org/optaplanner/persistence/jaxb/api/score/buildin/hardsoft/HardSoftScoreJaxbXmlAdapterTest.java
+++ b/optaplanner-persistence/optaplanner-persistence-jaxb/src/test/java/org/optaplanner/persistence/jaxb/api/score/buildin/hardsoft/HardSoftScoreJaxbXmlAdapterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,8 +28,10 @@ public class HardSoftScoreJaxbXmlAdapterTest extends AbstractScoreJaxbXmlAdapter
     @Test
     public void serializeAndDeserialize() {
         assertSerializeAndDeserialize(null, new TestHardSoftScoreWrapper(null));
+
         HardSoftScore score = HardSoftScore.of(1200, 34);
         assertSerializeAndDeserialize(score, new TestHardSoftScoreWrapper(score));
+
         score = HardSoftScore.ofUninitialized(-7, 1200, 34);
         assertSerializeAndDeserialize(score, new TestHardSoftScoreWrapper(score));
     }

--- a/optaplanner-persistence/optaplanner-persistence-jaxb/src/test/java/org/optaplanner/persistence/jaxb/api/score/buildin/hardsoftbigdecimal/HardSoftBigDecimalScoreJaxbXmlAdapterTest.java
+++ b/optaplanner-persistence/optaplanner-persistence-jaxb/src/test/java/org/optaplanner/persistence/jaxb/api/score/buildin/hardsoftbigdecimal/HardSoftBigDecimalScoreJaxbXmlAdapterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,8 +29,10 @@ public class HardSoftBigDecimalScoreJaxbXmlAdapterTest extends AbstractScoreJaxb
     @Test
     public void serializeAndDeserialize() {
         assertSerializeAndDeserialize(null, new TestHardSoftBigDecimalScoreWrapper(null));
+
         HardSoftBigDecimalScore score = HardSoftBigDecimalScore.of(new BigDecimal("1200.0021"), new BigDecimal("34.4300"));
         assertSerializeAndDeserialize(score, new TestHardSoftBigDecimalScoreWrapper(score));
+
         score = HardSoftBigDecimalScore.ofUninitialized(-7, new BigDecimal("1200.0021"), new BigDecimal("34.4300"));
         assertSerializeAndDeserialize(score, new TestHardSoftBigDecimalScoreWrapper(score));
     }

--- a/optaplanner-persistence/optaplanner-persistence-jaxb/src/test/java/org/optaplanner/persistence/jaxb/api/score/buildin/hardsoftdouble/HardSoftDoubleScoreJaxbXmlAdapterTest.java
+++ b/optaplanner-persistence/optaplanner-persistence-jaxb/src/test/java/org/optaplanner/persistence/jaxb/api/score/buildin/hardsoftdouble/HardSoftDoubleScoreJaxbXmlAdapterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,8 +28,10 @@ public class HardSoftDoubleScoreJaxbXmlAdapterTest extends AbstractScoreJaxbXmlA
     @Test
     public void serializeAndDeserialize() {
         assertSerializeAndDeserialize(null, new TestHardSoftDoubleScoreWrapper(null));
+
         HardSoftDoubleScore score = HardSoftDoubleScore.of(1200.0021, 34.4300);
         assertSerializeAndDeserialize(score, new TestHardSoftDoubleScoreWrapper(score));
+
         score = HardSoftDoubleScore.ofUninitialized(-7, 1200.0021, 34.4300);
         assertSerializeAndDeserialize(score, new TestHardSoftDoubleScoreWrapper(score));
     }

--- a/optaplanner-persistence/optaplanner-persistence-jaxb/src/test/java/org/optaplanner/persistence/jaxb/api/score/buildin/hardsoftlong/HardSoftLongScoreJaxbXmlAdapterTest.java
+++ b/optaplanner-persistence/optaplanner-persistence-jaxb/src/test/java/org/optaplanner/persistence/jaxb/api/score/buildin/hardsoftlong/HardSoftLongScoreJaxbXmlAdapterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,8 +28,10 @@ public class HardSoftLongScoreJaxbXmlAdapterTest extends AbstractScoreJaxbXmlAda
     @Test
     public void serializeAndDeserialize() {
         assertSerializeAndDeserialize(null, new TestHardSoftLongScoreWrapper(null));
+
         HardSoftLongScore score = HardSoftLongScore.of(1200L, 34L);
         assertSerializeAndDeserialize(score, new TestHardSoftLongScoreWrapper(score));
+
         score = HardSoftLongScore.ofUninitialized(-7, 1200L, 34L);
         assertSerializeAndDeserialize(score, new TestHardSoftLongScoreWrapper(score));
     }

--- a/optaplanner-persistence/optaplanner-persistence-jaxb/src/test/java/org/optaplanner/persistence/jaxb/api/score/buildin/simple/SimpleScoreJaxbXmlAdapterTest.java
+++ b/optaplanner-persistence/optaplanner-persistence-jaxb/src/test/java/org/optaplanner/persistence/jaxb/api/score/buildin/simple/SimpleScoreJaxbXmlAdapterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,8 +28,10 @@ public class SimpleScoreJaxbXmlAdapterTest extends AbstractScoreJaxbXmlAdapterTe
     @Test
     public void serializeAndDeserialize() {
         assertSerializeAndDeserialize(null, new TestSimpleScoreWrapper(null));
+
         SimpleScore score = SimpleScore.of(1234);
         assertSerializeAndDeserialize(score, new TestSimpleScoreWrapper(score));
+
         score = SimpleScore.ofUninitialized(-7, 1234);
         assertSerializeAndDeserialize(score, new TestSimpleScoreWrapper(score));
     }

--- a/optaplanner-persistence/optaplanner-persistence-jaxb/src/test/java/org/optaplanner/persistence/jaxb/api/score/buildin/simplebigdecimal/SimpleBigDecimalScoreJaxbXmlAdapterTest.java
+++ b/optaplanner-persistence/optaplanner-persistence-jaxb/src/test/java/org/optaplanner/persistence/jaxb/api/score/buildin/simplebigdecimal/SimpleBigDecimalScoreJaxbXmlAdapterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,8 +29,10 @@ public class SimpleBigDecimalScoreJaxbXmlAdapterTest extends AbstractScoreJaxbXm
     @Test
     public void serializeAndDeserialize() {
         assertSerializeAndDeserialize(null, new TestSimpleBigDecimalScoreWrapper(null));
+
         SimpleBigDecimalScore score = SimpleBigDecimalScore.of(new BigDecimal("1234.4321"));
         assertSerializeAndDeserialize(score, new TestSimpleBigDecimalScoreWrapper(score));
+
         score = SimpleBigDecimalScore.ofUninitialized(-7, new BigDecimal("1234.4321"));
         assertSerializeAndDeserialize(score, new TestSimpleBigDecimalScoreWrapper(score));
     }

--- a/optaplanner-persistence/optaplanner-persistence-jaxb/src/test/java/org/optaplanner/persistence/jaxb/api/score/buildin/simpledouble/SimpleDoubleScoreJaxbXmlAdapterTest.java
+++ b/optaplanner-persistence/optaplanner-persistence-jaxb/src/test/java/org/optaplanner/persistence/jaxb/api/score/buildin/simpledouble/SimpleDoubleScoreJaxbXmlAdapterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,8 +28,10 @@ public class SimpleDoubleScoreJaxbXmlAdapterTest extends AbstractScoreJaxbXmlAda
     @Test
     public void serializeAndDeserialize() {
         assertSerializeAndDeserialize(null, new TestSimpleDoubleScoreWrapper(null));
+
         SimpleDoubleScore score = SimpleDoubleScore.of(1234.4321);
         assertSerializeAndDeserialize(score, new TestSimpleDoubleScoreWrapper(score));
+
         score = SimpleDoubleScore.ofUninitialized(-7, 1234.4321);
         assertSerializeAndDeserialize(score, new TestSimpleDoubleScoreWrapper(score));
     }

--- a/optaplanner-persistence/optaplanner-persistence-jaxb/src/test/java/org/optaplanner/persistence/jaxb/api/score/buildin/simplelong/SimpleLongScoreJaxbXmlAdapterTest.java
+++ b/optaplanner-persistence/optaplanner-persistence-jaxb/src/test/java/org/optaplanner/persistence/jaxb/api/score/buildin/simplelong/SimpleLongScoreJaxbXmlAdapterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,8 +28,10 @@ public class SimpleLongScoreJaxbXmlAdapterTest extends AbstractScoreJaxbXmlAdapt
     @Test
     public void serializeAndDeserialize() {
         assertSerializeAndDeserialize(null, new TestSimpleLongScoreWrapper(null));
+
         SimpleLongScore score = SimpleLongScore.of(1234L);
         assertSerializeAndDeserialize(score, new TestSimpleLongScoreWrapper(score));
+
         score = SimpleLongScore.ofUninitialized(-7, 1234L);
         assertSerializeAndDeserialize(score, new TestSimpleLongScoreWrapper(score));
     }


### PR DESCRIPTION
Merge with: https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1185
Jira: https://issues.redhat.com/browse/PLANNER-1851

- Adds the MOXy JAXB provider dependency for JSON marshalling support.
- Adds JSON score marshalling tests
