### PR TITLE
Replace star imports

### DIFF
--- a/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/config/PlannerBenchmarkConfig.java
+++ b/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/config/PlannerBenchmarkConfig.java
@@ -16,7 +16,7 @@
 
 package org.optaplanner.benchmark.config;
 
-import static org.apache.commons.lang3.ObjectUtils.*;
+import static org.apache.commons.lang3.ObjectUtils.defaultIfNull;
 
 import java.io.File;
 import java.io.FileInputStream;

--- a/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/impl/aggregator/swingui/CheckBoxTree.java
+++ b/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/impl/aggregator/swingui/CheckBoxTree.java
@@ -15,7 +15,9 @@
  */
 package org.optaplanner.benchmark.impl.aggregator.swingui;
 
-import static org.optaplanner.benchmark.impl.aggregator.swingui.MixedCheckBox.MixedCheckBoxStatus.*;
+import static org.optaplanner.benchmark.impl.aggregator.swingui.MixedCheckBox.MixedCheckBoxStatus.CHECKED;
+import static org.optaplanner.benchmark.impl.aggregator.swingui.MixedCheckBox.MixedCheckBoxStatus.MIXED;
+import static org.optaplanner.benchmark.impl.aggregator.swingui.MixedCheckBox.MixedCheckBoxStatus.UNCHECKED;
 
 import java.awt.Color;
 import java.awt.Component;

--- a/optaplanner-benchmark/src/main/java/org/optaplanner/swing/impl/SwingUtils.java
+++ b/optaplanner-benchmark/src/main/java/org/optaplanner/swing/impl/SwingUtils.java
@@ -16,7 +16,19 @@
 
 package org.optaplanner.swing.impl;
 
-import static org.optaplanner.swing.impl.TangoColorFactory.*;
+import static org.optaplanner.swing.impl.TangoColorFactory.ALUMINIUM_1;
+import static org.optaplanner.swing.impl.TangoColorFactory.ALUMINIUM_2;
+import static org.optaplanner.swing.impl.TangoColorFactory.ALUMINIUM_3;
+import static org.optaplanner.swing.impl.TangoColorFactory.ALUMINIUM_4;
+import static org.optaplanner.swing.impl.TangoColorFactory.ALUMINIUM_6;
+import static org.optaplanner.swing.impl.TangoColorFactory.BUTTER_1;
+import static org.optaplanner.swing.impl.TangoColorFactory.BUTTER_2;
+import static org.optaplanner.swing.impl.TangoColorFactory.CHAMELEON_1;
+import static org.optaplanner.swing.impl.TangoColorFactory.ORANGE_2;
+import static org.optaplanner.swing.impl.TangoColorFactory.SCARLET_2;
+import static org.optaplanner.swing.impl.TangoColorFactory.SKY_BLUE_1;
+import static org.optaplanner.swing.impl.TangoColorFactory.SKY_BLUE_2;
+import static org.optaplanner.swing.impl.TangoColorFactory.SKY_BLUE_3;
 
 import java.awt.Color;
 import java.awt.Insets;

--- a/optaplanner-benchmark/src/test/java/org/optaplanner/benchmark/api/PlannerBenchmarkFactoryTest.java
+++ b/optaplanner-benchmark/src/test/java/org/optaplanner/benchmark/api/PlannerBenchmarkFactoryTest.java
@@ -17,7 +17,7 @@
 package org.optaplanner.benchmark.api;
 
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertNotNull;
 
 import java.io.File;
 import java.io.IOException;

--- a/optaplanner-benchmark/src/test/java/org/optaplanner/benchmark/config/PlannerBenchmarkConfigTest.java
+++ b/optaplanner-benchmark/src/test/java/org/optaplanner/benchmark/config/PlannerBenchmarkConfigTest.java
@@ -18,7 +18,9 @@ package org.optaplanner.benchmark.config;
 
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;

--- a/optaplanner-benchmark/src/test/java/org/optaplanner/benchmark/impl/measurement/ScoreDifferencePercentageTest.java
+++ b/optaplanner-benchmark/src/test/java/org/optaplanner/benchmark/impl/measurement/ScoreDifferencePercentageTest.java
@@ -17,7 +17,7 @@
 package org.optaplanner.benchmark.impl.measurement;
 
 import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 import org.junit.jupiter.api.Test;
 import org.optaplanner.core.api.score.buildin.bendable.BendableScore;

--- a/optaplanner-benchmark/src/test/java/org/optaplanner/benchmark/impl/ranking/ResilientScoreComparatorTest.java
+++ b/optaplanner-benchmark/src/test/java/org/optaplanner/benchmark/impl/ranking/ResilientScoreComparatorTest.java
@@ -16,7 +16,7 @@
 
 package org.optaplanner.benchmark.impl.ranking;
 
-import static org.optaplanner.core.impl.testdata.util.PlannerAssert.*;
+import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertCompareToOrder;
 
 import org.junit.jupiter.api.Test;
 import org.optaplanner.core.api.score.buildin.hardsoft.HardSoftScore;

--- a/optaplanner-benchmark/src/test/java/org/optaplanner/benchmark/impl/ranking/ScoreSubSingleBenchmarkRankingComparatorTest.java
+++ b/optaplanner-benchmark/src/test/java/org/optaplanner/benchmark/impl/ranking/ScoreSubSingleBenchmarkRankingComparatorTest.java
@@ -16,8 +16,8 @@
 
 package org.optaplanner.benchmark.impl.ranking;
 
-import static org.mockito.Mockito.*;
-import static org.optaplanner.core.impl.testdata.util.PlannerAssert.*;
+import static org.mockito.Mockito.mock;
+import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertCompareToOrder;
 
 import org.junit.jupiter.api.Test;
 import org.optaplanner.benchmark.impl.result.ProblemBenchmarkResult;

--- a/optaplanner-benchmark/src/test/java/org/optaplanner/benchmark/impl/ranking/TotalRankSolverRankingWeightFactoryTest.java
+++ b/optaplanner-benchmark/src/test/java/org/optaplanner/benchmark/impl/ranking/TotalRankSolverRankingWeightFactoryTest.java
@@ -16,8 +16,9 @@
 
 package org.optaplanner.benchmark.impl.ranking;
 
-import static org.mockito.Mockito.*;
-import static org.optaplanner.core.impl.testdata.util.PlannerAssert.*;
+import static org.mockito.Mockito.mock;
+import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertCompareToEquals;
+import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertCompareToOrder;
 
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/optaplanner-benchmark/src/test/java/org/optaplanner/benchmark/impl/ranking/TotalScoreSingleBenchmarkRankingComparatorTest.java
+++ b/optaplanner-benchmark/src/test/java/org/optaplanner/benchmark/impl/ranking/TotalScoreSingleBenchmarkRankingComparatorTest.java
@@ -16,8 +16,8 @@
 
 package org.optaplanner.benchmark.impl.ranking;
 
-import static org.mockito.Mockito.*;
-import static org.optaplanner.core.impl.testdata.util.PlannerAssert.*;
+import static org.mockito.Mockito.mock;
+import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertCompareToOrder;
 
 import org.junit.jupiter.api.Test;
 import org.optaplanner.benchmark.impl.result.ProblemBenchmarkResult;

--- a/optaplanner-benchmark/src/test/java/org/optaplanner/benchmark/impl/ranking/TotalScoreSolverRankingComparatorTest.java
+++ b/optaplanner-benchmark/src/test/java/org/optaplanner/benchmark/impl/ranking/TotalScoreSolverRankingComparatorTest.java
@@ -16,8 +16,9 @@
 
 package org.optaplanner.benchmark.impl.ranking;
 
-import static org.mockito.Mockito.*;
-import static org.optaplanner.core.impl.testdata.util.PlannerAssert.*;
+import static org.mockito.Mockito.mock;
+import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertCompareToEquals;
+import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertCompareToOrder;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/optaplanner-benchmark/src/test/java/org/optaplanner/benchmark/impl/ranking/WorstScoreSolverRankingComparatorTest.java
+++ b/optaplanner-benchmark/src/test/java/org/optaplanner/benchmark/impl/ranking/WorstScoreSolverRankingComparatorTest.java
@@ -16,8 +16,9 @@
 
 package org.optaplanner.benchmark.impl.ranking;
 
-import static org.mockito.Mockito.*;
-import static org.optaplanner.core.impl.testdata.util.PlannerAssert.*;
+import static org.mockito.Mockito.mock;
+import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertCompareToEquals;
+import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertCompareToOrder;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/optaplanner-benchmark/src/test/java/org/optaplanner/benchmark/impl/result/PlannerBenchmarkResultTest.java
+++ b/optaplanner-benchmark/src/test/java/org/optaplanner/benchmark/impl/result/PlannerBenchmarkResultTest.java
@@ -16,7 +16,7 @@
 
 package org.optaplanner.benchmark.impl.result;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 import java.io.File;
 import java.util.ArrayList;

--- a/optaplanner-benchmark/src/test/java/org/optaplanner/benchmark/impl/statistic/StatisticUtilsTest.java
+++ b/optaplanner-benchmark/src/test/java/org/optaplanner/benchmark/impl/statistic/StatisticUtilsTest.java
@@ -16,8 +16,10 @@
 
 package org.optaplanner.benchmark.impl.statistic;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/optaplanner-core/src/main/java/org/optaplanner/core/api/domain/constraintweight/ConstraintConfiguration.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/api/domain/constraintweight/ConstraintConfiguration.java
@@ -16,8 +16,8 @@
 
 package org.optaplanner.core.api.domain.constraintweight;
 
-import static java.lang.annotation.ElementType.*;
-import static java.lang.annotation.RetentionPolicy.*;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;

--- a/optaplanner-core/src/main/java/org/optaplanner/core/api/domain/constraintweight/ConstraintConfigurationProvider.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/api/domain/constraintweight/ConstraintConfigurationProvider.java
@@ -16,8 +16,9 @@
 
 package org.optaplanner.core.api.domain.constraintweight;
 
-import static java.lang.annotation.ElementType.*;
-import static java.lang.annotation.RetentionPolicy.*;
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;

--- a/optaplanner-core/src/main/java/org/optaplanner/core/api/domain/constraintweight/ConstraintWeight.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/api/domain/constraintweight/ConstraintWeight.java
@@ -16,8 +16,9 @@
 
 package org.optaplanner.core.api.domain.constraintweight;
 
-import static java.lang.annotation.ElementType.*;
-import static java.lang.annotation.RetentionPolicy.*;
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;

--- a/optaplanner-core/src/main/java/org/optaplanner/core/api/domain/lookup/PlanningId.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/api/domain/lookup/PlanningId.java
@@ -16,8 +16,9 @@
 
 package org.optaplanner.core.api.domain.lookup;
 
-import static java.lang.annotation.ElementType.*;
-import static java.lang.annotation.RetentionPolicy.*;
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;

--- a/optaplanner-core/src/main/java/org/optaplanner/core/api/domain/solution/PlanningEntityCollectionProperty.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/api/domain/solution/PlanningEntityCollectionProperty.java
@@ -16,8 +16,9 @@
 
 package org.optaplanner.core.api.domain.solution;
 
-import static java.lang.annotation.ElementType.*;
-import static java.lang.annotation.RetentionPolicy.*;
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;

--- a/optaplanner-core/src/main/java/org/optaplanner/core/api/domain/solution/PlanningEntityProperty.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/api/domain/solution/PlanningEntityProperty.java
@@ -16,8 +16,9 @@
 
 package org.optaplanner.core.api.domain.solution;
 
-import static java.lang.annotation.ElementType.*;
-import static java.lang.annotation.RetentionPolicy.*;
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;

--- a/optaplanner-core/src/main/java/org/optaplanner/core/api/domain/solution/PlanningScore.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/api/domain/solution/PlanningScore.java
@@ -16,8 +16,9 @@
 
 package org.optaplanner.core.api.domain.solution;
 
-import static java.lang.annotation.ElementType.*;
-import static java.lang.annotation.RetentionPolicy.*;
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;

--- a/optaplanner-core/src/main/java/org/optaplanner/core/api/domain/solution/PlanningSolution.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/api/domain/solution/PlanningSolution.java
@@ -16,8 +16,8 @@
 
 package org.optaplanner.core.api.domain.solution;
 
-import static java.lang.annotation.ElementType.*;
-import static java.lang.annotation.RetentionPolicy.*;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;

--- a/optaplanner-core/src/main/java/org/optaplanner/core/api/domain/solution/cloner/DeepPlanningClone.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/api/domain/solution/cloner/DeepPlanningClone.java
@@ -16,8 +16,10 @@
 
 package org.optaplanner.core.api.domain.solution.cloner;
 
-import static java.lang.annotation.ElementType.*;
-import static java.lang.annotation.RetentionPolicy.*;
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;

--- a/optaplanner-core/src/main/java/org/optaplanner/core/api/domain/valuerange/ValueRangeProvider.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/api/domain/valuerange/ValueRangeProvider.java
@@ -16,8 +16,9 @@
 
 package org.optaplanner.core.api.domain.valuerange;
 
-import static java.lang.annotation.ElementType.*;
-import static java.lang.annotation.RetentionPolicy.*;
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;

--- a/optaplanner-core/src/main/java/org/optaplanner/core/api/domain/variable/AnchorShadowVariable.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/api/domain/variable/AnchorShadowVariable.java
@@ -16,8 +16,9 @@
 
 package org.optaplanner.core.api.domain.variable;
 
-import static java.lang.annotation.ElementType.*;
-import static java.lang.annotation.RetentionPolicy.*;
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;

--- a/optaplanner-core/src/main/java/org/optaplanner/core/api/domain/variable/CustomShadowVariable.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/api/domain/variable/CustomShadowVariable.java
@@ -16,8 +16,9 @@
 
 package org.optaplanner.core.api.domain.variable;
 
-import static java.lang.annotation.ElementType.*;
-import static java.lang.annotation.RetentionPolicy.*;
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;

--- a/optaplanner-core/src/main/java/org/optaplanner/core/api/domain/variable/InverseRelationShadowVariable.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/api/domain/variable/InverseRelationShadowVariable.java
@@ -16,8 +16,9 @@
 
 package org.optaplanner.core.api.domain.variable;
 
-import static java.lang.annotation.ElementType.*;
-import static java.lang.annotation.RetentionPolicy.*;
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;

--- a/optaplanner-core/src/main/java/org/optaplanner/core/api/domain/variable/PlanningVariable.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/api/domain/variable/PlanningVariable.java
@@ -16,8 +16,9 @@
 
 package org.optaplanner.core.api.domain.variable;
 
-import static java.lang.annotation.ElementType.*;
-import static java.lang.annotation.RetentionPolicy.*;
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/constraintweight/descriptor/ConstraintConfigurationDescriptor.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/constraintweight/descriptor/ConstraintConfigurationDescriptor.java
@@ -16,7 +16,7 @@
 
 package org.optaplanner.core.impl.domain.constraintweight.descriptor;
 
-import static org.optaplanner.core.impl.domain.common.accessor.MemberAccessorFactory.MemberAccessorType.*;
+import static org.optaplanner.core.impl.domain.common.accessor.MemberAccessorFactory.MemberAccessorType.FIELD_OR_READ_METHOD;
 
 import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Member;

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/solution/descriptor/SolutionDescriptor.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/solution/descriptor/SolutionDescriptor.java
@@ -16,7 +16,9 @@
 
 package org.optaplanner.core.impl.domain.solution.descriptor;
 
-import static org.optaplanner.core.impl.domain.common.accessor.MemberAccessorFactory.MemberAccessorType.*;
+import static org.optaplanner.core.impl.domain.common.accessor.MemberAccessorFactory.MemberAccessorType.FIELD_OR_GETTER_METHOD;
+import static org.optaplanner.core.impl.domain.common.accessor.MemberAccessorFactory.MemberAccessorType.FIELD_OR_GETTER_METHOD_WITH_SETTER;
+import static org.optaplanner.core.impl.domain.common.accessor.MemberAccessorFactory.MemberAccessorType.FIELD_OR_READ_METHOD;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.AnnotatedElement;

--- a/optaplanner-core/src/test/java/org/optaplanner/core/api/domain/valuerange/ValueRangeFactoryTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/api/domain/valuerange/ValueRangeFactoryTest.java
@@ -16,7 +16,7 @@
 
 package org.optaplanner.core.api.domain.valuerange;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertNotNull;
 
 import java.util.Arrays;
 

