### PR TITLE
Performance improvements to Drools-based Constraint Streams

### DIFF
--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/common/BiTuple.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/common/BiTuple.java
@@ -45,7 +45,8 @@ public final class BiTuple<A, B> implements FactTuple {
             return false;
         }
         final BiTuple<?, ?> other = (BiTuple<?, ?>) o;
-        return Objects.equals(a, other.a) &&
+        return hashCode == other.hashCode &&
+                Objects.equals(a, other.a) &&
                 Objects.equals(b, other.b);
     }
 

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/common/DroolsAbstractBiCollectingGroupByAccumulator.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/common/DroolsAbstractBiCollectingGroupByAccumulator.java
@@ -17,74 +17,48 @@
 package org.optaplanner.core.impl.score.stream.drools.common;
 
 import java.util.Collection;
-import java.util.IdentityHashMap;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
-import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
-import java.util.function.BiFunction;
-import java.util.function.Supplier;
 
-public abstract class DroolsAbstractBiCollectingGroupByAccumulator<ResultContainer1, ResultContainer2, InTuple, KeyTuple,
-        OutTuple> implements GroupByAccumulator<InTuple, OutTuple> {
+public abstract class DroolsAbstractBiCollectingGroupByAccumulator<ResultContainer1, ResultContainer2, InTuple, KeyTuple, OutTuple>
+        extends DroolsAbstractGroupByAccumulator<InTuple, KeyTuple, OutTuple> {
 
-    // Containers may be identical in type and contents, yet they should still not count as the same container.
-    private final Map<ResultContainer1, Long> containersInUseMap1 = new IdentityHashMap<>(0);
-    private final Map<ResultContainer2, Long> containersInUseMap2 = new IdentityHashMap<>(0);
+    private final Map<KeyTuple, ResultContainer1> containersMap1 = new HashMap<>(0);
+    private final Map<KeyTuple, ResultContainer2> containersMap2 = new HashMap<>(0);
     // LinkedHashMap to maintain a consistent iteration order of resulting pairs.
-    private final Map<KeyTuple, ResultContainer1> containersMap1 = new LinkedHashMap<>(0);
-    private final Map<KeyTuple, ResultContainer2> containersMap2 = new LinkedHashMap<>(0);
-    // Transient as Spotbugs complains otherwise ("non-transient non-serializable instance field").
-    // It doesn't make sense to serialize this anyway, as it is recreated every time.
-    private final transient Set<OutTuple> resultSet = new LinkedHashSet<>(0);
+    private final Map<KeyTuple, OutTuple> resultMap = new LinkedHashMap<>(0);
 
-    private <ResultContainer> Runnable accumulate(InTuple input, Supplier<ResultContainer> containerSupplier,
-            BiFunction<InTuple, ResultContainer, Runnable> inputProcessor, Map<KeyTuple, ResultContainer> containersMap,
-            Map<ResultContainer, Long> containersInUseMap) {
+    @Override
+    public Runnable accumulate(InTuple input) {
         KeyTuple key = toKey(input);
-        ResultContainer container = containersMap.computeIfAbsent(key, __ -> containerSupplier.get());
-        Runnable undo = inputProcessor.apply(input, container);
-        containersInUseMap.compute(container, (__, count) -> increment(count)); // Increment use counter.
+        ResultContainer1 container1 = containersMap1.computeIfAbsent(key, __ -> newFirstContainer());
+        ResultContainer2 container2 = containersMap2.computeIfAbsent(key, __ -> newSecondContainer());
+        Runnable undo1 = processFirst(input, container1);
+        Runnable undo2 = processSecond(input, container2);
+        addTuple(key);
         return () -> {
-            undo.run();
-            // Decrement use counter. If 0, container is ignored during finishing. Removes empty groups from results.
-            Long currentCount = containersInUseMap.compute(container, (__, count) -> decrement(count));
-            if (currentCount == null) {
-                containersMap.remove(key);
+            undo1.run();
+            undo2.run();
+            long currentCount = removeTuple(key);
+            if (currentCount == 0L) {
+                containersMap1.remove(key);
+                containersMap2.remove(key);
+                resultMap.remove(key);
             }
         };
     }
 
     @Override
-    public Runnable accumulate(InTuple input) {
-        Runnable firstUndo = accumulate(input, this::newFirstContainer, this::processFirst, containersMap1,
-                containersInUseMap1);
-        Runnable secondUndo = accumulate(input, this::newSecondContainer, this::processSecond, containersMap2,
-                containersInUseMap2);
-        return () -> {
-            firstUndo.run();
-            secondUndo.run();
-        };
-    }
-
-    private static Long increment(Long count) {
-        return count == null ? 1L : count + 1L;
-    }
-
-    private static Long decrement(Long count) {
-        return count == 1L ? null : count - 1L;
-    }
-
-    @Override
     public Collection<OutTuple> finish() {
-        resultSet.clear();
-        for (Map.Entry<KeyTuple, ResultContainer1> entry : containersMap1.entrySet()) {
-            KeyTuple key = entry.getKey();
-            ResultContainer1 firstContainer = entry.getValue();
-            ResultContainer2 secondContainer = containersMap2.get(key);
-            resultSet.add(toResult(key, firstContainer, secondContainer));
+        Set<KeyTuple> dirtyTupleSet = clearDirtyTupleSet();
+        if (!dirtyTupleSet.isEmpty()) {
+            for (KeyTuple tuple : dirtyTupleSet) {
+                resultMap.put(tuple, toResult(tuple, containersMap1.get(tuple), containersMap2.get(tuple)));
+            }
         }
-        return resultSet;
+        return resultMap.values();
     }
 
     protected abstract KeyTuple toKey(InTuple tuple);

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/common/DroolsAbstractBiCollectingGroupByAccumulator.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/common/DroolsAbstractBiCollectingGroupByAccumulator.java
@@ -16,6 +16,7 @@
 
 package org.optaplanner.core.impl.score.stream.drools.common;
 
+import java.util.Collection;
 import java.util.IdentityHashMap;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
@@ -75,7 +76,7 @@ public abstract class DroolsAbstractBiCollectingGroupByAccumulator<ResultContain
     }
 
     @Override
-    public Set<OutTuple> finish() {
+    public Collection<OutTuple> finish() {
         resultSet.clear();
         for (Map.Entry<KeyTuple, ResultContainer1> entry : containersMap1.entrySet()) {
             KeyTuple key = entry.getKey();

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/common/DroolsAbstractGroupBy.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/common/DroolsAbstractGroupBy.java
@@ -17,9 +17,9 @@
 package org.optaplanner.core.impl.score.stream.drools.common;
 
 import java.io.Serializable;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Set;
 
 import org.drools.core.common.InternalFactHandle;
 
@@ -50,7 +50,7 @@ public abstract class DroolsAbstractGroupBy<InTuple, OutTuple> implements Serial
         undo.run();
     }
 
-    public Set<OutTuple> getResult() {
+    public Collection<OutTuple> getResult() {
         return acc.finish();
     }
 

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/common/DroolsAbstractGroupByAccumulator.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/common/DroolsAbstractGroupByAccumulator.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.core.impl.score.stream.drools.common;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+
+abstract class DroolsAbstractGroupByAccumulator<InTuple, KeyTuple, OutTuple>
+        implements GroupByAccumulator<InTuple, OutTuple> {
+
+    private final Map<KeyTuple, Long> tuplesInUseMap = new HashMap<>(0);
+    private Set<KeyTuple> dirtyTupleSet;
+
+    private static Long increment(Long count) {
+        return count == null ? 1L : count + 1L;
+    }
+
+    private static Long decrement(Long count) {
+        return count == 1L ? null : count - 1L;
+    }
+
+    protected void addTuple(KeyTuple tuple) {
+        tuplesInUseMap.compute(tuple, (__, count) -> increment(count));
+        markDirty(tuple);
+    }
+
+    protected long removeTuple(KeyTuple tuple) {
+        Long useCount = tuplesInUseMap.compute(tuple, (__, count) -> decrement(count));
+        if (useCount == null) {
+            unmarkDirty(tuple);
+            return 0L;
+        } else {
+            markDirty(tuple);
+            return useCount;
+        }
+    }
+
+    private void markDirty(KeyTuple tuple) {
+        if (dirtyTupleSet == null) {
+            dirtyTupleSet = new LinkedHashSet<>(1); // When trying a move, there will often only be 1 change.
+        }
+        dirtyTupleSet.add(tuple);
+    }
+
+    private void unmarkDirty(KeyTuple tuple) {
+        if (dirtyTupleSet != null) {
+            dirtyTupleSet.remove(tuple);
+            if (dirtyTupleSet.isEmpty()) {
+                clearDirtyTupleSet();
+            }
+        }
+    }
+
+    protected Set<KeyTuple> clearDirtyTupleSet() {
+        if (dirtyTupleSet == null) {
+            return Collections.emptySet();
+        } else {
+            Set<KeyTuple> currentDirtyTupleSet = dirtyTupleSet;
+            dirtyTupleSet = null; // Faster than calling clear().
+            return currentDirtyTupleSet;
+        }
+    }
+
+}

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/common/DroolsCondition.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/common/DroolsCondition.java
@@ -16,9 +16,13 @@
 
 package org.optaplanner.core.impl.score.stream.drools.common;
 
+import static org.drools.model.DSL.accFunction;
+import static org.drools.model.PatternDSL.alphaIndexedBy;
+import static org.drools.model.PatternDSL.pattern;
+
 import java.math.BigDecimal;
 import java.util.Arrays;
-import java.util.Set;
+import java.util.Collection;
 import java.util.function.BiFunction;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
@@ -47,10 +51,6 @@ import org.optaplanner.core.impl.score.stream.drools.tri.DroolsTriCondition;
 import org.optaplanner.core.impl.score.stream.drools.tri.DroolsTriRuleStructure;
 import org.optaplanner.core.impl.score.stream.drools.uni.DroolsUniCondition;
 import org.optaplanner.core.impl.score.stream.drools.uni.DroolsUniRuleStructure;
-
-import static org.drools.model.DSL.accFunction;
-import static org.drools.model.PatternDSL.alphaIndexedBy;
-import static org.drools.model.PatternDSL.pattern;
 
 /**
  * Encapsulates the low-level rule creation and manipulation operations via the Drools executable model DSL
@@ -116,11 +116,11 @@ public abstract class DroolsCondition<PatternVar, T extends DroolsRuleStructure<
                 .expand(p -> bindFunction.apply(p, mappedVariable))
                 .build();
         ViewItem<?> innerAccumulatePattern = getInnerAccumulatePattern(mainAccumulatePattern);
-        Variable<Set<InTuple>> tupleSet =
-                (Variable<Set<InTuple>>) ruleStructure.createVariable(Set.class,"tupleSet");
-        PatternDSL.PatternDef<Set<InTuple>> pattern = pattern(tupleSet)
+        Variable<Collection<InTuple>> tupleSet =
+                (Variable<Collection<InTuple>>) ruleStructure.createVariable(Collection.class,"tupleCollection");
+        PatternDSL.PatternDef<Collection<InTuple>> pattern = pattern(tupleSet)
                 .expr("Non-empty", set -> !set.isEmpty(),
-                        alphaIndexedBy(Integer.class, Index.ConstraintType.GREATER_THAN, -1, Set::size, 0));
+                        alphaIndexedBy(Integer.class, Index.ConstraintType.GREATER_THAN, -1, Collection::size, 0));
         ExprViewItem<Object> accumulate = DSL.accumulate(innerAccumulatePattern,
                 accFunction(CollectSetAccumulateFunction.class, mappedVariable).as(tupleSet));
         return mutator.apply(tupleSet, pattern, accumulate);
@@ -158,11 +158,11 @@ public abstract class DroolsCondition<PatternVar, T extends DroolsRuleStructure<
             C extends DroolsCondition<OutPatternVar, R>> C universalGroupWithCollect(
                     Supplier<? extends DroolsAbstractGroupByInvoker<InTuple>> invokerSupplier,
             Mutator<InTuple, OutPatternVar, R, C> mutator) {
-        Variable<Set<InTuple>> tupleSet =
-                (Variable<Set<InTuple>>) ruleStructure.createVariable(Set.class, "tupleSet");
-        PatternDSL.PatternDef<Set<InTuple>> pattern = pattern(tupleSet)
+        Variable<Collection<InTuple>> tupleSet =
+                (Variable<Collection<InTuple>>) ruleStructure.createVariable(Collection.class, "tupleCollection");
+        PatternDSL.PatternDef<Collection<InTuple>> pattern = pattern(tupleSet)
                 .expr("Non-empty", set -> !set.isEmpty(),
-                        alphaIndexedBy(Integer.class, Index.ConstraintType.GREATER_THAN, -1, Set::size, 0));
+                        alphaIndexedBy(Integer.class, Index.ConstraintType.GREATER_THAN, -1, Collection::size, 0));
         PatternDSL.PatternDef<PatternVar> innerCollectingPattern = ruleStructure.getPrimaryPatternBuilder().build();
         ViewItem<?> innerAccumulatePattern = getInnerAccumulatePattern(innerCollectingPattern);
         ViewItem<?> accumulate = DSL.accumulate(innerAccumulatePattern, accFunction(invokerSupplier).as(tupleSet));
@@ -214,7 +214,7 @@ public abstract class DroolsCondition<PatternVar, T extends DroolsRuleStructure<
     @FunctionalInterface
     private interface Mutator<InTuple, OutPatternVar, R extends DroolsRuleStructure<OutPatternVar>,
             C extends DroolsCondition<OutPatternVar, R>> extends
-            TriFunction<Variable<Set<InTuple>>, PatternDef<Set<InTuple>>, ViewItem<?>, C> {
+            TriFunction<Variable<Collection<InTuple>>, PatternDef<Collection<InTuple>>, ViewItem<?>, C> {
 
     }
 

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/common/DroolsCondition.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/common/DroolsCondition.java
@@ -116,14 +116,14 @@ public abstract class DroolsCondition<PatternVar, T extends DroolsRuleStructure<
                 .expand(p -> bindFunction.apply(p, mappedVariable))
                 .build();
         ViewItem<?> innerAccumulatePattern = getInnerAccumulatePattern(mainAccumulatePattern);
-        Variable<Collection<InTuple>> tupleSet =
+        Variable<Collection<InTuple>> tupleCollection =
                 (Variable<Collection<InTuple>>) ruleStructure.createVariable(Collection.class,"tupleCollection");
-        PatternDSL.PatternDef<Collection<InTuple>> pattern = pattern(tupleSet)
-                .expr("Non-empty", set -> !set.isEmpty(),
+        PatternDSL.PatternDef<Collection<InTuple>> pattern = pattern(tupleCollection)
+                .expr("Non-empty", collection -> !collection.isEmpty(),
                         alphaIndexedBy(Integer.class, Index.ConstraintType.GREATER_THAN, -1, Collection::size, 0));
         ExprViewItem<Object> accumulate = DSL.accumulate(innerAccumulatePattern,
-                accFunction(CollectSetAccumulateFunction.class, mappedVariable).as(tupleSet));
-        return mutator.apply(tupleSet, pattern, accumulate);
+                accFunction(CollectSetAccumulateFunction.class, mappedVariable).as(tupleCollection));
+        return mutator.apply(tupleCollection, pattern, accumulate);
     }
 
     protected <NewA, NewB, InTuple, OutPatternVar> DroolsBiCondition<NewA, NewB, OutPatternVar> groupWithCollect(
@@ -158,15 +158,15 @@ public abstract class DroolsCondition<PatternVar, T extends DroolsRuleStructure<
             C extends DroolsCondition<OutPatternVar, R>> C universalGroupWithCollect(
                     Supplier<? extends DroolsAbstractGroupByInvoker<InTuple>> invokerSupplier,
             Mutator<InTuple, OutPatternVar, R, C> mutator) {
-        Variable<Collection<InTuple>> tupleSet =
+        Variable<Collection<InTuple>> tupleCollection =
                 (Variable<Collection<InTuple>>) ruleStructure.createVariable(Collection.class, "tupleCollection");
-        PatternDSL.PatternDef<Collection<InTuple>> pattern = pattern(tupleSet)
-                .expr("Non-empty", set -> !set.isEmpty(),
+        PatternDSL.PatternDef<Collection<InTuple>> pattern = pattern(tupleCollection)
+                .expr("Non-empty", collection -> !collection.isEmpty(),
                         alphaIndexedBy(Integer.class, Index.ConstraintType.GREATER_THAN, -1, Collection::size, 0));
         PatternDSL.PatternDef<PatternVar> innerCollectingPattern = ruleStructure.getPrimaryPatternBuilder().build();
         ViewItem<?> innerAccumulatePattern = getInnerAccumulatePattern(innerCollectingPattern);
-        ViewItem<?> accumulate = DSL.accumulate(innerAccumulatePattern, accFunction(invokerSupplier).as(tupleSet));
-        return mutator.apply(tupleSet, pattern, accumulate);
+        ViewItem<?> accumulate = DSL.accumulate(innerAccumulatePattern, accFunction(invokerSupplier).as(tupleCollection));
+        return mutator.apply(tupleCollection, pattern, accumulate);
     }
 
     protected <S extends Score<S>, H extends AbstractScoreHolder<S>> void impactScore(Drools drools, H scoreHolder) {

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/common/DroolsRuleStructure.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/common/DroolsRuleStructure.java
@@ -16,7 +16,10 @@
 
 package org.optaplanner.core.impl.score.stream.drools.common;
 
+import static org.drools.model.DSL.from;
+
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
@@ -37,8 +40,6 @@ import org.optaplanner.core.impl.score.stream.drools.bi.DroolsBiRuleStructure;
 import org.optaplanner.core.impl.score.stream.drools.quad.DroolsQuadRuleStructure;
 import org.optaplanner.core.impl.score.stream.drools.tri.DroolsTriRuleStructure;
 import org.optaplanner.core.impl.score.stream.drools.uni.DroolsUniRuleStructure;
-
-import static org.drools.model.DSL.from;
 
 /**
  * Represents the left-hand side of a Drools rule.
@@ -225,8 +226,8 @@ public abstract class DroolsRuleStructure<PatternVar> {
                 Collections.emptyList(), getDependents(), getVariableIdSupplier());
     }
 
-    public <NewA> DroolsUniRuleStructure<NewA, NewA> regroup(Variable<Set<NewA>> newASource,
-            PatternDef<Set<NewA>> collectPattern, ViewItem<?> accumulatePattern) {
+    public <NewA> DroolsUniRuleStructure<NewA, NewA> regroup(Variable<Collection<NewA>> newASource,
+            PatternDef<Collection<NewA>> collectPattern, ViewItem<?> accumulatePattern) {
         Variable<NewA> newA = createVariable("groupKey", from(newASource));
         DroolsPatternBuilder<NewA> newPrimaryPattern = new DroolsPatternBuilder<>(newA);
         return new DroolsUniRuleStructure<>(newA, newPrimaryPattern, mergeShelved(accumulatePattern),
@@ -234,8 +235,8 @@ public abstract class DroolsRuleStructure<PatternVar> {
     }
 
     public <NewA, NewB> DroolsBiRuleStructure<NewA, NewB, BiTuple<NewA, NewB>> regroupBi(
-            Variable<Set<BiTuple<NewA, NewB>>> newSource, PatternDef<Set<BiTuple<NewA, NewB>>> collectPattern,
-            ViewItem<?> accumulatePattern) {
+            Variable<Collection<BiTuple<NewA, NewB>>> newSource,
+            PatternDef<Collection<BiTuple<NewA, NewB>>> collectPattern, ViewItem<?> accumulatePattern) {
         Variable<BiTuple<NewA, NewB>> newTuple =
                 (Variable<BiTuple<NewA, NewB>>) createVariable(BiTuple.class,"groupKey", from(newSource));
         Variable<NewA> newA = createVariable("newA");

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/common/GroupByAccumulator.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/common/GroupByAccumulator.java
@@ -17,12 +17,12 @@
 package org.optaplanner.core.impl.score.stream.drools.common;
 
 import java.io.Serializable;
-import java.util.Set;
+import java.util.Collection;
 
 public interface GroupByAccumulator<InTuple, OutTuple> extends Serializable {
 
     Runnable accumulate(InTuple input);
 
-    Set<OutTuple> finish();
+    Collection<OutTuple> finish();
 
 }

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/common/QuadTuple.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/common/QuadTuple.java
@@ -49,7 +49,8 @@ public final class QuadTuple<A, B, C, D> implements FactTuple {
             return false;
         }
         final QuadTuple<?, ?, ?, ?> other = (QuadTuple<?, ?, ?, ?>) o;
-        return Objects.equals(a, other.a) &&
+        return hashCode == other.hashCode &&
+                Objects.equals(a, other.a) &&
                 Objects.equals(b, other.b) &&
                 Objects.equals(c, other.c) &&
                 Objects.equals(d, other.d);

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/common/TriTuple.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/common/TriTuple.java
@@ -47,7 +47,8 @@ public final class TriTuple<A, B, C> implements FactTuple {
             return false;
         }
         final TriTuple<?, ?, ?> other = (TriTuple<?, ?, ?>) o;
-        return Objects.equals(a, other.a) &&
+        return hashCode == other.hashCode &&
+                Objects.equals(a, other.a) &&
                 Objects.equals(b, other.b) &&
                 Objects.equals(c, other.c);
     }


### PR DESCRIPTION
- More efficient accumulate() implementation which now scales much better.
- Several small shortcuts.

This doesn't solve the larger performance problem, which I'm having trouble reproducing in controlled benchmarks.