### PR TITLE
sort fields for deterministic order

### DIFF
--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/solution/AbstractSolution.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/solution/AbstractSolution.java
@@ -20,7 +20,9 @@ import java.io.Serializable;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 
@@ -74,7 +76,9 @@ public abstract class AbstractSolution<S extends Score> implements Serializable 
             // The field score should not be included
             return;
         }
-        for (Field field : instanceClass.getDeclaredFields()) {
+        Field[] fields = instanceClass.getDeclaredFields();
+        Arrays.sort(fields, Comparator.comparing(Field::getName));
+        for (Field field : fields) {
             field.setAccessible(true);
             if (isFieldAPlanningEntityPropertyOrPlanningEntityCollectionProperty(field, instanceClass)) {
                 continue;

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/domain/solution/descriptor/SolutionDescriptorTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/domain/solution/descriptor/SolutionDescriptorTest.java
@@ -188,7 +188,7 @@ public class SolutionDescriptorTest {
         solution.setExtraObject(new TestdataValue("extra"));
         solution.setEntityList(Arrays.asList(new TestdataEntity("e1"), new TestdataEntity("e2")));
 
-        assertAllCodesOfCollection(solutionDescriptor.getAllFacts(solution), "e1", "e2", "v1", "v2", "extra");
+        assertAllCodesOfCollection(solutionDescriptor.getAllFacts(solution), "e1", "e2", "extra", "v1", "v2");
     }
 
     @Test
@@ -208,7 +208,7 @@ public class SolutionDescriptorTest {
         solution.setExtraObject(new TestdataValue("extra"));
         solution.setEntityList(Arrays.asList(new TestdataEntity("e1"), new TestdataEntity("e2")));
 
-        assertAllCodesOfCollection(solutionDescriptor.getAllFacts(solution), "e1", "e2", "v1", "v2", "extra");
+        assertAllCodesOfCollection(solutionDescriptor.getAllFacts(solution), "e1", "e2", "extra", "v1", "v2");
     }
 
     // ************************************************************************


### PR DESCRIPTION
The tests in `org.optaplanner.core.impl.domain.solution.descriptor.SolutionDescriptorTest#extendedAbstractSolutionOverridesGetScore` and `extendedAbstractSolution` causes assertion failures due to the order of the elements.

The root cause is that when executing `solutionDescriptor.getAllFacts(solution)` in `SolutionDescriptorTest.java`, it will invoke the `org.optaplanner.core.impl.domain.solution.AbstractSolution.addProblemFactsFromClass`, which calls `java.lang.Class.getDeclaredFields`. The Java8 specification about `getDeclaredFields` is that "The elements in the returned array are not sorted and are not in any particular order", with reference here: https://docs.oracle.com/javase/8/docs/api/java/lang/Class.html. Therefore, this test may fail due to a different order.

In order to make the `for (Field field : instanceClass.getDeclaredFields())` iteration order stable and get rid of this non-deterministic behaviour, this fix is to sort the Field array returned by `getDeclaredFields()` by its name and then change the order of the `assertAllCodesOfCollection` to match with the sorted order.