--- a/optaplanner-core/src/test/java/org/optaplanner/core/api/score/buildin/AbstractScoreTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/api/score/buildin/AbstractScoreTest.java
@@ -16,7 +16,7 @@
 
 package org.optaplanner.core.api.score.buildin;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 import org.optaplanner.core.api.score.FeasibilityScore;
 

--- a/optaplanner-core/src/test/java/org/optaplanner/core/api/score/buildin/bendable/BendableScoreHolderTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/api/score/buildin/bendable/BendableScoreHolderTest.java
@@ -17,7 +17,8 @@
 package org.optaplanner.core.api.score.buildin.bendable;
 
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 import org.junit.jupiter.api.Test;
 import org.kie.api.definition.rule.Rule;

--- a/optaplanner-core/src/test/java/org/optaplanner/core/api/score/buildin/bendable/BendableScoreTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/api/score/buildin/bendable/BendableScoreTest.java
@@ -17,7 +17,7 @@
 package org.optaplanner.core.api.score.buildin.bendable;
 
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 import org.junit.jupiter.api.Test;
 import org.optaplanner.core.api.score.buildin.AbstractScoreTest;

--- a/optaplanner-core/src/test/java/org/optaplanner/core/api/score/buildin/bendablebigdecimal/BendableBigDecimalScoreHolderTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/api/score/buildin/bendablebigdecimal/BendableBigDecimalScoreHolderTest.java
@@ -17,7 +17,8 @@
 package org.optaplanner.core.api.score.buildin.bendablebigdecimal;
 
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 import java.math.BigDecimal;
 

--- a/optaplanner-core/src/test/java/org/optaplanner/core/api/score/buildin/bendablebigdecimal/BendableBigDecimalScoreTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/api/score/buildin/bendablebigdecimal/BendableBigDecimalScoreTest.java
@@ -17,7 +17,7 @@
 package org.optaplanner.core.api.score.buildin.bendablebigdecimal;
 
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 import java.math.BigDecimal;
 

--- a/optaplanner-core/src/test/java/org/optaplanner/core/api/score/buildin/bendablelong/BendableLongScoreHolderTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/api/score/buildin/bendablelong/BendableLongScoreHolderTest.java
@@ -17,7 +17,8 @@
 package org.optaplanner.core.api.score.buildin.bendablelong;
 
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 import org.junit.jupiter.api.Test;
 import org.kie.api.definition.rule.Rule;

--- a/optaplanner-core/src/test/java/org/optaplanner/core/api/score/buildin/bendablelong/BendableLongScoreTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/api/score/buildin/bendablelong/BendableLongScoreTest.java
@@ -17,7 +17,7 @@
 package org.optaplanner.core.api.score.buildin.bendablelong;
 
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 import org.junit.jupiter.api.Test;
 import org.optaplanner.core.api.score.buildin.AbstractScoreTest;

--- a/optaplanner-core/src/test/java/org/optaplanner/core/api/score/buildin/hardmediumsoft/HardMediumSoftScoreHolderTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/api/score/buildin/hardmediumsoft/HardMediumSoftScoreHolderTest.java
@@ -16,7 +16,8 @@
 
 package org.optaplanner.core.api.score.buildin.hardmediumsoft;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 import org.junit.jupiter.api.Test;
 import org.kie.api.definition.rule.Rule;

--- a/optaplanner-core/src/test/java/org/optaplanner/core/api/score/buildin/hardmediumsoft/HardMediumSoftScoreTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/api/score/buildin/hardmediumsoft/HardMediumSoftScoreTest.java
@@ -17,7 +17,7 @@
 package org.optaplanner.core.api.score.buildin.hardmediumsoft;
 
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 import org.junit.jupiter.api.Test;
 import org.optaplanner.core.api.score.buildin.AbstractScoreTest;

--- a/optaplanner-core/src/test/java/org/optaplanner/core/api/score/buildin/hardmediumsoftbigdecimal/HardMediumSoftBigDecimalScoreHolderTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/api/score/buildin/hardmediumsoftbigdecimal/HardMediumSoftBigDecimalScoreHolderTest.java
@@ -15,7 +15,8 @@
  */
 package org.optaplanner.core.api.score.buildin.hardmediumsoftbigdecimal;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 import java.math.BigDecimal;
 

--- a/optaplanner-core/src/test/java/org/optaplanner/core/api/score/buildin/hardmediumsoftbigdecimal/HardMediumSoftBigDecimalScoreTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/api/score/buildin/hardmediumsoftbigdecimal/HardMediumSoftBigDecimalScoreTest.java
@@ -17,7 +17,7 @@
 package org.optaplanner.core.api.score.buildin.hardmediumsoftbigdecimal;
 
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 import java.math.BigDecimal;
 

--- a/optaplanner-core/src/test/java/org/optaplanner/core/api/score/buildin/hardmediumsoftlong/HardMediumSoftLongScoreHolderTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/api/score/buildin/hardmediumsoftlong/HardMediumSoftLongScoreHolderTest.java
@@ -16,7 +16,8 @@
 
 package org.optaplanner.core.api.score.buildin.hardmediumsoftlong;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 import org.junit.jupiter.api.Test;
 import org.kie.api.definition.rule.Rule;

--- a/optaplanner-core/src/test/java/org/optaplanner/core/api/score/buildin/hardmediumsoftlong/HardMediumSoftLongScoreTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/api/score/buildin/hardmediumsoftlong/HardMediumSoftLongScoreTest.java
@@ -17,7 +17,7 @@
 package org.optaplanner.core.api.score.buildin.hardmediumsoftlong;
 
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 import org.junit.jupiter.api.Test;
 import org.optaplanner.core.api.score.buildin.AbstractScoreTest;

--- a/optaplanner-core/src/test/java/org/optaplanner/core/api/score/buildin/hardsoft/HardSoftScoreHolderTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/api/score/buildin/hardsoft/HardSoftScoreHolderTest.java
@@ -16,7 +16,8 @@
 
 package org.optaplanner.core.api.score.buildin.hardsoft;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 import org.junit.jupiter.api.Test;
 import org.kie.api.definition.rule.Rule;

--- a/optaplanner-core/src/test/java/org/optaplanner/core/api/score/buildin/hardsoft/HardSoftScoreTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/api/score/buildin/hardsoft/HardSoftScoreTest.java
@@ -17,7 +17,7 @@
 package org.optaplanner.core.api.score.buildin.hardsoft;
 
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 import org.junit.jupiter.api.Test;
 import org.optaplanner.core.api.score.buildin.AbstractScoreTest;

--- a/optaplanner-core/src/test/java/org/optaplanner/core/api/score/buildin/hardsoftbigdecimal/HardSoftBigDecimalScoreHolderTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/api/score/buildin/hardsoftbigdecimal/HardSoftBigDecimalScoreHolderTest.java
@@ -16,7 +16,8 @@
 
 package org.optaplanner.core.api.score.buildin.hardsoftbigdecimal;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 import java.math.BigDecimal;
 

--- a/optaplanner-core/src/test/java/org/optaplanner/core/api/score/buildin/hardsoftbigdecimal/HardSoftBigDecimalScoreTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/api/score/buildin/hardsoftbigdecimal/HardSoftBigDecimalScoreTest.java
@@ -17,7 +17,7 @@
 package org.optaplanner.core.api.score.buildin.hardsoftbigdecimal;
 
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 import java.math.BigDecimal;
 

--- a/optaplanner-core/src/test/java/org/optaplanner/core/api/score/buildin/hardsoftdouble/HardSoftDoubleScoreHolderTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/api/score/buildin/hardsoftdouble/HardSoftDoubleScoreHolderTest.java
@@ -16,7 +16,8 @@
 
 package org.optaplanner.core.api.score.buildin.hardsoftdouble;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 import org.junit.jupiter.api.Test;
 import org.kie.api.definition.rule.Rule;

--- a/optaplanner-core/src/test/java/org/optaplanner/core/api/score/buildin/hardsoftdouble/HardSoftDoubleScoreTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/api/score/buildin/hardsoftdouble/HardSoftDoubleScoreTest.java
@@ -17,7 +17,7 @@
 package org.optaplanner.core.api.score.buildin.hardsoftdouble;
 
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 import org.junit.jupiter.api.Test;
 import org.optaplanner.core.api.score.buildin.AbstractScoreTest;

--- a/optaplanner-core/src/test/java/org/optaplanner/core/api/score/buildin/hardsoftlong/HardSoftLongScoreHolderTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/api/score/buildin/hardsoftlong/HardSoftLongScoreHolderTest.java
@@ -16,7 +16,8 @@
 
 package org.optaplanner.core.api.score.buildin.hardsoftlong;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 import org.junit.jupiter.api.Test;
 import org.kie.api.definition.rule.Rule;

--- a/optaplanner-core/src/test/java/org/optaplanner/core/api/score/buildin/hardsoftlong/HardSoftLongScoreTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/api/score/buildin/hardsoftlong/HardSoftLongScoreTest.java
@@ -17,7 +17,7 @@
 package org.optaplanner.core.api.score.buildin.hardsoftlong;
 
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 import org.junit.jupiter.api.Test;
 import org.optaplanner.core.api.score.buildin.AbstractScoreTest;

--- a/optaplanner-core/src/test/java/org/optaplanner/core/api/score/buildin/simple/SimpleScoreHolderTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/api/score/buildin/simple/SimpleScoreHolderTest.java
@@ -16,7 +16,7 @@
 
 package org.optaplanner.core.api.score.buildin.simple;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 import org.junit.jupiter.api.Test;
 import org.kie.api.definition.rule.Rule;

--- a/optaplanner-core/src/test/java/org/optaplanner/core/api/score/buildin/simple/SimpleScoreTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/api/score/buildin/simple/SimpleScoreTest.java
@@ -17,7 +17,7 @@
 package org.optaplanner.core.api.score.buildin.simple;
 
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 import org.junit.jupiter.api.Test;
 import org.optaplanner.core.api.score.buildin.AbstractScoreTest;

--- a/optaplanner-core/src/test/java/org/optaplanner/core/api/score/buildin/simplebigdecimal/SimpleBigDecimalScoreHolderTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/api/score/buildin/simplebigdecimal/SimpleBigDecimalScoreHolderTest.java
@@ -16,7 +16,7 @@
 
 package org.optaplanner.core.api.score.buildin.simplebigdecimal;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 import java.math.BigDecimal;
 

--- a/optaplanner-core/src/test/java/org/optaplanner/core/api/score/buildin/simplebigdecimal/SimpleBigDecimalScoreTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/api/score/buildin/simplebigdecimal/SimpleBigDecimalScoreTest.java
@@ -17,7 +17,7 @@
 package org.optaplanner.core.api.score.buildin.simplebigdecimal;
 
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 import java.math.BigDecimal;
 

--- a/optaplanner-core/src/test/java/org/optaplanner/core/api/score/buildin/simpledouble/SimpleDoubleScoreHolderTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/api/score/buildin/simpledouble/SimpleDoubleScoreHolderTest.java
@@ -16,7 +16,7 @@
 
 package org.optaplanner.core.api.score.buildin.simpledouble;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 import org.junit.jupiter.api.Test;
 import org.kie.api.definition.rule.Rule;

--- a/optaplanner-core/src/test/java/org/optaplanner/core/api/score/buildin/simpledouble/SimpleDoubleScoreTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/api/score/buildin/simpledouble/SimpleDoubleScoreTest.java
@@ -17,7 +17,7 @@
 package org.optaplanner.core.api.score.buildin.simpledouble;
 
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 import org.junit.jupiter.api.Test;
 import org.optaplanner.core.api.score.buildin.AbstractScoreTest;

--- a/optaplanner-core/src/test/java/org/optaplanner/core/api/score/buildin/simplelong/SimpleLongScoreHolderTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/api/score/buildin/simplelong/SimpleLongScoreHolderTest.java
@@ -16,7 +16,7 @@
 
 package org.optaplanner.core.api.score.buildin.simplelong;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 import org.junit.jupiter.api.Test;
 import org.kie.api.definition.rule.Rule;

--- a/optaplanner-core/src/test/java/org/optaplanner/core/api/score/buildin/simplelong/SimpleLongScoreTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/api/score/buildin/simplelong/SimpleLongScoreTest.java
@@ -17,7 +17,7 @@
 package org.optaplanner.core.api.score.buildin.simplelong;
 
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 import org.junit.jupiter.api.Test;
 import org.optaplanner.core.api.score.buildin.AbstractScoreTest;

--- a/optaplanner-core/src/test/java/org/optaplanner/core/api/score/constraint/ConstraintMatchTotalTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/api/score/constraint/ConstraintMatchTotalTest.java
@@ -16,8 +16,8 @@
 
 package org.optaplanner.core.api.score.constraint;
 
-import static java.util.Arrays.*;
-import static org.junit.Assert.*;
+import static java.util.Arrays.asList;
+import static org.junit.Assert.assertEquals;
 
 import org.junit.jupiter.api.Test;
 import org.optaplanner.core.api.score.buildin.simple.SimpleScore;

--- a/optaplanner-core/src/test/java/org/optaplanner/core/api/score/constraint/IndictmentTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/api/score/constraint/IndictmentTest.java
@@ -16,8 +16,8 @@
 
 package org.optaplanner.core.api.score.constraint;
 
-import static java.util.Arrays.*;
-import static org.junit.Assert.*;
+import static java.util.Arrays.asList;
+import static org.junit.Assert.assertEquals;
 
 import org.junit.jupiter.api.Test;
 import org.optaplanner.core.api.score.buildin.simple.SimpleScore;

--- a/optaplanner-core/src/test/java/org/optaplanner/core/api/solver/KieContainerSolverFactoryTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/api/solver/KieContainerSolverFactoryTest.java
@@ -16,7 +16,7 @@
 
 package org.optaplanner.core.api.solver;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertNotNull;
 
 import java.io.IOException;
 import java.util.Collections;

--- a/optaplanner-core/src/test/java/org/optaplanner/core/api/solver/SolverFactoryTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/api/solver/SolverFactoryTest.java
@@ -17,7 +17,9 @@
 package org.optaplanner.core.api.solver;
 
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
 
 import java.io.File;
 import java.io.IOException;

--- a/optaplanner-core/src/test/java/org/optaplanner/core/api/solver/SolverManagerTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/api/solver/SolverManagerTest.java
@@ -18,11 +18,13 @@ package org.optaplanner.core.api.solver;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import static org.optaplanner.core.api.solver.SolverStatus.NOT_SOLVING;
 import static org.optaplanner.core.api.solver.SolverStatus.SOLVING_ACTIVE;
 import static org.optaplanner.core.api.solver.SolverStatus.SOLVING_SCHEDULED;
-import static org.optaplanner.core.impl.testdata.util.PlannerAssert.*;
+import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertSolutionInitialized;
 
 import java.util.ArrayList;
 import java.util.Collections;

--- a/optaplanner-core/src/test/java/org/optaplanner/core/config/constructionheuristic/placer/QueuedEntityPlacerConfigTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/config/constructionheuristic/placer/QueuedEntityPlacerConfigTest.java
@@ -16,7 +16,8 @@
 
 package org.optaplanner.core.config.constructionheuristic.placer;
 
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.util.Arrays;
 

--- a/optaplanner-core/src/test/java/org/optaplanner/core/config/heuristic/selector/AbstractSelectorConfigTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/config/heuristic/selector/AbstractSelectorConfigTest.java
@@ -16,7 +16,8 @@
 
 package org.optaplanner.core.config.heuristic.selector;
 
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import org.optaplanner.core.config.heuristic.policy.HeuristicConfigPolicy;
 import org.optaplanner.core.config.solver.EnvironmentMode;

--- a/optaplanner-core/src/test/java/org/optaplanner/core/config/heuristic/selector/entity/EntitySelectorConfigTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/config/heuristic/selector/entity/EntitySelectorConfigTest.java
@@ -17,7 +17,9 @@
 package org.optaplanner.core.config.heuristic.selector.entity;
 
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
-import static org.optaplanner.core.impl.testdata.util.PlannerAssert.*;
+import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertEquals;
+import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertInstanceOf;
+import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertNotInstanceOf;
 
 import org.junit.jupiter.api.Test;
 import org.optaplanner.core.config.heuristic.selector.AbstractSelectorConfigTest;

