### PR TITLE
PLANNER-1863: toMap() collector

### DIFF
--- a/optaplanner-core/src/main/java/org/optaplanner/core/api/score/stream/ConstraintCollectors.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/api/score/stream/ConstraintCollectors.java
@@ -73,9 +73,6 @@ public final class ConstraintCollectors {
     // count
     // ************************************************************************
 
-    private ConstraintCollectors() {
-    }
-
     public static <A> UniConstraintCollector<A, ?, Integer> count() {
         return new DefaultUniConstraintCollector<>(
                 () -> new int[1],
@@ -146,10 +143,6 @@ public final class ConstraintCollectors {
                 resultContainer -> resultContainer[0]);
     }
 
-    // ************************************************************************
-    // countDistinct
-    // ************************************************************************
-
     public static <A, B, C, D> QuadConstraintCollector<A, B, C, D, ?, Long> countLongQuad() {
         return new DefaultQuadConstraintCollector<>(
                 () -> new long[1],
@@ -159,6 +152,10 @@ public final class ConstraintCollectors {
                 },
                 resultContainer -> resultContainer[0]);
     }
+
+    // ************************************************************************
+    // countDistinct
+    // ************************************************************************
 
     public static <A> UniConstraintCollector<A, ?, Integer> countDistinct(Function<A, ?> groupValueMapping) {
         return new DefaultUniConstraintCollector<>(
@@ -296,6 +293,10 @@ public final class ConstraintCollectors {
         Map<Object, long[]> objectCountMap = new HashMap<>();
     }
 
+    // ************************************************************************
+    // sum
+    // ************************************************************************
+
     public static <A> UniConstraintCollector<A, ?, Integer> sum(ToIntFunction<? super A> groupValueMapping) {
         return new DefaultUniConstraintCollector<>(
                 () -> new int[1],
@@ -306,10 +307,6 @@ public final class ConstraintCollectors {
                 },
                 resultContainer -> resultContainer[0]);
     }
-
-    // ************************************************************************
-    // sum
-    // ************************************************************************
 
     public static <A> UniConstraintCollector<A, ?, Long> sumLong(ToLongFunction<? super A> groupValueMapping) {
         return new DefaultUniConstraintCollector<>(
@@ -1766,6 +1763,9 @@ public final class ConstraintCollectors {
                         .filter(e -> !e.value.isEmpty()) // Filter out keys without values.
                         .collect(Collectors.toMap(e -> e.key, e -> toValue(e.value, mergeFunction),
                                 ConstraintCollectors::throwOnKeyConflict, TreeMap::new)));
+    }
+
+    private ConstraintCollectors() {
     }
 
 }

--- a/optaplanner-core/src/main/java/org/optaplanner/core/api/score/stream/ConstraintCollectors.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/api/score/stream/ConstraintCollectors.java
@@ -1649,7 +1649,7 @@ public final class ConstraintCollectors {
                         .collect(Collectors.toMap(Map.Entry::getKey, e -> toValueSet(e.getValue(), valueSetFunction))));
     }
 
-    public static <A, B, C, D, Key, Value> Runnable toMapAccumulator(
+    private static <A, B, C, D, Key, Value> Runnable toMapAccumulator(
             QuadFunction<? super A, ? super B, ? super C, ? super D, ? extends Key> keyMapper,
             QuadFunction<? super A, ? super B, ? super C, ? super D, ? extends Value> valueMapper,
             ToMapResultContainer<Key, Value> resultContainer, A a, B b, C c, D d) {

--- a/optaplanner-core/src/main/java/org/optaplanner/core/api/score/stream/ConstraintCollectors.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/api/score/stream/ConstraintCollectors.java
@@ -44,6 +44,7 @@ import java.util.function.ToIntFunction;
 import java.util.function.ToLongBiFunction;
 import java.util.function.ToLongFunction;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.optaplanner.core.api.domain.solution.PlanningSolution;
 import org.optaplanner.core.api.function.QuadFunction;
@@ -1124,9 +1125,9 @@ public final class ConstraintCollectors {
         return new DefaultUniConstraintCollector<>(
                 (Supplier<ToMapResultContainer<Key, Value>>) ToMapResultContainer::new,
                 (resultContainer, a) -> toMapAccumulator(keyMapper, valueMapper, resultContainer, a),
-                resultContainer -> resultContainer.entrySet().stream()
-                        .filter(e -> !e.getValue().isEmpty()) // Filter out keys without values.
-                        .collect(Collectors.toMap(Map.Entry::getKey, e -> toValueSet(e.getValue(), valueSetFunction))));
+                resultContainer -> resultContainer.entries()
+                        .filter(e -> !e.value.isEmpty()) // Filter out keys without values.
+                        .collect(Collectors.toMap(e -> e.key, e -> toValueSet(e.value, valueSetFunction))));
     }
 
     private static final class ToMapPerKeyCounter<Value> {
@@ -1160,6 +1161,18 @@ public final class ConstraintCollectors {
 
     }
 
+    private static final class Tuple<Key, Value> {
+
+        public final Key key;
+        public final Value value;
+
+        public Tuple(Key key, Value value) {
+            this.key = key;
+            this.value = value;
+        }
+
+    }
+
     private static final class ToMapResultContainer<Key, Value> {
 
         private final Map<Key, ToMapPerKeyCounter<Value>> valueCounts = new HashMap<>(0);
@@ -1177,11 +1190,10 @@ public final class ConstraintCollectors {
             }
         }
 
-        public Set<Map.Entry<Key, Set<Value>>> entrySet() {
+        public Stream<Tuple<Key, Set<Value>>> entries() {
             return valueCounts.entrySet()
                     .stream()
-                    .collect(Collectors.toMap(Map.Entry::getKey, e -> e.getValue().getValues()))
-                    .entrySet();
+                    .map(e -> new Tuple<>(e.getKey(), e.getValue().getValues()));
         }
 
     }
@@ -1230,9 +1242,9 @@ public final class ConstraintCollectors {
         return new DefaultUniConstraintCollector<>(
                 (Supplier<ToMapResultContainer<Key, Value>>) ToMapResultContainer::new,
                 (resultContainer, a) -> toMapAccumulator(keyMapper, valueMapper, resultContainer, a),
-                resultContainer -> resultContainer.entrySet().stream()
-                        .filter(e -> !e.getValue().isEmpty()) // Filter out keys without values.
-                        .collect(Collectors.toMap(Map.Entry::getKey, e -> toValue(e.getValue(), mergeFunction))));
+                resultContainer -> resultContainer.entries()
+                        .filter(e -> e.value.isEmpty()) // Filter out keys without values.
+                        .collect(Collectors.toMap(e -> e.key, e -> toValue(e.value, mergeFunction))));
     }
 
     private static <Value> Value toValue(Set<Value> in, BinaryOperator<Value> mergeFunction) {
@@ -1287,9 +1299,9 @@ public final class ConstraintCollectors {
             return new DefaultUniConstraintCollector<>(
                     (Supplier<ToMapResultContainer<Key, Value>>) ToMapResultContainer::new,
                     (resultContainer, a) -> toMapAccumulator(keyMapper, valueMapper, resultContainer, a),
-                    resultContainer -> resultContainer.entrySet().stream()
-                            .filter(e -> !e.getValue().isEmpty()) // Filter out keys without values.
-                            .collect(Collectors.toMap(Map.Entry::getKey, e -> toValueSet(e.getValue(), valueSetFunction),
+                    resultContainer -> resultContainer.entries()
+                            .filter(e -> e.value.isEmpty()) // Filter out keys without values.
+                            .collect(Collectors.toMap(e -> e.key, e -> toValueSet(e.value, valueSetFunction),
                                     ConstraintCollectors::throwOnKeyConflict, TreeMap::new)));
     }
 
@@ -1317,9 +1329,9 @@ public final class ConstraintCollectors {
         return new DefaultUniConstraintCollector<>(
                 (Supplier<ToMapResultContainer<Key, Value>>) ToMapResultContainer::new,
                 (resultContainer, a) -> toMapAccumulator(keyMapper, valueMapper, resultContainer, a),
-                resultContainer -> resultContainer.entrySet().stream()
-                        .filter(e -> !e.getValue().isEmpty()) // Filter out keys without values.
-                        .collect(Collectors.toMap(Map.Entry::getKey, e -> toValue(e.getValue(), mergeFunction),
+                resultContainer -> resultContainer.entries()
+                        .filter(e -> e.value.isEmpty()) // Filter out keys without values.
+                        .collect(Collectors.toMap(e -> e.key, e -> toValue(e.value, mergeFunction),
                                 ConstraintCollectors::throwOnKeyConflict, TreeMap::new)));
     }
 
@@ -1357,9 +1369,9 @@ public final class ConstraintCollectors {
         return new DefaultBiConstraintCollector<>(
                 (Supplier<ToMapResultContainer<Key, Value>>) ToMapResultContainer::new,
                 (resultContainer, a, b) -> toMapAccumulator(keyMapper, valueMapper, resultContainer, a, b),
-                resultContainer -> resultContainer.entrySet().stream()
-                        .filter(e -> !e.getValue().isEmpty()) // Filter out keys without values.
-                        .collect(Collectors.toMap(Map.Entry::getKey, e -> toValueSet(e.getValue(), valueSetFunction))));
+                resultContainer -> resultContainer.entries()
+                        .filter(e -> e.value.isEmpty()) // Filter out keys without values.
+                        .collect(Collectors.toMap(e -> e.key, e -> toValueSet(e.value, valueSetFunction))));
     }
 
     private static <A, B, Key, Value> Runnable toMapAccumulator(
@@ -1388,9 +1400,9 @@ public final class ConstraintCollectors {
         return new DefaultBiConstraintCollector<>(
                 (Supplier<ToMapResultContainer<Key, Value>>) ToMapResultContainer::new,
                 (resultContainer, a, b) -> toMapAccumulator(keyMapper, valueMapper, resultContainer, a, b),
-                resultContainer -> resultContainer.entrySet().stream()
-                        .filter(e -> !e.getValue().isEmpty()) // Filter out keys without values.
-                        .collect(Collectors.toMap(Map.Entry::getKey, e -> toValue(e.getValue(), mergeFunction))));
+                resultContainer -> resultContainer.entries()
+                        .filter(e -> e.value.isEmpty()) // Filter out keys without values.
+                        .collect(Collectors.toMap(e -> e.key, e -> toValue(e.value, mergeFunction))));
     }
 
     /**
@@ -1428,9 +1440,9 @@ public final class ConstraintCollectors {
         return new DefaultBiConstraintCollector<>(
                 (Supplier<ToMapResultContainer<Key, Value>>) ToMapResultContainer::new,
                 (resultContainer, a, b) -> toMapAccumulator(keyMapper, valueMapper, resultContainer, a, b),
-                resultContainer -> resultContainer.entrySet().stream()
-                        .filter(e -> !e.getValue().isEmpty()) // Filter out keys without values.
-                        .collect(Collectors.toMap(Map.Entry::getKey, e -> toValueSet(e.getValue(), valueSetFunction),
+                resultContainer -> resultContainer.entries()
+                        .filter(e -> e.value.isEmpty()) // Filter out keys without values.
+                        .collect(Collectors.toMap(e -> e.key, e -> toValueSet(e.value, valueSetFunction),
                                 ConstraintCollectors::throwOnKeyConflict, TreeMap::new)));
     }
 
@@ -1451,9 +1463,9 @@ public final class ConstraintCollectors {
         return new DefaultBiConstraintCollector<>(
                 (Supplier<ToMapResultContainer<Key, Value>>) ToMapResultContainer::new,
                 (resultContainer, a, b) -> toMapAccumulator(keyMapper, valueMapper, resultContainer, a, b),
-                resultContainer -> resultContainer.entrySet().stream()
-                        .filter(e -> !e.getValue().isEmpty()) // Filter out keys without values.
-                        .collect(Collectors.toMap(Map.Entry::getKey, e -> toValue(e.getValue(), mergeFunction),
+                resultContainer -> resultContainer.entries()
+                        .filter(e -> e.value.isEmpty()) // Filter out keys without values.
+                        .collect(Collectors.toMap(e -> e.key, e -> toValue(e.value, mergeFunction),
                                 ConstraintCollectors::throwOnKeyConflict, TreeMap::new)));
     }
 
@@ -1495,9 +1507,9 @@ public final class ConstraintCollectors {
         return new DefaultTriConstraintCollector<>(
                 (Supplier<ToMapResultContainer<Key, Value>>) ToMapResultContainer::new,
                 (resultContainer, a, b, c) -> toMapAccumulator(keyMapper, valueMapper, resultContainer, a, b, c),
-                resultContainer -> resultContainer.entrySet().stream()
-                        .filter(e -> !e.getValue().isEmpty()) // Filter out keys without values.
-                        .collect(Collectors.toMap(Map.Entry::getKey, e -> toValueSet(e.getValue(), valueSetFunction))));
+                resultContainer -> resultContainer.entries()
+                        .filter(e -> e.value.isEmpty()) // Filter out keys without values.
+                        .collect(Collectors.toMap(e -> e.key, e -> toValueSet(e.value, valueSetFunction))));
     }
 
     private static <A, B, C, Key, Value> Runnable toMapAccumulator(
@@ -1528,9 +1540,9 @@ public final class ConstraintCollectors {
         return new DefaultTriConstraintCollector<>(
                 (Supplier<ToMapResultContainer<Key, Value>>) ToMapResultContainer::new,
                 (resultContainer, a, b, c) -> toMapAccumulator(keyMapper, valueMapper, resultContainer, a, b, c),
-                resultContainer -> resultContainer.entrySet().stream()
-                        .filter(e -> !e.getValue().isEmpty()) // Filter out keys without values.
-                        .collect(Collectors.toMap(Map.Entry::getKey, e -> toValue(e.getValue(), mergeFunction))));
+                resultContainer -> resultContainer.entries()
+                        .filter(e -> e.value.isEmpty()) // Filter out keys without values.
+                        .collect(Collectors.toMap(e -> e.key, e -> toValue(e.value, mergeFunction))));
     }
 
     /**
@@ -1572,9 +1584,9 @@ public final class ConstraintCollectors {
         return new DefaultTriConstraintCollector<>(
                 (Supplier<ToMapResultContainer<Key, Value>>) ToMapResultContainer::new,
                 (resultContainer, a, b, c) -> toMapAccumulator(keyMapper, valueMapper, resultContainer, a, b, c),
-                resultContainer -> resultContainer.entrySet().stream()
-                        .filter(e -> !e.getValue().isEmpty()) // Filter out keys without values.
-                        .collect(Collectors.toMap(Map.Entry::getKey, e -> toValueSet(e.getValue(), valueSetFunction),
+                resultContainer -> resultContainer.entries()
+                        .filter(e -> e.value.isEmpty()) // Filter out keys without values.
+                        .collect(Collectors.toMap(e -> e.key, e -> toValueSet(e.value, valueSetFunction),
                                 ConstraintCollectors::throwOnKeyConflict, TreeMap::new)));
     }
 
@@ -1598,9 +1610,9 @@ public final class ConstraintCollectors {
         return new DefaultTriConstraintCollector<>(
                 (Supplier<ToMapResultContainer<Key, Value>>) ToMapResultContainer::new,
                 (resultContainer, a, b, c) -> toMapAccumulator(keyMapper, valueMapper, resultContainer, a, b, c),
-                resultContainer -> resultContainer.entrySet().stream()
-                        .filter(e -> !e.getValue().isEmpty()) // Filter out keys without values.
-                        .collect(Collectors.toMap(Map.Entry::getKey, e -> toValue(e.getValue(), mergeFunction),
+                resultContainer -> resultContainer.entries()
+                        .filter(e -> e.value.isEmpty()) // Filter out keys without values.
+                        .collect(Collectors.toMap(e -> e.key, e -> toValue(e.value, mergeFunction),
                                 ConstraintCollectors::throwOnKeyConflict, TreeMap::new)));
     }
 
@@ -1644,9 +1656,9 @@ public final class ConstraintCollectors {
         return new DefaultQuadConstraintCollector<>(
                 (Supplier<ToMapResultContainer<Key, Value>>) ToMapResultContainer::new,
                 (resultContainer, a, b, c, d) -> toMapAccumulator(keyMapper, valueMapper, resultContainer, a, b, c, d),
-                resultContainer -> resultContainer.entrySet().stream()
-                        .filter(e -> !e.getValue().isEmpty()) // Filter out keys without values.
-                        .collect(Collectors.toMap(Map.Entry::getKey, e -> toValueSet(e.getValue(), valueSetFunction))));
+                resultContainer -> resultContainer.entries()
+                        .filter(e -> e.value.isEmpty()) // Filter out keys without values.
+                        .collect(Collectors.toMap(e -> e.key, e -> toValueSet(e.value, valueSetFunction))));
     }
 
     private static <A, B, C, D, Key, Value> Runnable toMapAccumulator(
@@ -1678,9 +1690,9 @@ public final class ConstraintCollectors {
         return new DefaultQuadConstraintCollector<>(
                 (Supplier<ToMapResultContainer<Key, Value>>) ToMapResultContainer::new,
                 (resultContainer, a, b, c, d) -> toMapAccumulator(keyMapper, valueMapper, resultContainer, a, b, c, d),
-                resultContainer -> resultContainer.entrySet().stream()
-                        .filter(e -> !e.getValue().isEmpty()) // Filter out keys without values.
-                        .collect(Collectors.toMap(Map.Entry::getKey, e -> toValue(e.getValue(), mergeFunction))));
+                resultContainer -> resultContainer.entries()
+                        .filter(e -> e.value.isEmpty()) // Filter out keys without values.
+                        .collect(Collectors.toMap(e -> e.key, e -> toValue(e.value, mergeFunction))));
     }
 
     /**
@@ -1724,9 +1736,9 @@ public final class ConstraintCollectors {
         return new DefaultQuadConstraintCollector<>(
                 (Supplier<ToMapResultContainer<Key, Value>>) ToMapResultContainer::new,
                 (resultContainer, a, b, c, d) -> toMapAccumulator(keyMapper, valueMapper, resultContainer, a, b, c, d),
-                resultContainer -> resultContainer.entrySet().stream()
-                        .filter(e -> !e.getValue().isEmpty()) // Filter out keys without values.
-                        .collect(Collectors.toMap(Map.Entry::getKey, e -> toValueSet(e.getValue(), valueSetFunction),
+                resultContainer -> resultContainer.entries()
+                        .filter(e -> e.value.isEmpty()) // Filter out keys without values.
+                        .collect(Collectors.toMap(e -> e.key, e -> toValueSet(e.value, valueSetFunction),
                                 ConstraintCollectors::throwOnKeyConflict, TreeMap::new)));
     }
 
@@ -1751,9 +1763,9 @@ public final class ConstraintCollectors {
         return new DefaultQuadConstraintCollector<>(
                 (Supplier<ToMapResultContainer<Key, Value>>) ToMapResultContainer::new,
                 (resultContainer, a, b, c, d) -> toMapAccumulator(keyMapper, valueMapper, resultContainer, a, b, c, d),
-                resultContainer -> resultContainer.entrySet().stream()
-                        .filter(e -> !e.getValue().isEmpty()) // Filter out keys without values.
-                        .collect(Collectors.toMap(Map.Entry::getKey, e -> toValue(e.getValue(), mergeFunction),
+                resultContainer -> resultContainer.entries()
+                        .filter(e -> e.value.isEmpty()) // Filter out keys without values.
+                        .collect(Collectors.toMap(e -> e.key, e -> toValue(e.value, mergeFunction),
                                 ConstraintCollectors::throwOnKeyConflict, TreeMap::new)));
     }
 

--- a/optaplanner-core/src/main/java/org/optaplanner/core/api/score/stream/ConstraintCollectors.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/api/score/stream/ConstraintCollectors.java
@@ -1242,7 +1242,7 @@ public final class ConstraintCollectors {
                 (Supplier<ToMapResultContainer<Key, Value>>) ToMapResultContainer::new,
                 (resultContainer, a) -> toMapAccumulator(keyMapper, valueMapper, resultContainer, a),
                 resultContainer -> resultContainer.entries()
-                        .filter(e -> e.value.isEmpty()) // Filter out keys without values.
+                        .filter(e -> !e.value.isEmpty()) // Filter out keys without values.
                         .collect(Collectors.toMap(e -> e.key, e -> toValue(e.value, mergeFunction))));
     }
 
@@ -1299,7 +1299,7 @@ public final class ConstraintCollectors {
                     (Supplier<ToMapResultContainer<Key, Value>>) ToMapResultContainer::new,
                     (resultContainer, a) -> toMapAccumulator(keyMapper, valueMapper, resultContainer, a),
                     resultContainer -> resultContainer.entries()
-                            .filter(e -> e.value.isEmpty()) // Filter out keys without values.
+                            .filter(e -> !e.value.isEmpty()) // Filter out keys without values.
                             .collect(Collectors.toMap(e -> e.key, e -> toValueSet(e.value, valueSetFunction),
                                     ConstraintCollectors::throwOnKeyConflict, TreeMap::new)));
     }
@@ -1329,7 +1329,7 @@ public final class ConstraintCollectors {
                 (Supplier<ToMapResultContainer<Key, Value>>) ToMapResultContainer::new,
                 (resultContainer, a) -> toMapAccumulator(keyMapper, valueMapper, resultContainer, a),
                 resultContainer -> resultContainer.entries()
-                        .filter(e -> e.value.isEmpty()) // Filter out keys without values.
+                        .filter(e -> !e.value.isEmpty()) // Filter out keys without values.
                         .collect(Collectors.toMap(e -> e.key, e -> toValue(e.value, mergeFunction),
                                 ConstraintCollectors::throwOnKeyConflict, TreeMap::new)));
     }
@@ -1369,7 +1369,7 @@ public final class ConstraintCollectors {
                 (Supplier<ToMapResultContainer<Key, Value>>) ToMapResultContainer::new,
                 (resultContainer, a, b) -> toMapAccumulator(keyMapper, valueMapper, resultContainer, a, b),
                 resultContainer -> resultContainer.entries()
-                        .filter(e -> e.value.isEmpty()) // Filter out keys without values.
+                        .filter(e -> !e.value.isEmpty()) // Filter out keys without values.
                         .collect(Collectors.toMap(e -> e.key, e -> toValueSet(e.value, valueSetFunction))));
     }
 
@@ -1400,7 +1400,7 @@ public final class ConstraintCollectors {
                 (Supplier<ToMapResultContainer<Key, Value>>) ToMapResultContainer::new,
                 (resultContainer, a, b) -> toMapAccumulator(keyMapper, valueMapper, resultContainer, a, b),
                 resultContainer -> resultContainer.entries()
-                        .filter(e -> e.value.isEmpty()) // Filter out keys without values.
+                        .filter(e -> !e.value.isEmpty()) // Filter out keys without values.
                         .collect(Collectors.toMap(e -> e.key, e -> toValue(e.value, mergeFunction))));
     }
 
@@ -1440,7 +1440,7 @@ public final class ConstraintCollectors {
                 (Supplier<ToMapResultContainer<Key, Value>>) ToMapResultContainer::new,
                 (resultContainer, a, b) -> toMapAccumulator(keyMapper, valueMapper, resultContainer, a, b),
                 resultContainer -> resultContainer.entries()
-                        .filter(e -> e.value.isEmpty()) // Filter out keys without values.
+                        .filter(e -> !e.value.isEmpty()) // Filter out keys without values.
                         .collect(Collectors.toMap(e -> e.key, e -> toValueSet(e.value, valueSetFunction),
                                 ConstraintCollectors::throwOnKeyConflict, TreeMap::new)));
     }
@@ -1463,7 +1463,7 @@ public final class ConstraintCollectors {
                 (Supplier<ToMapResultContainer<Key, Value>>) ToMapResultContainer::new,
                 (resultContainer, a, b) -> toMapAccumulator(keyMapper, valueMapper, resultContainer, a, b),
                 resultContainer -> resultContainer.entries()
-                        .filter(e -> e.value.isEmpty()) // Filter out keys without values.
+                        .filter(e -> !e.value.isEmpty()) // Filter out keys without values.
                         .collect(Collectors.toMap(e -> e.key, e -> toValue(e.value, mergeFunction),
                                 ConstraintCollectors::throwOnKeyConflict, TreeMap::new)));
     }
@@ -1507,7 +1507,7 @@ public final class ConstraintCollectors {
                 (Supplier<ToMapResultContainer<Key, Value>>) ToMapResultContainer::new,
                 (resultContainer, a, b, c) -> toMapAccumulator(keyMapper, valueMapper, resultContainer, a, b, c),
                 resultContainer -> resultContainer.entries()
-                        .filter(e -> e.value.isEmpty()) // Filter out keys without values.
+                        .filter(e -> !e.value.isEmpty()) // Filter out keys without values.
                         .collect(Collectors.toMap(e -> e.key, e -> toValueSet(e.value, valueSetFunction))));
     }
 
@@ -1540,7 +1540,7 @@ public final class ConstraintCollectors {
                 (Supplier<ToMapResultContainer<Key, Value>>) ToMapResultContainer::new,
                 (resultContainer, a, b, c) -> toMapAccumulator(keyMapper, valueMapper, resultContainer, a, b, c),
                 resultContainer -> resultContainer.entries()
-                        .filter(e -> e.value.isEmpty()) // Filter out keys without values.
+                        .filter(e -> !e.value.isEmpty()) // Filter out keys without values.
                         .collect(Collectors.toMap(e -> e.key, e -> toValue(e.value, mergeFunction))));
     }
 
@@ -1584,7 +1584,7 @@ public final class ConstraintCollectors {
                 (Supplier<ToMapResultContainer<Key, Value>>) ToMapResultContainer::new,
                 (resultContainer, a, b, c) -> toMapAccumulator(keyMapper, valueMapper, resultContainer, a, b, c),
                 resultContainer -> resultContainer.entries()
-                        .filter(e -> e.value.isEmpty()) // Filter out keys without values.
+                        .filter(e -> !e.value.isEmpty()) // Filter out keys without values.
                         .collect(Collectors.toMap(e -> e.key, e -> toValueSet(e.value, valueSetFunction),
                                 ConstraintCollectors::throwOnKeyConflict, TreeMap::new)));
     }
@@ -1610,7 +1610,7 @@ public final class ConstraintCollectors {
                 (Supplier<ToMapResultContainer<Key, Value>>) ToMapResultContainer::new,
                 (resultContainer, a, b, c) -> toMapAccumulator(keyMapper, valueMapper, resultContainer, a, b, c),
                 resultContainer -> resultContainer.entries()
-                        .filter(e -> e.value.isEmpty()) // Filter out keys without values.
+                        .filter(e -> !e.value.isEmpty()) // Filter out keys without values.
                         .collect(Collectors.toMap(e -> e.key, e -> toValue(e.value, mergeFunction),
                                 ConstraintCollectors::throwOnKeyConflict, TreeMap::new)));
     }
@@ -1656,7 +1656,7 @@ public final class ConstraintCollectors {
                 (Supplier<ToMapResultContainer<Key, Value>>) ToMapResultContainer::new,
                 (resultContainer, a, b, c, d) -> toMapAccumulator(keyMapper, valueMapper, resultContainer, a, b, c, d),
                 resultContainer -> resultContainer.entries()
-                        .filter(e -> e.value.isEmpty()) // Filter out keys without values.
+                        .filter(e -> !e.value.isEmpty()) // Filter out keys without values.
                         .collect(Collectors.toMap(e -> e.key, e -> toValueSet(e.value, valueSetFunction))));
     }
 
@@ -1690,7 +1690,7 @@ public final class ConstraintCollectors {
                 (Supplier<ToMapResultContainer<Key, Value>>) ToMapResultContainer::new,
                 (resultContainer, a, b, c, d) -> toMapAccumulator(keyMapper, valueMapper, resultContainer, a, b, c, d),
                 resultContainer -> resultContainer.entries()
-                        .filter(e -> e.value.isEmpty()) // Filter out keys without values.
+                        .filter(e -> !e.value.isEmpty()) // Filter out keys without values.
                         .collect(Collectors.toMap(e -> e.key, e -> toValue(e.value, mergeFunction))));
     }
 
@@ -1736,7 +1736,7 @@ public final class ConstraintCollectors {
                 (Supplier<ToMapResultContainer<Key, Value>>) ToMapResultContainer::new,
                 (resultContainer, a, b, c, d) -> toMapAccumulator(keyMapper, valueMapper, resultContainer, a, b, c, d),
                 resultContainer -> resultContainer.entries()
-                        .filter(e -> e.value.isEmpty()) // Filter out keys without values.
+                        .filter(e -> !e.value.isEmpty()) // Filter out keys without values.
                         .collect(Collectors.toMap(e -> e.key, e -> toValueSet(e.value, valueSetFunction),
                                 ConstraintCollectors::throwOnKeyConflict, TreeMap::new)));
     }
@@ -1763,7 +1763,7 @@ public final class ConstraintCollectors {
                 (Supplier<ToMapResultContainer<Key, Value>>) ToMapResultContainer::new,
                 (resultContainer, a, b, c, d) -> toMapAccumulator(keyMapper, valueMapper, resultContainer, a, b, c, d),
                 resultContainer -> resultContainer.entries()
-                        .filter(e -> e.value.isEmpty()) // Filter out keys without values.
+                        .filter(e -> !e.value.isEmpty()) // Filter out keys without values.
                         .collect(Collectors.toMap(e -> e.key, e -> toValue(e.value, mergeFunction),
                                 ConstraintCollectors::throwOnKeyConflict, TreeMap::new)));
     }

--- a/optaplanner-core/src/main/java/org/optaplanner/core/api/score/stream/ConstraintCollectors.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/api/score/stream/ConstraintCollectors.java
@@ -40,6 +40,7 @@ import java.util.function.ToIntBiFunction;
 import java.util.function.ToIntFunction;
 import java.util.function.ToLongBiFunction;
 import java.util.function.ToLongFunction;
+import java.util.stream.Collectors;
 
 import org.optaplanner.core.api.domain.solution.PlanningSolution;
 import org.optaplanner.core.api.function.QuadFunction;
@@ -67,6 +68,9 @@ public final class ConstraintCollectors {
     // ************************************************************************
     // count
     // ************************************************************************
+
+    private ConstraintCollectors() {
+    }
 
     public static <A> UniConstraintCollector<A, ?, Integer> count() {
         return new DefaultUniConstraintCollector<>(
@@ -138,6 +142,10 @@ public final class ConstraintCollectors {
                 resultContainer -> resultContainer[0]);
     }
 
+    // ************************************************************************
+    // countDistinct
+    // ************************************************************************
+
     public static <A, B, C, D> QuadConstraintCollector<A, B, C, D, ?, Long> countLongQuad() {
         return new DefaultQuadConstraintCollector<>(
                 () -> new long[1],
@@ -147,10 +155,6 @@ public final class ConstraintCollectors {
                 },
                 resultContainer -> resultContainer[0]);
     }
-
-    // ************************************************************************
-    // countDistinct
-    // ************************************************************************
 
     public static <A> UniConstraintCollector<A, ?, Integer> countDistinct(Function<A, ?> groupValueMapping) {
         return new DefaultUniConstraintCollector<>(
@@ -227,7 +231,6 @@ public final class ConstraintCollectors {
                 resultContainer -> resultContainer.count);
     }
 
-
     public static <A, B, C, D> QuadConstraintCollector<A, B, C, D, ?, Long> countDistinctLong(
             QuadFunction<A, B, C, D, ?> groupValueMapping) {
         return new DefaultQuadConstraintCollector<>(
@@ -237,11 +240,6 @@ public final class ConstraintCollectors {
                     return innerCountDistinctLong(resultContainer, value);
                 },
                 resultContainer -> resultContainer.count);
-    }
-
-    private static class CountDistinctResultContainer {
-        int count = 0;
-        Map<Object, int[]> objectCountMap = new HashMap<>();
     }
 
     private static Runnable innerCountDistinct(CountDistinctResultContainer resultContainer, Object value) {
@@ -264,9 +262,9 @@ public final class ConstraintCollectors {
         };
     }
 
-    private static class CountDistinctLongResultContainer {
-        long count = 0L;
-        Map<Object, long[]> objectCountMap = new HashMap<>();
+    private static class CountDistinctResultContainer {
+        int count = 0;
+        Map<Object, int[]> objectCountMap = new HashMap<>();
     }
 
     private static Runnable innerCountDistinctLong(CountDistinctLongResultContainer resultContainer, Object value) {
@@ -289,9 +287,10 @@ public final class ConstraintCollectors {
         };
     }
 
-    // ************************************************************************
-    // sum
-    // ************************************************************************
+    private static class CountDistinctLongResultContainer {
+        long count = 0L;
+        Map<Object, long[]> objectCountMap = new HashMap<>();
+    }
 
     public static <A> UniConstraintCollector<A, ?, Integer> sum(ToIntFunction<? super A> groupValueMapping) {
         return new DefaultUniConstraintCollector<>(
@@ -303,6 +302,10 @@ public final class ConstraintCollectors {
                 },
                 resultContainer -> resultContainer[0]);
     }
+
+    // ************************************************************************
+    // sum
+    // ************************************************************************
 
     public static <A> UniConstraintCollector<A, ?, Long> sumLong(ToLongFunction<? super A> groupValueMapping) {
         return new DefaultUniConstraintCollector<>(
@@ -523,10 +526,6 @@ public final class ConstraintCollectors {
         return sum(groupValueMapping, Period.ZERO, Period::plus, Period::minus);
     }
 
-    // ************************************************************************
-    // min
-    // ************************************************************************
-
     /**
      * Returns a collector that finds a minimum value in a group of {@link Comparable} elements.
      * <p>
@@ -541,13 +540,16 @@ public final class ConstraintCollectors {
      * {@link Comparable} by the {@code age} field.
      * To avoid this, always end your {@link Comparator} by an identity comparison, such as
      * {@code Comparator.comparing(Person::getAge).comparing(Person::getId))}.
-     *
      * @param <A> type of the matched fact
      * @return never null
      */
     public static <A extends Comparable<A>> UniConstraintCollector<A, ?, A> min() {
         return min(Function.identity(), Comparable::compareTo);
     }
+
+    // ************************************************************************
+    // min
+    // ************************************************************************
 
     /**
      * Returns a collector that finds a minimum value in a group of {@link Comparable} elements.
@@ -560,7 +562,6 @@ public final class ConstraintCollectors {
      * <p>
      * For example, {@code [Ann(age = 20), Beth(age = 25), Cathy(age = 30), David(age = 30), Eric(age = 20)]} with
      * {@code .groupBy(min(Person::getAge))} returns {@code 20}.
-     *
      * @param <A> type of the matched fact
      * @param <Mapped> type of the result
      * @param groupValueMapping never null, maps facts from the matched type to the result type
@@ -634,10 +635,6 @@ public final class ConstraintCollectors {
         return minOrMax(groupValueMapping, comparator, true);
     }
 
-    // ************************************************************************
-    // max
-    // ************************************************************************
-
     /**
      * Returns a collector that finds a maximum value in a group of {@link Comparable} elements.
      * <p>
@@ -652,13 +649,16 @@ public final class ConstraintCollectors {
      * {@link Comparable} by the {@code age} field.
      * To avoid this, always end your {@link Comparator} by an identity comparison, such as
      * {@code Comparator.comparing(Person::getAge).comparing(Person::getId))}.
-     *
      * @param <A> type of the matched fact
      * @return never null
      */
     public static <A extends Comparable<A>> UniConstraintCollector<A, ?, A> max() {
         return max(Function.identity(), Comparable::compareTo);
     }
+
+    // ************************************************************************
+    // max
+    // ************************************************************************
 
     /**
      * Returns a collector that finds a maximum value in a group of {@link Comparable} elements.
@@ -671,7 +671,6 @@ public final class ConstraintCollectors {
      * <p>
      * For example, {@code [Ann(age = 20), Beth(age = 25), Cathy(age = 30), David(age = 30), Eric(age = 20)]} with
      * {@code .groupBy(max(Person::getAge))} returns {@code 30}.
-     *
      * @param <A> type of the matched fact
      * @param <Mapped> type of the result
      * @param groupValueMapping never null, maps facts from the matched type to the result type
@@ -799,18 +798,17 @@ public final class ConstraintCollectors {
         return resultContainer.isEmpty() ? null : keySupplier.apply(resultContainer);
     }
 
-    // ************************************************************************
-    // toCollection
-    // ************************************************************************
-
     public static <A, Result extends Collection<A>> UniConstraintCollector<A, ?, Result> toCollection(
             IntFunction<Result> collectionFunction) {
         return toCollection(Function.identity(), collectionFunction);
     }
 
+    // ************************************************************************
+    // toCollection
+    // ************************************************************************
+
     /**
      * As defined by {@link #toList()}, with {@link Set} as the resulting collection.
-     *
      * @param <A> type of the matched fact
      * @return never null
      */
@@ -823,7 +821,6 @@ public final class ConstraintCollectors {
      * {@link UniConstraintStream}.
      * Makes no guarantees on iteration order.
      * For stable iteration order, use {@link #toCollection(IntFunction)} together with a sorted collection.
-     *
      * @param <A> type of the matched fact
      * @return never null
      */
@@ -855,7 +852,6 @@ public final class ConstraintCollectors {
 
     /**
      * As defined by {@link #toList(Function)}, with {@link Set} as the resulting collection.
-     *
      * @param groupValueMapping never null, converts matched facts to elements of the resulting collection
      * @param <A> type of the matched fact
      * @param <Mapped> type of elements in the resulting collection
@@ -869,7 +865,6 @@ public final class ConstraintCollectors {
      * Creates constraint collector that returns {@link List} of the given element type.
      * Makes no guarantees on iteration order.
      * For stable iteration order, use {@link #toCollection(Function, IntFunction)} together with a sorted collection.
-     *
      * @param groupValueMapping never null, converts matched facts to elements of the resulting collection
      * @param <A> type of the matched fact
      * @param <Mapped> type of elements in the resulting collection
@@ -893,7 +888,6 @@ public final class ConstraintCollectors {
 
     /**
      * As defined by {@link #toList(BiFunction)}, with {@link Set} as the resulting collection.
-     *
      * @param groupValueMapping never null, converts matched facts to elements of the resulting collection
      * @param <A> type of the first matched fact
      * @param <B> type of the second matched fact
@@ -909,7 +903,6 @@ public final class ConstraintCollectors {
      * Creates constraint collector that returns {@link List} of the given element type.
      * Makes no guarantees on iteration order.
      * For stable iteration order, use {@link #toCollection(BiFunction, IntFunction)} together with a sorted collection.
-     *
      * @param groupValueMapping never null, converts matched facts to elements of the resulting collection
      * @param <A> type of the first matched fact
      * @param <B> type of the second matched fact
@@ -935,7 +928,6 @@ public final class ConstraintCollectors {
 
     /**
      * As defined by {@link #toList(TriFunction)}, with {@link Set} as the resulting collection.
-     *
      * @param groupValueMapping never null, converts matched facts to elements of the resulting collection
      * @param <A> type of the first matched fact
      * @param <B> type of the second matched fact
@@ -952,7 +944,6 @@ public final class ConstraintCollectors {
      * Creates constraint collector that returns {@link List} of the given element type.
      * Makes no guarantees on iteration order.
      * For stable iteration order, use {@link #toCollection(TriFunction, IntFunction)} together with a sorted collection.
-     *
      * @param groupValueMapping never null, converts matched facts to elements of the resulting collection
      * @param <A> type of the first matched fact
      * @param <B> type of the second matched fact
@@ -979,7 +970,6 @@ public final class ConstraintCollectors {
 
     /**
      * As defined by {@link #toList(QuadFunction)}, with {@link Set} as the resulting collection.
-     *
      * @param groupValueMapping never null, converts matched facts to elements of the resulting collection
      * @param <A> type of the first matched fact
      * @param <B> type of the second matched fact
@@ -997,7 +987,6 @@ public final class ConstraintCollectors {
      * Creates constraint collector that returns {@link List} of the given element type.
      * Makes no guarantees on iteration order.
      * For stable iteration order, use {@link #toCollection(QuadFunction, IntFunction)} together with a sorted collection.
-     *
      * @param groupValueMapping never null, converts matched facts to elements of the resulting collection
      * @param <A> type of the first matched fact
      * @param <B> type of the second matched fact
@@ -1011,7 +1000,634 @@ public final class ConstraintCollectors {
         return toCollection(groupValueMapping, ArrayList::new);
     }
 
-    private ConstraintCollectors() {
+    // ************************************************************************
+    // toMap
+    // ************************************************************************
+
+    /**
+     * Creates a constraint collector that returns a {@link Map} with given keys and values consisting of a
+     * {@link Set} of mappings.
+     * <p>
+     * For example, {@code [Ann(age = 20), Beth(age = 25), Cathy(age = 30), David(age = 30), Eric(age = 20)]}
+     * with {@code .groupBy(toMap(Person::getAge, Person::getName))} returns
+     * {@code {20: [Ann, Eric], 25: [Beth], 30: [Cathy, David]}}.
+     * <p>
+     * Makes no guarantees on iteration order, neither for map entries, nor for the value sets.
+     * For stable iteration order, use {@link #toSortedMap(Function, Function, IntFunction)}.
+     * @param keyMapper map matched fact to a map key
+     * @param valueMapper map matched fact to a value
+     * @param <A> type of the matched fact
+     * @param <Key> type of map key
+     * @param <Value> type of map value
+     * @return never null
+     */
+    public static <A, Key, Value> UniConstraintCollector<A, ?, Map<Key, Set<Value>>> toMap(
+            Function<? super A, ? extends Key> keyMapper, Function<? super A, ? extends Value> valueMapper) {
+        return toMap(keyMapper, valueMapper, (IntFunction<Set<Value>>) LinkedHashSet::new);
+    }
+
+    /**
+     * Creates a constraint collector that returns a {@link Map} with given keys and values consisting of a
+     * {@link Set} of mappings.
+     * <p>
+     * For example, {@code [Ann(age = 20), Beth(age = 25), Cathy(age = 30), David(age = 30), Eric(age = 20)]}
+     * with {@code .groupBy(toMap(Person::getAge, Person::getName))} returns
+     * {@code {20: [Ann, Eric], 25: [Beth], 30: [Cathy, David]}}.
+     * <p>
+     * Iteration order of value collections depends on the {@link Set} provided.
+     * Makes no guarantees on iteration order for map entries, use {@link #toSortedMap(Function, Function, IntFunction)}
+     * for that.
+     * @param keyMapper map matched fact to a map key
+     * @param valueMapper map matched fact to a value
+     * @param valueSetFunction creates a set that will be used to store value mappings
+     * @param <A> type of the matched fact
+     * @param <Key> type of map key
+     * @param <Value> type of map value
+     * @param <ValueSet> type of the value set
+     * @return never null
+     */
+    public static <A, Key, Value, ValueSet extends Set<Value>> UniConstraintCollector<A, ?, Map<Key, ValueSet>>
+    toMap(Function<? super A, ? extends Key> keyMapper, Function<? super A, ? extends Value> valueMapper,
+            IntFunction<ValueSet> valueSetFunction) {
+        return new DefaultUniConstraintCollector<>(
+                (Supplier<HashMap<Key, List<Value>>>) HashMap::new,
+                (resultContainer, a) -> toMapAccumulator(keyMapper, valueMapper, resultContainer, a),
+                resultContainer -> resultContainer.entrySet().stream()
+                        .filter(e -> !e.getValue().isEmpty()) // Filter out keys without values.
+                        .collect(Collectors.toMap(Map.Entry::getKey, e -> listToSet(e.getValue(), valueSetFunction))));
+    }
+
+    private static <A, Key, Value> Runnable toMapAccumulator(Function<? super A, ? extends Key> keyMapper,
+            Function<? super A, ? extends Value> valueMapper, Map<Key, List<Value>> resultContainer, A a) {
+        Key key = keyMapper.apply(a);
+        Value value = valueMapper.apply(a);
+        return toMapInnerAccumulator(key, value, resultContainer);
+    }
+
+    private static <Key, Value> Runnable toMapInnerAccumulator(Key key, Value value,
+            Map<Key, List<Value>> resultContainer) {
+        // For every key, we collect a list of values, even if they are the same value. Important for undo.
+        List<Value> values = resultContainer.computeIfAbsent(key, currentKey -> new ArrayList<>(1));
+        values.add(value);
+        return () -> values.remove(value);
+    }
+
+    private static <Value, ValueSet extends Set<Value>> ValueSet listToSet(List<Value> in,
+            IntFunction<ValueSet> valueSetFunction) {
+        ValueSet result = valueSetFunction.apply(0);
+        result.addAll(in);
+        return result;
+    }
+
+    /**
+     * Creates a constraint collector that returns a {@link Map}.
+     * <p>
+     * For example, {@code [Ann(age = 20), Beth(age = 25), Cathy(age = 30), David(age = 30), Eric(age = 20)]}
+     * with {@code .groupBy(toMap(Person::getAge, Person::getName, (name1, name2) -> name1 + " and " + name2)} returns
+     * {@code {20: "Ann and Eric", 25: "Beth", 30: "Cathy and David"}}.
+     * <p>
+     * Makes no guarantees on iteration order for map entries.
+     * For stable iteration order, use {@link #toSortedMap(Function, Function, BinaryOperator)}.
+     * @param keyMapper map matched fact to a map key
+     * @param valueMapper map matched fact to a value
+     * @param mergeFunction takes two values and merges them to one
+     * @param <A> type of the matched fact
+     * @param <Key> type of map key
+     * @param <Value> type of map value
+     * @return never null
+     */
+    public static <A, Key, Value> UniConstraintCollector<A, ?, Map<Key, Value>> toMap(
+            Function<? super A, ? extends Key> keyMapper, Function<? super A, ? extends Value> valueMapper,
+            BinaryOperator<Value> mergeFunction) {
+        return new DefaultUniConstraintCollector<>(
+                (Supplier<HashMap<Key, List<Value>>>) HashMap::new,
+                (resultContainer, a) -> toMapAccumulator(keyMapper, valueMapper, resultContainer, a),
+                resultContainer -> resultContainer.entrySet().stream()
+                        .filter(e -> !e.getValue().isEmpty()) // Filter out keys without values.
+                        .collect(Collectors.toMap(Map.Entry::getKey, e -> listToValue(e.getValue(), mergeFunction))));
+    }
+
+    private static <Value> Value listToValue(List<Value> in, BinaryOperator<Value> mergeFunction) {
+        return in.stream()
+                .distinct()
+                .reduce(mergeFunction)
+                .orElseThrow(() -> new IllegalStateException("Programming error: Should have had at least one value."));
+    }
+
+    /**
+     * Creates a constraint collector that returns a {@link SortedMap} with given keys and values consisting of a
+     * {@link Set} of mappings.
+     * <p>
+     * For example, {@code [Ann(age = 20), Beth(age = 25), Cathy(age = 30), David(age = 30), Eric(age = 20)]}
+     * with {@code .groupBy(toMap(Person::getAge, Person::getName))} returns
+     * {@code {20: [Ann, Eric], 25: [Beth], 30: [Cathy, David]}}.
+     * <p>
+     * Makes no guarantees on iteration order for the value sets use
+     * {@link #toSortedMap(Function, Function, IntFunction)} for that.
+     * @param keyMapper map matched fact to a map key
+     * @param valueMapper map matched fact to a value
+     * @param <A> type of the matched fact
+     * @param <Key> type of map key
+     * @param <Value> type of map value
+     * @return never null
+     */
+    public static <A, Key extends Comparable<Key>, Value> UniConstraintCollector<A, ?, SortedMap<Key, Set<Value>>>
+    toSortedMap(Function<? super A, ? extends Key> keyMapper, Function<? super A, ? extends Value> valueMapper) {
+        return toSortedMap(keyMapper, valueMapper, (IntFunction<Set<Value>>) LinkedHashSet::new);
+    }
+
+    /**
+     * Creates a constraint collector that returns a {@link SortedMap} with given keys and values consisting of a
+     * {@link Set} of mappings.
+     * <p>
+     * For example, {@code [Ann(age = 20), Beth(age = 25), Cathy(age = 30), David(age = 30), Eric(age = 20)]}
+     * with {@code .groupBy(toMap(Person::getAge, Person::getName))} returns
+     * {@code {20: [Ann, Eric], 25: [Beth], 30: [Cathy, David]}}.
+     * <p>
+     * Iteration order of value collections depends on the {@link Set} provided.
+     * @param keyMapper map matched fact to a map key
+     * @param valueMapper map matched fact to a value
+     * @param valueSetFunction creates a set that will be used to store value mappings
+     * @param <A> type of the matched fact
+     * @param <Key> type of map key
+     * @param <Value> type of map value
+     * @param <ValueSet> type of the value set
+     * @return never null
+     */
+    public static <A, Key extends Comparable<Key>, Value, ValueSet extends Set<Value>>
+    UniConstraintCollector<A, ?, SortedMap<Key, ValueSet>> toSortedMap(Function<? super A, ? extends Key> keyMapper,
+            Function<? super A, ? extends Value> valueMapper, IntFunction<ValueSet> valueSetFunction) {
+            return new DefaultUniConstraintCollector<>(
+                    (Supplier<HashMap<Key, List<Value>>>) HashMap::new,
+                    (resultContainer, a) -> toMapAccumulator(keyMapper, valueMapper, resultContainer, a),
+                    resultContainer -> resultContainer.entrySet().stream()
+                            .filter(e -> !e.getValue().isEmpty()) // Filter out keys without values.
+                            .collect(Collectors.toMap(Map.Entry::getKey, e -> listToSet(e.getValue(), valueSetFunction),
+                                    ConstraintCollectors::throwOnKeyConflict, TreeMap::new)));
+    }
+
+    private static <Value> Value throwOnKeyConflict(Value firstValue, Value secondValue) {
+        throw new IllegalStateException("Programming error, key conflict: (" + firstValue + "), (" + secondValue + ").");
+    }
+
+    /**
+     * Creates a constraint collector that returns a {@link SortedMap}.
+     * <p>
+     * For example, {@code [Ann(age = 20), Beth(age = 25), Cathy(age = 30), David(age = 30), Eric(age = 20)]}
+     * with {@code .groupBy(toMap(Person::getAge, Person::getName, (name1, name2) -> name1 + " and " + name2)} returns
+     * {@code {20: "Ann and Eric", 25: "Beth", 30: "Cathy and David"}}.
+     * @param keyMapper map matched fact to a map key
+     * @param valueMapper map matched fact to a value
+     * @param mergeFunction takes two values and merges them to one
+     * @param <A> type of the matched fact
+     * @param <Key> type of map key
+     * @param <Value> type of map value
+     * @return never null
+     */
+    public static <A, Key extends Comparable<Key>, Value> UniConstraintCollector<A, ?, SortedMap<Key, Value>>
+    toSortedMap(Function<? super A, ? extends Key> keyMapper, Function<? super A, ? extends Value> valueMapper,
+            BinaryOperator<Value> mergeFunction) {
+        return new DefaultUniConstraintCollector<>(
+                (Supplier<HashMap<Key, List<Value>>>) HashMap::new,
+                (resultContainer, a) -> toMapAccumulator(keyMapper, valueMapper, resultContainer, a),
+                resultContainer -> resultContainer.entrySet().stream()
+                        .filter(e -> !e.getValue().isEmpty()) // Filter out keys without values.
+                        .collect(Collectors.toMap(Map.Entry::getKey, e -> listToValue(e.getValue(), mergeFunction),
+                                ConstraintCollectors::throwOnKeyConflict, TreeMap::new)));
+    }
+
+    /**
+     * As defined by {@link #toMap(Function, Function)}.
+     * @param keyMapper map matched fact to a map key
+     * @param valueMapper map matched fact to a value
+     * @param <A> type of the first matched fact
+     * @param <B> type of the second matched fact
+     * @param <Key> type of map key
+     * @param <Value> type of map value
+     * @return never null
+     */
+    public static <A, B, Key, Value> BiConstraintCollector<A, B, ?, Map<Key, Set<Value>>> toMap(
+            BiFunction<? super A, ? super B, ? extends Key> keyMapper,
+            BiFunction<? super A, ? super B, ? extends Value> valueMapper) {
+        return toMap(keyMapper, valueMapper, (IntFunction<Set<Value>>) LinkedHashSet::new);
+    }
+
+    /**
+     * As defined by {@link #toMap(Function, Function, IntFunction)}.
+     * @param keyMapper map matched fact to a map key
+     * @param valueMapper map matched fact to a value
+     * @param valueSetFunction creates a set that will be used to store value mappings
+     * @param <A> type of the first matched fact
+     * @param <B> type of the second matched fact
+     * @param <Key> type of map key
+     * @param <Value> type of map value
+     * @param <ValueSet> type of the value set
+     * @return never null
+     */
+    public static <A, B, Key, Value, ValueSet extends Set<Value>> BiConstraintCollector<A, B, ?, Map<Key, ValueSet>>
+    toMap(BiFunction<? super A, ? super B, ? extends Key> keyMapper,
+            BiFunction<? super A, ? super B, ? extends Value> valueMapper, IntFunction<ValueSet> valueSetFunction) {
+        return new DefaultBiConstraintCollector<>(
+                (Supplier<HashMap<Key, List<Value>>>) HashMap::new,
+                (resultContainer, a, b) -> toMapAccumulator(keyMapper, valueMapper, resultContainer, a, b),
+                resultContainer -> resultContainer.entrySet().stream()
+                        .filter(e -> !e.getValue().isEmpty()) // Filter out keys without values.
+                        .collect(Collectors.toMap(Map.Entry::getKey, e -> listToSet(e.getValue(), valueSetFunction))));
+    }
+
+    private static <A, B, Key, Value> Runnable toMapAccumulator(
+            BiFunction<? super A, ? super B, ? extends Key> keyMapper,
+            BiFunction<? super A, ? super B, ? extends Value> valueMapper, Map<Key, List<Value>> resultContainer, A a,
+            B b) {
+        Key key = keyMapper.apply(a, b);
+        Value value = valueMapper.apply(a, b);
+        return toMapInnerAccumulator(key, value, resultContainer);
+    }
+
+    /**
+     * As defined by {@link #toMap(Function, Function, BinaryOperator)}.
+     * @param keyMapper map matched fact to a map key
+     * @param valueMapper map matched fact to a value
+     * @param mergeFunction takes two values and merges them to one
+     * @param <A> type of the first matched fact
+     * @param <B> type of the second matched fact
+     * @param <Key> type of map key
+     * @param <Value> type of map value
+     * @return never null
+     */
+    public static <A, B, Key, Value> BiConstraintCollector<A, B, ?, Map<Key, Value>> toMap(
+            BiFunction<? super A, ? super B, ? extends Key> keyMapper,
+            BiFunction<? super A, ? super B, ? extends Value> valueMapper, BinaryOperator<Value> mergeFunction) {
+        return new DefaultBiConstraintCollector<>(
+                (Supplier<HashMap<Key, List<Value>>>) HashMap::new,
+                (resultContainer, a, b) -> toMapAccumulator(keyMapper, valueMapper, resultContainer, a, b),
+                resultContainer -> resultContainer.entrySet().stream()
+                        .filter(e -> !e.getValue().isEmpty()) // Filter out keys without values.
+                        .collect(Collectors.toMap(Map.Entry::getKey, e -> listToValue(e.getValue(), mergeFunction))));
+    }
+
+    /**
+     * As defined by {@link #toSortedMap(Function, Function)}.
+     * @param keyMapper map matched fact to a map key
+     * @param valueMapper map matched fact to a value
+     * @param <A> type of the first matched fact
+     * @param <B> type of the second matched fact
+     * @param <Key> type of map key
+     * @param <Value> type of map value
+     * @return never null
+     */
+    public static <A, B, Key extends Comparable<Key>, Value> BiConstraintCollector<A, B, ?, SortedMap<Key, Set<Value>>>
+    toSortedMap(BiFunction<? super A, ? super B, ? extends Key> keyMapper,
+            BiFunction<? super A, ? super B, ? extends Value> valueMapper) {
+        return toSortedMap(keyMapper, valueMapper, (IntFunction<Set<Value>>) LinkedHashSet::new);
+    }
+
+    /**
+     * As defined by {@link #toSortedMap(Function, Function, IntFunction)}.
+     * @param keyMapper map matched fact to a map key
+     * @param valueMapper map matched fact to a value
+     * @param valueSetFunction creates a set that will be used to store value mappings
+     * @param <A> type of the first matched fact
+     * @param <B> type of the second matched fact
+     * @param <Key> type of map key
+     * @param <Value> type of map value
+     * @param <ValueSet> type of the value set
+     * @return never null
+     */
+    public static <A, B, Key extends Comparable<Key>, Value, ValueSet extends Set<Value>>
+    BiConstraintCollector<A, B, ?, SortedMap<Key, ValueSet>> toSortedMap(
+            BiFunction<? super A, ? super B, ? extends Key> keyMapper,
+            BiFunction<? super A, ? super B, ? extends Value> valueMapper, IntFunction<ValueSet> valueSetFunction) {
+        return new DefaultBiConstraintCollector<>(
+                (Supplier<HashMap<Key, List<Value>>>) HashMap::new,
+                (resultContainer, a, b) -> toMapAccumulator(keyMapper, valueMapper, resultContainer, a, b),
+                resultContainer -> resultContainer.entrySet().stream()
+                        .filter(e -> !e.getValue().isEmpty()) // Filter out keys without values.
+                        .collect(Collectors.toMap(Map.Entry::getKey, e -> listToSet(e.getValue(), valueSetFunction),
+                                ConstraintCollectors::throwOnKeyConflict, TreeMap::new)));
+    }
+
+    /**
+     * As defined by {@link #toSortedMap(Function, Function, BinaryOperator)}.
+     * @param keyMapper map matched fact to a map key
+     * @param valueMapper map matched fact to a value
+     * @param mergeFunction takes two values and merges them to one
+     * @param <A> type of the first matched fact
+     * @param <B> type of the second matched fact
+     * @param <Key> type of map key
+     * @param <Value> type of map value
+     * @return never null
+     */
+    public static <A, B, Key extends Comparable<Key>, Value> BiConstraintCollector<A, B, ?, SortedMap<Key, Value>>
+    toSortedMap(BiFunction<? super A, ? super B, ? extends Key> keyMapper,
+            BiFunction<? super A, ? super B, ? extends Value> valueMapper, BinaryOperator<Value> mergeFunction) {
+        return new DefaultBiConstraintCollector<>(
+                (Supplier<HashMap<Key, List<Value>>>) HashMap::new,
+                (resultContainer, a, b) -> toMapAccumulator(keyMapper, valueMapper, resultContainer, a, b),
+                resultContainer -> resultContainer.entrySet().stream()
+                        .filter(e -> !e.getValue().isEmpty()) // Filter out keys without values.
+                        .collect(Collectors.toMap(Map.Entry::getKey, e -> listToValue(e.getValue(), mergeFunction),
+                                ConstraintCollectors::throwOnKeyConflict, TreeMap::new)));
+    }
+
+    /**
+     * As defined by {@link #toMap(Function, Function)}.
+     * @param keyMapper map matched fact to a map key
+     * @param valueMapper map matched fact to a value
+     * @param <A> type of the first matched fact
+     * @param <B> type of the second matched fact
+     * @param <C> type of the third matched fact
+     * @param <Key> type of map key
+     * @param <Value> type of map value
+     * @return never null
+     */
+    public static <A, B, C, Key, Value> TriConstraintCollector<A, B, C, ?, Map<Key, Set<Value>>> toMap(
+            TriFunction<? super A, ? super B, ? super C, ? extends Key> keyMapper,
+            TriFunction<? super A, ? super B, ? super C, ? extends Value> valueMapper) {
+        return toMap(keyMapper, valueMapper, (IntFunction<Set<Value>>) LinkedHashSet::new);
+    }
+
+    /**
+     * As defined by {@link #toMap(Function, Function, IntFunction)}.
+     * @param keyMapper map matched fact to a map key
+     * @param valueMapper map matched fact to a value
+     * @param valueSetFunction creates a set that will be used to store value mappings
+     * @param <A> type of the first matched fact
+     * @param <B> type of the second matched fact
+     * @param <C> type of the third matched fact
+     * @param <Key> type of map key
+     * @param <Value> type of map value
+     * @param <ValueSet> type of the value set
+     * @return never null
+     */
+    public static <A, B, C, Key, Value, ValueSet extends Set<Value>>
+    TriConstraintCollector<A, B, C, ?, Map<Key, ValueSet>> toMap(
+            TriFunction<? super A, ? super B, ? super C, ? extends Key> keyMapper,
+            TriFunction<? super A, ? super B, ? super C, ? extends Value> valueMapper,
+            IntFunction<ValueSet> valueSetFunction) {
+        return new DefaultTriConstraintCollector<>(
+                (Supplier<HashMap<Key, List<Value>>>) HashMap::new,
+                (resultContainer, a, b, c) -> toMapAccumulator(keyMapper, valueMapper, resultContainer, a, b, c),
+                resultContainer -> resultContainer.entrySet().stream()
+                        .filter(e -> !e.getValue().isEmpty()) // Filter out keys without values.
+                        .collect(Collectors.toMap(Map.Entry::getKey, e -> listToSet(e.getValue(), valueSetFunction))));
+    }
+
+    private static <A, B, C, Key, Value> Runnable toMapAccumulator(
+            TriFunction<? super A, ? super B, ? super C, ? extends Key> keyMapper,
+            TriFunction<? super A, ? super B, ? super C, ? extends Value> valueMapper, Map<Key, List<Value>> resultContainer, A a,
+            B b, C c) {
+        Key key = keyMapper.apply(a, b, c);
+        Value value = valueMapper.apply(a, b, c);
+        return toMapInnerAccumulator(key, value, resultContainer);
+    }
+
+    /**
+     * As defined by {@link #toMap(Function, Function, BinaryOperator)}.
+     * @param keyMapper map matched fact to a map key
+     * @param valueMapper map matched fact to a value
+     * @param mergeFunction takes two values and merges them to one
+     * @param <A> type of the first matched fact
+     * @param <B> type of the second matched fact
+     * @param <C> type of the third matched fact
+     * @param <Key> type of map key
+     * @param <Value> type of map value
+     * @return never null
+     */
+    public static <A, B, C, Key, Value> TriConstraintCollector<A, B, C, ?, Map<Key, Value>> toMap(
+            TriFunction<? super A, ? super B, ? super C, ? extends Key> keyMapper,
+            TriFunction<? super A, ? super B, ? super C, ? extends Value> valueMapper,
+            BinaryOperator<Value> mergeFunction) {
+        return new DefaultTriConstraintCollector<>(
+                (Supplier<HashMap<Key, List<Value>>>) HashMap::new,
+                (resultContainer, a, b, c) -> toMapAccumulator(keyMapper, valueMapper, resultContainer, a, b, c),
+                resultContainer -> resultContainer.entrySet().stream()
+                        .filter(e -> !e.getValue().isEmpty()) // Filter out keys without values.
+                        .collect(Collectors.toMap(Map.Entry::getKey, e -> listToValue(e.getValue(), mergeFunction))));
+    }
+
+    /**
+     * As defined by {@link #toSortedMap(Function, Function)}.
+     * @param keyMapper map matched fact to a map key
+     * @param valueMapper map matched fact to a value
+     * @param <A> type of the first matched fact
+     * @param <B> type of the second matched fact
+     * @param <C> type of the third matched fact
+     * @param <Key> type of map key
+     * @param <Value> type of map value
+     * @return never null
+     */
+    public static <A, B, C, Key extends Comparable<Key>, Value>
+    TriConstraintCollector<A, B, C, ?, SortedMap<Key, Set<Value>>> toSortedMap(
+            TriFunction<? super A, ? super B, ? super C, ? extends Key> keyMapper,
+            TriFunction<? super A, ? super B, ? super C, ? extends Value> valueMapper) {
+        return toSortedMap(keyMapper, valueMapper, (IntFunction<Set<Value>>) LinkedHashSet::new);
+    }
+
+    /**
+     * As defined by {@link #toSortedMap(Function, Function, IntFunction)}.
+     * @param keyMapper map matched fact to a map key
+     * @param valueMapper map matched fact to a value
+     * @param valueSetFunction creates a set that will be used to store value mappings
+     * @param <A> type of the first matched fact
+     * @param <B> type of the second matched fact
+     * @param <C> type of the third matched fact
+     * @param <Key> type of map key
+     * @param <Value> type of map value
+     * @param <ValueSet> type of the value set
+     * @return never null
+     */
+    public static <A, B, C, Key extends Comparable<Key>, Value, ValueSet extends Set<Value>>
+    TriConstraintCollector<A, B, C, ?, SortedMap<Key, ValueSet>> toSortedMap(
+            TriFunction<? super A, ? super B, ? super C, ? extends Key> keyMapper,
+            TriFunction<? super A, ? super B, ? super C, ? extends Value> valueMapper,
+            IntFunction<ValueSet> valueSetFunction) {
+        return new DefaultTriConstraintCollector<>(
+                (Supplier<HashMap<Key, List<Value>>>) HashMap::new,
+                (resultContainer, a, b, c) -> toMapAccumulator(keyMapper, valueMapper, resultContainer, a, b, c),
+                resultContainer -> resultContainer.entrySet().stream()
+                        .filter(e -> !e.getValue().isEmpty()) // Filter out keys without values.
+                        .collect(Collectors.toMap(Map.Entry::getKey, e -> listToSet(e.getValue(), valueSetFunction),
+                                ConstraintCollectors::throwOnKeyConflict, TreeMap::new)));
+    }
+
+    /**
+     * As defined by {@link #toSortedMap(Function, Function, BinaryOperator)}.
+     * @param keyMapper map matched fact to a map key
+     * @param valueMapper map matched fact to a value
+     * @param mergeFunction takes two values and merges them to one
+     * @param <A> type of the first matched fact
+     * @param <B> type of the second matched fact
+     * @param <C> type of the third matched fact
+     * @param <Key> type of map key
+     * @param <Value> type of map value
+     * @return never null
+     */
+    public static <A, B, C, Key extends Comparable<Key>, Value>
+    TriConstraintCollector<A, B, C, ?, SortedMap<Key, Value>> toSortedMap(
+            TriFunction<? super A, ? super B, ? super C, ? extends Key> keyMapper,
+            TriFunction<? super A, ? super B, ? super C, ? extends Value> valueMapper,
+            BinaryOperator<Value> mergeFunction) {
+        return new DefaultTriConstraintCollector<>(
+                (Supplier<HashMap<Key, List<Value>>>) HashMap::new,
+                (resultContainer, a, b, c) -> toMapAccumulator(keyMapper, valueMapper, resultContainer, a, b, c),
+                resultContainer -> resultContainer.entrySet().stream()
+                        .filter(e -> !e.getValue().isEmpty()) // Filter out keys without values.
+                        .collect(Collectors.toMap(Map.Entry::getKey, e -> listToValue(e.getValue(), mergeFunction),
+                                ConstraintCollectors::throwOnKeyConflict, TreeMap::new)));
+    }
+
+    /**
+     * As defined by {@link #toMap(Function, Function)}.
+     * @param keyMapper map matched fact to a map key
+     * @param valueMapper map matched fact to a value
+     * @param <A> type of the first matched fact
+     * @param <B> type of the second matched fact
+     * @param <C> type of the third matched fact
+     * @param <D> type of the fourth matched fact
+     * @param <Key> type of map key
+     * @param <Value> type of map value
+     * @return never null
+     */
+    public static <A, B, C, D, Key, Value> QuadConstraintCollector<A, B, C, D, ?, Map<Key, Set<Value>>> toMap(
+            QuadFunction<? super A, ? super B, ? super C, ? super D, ? extends Key> keyMapper,
+            QuadFunction<? super A, ? super B, ? super C, ? super D, ? extends Value> valueMapper) {
+        return toMap(keyMapper, valueMapper, (IntFunction<Set<Value>>) LinkedHashSet::new);
+    }
+
+    /**
+     * As defined by {@link #toMap(Function, Function, IntFunction)}.
+     * @param keyMapper map matched fact to a map key
+     * @param valueMapper map matched fact to a value
+     * @param valueSetFunction creates a set that will be used to store value mappings
+     * @param <A> type of the first matched fact
+     * @param <B> type of the second matched fact
+     * @param <C> type of the third matched fact
+     * @param <D> type of the fourth matched fact
+     * @param <Key> type of map key
+     * @param <Value> type of map value
+     * @param <ValueSet> type of the value set
+     * @return never null
+     */
+    public static <A, B, C, D, Key, Value, ValueSet extends Set<Value>>
+    QuadConstraintCollector<A, B, C, D, ?, Map<Key, ValueSet>> toMap(
+            QuadFunction<? super A, ? super B, ? super C, ? super D, ? extends Key> keyMapper,
+            QuadFunction<? super A, ? super B, ? super C, ? super D, ? extends Value> valueMapper,
+            IntFunction<ValueSet> valueSetFunction) {
+        return new DefaultQuadConstraintCollector<>(
+                (Supplier<HashMap<Key, List<Value>>>) HashMap::new,
+                (resultContainer, a, b, c, d) -> toMapAccumulator(keyMapper, valueMapper, resultContainer, a, b, c, d),
+                resultContainer -> resultContainer.entrySet().stream()
+                        .filter(e -> !e.getValue().isEmpty()) // Filter out keys without values.
+                        .collect(Collectors.toMap(Map.Entry::getKey, e -> listToSet(e.getValue(), valueSetFunction))));
+    }
+
+    public static <A, B, C, D, Key, Value> Runnable toMapAccumulator(
+            QuadFunction<? super A, ? super B, ? super C, ? super D, ? extends Key> keyMapper,
+            QuadFunction<? super A, ? super B, ? super C, ? super D, ? extends Value> valueMapper,
+            Map<Key, List<Value>> resultContainer, A a, B b, C c, D d) {
+        Key key = keyMapper.apply(a, b, c, d);
+        Value value = valueMapper.apply(a, b, c, d);
+        return toMapInnerAccumulator(key, value, resultContainer);
+    }
+
+    /**
+     * As defined by {@link #toMap(Function, Function, BinaryOperator)}.
+     * @param keyMapper map matched fact to a map key
+     * @param valueMapper map matched fact to a value
+     * @param mergeFunction takes two values and merges them to one
+     * @param <A> type of the first matched fact
+     * @param <B> type of the second matched fact
+     * @param <C> type of the third matched fact
+     * @param <D> type of the fourth matched fact
+     * @param <Key> type of map key
+     * @param <Value> type of map value
+     * @return never null
+     */
+    public static <A, B, C, D, Key, Value> QuadConstraintCollector<A, B, C, D, ?, Map<Key, Value>> toMap(
+            QuadFunction<? super A, ? super B, ? super C, ? super D, ? extends Key> keyMapper,
+            QuadFunction<? super A, ? super B, ? super C, ? super D, ? extends Value> valueMapper,
+            BinaryOperator<Value> mergeFunction) {
+        return new DefaultQuadConstraintCollector<>(
+                (Supplier<HashMap<Key, List<Value>>>) HashMap::new,
+                (resultContainer, a, b, c, d) -> toMapAccumulator(keyMapper, valueMapper, resultContainer, a, b, c, d),
+                resultContainer -> resultContainer.entrySet().stream()
+                        .filter(e -> !e.getValue().isEmpty()) // Filter out keys without values.
+                        .collect(Collectors.toMap(Map.Entry::getKey, e -> listToValue(e.getValue(), mergeFunction))));
+    }
+
+    /**
+     * As defined by {@link #toSortedMap(Function, Function)}.
+     * @param keyMapper map matched fact to a map key
+     * @param valueMapper map matched fact to a value
+     * @param <A> type of the first matched fact
+     * @param <B> type of the second matched fact
+     * @param <C> type of the third matched fact
+     * @param <D> type of the fourth matched fact
+     * @param <Key> type of map key
+     * @param <Value> type of map value
+     * @return never null
+     */
+    public static <A, B, C, D, Key extends Comparable<Key>, Value>
+    QuadConstraintCollector<A, B, C, D, ?, SortedMap<Key, Set<Value>>> toSortedMap(
+            QuadFunction<? super A, ? super B, ? super C, ? super D, ? extends Key> keyMapper,
+            QuadFunction<? super A, ? super B, ? super C, ? super D, ? extends Value> valueMapper) {
+        return toSortedMap(keyMapper, valueMapper, (IntFunction<Set<Value>>) LinkedHashSet::new);
+    }
+
+    /**
+     * As defined by {@link #toSortedMap(Function, Function, IntFunction)}.
+     * @param keyMapper map matched fact to a map key
+     * @param valueMapper map matched fact to a value
+     * @param valueSetFunction creates a set that will be used to store value mappings
+     * @param <A> type of the first matched fact
+     * @param <B> type of the second matched fact
+     * @param <C> type of the third matched fact
+     * @param <D> type of the fourth matched fact
+     * @param <Key> type of map key
+     * @param <Value> type of map value
+     * @param <ValueSet> type of the value set
+     * @return never null
+     */
+    public static <A, B, C, D, Key extends Comparable<Key>, Value, ValueSet extends Set<Value>>
+    QuadConstraintCollector<A, B, C, D, ?, SortedMap<Key, ValueSet>> toSortedMap(
+            QuadFunction<? super A, ? super B, ? super C, ? super D, ? extends Key> keyMapper,
+            QuadFunction<? super A, ? super B, ? super C, ? super D, ? extends Value> valueMapper,
+            IntFunction<ValueSet> valueSetFunction) {
+        return new DefaultQuadConstraintCollector<>(
+                (Supplier<HashMap<Key, List<Value>>>) HashMap::new,
+                (resultContainer, a, b, c, d) -> toMapAccumulator(keyMapper, valueMapper, resultContainer, a, b, c, d),
+                resultContainer -> resultContainer.entrySet().stream()
+                        .filter(e -> !e.getValue().isEmpty()) // Filter out keys without values.
+                        .collect(Collectors.toMap(Map.Entry::getKey, e -> listToSet(e.getValue(), valueSetFunction),
+                                ConstraintCollectors::throwOnKeyConflict, TreeMap::new)));
+    }
+
+    /**
+     * As defined by {@link #toSortedMap(Function, Function, BinaryOperator)}.
+     * @param keyMapper map matched fact to a map key
+     * @param valueMapper map matched fact to a value
+     * @param mergeFunction takes two values and merges them to one
+     * @param <A> type of the first matched fact
+     * @param <B> type of the second matched fact
+     * @param <C> type of the third matched fact
+     * @param <D> type of the fourth matched fact
+     * @param <Key> type of map key
+     * @param <Value> type of map value
+     * @return never null
+     */
+    public static <A, B, C, D, Key extends Comparable<Key>, Value>
+    QuadConstraintCollector<A, B, C, D, ?, SortedMap<Key, Value>> toSortedMap(
+            QuadFunction<? super A, ? super B, ? super C, ? super D, ? extends Key> keyMapper,
+            QuadFunction<? super A, ? super B, ? super C, ? super D, ? extends Value> valueMapper,
+            BinaryOperator<Value> mergeFunction) {
+        return new DefaultQuadConstraintCollector<>(
+                (Supplier<HashMap<Key, List<Value>>>) HashMap::new,
+                (resultContainer, a, b, c, d) -> toMapAccumulator(keyMapper, valueMapper, resultContainer, a, b, c, d),
+                resultContainer -> resultContainer.entrySet().stream()
+                        .filter(e -> !e.getValue().isEmpty()) // Filter out keys without values.
+                        .collect(Collectors.toMap(Map.Entry::getKey, e -> listToValue(e.getValue(), mergeFunction),
+                                ConstraintCollectors::throwOnKeyConflict, TreeMap::new)));
     }
 
 }

--- a/optaplanner-core/src/main/java/org/optaplanner/core/api/score/stream/ConstraintCollectors.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/api/score/stream/ConstraintCollectors.java
@@ -1198,7 +1198,6 @@ public final class ConstraintCollectors {
 
     }
 
-
     private static <A, Key, Value> Runnable toMapAccumulator(Function<? super A, ? extends Key> keyMapper,
             Function<? super A, ? extends Value> valueMapper, ToMapResultContainer<Key, Value> resultContainer, A a) {
         Key key = keyMapper.apply(a);
@@ -1261,7 +1260,7 @@ public final class ConstraintCollectors {
      * with {@code .groupBy(toMap(Person::getAge, Person::getName))} returns
      * {@code {20: [Ann, Eric], 25: [Beth], 30: [Cathy, David]}}.
      * <p>
-     * Makes no guarantees on iteration order for the value sets use
+     * Makes no guarantees on iteration order for the value sets, use
      * {@link #toSortedMap(Function, Function, IntFunction)} for that.
      * @param keyMapper map matched fact to a map key
      * @param valueMapper map matched fact to a value

--- a/optaplanner-core/src/main/java/org/optaplanner/core/api/score/stream/ConstraintCollectors.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/api/score/stream/ConstraintCollectors.java
@@ -30,7 +30,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.SortedMap;
+import java.util.SortedSet;
 import java.util.TreeMap;
+import java.util.TreeSet;
 import java.util.function.BiFunction;
 import java.util.function.BinaryOperator;
 import java.util.function.Function;
@@ -808,7 +810,9 @@ public final class ConstraintCollectors {
     // ************************************************************************
 
     /**
-     * As defined by {@link #toList()}, with {@link Set} as the resulting collection.
+     * Creates constraint collector that returns {@link Set} of the same element type as the {@link ConstraintStream}.
+     * Makes no guarantees on iteration order.
+     * For stable iteration order, use {@link #toSortedSet()}.
      * @param <A> type of the matched fact
      * @return never null
      */
@@ -817,10 +821,19 @@ public final class ConstraintCollectors {
     }
 
     /**
-     * Creates constraint collector that returns {@link List} of the same element type as the
-     * {@link UniConstraintStream}.
+     * Creates constraint collector that returns {@link SortedSet} of the same element type as the
+     * {@link ConstraintStream}.
+     * @param <A> type of the matched fact
+     * @return never null
+     */
+    public static <A extends Comparable<A>> UniConstraintCollector<A, ?, SortedSet<A>> toSortedSet() {
+        return toCollection(Function.identity(), i -> new TreeSet<>());
+    }
+
+    /**
+     * Creates constraint collector that returns {@link List} of the same element type as the {@link ConstraintStream}.
      * Makes no guarantees on iteration order.
-     * For stable iteration order, use {@link #toCollection(IntFunction)} together with a sorted collection.
+     * For stable iteration order, use {@link #toSortedSet()}.
      * @param <A> type of the matched fact
      * @return never null
      */
@@ -851,10 +864,12 @@ public final class ConstraintCollectors {
     }
 
     /**
-     * As defined by {@link #toList(Function)}, with {@link Set} as the resulting collection.
-     * @param groupValueMapping never null, converts matched facts to elements of the resulting collection
+     * Creates constraint collector that returns {@link Set} of the same element type as the {@link ConstraintStream}.
+     * Makes no guarantees on iteration order.
+     * For stable iteration order, use {@link #toSortedSet()}.
+     * @param groupValueMapping never null, converts matched facts to elements of the resulting set
      * @param <A> type of the matched fact
-     * @param <Mapped> type of elements in the resulting collection
+     * @param <Mapped> type of elements in the resulting set
      * @return never null
      */
     public static <A, Mapped> UniConstraintCollector<A, ?, Set<Mapped>> toSet(Function<A, Mapped> groupValueMapping) {
@@ -862,9 +877,22 @@ public final class ConstraintCollectors {
     }
 
     /**
+     * Creates constraint collector that returns {@link SortedSet} of the same element type as the
+     * {@link ConstraintStream}.
+     * @param groupValueMapping never null, converts matched facts to elements of the resulting set
+     * @param <A> type of the matched fact
+     * @param <Mapped> type of elements in the resulting set
+     * @return never null
+     */
+    public static <A, Mapped extends Comparable<Mapped>> UniConstraintCollector<A, ?, SortedSet<Mapped>> toSortedSet(
+            Function<A, Mapped> groupValueMapping) {
+        return toCollection(groupValueMapping, i -> new TreeSet<>());
+    }
+
+    /**
      * Creates constraint collector that returns {@link List} of the given element type.
      * Makes no guarantees on iteration order.
-     * For stable iteration order, use {@link #toCollection(Function, IntFunction)} together with a sorted collection.
+     * For stable iteration order, use {@link #toSortedSet(Function)}.
      * @param groupValueMapping never null, converts matched facts to elements of the resulting collection
      * @param <A> type of the matched fact
      * @param <Mapped> type of elements in the resulting collection
@@ -887,11 +915,11 @@ public final class ConstraintCollectors {
     }
 
     /**
-     * As defined by {@link #toList(BiFunction)}, with {@link Set} as the resulting collection.
-     * @param groupValueMapping never null, converts matched facts to elements of the resulting collection
+     * As defined by {@link #toSet(Function)}.
+     * @param groupValueMapping never null, converts matched facts to elements of the resulting set
      * @param <A> type of the first matched fact
      * @param <B> type of the second matched fact
-     * @param <Mapped> type of elements in the resulting collection
+     * @param <Mapped> type of elements in the resulting set
      * @return never null
      */
     public static <A, B, Mapped> BiConstraintCollector<A, B, ?, Set<Mapped>> toSet(
@@ -900,9 +928,22 @@ public final class ConstraintCollectors {
     }
 
     /**
+     * As defined by {@link #toSortedSet(Function)}.
+     * @param groupValueMapping never null, converts matched facts to elements of the resulting set
+     * @param <A> type of the first matched fact
+     * @param <B> type of the second matched fact
+     * @param <Mapped> type of elements in the resulting set
+     * @return never null
+     */
+    public static <A, B, Mapped extends Comparable<Mapped>> BiConstraintCollector<A, B, ?, SortedSet<Mapped>>
+    toSortedSet(BiFunction<A, B, Mapped> groupValueMapping) {
+        return toCollection(groupValueMapping, i -> new TreeSet<>());
+    }
+
+    /**
      * Creates constraint collector that returns {@link List} of the given element type.
      * Makes no guarantees on iteration order.
-     * For stable iteration order, use {@link #toCollection(BiFunction, IntFunction)} together with a sorted collection.
+     * For stable iteration order, use {@link #toSortedSet(BiFunction)}.
      * @param groupValueMapping never null, converts matched facts to elements of the resulting collection
      * @param <A> type of the first matched fact
      * @param <B> type of the second matched fact
@@ -927,12 +968,12 @@ public final class ConstraintCollectors {
     }
 
     /**
-     * As defined by {@link #toList(TriFunction)}, with {@link Set} as the resulting collection.
-     * @param groupValueMapping never null, converts matched facts to elements of the resulting collection
+     * As defined by {@link #toSet(Function)}.
+     * @param groupValueMapping never null, converts matched facts to elements of the resulting set
      * @param <A> type of the first matched fact
      * @param <B> type of the second matched fact
      * @param <C> type of the third matched fact
-     * @param <Mapped> type of elements in the resulting collection
+     * @param <Mapped> type of elements in the resulting set
      * @return never null
      */
     public static <A, B, C, Mapped> TriConstraintCollector<A, B, C, ?, Set<Mapped>> toSet(
@@ -941,9 +982,23 @@ public final class ConstraintCollectors {
     }
 
     /**
+     * As defined by {@link #toSortedSet(Function)}.
+     * @param groupValueMapping never null, converts matched facts to elements of the resulting set
+     * @param <A> type of the first matched fact
+     * @param <B> type of the second matched fact
+     * @param <C> type of the third matched fact
+     * @param <Mapped> type of elements in the resulting set
+     * @return never null
+     */
+    public static <A, B, C, Mapped extends Comparable<Mapped>> TriConstraintCollector<A, B, C, ?, SortedSet<Mapped>>
+    toSortedSet(TriFunction<A, B, C, Mapped> groupValueMapping) {
+        return toCollection(groupValueMapping, i -> new TreeSet<>());
+    }
+
+    /**
      * Creates constraint collector that returns {@link List} of the given element type.
      * Makes no guarantees on iteration order.
-     * For stable iteration order, use {@link #toCollection(TriFunction, IntFunction)} together with a sorted collection.
+     * For stable iteration order, use {@link #toSortedSet(TriFunction)}.
      * @param groupValueMapping never null, converts matched facts to elements of the resulting collection
      * @param <A> type of the first matched fact
      * @param <B> type of the second matched fact
@@ -969,13 +1024,13 @@ public final class ConstraintCollectors {
     }
 
     /**
-     * As defined by {@link #toList(QuadFunction)}, with {@link Set} as the resulting collection.
-     * @param groupValueMapping never null, converts matched facts to elements of the resulting collection
+     * As defined by {@link #toSet(Function)}.
+     * @param groupValueMapping never null, converts matched facts to elements of the resulting set
      * @param <A> type of the first matched fact
      * @param <B> type of the second matched fact
      * @param <C> type of the third matched fact
      * @param <D> type of the fourth matched fact
-     * @param <Mapped> type of elements in the resulting collection
+     * @param <Mapped> type of elements in the resulting set
      * @return never null
      */
     public static <A, B, C, D, Mapped> QuadConstraintCollector<A, B, C, D, ?, Set<Mapped>> toSet(
@@ -984,9 +1039,25 @@ public final class ConstraintCollectors {
     }
 
     /**
+     * As defined by {@link #toSortedSet(Function)}.
+     * @param groupValueMapping never null, converts matched facts to elements of the resulting set
+     * @param <A> type of the first matched fact
+     * @param <B> type of the second matched fact
+     * @param <C> type of the third matched fact
+     * @param <D> type of the fourth matched fact
+     * @param <Mapped> type of elements in the resulting set
+     * @return never null
+     */
+    public static <A, B, C, D, Mapped extends Comparable<Mapped>>
+    QuadConstraintCollector<A, B, C, D, ?, SortedSet<Mapped>> toSortedSet(
+            QuadFunction<A, B, C, D, Mapped> groupValueMapping) {
+        return toCollection(groupValueMapping, i -> new TreeSet<>());
+    }
+
+    /**
      * Creates constraint collector that returns {@link List} of the given element type.
      * Makes no guarantees on iteration order.
-     * For stable iteration order, use {@link #toCollection(QuadFunction, IntFunction)} together with a sorted collection.
+     * For stable iteration order, use {@link #toSortedSet(QuadFunction)}.
      * @param groupValueMapping never null, converts matched facts to elements of the resulting collection
      * @param <A> type of the first matched fact
      * @param <B> type of the second matched fact

--- a/optaplanner-core/src/test/java/org/optaplanner/core/api/score/stream/ConstraintCollectorsTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/api/score/stream/ConstraintCollectorsTest.java
@@ -26,7 +26,9 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.SortedMap;
 import java.util.SortedSet;
+import java.util.TreeMap;
 import java.util.TreeSet;
 import java.util.function.BiFunction;
 import java.util.function.Function;
@@ -43,6 +45,7 @@ import static java.util.Arrays.stream;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.emptySet;
+import static java.util.Collections.emptySortedMap;
 import static java.util.Collections.emptySortedSet;
 import static java.util.Collections.singleton;
 import static java.util.Collections.singletonList;
@@ -2185,6 +2188,122 @@ public class ConstraintCollectorsTest {
         assertResult(collector, container, emptyMap());
     }
 
+    @Test
+    public void toSortedMapMerged() {
+        UniConstraintCollector<Integer, ?, SortedMap<Integer, Integer>> collector =
+                ConstraintCollectors.toSortedMap(a -> a, Function.identity(), Integer::sum);
+        Object container = collector.supplier().get();
+
+        assertResult(collector, container, emptySortedMap());
+        // Add first value, we have one now.
+        int firstValue = 2;
+        Runnable firstRetractor = accumulate(collector, container, firstValue);
+        assertResult(collector, container, asSortedMap(2, 2));
+        // Add second value, we have two now.
+        int secondValue = 1;
+        Runnable secondRetractor = accumulate(collector, container, secondValue);
+        assertResult(collector, container, asSortedMap(2, 2, 1, 1));
+        // Add third value, same as the second. We now have three values, two of which map to the same key.
+        Runnable thirdRetractor = accumulate(collector, container, secondValue);
+        assertResult(collector, container, asSortedMap(2, 2, 1, 1));
+        // Retract one instance of the second value; we only have two values now.
+        secondRetractor.run();
+        assertResult(collector, container, asSortedMap(2, 2, 1, 1));
+        // Retract final instance of the second value; we only have one value now.
+        thirdRetractor.run();
+        assertResult(collector, container, asSortedMap(2, 2));
+        // Retract last value; there are no values now.
+        firstRetractor.run();
+        assertResult(collector, container, emptySortedMap());
+    }
+
+    @Test
+    public void toSortedMapBiMerged() {
+        BiConstraintCollector<Integer, Integer, ?, SortedMap<Integer, Integer>> collector =
+                ConstraintCollectors.toSortedMap(Integer::sum, Integer::sum, Integer::sum);
+        Object container = collector.supplier().get();
+
+        assertResult(collector, container, emptySortedMap());
+        // Add first value, we have one now.
+        int firstValue = 2;
+        Runnable firstRetractor = accumulate(collector, container, firstValue, 0);
+        assertResult(collector, container, asSortedMap(2, 2));
+        // Add second value, we have two now.
+        int secondValue = 1;
+        Runnable secondRetractor = accumulate(collector, container, secondValue, 0);
+        assertResult(collector, container, asSortedMap(2, 2, 1, 1));
+        // Add third value, same as the second. We now have three values, two of which map to the same key.
+        Runnable thirdRetractor = accumulate(collector, container, secondValue, 0);
+        assertResult(collector, container, asSortedMap(2, 2, 1, 1));
+        // Retract one instance of the second value; we only have two values now.
+        secondRetractor.run();
+        assertResult(collector, container, asSortedMap(2, 2, 1, 1));
+        // Retract final instance of the second value; we only have one value now.
+        thirdRetractor.run();
+        assertResult(collector, container, asSortedMap(2, 2));
+        // Retract last value; there are no values now.
+        firstRetractor.run();
+        assertResult(collector, container, emptySortedMap());
+    }
+
+    @Test
+    public void toSortedMapTriMerged() {
+        TriConstraintCollector<Integer, Integer, Integer, ?, SortedMap<Integer, Integer>> collector =
+                ConstraintCollectors.toSortedMap((a, b, c) -> a + b + c, (a, b, c) -> a + b + c, Integer::sum);
+        Object container = collector.supplier().get();
+
+        assertResult(collector, container, emptySortedMap());
+        // Add first value, we have one now.
+        int firstValue = 2;
+        Runnable firstRetractor = accumulate(collector, container, firstValue, 0, 0);
+        assertResult(collector, container, asSortedMap(2, 2));
+        // Add second value, we have two now.
+        int secondValue = 1;
+        Runnable secondRetractor = accumulate(collector, container, secondValue, 0, 0);
+        assertResult(collector, container, asSortedMap(2, 2, 1, 1));
+        // Add third value, same as the second. We now have three values, two of which map to the same key.
+        Runnable thirdRetractor = accumulate(collector, container, secondValue, 0, 0);
+        assertResult(collector, container, asSortedMap(2, 2, 1, 1));
+        // Retract one instance of the second value; we only have two values now.
+        secondRetractor.run();
+        assertResult(collector, container, asSortedMap(2, 2, 1, 1));
+        // Retract final instance of the second value; we only have one value now.
+        thirdRetractor.run();
+        assertResult(collector, container, asSortedMap(2, 2));
+        // Retract last value; there are no values now.
+        firstRetractor.run();
+        assertResult(collector, container, emptySortedMap());
+    }
+
+    @Test
+    public void toSortedMapQuadMerged() {
+        QuadConstraintCollector<Integer, Integer, Integer, Integer, ?, SortedMap<Integer, Integer>> collector =
+                ConstraintCollectors.toSortedMap((a, b, c, d) -> a + b + c + d, (a, b, c, d) -> a + b + c + d, Integer::sum);
+        Object container = collector.supplier().get();
+
+        assertResult(collector, container, emptySortedMap());
+        // Add first value, we have one now.
+        int firstValue = 2;
+        Runnable firstRetractor = accumulate(collector, container, firstValue, 0, 0, 0);
+        assertResult(collector, container, asSortedMap(2, 2));
+        // Add second value, we have two now.
+        int secondValue = 1;
+        Runnable secondRetractor = accumulate(collector, container, secondValue, 0, 0, 0);
+        assertResult(collector, container, asSortedMap(2, 2, 1, 1));
+        // Add third value, same as the second. We now have three values, two of which map to the same key.
+        Runnable thirdRetractor = accumulate(collector, container, secondValue, 0, 0, 0);
+        assertResult(collector, container, asSortedMap(2, 2, 1, 1));
+        // Retract one instance of the second value; we only have two values now.
+        secondRetractor.run();
+        assertResult(collector, container, asSortedMap(2, 2, 1, 1));
+        // Retract final instance of the second value; we only have one value now.
+        thirdRetractor.run();
+        assertResult(collector, container, asSortedMap(2, 2));
+        // Retract last value; there are no values now.
+        firstRetractor.run();
+        assertResult(collector, container, emptySortedMap());
+    }
+
     private static <A, B, C, D> Runnable accumulate(QuadConstraintCollector<A, A, A, A, B, C> collector, Object container,
             A valueA, A valueB, A valueC, A valueD) {
         return collector.accumulator().apply((B) container, valueA, valueB, valueC, valueD);
@@ -2228,10 +2347,12 @@ public class ConstraintCollectorsTest {
         assertEquals("Collector (" + collector + ") did not produce expected result.", expectedResult, actualResult);
     }
 
+    @SafeVarargs
     private static <X> Set<X> asSet(X... items) {
         return stream(items).collect(Collectors.toCollection(LinkedHashSet::new));
     }
 
+    @SafeVarargs
     private static <X> SortedSet<X> asSortedSet(X... items) {
         return stream(items).collect(Collectors.toCollection(TreeSet::new));
     }
@@ -2248,9 +2369,16 @@ public class ConstraintCollectorsTest {
         return result;
     }
 
-    private static <X, Y> Map<X, Y> asMap(X x1, Y y1, X x2, Y y2, X x3, Y y3) {
-        Map<X, Y> result = asMap(x1, y1, x2, y2);
-        result.put(x3, y3);
+    private static <X extends Comparable<X>, Y extends Comparable<Y>> SortedMap<X, Y> asSortedMap(X x1, Y y1) {
+        SortedMap<X, Y> result = new TreeMap<>();
+        result.put(x1, y1);
+        return result;
+    }
+
+    private static <X extends Comparable<X>, Y extends Comparable<Y>> SortedMap<X, Y> asSortedMap(X x1, Y y1, X x2,
+            Y y2) {
+        SortedMap<X, Y> result = asSortedMap(x1, y1);
+        result.put(x2, y2);
         return result;
     }
 

--- a/optaplanner-core/src/test/java/org/optaplanner/core/api/score/stream/ConstraintCollectorsTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/api/score/stream/ConstraintCollectorsTest.java
@@ -21,8 +21,10 @@ import java.math.BigInteger;
 import java.time.Duration;
 import java.time.Period;
 import java.util.Comparator;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
@@ -39,6 +41,7 @@ import org.optaplanner.core.api.score.stream.uni.UniConstraintCollector;
 import static java.util.Arrays.asList;
 import static java.util.Arrays.stream;
 import static java.util.Collections.emptyList;
+import static java.util.Collections.emptyMap;
 import static java.util.Collections.emptySet;
 import static java.util.Collections.emptySortedSet;
 import static java.util.Collections.singleton;
@@ -2066,6 +2069,122 @@ public class ConstraintCollectorsTest {
         assertResult(collector, container, emptyList());
     }
 
+    @Test
+    public void toMapMerged() {
+        UniConstraintCollector<Integer, ?, Map<Integer, Integer>> collector =
+                ConstraintCollectors.toMap(Function.identity(), Function.identity(), Integer::sum);
+        Object container = collector.supplier().get();
+
+        assertResult(collector, container, emptyMap());
+        // Add first value, we have one now.
+        int firstValue = 2;
+        Runnable firstRetractor = accumulate(collector, container, firstValue);
+        assertResult(collector, container, asMap(2, 2));
+        // Add second value, we have two now.
+        int secondValue = 1;
+        Runnable secondRetractor = accumulate(collector, container, secondValue);
+        assertResult(collector, container, asMap(2, 2, 1, 1));
+        // Add third value, same as the second. We now have three values, two of which map to the same key.
+        Runnable thirdRetractor = accumulate(collector, container, secondValue);
+        assertResult(collector, container, asMap(2, 2, 1, 1));
+        // Retract one instance of the second value; we only have two values now.
+        secondRetractor.run();
+        assertResult(collector, container, asMap(2, 2, 1, 1));
+        // Retract final instance of the second value; we only have one value now.
+        thirdRetractor.run();
+        assertResult(collector, container, asMap(2, 2));
+        // Retract last value; there are no values now.
+        firstRetractor.run();
+        assertResult(collector, container, emptyMap());
+    }
+
+    @Test
+    public void toMapBiMerged() {
+        BiConstraintCollector<Integer, Integer, ?, Map<Integer, Integer>> collector =
+                ConstraintCollectors.toMap(Integer::sum, Integer::sum, Integer::sum);
+        Object container = collector.supplier().get();
+
+        assertResult(collector, container, emptyMap());
+        // Add first value, we have one now.
+        int firstValue = 2;
+        Runnable firstRetractor = accumulate(collector, container, firstValue, 0);
+        assertResult(collector, container, asMap(2, 2));
+        // Add second value, we have two now.
+        int secondValue = 1;
+        Runnable secondRetractor = accumulate(collector, container, secondValue, 0);
+        assertResult(collector, container, asMap(2, 2, 1, 1));
+        // Add third value, same as the second. We now have three values, two of which map to the same key.
+        Runnable thirdRetractor = accumulate(collector, container, secondValue, 0);
+        assertResult(collector, container, asMap(2, 2, 1, 1));
+        // Retract one instance of the second value; we only have two values now.
+        secondRetractor.run();
+        assertResult(collector, container, asMap(2, 2, 1, 1));
+        // Retract final instance of the second value; we only have one value now.
+        thirdRetractor.run();
+        assertResult(collector, container, asMap(2, 2));
+        // Retract last value; there are no values now.
+        firstRetractor.run();
+        assertResult(collector, container, emptyMap());
+    }
+
+    @Test
+    public void toMapTriMerged() {
+        TriConstraintCollector<Integer, Integer, Integer, ?, Map<Integer, Integer>> collector =
+                ConstraintCollectors.toMap((a, b, c) -> a + b + c, (a, b, c) -> a + b + c, Integer::sum);
+        Object container = collector.supplier().get();
+
+        assertResult(collector, container, emptyMap());
+        // Add first value, we have one now.
+        int firstValue = 2;
+        Runnable firstRetractor = accumulate(collector, container, firstValue, 0, 0);
+        assertResult(collector, container, asMap(2, 2));
+        // Add second value, we have two now.
+        int secondValue = 1;
+        Runnable secondRetractor = accumulate(collector, container, secondValue, 0, 0);
+        assertResult(collector, container, asMap(2, 2, 1, 1));
+        // Add third value, same as the second. We now have three values, two of which map to the same key.
+        Runnable thirdRetractor = accumulate(collector, container, secondValue, 0, 0);
+        assertResult(collector, container, asMap(2, 2, 1, 1));
+        // Retract one instance of the second value; we only have two values now.
+        secondRetractor.run();
+        assertResult(collector, container, asMap(2, 2, 1, 1));
+        // Retract final instance of the second value; we only have one value now.
+        thirdRetractor.run();
+        assertResult(collector, container, asMap(2, 2));
+        // Retract last value; there are no values now.
+        firstRetractor.run();
+        assertResult(collector, container, emptyMap());
+    }
+
+    @Test
+    public void toMapQuadMerged() {
+        QuadConstraintCollector<Integer, Integer, Integer, Integer, ?, Map<Integer, Integer>> collector =
+                ConstraintCollectors.toMap((a, b, c, d) -> a + b + c + d, (a, b, c, d) -> a + b + c + d, Integer::sum);
+        Object container = collector.supplier().get();
+
+        assertResult(collector, container, emptyMap());
+        // Add first value, we have one now.
+        int firstValue = 2;
+        Runnable firstRetractor = accumulate(collector, container, firstValue, 0, 0, 0);
+        assertResult(collector, container, asMap(2, 2));
+        // Add second value, we have two now.
+        int secondValue = 1;
+        Runnable secondRetractor = accumulate(collector, container, secondValue, 0, 0, 0);
+        assertResult(collector, container, asMap(2, 2, 1, 1));
+        // Add third value, same as the second. We now have three values, two of which map to the same key.
+        Runnable thirdRetractor = accumulate(collector, container, secondValue, 0, 0, 0);
+        assertResult(collector, container, asMap(2, 2, 1, 1));
+        // Retract one instance of the second value; we only have two values now.
+        secondRetractor.run();
+        assertResult(collector, container, asMap(2, 2, 1, 1));
+        // Retract final instance of the second value; we only have one value now.
+        thirdRetractor.run();
+        assertResult(collector, container, asMap(2, 2));
+        // Retract last value; there are no values now.
+        firstRetractor.run();
+        assertResult(collector, container, emptyMap());
+    }
+
     private static <A, B, C, D> Runnable accumulate(QuadConstraintCollector<A, A, A, A, B, C> collector, Object container,
             A valueA, A valueB, A valueC, A valueD) {
         return collector.accumulator().apply((B) container, valueA, valueB, valueC, valueD);
@@ -2115,6 +2234,24 @@ public class ConstraintCollectorsTest {
 
     private static <X> SortedSet<X> asSortedSet(X... items) {
         return stream(items).collect(Collectors.toCollection(TreeSet::new));
+    }
+
+    private static <X, Y> Map<X, Y> asMap(X x1, Y y1) {
+        Map<X, Y> result = new LinkedHashMap<>(0);
+        result.put(x1, y1);
+        return result;
+    }
+
+    private static <X, Y> Map<X, Y> asMap(X x1, Y y1, X x2, Y y2) {
+        Map<X, Y> result = asMap(x1, y1);
+        result.put(x2, y2);
+        return result;
+    }
+
+    private static <X, Y> Map<X, Y> asMap(X x1, Y y1, X x2, Y y2, X x3, Y y3) {
+        Map<X, Y> result = asMap(x1, y1, x2, y2);
+        result.put(x3, y3);
+        return result;
     }
 
 }

--- a/optaplanner-core/src/test/java/org/optaplanner/core/api/score/stream/ConstraintCollectorsTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/api/score/stream/ConstraintCollectorsTest.java
@@ -24,6 +24,8 @@ import java.util.Comparator;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.SortedSet;
+import java.util.TreeSet;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -38,6 +40,7 @@ import static java.util.Arrays.asList;
 import static java.util.Arrays.stream;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.emptySet;
+import static java.util.Collections.emptySortedSet;
 import static java.util.Collections.singleton;
 import static java.util.Collections.singletonList;
 import static org.junit.Assert.assertEquals;
@@ -1735,6 +1738,32 @@ public class ConstraintCollectorsTest {
     }
 
     @Test
+    public void toSortedSet() {
+        UniConstraintCollector<Integer, ?, SortedSet<Integer>> collector = ConstraintCollectors.toSortedSet();
+        Object container = collector.supplier().get();
+        // Add first value, we have one now.
+        int firstValue = 2;
+        Runnable firstRetractor = accumulate(collector, container, firstValue);
+        assertResult(collector, container, asSortedSet(firstValue));
+        // Add second value, we have two now.
+        int secondValue = 1;
+        Runnable secondRetractor = accumulate(collector, container, secondValue);
+        assertResult(collector, container, asSortedSet(firstValue, secondValue));
+        // Add third value, same as the second. We now have three values, two of which are the same.
+        Runnable thirdRetractor = accumulate(collector, container, secondValue);
+        assertResult(collector, container, asSortedSet(firstValue, secondValue));
+        // Retract one instance of the second value; we only have two values now.
+        secondRetractor.run();
+        assertResult(collector, container,asSortedSet(firstValue, secondValue));
+        // Retract final instance of the second value; we only have one value now.
+        thirdRetractor.run();
+        assertResult(collector, container, asSortedSet(firstValue));
+        // Retract last value; there are no values now.
+        firstRetractor.run();
+        assertResult(collector, container, emptySortedSet());
+    }
+
+    @Test
     public void toList() {
         UniConstraintCollector<Integer, ?, List<Integer>> collector = ConstraintCollectors.toList();
         Object container = collector.supplier().get();
@@ -1786,6 +1815,35 @@ public class ConstraintCollectorsTest {
         // Retract last value; there are no values now.
         firstRetractor.run();
         assertResult(collector, container, emptySet());
+    }
+
+    @Test
+    public void toSortedSetBi() {
+        BiConstraintCollector<Integer, Integer, ?, SortedSet<Integer>> collector =
+                ConstraintCollectors.toSortedSet(Integer::sum);
+        Object container = collector.supplier().get();
+        // Add first value, we have one now.
+        int firstValueA = 2;
+        int firstValueB = 1;
+        Runnable firstRetractor = accumulate(collector, container, firstValueA, firstValueB);
+        assertResult(collector, container, asSortedSet(3));
+        // Add second value, we have two now.
+        int secondValueA = 3;
+        int secondValueB = 4;
+        Runnable secondRetractor = accumulate(collector, container, secondValueA, secondValueB);
+        assertResult(collector, container, asSortedSet(3, 7));
+        // Add third value, same as the second. We now have three values, two of which are the same.
+        Runnable thirdRetractor = accumulate(collector, container, secondValueA, secondValueB);
+        assertResult(collector, container, asSortedSet(3, 7));
+        // Retract one instance of the second value; we only have two values now.
+        secondRetractor.run();
+        assertResult(collector, container, asSortedSet(3, 7));
+        // Retract final instance of the second value; we only have one value now.
+        thirdRetractor.run();
+        assertResult(collector, container, asSortedSet(3));
+        // Retract last value; there are no values now.
+        firstRetractor.run();
+        assertResult(collector, container, emptySortedSet());
     }
 
     @Test
@@ -1845,6 +1903,37 @@ public class ConstraintCollectorsTest {
         // Retract last value; there are no values now.
         firstRetractor.run();
         assertResult(collector, container, emptySet());
+    }
+
+    @Test
+    public void toSortedSetTri() {
+        TriConstraintCollector<Integer, Integer, Integer, ?, SortedSet<Integer>> collector =
+                ConstraintCollectors.toSortedSet((a, b, c) -> a + b + c);
+        Object container = collector.supplier().get();
+        // Add first value, we have one now.
+        int firstValueA = 2;
+        int firstValueB = 1;
+        int firstValueC = 3;
+        Runnable firstRetractor = accumulate(collector, container, firstValueA, firstValueB, firstValueC);
+        assertResult(collector, container, asSortedSet(6));
+        // Add second value, we have two now.
+        int secondValueA = 3;
+        int secondValueB = 4;
+        int secondValueC = 2;
+        Runnable secondRetractor = accumulate(collector, container, secondValueA, secondValueB, secondValueC);
+        assertResult(collector, container, asSortedSet(6, 9));
+        // Add third value, same as the second. We now have three values, two of which are the same.
+        Runnable thirdRetractor = accumulate(collector, container, secondValueA, secondValueB, secondValueC);
+        assertResult(collector, container, asSortedSet(6, 9));
+        // Retract one instance of the second value; we only have two values now.
+        secondRetractor.run();
+        assertResult(collector, container, asSortedSet(6, 9));
+        // Retract final instance of the second value; we only have one value now.
+        thirdRetractor.run();
+        assertResult(collector, container, asSortedSet(6));
+        // Retract last value; there are no values now.
+        firstRetractor.run();
+        assertResult(collector, container, emptySortedSet());
     }
 
     @Test
@@ -1909,6 +1998,39 @@ public class ConstraintCollectorsTest {
         // Retract last value; there are no values now.
         firstRetractor.run();
         assertResult(collector, container, emptySet());
+    }
+
+    @Test
+    public void toSortedSetQuad() {
+        QuadConstraintCollector<Integer, Integer, Integer, Integer, ?, SortedSet<Integer>> collector =
+                ConstraintCollectors.toSortedSet((a, b, c, d) -> a + b + c + d);
+        Object container = collector.supplier().get();
+        // Add first value, we have one now.
+        int firstValueA = 2;
+        int firstValueB = 1;
+        int firstValueC = 3;
+        int firstValueD = 4;
+        Runnable firstRetractor = accumulate(collector, container, firstValueA, firstValueB, firstValueC, firstValueD);
+        assertResult(collector, container, asSortedSet(10));
+        // Add second value, we have two now.
+        int secondValueA = 3;
+        int secondValueB = 4;
+        int secondValueC = 2;
+        int secondValueD = 5;
+        Runnable secondRetractor = accumulate(collector, container, secondValueA, secondValueB, secondValueC, secondValueD);
+        assertResult(collector, container, asSortedSet(10, 14));
+        // Add third value, same as the second. We now have three values, two of which are the same.
+        Runnable thirdRetractor = accumulate(collector, container, secondValueA, secondValueB, secondValueC, secondValueD);
+        assertResult(collector, container, asSortedSet(10, 14));
+        // Retract one instance of the second value; we only have two values now.
+        secondRetractor.run();
+        assertResult(collector, container, asSortedSet(10, 14));
+        // Retract final instance of the second value; we only have one value now.
+        thirdRetractor.run();
+        assertResult(collector, container, asSortedSet(10));
+        // Retract last value; there are no values now.
+        firstRetractor.run();
+        assertResult(collector, container, emptySortedSet());
     }
 
     @Test
@@ -1989,6 +2111,10 @@ public class ConstraintCollectorsTest {
 
     private static <X> Set<X> asSet(X... items) {
         return stream(items).collect(Collectors.toCollection(LinkedHashSet::new));
+    }
+
+    private static <X> SortedSet<X> asSortedSet(X... items) {
+        return stream(items).collect(Collectors.toCollection(TreeSet::new));
     }
 
 }

--- a/optaplanner-core/src/test/java/org/optaplanner/core/api/score/stream/ConstraintCollectorsTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/api/score/stream/ConstraintCollectorsTest.java
@@ -2073,6 +2073,35 @@ public class ConstraintCollectorsTest {
     }
 
     @Test
+    public void toMap() {
+        UniConstraintCollector<Integer, ?, Map<Integer, Set<Integer>>> collector =
+                ConstraintCollectors.toMap(Function.identity(), Function.identity());
+        Object container = collector.supplier().get();
+
+        assertResult(collector, container, emptyMap());
+        // Add first value, we have one now.
+        int firstValue = 2;
+        Runnable firstRetractor = accumulate(collector, container, firstValue);
+        assertResult(collector, container, asMap(2, singleton(2)));
+        // Add second value, we have two now.
+        int secondValue = 1;
+        Runnable secondRetractor = accumulate(collector, container, secondValue);
+        assertResult(collector, container, asMap(2, singleton(2), 1, singleton(1)));
+        // Add third value, same as the second. We now have three values, two of which map to the same key.
+        Runnable thirdRetractor = accumulate(collector, container, secondValue);
+        assertResult(collector, container, asMap(2, singleton(2), 1, singleton(1)));
+        // Retract one instance of the second value; we only have two values now.
+        secondRetractor.run();
+        assertResult(collector, container, asMap(2, singleton(2), 1, singleton(1)));
+        // Retract final instance of the second value; we only have one value now.
+        thirdRetractor.run();
+        assertResult(collector, container, asMap(2, singleton(2)));
+        // Retract last value; there are no values now.
+        firstRetractor.run();
+        assertResult(collector, container, emptyMap());
+    }
+
+    @Test
     public void toMapMerged() {
         UniConstraintCollector<Integer, ?, Map<Integer, Integer>> collector =
                 ConstraintCollectors.toMap(Function.identity(), Function.identity(), Integer::sum);
@@ -2096,6 +2125,35 @@ public class ConstraintCollectorsTest {
         // Retract final instance of the second value; we only have one value now.
         thirdRetractor.run();
         assertResult(collector, container, asMap(2, 2));
+        // Retract last value; there are no values now.
+        firstRetractor.run();
+        assertResult(collector, container, emptyMap());
+    }
+
+    @Test
+    public void toBiMap() {
+        BiConstraintCollector<Integer, Integer, ?, Map<Integer, Set<Integer>>> collector =
+                ConstraintCollectors.toMap(Integer::sum, Integer::sum);
+        Object container = collector.supplier().get();
+
+        assertResult(collector, container, emptyMap());
+        // Add first value, we have one now.
+        int firstValue = 2;
+        Runnable firstRetractor = accumulate(collector, container, firstValue, 0);
+        assertResult(collector, container, asMap(2, singleton(2)));
+        // Add second value, we have two now.
+        int secondValue = 1;
+        Runnable secondRetractor = accumulate(collector, container, secondValue, 0);
+        assertResult(collector, container, asMap(2, singleton(2), 1, singleton(1)));
+        // Add third value, same as the second. We now have three values, two of which map to the same key.
+        Runnable thirdRetractor = accumulate(collector, container, secondValue, 0);
+        assertResult(collector, container, asMap(2, singleton(2), 1, singleton(1)));
+        // Retract one instance of the second value; we only have two values now.
+        secondRetractor.run();
+        assertResult(collector, container, asMap(2, singleton(2), 1, singleton(1)));
+        // Retract final instance of the second value; we only have one value now.
+        thirdRetractor.run();
+        assertResult(collector, container, asMap(2, singleton(2)));
         // Retract last value; there are no values now.
         firstRetractor.run();
         assertResult(collector, container, emptyMap());
@@ -2131,6 +2189,35 @@ public class ConstraintCollectorsTest {
     }
 
     @Test
+    public void toMapTri() {
+        TriConstraintCollector<Integer, Integer, Integer, ?, Map<Integer, Set<Integer>>> collector =
+                ConstraintCollectors.toMap((a, b, c) -> a + b + c, (a, b, c) -> a + b + c);
+        Object container = collector.supplier().get();
+
+        assertResult(collector, container, emptyMap());
+        // Add first value, we have one now.
+        int firstValue = 2;
+        Runnable firstRetractor = accumulate(collector, container, firstValue, 0, 0);
+        assertResult(collector, container, asMap(2, singleton(2)));
+        // Add second value, we have two now.
+        int secondValue = 1;
+        Runnable secondRetractor = accumulate(collector, container, secondValue, 0, 0);
+        assertResult(collector, container, asMap(2, singleton(2), 1, singleton(1)));
+        // Add third value, same as the second. We now have three values, two of which map to the same key.
+        Runnable thirdRetractor = accumulate(collector, container, secondValue, 0, 0);
+        assertResult(collector, container, asMap(2, singleton(2), 1, singleton(1)));
+        // Retract one instance of the second value; we only have two values now.
+        secondRetractor.run();
+        assertResult(collector, container, asMap(2, singleton(2), 1, singleton(1)));
+        // Retract final instance of the second value; we only have one value now.
+        thirdRetractor.run();
+        assertResult(collector, container, asMap(2, singleton(2)));
+        // Retract last value; there are no values now.
+        firstRetractor.run();
+        assertResult(collector, container, emptyMap());
+    }
+
+    @Test
     public void toMapTriMerged() {
         TriConstraintCollector<Integer, Integer, Integer, ?, Map<Integer, Integer>> collector =
                 ConstraintCollectors.toMap((a, b, c) -> a + b + c, (a, b, c) -> a + b + c, Integer::sum);
@@ -2154,6 +2241,35 @@ public class ConstraintCollectorsTest {
         // Retract final instance of the second value; we only have one value now.
         thirdRetractor.run();
         assertResult(collector, container, asMap(2, 2));
+        // Retract last value; there are no values now.
+        firstRetractor.run();
+        assertResult(collector, container, emptyMap());
+    }
+
+    @Test
+    public void toMapQuad() {
+        QuadConstraintCollector<Integer, Integer, Integer, Integer, ?, Map<Integer, Set<Integer>>> collector =
+                ConstraintCollectors.toMap((a, b, c, d) -> a + b + c + d, (a, b, c, d) -> a + b + c + d);
+        Object container = collector.supplier().get();
+
+        assertResult(collector, container, emptyMap());
+        // Add first value, we have one now.
+        int firstValue = 2;
+        Runnable firstRetractor = accumulate(collector, container, firstValue, 0, 0, 0);
+        assertResult(collector, container, asMap(2, singleton(2)));
+        // Add second value, we have two now.
+        int secondValue = 1;
+        Runnable secondRetractor = accumulate(collector, container, secondValue, 0, 0, 0);
+        assertResult(collector, container, asMap(2, singleton(2), 1, singleton(1)));
+        // Add third value, same as the second. We now have three values, two of which map to the same key.
+        Runnable thirdRetractor = accumulate(collector, container, secondValue, 0, 0, 0);
+        assertResult(collector, container, asMap(2, singleton(2), 1, singleton(1)));
+        // Retract one instance of the second value; we only have two values now.
+        secondRetractor.run();
+        assertResult(collector, container, asMap(2, singleton(2), 1, singleton(1)));
+        // Retract final instance of the second value; we only have one value now.
+        thirdRetractor.run();
+        assertResult(collector, container, asMap(2, singleton(2)));
         // Retract last value; there are no values now.
         firstRetractor.run();
         assertResult(collector, container, emptyMap());
@@ -2189,6 +2305,35 @@ public class ConstraintCollectorsTest {
     }
 
     @Test
+    public void toSortedMap() {
+        UniConstraintCollector<Integer, ?, SortedMap<Integer, Set<Integer>>> collector =
+                ConstraintCollectors.toSortedMap(a -> a, Function.identity());
+        Object container = collector.supplier().get();
+
+        assertResult(collector, container, emptySortedMap());
+        // Add first value, we have one now.
+        int firstValue = 2;
+        Runnable firstRetractor = accumulate(collector, container, firstValue);
+        assertResult(collector, container, asSortedMap(2, singleton(2)));
+        // Add second value, we have two now.
+        int secondValue = 1;
+        Runnable secondRetractor = accumulate(collector, container, secondValue);
+        assertResult(collector, container, asSortedMap(2, singleton(2), 1, singleton(1)));
+        // Add third value, same as the second. We now have three values, two of which map to the same key.
+        Runnable thirdRetractor = accumulate(collector, container, secondValue);
+        assertResult(collector, container, asSortedMap(2, singleton(2), 1, singleton(1)));
+        // Retract one instance of the second value; we only have two values now.
+        secondRetractor.run();
+        assertResult(collector, container, asSortedMap(2, singleton(2), 1, singleton(1)));
+        // Retract final instance of the second value; we only have one value now.
+        thirdRetractor.run();
+        assertResult(collector, container, asSortedMap(2, singleton(2)));
+        // Retract last value; there are no values now.
+        firstRetractor.run();
+        assertResult(collector, container, emptySortedMap());
+    }
+
+    @Test
     public void toSortedMapMerged() {
         UniConstraintCollector<Integer, ?, SortedMap<Integer, Integer>> collector =
                 ConstraintCollectors.toSortedMap(a -> a, Function.identity(), Integer::sum);
@@ -2212,6 +2357,35 @@ public class ConstraintCollectorsTest {
         // Retract final instance of the second value; we only have one value now.
         thirdRetractor.run();
         assertResult(collector, container, asSortedMap(2, 2));
+        // Retract last value; there are no values now.
+        firstRetractor.run();
+        assertResult(collector, container, emptySortedMap());
+    }
+
+    @Test
+    public void toSortedMapBi() {
+        BiConstraintCollector<Integer, Integer, ?, SortedMap<Integer, Set<Integer>>> collector =
+                ConstraintCollectors.toSortedMap(Integer::sum, Integer::sum);
+        Object container = collector.supplier().get();
+
+        assertResult(collector, container, emptySortedMap());
+        // Add first value, we have one now.
+        int firstValue = 2;
+        Runnable firstRetractor = accumulate(collector, container, firstValue, 0);
+        assertResult(collector, container, asSortedMap(2, singleton(2)));
+        // Add second value, we have two now.
+        int secondValue = 1;
+        Runnable secondRetractor = accumulate(collector, container, secondValue, 0);
+        assertResult(collector, container, asSortedMap(2, singleton(2), 1, singleton(1)));
+        // Add third value, same as the second. We now have three values, two of which map to the same key.
+        Runnable thirdRetractor = accumulate(collector, container, secondValue, 0);
+        assertResult(collector, container, asSortedMap(2, singleton(2), 1, singleton(1)));
+        // Retract one instance of the second value; we only have two values now.
+        secondRetractor.run();
+        assertResult(collector, container, asSortedMap(2, singleton(2), 1, singleton(1)));
+        // Retract final instance of the second value; we only have one value now.
+        thirdRetractor.run();
+        assertResult(collector, container, asSortedMap(2, singleton(2)));
         // Retract last value; there are no values now.
         firstRetractor.run();
         assertResult(collector, container, emptySortedMap());
@@ -2247,6 +2421,35 @@ public class ConstraintCollectorsTest {
     }
 
     @Test
+    public void toSortedMapTri() {
+        TriConstraintCollector<Integer, Integer, Integer, ?, SortedMap<Integer, Set<Integer>>> collector =
+                ConstraintCollectors.toSortedMap((a, b, c) -> a + b + c, (a, b, c) -> a + b + c);
+        Object container = collector.supplier().get();
+
+        assertResult(collector, container, emptySortedMap());
+        // Add first value, we have one now.
+        int firstValue = 2;
+        Runnable firstRetractor = accumulate(collector, container, firstValue, 0, 0);
+        assertResult(collector, container, asSortedMap(2, singleton(2)));
+        // Add second value, we have two now.
+        int secondValue = 1;
+        Runnable secondRetractor = accumulate(collector, container, secondValue, 0, 0);
+        assertResult(collector, container, asSortedMap(2, singleton(2), 1, singleton(1)));
+        // Add third value, same as the second. We now have three values, two of which map to the same key.
+        Runnable thirdRetractor = accumulate(collector, container, secondValue, 0, 0);
+        assertResult(collector, container, asSortedMap(2, singleton(2), 1, singleton(1)));
+        // Retract one instance of the second value; we only have two values now.
+        secondRetractor.run();
+        assertResult(collector, container, asSortedMap(2, singleton(2), 1, singleton(1)));
+        // Retract final instance of the second value; we only have one value now.
+        thirdRetractor.run();
+        assertResult(collector, container, asSortedMap(2, singleton(2)));
+        // Retract last value; there are no values now.
+        firstRetractor.run();
+        assertResult(collector, container, emptySortedMap());
+    }
+
+    @Test
     public void toSortedMapTriMerged() {
         TriConstraintCollector<Integer, Integer, Integer, ?, SortedMap<Integer, Integer>> collector =
                 ConstraintCollectors.toSortedMap((a, b, c) -> a + b + c, (a, b, c) -> a + b + c, Integer::sum);
@@ -2270,6 +2473,35 @@ public class ConstraintCollectorsTest {
         // Retract final instance of the second value; we only have one value now.
         thirdRetractor.run();
         assertResult(collector, container, asSortedMap(2, 2));
+        // Retract last value; there are no values now.
+        firstRetractor.run();
+        assertResult(collector, container, emptySortedMap());
+    }
+
+    @Test
+    public void toSortedMapQuad() {
+        QuadConstraintCollector<Integer, Integer, Integer, Integer, ?, SortedMap<Integer, Set<Integer>>> collector =
+                ConstraintCollectors.toSortedMap((a, b, c, d) -> a + b + c + d, (a, b, c, d) -> a + b + c + d);
+        Object container = collector.supplier().get();
+
+        assertResult(collector, container, emptySortedMap());
+        // Add first value, we have one now.
+        int firstValue = 2;
+        Runnable firstRetractor = accumulate(collector, container, firstValue, 0, 0, 0);
+        assertResult(collector, container, asSortedMap(2, singleton(2)));
+        // Add second value, we have two now.
+        int secondValue = 1;
+        Runnable secondRetractor = accumulate(collector, container, secondValue, 0, 0, 0);
+        assertResult(collector, container, asSortedMap(2, singleton(2), 1, singleton(1)));
+        // Add third value, same as the second. We now have three values, two of which map to the same key.
+        Runnable thirdRetractor = accumulate(collector, container, secondValue, 0, 0, 0);
+        assertResult(collector, container, asSortedMap(2, singleton(2), 1, singleton(1)));
+        // Retract one instance of the second value; we only have two values now.
+        secondRetractor.run();
+        assertResult(collector, container, asSortedMap(2, singleton(2), 1, singleton(1)));
+        // Retract final instance of the second value; we only have one value now.
+        thirdRetractor.run();
+        assertResult(collector, container, asSortedMap(2, singleton(2)));
         // Retract last value; there are no values now.
         firstRetractor.run();
         assertResult(collector, container, emptySortedMap());
@@ -2369,14 +2601,13 @@ public class ConstraintCollectorsTest {
         return result;
     }
 
-    private static <X extends Comparable<X>, Y extends Comparable<Y>> SortedMap<X, Y> asSortedMap(X x1, Y y1) {
+    private static <X extends Comparable<X>, Y> SortedMap<X, Y> asSortedMap(X x1, Y y1) {
         SortedMap<X, Y> result = new TreeMap<>();
         result.put(x1, y1);
         return result;
     }
 
-    private static <X extends Comparable<X>, Y extends Comparable<Y>> SortedMap<X, Y> asSortedMap(X x1, Y y1, X x2,
-            Y y2) {
+    private static <X extends Comparable<X>, Y> SortedMap<X, Y> asSortedMap(X x1, Y y1, X x2, Y y2) {
         SortedMap<X, Y> result = asSortedMap(x1, y1);
         result.put(x2, y2);
         return result;


### PR DESCRIPTION
This, I think, completes our collection of collectors. I can't think of anything else we'd need out of the box.

Introduces six kinds of methods, the end result of which is:

1. `Map<X, Set<Y>>`.
1. `Map<X, C<Y>>`, where `C` is a `Set` provided by the user. (So that they can use `TreeSet`.)
1. `Map<X, Y>` with a reducer from `Set<Y>` to `<Y>`. 
1. `SortedMap<X, Set<Y>>`.
1. `SortedMap<X, C<Y>>`, where `C` is a `Set` provided by the user. (So that they can use `TreeSet`.)
1. `SortedMap<X, Y>` with a reducer from `Set<Y>` to `<Y>`. 

Also, for consistency, I'm adding similar `toSortedSet()` methods to accompany the current `toSet()` methods.