### PR TITLE
Fix plural forms

### DIFF
--- a/optaplanner-docs/src/main/asciidoc/Integration/Integration-chapter.adoc
+++ b/optaplanner-docs/src/main/asciidoc/Integration/Integration-chapter.adoc
@@ -11,12 +11,12 @@
 [[integrationOverview]]
 == Overview
 
-OptaPlanner's input and output data (the planning problem and the best solution) are plain old JavaBeans (POJO's), so integration with other Java technologies is straightforward.
+OptaPlanner's input and output data (the planning problem and the best solution) are plain old JavaBeans (POJOs), so integration with other Java technologies is straightforward.
 For example:
 
-* To read a planning problem from the database (and store the best solution in it), annotate the domain POJO's with JPA annotations.
-* To read a planning problem from an XML file (and store the best solution in it), annotate the domain POJO's with XStream or JAXB annotations.
-* To expose the Solver as a REST Service that reads the planning problem and responds with the best solution, annotate the domain POJO's with XStream, JAXB or Jackson annotations and hook the `Solver` in Camel or RESTEasy.
+* To read a planning problem from the database (and store the best solution in it), annotate the domain POJOs with JPA annotations.
+* To read a planning problem from an XML file (and store the best solution in it), annotate the domain POJOs with XStream or JAXB annotations.
+* To expose the Solver as a REST Service that reads the planning problem and responds with the best solution, annotate the domain POJOs with XStream, JAXB or Jackson annotations and hook the `Solver` in Camel or RESTEasy.
 
 image::Integration/integrationOverview.png[align="center"]
 
@@ -28,7 +28,7 @@ image::Integration/integrationOverview.png[align="center"]
 [[integrationWithJpaAndHibernate]]
 === Database: JPA and Hibernate
 
-Enrich domain POJO's (solution, entities and problem facts) with JPA annotations
+Enrich domain POJOs (solution, entities and problem facts) with JPA annotations
 to store them in a database by calling `EntityManager.persist()`.
 
 [NOTE]
@@ -189,7 +189,7 @@ Neglecting to do this can lead to persisting duplicate solutions, JPA exceptions
 [[integrationWithXStream]]
 === XML or JSON: XStream
 
-Enrich domain POJO's (solution, entities and problem facts) with XStream annotations to serialize them to/from XML or JSON.
+Enrich domain POJOs (solution, entities and problem facts) with XStream annotations to serialize them to/from XML or JSON.
 
 Add a dependency to the `optaplanner-persistence-xstream` jar to take advantage of these extra integration features:
 
@@ -257,7 +257,7 @@ must always be in sync with those in the solver.
 [[integrationWithJaxb]]
 === XML or JSON: JAXB
 
-Enrich domain POJO's (solution, entities and problem facts) with JAXB annotations to serialize them to/from XML or JSON.
+Enrich domain POJOs (solution, entities and problem facts) with JAXB annotations to serialize them to/from XML or JSON.
 
 Add a dependency to the `optaplanner-persistence-jaxb` jar to take advantage of these extra integration features:
 
@@ -324,7 +324,7 @@ The `hardLevelsSize` and `softLevelsSize` implied, when reading a bendable score
 [[integrationWithJackson]]
 === JSON: Jackson
 
-Enrich domain POJO's (solution, entities and problem facts) with Jackson annotations to serialize them to/from JSON.
+Enrich domain POJOs (solution, entities and problem facts) with Jackson annotations to serialize them to/from JSON.
 
 Add a dependency to the `optaplanner-persistence-jackson` jar and register `OptaPlannerJacksonModule`:
 
@@ -488,7 +488,7 @@ That component works in Karaf too.
 === JBoss Modules, WildFly, and JBoss EAP
 
 Because of JBoss Modules' `ClassLoader` magic, provide the `ClassLoader` of your classes <<solverConfigurationByXML,during the SolverFactory creation>>,
-so it can find the classpath resources (such as the solver config, score DRL's and domain classes) in your jars.
+so it can find the classpath resources (such as the solver config, score DRLs and domain classes) in your jars.
 
 It's also recommended <<customThreadFactory,to plug in WildFly's thread factory>>,
 especially with <<multithreadedSolving,multithreaded solving>>.
@@ -624,7 +624,7 @@ The `optaplanner-core` jar includes OSGi metadata in its `MANIFEST.MF` file to f
 Furthermore, the maven artifact `kie-karaf-features` contains a `features.xml` file that supports the OSGi-feature ``optaplanner-engine``.
 
 Because of the OSGi's `ClassLoader` magic, provide the `ClassLoader` of your classes <<solverConfigurationByXML,during the SolverFactory creation>>,
-so it can find the classpath resources (such as the solver config, score DRL's and domain classes) in your jars.
+so it can find the classpath resources (such as the solver config, score DRLs and domain classes) in your jars.
 
 [NOTE]
 ====

--- a/optaplanner-docs/src/main/asciidoc/LocalSearch/LocalSearch-chapter.adoc
+++ b/optaplanner-docs/src/main/asciidoc/LocalSearch/LocalSearch-chapter.adoc
@@ -312,7 +312,7 @@ Simplest configuration:
   </localSearch>
 ----
 
-When Tabu Search takes steps it creates one or more tabu's.
+When Tabu Search takes steps it creates one or more tabus.
 For a number of steps, it does not accept a move if that move breaks tabu.
 That number of steps is the tabu size.
 Advanced configuration:

--- a/optaplanner-docs/src/main/asciidoc/PlannerConfiguration/PlannerConfiguration-chapter.adoc
+++ b/optaplanner-docs/src/main/asciidoc/PlannerConfiguration/PlannerConfiguration-chapter.adoc
@@ -45,7 +45,7 @@ However, for portability reasons, a classpath resource is recommended.
 
 [NOTE]
 ====
-On some environments (<<integrationWithOSGi,OSGi>>, <<integrationWithJBossModules,JBoss modules>>, ...), classpath resources (such as the solver config, score DRL's and domain classes) in your jars might not be available to the default `ClassLoader` of the `optaplanner-core` jar.
+On some environments (<<integrationWithOSGi,OSGi>>, <<integrationWithJBossModules,JBoss modules>>, ...), classpath resources (such as the solver config, score DRLs and domain classes) in your jars might not be available to the default `ClassLoader` of the `optaplanner-core` jar.
 In those cases, provide the `ClassLoader` of your classes as a parameter:
 
 [source,java,options="nowrap"]

--- a/optaplanner-docs/src/main/asciidoc/ScoreCalculation/ScoreCalculation-chapter.adoc
+++ b/optaplanner-docs/src/main/asciidoc/ScoreCalculation/ScoreCalculation-chapter.adoc
@@ -1115,7 +1115,7 @@ These connect the constraint weight with the constraint implementation.
 *For each constraint weight, there must be a constraint implementation with the same package and the same name.*
 
 * The `@ConstraintConfiguration` annotation has a `constraintPackage` property that defaults to the package of the constraint configuration class.
-Most cases with <<droolsScoreCalculation,Drools score calculation>>, need to override that because the DRL's use another package.
+Most cases with <<droolsScoreCalculation,Drools score calculation>>, need to override that because the DRLs use another package.
 For example, the DRL below uses the package `...conferencescheduling.solver`,
 so the constraint configuration above specifies a `constraintPackage`.
 Cases with <<constraintStreams,Constraint streams>>, normally don't need to specify it.


### PR DESCRIPTION
Replace `'s` (indicates a possessive form) where a plural form was actually intended.