--- a/optaplanner-core/src/test/java/org/optaplanner/core/config/heuristic/selector/move/MoveSelectorConfigTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/config/heuristic/selector/move/MoveSelectorConfigTest.java
@@ -17,8 +17,9 @@
 package org.optaplanner.core.config.heuristic.selector.move;
 
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
-import static org.junit.Assert.*;
-import static org.optaplanner.core.impl.testdata.util.PlannerAssert.*;
+import static org.junit.Assert.assertEquals;
+import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertInstanceOf;
+import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertNotInstanceOf;
 import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertSame;
 
 import org.junit.jupiter.api.Test;

--- a/optaplanner-core/src/test/java/org/optaplanner/core/config/heuristic/selector/move/generic/ChangeMoveSelectorConfigTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/config/heuristic/selector/move/generic/ChangeMoveSelectorConfigTest.java
@@ -18,7 +18,7 @@ package org.optaplanner.core.config.heuristic.selector.move.generic;
 
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.junit.Assert.assertEquals;
-import static org.optaplanner.core.impl.testdata.util.PlannerAssert.*;
+import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertInstanceOf;
 
 import org.junit.jupiter.api.Test;
 import org.optaplanner.core.config.heuristic.selector.AbstractSelectorConfigTest;

--- a/optaplanner-core/src/test/java/org/optaplanner/core/config/heuristic/selector/move/generic/SwapMoveSelectorConfigTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/config/heuristic/selector/move/generic/SwapMoveSelectorConfigTest.java
@@ -18,7 +18,7 @@ package org.optaplanner.core.config.heuristic.selector.move.generic;
 
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.junit.Assert.assertEquals;
-import static org.optaplanner.core.impl.testdata.util.PlannerAssert.*;
+import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertInstanceOf;
 
 import java.util.Arrays;
 

--- a/optaplanner-core/src/test/java/org/optaplanner/core/config/heuristic/selector/value/ValueSelectorConfigTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/config/heuristic/selector/value/ValueSelectorConfigTest.java
@@ -18,7 +18,8 @@ package org.optaplanner.core.config.heuristic.selector.value;
 
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.junit.Assert.assertEquals;
-import static org.optaplanner.core.impl.testdata.util.PlannerAssert.*;
+import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertInstanceOf;
+import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertNotInstanceOf;
 
 import org.junit.jupiter.api.Test;
 import org.optaplanner.core.config.heuristic.policy.HeuristicConfigPolicy;

--- a/optaplanner-core/src/test/java/org/optaplanner/core/config/score/director/ScoreDirectorFactoryConfigTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/config/score/director/ScoreDirectorFactoryConfigTest.java
@@ -16,8 +16,11 @@
 
 package org.optaplanner.core.config.score.director;
 
-import static org.junit.Assert.*;
-import static org.optaplanner.core.impl.testdata.util.PlannerAssert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertInstanceOf;
 
 import java.util.HashMap;
 

--- a/optaplanner-core/src/test/java/org/optaplanner/core/config/solver/SolverConfigMultiThreadedTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/config/solver/SolverConfigMultiThreadedTest.java
@@ -17,8 +17,12 @@
 package org.optaplanner.core.config.solver;
 
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
 
 import java.util.List;
 import java.util.stream.Collectors;

--- a/optaplanner-core/src/test/java/org/optaplanner/core/config/solver/SolverConfigTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/config/solver/SolverConfigTest.java
@@ -16,7 +16,8 @@
 
 package org.optaplanner.core.config.solver;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;

--- a/optaplanner-core/src/test/java/org/optaplanner/core/config/solver/termination/TerminationConfigTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/config/solver/termination/TerminationConfigTest.java
@@ -16,9 +16,11 @@
 
 package org.optaplanner.core.config.solver.termination;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
-import static org.optaplanner.core.impl.testdata.util.PlannerAssert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertInstanceOf;
 
 import java.time.Duration;
 

--- a/optaplanner-core/src/test/java/org/optaplanner/core/config/util/KeyAsElementMapConverterTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/config/util/KeyAsElementMapConverterTest.java
@@ -16,7 +16,7 @@
 
 package org.optaplanner.core.config.util;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 import java.util.Map;
 

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/constructionheuristic/DefaultConstructionHeuristicPhaseTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/constructionheuristic/DefaultConstructionHeuristicPhaseTest.java
@@ -18,7 +18,7 @@ package org.optaplanner.core.impl.constructionheuristic;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.optaplanner.core.impl.testdata.util.PlannerAssert.*;
+import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertCode;
 
 import java.util.Arrays;
 import java.util.Collections;

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/constructionheuristic/decider/forager/DefaultConstructionHeuristicForagerTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/constructionheuristic/decider/forager/DefaultConstructionHeuristicForagerTest.java
@@ -16,8 +16,9 @@
 
 package org.optaplanner.core.impl.constructionheuristic.decider.forager;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import org.junit.jupiter.api.Test;
 import org.optaplanner.core.api.score.Score;

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/constructionheuristic/placer/entity/AbstractEntityPlacerTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/constructionheuristic/placer/entity/AbstractEntityPlacerTest.java
@@ -19,7 +19,7 @@ package org.optaplanner.core.impl.constructionheuristic.placer.entity;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
-import static org.optaplanner.core.impl.testdata.util.PlannerAssert.*;
+import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertCode;
 
 import java.util.Iterator;
 

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/constructionheuristic/placer/entity/PooledEntityPlacerTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/constructionheuristic/placer/entity/PooledEntityPlacerTest.java
@@ -17,8 +17,10 @@
 package org.optaplanner.core.impl.constructionheuristic.placer.entity;
 
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.*;
-import static org.optaplanner.core.impl.testdata.util.PlannerAssert.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertAllCodesOfIterator;
+import static org.optaplanner.core.impl.testdata.util.PlannerAssert.verifyPhaseLifecycle;
 
 import java.util.Iterator;
 

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/constructionheuristic/placer/entity/QueuedEntityPlacerTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/constructionheuristic/placer/entity/QueuedEntityPlacerTest.java
@@ -19,8 +19,10 @@ package org.optaplanner.core.impl.constructionheuristic.placer.entity;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.*;
-import static org.optaplanner.core.impl.testdata.util.PlannerAssert.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertAllCodesOfIterator;
+import static org.optaplanner.core.impl.testdata.util.PlannerAssert.verifyPhaseLifecycle;
 
 import java.util.ArrayList;
 import java.util.Collections;

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/constructionheuristic/placer/entity/QueuedValuePlacerTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/constructionheuristic/placer/entity/QueuedValuePlacerTest.java
@@ -17,8 +17,9 @@
 package org.optaplanner.core.impl.constructionheuristic.placer.entity;
 
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.*;
-import static org.optaplanner.core.impl.testdata.util.PlannerAssert.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.optaplanner.core.impl.testdata.util.PlannerAssert.verifyPhaseLifecycle;
 
 import java.util.Iterator;
 

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/domain/common/accessor/MemberAccessorFactoryTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/domain/common/accessor/MemberAccessorFactoryTest.java
@@ -18,7 +18,7 @@ package org.optaplanner.core.impl.domain.common.accessor;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertSame;
-import static org.optaplanner.core.impl.testdata.util.PlannerAssert.*;
+import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertInstanceOf;
 
 import org.junit.jupiter.api.Test;
 import org.optaplanner.core.api.domain.solution.drools.ProblemFactProperty;

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/domain/common/accessor/ReflectionBeanPropertyMemberAccessorTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/domain/common/accessor/ReflectionBeanPropertyMemberAccessorTest.java
@@ -16,7 +16,8 @@
 
 package org.optaplanner.core.impl.domain.common.accessor;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 import org.junit.jupiter.api.Test;
 import org.optaplanner.core.api.domain.variable.PlanningVariable;

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/domain/common/accessor/ReflectionFieldMemberAccessorTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/domain/common/accessor/ReflectionFieldMemberAccessorTest.java
@@ -16,7 +16,8 @@
 
 package org.optaplanner.core.impl.domain.common.accessor;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 import org.junit.jupiter.api.Test;
 import org.optaplanner.core.api.domain.variable.PlanningVariable;

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/domain/constraintweight/descriptor/ConstraintWeightDescriptorTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/domain/constraintweight/descriptor/ConstraintWeightDescriptorTest.java
@@ -16,7 +16,8 @@
 
 package org.optaplanner.core.impl.domain.constraintweight.descriptor;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 import org.junit.jupiter.api.Test;
 import org.optaplanner.core.api.score.buildin.simple.SimpleScore;

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/domain/entity/descriptor/EntityDescriptorTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/domain/entity/descriptor/EntityDescriptorTest.java
@@ -16,8 +16,9 @@
 
 package org.optaplanner.core.impl.domain.entity.descriptor;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.mock;
 
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/domain/lookup/LookUpStrategyImmutableTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/domain/lookup/LookUpStrategyImmutableTest.java
@@ -15,7 +15,7 @@
  */
 package org.optaplanner.core.impl.domain.lookup;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 import java.math.BigDecimal;

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/domain/solution/AbstractSolutionTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/domain/solution/AbstractSolutionTest.java
@@ -17,7 +17,7 @@
 package org.optaplanner.core.impl.domain.solution;
 
 import static org.junit.Assert.assertEquals;
-import static org.optaplanner.core.impl.testdata.util.PlannerAssert.*;
+import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertCollectionContainsExactly;
 
 import java.util.Arrays;
 import java.util.List;

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/domain/solution/cloner/AbstractSolutionClonerTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/domain/solution/cloner/AbstractSolutionClonerTest.java
@@ -20,7 +20,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
-import static org.optaplanner.core.impl.testdata.util.PlannerAssert.*;
+import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertCode;
 import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertNull;
 
 import java.util.Arrays;

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/domain/solution/descriptor/SolutionDescriptorTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/domain/solution/descriptor/SolutionDescriptorTest.java
@@ -17,7 +17,9 @@ package org.optaplanner.core.impl.domain.solution.descriptor;
 
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
-import static org.optaplanner.core.impl.testdata.util.PlannerAssert.*;
+import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertAllCodesOfCollection;
+import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertEquals;
+import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertMapContainsKeysExactly;
 
 import java.util.Arrays;
 import java.util.List;

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/domain/solution/mutation/MutationCounterTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/domain/solution/mutation/MutationCounterTest.java
@@ -16,7 +16,7 @@
 
 package org.optaplanner.core.impl.domain.solution.mutation;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 import java.util.Arrays;
 import java.util.List;

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/domain/valuerange/buildin/bigdecimal/BigDecimalValueRangeTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/domain/valuerange/buildin/bigdecimal/BigDecimalValueRangeTest.java
@@ -17,8 +17,11 @@
 package org.optaplanner.core.impl.domain.valuerange.buildin.bigdecimal;
 
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.*;
-import static org.optaplanner.core.impl.testdata.util.PlannerAssert.*;
+import static org.mockito.Mockito.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertAllElementsOfIterator;
+import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertElementsOfIterator;
 
 import java.math.BigDecimal;
 import java.util.Random;

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/domain/valuerange/buildin/biginteger/BigIntegerValueRangeTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/domain/valuerange/buildin/biginteger/BigIntegerValueRangeTest.java
@@ -17,8 +17,11 @@
 package org.optaplanner.core.impl.domain.valuerange.buildin.biginteger;
 
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.*;
-import static org.optaplanner.core.impl.testdata.util.PlannerAssert.*;
+import static org.mockito.Mockito.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertAllElementsOfIterator;
+import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertElementsOfIterator;
 
 import java.math.BigInteger;
 import java.util.Random;

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/domain/valuerange/buildin/collection/ListValueRangeTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/domain/valuerange/buildin/collection/ListValueRangeTest.java
@@ -17,8 +17,11 @@
 package org.optaplanner.core.impl.domain.valuerange.buildin.collection;
 
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.*;
-import static org.optaplanner.core.impl.testdata.util.PlannerAssert.*;
+import static org.mockito.Mockito.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertAllElementsOfIterator;
+import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertElementsOfIterator;
 
 import java.util.Arrays;
 import java.util.Collections;

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/domain/valuerange/buildin/composite/CompositeCountableValueRangeTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/domain/valuerange/buildin/composite/CompositeCountableValueRangeTest.java
@@ -17,8 +17,11 @@
 package org.optaplanner.core.impl.domain.valuerange.buildin.composite;
 
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.*;
-import static org.optaplanner.core.impl.testdata.util.PlannerAssert.*;
+import static org.mockito.Mockito.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertAllElementsOfIterator;
+import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertElementsOfIterator;
 
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/domain/valuerange/buildin/composite/EmptyValueRangeTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/domain/valuerange/buildin/composite/EmptyValueRangeTest.java
@@ -18,8 +18,9 @@ package org.optaplanner.core.impl.domain.valuerange.buildin.composite;
 
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.*;
-import static org.optaplanner.core.impl.testdata.util.PlannerAssert.*;
+import static org.mockito.Mockito.mock;
+import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertAllElementsOfIterator;
+import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertElementsOfIterator;
 
 import java.util.Random;
 

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/domain/valuerange/buildin/composite/NullableCountableValueRangeTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/domain/valuerange/buildin/composite/NullableCountableValueRangeTest.java
@@ -17,8 +17,11 @@
 package org.optaplanner.core.impl.domain.valuerange.buildin.composite;
 
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.*;
-import static org.optaplanner.core.impl.testdata.util.PlannerAssert.*;
+import static org.mockito.Mockito.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertAllElementsOfIterator;
+import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertElementsOfIterator;
 
 import java.util.Arrays;
 import java.util.Collections;

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/domain/valuerange/buildin/primboolean/BooleanValueRangeTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/domain/valuerange/buildin/primboolean/BooleanValueRangeTest.java
@@ -18,8 +18,10 @@ package org.optaplanner.core.impl.domain.valuerange.buildin.primboolean;
 
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.*;
-import static org.optaplanner.core.impl.testdata.util.PlannerAssert.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertAllElementsOfIterator;
+import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertElementsOfIterator;
 
 import java.util.Random;
 

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/domain/valuerange/buildin/primdouble/DoubleValueRangeTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/domain/valuerange/buildin/primdouble/DoubleValueRangeTest.java
@@ -17,8 +17,10 @@
 package org.optaplanner.core.impl.domain.valuerange.buildin.primdouble;
 
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.*;
-import static org.optaplanner.core.impl.testdata.util.PlannerAssert.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertAllElementsOfIterator;
+import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertElementsOfIterator;
 
 import java.util.Random;
 

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/domain/valuerange/buildin/primint/IntValueRangeTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/domain/valuerange/buildin/primint/IntValueRangeTest.java
@@ -17,8 +17,11 @@
 package org.optaplanner.core.impl.domain.valuerange.buildin.primint;
 
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.*;
-import static org.optaplanner.core.impl.testdata.util.PlannerAssert.*;
+import static org.mockito.Mockito.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertAllElementsOfIterator;
+import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertElementsOfIterator;
 
 import java.util.Random;
 

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/domain/valuerange/buildin/primlong/LongValueRangeTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/domain/valuerange/buildin/primlong/LongValueRangeTest.java
@@ -17,8 +17,11 @@
 package org.optaplanner.core.impl.domain.valuerange.buildin.primlong;
 
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.*;
-import static org.optaplanner.core.impl.testdata.util.PlannerAssert.*;
+import static org.mockito.Mockito.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertAllElementsOfIterator;
+import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertElementsOfIterator;
 
 import java.util.Random;
 

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/domain/valuerange/buildin/temporal/TemporalValueRangeTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/domain/valuerange/buildin/temporal/TemporalValueRangeTest.java
@@ -17,9 +17,16 @@ package org.optaplanner.core.impl.domain.valuerange.buildin.temporal;
 
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
-import static org.optaplanner.core.impl.testdata.util.PlannerAssert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertAllElementsOfIterator;
+import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertElementsOfIterator;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/domain/variable/anchor/AnchorVariableListenerTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/domain/variable/anchor/AnchorVariableListenerTest.java
@@ -16,8 +16,9 @@
 
 package org.optaplanner.core.impl.domain.variable.anchor;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertSame;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
 
 import java.util.Arrays;
 

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/domain/variable/anchor/ExternalizedAnchorVariableSupplyTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/domain/variable/anchor/ExternalizedAnchorVariableSupplyTest.java
@@ -16,8 +16,9 @@
 
 package org.optaplanner.core.impl.domain.variable.anchor;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertSame;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.util.Arrays;
 

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/domain/variable/custom/CustomVariableListenerTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/domain/variable/custom/CustomVariableListenerTest.java
@@ -17,7 +17,7 @@
 package org.optaplanner.core.impl.domain.variable.custom;
 
 import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 import java.util.Arrays;
 

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/domain/variable/inverserelation/CollectionInverseVariableListenerTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/domain/variable/inverserelation/CollectionInverseVariableListenerTest.java
@@ -16,8 +16,8 @@
 
 package org.optaplanner.core.impl.domain.variable.inverserelation;
 
-import static org.mockito.Mockito.*;
-import static org.optaplanner.core.impl.testdata.util.PlannerAssert.*;
+import static org.mockito.Mockito.mock;
+import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertCollectionContainsExactly;
 
 import java.util.Arrays;
 

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/domain/variable/inverserelation/ExternalizedCollectionInverseVariableSupplyTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/domain/variable/inverserelation/ExternalizedCollectionInverseVariableSupplyTest.java
@@ -16,8 +16,9 @@
 
 package org.optaplanner.core.impl.domain.variable.inverserelation;
 
-import static org.mockito.Mockito.*;
-import static org.optaplanner.core.impl.testdata.util.PlannerAssert.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertCollectionContainsExactly;
 
 import java.util.Arrays;
 import java.util.Collection;

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/domain/variable/inverserelation/ExternalizedSingletonInverseVariableSupplyTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/domain/variable/inverserelation/ExternalizedSingletonInverseVariableSupplyTest.java
@@ -16,8 +16,9 @@
 
 package org.optaplanner.core.impl.domain.variable.inverserelation;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertSame;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.util.Arrays;
 

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/domain/variable/inverserelation/SingletonInverseVariableListenerTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/domain/variable/inverserelation/SingletonInverseVariableListenerTest.java
@@ -16,8 +16,9 @@
 
 package org.optaplanner.core.impl.domain.variable.inverserelation;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
 
 import java.util.Arrays;
 

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/domain/variable/listener/support/SmallScalingOrderedSetTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/domain/variable/listener/support/SmallScalingOrderedSetTest.java
@@ -16,7 +16,9 @@
 
 package org.optaplanner.core.impl.domain.variable.listener.support;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import java.util.Arrays;
 

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/domain/variable/listener/support/VariableListenerSupportTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/domain/variable/listener/support/VariableListenerSupportTest.java
@@ -17,8 +17,9 @@
 package org.optaplanner.core.impl.domain.variable.listener.support;
 
 import static org.junit.Assert.assertSame;
-import static org.mockito.Mockito.*;
-import static org.optaplanner.core.impl.testdata.util.PlannerAssert.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertInstanceOf;
 
 import java.util.Collections;
 

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/exhaustivesearch/DefaultExhaustiveSearchPhaseTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/exhaustivesearch/DefaultExhaustiveSearchPhaseTest.java
@@ -18,8 +18,12 @@ package org.optaplanner.core.impl.exhaustivesearch;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.mockito.Mockito.*;
-import static org.optaplanner.core.impl.testdata.util.PlannerAssert.*;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertCode;
 
 import java.util.Arrays;
 import java.util.Collections;

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/exhaustivesearch/node/comparator/AbstractNodeComparatorTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/exhaustivesearch/node/comparator/AbstractNodeComparatorTest.java
@@ -16,8 +16,9 @@
 
 package org.optaplanner.core.impl.exhaustivesearch.node.comparator;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.util.Comparator;
 

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/exhaustivesearch/scope/ExhaustiveSearchPhaseScopeTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/exhaustivesearch/scope/ExhaustiveSearchPhaseScopeTest.java
@@ -15,7 +15,7 @@
  */
 package org.optaplanner.core.impl.exhaustivesearch.scope;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 import java.util.TreeSet;
 

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/heuristic/move/CompositeMoveTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/heuristic/move/CompositeMoveTest.java
@@ -16,9 +16,19 @@
 
 package org.optaplanner.core.impl.heuristic.move;
 
-import static org.mockito.Mockito.*;
-import static org.optaplanner.core.impl.testdata.util.PlannerAssert.*;
-import static org.optaplanner.core.impl.testdata.util.PlannerTestUtils.*;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertAllCodesOfArray;
+import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertEquals;
+import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertFalse;
+import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertInstanceOf;
+import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertSame;
+import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertTrue;
+import static org.optaplanner.core.impl.testdata.util.PlannerTestUtils.mockRebasingScoreDirector;
+import static org.optaplanner.core.impl.testdata.util.PlannerTestUtils.mockScoreDirector;
 
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/heuristic/move/NoChangeMoveTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/heuristic/move/NoChangeMoveTest.java
@@ -17,8 +17,8 @@
 package org.optaplanner.core.impl.heuristic.move;
 
 import static org.junit.Assert.assertEquals;
-import static org.optaplanner.core.impl.testdata.util.PlannerAssert.*;
-import static org.optaplanner.core.impl.testdata.util.PlannerTestUtils.*;
+import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertInstanceOf;
+import static org.optaplanner.core.impl.testdata.util.PlannerTestUtils.mockRebasingScoreDirector;
 
 import org.junit.jupiter.api.Test;
 import org.optaplanner.core.impl.score.director.ScoreDirector;

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/heuristic/selector/SelectorTestUtils.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/heuristic/selector/SelectorTestUtils.java
@@ -16,8 +16,10 @@
 
 package org.optaplanner.core.impl.heuristic.selector;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.util.Arrays;
 import java.util.Collection;

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/heuristic/selector/common/decorator/ComparatorSelectionSorterTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/heuristic/selector/common/decorator/ComparatorSelectionSorterTest.java
@@ -16,7 +16,7 @@
 
 package org.optaplanner.core.impl.heuristic.selector.common.decorator;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertTrue;
 
 import java.util.ArrayList;
 import java.util.Collections;

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/heuristic/selector/common/decorator/WeightFactorySelectionSorterTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/heuristic/selector/common/decorator/WeightFactorySelectionSorterTest.java
@@ -16,8 +16,8 @@
 
 package org.optaplanner.core.impl.heuristic.selector.common.decorator;
 
-import static org.mockito.Mockito.*;
-import static org.optaplanner.core.impl.testdata.util.PlannerAssert.*;
+import static org.mockito.Mockito.mock;
+import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertCodesOfIterator;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/heuristic/selector/common/nearby/BetaDistributionNearbyRandomTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/heuristic/selector/common/nearby/BetaDistributionNearbyRandomTest.java
@@ -17,8 +17,9 @@
 package org.optaplanner.core.impl.heuristic.selector.common.nearby;
 
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.util.Random;
 

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/heuristic/selector/common/nearby/BlockDistributionNearbyRandomTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/heuristic/selector/common/nearby/BlockDistributionNearbyRandomTest.java
@@ -17,8 +17,11 @@
 package org.optaplanner.core.impl.heuristic.selector.common.nearby;
 
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.util.Random;
 

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/heuristic/selector/common/nearby/LinearDistributionNearbyRandomTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/heuristic/selector/common/nearby/LinearDistributionNearbyRandomTest.java
@@ -17,8 +17,9 @@
 package org.optaplanner.core.impl.heuristic.selector.common.nearby;
 
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.util.Random;
 

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/heuristic/selector/common/nearby/NearbyDistanceMatrixTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/heuristic/selector/common/nearby/NearbyDistanceMatrixTest.java
@@ -16,7 +16,7 @@
 
 package org.optaplanner.core.impl.heuristic.selector.common.nearby;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertSame;
 
 import java.util.Arrays;
 import java.util.List;

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/heuristic/selector/common/nearby/ParabolicDistributionNearbyRandomTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/heuristic/selector/common/nearby/ParabolicDistributionNearbyRandomTest.java
@@ -17,8 +17,9 @@
 package org.optaplanner.core.impl.heuristic.selector.common.nearby;
 
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.util.Random;
 

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/heuristic/selector/entity/FromSolutionEntitySelectorTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/heuristic/selector/entity/FromSolutionEntitySelectorTest.java
@@ -17,8 +17,12 @@
 package org.optaplanner.core.impl.heuristic.selector.entity;
 
 import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
-import static org.mockito.Mockito.*;
-import static org.optaplanner.core.impl.testdata.util.PlannerAssert.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertAllCodesOfEntitySelector;
+import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertCodesOfNeverEndingOfEntitySelector;
 
 import java.util.Arrays;
 import java.util.List;

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/heuristic/selector/entity/decorator/CachingEntitySelectorTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/heuristic/selector/entity/decorator/CachingEntitySelectorTest.java
@@ -17,8 +17,16 @@
 package org.optaplanner.core.impl.heuristic.selector.entity.decorator;
 
 import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
-import static org.mockito.Mockito.*;
-import static org.optaplanner.core.impl.testdata.util.PlannerAssert.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertAllCodesOfEntitySelector;
+import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertFalse;
+import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertInstanceOf;
+import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertNotInstanceOf;
+import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertTrue;
+import static org.optaplanner.core.impl.testdata.util.PlannerAssert.verifyPhaseLifecycle;
 
 import org.junit.jupiter.api.Test;
 import org.optaplanner.core.config.heuristic.selector.common.SelectionCacheType;

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/heuristic/selector/entity/decorator/FilteringEntitySelectorTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/heuristic/selector/entity/decorator/FilteringEntitySelectorTest.java
@@ -17,8 +17,12 @@
 package org.optaplanner.core.impl.heuristic.selector.entity.decorator;
 
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
-import static org.mockito.Mockito.*;
-import static org.optaplanner.core.impl.testdata.util.PlannerAssert.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertAllCodesOfEntitySelector;
+import static org.optaplanner.core.impl.testdata.util.PlannerAssert.verifyPhaseLifecycle;
 
 import java.util.Arrays;
 import java.util.List;

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/heuristic/selector/entity/decorator/NullValueReinitializeVariableEntityFilterTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/heuristic/selector/entity/decorator/NullValueReinitializeVariableEntityFilterTest.java
@@ -16,7 +16,7 @@
 
 package org.optaplanner.core.impl.heuristic.selector.entity.decorator;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 import org.junit.jupiter.api.Test;
 import org.optaplanner.core.impl.domain.entity.descriptor.EntityDescriptor;

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/heuristic/selector/entity/decorator/ProbabilityEntitySelectorTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/heuristic/selector/entity/decorator/ProbabilityEntitySelectorTest.java
@@ -20,8 +20,12 @@ import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException
 import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.*;
-import static org.optaplanner.core.impl.testdata.util.PlannerAssert.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertCode;
+import static org.optaplanner.core.impl.testdata.util.PlannerAssert.verifyPhaseLifecycle;
 
 import java.util.Iterator;
 import java.util.Random;

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/heuristic/selector/entity/decorator/SelectedCountLimitEntitySelectorTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/heuristic/selector/entity/decorator/SelectedCountLimitEntitySelectorTest.java
@@ -16,8 +16,14 @@
 
 package org.optaplanner.core.impl.heuristic.selector.entity.decorator;
 
-import static org.mockito.Mockito.*;
-import static org.optaplanner.core.impl.testdata.util.PlannerAssert.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertAllCodesOfEntitySelector;
+import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertAllCodesOfIterator;
+import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertEquals;
+import static org.optaplanner.core.impl.testdata.util.PlannerAssert.verifyPhaseLifecycle;
 
 import org.junit.jupiter.api.Test;
 import org.optaplanner.core.impl.heuristic.selector.SelectorTestUtils;

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/heuristic/selector/entity/decorator/ShufflingEntitySelectorTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/heuristic/selector/entity/decorator/ShufflingEntitySelectorTest.java
@@ -16,8 +16,8 @@
 
 package org.optaplanner.core.impl.heuristic.selector.entity.decorator;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
 
 import org.junit.jupiter.api.Test;
 import org.optaplanner.core.config.heuristic.selector.common.SelectionCacheType;

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/heuristic/selector/entity/decorator/SortingEntitySelectorTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/heuristic/selector/entity/decorator/SortingEntitySelectorTest.java
@@ -18,8 +18,12 @@ package org.optaplanner.core.impl.heuristic.selector.entity.decorator;
 
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.*;
-import static org.optaplanner.core.impl.testdata.util.PlannerAssert.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertAllCodesOfEntitySelector;
+import static org.optaplanner.core.impl.testdata.util.PlannerAssert.verifyPhaseLifecycle;
 
 import java.util.Comparator;
 

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/heuristic/selector/entity/mimic/MimicReplayingEntitySelectorTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/heuristic/selector/entity/mimic/MimicReplayingEntitySelectorTest.java
@@ -18,8 +18,12 @@ package org.optaplanner.core.impl.heuristic.selector.entity.mimic;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.mockito.Mockito.*;
-import static org.optaplanner.core.impl.testdata.util.PlannerAssert.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertCode;
+import static org.optaplanner.core.impl.testdata.util.PlannerAssert.verifyPhaseLifecycle;
 
 import java.util.Iterator;
 

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/heuristic/selector/move/composite/CartesianProductMoveSelectorTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/heuristic/selector/move/composite/CartesianProductMoveSelectorTest.java
@@ -16,8 +16,14 @@
 
 package org.optaplanner.core.impl.heuristic.selector.move.composite;
 
-import static org.mockito.Mockito.*;
-import static org.optaplanner.core.impl.testdata.util.PlannerAssert.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.optaplanner.core.impl.testdata.util.PlannerAssert.DO_NOT_ASSERT_SIZE;
+import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertAllCodesOfMoveSelector;
+import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertCodesOfNeverEndingMoveSelector;
+import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertEmptyNeverEndingMoveSelector;
+import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertTrue;
+import static org.optaplanner.core.impl.testdata.util.PlannerAssert.verifyPhaseLifecycle;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/heuristic/selector/move/composite/UnionMoveSelectorTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/heuristic/selector/move/composite/UnionMoveSelectorTest.java
@@ -16,8 +16,10 @@
 
 package org.optaplanner.core.impl.heuristic.selector.move.composite;
 
-import static org.mockito.Mockito.*;
-import static org.optaplanner.core.impl.testdata.util.PlannerAssert.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertAllCodesOfMoveSelector;
+import static org.optaplanner.core.impl.testdata.util.PlannerAssert.verifyPhaseLifecycle;
 
 import java.util.ArrayList;
 import java.util.HashMap;

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/heuristic/selector/move/decorator/CachingMoveSelectorTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/heuristic/selector/move/decorator/CachingMoveSelectorTest.java
@@ -16,8 +16,13 @@
 
 package org.optaplanner.core.impl.heuristic.selector.move.decorator;
 
-import static org.mockito.Mockito.*;
-import static org.optaplanner.core.impl.testdata.util.PlannerAssert.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertAllCodesOfMoveSelector;
+import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertCodesOfNeverEndingMoveSelector;
+import static org.optaplanner.core.impl.testdata.util.PlannerAssert.verifyPhaseLifecycle;
 
 import java.util.Random;
 

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/heuristic/selector/move/decorator/FilteringMoveSelectorTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/heuristic/selector/move/decorator/FilteringMoveSelectorTest.java
@@ -16,8 +16,12 @@
 
 package org.optaplanner.core.impl.heuristic.selector.move.decorator;
 
-import static org.mockito.Mockito.*;
-import static org.optaplanner.core.impl.testdata.util.PlannerAssert.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertAllCodesOfMoveSelector;
+import static org.optaplanner.core.impl.testdata.util.PlannerAssert.verifyPhaseLifecycle;
 
 import java.util.Arrays;
 import java.util.List;

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/heuristic/selector/move/decorator/ProbabilityMoveSelectorTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/heuristic/selector/move/decorator/ProbabilityMoveSelectorTest.java
@@ -16,8 +16,12 @@
 
 package org.optaplanner.core.impl.heuristic.selector.move.decorator;
 
-import static org.mockito.Mockito.*;
-import static org.optaplanner.core.impl.testdata.util.PlannerAssert.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertCodesOfNeverEndingMoveSelector;
+import static org.optaplanner.core.impl.testdata.util.PlannerAssert.verifyPhaseLifecycle;
 
 import java.util.Random;
 

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/heuristic/selector/move/decorator/SelectedCountLimitMoveSelectorTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/heuristic/selector/move/decorator/SelectedCountLimitMoveSelectorTest.java
@@ -16,8 +16,12 @@
 
 package org.optaplanner.core.impl.heuristic.selector.move.decorator;
 
-import static org.mockito.Mockito.*;
-import static org.optaplanner.core.impl.testdata.util.PlannerAssert.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertAllCodesOfMoveSelector;
+import static org.optaplanner.core.impl.testdata.util.PlannerAssert.verifyPhaseLifecycle;
 
 import org.junit.jupiter.api.Test;
 import org.optaplanner.core.impl.heuristic.move.DummyMove;

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/heuristic/selector/move/decorator/ShufflingMoveSelectorTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/heuristic/selector/move/decorator/ShufflingMoveSelectorTest.java
@@ -16,8 +16,12 @@
 
 package org.optaplanner.core.impl.heuristic.selector.move.decorator;
 
-import static org.mockito.Mockito.*;
-import static org.optaplanner.core.impl.testdata.util.PlannerAssert.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertAllCodesOfMoveSelector;
+import static org.optaplanner.core.impl.testdata.util.PlannerAssert.verifyPhaseLifecycle;
 
 import java.util.Random;
 

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/heuristic/selector/move/decorator/SortingMoveSelectorTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/heuristic/selector/move/decorator/SortingMoveSelectorTest.java
@@ -17,8 +17,12 @@
 package org.optaplanner.core.impl.heuristic.selector.move.decorator;
 
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
-import static org.mockito.Mockito.*;
-import static org.optaplanner.core.impl.testdata.util.PlannerAssert.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertAllCodesOfMoveSelector;
+import static org.optaplanner.core.impl.testdata.util.PlannerAssert.verifyPhaseLifecycle;
 
 import java.util.Comparator;
 

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/heuristic/selector/move/generic/ChangeMoveSelectorTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/heuristic/selector/move/generic/ChangeMoveSelectorTest.java
@@ -16,8 +16,11 @@
 
 package org.optaplanner.core.impl.heuristic.selector.move.generic;
 
-import static org.mockito.Mockito.*;
-import static org.optaplanner.core.impl.testdata.util.PlannerAssert.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertAllCodesOfMoveSelector;
+import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertCodesOfNeverEndingMoveSelector;
+import static org.optaplanner.core.impl.testdata.util.PlannerAssert.verifyPhaseLifecycle;
 
 import org.junit.jupiter.api.Test;
 import org.optaplanner.core.impl.heuristic.selector.SelectorTestUtils;

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/heuristic/selector/move/generic/ChangeMoveTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/heuristic/selector/move/generic/ChangeMoveTest.java
@@ -17,10 +17,10 @@
 package org.optaplanner.core.impl.heuristic.selector.move.generic;
 
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.*;
-import static org.optaplanner.core.impl.testdata.util.PlannerAssert.*;
+import static org.mockito.Mockito.mock;
+import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertCode;
 import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertSame;
-import static org.optaplanner.core.impl.testdata.util.PlannerTestUtils.*;
+import static org.optaplanner.core.impl.testdata.util.PlannerTestUtils.mockRebasingScoreDirector;
 
 import java.util.Arrays;
 

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/heuristic/selector/move/generic/PillarChangeMoveTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/heuristic/selector/move/generic/PillarChangeMoveTest.java
@@ -17,10 +17,12 @@
 package org.optaplanner.core.impl.heuristic.selector.move.generic;
 
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.*;
-import static org.optaplanner.core.impl.testdata.util.PlannerAssert.*;
+import static org.mockito.Mockito.mock;
+import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertAllCodesOfCollection;
+import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertCode;
+import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertListElementsSameExactly;
 import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertSame;
-import static org.optaplanner.core.impl.testdata.util.PlannerTestUtils.*;
+import static org.optaplanner.core.impl.testdata.util.PlannerTestUtils.mockRebasingScoreDirector;
 
 import java.util.Arrays;
 import java.util.List;

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/heuristic/selector/move/generic/PillarSwapMoveTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/heuristic/selector/move/generic/PillarSwapMoveTest.java
@@ -17,9 +17,11 @@
 package org.optaplanner.core.impl.heuristic.selector.move.generic;
 
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.*;
-import static org.optaplanner.core.impl.testdata.util.PlannerAssert.*;
-import static org.optaplanner.core.impl.testdata.util.PlannerTestUtils.*;
+import static org.mockito.Mockito.mock;
+import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertAllCodesOfCollection;
+import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertCollectionContainsExactly;
+import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertListElementsSameExactly;
+import static org.optaplanner.core.impl.testdata.util.PlannerTestUtils.mockRebasingScoreDirector;
 
 import java.util.Arrays;
 import java.util.List;

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/heuristic/selector/move/generic/SwapMoveSelectorTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/heuristic/selector/move/generic/SwapMoveSelectorTest.java
@@ -16,8 +16,10 @@
 
 package org.optaplanner.core.impl.heuristic.selector.move.generic;
 
-import static org.mockito.Mockito.*;
-import static org.optaplanner.core.impl.testdata.util.PlannerAssert.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertAllCodesOfMoveSelector;
+import static org.optaplanner.core.impl.testdata.util.PlannerAssert.verifyPhaseLifecycle;
 
 import org.junit.jupiter.api.Test;
 import org.optaplanner.core.impl.domain.entity.descriptor.EntityDescriptor;

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/heuristic/selector/move/generic/SwapMoveTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/heuristic/selector/move/generic/SwapMoveTest.java
@@ -17,10 +17,11 @@
 package org.optaplanner.core.impl.heuristic.selector.move.generic;
 
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.*;
-import static org.optaplanner.core.impl.testdata.util.PlannerAssert.*;
+import static org.mockito.Mockito.mock;
+import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertCode;
+import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertCollectionContainsExactly;
 import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertSame;
-import static org.optaplanner.core.impl.testdata.util.PlannerTestUtils.*;
+import static org.optaplanner.core.impl.testdata.util.PlannerTestUtils.mockRebasingScoreDirector;
 
 import java.util.Arrays;
 import java.util.List;

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/heuristic/selector/move/generic/chained/ChainedChangeMoveTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/heuristic/selector/move/generic/chained/ChainedChangeMoveTest.java
@@ -16,9 +16,11 @@
 
 package org.optaplanner.core.impl.heuristic.selector.move.generic.chained;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
-import static org.optaplanner.core.impl.testdata.util.PlannerTestUtils.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.optaplanner.core.impl.testdata.util.PlannerTestUtils.mockRebasingScoreDirector;
 
 import org.junit.jupiter.api.Test;
 import org.optaplanner.core.impl.domain.variable.descriptor.GenuineVariableDescriptor;

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/heuristic/selector/move/generic/chained/ChainedSwapMoveTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/heuristic/selector/move/generic/chained/ChainedSwapMoveTest.java
@@ -16,9 +16,11 @@
 
 package org.optaplanner.core.impl.heuristic.selector.move.generic.chained;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
-import static org.optaplanner.core.impl.testdata.util.PlannerTestUtils.*;
+import static org.junit.Assert.assertSame;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.optaplanner.core.impl.testdata.util.PlannerTestUtils.mockRebasingScoreDirector;
 
 import java.util.Collections;
 import java.util.List;

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/heuristic/selector/move/generic/chained/KOptMoveTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/heuristic/selector/move/generic/chained/KOptMoveTest.java
@@ -16,9 +16,10 @@
 
 package org.optaplanner.core.impl.heuristic.selector.move.generic.chained;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
-import static org.optaplanner.core.impl.testdata.util.PlannerAssert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import static org.mockito.Mockito.mock;
+import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertArrayElementsSameExactly;
 import static org.optaplanner.core.impl.testdata.util.PlannerTestUtils.mockRebasingScoreDirector;
 
 import java.util.Arrays;

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/heuristic/selector/move/generic/chained/SubChainChangeMoveSelectorTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/heuristic/selector/move/generic/chained/SubChainChangeMoveSelectorTest.java
@@ -17,8 +17,9 @@
 package org.optaplanner.core.impl.heuristic.selector.move.generic.chained;
 
 import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import org.junit.jupiter.api.Test;
 import org.optaplanner.core.impl.domain.variable.descriptor.GenuineVariableDescriptor;

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/heuristic/selector/move/generic/chained/SubChainChangeMoveTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/heuristic/selector/move/generic/chained/SubChainChangeMoveTest.java
@@ -18,9 +18,10 @@ package org.optaplanner.core.impl.heuristic.selector.move.generic.chained;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertSame;
-import static org.mockito.Mockito.*;
-import static org.optaplanner.core.impl.testdata.util.PlannerAssert.*;
-import static org.optaplanner.core.impl.testdata.util.PlannerTestUtils.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertListElementsSameExactly;
+import static org.optaplanner.core.impl.testdata.util.PlannerTestUtils.mockRebasingScoreDirector;
 
 import java.util.Arrays;
 import java.util.List;

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/heuristic/selector/move/generic/chained/SubChainReversingChangeMoveTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/heuristic/selector/move/generic/chained/SubChainReversingChangeMoveTest.java
@@ -18,9 +18,10 @@ package org.optaplanner.core.impl.heuristic.selector.move.generic.chained;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertSame;
-import static org.mockito.Mockito.*;
-import static org.optaplanner.core.impl.testdata.util.PlannerAssert.*;
-import static org.optaplanner.core.impl.testdata.util.PlannerTestUtils.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertListElementsSameExactly;
+import static org.optaplanner.core.impl.testdata.util.PlannerTestUtils.mockRebasingScoreDirector;
 
 import java.util.Arrays;
 import java.util.List;

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/heuristic/selector/move/generic/chained/SubChainReversingSwapMoveTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/heuristic/selector/move/generic/chained/SubChainReversingSwapMoveTest.java
@@ -17,9 +17,10 @@
 package org.optaplanner.core.impl.heuristic.selector.move.generic.chained;
 
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.*;
-import static org.optaplanner.core.impl.testdata.util.PlannerAssert.*;
-import static org.optaplanner.core.impl.testdata.util.PlannerTestUtils.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertListElementsSameExactly;
+import static org.optaplanner.core.impl.testdata.util.PlannerTestUtils.mockRebasingScoreDirector;
 
 import java.util.Arrays;
 import java.util.List;

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/heuristic/selector/move/generic/chained/SubChainSwapMoveTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/heuristic/selector/move/generic/chained/SubChainSwapMoveTest.java
@@ -17,9 +17,10 @@
 package org.optaplanner.core.impl.heuristic.selector.move.generic.chained;
 
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.*;
-import static org.optaplanner.core.impl.testdata.util.PlannerAssert.*;
-import static org.optaplanner.core.impl.testdata.util.PlannerTestUtils.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertListElementsSameExactly;
+import static org.optaplanner.core.impl.testdata.util.PlannerTestUtils.mockRebasingScoreDirector;
 
 import java.util.Arrays;
 import java.util.List;

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/heuristic/selector/move/generic/chained/TailChainSwapMoveTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/heuristic/selector/move/generic/chained/TailChainSwapMoveTest.java
@@ -16,9 +16,10 @@
 
 package org.optaplanner.core.impl.heuristic.selector.move.generic.chained;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
-import static org.optaplanner.core.impl.testdata.util.PlannerTestUtils.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import static org.mockito.Mockito.mock;
+import static org.optaplanner.core.impl.testdata.util.PlannerTestUtils.mockRebasingScoreDirector;
 
 import java.util.Arrays;
 

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/heuristic/selector/value/decorator/CachingValueSelectorTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/heuristic/selector/value/decorator/CachingValueSelectorTest.java
@@ -16,8 +16,12 @@
 
 package org.optaplanner.core.impl.heuristic.selector.value.decorator;
 
-import static org.mockito.Mockito.*;
-import static org.optaplanner.core.impl.testdata.util.PlannerAssert.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertAllCodesOfValueSelector;
+import static org.optaplanner.core.impl.testdata.util.PlannerAssert.verifyPhaseLifecycle;
 
 import org.junit.jupiter.api.Test;
 import org.optaplanner.core.config.heuristic.selector.common.SelectionCacheType;

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/heuristic/selector/value/decorator/EntityIndependentFilteringValueSelectorTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/heuristic/selector/value/decorator/EntityIndependentFilteringValueSelectorTest.java
@@ -16,8 +16,12 @@
 
 package org.optaplanner.core.impl.heuristic.selector.value.decorator;
 
-import static org.mockito.Mockito.*;
-import static org.optaplanner.core.impl.testdata.util.PlannerAssert.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertAllCodesOfValueSelector;
+import static org.optaplanner.core.impl.testdata.util.PlannerAssert.verifyPhaseLifecycle;
 
 import java.util.Arrays;
 import java.util.List;

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/heuristic/selector/value/decorator/FilteringValueSelectorTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/heuristic/selector/value/decorator/FilteringValueSelectorTest.java
@@ -16,8 +16,12 @@
 
 package org.optaplanner.core.impl.heuristic.selector.value.decorator;
 
-import static org.mockito.Mockito.*;
-import static org.optaplanner.core.impl.testdata.util.PlannerAssert.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertAllCodesOfValueSelectorForEntity;
+import static org.optaplanner.core.impl.testdata.util.PlannerAssert.verifyPhaseLifecycle;
 
 import java.util.Arrays;
 import java.util.List;

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/heuristic/selector/value/decorator/InitializedValueSelectorTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/heuristic/selector/value/decorator/InitializedValueSelectorTest.java
@@ -16,8 +16,13 @@
 
 package org.optaplanner.core.impl.heuristic.selector.value.decorator;
 
-import static org.mockito.Mockito.*;
-import static org.optaplanner.core.impl.testdata.util.PlannerAssert.*;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertAllCodesOfValueSelectorForEntity;
+import static org.optaplanner.core.impl.testdata.util.PlannerAssert.verifyPhaseLifecycle;
 
 import org.junit.jupiter.api.Test;
 import org.optaplanner.core.impl.domain.entity.descriptor.EntityDescriptor;

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/heuristic/selector/value/decorator/MovableChainedTrailingValueFilterTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/heuristic/selector/value/decorator/MovableChainedTrailingValueFilterTest.java
@@ -16,7 +16,8 @@
 
 package org.optaplanner.core.impl.heuristic.selector.value.decorator;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 import java.util.Arrays;
 

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/heuristic/selector/value/decorator/ReinitializeVariableValueSelectorTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/heuristic/selector/value/decorator/ReinitializeVariableValueSelectorTest.java
@@ -16,8 +16,13 @@
 
 package org.optaplanner.core.impl.heuristic.selector.value.decorator;
 
-import static org.mockito.Mockito.*;
-import static org.optaplanner.core.impl.testdata.util.PlannerAssert.*;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.atMost;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertAllCodesOfValueSelectorForEntity;
+import static org.optaplanner.core.impl.testdata.util.PlannerAssert.verifyPhaseLifecycle;
 
 import org.junit.jupiter.api.Test;
 import org.optaplanner.core.impl.domain.entity.descriptor.EntityDescriptor;

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/heuristic/selector/value/decorator/SelectedCountLimitValueSelectorTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/heuristic/selector/value/decorator/SelectedCountLimitValueSelectorTest.java
@@ -16,8 +16,13 @@
 
 package org.optaplanner.core.impl.heuristic.selector.value.decorator;
 
-import static org.mockito.Mockito.*;
-import static org.optaplanner.core.impl.testdata.util.PlannerAssert.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertAllCodesOfValueSelector;
+import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertAllCodesOfValueSelectorForEntity;
+import static org.optaplanner.core.impl.testdata.util.PlannerAssert.verifyPhaseLifecycle;
 
 import org.junit.jupiter.api.Test;
 import org.optaplanner.core.impl.heuristic.selector.SelectorTestUtils;

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/heuristic/selector/value/decorator/SortingValueSelectorTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/heuristic/selector/value/decorator/SortingValueSelectorTest.java
@@ -16,8 +16,12 @@
 
 package org.optaplanner.core.impl.heuristic.selector.value.decorator;
 
-import static org.mockito.Mockito.*;
-import static org.optaplanner.core.impl.testdata.util.PlannerAssert.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertAllCodesOfValueSelector;
+import static org.optaplanner.core.impl.testdata.util.PlannerAssert.verifyPhaseLifecycle;
 
 import java.util.Comparator;
 

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/heuristic/selector/value/mimic/MimicReplayingValueSelectorTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/heuristic/selector/value/mimic/MimicReplayingValueSelectorTest.java
@@ -18,8 +18,12 @@ package org.optaplanner.core.impl.heuristic.selector.value.mimic;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.mockito.Mockito.*;
-import static org.optaplanner.core.impl.testdata.util.PlannerAssert.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertCode;
+import static org.optaplanner.core.impl.testdata.util.PlannerAssert.verifyPhaseLifecycle;
 
 import java.util.Iterator;
 

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/heuristic/selector/value/nearby/NearEntityNearbyValueSelectorTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/heuristic/selector/value/nearby/NearEntityNearbyValueSelectorTest.java
@@ -16,8 +16,10 @@
 
 package org.optaplanner.core.impl.heuristic.selector.value.nearby;
 
-import static org.mockito.Mockito.*;
-import static org.optaplanner.core.impl.testdata.util.PlannerAssert.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertAllCodesOfValueSelectorForEntity;
+import static org.optaplanner.core.impl.testdata.util.PlannerAssert.verifyPhaseLifecycle;
 
 import org.junit.jupiter.api.Test;
 import org.optaplanner.core.impl.domain.variable.descriptor.GenuineVariableDescriptor;

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/localsearch/DefaultLocalSearchPhaseTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/localsearch/DefaultLocalSearchPhaseTest.java
@@ -18,7 +18,7 @@ package org.optaplanner.core.impl.localsearch;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.optaplanner.core.impl.testdata.util.PlannerAssert.*;
+import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertCode;
 
 import java.util.Arrays;
 import java.util.Collections;

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/localsearch/decider/acceptor/AbstractAcceptorTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/localsearch/decider/acceptor/AbstractAcceptorTest.java
@@ -16,7 +16,7 @@
 
 package org.optaplanner.core.impl.localsearch.decider.acceptor;
 
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
 
 import org.optaplanner.core.api.score.buildin.simple.SimpleScore;
 import org.optaplanner.core.impl.heuristic.move.Move;

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/localsearch/decider/acceptor/greatdeluge/GreatDelugeAcceptorTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/localsearch/decider/acceptor/greatdeluge/GreatDelugeAcceptorTest.java
@@ -1,7 +1,7 @@
 package org.optaplanner.core.impl.localsearch.decider.acceptor.greatdeluge;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
 
 import org.junit.jupiter.api.Test;
 import org.optaplanner.core.api.score.buildin.hardmediumsoft.HardMediumSoftScore;

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/localsearch/decider/acceptor/hillclimbing/HillClimbingAcceptorTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/localsearch/decider/acceptor/hillclimbing/HillClimbingAcceptorTest.java
@@ -16,7 +16,7 @@
 
 package org.optaplanner.core.impl.localsearch.decider.acceptor.hillclimbing;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 import org.junit.jupiter.api.Test;
 import org.optaplanner.core.api.score.buildin.simple.SimpleScore;

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/localsearch/decider/acceptor/lateacceptance/LateAcceptanceAcceptorTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/localsearch/decider/acceptor/lateacceptance/LateAcceptanceAcceptorTest.java
@@ -17,7 +17,7 @@
 package org.optaplanner.core.impl.localsearch.decider.acceptor.lateacceptance;
 
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 import org.junit.jupiter.api.Test;
 import org.optaplanner.core.api.score.buildin.simple.SimpleScore;

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/localsearch/decider/acceptor/simulatedannealing/SimulatedAnnealingAcceptorTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/localsearch/decider/acceptor/simulatedannealing/SimulatedAnnealingAcceptorTest.java
@@ -17,8 +17,9 @@
 package org.optaplanner.core.impl.localsearch.decider.acceptor.simulatedannealing;
 
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.util.Random;
 

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/localsearch/decider/acceptor/stepcountinghillclimbing/StepCountingHillClimbingAcceptorTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/localsearch/decider/acceptor/stepcountinghillclimbing/StepCountingHillClimbingAcceptorTest.java
@@ -17,7 +17,7 @@
 package org.optaplanner.core.impl.localsearch.decider.acceptor.stepcountinghillclimbing;
 
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 import org.junit.jupiter.api.Test;
 import org.optaplanner.core.api.score.buildin.simple.SimpleScore;

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/localsearch/decider/acceptor/tabu/EntityTabuAcceptorTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/localsearch/decider/acceptor/tabu/EntityTabuAcceptorTest.java
@@ -16,8 +16,9 @@
 
 package org.optaplanner.core.impl.localsearch.decider.acceptor.tabu;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.util.Arrays;
 import java.util.Collection;

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/localsearch/decider/acceptor/tabu/ValueTabuAcceptorTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/localsearch/decider/acceptor/tabu/ValueTabuAcceptorTest.java
@@ -16,8 +16,9 @@
 
 package org.optaplanner.core.impl.localsearch.decider.acceptor.tabu;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.util.Arrays;
 import java.util.Collection;

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/localsearch/decider/acceptor/tabu/size/EntityRatioTabuSizeStrategyTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/localsearch/decider/acceptor/tabu/size/EntityRatioTabuSizeStrategyTest.java
@@ -16,8 +16,9 @@
 
 package org.optaplanner.core.impl.localsearch.decider.acceptor.tabu.size;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import org.junit.jupiter.api.Test;
 import org.optaplanner.core.impl.localsearch.scope.LocalSearchPhaseScope;

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/localsearch/decider/acceptor/tabu/size/FixedTabuSizeStrategyTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/localsearch/decider/acceptor/tabu/size/FixedTabuSizeStrategyTest.java
@@ -16,8 +16,8 @@
 
 package org.optaplanner.core.impl.localsearch.decider.acceptor.tabu.size;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
 
 import org.junit.jupiter.api.Test;
 import org.optaplanner.core.impl.localsearch.scope.LocalSearchStepScope;

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/localsearch/decider/acceptor/tabu/size/ValueRatioTabuSizeStrategyTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/localsearch/decider/acceptor/tabu/size/ValueRatioTabuSizeStrategyTest.java
@@ -16,8 +16,9 @@
 
 package org.optaplanner.core.impl.localsearch.decider.acceptor.tabu.size;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import org.junit.jupiter.api.Test;
 import org.optaplanner.core.impl.localsearch.scope.LocalSearchPhaseScope;

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/localsearch/decider/forager/AcceptedLocalSearchForagerTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/localsearch/decider/forager/AcceptedLocalSearchForagerTest.java
@@ -16,8 +16,11 @@
 
 package org.optaplanner.core.impl.localsearch.decider.forager;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.util.Random;
 

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/localsearch/decider/forager/finalist/StrategicOscillationByLevelFinalistPodiumTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/localsearch/decider/forager/finalist/StrategicOscillationByLevelFinalistPodiumTest.java
@@ -16,9 +16,9 @@
 
 package org.optaplanner.core.impl.localsearch.decider.forager.finalist;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
-import static org.optaplanner.core.impl.testdata.util.PlannerAssert.*;
+import static org.junit.Assert.assertSame;
+import static org.mockito.Mockito.mock;
+import static org.optaplanner.core.impl.testdata.util.PlannerAssert.extractSingleton;
 
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/partitionedsearch/DefaultPartitionedSearchPhaseTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/partitionedsearch/DefaultPartitionedSearchPhaseTest.java
@@ -16,7 +16,9 @@
 package org.optaplanner.core.impl.partitionedsearch;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.util.Arrays;

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/partitionedsearch/queue/PartitionQueueTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/partitionedsearch/queue/PartitionQueueTest.java
@@ -16,7 +16,8 @@
 
 package org.optaplanner.core.impl.partitionedsearch.queue;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.fail;
 
 import java.util.Iterator;
 import java.util.concurrent.ExecutionException;

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/phase/NoChangePhaseTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/phase/NoChangePhaseTest.java
@@ -18,7 +18,7 @@ package org.optaplanner.core.impl.phase;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.optaplanner.core.impl.testdata.util.PlannerAssert.*;
+import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertCode;
 
 import java.util.Arrays;
 import java.util.Collections;

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/phase/PhaseLifecycleTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/phase/PhaseLifecycleTest.java
@@ -15,7 +15,8 @@
  */
 package org.optaplanner.core.impl.phase;
 
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
 
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/score/ScoreUtilsTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/score/ScoreUtilsTest.java
@@ -16,7 +16,7 @@
 
 package org.optaplanner.core.impl.score;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 import java.math.BigDecimal;
 

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/score/buildin/bendable/BendableScoreInlinerTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/score/buildin/bendable/BendableScoreInlinerTest.java
@@ -16,7 +16,7 @@
 
 package org.optaplanner.core.impl.score.buildin.bendable;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 import java.util.function.Consumer;
 

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/score/buildin/bendablebigdecimal/BendableBigDecimalScoreInlinerTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/score/buildin/bendablebigdecimal/BendableBigDecimalScoreInlinerTest.java
@@ -16,7 +16,7 @@
 
 package org.optaplanner.core.impl.score.buildin.bendablebigdecimal;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 import java.math.BigDecimal;
 import java.util.function.Consumer;

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/score/buildin/bendablelong/BendableLongScoreInlinerTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/score/buildin/bendablelong/BendableLongScoreInlinerTest.java
@@ -16,7 +16,7 @@
 
 package org.optaplanner.core.impl.score.buildin.bendablelong;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 import java.util.function.Consumer;
 

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/score/buildin/hardmediumsoft/HardMediumSoftScoreInlinerTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/score/buildin/hardmediumsoft/HardMediumSoftScoreInlinerTest.java
@@ -16,7 +16,7 @@
 
 package org.optaplanner.core.impl.score.buildin.hardmediumsoft;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 import java.util.function.Consumer;
 

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/score/buildin/hardmediumsoftbigdecimal/HardMediumSoftBigDecimalScoreInlinerTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/score/buildin/hardmediumsoftbigdecimal/HardMediumSoftBigDecimalScoreInlinerTest.java
@@ -16,7 +16,7 @@
 
 package org.optaplanner.core.impl.score.buildin.hardmediumsoftbigdecimal;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 import java.math.BigDecimal;
 import java.util.function.Consumer;

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/score/buildin/hardmediumsoftlong/HardMediumSoftLongScoreInlinerTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/score/buildin/hardmediumsoftlong/HardMediumSoftLongScoreInlinerTest.java
@@ -16,7 +16,7 @@
 
 package org.optaplanner.core.impl.score.buildin.hardmediumsoftlong;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 import java.util.function.Consumer;
 

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/score/buildin/hardsoft/HardSoftScoreInlinerTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/score/buildin/hardsoft/HardSoftScoreInlinerTest.java
@@ -16,7 +16,7 @@
 
 package org.optaplanner.core.impl.score.buildin.hardsoft;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 import java.util.function.Consumer;
 

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/score/buildin/hardsoftbigdecimal/HardSoftBigDecimalScoreInlinerTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/score/buildin/hardsoftbigdecimal/HardSoftBigDecimalScoreInlinerTest.java
@@ -16,7 +16,7 @@
 
 package org.optaplanner.core.impl.score.buildin.hardsoftbigdecimal;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 import java.math.BigDecimal;
 import java.util.function.Consumer;

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/score/buildin/hardsoftlong/HardSoftLongScoreInlinerTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/score/buildin/hardsoftlong/HardSoftLongScoreInlinerTest.java
@@ -16,7 +16,7 @@
 
 package org.optaplanner.core.impl.score.buildin.hardsoftlong;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 import java.util.function.Consumer;
 

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/score/buildin/simple/SimpleScoreInlinerTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/score/buildin/simple/SimpleScoreInlinerTest.java
@@ -16,7 +16,7 @@
 
 package org.optaplanner.core.impl.score.buildin.simple;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 import java.util.function.Consumer;
 

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/score/buildin/simplebigdecimal/SimpleBigDecimalScoreInlinerTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/score/buildin/simplebigdecimal/SimpleBigDecimalScoreInlinerTest.java
@@ -16,7 +16,7 @@
 
 package org.optaplanner.core.impl.score.buildin.simplebigdecimal;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 import java.math.BigDecimal;
 import java.util.function.Consumer;

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/score/buildin/simplelong/SimpleLongScoreInlinerTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/score/buildin/simplelong/SimpleLongScoreInlinerTest.java
@@ -16,7 +16,7 @@
 
 package org.optaplanner.core.impl.score.buildin.simplelong;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 import java.util.function.Consumer;
 

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/score/comparator/FlatteningHardSoftScoreComparatorTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/score/comparator/FlatteningHardSoftScoreComparatorTest.java
@@ -16,7 +16,7 @@
 
 package org.optaplanner.core.impl.score.comparator;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 import java.util.Arrays;
 import java.util.Collection;

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/score/director/drools/testgen/fact/TestGenValueFactTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/score/director/drools/testgen/fact/TestGenValueFactTest.java
@@ -15,7 +15,10 @@
  */
 package org.optaplanner.core.impl.score.director.drools.testgen.fact;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/score/director/drools/testgen/mutation/TestGenHeadCuttingMutatorTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/score/director/drools/testgen/mutation/TestGenHeadCuttingMutatorTest.java
@@ -15,7 +15,9 @@
  */
 package org.optaplanner.core.impl.score.director.drools.testgen.mutation;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import java.util.ArrayList;
 

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/score/director/drools/testgen/mutation/TestGenRemoveRandomBlockMutatorTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/score/director/drools/testgen/mutation/TestGenRemoveRandomBlockMutatorTest.java
@@ -15,7 +15,9 @@
  */
 package org.optaplanner.core.impl.score.director.drools.testgen.mutation;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/score/director/easy/EasyScoreDirectorFactoryTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/score/director/easy/EasyScoreDirectorFactoryTest.java
@@ -16,8 +16,10 @@
 
 package org.optaplanner.core.impl.score.director.easy;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.util.Collections;
 

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/score/trend/InitializingScoreTrendTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/score/trend/InitializingScoreTrendTest.java
@@ -16,7 +16,8 @@
 
 package org.optaplanner.core.impl.score.trend;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
 
 import org.junit.jupiter.api.Test;
 import org.optaplanner.core.config.score.trend.InitializingScoreTrendLevel;

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/solver/DefaultSolverTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/solver/DefaultSolverTest.java
@@ -16,7 +16,10 @@
 
 package org.optaplanner.core.impl.solver;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.fail;
 
 import java.util.Arrays;
 import java.util.Collections;

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/solver/recaller/BestSolutionRecallerTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/solver/recaller/BestSolutionRecallerTest.java
@@ -16,8 +16,9 @@
 
 package org.optaplanner.core.impl.solver.recaller;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import org.junit.jupiter.api.Test;
 import org.optaplanner.core.api.score.Score;

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/solver/termination/AndCompositeTerminationTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/solver/termination/AndCompositeTerminationTest.java
@@ -1,7 +1,10 @@
 package org.optaplanner.core.impl.solver.termination;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.util.Arrays;
 

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/solver/termination/BasicPlumbingTerminationTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/solver/termination/BasicPlumbingTerminationTest.java
@@ -16,7 +16,7 @@
 
 package org.optaplanner.core.impl.solver.termination;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 import java.util.Arrays;
 import java.util.concurrent.atomic.AtomicInteger;

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/solver/termination/BestScoreFeasibleTerminationTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/solver/termination/BestScoreFeasibleTerminationTest.java
@@ -15,8 +15,9 @@
  */
 package org.optaplanner.core.impl.solver.termination;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import org.junit.jupiter.api.Test;
 import org.optaplanner.core.api.score.buildin.bendable.BendableScore;

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/solver/termination/BestScoreTerminationTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/solver/termination/BestScoreTerminationTest.java
@@ -16,8 +16,9 @@
 
 package org.optaplanner.core.impl.solver.termination;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.math.BigDecimal;
 

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/solver/termination/ScoreCalculationCountTerminationTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/solver/termination/ScoreCalculationCountTerminationTest.java
@@ -16,8 +16,9 @@
 
 package org.optaplanner.core.impl.solver.termination;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import org.junit.jupiter.api.Test;
 import org.optaplanner.core.impl.phase.scope.AbstractPhaseScope;

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/solver/termination/StepCountTerminationTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/solver/termination/StepCountTerminationTest.java
@@ -16,8 +16,9 @@
 
 package org.optaplanner.core.impl.solver.termination;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import org.junit.jupiter.api.Test;
 import org.optaplanner.core.impl.phase.scope.AbstractPhaseScope;

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/solver/termination/TimeMillisSpentTerminationTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/solver/termination/TimeMillisSpentTerminationTest.java
@@ -16,8 +16,9 @@
 
 package org.optaplanner.core.impl.solver.termination;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import org.junit.jupiter.api.Test;
 import org.optaplanner.core.impl.phase.scope.AbstractPhaseScope;

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/solver/termination/UnimprovedStepCountTerminationTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/solver/termination/UnimprovedStepCountTerminationTest.java
@@ -16,8 +16,9 @@
 
 package org.optaplanner.core.impl.solver.termination;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import org.junit.jupiter.api.Test;
 import org.optaplanner.core.impl.phase.scope.AbstractPhaseScope;

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/solver/thread/OrderByMoveIndexBlockingQueueTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/solver/thread/OrderByMoveIndexBlockingQueueTest.java
@@ -17,7 +17,7 @@
 package org.optaplanner.core.impl.solver.thread;
 
 import static org.junit.Assert.assertEquals;
-import static org.optaplanner.core.impl.testdata.util.PlannerAssert.*;
+import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertCode;
 import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertSame;
 import static org.optaplanner.core.impl.testdata.util.PlannerAssert.fail;
 

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/testdata/util/PlannerAssert.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/testdata/util/PlannerAssert.java
@@ -17,7 +17,9 @@
 
 package org.optaplanner.core.impl.testdata.util;
 
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 import java.util.Collection;
 import java.util.Comparator;

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/testdata/util/PlannerTestUtils.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/testdata/util/PlannerTestUtils.java
@@ -17,7 +17,9 @@
 package org.optaplanner.core.impl.testdata.util;
 
 import static java.util.Arrays.stream;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.io.Serializable;
 import java.util.ArrayList;

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/curriculumcourse/domain/solver/LectureDifficultyWeightFactory.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/curriculumcourse/domain/solver/LectureDifficultyWeightFactory.java
@@ -16,7 +16,8 @@
 
 package org.optaplanner.examples.curriculumcourse.domain.solver;
 
-import static java.util.Comparator.*;
+import static java.util.Comparator.comparingInt;
+import static java.util.Comparator.comparingLong;
 
 import java.util.Comparator;
 

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/curriculumcourse/domain/solver/RoomStrengthWeightFactory.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/curriculumcourse/domain/solver/RoomStrengthWeightFactory.java
@@ -16,7 +16,7 @@
 
 package org.optaplanner.examples.curriculumcourse.domain.solver;
 
-import static java.util.Comparator.*;
+import static java.util.Comparator.comparingInt;
 
 import java.util.Comparator;
 

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/curriculumcourse/optional/score/CourseScheduleConstraintProvider.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/curriculumcourse/optional/score/CourseScheduleConstraintProvider.java
@@ -16,8 +16,9 @@
 
 package org.optaplanner.examples.curriculumcourse.optional.score;
 
-import static org.optaplanner.core.api.score.stream.ConstraintCollectors.*;
-import static org.optaplanner.core.api.score.stream.Joiners.*;
+import static org.optaplanner.core.api.score.stream.ConstraintCollectors.countDistinct;
+import static org.optaplanner.core.api.score.stream.Joiners.equal;
+import static org.optaplanner.core.api.score.stream.Joiners.lessThan;
 
 import org.optaplanner.core.api.score.buildin.hardsoft.HardSoftScore;
 import org.optaplanner.core.api.score.stream.Constraint;

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/curriculumcourse/persistence/CurriculumCourseGenerator.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/curriculumcourse/persistence/CurriculumCourseGenerator.java
@@ -16,7 +16,7 @@
 
 package org.optaplanner.examples.curriculumcourse.persistence;
 
-import static org.optaplanner.examples.common.persistence.AbstractSolutionImporter.*;
+import static org.optaplanner.examples.common.persistence.AbstractSolutionImporter.getFlooredPossibleSolutionSize;
 
 import java.io.File;
 import java.math.BigInteger;

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/curriculumcourse/swingui/CurriculumCoursePanel.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/curriculumcourse/swingui/CurriculumCoursePanel.java
@@ -16,8 +16,9 @@
 
 package org.optaplanner.examples.curriculumcourse.swingui;
 
-import static org.optaplanner.examples.common.swingui.timetable.TimeTablePanel.HeaderColumnKey.*;
-import static org.optaplanner.examples.common.swingui.timetable.TimeTablePanel.HeaderRowKey.*;
+import static org.optaplanner.examples.common.swingui.timetable.TimeTablePanel.HeaderColumnKey.HEADER_COLUMN;
+import static org.optaplanner.examples.common.swingui.timetable.TimeTablePanel.HeaderColumnKey.HEADER_COLUMN_GROUP1;
+import static org.optaplanner.examples.common.swingui.timetable.TimeTablePanel.HeaderRowKey.HEADER_ROW;
 
 import java.awt.BorderLayout;
 import java.awt.Color;

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/examination/domain/solver/RoomStrengthWeightFactory.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/examination/domain/solver/RoomStrengthWeightFactory.java
@@ -16,7 +16,7 @@
 
 package org.optaplanner.examples.examination.domain.solver;
 
-import static java.util.Comparator.*;
+import static java.util.Comparator.comparingInt;
 
 import java.util.Comparator;
 

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/examination/swingui/ExaminationPanel.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/examination/swingui/ExaminationPanel.java
@@ -16,8 +16,8 @@
 
 package org.optaplanner.examples.examination.swingui;
 
-import static org.optaplanner.examples.common.swingui.timetable.TimeTablePanel.HeaderColumnKey.*;
-import static org.optaplanner.examples.common.swingui.timetable.TimeTablePanel.HeaderRowKey.*;
+import static org.optaplanner.examples.common.swingui.timetable.TimeTablePanel.HeaderColumnKey.HEADER_COLUMN;
+import static org.optaplanner.examples.common.swingui.timetable.TimeTablePanel.HeaderRowKey.HEADER_ROW;
 
 import java.awt.BorderLayout;
 import java.awt.Color;

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/investment/swingui/InvestmentPanel.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/investment/swingui/InvestmentPanel.java
@@ -16,8 +16,15 @@
 
 package org.optaplanner.examples.investment.swingui;
 
-import static org.optaplanner.examples.common.swingui.timetable.TimeTablePanel.HeaderColumnKey.*;
-import static org.optaplanner.examples.common.swingui.timetable.TimeTablePanel.HeaderRowKey.*;
+import static org.optaplanner.examples.common.swingui.timetable.TimeTablePanel.HeaderColumnKey.HEADER_COLUMN;
+import static org.optaplanner.examples.common.swingui.timetable.TimeTablePanel.HeaderColumnKey.HEADER_COLUMN_EXTRA_PROPERTY_1;
+import static org.optaplanner.examples.common.swingui.timetable.TimeTablePanel.HeaderColumnKey.HEADER_COLUMN_EXTRA_PROPERTY_2;
+import static org.optaplanner.examples.common.swingui.timetable.TimeTablePanel.HeaderColumnKey.HEADER_COLUMN_EXTRA_PROPERTY_3;
+import static org.optaplanner.examples.common.swingui.timetable.TimeTablePanel.HeaderColumnKey.HEADER_COLUMN_EXTRA_PROPERTY_4;
+import static org.optaplanner.examples.common.swingui.timetable.TimeTablePanel.HeaderColumnKey.HEADER_COLUMN_EXTRA_PROPERTY_5;
+import static org.optaplanner.examples.common.swingui.timetable.TimeTablePanel.HeaderRowKey.HEADER_ROW;
+import static org.optaplanner.examples.common.swingui.timetable.TimeTablePanel.HeaderRowKey.HEADER_ROW_GROUP1;
+import static org.optaplanner.examples.common.swingui.timetable.TimeTablePanel.HeaderRowKey.TRAILING_HEADER_ROW;
 
 import java.awt.BorderLayout;
 import java.awt.FlowLayout;

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/meetingscheduling/persistence/MeetingSchedulingXlsxFileIO.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/meetingscheduling/persistence/MeetingSchedulingXlsxFileIO.java
@@ -1,7 +1,21 @@
 package org.optaplanner.examples.meetingscheduling.persistence;
 
-import static java.util.stream.Collectors.*;
-import static org.optaplanner.examples.meetingscheduling.domain.MeetingConstraintConfiguration.*;
+import static java.util.stream.Collectors.groupingBy;
+import static java.util.stream.Collectors.joining;
+import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toMap;
+import static org.optaplanner.examples.meetingscheduling.domain.MeetingConstraintConfiguration.ASSIGN_LARGER_ROOMS_FIRST;
+import static org.optaplanner.examples.meetingscheduling.domain.MeetingConstraintConfiguration.DONT_GO_IN_OVERTIME;
+import static org.optaplanner.examples.meetingscheduling.domain.MeetingConstraintConfiguration.DO_ALL_MEETINGS_AS_SOON_AS_POSSIBLE;
+import static org.optaplanner.examples.meetingscheduling.domain.MeetingConstraintConfiguration.ONE_TIME_GRAIN_BREAK_BETWEEN_TWO_CONSECUTIVE_MEETINGS;
+import static org.optaplanner.examples.meetingscheduling.domain.MeetingConstraintConfiguration.OVERLAPPING_MEETINGS;
+import static org.optaplanner.examples.meetingscheduling.domain.MeetingConstraintConfiguration.PREFERRED_ATTENDANCE_CONFLICT;
+import static org.optaplanner.examples.meetingscheduling.domain.MeetingConstraintConfiguration.REQUIRED_AND_PREFERRED_ATTENDANCE_CONFLICT;
+import static org.optaplanner.examples.meetingscheduling.domain.MeetingConstraintConfiguration.REQUIRED_ATTENDANCE_CONFLICT;
+import static org.optaplanner.examples.meetingscheduling.domain.MeetingConstraintConfiguration.REQUIRED_ROOM_CAPACITY;
+import static org.optaplanner.examples.meetingscheduling.domain.MeetingConstraintConfiguration.ROOM_CONFLICT;
+import static org.optaplanner.examples.meetingscheduling.domain.MeetingConstraintConfiguration.ROOM_STABILITY;
+import static org.optaplanner.examples.meetingscheduling.domain.MeetingConstraintConfiguration.START_AND_END_ON_SAME_DAY;
 
 import java.io.BufferedInputStream;
 import java.io.File;

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/meetingscheduling/swingui/MeetingSchedulingPanel.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/meetingscheduling/swingui/MeetingSchedulingPanel.java
@@ -16,9 +16,11 @@
 
 package org.optaplanner.examples.meetingscheduling.swingui;
 
-import static org.apache.commons.lang3.ObjectUtils.*;
-import static org.optaplanner.examples.common.swingui.timetable.TimeTablePanel.HeaderColumnKey.*;
-import static org.optaplanner.examples.common.swingui.timetable.TimeTablePanel.HeaderRowKey.*;
+import static org.apache.commons.lang3.ObjectUtils.defaultIfNull;
+import static org.optaplanner.examples.common.swingui.timetable.TimeTablePanel.HeaderColumnKey.HEADER_COLUMN;
+import static org.optaplanner.examples.common.swingui.timetable.TimeTablePanel.HeaderColumnKey.HEADER_COLUMN_GROUP1;
+import static org.optaplanner.examples.common.swingui.timetable.TimeTablePanel.HeaderRowKey.HEADER_ROW;
+import static org.optaplanner.examples.common.swingui.timetable.TimeTablePanel.HeaderRowKey.HEADER_ROW_GROUP1;
 
 import java.awt.BorderLayout;
 import java.awt.Color;

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/nurserostering/domain/solver/EmployeeStrengthComparator.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/nurserostering/domain/solver/EmployeeStrengthComparator.java
@@ -16,7 +16,7 @@
 
 package org.optaplanner.examples.nurserostering.domain.solver;
 
-import static java.util.Comparator.*;
+import static java.util.Comparator.comparingInt;
 
 import java.io.Serializable;
 import java.util.Comparator;

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/nurserostering/persistence/NurseRosteringImporter.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/nurserostering/persistence/NurseRosteringImporter.java
@@ -16,7 +16,7 @@
 
 package org.optaplanner.examples.nurserostering.persistence;
 
-import static java.time.temporal.ChronoUnit.*;
+import static java.time.temporal.ChronoUnit.DAYS;
 
 import java.io.IOException;
 import java.math.BigInteger;

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/pas/domain/solver/BedStrengthComparator.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/pas/domain/solver/BedStrengthComparator.java
@@ -16,8 +16,9 @@
 
 package org.optaplanner.examples.pas.domain.solver;
 
-import static java.util.Comparator.*;
 import static java.util.Comparator.comparing;
+import static java.util.Comparator.comparingInt;
+import static java.util.Comparator.nullsFirst;
 
 import java.io.Serializable;
 import java.util.Collections;

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/pas/solver/move/factory/BedDesignationPillarPartSwapMoveFactory.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/pas/solver/move/factory/BedDesignationPillarPartSwapMoveFactory.java
@@ -16,7 +16,8 @@
 
 package org.optaplanner.examples.pas.solver.move.factory;
 
-import static java.util.Comparator.*;
+import static java.util.Comparator.comparing;
+import static java.util.Comparator.comparingLong;
 
 import java.util.ArrayList;
 import java.util.Collections;

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/pas/swingui/PatientAdmissionSchedulePanel.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/pas/swingui/PatientAdmissionSchedulePanel.java
@@ -16,8 +16,10 @@
 
 package org.optaplanner.examples.pas.swingui;
 
-import static org.optaplanner.examples.common.swingui.timetable.TimeTablePanel.HeaderColumnKey.*;
-import static org.optaplanner.examples.common.swingui.timetable.TimeTablePanel.HeaderRowKey.*;
+import static org.optaplanner.examples.common.swingui.timetable.TimeTablePanel.HeaderColumnKey.HEADER_COLUMN;
+import static org.optaplanner.examples.common.swingui.timetable.TimeTablePanel.HeaderColumnKey.HEADER_COLUMN_GROUP1;
+import static org.optaplanner.examples.common.swingui.timetable.TimeTablePanel.HeaderColumnKey.HEADER_COLUMN_GROUP2;
+import static org.optaplanner.examples.common.swingui.timetable.TimeTablePanel.HeaderRowKey.HEADER_ROW;
 
 import java.awt.BorderLayout;
 import java.awt.Color;

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/projectjobscheduling/domain/solver/ExecutionModeStrengthWeightFactory.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/projectjobscheduling/domain/solver/ExecutionModeStrengthWeightFactory.java
@@ -16,7 +16,8 @@
 
 package org.optaplanner.examples.projectjobscheduling.domain.solver;
 
-import static java.util.Comparator.*;
+import static java.util.Comparator.comparingDouble;
+import static java.util.Comparator.comparingLong;
 
 import java.util.Comparator;
 import java.util.HashMap;

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/rocktour/domain/RockShow.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/rocktour/domain/RockShow.java
@@ -16,7 +16,7 @@
 
 package org.optaplanner.examples.rocktour.domain;
 
-import static java.time.temporal.ChronoUnit.*;
+import static java.time.temporal.ChronoUnit.DAYS;
 
 import java.time.LocalDate;
 import java.util.NavigableSet;

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/rocktour/persistence/RockTourXlsxFileIO.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/rocktour/persistence/RockTourXlsxFileIO.java
@@ -16,8 +16,21 @@
 
 package org.optaplanner.examples.rocktour.persistence;
 
-import static java.util.stream.Collectors.*;
-import static org.optaplanner.examples.rocktour.domain.RockTourConstraintConfiguration.*;
+import static java.util.stream.Collectors.groupingBy;
+import static java.util.stream.Collectors.joining;
+import static java.util.stream.Collectors.toList;
+import static org.optaplanner.examples.rocktour.domain.RockTourConstraintConfiguration.DELAY_SHOW_COST_PER_DAY;
+import static org.optaplanner.examples.rocktour.domain.RockTourConstraintConfiguration.DRIVING_TIME_TO_BUS_ARRIVAL_PER_SECOND;
+import static org.optaplanner.examples.rocktour.domain.RockTourConstraintConfiguration.DRIVING_TIME_TO_SHOW_PER_SECOND;
+import static org.optaplanner.examples.rocktour.domain.RockTourConstraintConfiguration.EARLY_LATE_BREAK_DRIVING_SECONDS;
+import static org.optaplanner.examples.rocktour.domain.RockTourConstraintConfiguration.HOS_WEEK_CONSECUTIVE_DRIVING_DAYS_BUDGET;
+import static org.optaplanner.examples.rocktour.domain.RockTourConstraintConfiguration.HOS_WEEK_DRIVING_SECONDS_BUDGET;
+import static org.optaplanner.examples.rocktour.domain.RockTourConstraintConfiguration.HOS_WEEK_REST_DAYS;
+import static org.optaplanner.examples.rocktour.domain.RockTourConstraintConfiguration.NIGHT_DRIVING_SECONDS;
+import static org.optaplanner.examples.rocktour.domain.RockTourConstraintConfiguration.REQUIRED_SHOW;
+import static org.optaplanner.examples.rocktour.domain.RockTourConstraintConfiguration.REVENUE_OPPORTUNITY;
+import static org.optaplanner.examples.rocktour.domain.RockTourConstraintConfiguration.SHORTEN_DRIVING_TIME_PER_MILLISECOND_SQUARED;
+import static org.optaplanner.examples.rocktour.domain.RockTourConstraintConfiguration.UNASSIGNED_SHOW;
 
 import java.io.BufferedInputStream;
 import java.io.File;

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/scrabble/swingui/ScrabblePanel.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/scrabble/swingui/ScrabblePanel.java
@@ -16,8 +16,8 @@
 
 package org.optaplanner.examples.scrabble.swingui;
 
-import static org.optaplanner.examples.common.swingui.timetable.TimeTablePanel.HeaderColumnKey.*;
-import static org.optaplanner.examples.common.swingui.timetable.TimeTablePanel.HeaderRowKey.*;
+import static org.optaplanner.examples.common.swingui.timetable.TimeTablePanel.HeaderColumnKey.HEADER_COLUMN;
+import static org.optaplanner.examples.common.swingui.timetable.TimeTablePanel.HeaderRowKey.HEADER_ROW;
 
 import java.awt.BorderLayout;
 

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/taskassigning/swingui/TaskAssigningPanel.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/taskassigning/swingui/TaskAssigningPanel.java
@@ -16,7 +16,7 @@
 
 package org.optaplanner.examples.taskassigning.swingui;
 
-import static org.optaplanner.examples.taskassigning.persistence.TaskAssigningGenerator.*;
+import static org.optaplanner.examples.taskassigning.persistence.TaskAssigningGenerator.BASE_DURATION_AVERAGE;
 
 import java.awt.BorderLayout;
 import java.awt.FlowLayout;

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/tennis/swingui/TennisPanel.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/tennis/swingui/TennisPanel.java
@@ -16,8 +16,9 @@
 
 package org.optaplanner.examples.tennis.swingui;
 
-import static org.optaplanner.examples.common.swingui.timetable.TimeTablePanel.HeaderColumnKey.*;
-import static org.optaplanner.examples.common.swingui.timetable.TimeTablePanel.HeaderRowKey.*;
+import static org.optaplanner.examples.common.swingui.timetable.TimeTablePanel.HeaderColumnKey.HEADER_COLUMN;
+import static org.optaplanner.examples.common.swingui.timetable.TimeTablePanel.HeaderColumnKey.TRAILING_HEADER_COLUMN;
+import static org.optaplanner.examples.common.swingui.timetable.TimeTablePanel.HeaderRowKey.HEADER_ROW;
 
 import java.awt.BorderLayout;
 import java.awt.Color;

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/travelingtournament/swingui/TravelingTournamentPanel.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/travelingtournament/swingui/TravelingTournamentPanel.java
@@ -16,8 +16,8 @@
 
 package org.optaplanner.examples.travelingtournament.swingui;
 
-import static org.optaplanner.examples.common.swingui.timetable.TimeTablePanel.HeaderColumnKey.*;
-import static org.optaplanner.examples.common.swingui.timetable.TimeTablePanel.HeaderRowKey.*;
+import static org.optaplanner.examples.common.swingui.timetable.TimeTablePanel.HeaderColumnKey.HEADER_COLUMN;
+import static org.optaplanner.examples.common.swingui.timetable.TimeTablePanel.HeaderRowKey.HEADER_ROW;
 
 import java.awt.BorderLayout;
 import java.awt.Color;

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/tsp/domain/solver/DomicileAngleVisitDifficultyWeightFactory.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/tsp/domain/solver/DomicileAngleVisitDifficultyWeightFactory.java
@@ -16,7 +16,8 @@
 
 package org.optaplanner.examples.tsp.domain.solver;
 
-import static java.util.Comparator.*;
+import static java.util.Comparator.comparingDouble;
+import static java.util.Comparator.comparingLong;
 
 import java.util.Comparator;
 

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/tsp/domain/solver/DomicileDistanceVisitDifficultyWeightFactory.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/tsp/domain/solver/DomicileDistanceVisitDifficultyWeightFactory.java
@@ -16,7 +16,7 @@
 
 package org.optaplanner.examples.tsp.domain.solver;
 
-import static java.util.Comparator.*;
+import static java.util.Comparator.comparingLong;
 
 import java.util.Comparator;
 

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/vehiclerouting/domain/solver/DepotAngleCustomerDifficultyWeightFactory.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/vehiclerouting/domain/solver/DepotAngleCustomerDifficultyWeightFactory.java
@@ -16,7 +16,8 @@
 
 package org.optaplanner.examples.vehiclerouting.domain.solver;
 
-import static java.util.Comparator.*;
+import static java.util.Comparator.comparingDouble;
+import static java.util.Comparator.comparingLong;
 
 import java.util.Comparator;
 

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/vehiclerouting/domain/solver/DepotDistanceCustomerDifficultyWeightFactory.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/vehiclerouting/domain/solver/DepotDistanceCustomerDifficultyWeightFactory.java
@@ -16,7 +16,7 @@
 
 package org.optaplanner.examples.vehiclerouting.domain.solver;
 
-import static java.util.Comparator.*;
+import static java.util.Comparator.comparingLong;
 
 import java.util.Comparator;
 

--- a/optaplanner-examples/src/test/java/org/optaplanner/examples/cloudbalancing/app/CloudBalancingDaemonTest.java
+++ b/optaplanner-examples/src/test/java/org/optaplanner/examples/cloudbalancing/app/CloudBalancingDaemonTest.java
@@ -16,7 +16,7 @@
 
 package org.optaplanner.examples.cloudbalancing.app;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 import java.util.ArrayDeque;
 import java.util.ArrayList;

--- a/optaplanner-examples/src/test/java/org/optaplanner/examples/common/business/AlphaNumericStringComparatorTest.java
+++ b/optaplanner-examples/src/test/java/org/optaplanner/examples/common/business/AlphaNumericStringComparatorTest.java
@@ -16,7 +16,7 @@
 
 package org.optaplanner.examples.common.business;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 import java.util.Comparator;
 

--- a/optaplanner-examples/src/test/java/org/optaplanner/examples/common/persistence/AbstractSolutionImporterTest.java
+++ b/optaplanner-examples/src/test/java/org/optaplanner/examples/common/persistence/AbstractSolutionImporterTest.java
@@ -16,7 +16,7 @@
 
 package org.optaplanner.examples.common.persistence;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 import java.math.BigInteger;
 

--- a/optaplanner-examples/src/test/java/org/optaplanner/examples/common/persistence/AbstractTxtSolutionImporterTest.java
+++ b/optaplanner-examples/src/test/java/org/optaplanner/examples/common/persistence/AbstractTxtSolutionImporterTest.java
@@ -16,7 +16,7 @@
 
 package org.optaplanner.examples.common.persistence;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertArrayEquals;
 
 import java.io.IOException;
 

--- a/optaplanner-examples/src/test/java/org/optaplanner/examples/common/persistence/StringDataGeneratorTest.java
+++ b/optaplanner-examples/src/test/java/org/optaplanner/examples/common/persistence/StringDataGeneratorTest.java
@@ -16,7 +16,7 @@
 
 package org.optaplanner.examples.common.persistence;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 import org.junit.jupiter.api.Test;
 import org.optaplanner.examples.common.persistence.generator.StringDataGenerator;

--- a/optaplanner-examples/src/test/java/org/optaplanner/examples/common/solver/drools/functions/LoadBalanceByCountAccumulateFunctionTest.java
+++ b/optaplanner-examples/src/test/java/org/optaplanner/examples/common/solver/drools/functions/LoadBalanceByCountAccumulateFunctionTest.java
@@ -16,7 +16,7 @@
 
 package org.optaplanner.examples.common.solver.drools.functions;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 import org.junit.jupiter.api.Test;
 

--- a/optaplanner-examples/src/test/java/org/optaplanner/examples/nqueens/app/NQueensAppTest.java
+++ b/optaplanner-examples/src/test/java/org/optaplanner/examples/nqueens/app/NQueensAppTest.java
@@ -16,7 +16,7 @@
 
 package org.optaplanner.examples.nqueens.app;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertNotNull;
 
 import org.junit.jupiter.api.Test;
 import org.optaplanner.core.api.solver.Solver;

--- a/optaplanner-examples/src/test/java/org/optaplanner/examples/nqueens/solver/tracking/NQueensAbstractTrackingTest.java
+++ b/optaplanner-examples/src/test/java/org/optaplanner/examples/nqueens/solver/tracking/NQueensAbstractTrackingTest.java
@@ -16,7 +16,7 @@
 
 package org.optaplanner.examples.nqueens.solver.tracking;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 import java.util.List;
 

--- a/optaplanner-examples/src/test/java/org/optaplanner/examples/vehiclerouting/app/VehicleRoutingMultiThreadedReproducibilityTest.java
+++ b/optaplanner-examples/src/test/java/org/optaplanner/examples/vehiclerouting/app/VehicleRoutingMultiThreadedReproducibilityTest.java
@@ -1,6 +1,6 @@
 package org.optaplanner.examples.vehiclerouting.app;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 import java.io.File;
 import java.util.stream.IntStream;

--- a/optaplanner-examples/src/test/java/org/optaplanner/examples/vehiclerouting/domain/location/segmented/RoadSegmentLocationTest.java
+++ b/optaplanner-examples/src/test/java/org/optaplanner/examples/vehiclerouting/domain/location/segmented/RoadSegmentLocationTest.java
@@ -16,7 +16,7 @@
 
 package org.optaplanner.examples.vehiclerouting.domain.location.segmented;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 import java.util.LinkedHashMap;
 import java.util.Map;

--- a/optaplanner-integration/optaplanner-spring-boot-autoconfigure/src/test/java/org/optaplanner/spring/boot/autoconfigure/OptaPlannerAutoConfigurationTest.java
+++ b/optaplanner-integration/optaplanner-spring-boot-autoconfigure/src/test/java/org/optaplanner/spring/boot/autoconfigure/OptaPlannerAutoConfigurationTest.java
@@ -17,7 +17,11 @@
 package org.optaplanner.spring.boot.autoconfigure;
 
 import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
 
 import java.time.Duration;
 import java.util.Collections;

--- a/optaplanner-persistence/optaplanner-persistence-jackson/src/test/java/org/optaplanner/persistence/jackson/api/AbstractJacksonJsonSerializerAndDeserializerTest.java
+++ b/optaplanner-persistence/optaplanner-persistence-jackson/src/test/java/org/optaplanner/persistence/jackson/api/AbstractJacksonJsonSerializerAndDeserializerTest.java
@@ -16,8 +16,6 @@
 
 package org.optaplanner.persistence.jackson.api;
 
-import static org.junit.Assert.*;
-
 import java.io.IOException;
 
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/optaplanner-persistence/optaplanner-persistence-jackson/src/test/java/org/optaplanner/persistence/jackson/api/OptaPlannerJacksonModuleTest.java
+++ b/optaplanner-persistence/optaplanner-persistence-jackson/src/test/java/org/optaplanner/persistence/jackson/api/OptaPlannerJacksonModuleTest.java
@@ -16,7 +16,7 @@
 
 package org.optaplanner.persistence.jackson.api;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 import org.junit.jupiter.api.Test;
 import org.optaplanner.core.api.score.Score;

--- a/optaplanner-persistence/optaplanner-persistence-jackson/src/test/java/org/optaplanner/persistence/jackson/api/score/AbstractScoreJacksonJsonSerializerAndDeserializerTest.java
+++ b/optaplanner-persistence/optaplanner-persistence-jackson/src/test/java/org/optaplanner/persistence/jackson/api/score/AbstractScoreJacksonJsonSerializerAndDeserializerTest.java
@@ -16,7 +16,8 @@
 
 package org.optaplanner.persistence.jackson.api.score;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 import java.io.IOException;
 import java.io.Serializable;

--- a/optaplanner-persistence/optaplanner-persistence-jaxb/src/test/java/org/optaplanner/persistence/jaxb/api/score/AbstractScoreJaxbXmlAdapterTest.java
+++ b/optaplanner-persistence/optaplanner-persistence-jaxb/src/test/java/org/optaplanner/persistence/jaxb/api/score/AbstractScoreJaxbXmlAdapterTest.java
@@ -16,7 +16,8 @@
 
 package org.optaplanner.persistence.jaxb.api.score;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 import java.io.Serializable;
 import java.io.StringReader;

--- a/optaplanner-persistence/optaplanner-persistence-jaxb/src/test/java/org/optaplanner/persistence/jaxb/impl/domain/solution/JaxbSolutionFileIOTest.java
+++ b/optaplanner-persistence/optaplanner-persistence-jaxb/src/test/java/org/optaplanner/persistence/jaxb/impl/domain/solution/JaxbSolutionFileIOTest.java
@@ -19,7 +19,8 @@ package org.optaplanner.persistence.jaxb.impl.domain.solution;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertSame;
-import static org.optaplanner.core.impl.testdata.util.PlannerAssert.*;
+import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertAllCodesOfIterator;
+import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertCode;
 
 import java.io.File;
 import java.io.IOException;

--- a/optaplanner-persistence/optaplanner-persistence-jpa/src/test/java/org/optaplanner/persistence/jpa/impl/score/AbstractScoreHibernateTypeTest.java
+++ b/optaplanner-persistence/optaplanner-persistence-jpa/src/test/java/org/optaplanner/persistence/jpa/impl/score/AbstractScoreHibernateTypeTest.java
@@ -16,7 +16,8 @@
 
 package org.optaplanner.persistence.jpa.impl.score;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 import java.util.Map;
 

--- a/optaplanner-persistence/optaplanner-persistence-xstream/src/test/java/org/optaplanner/persistence/xstream/api/score/AbstractScoreXStreamConverterTest.java
+++ b/optaplanner-persistence/optaplanner-persistence-xstream/src/test/java/org/optaplanner/persistence/xstream/api/score/AbstractScoreXStreamConverterTest.java
@@ -16,7 +16,8 @@
 
 package org.optaplanner.persistence.xstream.api.score;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 import java.io.Serializable;
 

--- a/optaplanner-persistence/optaplanner-persistence-xstream/src/test/java/org/optaplanner/persistence/xstream/impl/domain/solution/XStreamSolutionFileIOTest.java
+++ b/optaplanner-persistence/optaplanner-persistence-xstream/src/test/java/org/optaplanner/persistence/xstream/impl/domain/solution/XStreamSolutionFileIOTest.java
@@ -19,7 +19,8 @@ package org.optaplanner.persistence.xstream.impl.domain.solution;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertSame;
-import static org.optaplanner.core.impl.testdata.util.PlannerAssert.*;
+import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertAllCodesOfIterator;
+import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertCode;
 
 import java.io.File;
 import java.io.IOException;

--- a/optaplanner-test/src/main/java/org/optaplanner/test/impl/score/AbstractScoreVerifier.java
+++ b/optaplanner-test/src/main/java/org/optaplanner/test/impl/score/AbstractScoreVerifier.java
@@ -16,7 +16,7 @@
 
 package org.optaplanner.test.impl.score;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;


### PR DESCRIPTION
Verified that:
- no more star imports are present (via additional checkstyle configuration that was removed before opening this PR)
- `mvn process-sources` causes no additional changes (compatibility with the formatter)