### PR TITLE
Fix issues in quarkus code style

### DIFF
--- a/ide-configuration/eclipse-format.xml
+++ b/ide-configuration/eclipse-format.xml
@@ -1,323 +1,322 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <profiles version="15">
-<profile kind="CodeFormatterProfile" name="Quarkus" version="15">
-<setting id="org.eclipse.jdt.core.formatter.align_assignment_statements_on_columns" value="false"/>
-<setting id="org.eclipse.jdt.core.formatter.align_fields_grouping_blank_lines" value="2147483647"/>
-<setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_allocation_expression" value="16"/>
-<setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_annotation" value="0"/>
-<setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_enum_constant" value="16"/>
-<setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_explicit_constructor_call" value="16"/>
-<setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_method_invocation" value="16"/>
-<setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_qualified_allocation_expression" value="16"/>
-<setting id="org.eclipse.jdt.core.formatter.alignment_for_assignment" value="0"/>
-<setting id="org.eclipse.jdt.core.formatter.alignment_for_binary_expression" value="16"/>
-<setting id="org.eclipse.jdt.core.formatter.alignment_for_compact_if" value="16"/>
-<setting id="org.eclipse.jdt.core.formatter.alignment_for_compact_loops" value="16"/>
-<setting id="org.eclipse.jdt.core.formatter.alignment_for_conditional_expression" value="80"/>
-<setting id="org.eclipse.jdt.core.formatter.alignment_for_enum_constants" value="49"/>
-<setting id="org.eclipse.jdt.core.formatter.alignment_for_expressions_in_array_initializer" value="16"/>
-<setting id="org.eclipse.jdt.core.formatter.alignment_for_expressions_in_for_loop_header" value="0"/>
-<setting id="org.eclipse.jdt.core.formatter.alignment_for_method_declaration" value="0"/>
-<setting id="org.eclipse.jdt.core.formatter.alignment_for_module_statements" value="16"/>
-<setting id="org.eclipse.jdt.core.formatter.alignment_for_multiple_fields" value="16"/>
-<setting id="org.eclipse.jdt.core.formatter.alignment_for_parameterized_type_references" value="0"/>
-<setting id="org.eclipse.jdt.core.formatter.alignment_for_parameters_in_constructor_declaration" value="16"/>
-<setting id="org.eclipse.jdt.core.formatter.alignment_for_parameters_in_method_declaration" value="16"/>
-<setting id="org.eclipse.jdt.core.formatter.alignment_for_resources_in_try" value="80"/>
-<setting id="org.eclipse.jdt.core.formatter.alignment_for_selector_in_method_invocation" value="16"/>
-<setting id="org.eclipse.jdt.core.formatter.alignment_for_superclass_in_type_declaration" value="16"/>
-<setting id="org.eclipse.jdt.core.formatter.alignment_for_superinterfaces_in_enum_declaration" value="16"/>
-<setting id="org.eclipse.jdt.core.formatter.alignment_for_superinterfaces_in_type_declaration" value="16"/>
-<setting id="org.eclipse.jdt.core.formatter.alignment_for_throws_clause_in_constructor_declaration" value="16"/>
-<setting id="org.eclipse.jdt.core.formatter.alignment_for_throws_clause_in_method_declaration" value="16"/>
-<setting id="org.eclipse.jdt.core.formatter.alignment_for_type_arguments" value="0"/>
-<setting id="org.eclipse.jdt.core.formatter.alignment_for_type_parameters" value="0"/>
-<setting id="org.eclipse.jdt.core.formatter.alignment_for_union_type_in_multicatch" value="16"/>
-<setting id="org.eclipse.jdt.core.formatter.align_type_members_on_columns" value="false"/>
-<setting id="org.eclipse.jdt.core.formatter.align_variable_declarations_on_columns" value="false"/>
-<setting id="org.eclipse.jdt.core.formatter.align_with_spaces" value="false"/>
-<setting id="org.eclipse.jdt.core.formatter.blank_lines_after_imports" value="1"/>
-<setting id="org.eclipse.jdt.core.formatter.blank_lines_after_package" value="1"/>
-<setting id="org.eclipse.jdt.core.formatter.blank_lines_before_field" value="0"/>
-<setting id="org.eclipse.jdt.core.formatter.blank_lines_before_first_class_body_declaration" value="0"/>
-<setting id="org.eclipse.jdt.core.formatter.blank_lines_before_imports" value="1"/>
-<setting id="org.eclipse.jdt.core.formatter.blank_lines_before_member_type" value="1"/>
-<setting id="org.eclipse.jdt.core.formatter.blank_lines_before_method" value="1"/>
-<setting id="org.eclipse.jdt.core.formatter.blank_lines_before_new_chunk" value="1"/>
-<setting id="org.eclipse.jdt.core.formatter.blank_lines_before_package" value="0"/>
-<setting id="org.eclipse.jdt.core.formatter.blank_lines_between_import_groups" value="1"/>
-<setting id="org.eclipse.jdt.core.formatter.blank_lines_between_type_declarations" value="1"/>
-<setting id="org.eclipse.jdt.core.formatter.brace_position_for_annotation_type_declaration" value="end_of_line"/>
-<setting id="org.eclipse.jdt.core.formatter.brace_position_for_anonymous_type_declaration" value="end_of_line"/>
-<setting id="org.eclipse.jdt.core.formatter.brace_position_for_array_initializer" value="end_of_line"/>
-<setting id="org.eclipse.jdt.core.formatter.brace_position_for_block_in_case" value="end_of_line"/>
-<setting id="org.eclipse.jdt.core.formatter.brace_position_for_block" value="end_of_line"/>
-<setting id="org.eclipse.jdt.core.formatter.brace_position_for_constructor_declaration" value="end_of_line"/>
-<setting id="org.eclipse.jdt.core.formatter.brace_position_for_enum_constant" value="end_of_line"/>
-<setting id="org.eclipse.jdt.core.formatter.brace_position_for_enum_declaration" value="end_of_line"/>
-<setting id="org.eclipse.jdt.core.formatter.brace_position_for_lambda_body" value="end_of_line"/>
-<setting id="org.eclipse.jdt.core.formatter.brace_position_for_method_declaration" value="end_of_line"/>
-<setting id="org.eclipse.jdt.core.formatter.brace_position_for_switch" value="end_of_line"/>
-<setting id="org.eclipse.jdt.core.formatter.brace_position_for_type_declaration" value="end_of_line"/>
-<setting id="org.eclipse.jdt.core.formatter.comment.align_tags_descriptions_grouped" value="false"/>
-<setting id="org.eclipse.jdt.core.formatter.comment.align_tags_names_descriptions" value="false"/>
-<setting id="org.eclipse.jdt.core.formatter.comment.clear_blank_lines_in_block_comment" value="false"/>
-<setting id="org.eclipse.jdt.core.formatter.comment.clear_blank_lines_in_javadoc_comment" value="false"/>
-<setting id="org.eclipse.jdt.core.formatter.comment.count_line_length_from_starting_position" value="false"/>
-<setting id="org.eclipse.jdt.core.formatter.comment.format_block_comments" value="true"/>
-<setting id="org.eclipse.jdt.core.formatter.comment.format_header" value="false"/>
-<setting id="org.eclipse.jdt.core.formatter.comment.format_html" value="true"/>
-<setting id="org.eclipse.jdt.core.formatter.comment.format_javadoc_comments" value="true"/>
-<setting id="org.eclipse.jdt.core.formatter.comment.format_line_comments" value="false"/>
-<setting id="org.eclipse.jdt.core.formatter.comment.format_source_code" value="true"/>
-<setting id="org.eclipse.jdt.core.formatter.comment.indent_parameter_description" value="false"/>
-<setting id="org.eclipse.jdt.core.formatter.comment.indent_root_tags" value="true"/>
-<setting id="org.eclipse.jdt.core.formatter.comment.insert_new_line_before_root_tags" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.comment.insert_new_line_for_parameter" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.comment.line_length" value="128"/>
-<setting id="org.eclipse.jdt.core.formatter.comment.new_lines_at_block_boundaries" value="true"/>
-<setting id="org.eclipse.jdt.core.formatter.comment.new_lines_at_javadoc_boundaries" value="true"/>
-<setting id="org.eclipse.jdt.core.formatter.comment.preserve_white_space_between_code_and_line_comments" value="false"/>
-<setting id="org.eclipse.jdt.core.formatter.compact_else_if" value="true"/>
-<setting id="org.eclipse.jdt.core.formatter.continuation_indentation_for_array_initializer" value="2"/>
-<setting id="org.eclipse.jdt.core.formatter.continuation_indentation" value="2"/>
-<setting id="org.eclipse.jdt.core.formatter.disabling_tag" value="@formatter:off"/>
-<setting id="org.eclipse.jdt.core.formatter.enabling_tag" value="@formatter:on"/>
-<setting id="org.eclipse.jdt.core.formatter.format_guardian_clause_on_one_line" value="false"/>
-<setting id="org.eclipse.jdt.core.formatter.format_line_comment_starting_on_first_column" value="false"/>
-<setting id="org.eclipse.jdt.core.formatter.indentation.size" value="4"/>
-<setting id="org.eclipse.jdt.core.formatter.indent_body_declarations_compare_to_annotation_declaration_header" value="true"/>
-<setting id="org.eclipse.jdt.core.formatter.indent_body_declarations_compare_to_enum_constant_header" value="true"/>
-<setting id="org.eclipse.jdt.core.formatter.indent_body_declarations_compare_to_enum_declaration_header" value="true"/>
-<setting id="org.eclipse.jdt.core.formatter.indent_body_declarations_compare_to_type_header" value="true"/>
-<setting id="org.eclipse.jdt.core.formatter.indent_breaks_compare_to_cases" value="true"/>
-<setting id="org.eclipse.jdt.core.formatter.indent_empty_lines" value="false"/>
-<setting id="org.eclipse.jdt.core.formatter.indent_statements_compare_to_block" value="true"/>
-<setting id="org.eclipse.jdt.core.formatter.indent_statements_compare_to_body" value="true"/>
-<setting id="org.eclipse.jdt.core.formatter.indent_switchstatements_compare_to_cases" value="true"/>
-<setting id="org.eclipse.jdt.core.formatter.indent_switchstatements_compare_to_switch" value="true"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_enum_constant" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_field" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_local_variable" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_method" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_package" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_parameter" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_type" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_label" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_opening_brace_in_array_initializer" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_type_annotation" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_new_line_at_end_of_file_if_missing" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_catch_in_try_statement" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_closing_brace_in_array_initializer" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_else_in_if_statement" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_finally_in_try_statement" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_while_in_do_statement" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_and_in_type_parameter" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_assignment_operator" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_at_in_annotation_type_declaration" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_at_in_annotation" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_binary_operator" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_closing_angle_bracket_in_type_arguments" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_closing_angle_bracket_in_type_parameters" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_closing_brace_in_block" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_closing_paren_in_cast" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_assert" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_case" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_conditional" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_for" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_labeled_statement" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_allocation_expression" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_annotation" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_array_initializer" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_constructor_declaration_parameters" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_constructor_declaration_throws" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_enum_constant_arguments" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_enum_declarations" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_explicitconstructorcall_arguments" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_for_increments" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_for_inits" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_method_declaration_parameters" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_method_declaration_throws" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_method_invocation_arguments" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_multiple_field_declarations" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_multiple_local_declarations" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_parameterized_type_reference" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_superinterfaces" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_type_arguments" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_type_parameters" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_ellipsis" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_lambda_arrow" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_angle_bracket_in_parameterized_type_reference" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_angle_bracket_in_type_arguments" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_angle_bracket_in_type_parameters" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_brace_in_array_initializer" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_bracket_in_array_allocation_expression" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_bracket_in_array_reference" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_annotation" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_cast" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_catch" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_constructor_declaration" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_enum_constant" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_for" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_if" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_method_declaration" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_method_invocation" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_parenthesized_expression" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_switch" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_synchronized" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_try" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_while" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_postfix_operator" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_prefix_operator" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_question_in_conditional" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_question_in_wildcard" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_semicolon_in_for" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_semicolon_in_try_resources" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_unary_operator" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_and_in_type_parameter" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_assignment_operator" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_at_in_annotation_type_declaration" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_binary_operator" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_angle_bracket_in_parameterized_type_reference" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_angle_bracket_in_type_arguments" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_angle_bracket_in_type_parameters" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_brace_in_array_initializer" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_bracket_in_array_allocation_expression" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_bracket_in_array_reference" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_annotation" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_cast" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_catch" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_constructor_declaration" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_enum_constant" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_for" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_if" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_method_declaration" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_method_invocation" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_parenthesized_expression" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_switch" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_synchronized" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_try" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_while" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_assert" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_case" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_conditional" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_default" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_for" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_labeled_statement" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_allocation_expression" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_annotation" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_array_initializer" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_constructor_declaration_parameters" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_constructor_declaration_throws" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_enum_constant_arguments" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_enum_declarations" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_explicitconstructorcall_arguments" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_for_increments" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_for_inits" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_method_declaration_parameters" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_method_declaration_throws" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_method_invocation_arguments" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_multiple_field_declarations" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_multiple_local_declarations" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_parameterized_type_reference" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_superinterfaces" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_type_arguments" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_type_parameters" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_ellipsis" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_lambda_arrow" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_angle_bracket_in_parameterized_type_reference" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_angle_bracket_in_type_arguments" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_angle_bracket_in_type_parameters" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_annotation_type_declaration" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_anonymous_type_declaration" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_array_initializer" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_block" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_constructor_declaration" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_enum_constant" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_enum_declaration" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_method_declaration" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_switch" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_type_declaration" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_bracket_in_array_allocation_expression" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_bracket_in_array_reference" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_bracket_in_array_type_reference" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_annotation_type_member_declaration" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_annotation" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_catch" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_constructor_declaration" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_enum_constant" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_for" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_if" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_method_declaration" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_method_invocation" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_parenthesized_expression" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_switch" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_synchronized" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_try" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_while" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_parenthesized_expression_in_return" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_parenthesized_expression_in_throw" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_postfix_operator" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_prefix_operator" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_question_in_conditional" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_question_in_wildcard" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_semicolon_in_for" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_semicolon_in_try_resources" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_semicolon" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_unary_operator" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_between_brackets_in_array_type_reference" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_braces_in_array_initializer" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_brackets_in_array_allocation_expression" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_annotation_type_member_declaration" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_constructor_declaration" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_enum_constant" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_method_declaration" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_method_invocation" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.join_lines_in_comments" value="false"/>
-<setting id="org.eclipse.jdt.core.formatter.join_wrapped_lines" value="false"/>
-<setting id="org.eclipse.jdt.core.formatter.keep_annotation_declaration_on_one_line" value="one_line_never"/>
-<setting id="org.eclipse.jdt.core.formatter.keep_anonymous_type_declaration_on_one_line" value="one_line_never"/>
-<setting id="org.eclipse.jdt.core.formatter.keep_code_block_on_one_line" value="one_line_never"/>
-<setting id="org.eclipse.jdt.core.formatter.keep_else_statement_on_same_line" value="false"/>
-<setting id="org.eclipse.jdt.core.formatter.keep_empty_array_initializer_on_one_line" value="false"/>
-<setting id="org.eclipse.jdt.core.formatter.keep_enum_constant_declaration_on_one_line" value="one_line_never"/>
-<setting id="org.eclipse.jdt.core.formatter.keep_enum_declaration_on_one_line" value="one_line_never"/>
-<setting id="org.eclipse.jdt.core.formatter.keep_if_then_body_block_on_one_line" value="one_line_never"/>
-<setting id="org.eclipse.jdt.core.formatter.keep_imple_if_on_one_line" value="false"/>
-<setting id="org.eclipse.jdt.core.formatter.keep_lambda_body_block_on_one_line" value="one_line_never"/>
-<setting id="org.eclipse.jdt.core.formatter.keep_loop_body_block_on_one_line" value="one_line_never"/>
-<setting id="org.eclipse.jdt.core.formatter.keep_method_body_on_one_line" value="one_line_never"/>
-<setting id="org.eclipse.jdt.core.formatter.keep_simple_do_while_body_on_same_line" value="false"/>
-<setting id="org.eclipse.jdt.core.formatter.keep_simple_for_body_on_same_line" value="false"/>
-<setting id="org.eclipse.jdt.core.formatter.keep_simple_getter_setter_on_one_line" value="false"/>
-<setting id="org.eclipse.jdt.core.formatter.keep_simple_while_body_on_same_line" value="false"/>
-<setting id="org.eclipse.jdt.core.formatter.keep_then_statement_on_same_line" value="false"/>
-<setting id="org.eclipse.jdt.core.formatter.keep_type_declaration_on_one_line" value="one_line_never"/>
-<setting id="org.eclipse.jdt.core.formatter.lineSplit" value="128"/>
-<setting id="org.eclipse.jdt.core.formatter.never_indent_block_comments_on_first_column" value="false"/>
-<setting id="org.eclipse.jdt.core.formatter.never_indent_line_comments_on_first_column" value="false"/>
-<setting id="org.eclipse.jdt.core.formatter.number_of_blank_lines_at_beginning_of_method_body" value="0"/>
-<setting id="org.eclipse.jdt.core.formatter.number_of_empty_lines_to_preserve" value="1"/>
-<setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_annotation" value="common_lines"/>
-<setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_catch_clause" value="common_lines"/>
-<setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_enum_constant_declaration" value="common_lines"/>
-<setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_for_statment" value="common_lines"/>
-<setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_if_while_statement" value="common_lines"/>
-<setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_lambda_declaration" value="common_lines"/>
-<setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_method_delcaration" value="common_lines"/>
-<setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_method_invocation" value="common_lines"/>
-<setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_switch_statement" value="common_lines"/>
-<setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_try_clause" value="common_lines"/>
-<setting id="org.eclipse.jdt.core.formatter.put_empty_statement_on_new_line" value="true"/>
-<setting id="org.eclipse.jdt.core.formatter.tabulation.char" value="space"/>
-<setting id="org.eclipse.jdt.core.formatter.tabulation.size" value="4"/>
-<setting id="org.eclipse.jdt.core.formatter.use_on_off_tags" value="true"/>
-<setting id="org.eclipse.jdt.core.formatter.use_tabs_only_for_leading_indentations" value="false"/>
-<setting id="org.eclipse.jdt.core.formatter.wrap_before_assignment_operator" value="false"/>
-<setting id="org.eclipse.jdt.core.formatter.wrap_before_binary_operator" value="true"/>
-<setting id="org.eclipse.jdt.core.formatter.wrap_before_conditional_operator" value="true"/>
-<setting id="org.eclipse.jdt.core.formatter.wrap_before_or_operator_multicatch" value="true"/>
-<setting id="org.eclipse.jdt.core.formatter.wrap_outer_expressions_when_nested" value="true"/>
-</profile>
+  <profile kind="CodeFormatterProfile" name="Quarkus" version="15">
+    <setting id="org.eclipse.jdt.core.formatter.align_assignment_statements_on_columns" value="false"/>
+    <setting id="org.eclipse.jdt.core.formatter.align_fields_grouping_blank_lines" value="2147483647"/>
+    <setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_allocation_expression" value="16"/>
+    <setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_annotation" value="16"/>
+    <setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_enum_constant" value="16"/>
+    <setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_explicit_constructor_call" value="16"/>
+    <setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_method_invocation" value="16"/>
+    <setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_qualified_allocation_expression" value="16"/>
+    <setting id="org.eclipse.jdt.core.formatter.alignment_for_assignment" value="16"/>
+    <setting id="org.eclipse.jdt.core.formatter.alignment_for_binary_expression" value="16"/>
+    <setting id="org.eclipse.jdt.core.formatter.alignment_for_compact_if" value="16"/>
+    <setting id="org.eclipse.jdt.core.formatter.alignment_for_compact_loops" value="16"/>
+    <setting id="org.eclipse.jdt.core.formatter.alignment_for_conditional_expression" value="80"/>
+    <setting id="org.eclipse.jdt.core.formatter.alignment_for_enum_constants" value="49"/>
+    <setting id="org.eclipse.jdt.core.formatter.alignment_for_expressions_in_array_initializer" value="16"/>
+    <setting id="org.eclipse.jdt.core.formatter.alignment_for_expressions_in_for_loop_header" value="0"/>
+    <setting id="org.eclipse.jdt.core.formatter.alignment_for_method_declaration" value="16"/>
+    <setting id="org.eclipse.jdt.core.formatter.alignment_for_module_statements" value="16"/>
+    <setting id="org.eclipse.jdt.core.formatter.alignment_for_multiple_fields" value="16"/>
+    <setting id="org.eclipse.jdt.core.formatter.alignment_for_parameterized_type_references" value="0"/>
+    <setting id="org.eclipse.jdt.core.formatter.alignment_for_parameters_in_constructor_declaration" value="16"/>
+    <setting id="org.eclipse.jdt.core.formatter.alignment_for_parameters_in_method_declaration" value="16"/>
+    <setting id="org.eclipse.jdt.core.formatter.alignment_for_resources_in_try" value="80"/>
+    <setting id="org.eclipse.jdt.core.formatter.alignment_for_selector_in_method_invocation" value="16"/>
+    <setting id="org.eclipse.jdt.core.formatter.alignment_for_superclass_in_type_declaration" value="16"/>
+    <setting id="org.eclipse.jdt.core.formatter.alignment_for_superinterfaces_in_enum_declaration" value="16"/>
+    <setting id="org.eclipse.jdt.core.formatter.alignment_for_superinterfaces_in_type_declaration" value="16"/>
+    <setting id="org.eclipse.jdt.core.formatter.alignment_for_throws_clause_in_constructor_declaration" value="16"/>
+    <setting id="org.eclipse.jdt.core.formatter.alignment_for_throws_clause_in_method_declaration" value="16"/>
+    <setting id="org.eclipse.jdt.core.formatter.alignment_for_type_arguments" value="0"/>
+    <setting id="org.eclipse.jdt.core.formatter.alignment_for_type_parameters" value="0"/>
+    <setting id="org.eclipse.jdt.core.formatter.alignment_for_union_type_in_multicatch" value="16"/>
+    <setting id="org.eclipse.jdt.core.formatter.align_type_members_on_columns" value="false"/>
+    <setting id="org.eclipse.jdt.core.formatter.align_variable_declarations_on_columns" value="false"/>
+    <setting id="org.eclipse.jdt.core.formatter.align_with_spaces" value="false"/>
+    <setting id="org.eclipse.jdt.core.formatter.blank_lines_after_imports" value="1"/>
+    <setting id="org.eclipse.jdt.core.formatter.blank_lines_after_package" value="1"/>
+    <setting id="org.eclipse.jdt.core.formatter.blank_lines_before_field" value="0"/>
+    <setting id="org.eclipse.jdt.core.formatter.blank_lines_before_first_class_body_declaration" value="0"/>
+    <setting id="org.eclipse.jdt.core.formatter.blank_lines_before_imports" value="1"/>
+    <setting id="org.eclipse.jdt.core.formatter.blank_lines_before_member_type" value="1"/>
+    <setting id="org.eclipse.jdt.core.formatter.blank_lines_before_method" value="1"/>
+    <setting id="org.eclipse.jdt.core.formatter.blank_lines_before_new_chunk" value="1"/>
+    <setting id="org.eclipse.jdt.core.formatter.blank_lines_before_package" value="0"/>
+    <setting id="org.eclipse.jdt.core.formatter.blank_lines_between_import_groups" value="1"/>
+    <setting id="org.eclipse.jdt.core.formatter.blank_lines_between_type_declarations" value="1"/>
+    <setting id="org.eclipse.jdt.core.formatter.brace_position_for_annotation_type_declaration" value="end_of_line"/>
+    <setting id="org.eclipse.jdt.core.formatter.brace_position_for_anonymous_type_declaration" value="end_of_line"/>
+    <setting id="org.eclipse.jdt.core.formatter.brace_position_for_array_initializer" value="end_of_line"/>
+    <setting id="org.eclipse.jdt.core.formatter.brace_position_for_block_in_case" value="end_of_line"/>
+    <setting id="org.eclipse.jdt.core.formatter.brace_position_for_block" value="end_of_line"/>
+    <setting id="org.eclipse.jdt.core.formatter.brace_position_for_constructor_declaration" value="end_of_line"/>
+    <setting id="org.eclipse.jdt.core.formatter.brace_position_for_enum_constant" value="end_of_line"/>
+    <setting id="org.eclipse.jdt.core.formatter.brace_position_for_enum_declaration" value="end_of_line"/>
+    <setting id="org.eclipse.jdt.core.formatter.brace_position_for_lambda_body" value="end_of_line"/>
+    <setting id="org.eclipse.jdt.core.formatter.brace_position_for_method_declaration" value="end_of_line"/>
+    <setting id="org.eclipse.jdt.core.formatter.brace_position_for_switch" value="end_of_line"/>
+    <setting id="org.eclipse.jdt.core.formatter.brace_position_for_type_declaration" value="end_of_line"/>
+    <setting id="org.eclipse.jdt.core.formatter.comment.align_tags_descriptions_grouped" value="false"/>
+    <setting id="org.eclipse.jdt.core.formatter.comment.align_tags_names_descriptions" value="false"/>
+    <setting id="org.eclipse.jdt.core.formatter.comment.clear_blank_lines_in_block_comment" value="false"/>
+    <setting id="org.eclipse.jdt.core.formatter.comment.clear_blank_lines_in_javadoc_comment" value="false"/>
+    <setting id="org.eclipse.jdt.core.formatter.comment.count_line_length_from_starting_position" value="false"/>
+    <setting id="org.eclipse.jdt.core.formatter.comment.format_block_comments" value="true"/>
+    <setting id="org.eclipse.jdt.core.formatter.comment.format_header" value="false"/>
+    <setting id="org.eclipse.jdt.core.formatter.comment.format_html" value="true"/>
+    <setting id="org.eclipse.jdt.core.formatter.comment.format_javadoc_comments" value="true"/>
+    <setting id="org.eclipse.jdt.core.formatter.comment.format_line_comments" value="false"/>
+    <setting id="org.eclipse.jdt.core.formatter.comment.format_source_code" value="true"/>
+    <setting id="org.eclipse.jdt.core.formatter.comment.indent_parameter_description" value="false"/>
+    <setting id="org.eclipse.jdt.core.formatter.comment.indent_root_tags" value="true"/>
+    <setting id="org.eclipse.jdt.core.formatter.comment.insert_new_line_before_root_tags" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.comment.insert_new_line_for_parameter" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.comment.line_length" value="128"/>
+    <setting id="org.eclipse.jdt.core.formatter.comment.new_lines_at_block_boundaries" value="true"/>
+    <setting id="org.eclipse.jdt.core.formatter.comment.new_lines_at_javadoc_boundaries" value="true"/>
+    <setting id="org.eclipse.jdt.core.formatter.comment.preserve_white_space_between_code_and_line_comments" value="false"/>
+    <setting id="org.eclipse.jdt.core.formatter.compact_else_if" value="true"/>
+    <setting id="org.eclipse.jdt.core.formatter.continuation_indentation_for_array_initializer" value="2"/>
+    <setting id="org.eclipse.jdt.core.formatter.continuation_indentation" value="2"/>
+    <setting id="org.eclipse.jdt.core.formatter.disabling_tag" value="@formatter:off"/>
+    <setting id="org.eclipse.jdt.core.formatter.enabling_tag" value="@formatter:on"/>
+    <setting id="org.eclipse.jdt.core.formatter.format_guardian_clause_on_one_line" value="false"/>
+    <setting id="org.eclipse.jdt.core.formatter.format_line_comment_starting_on_first_column" value="false"/>
+    <setting id="org.eclipse.jdt.core.formatter.indentation.size" value="4"/>
+    <setting id="org.eclipse.jdt.core.formatter.indent_body_declarations_compare_to_annotation_declaration_header" value="true"/>
+    <setting id="org.eclipse.jdt.core.formatter.indent_body_declarations_compare_to_enum_constant_header" value="true"/>
+    <setting id="org.eclipse.jdt.core.formatter.indent_body_declarations_compare_to_enum_declaration_header" value="true"/>
+    <setting id="org.eclipse.jdt.core.formatter.indent_body_declarations_compare_to_type_header" value="true"/>
+    <setting id="org.eclipse.jdt.core.formatter.indent_breaks_compare_to_cases" value="true"/>
+    <setting id="org.eclipse.jdt.core.formatter.indent_empty_lines" value="false"/>
+    <setting id="org.eclipse.jdt.core.formatter.indent_statements_compare_to_block" value="true"/>
+    <setting id="org.eclipse.jdt.core.formatter.indent_statements_compare_to_body" value="true"/>
+    <setting id="org.eclipse.jdt.core.formatter.indent_switchstatements_compare_to_cases" value="true"/>
+    <setting id="org.eclipse.jdt.core.formatter.indent_switchstatements_compare_to_switch" value="true"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_enum_constant" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_field" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_local_variable" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_method" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_package" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_parameter" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_type" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_label" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_opening_brace_in_array_initializer" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_type_annotation" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_new_line_at_end_of_file_if_missing" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_catch_in_try_statement" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_closing_brace_in_array_initializer" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_else_in_if_statement" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_finally_in_try_statement" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_while_in_do_statement" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_after_and_in_type_parameter" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_after_assignment_operator" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_after_at_in_annotation_type_declaration" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_after_at_in_annotation" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_after_binary_operator" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_after_closing_angle_bracket_in_type_arguments" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_after_closing_angle_bracket_in_type_parameters" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_after_closing_brace_in_block" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_after_closing_paren_in_cast" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_assert" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_case" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_conditional" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_for" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_labeled_statement" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_allocation_expression" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_annotation" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_array_initializer" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_constructor_declaration_parameters" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_constructor_declaration_throws" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_enum_constant_arguments" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_enum_declarations" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_explicitconstructorcall_arguments" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_for_increments" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_for_inits" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_method_declaration_parameters" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_method_declaration_throws" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_method_invocation_arguments" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_multiple_field_declarations" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_multiple_local_declarations" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_parameterized_type_reference" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_superinterfaces" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_type_arguments" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_type_parameters" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_after_ellipsis" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_after_lambda_arrow" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_angle_bracket_in_parameterized_type_reference" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_angle_bracket_in_type_arguments" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_angle_bracket_in_type_parameters" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_brace_in_array_initializer" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_bracket_in_array_allocation_expression" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_bracket_in_array_reference" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_annotation" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_cast" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_catch" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_constructor_declaration" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_enum_constant" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_for" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_if" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_method_declaration" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_method_invocation" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_parenthesized_expression" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_switch" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_synchronized" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_try" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_while" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_after_postfix_operator" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_after_prefix_operator" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_after_question_in_conditional" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_after_question_in_wildcard" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_after_semicolon_in_for" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_after_semicolon_in_try_resources" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_after_unary_operator" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_and_in_type_parameter" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_assignment_operator" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_at_in_annotation_type_declaration" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_binary_operator" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_angle_bracket_in_parameterized_type_reference" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_angle_bracket_in_type_arguments" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_angle_bracket_in_type_parameters" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_brace_in_array_initializer" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_bracket_in_array_allocation_expression" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_bracket_in_array_reference" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_annotation" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_cast" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_catch" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_constructor_declaration" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_enum_constant" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_for" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_if" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_method_declaration" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_method_invocation" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_parenthesized_expression" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_switch" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_synchronized" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_try" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_while" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_assert" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_case" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_conditional" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_default" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_for" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_labeled_statement" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_allocation_expression" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_annotation" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_array_initializer" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_constructor_declaration_parameters" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_constructor_declaration_throws" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_enum_constant_arguments" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_enum_declarations" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_explicitconstructorcall_arguments" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_for_increments" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_for_inits" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_method_declaration_parameters" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_method_declaration_throws" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_method_invocation_arguments" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_multiple_field_declarations" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_multiple_local_declarations" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_parameterized_type_reference" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_superinterfaces" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_type_arguments" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_type_parameters" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_ellipsis" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_lambda_arrow" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_angle_bracket_in_parameterized_type_reference" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_angle_bracket_in_type_arguments" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_angle_bracket_in_type_parameters" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_annotation_type_declaration" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_anonymous_type_declaration" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_array_initializer" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_block" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_constructor_declaration" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_enum_constant" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_enum_declaration" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_method_declaration" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_switch" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_type_declaration" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_bracket_in_array_allocation_expression" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_bracket_in_array_reference" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_bracket_in_array_type_reference" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_annotation_type_member_declaration" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_annotation" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_catch" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_constructor_declaration" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_enum_constant" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_for" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_if" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_method_declaration" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_method_invocation" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_parenthesized_expression" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_switch" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_synchronized" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_try" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_while" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_parenthesized_expression_in_return" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_parenthesized_expression_in_throw" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_postfix_operator" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_prefix_operator" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_question_in_conditional" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_question_in_wildcard" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_semicolon_in_for" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_semicolon_in_try_resources" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_semicolon" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_unary_operator" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_between_brackets_in_array_type_reference" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_braces_in_array_initializer" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_brackets_in_array_allocation_expression" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_annotation_type_member_declaration" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_constructor_declaration" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_enum_constant" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_method_declaration" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_method_invocation" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.join_lines_in_comments" value="false"/>
+    <setting id="org.eclipse.jdt.core.formatter.join_wrapped_lines" value="false"/>
+    <setting id="org.eclipse.jdt.core.formatter.keep_annotation_declaration_on_one_line" value="one_line_never"/>
+    <setting id="org.eclipse.jdt.core.formatter.keep_anonymous_type_declaration_on_one_line" value="one_line_never"/>
+    <setting id="org.eclipse.jdt.core.formatter.keep_code_block_on_one_line" value="one_line_never"/>
+    <setting id="org.eclipse.jdt.core.formatter.keep_else_statement_on_same_line" value="false"/>
+    <setting id="org.eclipse.jdt.core.formatter.keep_empty_array_initializer_on_one_line" value="false"/>
+    <setting id="org.eclipse.jdt.core.formatter.keep_enum_constant_declaration_on_one_line" value="one_line_never"/>
+    <setting id="org.eclipse.jdt.core.formatter.keep_enum_declaration_on_one_line" value="one_line_never"/>
+    <setting id="org.eclipse.jdt.core.formatter.keep_if_then_body_block_on_one_line" value="one_line_never"/>
+    <setting id="org.eclipse.jdt.core.formatter.keep_imple_if_on_one_line" value="false"/>
+    <setting id="org.eclipse.jdt.core.formatter.keep_lambda_body_block_on_one_line" value="one_line_never"/>
+    <setting id="org.eclipse.jdt.core.formatter.keep_loop_body_block_on_one_line" value="one_line_never"/>
+    <setting id="org.eclipse.jdt.core.formatter.keep_method_body_on_one_line" value="one_line_never"/>
+    <setting id="org.eclipse.jdt.core.formatter.keep_simple_do_while_body_on_same_line" value="false"/>
+    <setting id="org.eclipse.jdt.core.formatter.keep_simple_for_body_on_same_line" value="false"/>
+    <setting id="org.eclipse.jdt.core.formatter.keep_simple_getter_setter_on_one_line" value="false"/>
+    <setting id="org.eclipse.jdt.core.formatter.keep_simple_while_body_on_same_line" value="false"/>
+    <setting id="org.eclipse.jdt.core.formatter.keep_then_statement_on_same_line" value="false"/>
+    <setting id="org.eclipse.jdt.core.formatter.keep_type_declaration_on_one_line" value="one_line_never"/>
+    <setting id="org.eclipse.jdt.core.formatter.lineSplit" value="128"/>
+    <setting id="org.eclipse.jdt.core.formatter.never_indent_block_comments_on_first_column" value="false"/>
+    <setting id="org.eclipse.jdt.core.formatter.never_indent_line_comments_on_first_column" value="false"/>
+    <setting id="org.eclipse.jdt.core.formatter.number_of_blank_lines_at_beginning_of_method_body" value="0"/>
+    <setting id="org.eclipse.jdt.core.formatter.number_of_empty_lines_to_preserve" value="1"/>
+    <setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_annotation" value="common_lines"/>
+    <setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_catch_clause" value="common_lines"/>
+    <setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_enum_constant_declaration" value="common_lines"/>
+    <setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_for_statment" value="common_lines"/>
+    <setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_if_while_statement" value="common_lines"/>
+    <setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_lambda_declaration" value="common_lines"/>
+    <setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_method_delcaration" value="common_lines"/>
+    <setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_method_invocation" value="common_lines"/>
+    <setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_switch_statement" value="common_lines"/>
+    <setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_try_clause" value="common_lines"/>
+    <setting id="org.eclipse.jdt.core.formatter.put_empty_statement_on_new_line" value="true"/>
+    <setting id="org.eclipse.jdt.core.formatter.tabulation.char" value="space"/>
+    <setting id="org.eclipse.jdt.core.formatter.tabulation.size" value="4"/>
+    <setting id="org.eclipse.jdt.core.formatter.use_on_off_tags" value="true"/>
+    <setting id="org.eclipse.jdt.core.formatter.use_tabs_only_for_leading_indentations" value="false"/>
+    <setting id="org.eclipse.jdt.core.formatter.wrap_before_assignment_operator" value="false"/>
+    <setting id="org.eclipse.jdt.core.formatter.wrap_before_binary_operator" value="true"/>
+    <setting id="org.eclipse.jdt.core.formatter.wrap_before_conditional_operator" value="true"/>
+    <setting id="org.eclipse.jdt.core.formatter.wrap_before_or_operator_multicatch" value="true"/>
+    <setting id="org.eclipse.jdt.core.formatter.wrap_outer_expressions_when_nested" value="true"/>
+  </profile>
 </profiles>
-

--- a/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/impl/ranking/TotalRankSolverRankingWeightFactory.java
+++ b/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/impl/ranking/TotalRankSolverRankingWeightFactory.java
@@ -37,7 +37,8 @@ import org.optaplanner.core.api.score.Score;
  */
 public class TotalRankSolverRankingWeightFactory implements SolverRankingWeightFactory {
 
-    private final Comparator<SingleBenchmarkResult> singleBenchmarkRankingComparator = new TotalScoreSingleBenchmarkRankingComparator();
+    private final Comparator<SingleBenchmarkResult> singleBenchmarkRankingComparator =
+            new TotalScoreSingleBenchmarkRankingComparator();
 
     @Override
     public Comparable createRankingWeight(List<SolverBenchmarkResult> solverBenchmarkResultList,
@@ -67,7 +68,8 @@ public class TotalRankSolverRankingWeightFactory implements SolverRankingWeightF
 
     public static class TotalRankSolverRankingWeight implements Comparable<TotalRankSolverRankingWeight> {
 
-        private final Comparator<SolverBenchmarkResult> totalScoreSolverRankingComparator = new TotalScoreSolverRankingComparator();
+        private final Comparator<SolverBenchmarkResult> totalScoreSolverRankingComparator =
+                new TotalScoreSolverRankingComparator();
 
         private SolverBenchmarkResult solverBenchmarkResult;
         private int betterCount;

--- a/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/impl/ranking/WorstScoreSolverRankingComparator.java
+++ b/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/impl/ranking/WorstScoreSolverRankingComparator.java
@@ -30,7 +30,8 @@ import org.optaplanner.core.api.score.Score;
  */
 public class WorstScoreSolverRankingComparator implements Comparator<SolverBenchmarkResult>, Serializable {
 
-    private final Comparator<SingleBenchmarkResult> singleBenchmarkComparator = new TotalScoreSingleBenchmarkRankingComparator();
+    private final Comparator<SingleBenchmarkResult> singleBenchmarkComparator =
+            new TotalScoreSingleBenchmarkRankingComparator();
 
     @Override
     public int compare(SolverBenchmarkResult a, SolverBenchmarkResult b) {

--- a/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/impl/result/SingleBenchmarkResult.java
+++ b/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/impl/result/SingleBenchmarkResult.java
@@ -374,7 +374,8 @@ public class SingleBenchmarkResult implements BenchmarkResult {
     }
 
     private void determineRanking(List<SubSingleBenchmarkResult> rankedSubSingleBenchmarkResultList) {
-        Comparator<SubSingleBenchmarkResult> subSingleBenchmarkRankingComparator = new ScoreSubSingleBenchmarkRankingComparator();
+        Comparator<SubSingleBenchmarkResult> subSingleBenchmarkRankingComparator =
+                new ScoreSubSingleBenchmarkRankingComparator();
         rankedSubSingleBenchmarkResultList.sort(Collections.reverseOrder(subSingleBenchmarkRankingComparator));
         int ranking = 0;
         SubSingleBenchmarkResult previousSubSingleBenchmarkResult = null;

--- a/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/impl/statistic/bestsolutionmutation/BestSolutionMutationProblemStatistic.java
+++ b/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/impl/statistic/bestsolutionmutation/BestSolutionMutationProblemStatistic.java
@@ -77,8 +77,9 @@ public class BestSolutionMutationProblemStatistic extends ProblemStatistic {
                     singleBenchmarkResult.getSolverBenchmarkResult().getNameWithFavoriteSuffix());
             XYItemRenderer renderer = new YIntervalRenderer();
             if (singleBenchmarkResult.hasAllSuccess()) {
-                BestSolutionMutationSubSingleStatistic subSingleStatistic = (BestSolutionMutationSubSingleStatistic) singleBenchmarkResult
-                        .getSubSingleStatistic(problemStatisticType);
+                BestSolutionMutationSubSingleStatistic subSingleStatistic =
+                        (BestSolutionMutationSubSingleStatistic) singleBenchmarkResult
+                                .getSubSingleStatistic(problemStatisticType);
                 List<BestSolutionMutationStatisticPoint> points = subSingleStatistic.getPointList();
                 for (BestSolutionMutationStatisticPoint point : points) {
                     long timeMillisSpent = point.getTimeMillisSpent();

--- a/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/impl/statistic/movecountperstep/MoveCountPerStepProblemStatistic.java
+++ b/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/impl/statistic/movecountperstep/MoveCountPerStepProblemStatistic.java
@@ -90,8 +90,8 @@ public class MoveCountPerStepProblemStatistic extends ProblemStatistic {
                     singleBenchmarkResult.getSolverBenchmarkResult().getNameWithFavoriteSuffix() + " selected");
             XYItemRenderer renderer = new XYLineAndShapeRenderer(true, false);
             if (singleBenchmarkResult.hasAllSuccess()) {
-                MoveCountPerStepSubSingleStatistic subSingleStatistic = (MoveCountPerStepSubSingleStatistic) singleBenchmarkResult
-                        .getSubSingleStatistic(problemStatisticType);
+                MoveCountPerStepSubSingleStatistic subSingleStatistic =
+                        (MoveCountPerStepSubSingleStatistic) singleBenchmarkResult.getSubSingleStatistic(problemStatisticType);
                 List<MoveCountPerStepStatisticPoint> list = subSingleStatistic.getPointList();
                 for (MoveCountPerStepStatisticPoint point : list) {
                     long timeMillisSpent = point.getTimeMillisSpent();

--- a/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/impl/statistic/scorecalculationspeed/ScoreCalculationSpeedProblemStatistic.java
+++ b/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/impl/statistic/scorecalculationspeed/ScoreCalculationSpeedProblemStatistic.java
@@ -83,8 +83,9 @@ public class ScoreCalculationSpeedProblemStatistic extends ProblemStatistic {
             XYSeries series = new XYSeries(singleBenchmarkResult.getSolverBenchmarkResult().getNameWithFavoriteSuffix());
             XYItemRenderer renderer = new XYLineAndShapeRenderer();
             if (singleBenchmarkResult.hasAllSuccess()) {
-                ScoreCalculationSpeedSubSingleStatistic subSingleStatistic = (ScoreCalculationSpeedSubSingleStatistic) singleBenchmarkResult
-                        .getSubSingleStatistic(problemStatisticType);
+                ScoreCalculationSpeedSubSingleStatistic subSingleStatistic =
+                        (ScoreCalculationSpeedSubSingleStatistic) singleBenchmarkResult
+                                .getSubSingleStatistic(problemStatisticType);
                 List<ScoreCalculationSpeedStatisticPoint> points = subSingleStatistic.getPointList();
                 for (ScoreCalculationSpeedStatisticPoint point : points) {
                     long timeMillisSpent = point.getTimeMillisSpent();

--- a/optaplanner-core/src/main/java/org/optaplanner/core/api/domain/valuerange/ValueRangeFactory.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/api/domain/valuerange/ValueRangeFactory.java
@@ -209,8 +209,8 @@ public class ValueRangeFactory {
      * @param incrementUnitType never null, must be {@link Temporal#isSupported(TemporalUnit) supported} by {@code from} and
      *        {@code to}
      */
-    public static <Temporal_ extends Temporal & Comparable<? super Temporal_>> CountableValueRange<Temporal_> createTemporalValueRange(
-            Temporal_ from, Temporal_ to, long incrementUnitAmount, TemporalUnit incrementUnitType) {
+    public static <Temporal_ extends Temporal & Comparable<? super Temporal_>> CountableValueRange<Temporal_>
+            createTemporalValueRange(Temporal_ from, Temporal_ to, long incrementUnitAmount, TemporalUnit incrementUnitType) {
         return new TemporalValueRange<>(from, to, incrementUnitAmount, incrementUnitType);
     }
 

--- a/optaplanner-core/src/main/java/org/optaplanner/core/api/score/buildin/hardmediumsoftbigdecimal/HardMediumSoftBigDecimalScoreHolder.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/api/score/buildin/hardmediumsoftbigdecimal/HardMediumSoftBigDecimalScoreHolder.java
@@ -33,7 +33,8 @@ public class HardMediumSoftBigDecimalScoreHolder extends AbstractScoreHolder<Har
 
     protected final Map<Rule, BiConsumer<RuleContext, BigDecimal>> matchExecutorByNumberMap = new LinkedHashMap<>();
     /** Slower than {@link #matchExecutorByNumberMap} */
-    protected final Map<Rule, BiConsumer<RuleContext, HardMediumSoftBigDecimalScore>> matchExecutorByScoreMap = new LinkedHashMap<>();
+    protected final Map<Rule, BiConsumer<RuleContext, HardMediumSoftBigDecimalScore>> matchExecutorByScoreMap =
+            new LinkedHashMap<>();
 
     protected BigDecimal hardScore = BigDecimal.ZERO;
     protected BigDecimal mediumScore = BigDecimal.ZERO;

--- a/optaplanner-core/src/main/java/org/optaplanner/core/api/score/stream/ConstraintCollectors.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/api/score/stream/ConstraintCollectors.java
@@ -1004,8 +1004,8 @@ public final class ConstraintCollectors {
      * @param <Mapped> type of elements in the resulting set
      * @return never null
      */
-    public static <A, B, C, Mapped extends Comparable<Mapped>> TriConstraintCollector<A, B, C, ?, SortedSet<Mapped>> toSortedSet(
-            TriFunction<A, B, C, Mapped> groupValueMapping) {
+    public static <A, B, C, Mapped extends Comparable<Mapped>> TriConstraintCollector<A, B, C, ?, SortedSet<Mapped>>
+            toSortedSet(TriFunction<A, B, C, Mapped> groupValueMapping) {
         return toCollection(groupValueMapping, i -> new TreeSet<>());
     }
 
@@ -1026,8 +1026,8 @@ public final class ConstraintCollectors {
         return toCollection(groupValueMapping, ArrayList::new);
     }
 
-    public static <A, B, C, D, Mapped, Result extends Collection<Mapped>> QuadConstraintCollector<A, B, C, D, ?, Result> toCollection(
-            QuadFunction<A, B, C, D, Mapped> groupValueMapping, IntFunction<Result> collectionFunction) {
+    public static <A, B, C, D, Mapped, Result extends Collection<Mapped>> QuadConstraintCollector<A, B, C, D, ?, Result>
+            toCollection(QuadFunction<A, B, C, D, Mapped> groupValueMapping, IntFunction<Result> collectionFunction) {
         return new DefaultQuadConstraintCollector<>(
                 (Supplier<List<Mapped>>) ArrayList::new,
                 (resultContainer, a, b, c, d) -> {
@@ -1065,8 +1065,8 @@ public final class ConstraintCollectors {
      * @param <Mapped> type of elements in the resulting set
      * @return never null
      */
-    public static <A, B, C, D, Mapped extends Comparable<Mapped>> QuadConstraintCollector<A, B, C, D, ?, SortedSet<Mapped>> toSortedSet(
-            QuadFunction<A, B, C, D, Mapped> groupValueMapping) {
+    public static <A, B, C, D, Mapped extends Comparable<Mapped>> QuadConstraintCollector<A, B, C, D, ?, SortedSet<Mapped>>
+            toSortedSet(QuadFunction<A, B, C, D, Mapped> groupValueMapping) {
         return toCollection(groupValueMapping, i -> new TreeSet<>());
     }
 
@@ -1312,9 +1312,10 @@ public final class ConstraintCollectors {
      * @param <ValueSet> type of the value set
      * @return never null
      */
-    public static <A, Key extends Comparable<Key>, Value, ValueSet extends Set<Value>> UniConstraintCollector<A, ?, SortedMap<Key, ValueSet>> toSortedMap(
-            Function<? super A, ? extends Key> keyMapper,
-            Function<? super A, ? extends Value> valueMapper, IntFunction<ValueSet> valueSetFunction) {
+    public static <A, Key extends Comparable<Key>, Value, ValueSet extends Set<Value>>
+            UniConstraintCollector<A, ?, SortedMap<Key, ValueSet>> toSortedMap(
+                    Function<? super A, ? extends Key> keyMapper,
+                    Function<? super A, ? extends Value> valueMapper, IntFunction<ValueSet> valueSetFunction) {
         return new DefaultUniConstraintCollector<>(
                 (Supplier<ToMapResultContainer<Key, Value>>) ToMapResultContainer::new,
                 (resultContainer, a) -> toMapAccumulator(keyMapper, valueMapper, resultContainer, a),
@@ -1439,9 +1440,9 @@ public final class ConstraintCollectors {
      * @param <Value> type of map value
      * @return never null
      */
-    public static <A, B, Key extends Comparable<Key>, Value> BiConstraintCollector<A, B, ?, SortedMap<Key, Set<Value>>> toSortedMap(
-            BiFunction<? super A, ? super B, ? extends Key> keyMapper,
-            BiFunction<? super A, ? super B, ? extends Value> valueMapper) {
+    public static <A, B, Key extends Comparable<Key>, Value> BiConstraintCollector<A, B, ?, SortedMap<Key, Set<Value>>>
+            toSortedMap(BiFunction<? super A, ? super B, ? extends Key> keyMapper,
+                    BiFunction<? super A, ? super B, ? extends Value> valueMapper) {
         return toSortedMap(keyMapper, valueMapper, (IntFunction<Set<Value>>) LinkedHashSet::new);
     }
 
@@ -1458,9 +1459,10 @@ public final class ConstraintCollectors {
      * @param <ValueSet> type of the value set
      * @return never null
      */
-    public static <A, B, Key extends Comparable<Key>, Value, ValueSet extends Set<Value>> BiConstraintCollector<A, B, ?, SortedMap<Key, ValueSet>> toSortedMap(
-            BiFunction<? super A, ? super B, ? extends Key> keyMapper,
-            BiFunction<? super A, ? super B, ? extends Value> valueMapper, IntFunction<ValueSet> valueSetFunction) {
+    public static <A, B, Key extends Comparable<Key>, Value, ValueSet extends Set<Value>>
+            BiConstraintCollector<A, B, ?, SortedMap<Key, ValueSet>> toSortedMap(
+                    BiFunction<? super A, ? super B, ? extends Key> keyMapper,
+                    BiFunction<? super A, ? super B, ? extends Value> valueMapper, IntFunction<ValueSet> valueSetFunction) {
         return new DefaultBiConstraintCollector<>(
                 (Supplier<ToMapResultContainer<Key, Value>>) ToMapResultContainer::new,
                 (resultContainer, a, b) -> toMapAccumulator(keyMapper, valueMapper, resultContainer, a, b),
@@ -1526,10 +1528,10 @@ public final class ConstraintCollectors {
      * @param <ValueSet> type of the value set
      * @return never null
      */
-    public static <A, B, C, Key, Value, ValueSet extends Set<Value>> TriConstraintCollector<A, B, C, ?, Map<Key, ValueSet>> toMap(
-            TriFunction<? super A, ? super B, ? super C, ? extends Key> keyMapper,
-            TriFunction<? super A, ? super B, ? super C, ? extends Value> valueMapper,
-            IntFunction<ValueSet> valueSetFunction) {
+    public static <A, B, C, Key, Value, ValueSet extends Set<Value>> TriConstraintCollector<A, B, C, ?, Map<Key, ValueSet>>
+            toMap(TriFunction<? super A, ? super B, ? super C, ? extends Key> keyMapper,
+                    TriFunction<? super A, ? super B, ? super C, ? extends Value> valueMapper,
+                    IntFunction<ValueSet> valueSetFunction) {
         return new DefaultTriConstraintCollector<>(
                 (Supplier<ToMapResultContainer<Key, Value>>) ToMapResultContainer::new,
                 (resultContainer, a, b, c) -> toMapAccumulator(keyMapper, valueMapper, resultContainer, a, b, c),
@@ -1584,9 +1586,9 @@ public final class ConstraintCollectors {
      * @param <Value> type of map value
      * @return never null
      */
-    public static <A, B, C, Key extends Comparable<Key>, Value> TriConstraintCollector<A, B, C, ?, SortedMap<Key, Set<Value>>> toSortedMap(
-            TriFunction<? super A, ? super B, ? super C, ? extends Key> keyMapper,
-            TriFunction<? super A, ? super B, ? super C, ? extends Value> valueMapper) {
+    public static <A, B, C, Key extends Comparable<Key>, Value> TriConstraintCollector<A, B, C, ?, SortedMap<Key, Set<Value>>>
+            toSortedMap(TriFunction<? super A, ? super B, ? super C, ? extends Key> keyMapper,
+                    TriFunction<? super A, ? super B, ? super C, ? extends Value> valueMapper) {
         return toSortedMap(keyMapper, valueMapper, (IntFunction<Set<Value>>) LinkedHashSet::new);
     }
 
@@ -1604,10 +1606,11 @@ public final class ConstraintCollectors {
      * @param <ValueSet> type of the value set
      * @return never null
      */
-    public static <A, B, C, Key extends Comparable<Key>, Value, ValueSet extends Set<Value>> TriConstraintCollector<A, B, C, ?, SortedMap<Key, ValueSet>> toSortedMap(
-            TriFunction<? super A, ? super B, ? super C, ? extends Key> keyMapper,
-            TriFunction<? super A, ? super B, ? super C, ? extends Value> valueMapper,
-            IntFunction<ValueSet> valueSetFunction) {
+    public static <A, B, C, Key extends Comparable<Key>, Value, ValueSet extends Set<Value>>
+            TriConstraintCollector<A, B, C, ?, SortedMap<Key, ValueSet>> toSortedMap(
+                    TriFunction<? super A, ? super B, ? super C, ? extends Key> keyMapper,
+                    TriFunction<? super A, ? super B, ? super C, ? extends Value> valueMapper,
+                    IntFunction<ValueSet> valueSetFunction) {
         return new DefaultTriConstraintCollector<>(
                 (Supplier<ToMapResultContainer<Key, Value>>) ToMapResultContainer::new,
                 (resultContainer, a, b, c) -> toMapAccumulator(keyMapper, valueMapper, resultContainer, a, b, c),
@@ -1630,10 +1633,10 @@ public final class ConstraintCollectors {
      * @param <Value> type of map value
      * @return never null
      */
-    public static <A, B, C, Key extends Comparable<Key>, Value> TriConstraintCollector<A, B, C, ?, SortedMap<Key, Value>> toSortedMap(
-            TriFunction<? super A, ? super B, ? super C, ? extends Key> keyMapper,
-            TriFunction<? super A, ? super B, ? super C, ? extends Value> valueMapper,
-            BinaryOperator<Value> mergeFunction) {
+    public static <A, B, C, Key extends Comparable<Key>, Value> TriConstraintCollector<A, B, C, ?, SortedMap<Key, Value>>
+            toSortedMap(TriFunction<? super A, ? super B, ? super C, ? extends Key> keyMapper,
+                    TriFunction<? super A, ? super B, ? super C, ? extends Value> valueMapper,
+                    BinaryOperator<Value> mergeFunction) {
         return new DefaultTriConstraintCollector<>(
                 (Supplier<ToMapResultContainer<Key, Value>>) ToMapResultContainer::new,
                 (resultContainer, a, b, c) -> toMapAccumulator(keyMapper, valueMapper, resultContainer, a, b, c),
@@ -1677,10 +1680,11 @@ public final class ConstraintCollectors {
      * @param <ValueSet> type of the value set
      * @return never null
      */
-    public static <A, B, C, D, Key, Value, ValueSet extends Set<Value>> QuadConstraintCollector<A, B, C, D, ?, Map<Key, ValueSet>> toMap(
-            QuadFunction<? super A, ? super B, ? super C, ? super D, ? extends Key> keyMapper,
-            QuadFunction<? super A, ? super B, ? super C, ? super D, ? extends Value> valueMapper,
-            IntFunction<ValueSet> valueSetFunction) {
+    public static <A, B, C, D, Key, Value, ValueSet extends Set<Value>>
+            QuadConstraintCollector<A, B, C, D, ?, Map<Key, ValueSet>> toMap(
+                    QuadFunction<? super A, ? super B, ? super C, ? super D, ? extends Key> keyMapper,
+                    QuadFunction<? super A, ? super B, ? super C, ? super D, ? extends Value> valueMapper,
+                    IntFunction<ValueSet> valueSetFunction) {
         return new DefaultQuadConstraintCollector<>(
                 (Supplier<ToMapResultContainer<Key, Value>>) ToMapResultContainer::new,
                 (resultContainer, a, b, c, d) -> toMapAccumulator(keyMapper, valueMapper, resultContainer, a, b, c, d),
@@ -1737,9 +1741,10 @@ public final class ConstraintCollectors {
      * @param <Value> type of map value
      * @return never null
      */
-    public static <A, B, C, D, Key extends Comparable<Key>, Value> QuadConstraintCollector<A, B, C, D, ?, SortedMap<Key, Set<Value>>> toSortedMap(
-            QuadFunction<? super A, ? super B, ? super C, ? super D, ? extends Key> keyMapper,
-            QuadFunction<? super A, ? super B, ? super C, ? super D, ? extends Value> valueMapper) {
+    public static <A, B, C, D, Key extends Comparable<Key>, Value>
+            QuadConstraintCollector<A, B, C, D, ?, SortedMap<Key, Set<Value>>> toSortedMap(
+                    QuadFunction<? super A, ? super B, ? super C, ? super D, ? extends Key> keyMapper,
+                    QuadFunction<? super A, ? super B, ? super C, ? super D, ? extends Value> valueMapper) {
         return toSortedMap(keyMapper, valueMapper, (IntFunction<Set<Value>>) LinkedHashSet::new);
     }
 
@@ -1758,10 +1763,11 @@ public final class ConstraintCollectors {
      * @param <ValueSet> type of the value set
      * @return never null
      */
-    public static <A, B, C, D, Key extends Comparable<Key>, Value, ValueSet extends Set<Value>> QuadConstraintCollector<A, B, C, D, ?, SortedMap<Key, ValueSet>> toSortedMap(
-            QuadFunction<? super A, ? super B, ? super C, ? super D, ? extends Key> keyMapper,
-            QuadFunction<? super A, ? super B, ? super C, ? super D, ? extends Value> valueMapper,
-            IntFunction<ValueSet> valueSetFunction) {
+    public static <A, B, C, D, Key extends Comparable<Key>, Value, ValueSet extends Set<Value>>
+            QuadConstraintCollector<A, B, C, D, ?, SortedMap<Key, ValueSet>> toSortedMap(
+                    QuadFunction<? super A, ? super B, ? super C, ? super D, ? extends Key> keyMapper,
+                    QuadFunction<? super A, ? super B, ? super C, ? super D, ? extends Value> valueMapper,
+                    IntFunction<ValueSet> valueSetFunction) {
         return new DefaultQuadConstraintCollector<>(
                 (Supplier<ToMapResultContainer<Key, Value>>) ToMapResultContainer::new,
                 (resultContainer, a, b, c, d) -> toMapAccumulator(keyMapper, valueMapper, resultContainer, a, b, c, d),
@@ -1785,10 +1791,10 @@ public final class ConstraintCollectors {
      * @param <Value> type of map value
      * @return never null
      */
-    public static <A, B, C, D, Key extends Comparable<Key>, Value> QuadConstraintCollector<A, B, C, D, ?, SortedMap<Key, Value>> toSortedMap(
-            QuadFunction<? super A, ? super B, ? super C, ? super D, ? extends Key> keyMapper,
-            QuadFunction<? super A, ? super B, ? super C, ? super D, ? extends Value> valueMapper,
-            BinaryOperator<Value> mergeFunction) {
+    public static <A, B, C, D, Key extends Comparable<Key>, Value> QuadConstraintCollector<A, B, C, D, ?, SortedMap<Key, Value>>
+            toSortedMap(QuadFunction<? super A, ? super B, ? super C, ? super D, ? extends Key> keyMapper,
+                    QuadFunction<? super A, ? super B, ? super C, ? super D, ? extends Value> valueMapper,
+                    BinaryOperator<Value> mergeFunction) {
         return new DefaultQuadConstraintCollector<>(
                 (Supplier<ToMapResultContainer<Key, Value>>) ToMapResultContainer::new,
                 (resultContainer, a, b, c, d) -> toMapAccumulator(keyMapper, valueMapper, resultContainer, a, b, c, d),

--- a/optaplanner-core/src/main/java/org/optaplanner/core/api/score/stream/bi/BiConstraintStream.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/api/score/stream/bi/BiConstraintStream.java
@@ -486,10 +486,11 @@ public interface BiConstraintStream<A, B> extends ConstraintStream {
      * @param <ResultD_> the type of the fourth fact in the destination {@link QuadConstraintStream}'s tuple
      * @return never null
      */
-    <GroupKeyA_, GroupKeyB_, ResultContainerC_, ResultC_, ResultContainerD_, ResultD_> QuadConstraintStream<GroupKeyA_, GroupKeyB_, ResultC_, ResultD_> groupBy(
-            BiFunction<A, B, GroupKeyA_> groupKeyAMapping, BiFunction<A, B, GroupKeyB_> groupKeyBMapping,
-            BiConstraintCollector<A, B, ResultContainerC_, ResultC_> collectorC,
-            BiConstraintCollector<A, B, ResultContainerD_, ResultD_> collectorD);
+    <GroupKeyA_, GroupKeyB_, ResultContainerC_, ResultC_, ResultContainerD_, ResultD_>
+            QuadConstraintStream<GroupKeyA_, GroupKeyB_, ResultC_, ResultD_> groupBy(
+                    BiFunction<A, B, GroupKeyA_> groupKeyAMapping, BiFunction<A, B, GroupKeyB_> groupKeyBMapping,
+                    BiConstraintCollector<A, B, ResultContainerC_, ResultC_> collectorC,
+                    BiConstraintCollector<A, B, ResultContainerD_, ResultD_> collectorD);
 
     // ************************************************************************
     // Penalize/reward

--- a/optaplanner-core/src/main/java/org/optaplanner/core/api/score/stream/quad/QuadConstraintStream.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/api/score/stream/quad/QuadConstraintStream.java
@@ -350,10 +350,12 @@ public interface QuadConstraintStream<A, B, C, D> extends ConstraintStream {
      * @param <ResultD_> the type of the fourth fact in the destination {@link QuadConstraintStream}'s tuple
      * @return never null
      */
-    <GroupKeyA_, GroupKeyB_, ResultContainerC_, ResultC_, ResultContainerD_, ResultD_> QuadConstraintStream<GroupKeyA_, GroupKeyB_, ResultC_, ResultD_> groupBy(
-            QuadFunction<A, B, C, D, GroupKeyA_> groupKeyAMapping, QuadFunction<A, B, C, D, GroupKeyB_> groupKeyBMapping,
-            QuadConstraintCollector<A, B, C, D, ResultContainerC_, ResultC_> collectorC,
-            QuadConstraintCollector<A, B, C, D, ResultContainerD_, ResultD_> collectorD);
+    <GroupKeyA_, GroupKeyB_, ResultContainerC_, ResultC_, ResultContainerD_, ResultD_>
+            QuadConstraintStream<GroupKeyA_, GroupKeyB_, ResultC_, ResultD_> groupBy(
+                    QuadFunction<A, B, C, D, GroupKeyA_> groupKeyAMapping,
+                    QuadFunction<A, B, C, D, GroupKeyB_> groupKeyBMapping,
+                    QuadConstraintCollector<A, B, C, D, ResultContainerC_, ResultC_> collectorC,
+                    QuadConstraintCollector<A, B, C, D, ResultContainerD_, ResultD_> collectorD);
 
     // ************************************************************************
     // Penalize/reward

--- a/optaplanner-core/src/main/java/org/optaplanner/core/api/score/stream/tri/TriConstraintStream.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/api/score/stream/tri/TriConstraintStream.java
@@ -487,10 +487,11 @@ public interface TriConstraintStream<A, B, C> extends ConstraintStream {
      * @param <ResultD_> the type of the fourth fact in the destination {@link QuadConstraintStream}'s tuple
      * @return never null
      */
-    <GroupKeyA_, GroupKeyB_, ResultContainerC_, ResultC_, ResultContainerD_, ResultD_> QuadConstraintStream<GroupKeyA_, GroupKeyB_, ResultC_, ResultD_> groupBy(
-            TriFunction<A, B, C, GroupKeyA_> groupKeyAMapping, TriFunction<A, B, C, GroupKeyB_> groupKeyBMapping,
-            TriConstraintCollector<A, B, C, ResultContainerC_, ResultC_> collectorC,
-            TriConstraintCollector<A, B, C, ResultContainerD_, ResultD_> collectorD);
+    <GroupKeyA_, GroupKeyB_, ResultContainerC_, ResultC_, ResultContainerD_, ResultD_>
+            QuadConstraintStream<GroupKeyA_, GroupKeyB_, ResultC_, ResultD_> groupBy(
+                    TriFunction<A, B, C, GroupKeyA_> groupKeyAMapping, TriFunction<A, B, C, GroupKeyB_> groupKeyBMapping,
+                    TriConstraintCollector<A, B, C, ResultContainerC_, ResultC_> collectorC,
+                    TriConstraintCollector<A, B, C, ResultContainerD_, ResultD_> collectorD);
 
     // ************************************************************************
     // Penalize/reward

--- a/optaplanner-core/src/main/java/org/optaplanner/core/api/score/stream/uni/UniConstraintStream.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/api/score/stream/uni/UniConstraintStream.java
@@ -665,10 +665,11 @@ public interface UniConstraintStream<A> extends ConstraintStream {
      * @param <ResultD_> the type of the fourth fact in the destination {@link QuadConstraintStream}'s tuple
      * @return never null
      */
-    <GroupKeyA_, GroupKeyB_, ResultContainerC_, ResultC_, ResultContainerD_, ResultD_> QuadConstraintStream<GroupKeyA_, GroupKeyB_, ResultC_, ResultD_> groupBy(
-            Function<A, GroupKeyA_> groupKeyAMapping, Function<A, GroupKeyB_> groupKeyBMapping,
-            UniConstraintCollector<A, ResultContainerC_, ResultC_> collectorC,
-            UniConstraintCollector<A, ResultContainerD_, ResultD_> collectorD);
+    <GroupKeyA_, GroupKeyB_, ResultContainerC_, ResultC_, ResultContainerD_, ResultD_>
+            QuadConstraintStream<GroupKeyA_, GroupKeyB_, ResultC_, ResultD_> groupBy(
+                    Function<A, GroupKeyA_> groupKeyAMapping, Function<A, GroupKeyB_> groupKeyBMapping,
+                    UniConstraintCollector<A, ResultContainerC_, ResultC_> collectorC,
+                    UniConstraintCollector<A, ResultContainerD_, ResultD_> collectorD);
 
     // ************************************************************************
     // Penalize/reward

--- a/optaplanner-core/src/main/java/org/optaplanner/core/config/heuristic/selector/common/nearby/NearbySelectionConfig.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/config/heuristic/selector/common/nearby/NearbySelectionConfig.java
@@ -214,10 +214,12 @@ public class NearbySelectionConfig extends SelectorConfig<NearbySelectionConfig>
                 || blockDistributionSizeMaximum != null
                 || blockDistributionSizeRatio != null
                 || blockDistributionUniformDistributionProbability != null;
-        boolean linearDistributionEnabled = nearbySelectionDistributionType == NearbySelectionDistributionType.LINEAR_DISTRIBUTION
-                || linearDistributionSizeMaximum != null;
-        boolean parabolicDistributionEnabled = nearbySelectionDistributionType == NearbySelectionDistributionType.PARABOLIC_DISTRIBUTION
-                || parabolicDistributionSizeMaximum != null;
+        boolean linearDistributionEnabled =
+                nearbySelectionDistributionType == NearbySelectionDistributionType.LINEAR_DISTRIBUTION
+                        || linearDistributionSizeMaximum != null;
+        boolean parabolicDistributionEnabled =
+                nearbySelectionDistributionType == NearbySelectionDistributionType.PARABOLIC_DISTRIBUTION
+                        || parabolicDistributionSizeMaximum != null;
         boolean betaDistributionEnabled = nearbySelectionDistributionType == NearbySelectionDistributionType.BETA_DISTRIBUTION
                 || betaDistributionAlpha != null
                 || betaDistributionBeta != null;

--- a/optaplanner-core/src/main/java/org/optaplanner/core/config/score/director/ScoreDirectorFactoryConfig.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/config/score/director/ScoreDirectorFactoryConfig.java
@@ -484,8 +484,8 @@ public class ScoreDirectorFactoryConfig extends AbstractConfig<ScoreDirectorFact
             SolverConfigContext configContext, ClassLoader classLoader, EnvironmentMode environmentMode,
             SolutionDescriptor<Solution_> solutionDescriptor) {
         AbstractScoreDirectorFactory<Solution_> easyScoreDirectorFactory = buildEasyScoreDirectorFactory(solutionDescriptor);
-        AbstractScoreDirectorFactory<Solution_> constraintStreamScoreDirectorFactory = buildConstraintStreamScoreDirectorFactory(
-                solutionDescriptor);
+        AbstractScoreDirectorFactory<Solution_> constraintStreamScoreDirectorFactory =
+                buildConstraintStreamScoreDirectorFactory(solutionDescriptor);
         AbstractScoreDirectorFactory<Solution_> incrementalScoreDirectorFactory = buildIncrementalScoreDirectorFactory(
                 solutionDescriptor);
         AbstractScoreDirectorFactory<Solution_> droolsScoreDirectorFactory = buildDroolsScoreDirectorFactory(configContext,

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/solution/descriptor/SolutionDescriptor.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/solution/descriptor/SolutionDescriptor.java
@@ -172,7 +172,8 @@ public class SolutionDescriptor<Solution_> {
     private final Map<Class<?>, EntityDescriptor<Solution_>> entityDescriptorMap;
     private final List<Class<?>> reversedEntityClassList;
 
-    private final ConcurrentMap<Class<?>, EntityDescriptor<Solution_>> lowestEntityDescriptorMemoization = new ConcurrentMemoization<>();
+    private final ConcurrentMap<Class<?>, EntityDescriptor<Solution_>> lowestEntityDescriptorMemoization =
+            new ConcurrentMemoization<>();
     private LookUpStrategyResolver lookUpStrategyResolver = null;
 
     // ************************************************************************
@@ -749,7 +750,8 @@ public class SolutionDescriptor<Solution_> {
     private void determineGlobalShadowOrder() {
         // Topological sorting with Kahn's algorithm
         List<Pair<ShadowVariableDescriptor<Solution_>, Integer>> pairList = new ArrayList<>();
-        Map<ShadowVariableDescriptor<Solution_>, Pair<ShadowVariableDescriptor<Solution_>, Integer>> shadowToPairMap = new HashMap<>();
+        Map<ShadowVariableDescriptor<Solution_>, Pair<ShadowVariableDescriptor<Solution_>, Integer>> shadowToPairMap =
+                new HashMap<>();
         for (EntityDescriptor<Solution_> entityDescriptor : entityDescriptorMap.values()) {
             for (ShadowVariableDescriptor<Solution_> shadow : entityDescriptor.getDeclaredShadowVariableDescriptors()) {
                 int sourceSize = shadow.getSourceVariableDescriptorList().size();

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/valuerange/descriptor/CompositeValueRangeDescriptor.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/valuerange/descriptor/CompositeValueRangeDescriptor.java
@@ -79,7 +79,8 @@ public class CompositeValueRangeDescriptor<Solution_> extends AbstractValueRange
     public ValueRange<?> extractValueRange(Solution_ solution) {
         List<CountableValueRange<?>> childValueRangeList = new ArrayList<>(childValueRangeDescriptorList.size());
         for (ValueRangeDescriptor<Solution_> valueRangeDescriptor : childValueRangeDescriptorList) {
-            EntityIndependentValueRangeDescriptor<Solution_> entityIndependentValueRangeDescriptor = (EntityIndependentValueRangeDescriptor) valueRangeDescriptor;
+            EntityIndependentValueRangeDescriptor<Solution_> entityIndependentValueRangeDescriptor =
+                    (EntityIndependentValueRangeDescriptor) valueRangeDescriptor;
             childValueRangeList.add((CountableValueRange) entityIndependentValueRangeDescriptor.extractValueRange(solution));
         }
         return doNullInValueRangeWrapping(new CompositeCountableValueRange(childValueRangeList));

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/AbstractScoreDirector.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/AbstractScoreDirector.java
@@ -342,8 +342,9 @@ public abstract class AbstractScoreDirector<Solution_, Factory_ extends Abstract
     @Override
     public InnerScoreDirector<Solution_> createChildThreadScoreDirector(ChildThreadType childThreadType) {
         if (childThreadType == ChildThreadType.PART_THREAD) {
-            AbstractScoreDirector<Solution_, Factory_> childThreadScoreDirector = (AbstractScoreDirector<Solution_, Factory_>) scoreDirectorFactory
-                    .buildScoreDirector(isLookUpEnabled(), constraintMatchEnabledPreference);
+            AbstractScoreDirector<Solution_, Factory_> childThreadScoreDirector =
+                    (AbstractScoreDirector<Solution_, Factory_>) scoreDirectorFactory
+                            .buildScoreDirector(isLookUpEnabled(), constraintMatchEnabledPreference);
             // ScoreCalculationCountTermination takes into account previous phases
             // but the calculationCount of partitions is maxed, not summed.
             childThreadScoreDirector.calculationCount = calculationCount;
@@ -351,8 +352,9 @@ public abstract class AbstractScoreDirector<Solution_, Factory_ extends Abstract
         } else if (childThreadType == ChildThreadType.MOVE_THREAD) {
             // TODO The move thread must use constraintMatchEnabledPreference in FULL_ASSERT,
             // but it doesn't have to for Indictment Local Search, in which case it is a performance loss
-            AbstractScoreDirector<Solution_, Factory_> childThreadScoreDirector = (AbstractScoreDirector<Solution_, Factory_>) scoreDirectorFactory
-                    .buildScoreDirector(true, constraintMatchEnabledPreference);
+            AbstractScoreDirector<Solution_, Factory_> childThreadScoreDirector =
+                    (AbstractScoreDirector<Solution_, Factory_>) scoreDirectorFactory
+                            .buildScoreDirector(true, constraintMatchEnabledPreference);
             childThreadScoreDirector.setWorkingSolution(cloneWorkingSolution());
             return childThreadScoreDirector;
         } else {

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/incremental/IncrementalScoreDirector.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/incremental/IncrementalScoreDirector.java
@@ -120,8 +120,8 @@ public class IncrementalScoreDirector<Solution_>
             throw new IllegalStateException("When constraintMatchEnabled (" + isConstraintMatchEnabled()
                     + ") is disabled in the constructor, this method should not be called.");
         }
-        Map<Object, Indictment> incrementalIndictmentMap = ((ConstraintMatchAwareIncrementalScoreCalculator<Solution_>) incrementalScoreCalculator)
-                .getIndictmentMap();
+        Map<Object, Indictment> incrementalIndictmentMap =
+                ((ConstraintMatchAwareIncrementalScoreCalculator<Solution_>) incrementalScoreCalculator).getIndictmentMap();
         if (incrementalIndictmentMap != null) {
             return incrementalIndictmentMap;
         }

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/bavet/bi/BavetAbstractBiConstraintStream.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/bavet/bi/BavetAbstractBiConstraintStream.java
@@ -166,10 +166,11 @@ public abstract class BavetAbstractBiConstraintStream<Solution_, A, B> extends B
     }
 
     @Override
-    public <GroupKeyA_, GroupKeyB_, ResultContainerC_, ResultC_, ResultContainerD_, ResultD_> QuadConstraintStream<GroupKeyA_, GroupKeyB_, ResultC_, ResultD_> groupBy(
-            BiFunction<A, B, GroupKeyA_> groupKeyAMapping, BiFunction<A, B, GroupKeyB_> groupKeyBMapping,
-            BiConstraintCollector<A, B, ResultContainerC_, ResultC_> collectorC,
-            BiConstraintCollector<A, B, ResultContainerD_, ResultD_> collectorD) {
+    public <GroupKeyA_, GroupKeyB_, ResultContainerC_, ResultC_, ResultContainerD_, ResultD_>
+            QuadConstraintStream<GroupKeyA_, GroupKeyB_, ResultC_, ResultD_> groupBy(
+                    BiFunction<A, B, GroupKeyA_> groupKeyAMapping, BiFunction<A, B, GroupKeyB_> groupKeyBMapping,
+                    BiConstraintCollector<A, B, ResultContainerC_, ResultC_> collectorC,
+                    BiConstraintCollector<A, B, ResultContainerD_, ResultD_> collectorD) {
         throw new UnsupportedOperationException();
     }
 

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/bavet/bi/BavetScoringBiConstraintStream.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/bavet/bi/BavetScoringBiConstraintStream.java
@@ -142,7 +142,8 @@ public final class BavetScoringBiConstraintStream<Solution_, A, B>
                         + ") must return a long.");
             }
         } else if (weightedScoreImpacter instanceof BigDecimalWeightedScoreImpacter) {
-            BigDecimalWeightedScoreImpacter castedWeightedScoreImpacter = (BigDecimalWeightedScoreImpacter) weightedScoreImpacter;
+            BigDecimalWeightedScoreImpacter castedWeightedScoreImpacter =
+                    (BigDecimalWeightedScoreImpacter) weightedScoreImpacter;
             if (bigDecimalMatchWeigher != null) {
                 scoreImpacter = (A a, B b, Consumer<Score<?>> matchScoreConsumer) -> {
                     BigDecimal matchWeight = bigDecimalMatchWeigher.apply(a, b);

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/bavet/common/BavetNodeBuildPolicy.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/bavet/common/BavetNodeBuildPolicy.java
@@ -28,7 +28,8 @@ public class BavetNodeBuildPolicy<Solution_> {
 
     private int nodeOrderMaximum = 0;
     private Map<String, BavetScoringNode> constraintIdToScoringNodeMap;
-    private Map<BavetJoinConstraintStream<Solution_>, BavetJoinBridgeNode> joinConstraintStreamToJoinBridgeNodeMap = new HashMap<>();
+    private Map<BavetJoinConstraintStream<Solution_>, BavetJoinBridgeNode> joinConstraintStreamToJoinBridgeNodeMap =
+            new HashMap<>();
     private Map<BavetAbstractNode, BavetAbstractNode> sharableNodeMap = new HashMap<>();
 
     public BavetNodeBuildPolicy(BavetConstraintSession session, int constraintCount) {

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/bavet/tri/BavetAbstractTriConstraintStream.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/bavet/tri/BavetAbstractTriConstraintStream.java
@@ -134,10 +134,11 @@ public abstract class BavetAbstractTriConstraintStream<Solution_, A, B, C> exten
     }
 
     @Override
-    public <GroupKeyA_, GroupKeyB_, ResultContainerC_, ResultC_, ResultContainerD_, ResultD_> QuadConstraintStream<GroupKeyA_, GroupKeyB_, ResultC_, ResultD_> groupBy(
-            TriFunction<A, B, C, GroupKeyA_> groupKeyAMapping, TriFunction<A, B, C, GroupKeyB_> groupKeyBMapping,
-            TriConstraintCollector<A, B, C, ResultContainerC_, ResultC_> collectorC,
-            TriConstraintCollector<A, B, C, ResultContainerD_, ResultD_> collectorD) {
+    public <GroupKeyA_, GroupKeyB_, ResultContainerC_, ResultC_, ResultContainerD_, ResultD_>
+            QuadConstraintStream<GroupKeyA_, GroupKeyB_, ResultC_, ResultD_> groupBy(
+                    TriFunction<A, B, C, GroupKeyA_> groupKeyAMapping, TriFunction<A, B, C, GroupKeyB_> groupKeyBMapping,
+                    TriConstraintCollector<A, B, C, ResultContainerC_, ResultC_> collectorC,
+                    TriConstraintCollector<A, B, C, ResultContainerD_, ResultD_> collectorD) {
         throw new UnsupportedOperationException();
     }
 

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/bavet/tri/BavetScoringTriConstraintStream.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/bavet/tri/BavetScoringTriConstraintStream.java
@@ -142,7 +142,8 @@ public final class BavetScoringTriConstraintStream<Solution_, A, B, C>
                         + ") must return a long.");
             }
         } else if (weightedScoreImpacter instanceof BigDecimalWeightedScoreImpacter) {
-            BigDecimalWeightedScoreImpacter castedWeightedScoreImpacter = (BigDecimalWeightedScoreImpacter) weightedScoreImpacter;
+            BigDecimalWeightedScoreImpacter castedWeightedScoreImpacter =
+                    (BigDecimalWeightedScoreImpacter) weightedScoreImpacter;
             if (bigDecimalMatchWeigher != null) {
                 scoreImpacter = (A a, B b, C c, Consumer<Score<?>> matchScoreConsumer) -> {
                     BigDecimal matchWeight = bigDecimalMatchWeigher.apply(a, b, c);

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/bavet/uni/BavetAbstractUniConstraintStream.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/bavet/uni/BavetAbstractUniConstraintStream.java
@@ -171,11 +171,11 @@ public abstract class BavetAbstractUniConstraintStream<Solution_, A> extends Bav
     public <GroupKey_, ResultContainer_, Result_> BiConstraintStream<GroupKey_, Result_> groupBy(
             Function<A, GroupKey_> groupKeyMapping,
             UniConstraintCollector<A, ResultContainer_, Result_> collector) {
-        BavetGroupBridgeUniConstraintStream<Solution_, A, GroupKey_, ResultContainer_, Result_> bridge = new BavetGroupBridgeUniConstraintStream<>(
-                constraintFactory, this, groupKeyMapping, collector);
+        BavetGroupBridgeUniConstraintStream<Solution_, A, GroupKey_, ResultContainer_, Result_> bridge =
+                new BavetGroupBridgeUniConstraintStream<>(constraintFactory, this, groupKeyMapping, collector);
         childStreamList.add(bridge);
-        BavetGroupBiConstraintStream<Solution_, GroupKey_, ResultContainer_, Result_> groupStream = new BavetGroupBiConstraintStream<>(
-                constraintFactory, bridge, collector.finisher());
+        BavetGroupBiConstraintStream<Solution_, GroupKey_, ResultContainer_, Result_> groupStream =
+                new BavetGroupBiConstraintStream<>(constraintFactory, bridge, collector.finisher());
         bridge.setGroupStream(groupStream);
         return groupStream;
     }
@@ -188,10 +188,11 @@ public abstract class BavetAbstractUniConstraintStream<Solution_, A> extends Bav
     }
 
     @Override
-    public <GroupKeyA_, GroupKeyB_, ResultContainerC_, ResultC_, ResultContainerD_, ResultD_> QuadConstraintStream<GroupKeyA_, GroupKeyB_, ResultC_, ResultD_> groupBy(
-            Function<A, GroupKeyA_> groupKeyAMapping,
-            Function<A, GroupKeyB_> groupKeyBMapping, UniConstraintCollector<A, ResultContainerC_, ResultC_> collectorC,
-            UniConstraintCollector<A, ResultContainerD_, ResultD_> collectorD) {
+    public <GroupKeyA_, GroupKeyB_, ResultContainerC_, ResultC_, ResultContainerD_, ResultD_>
+            QuadConstraintStream<GroupKeyA_, GroupKeyB_, ResultC_, ResultD_> groupBy(
+                    Function<A, GroupKeyA_> groupKeyAMapping,
+                    Function<A, GroupKeyB_> groupKeyBMapping, UniConstraintCollector<A, ResultContainerC_, ResultC_> collectorC,
+                    UniConstraintCollector<A, ResultContainerD_, ResultD_> collectorD) {
         throw new UnsupportedOperationException(); // TODO
     }
 

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/bavet/uni/BavetScoringUniConstraintStream.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/bavet/uni/BavetScoringUniConstraintStream.java
@@ -140,7 +140,8 @@ public final class BavetScoringUniConstraintStream<Solution_, A> extends BavetAb
                         + ") must return a long.");
             }
         } else if (weightedScoreImpacter instanceof BigDecimalWeightedScoreImpacter) {
-            BigDecimalWeightedScoreImpacter castedWeightedScoreImpacter = (BigDecimalWeightedScoreImpacter) weightedScoreImpacter;
+            BigDecimalWeightedScoreImpacter castedWeightedScoreImpacter =
+                    (BigDecimalWeightedScoreImpacter) weightedScoreImpacter;
             if (bigDecimalMatchWeigher != null) {
                 scoreImpacter = (A a, Consumer<Score<?>> matchScoreConsumer) -> {
                     BigDecimal matchWeight = bigDecimalMatchWeigher.apply(a);

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/bi/DroolsAbstractBiConstraintStream.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/bi/DroolsAbstractBiConstraintStream.java
@@ -148,21 +148,21 @@ public abstract class DroolsAbstractBiConstraintStream<Solution_, A, B>
     public <GroupKeyA_, GroupKeyB_, ResultContainer_, Result_> TriConstraintStream<GroupKeyA_, GroupKeyB_, Result_> groupBy(
             BiFunction<A, B, GroupKeyA_> groupKeyAMapping, BiFunction<A, B, GroupKeyB_> groupKeyBMapping,
             BiConstraintCollector<A, B, ResultContainer_, Result_> collector) {
-        DroolsGroupingTriConstraintStream<Solution_, GroupKeyA_, GroupKeyB_, Result_> stream = new DroolsGroupingTriConstraintStream<>(
-                constraintFactory, this, groupKeyAMapping,
-                groupKeyBMapping, collector);
+        DroolsGroupingTriConstraintStream<Solution_, GroupKeyA_, GroupKeyB_, Result_> stream =
+                new DroolsGroupingTriConstraintStream<>(constraintFactory, this, groupKeyAMapping, groupKeyBMapping, collector);
         addChildStream(stream);
         return stream;
     }
 
     @Override
-    public <GroupKeyA_, GroupKeyB_, ResultContainerC_, ResultC_, ResultContainerD_, ResultD_> QuadConstraintStream<GroupKeyA_, GroupKeyB_, ResultC_, ResultD_> groupBy(
-            BiFunction<A, B, GroupKeyA_> groupKeyAMapping, BiFunction<A, B, GroupKeyB_> groupKeyBMapping,
-            BiConstraintCollector<A, B, ResultContainerC_, ResultC_> collectorC,
-            BiConstraintCollector<A, B, ResultContainerD_, ResultD_> collectorD) {
-        DroolsGroupingQuadConstraintStream<Solution_, GroupKeyA_, GroupKeyB_, ResultC_, ResultD_> stream = new DroolsGroupingQuadConstraintStream<>(
-                constraintFactory, this, groupKeyAMapping,
-                groupKeyBMapping, collectorC, collectorD);
+    public <GroupKeyA_, GroupKeyB_, ResultContainerC_, ResultC_, ResultContainerD_, ResultD_>
+            QuadConstraintStream<GroupKeyA_, GroupKeyB_, ResultC_, ResultD_> groupBy(
+                    BiFunction<A, B, GroupKeyA_> groupKeyAMapping, BiFunction<A, B, GroupKeyB_> groupKeyBMapping,
+                    BiConstraintCollector<A, B, ResultContainerC_, ResultC_> collectorC,
+                    BiConstraintCollector<A, B, ResultContainerD_, ResultD_> collectorD) {
+        DroolsGroupingQuadConstraintStream<Solution_, GroupKeyA_, GroupKeyB_, ResultC_, ResultD_> stream =
+                new DroolsGroupingQuadConstraintStream<>(constraintFactory, this, groupKeyAMapping, groupKeyBMapping,
+                        collectorC, collectorD);
         addChildStream(stream);
         return stream;
     }

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/bi/DroolsBiCondition.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/bi/DroolsBiCondition.java
@@ -211,9 +211,9 @@ public final class DroolsBiCondition<A, B, PatternVar>
                 getRuleStructure().getA(), getRuleStructure().getB()));
     }
 
-    public <NewA, NewB, NewC, NewD> DroolsQuadCondition<NewA, NewB, NewC, NewD, QuadTuple<NewA, NewB, NewC, NewD>> andGroupBiWithCollectBi(
-            BiFunction<A, B, NewA> groupKeyAMapping, BiFunction<A, B, NewB> groupKeyBMapping,
-            BiConstraintCollector<A, B, ?, NewC> collectorC, BiConstraintCollector<A, B, ?, NewD> collectorD) {
+    public <NewA, NewB, NewC, NewD> DroolsQuadCondition<NewA, NewB, NewC, NewD, QuadTuple<NewA, NewB, NewC, NewD>>
+            andGroupBiWithCollectBi(BiFunction<A, B, NewA> groupKeyAMapping, BiFunction<A, B, NewB> groupKeyBMapping,
+                    BiConstraintCollector<A, B, ?, NewC> collectorC, BiConstraintCollector<A, B, ?, NewD> collectorD) {
         return groupBiWithCollectBi(() -> new DroolsBiToQuadGroupByAccumulator<>(groupKeyAMapping, groupKeyBMapping,
                 collectorC, collectorD, getRuleStructure().getA(), getRuleStructure().getB()));
     }

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/common/DroolsCondition.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/common/DroolsCondition.java
@@ -105,8 +105,8 @@ public abstract class DroolsCondition<PatternVar, T extends DroolsRuleStructure<
         });
     }
 
-    protected <NewA, NewB, NewC, NewD, InTuple, OutPatternVar> DroolsQuadCondition<NewA, NewB, NewC, NewD, OutPatternVar> groupBiWithCollectBi(
-            Supplier<? extends DroolsAbstractGroupByAccumulator<InTuple>> invokerSupplier) {
+    protected <NewA, NewB, NewC, NewD, InTuple, OutPatternVar> DroolsQuadCondition<NewA, NewB, NewC, NewD, OutPatternVar>
+            groupBiWithCollectBi(Supplier<? extends DroolsAbstractGroupByAccumulator<InTuple>> invokerSupplier) {
         return universalGroupWithCollect(invokerSupplier, (var, pattern, accumulate) -> {
             DroolsQuadRuleStructure<NewA, NewB, NewC, NewD, OutPatternVar> newRuleStructure = ruleStructure
                     .regroupBiToQuad((Variable) var, (PatternDef) pattern, accumulate);
@@ -114,9 +114,9 @@ public abstract class DroolsCondition<PatternVar, T extends DroolsRuleStructure<
         });
     }
 
-    private <InTuple, OutPatternVar, R extends DroolsRuleStructure<OutPatternVar>, C extends DroolsCondition<OutPatternVar, R>> C universalGroupWithCollect(
-            Supplier<? extends DroolsAbstractGroupByAccumulator<InTuple>> invokerSupplier,
-            Mutator<InTuple, OutPatternVar, R, C> mutator) {
+    private <InTuple, OutPatternVar, R extends DroolsRuleStructure<OutPatternVar>, C extends DroolsCondition<OutPatternVar, R>>
+            C universalGroupWithCollect(Supplier<? extends DroolsAbstractGroupByAccumulator<InTuple>> invokerSupplier,
+                    Mutator<InTuple, OutPatternVar, R, C> mutator) {
         Variable<Collection<InTuple>> tupleCollection = (Variable<Collection<InTuple>>) ruleStructure
                 .createVariable(Collection.class, "tupleCollection");
         PatternDSL.PatternDef<Collection<InTuple>> pattern = pattern(tupleCollection)

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/common/DroolsRuleStructure.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/common/DroolsRuleStructure.java
@@ -266,9 +266,9 @@ public abstract class DroolsRuleStructure<PatternVar> {
                 singletonList(collectPattern), emptyList(), getVariableIdSupplier());
     }
 
-    public <NewA, NewB, NewC, NewD> DroolsQuadRuleStructure<NewA, NewB, NewC, NewD, QuadTuple<NewA, NewB, NewC, NewD>> regroupBiToQuad(
-            Variable<Set<QuadTuple<NewA, NewB, NewC, NewD>>> newSource,
-            PatternDef<Set<QuadTuple<NewA, NewB, NewC, NewD>>> collectPattern, ViewItem<?> accumulatePattern) {
+    public <NewA, NewB, NewC, NewD> DroolsQuadRuleStructure<NewA, NewB, NewC, NewD, QuadTuple<NewA, NewB, NewC, NewD>>
+            regroupBiToQuad(Variable<Set<QuadTuple<NewA, NewB, NewC, NewD>>> newSource,
+                    PatternDef<Set<QuadTuple<NewA, NewB, NewC, NewD>>> collectPattern, ViewItem<?> accumulatePattern) {
         Variable<QuadTuple<NewA, NewB, NewC, NewD>> newTuple = (Variable<QuadTuple<NewA, NewB, NewC, NewD>>) createVariable(
                 QuadTuple.class, "groupKey", from(newSource));
         Variable<NewA> newA = createVariable("newA");

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/quad/DroolsAbstractQuadConstraintStream.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/quad/DroolsAbstractQuadConstraintStream.java
@@ -144,22 +144,22 @@ public abstract class DroolsAbstractQuadConstraintStream<Solution_, A, B, C, D>
             QuadFunction<A, B, C, D, GroupKeyA_> groupKeyAMapping,
             QuadFunction<A, B, C, D, GroupKeyB_> groupKeyBMapping,
             QuadConstraintCollector<A, B, C, D, ResultContainer_, Result_> collector) {
-        DroolsGroupingTriConstraintStream<Solution_, GroupKeyA_, GroupKeyB_, Result_> stream = new DroolsGroupingTriConstraintStream<>(
-                constraintFactory, this, groupKeyAMapping,
-                groupKeyBMapping, collector);
+        DroolsGroupingTriConstraintStream<Solution_, GroupKeyA_, GroupKeyB_, Result_> stream =
+                new DroolsGroupingTriConstraintStream<>(constraintFactory, this, groupKeyAMapping, groupKeyBMapping, collector);
         addChildStream(stream);
         return stream;
     }
 
     @Override
-    public <GroupKeyA_, GroupKeyB_, ResultContainerC_, ResultC_, ResultContainerD_, ResultD_> QuadConstraintStream<GroupKeyA_, GroupKeyB_, ResultC_, ResultD_> groupBy(
-            QuadFunction<A, B, C, D, GroupKeyA_> groupKeyAMapping,
-            QuadFunction<A, B, C, D, GroupKeyB_> groupKeyBMapping,
-            QuadConstraintCollector<A, B, C, D, ResultContainerC_, ResultC_> collectorC,
-            QuadConstraintCollector<A, B, C, D, ResultContainerD_, ResultD_> collectorD) {
-        DroolsGroupingQuadConstraintStream<Solution_, GroupKeyA_, GroupKeyB_, ResultC_, ResultD_> stream = new DroolsGroupingQuadConstraintStream<>(
-                constraintFactory, this, groupKeyAMapping,
-                groupKeyBMapping, collectorC, collectorD);
+    public <GroupKeyA_, GroupKeyB_, ResultContainerC_, ResultC_, ResultContainerD_, ResultD_>
+            QuadConstraintStream<GroupKeyA_, GroupKeyB_, ResultC_, ResultD_> groupBy(
+                    QuadFunction<A, B, C, D, GroupKeyA_> groupKeyAMapping,
+                    QuadFunction<A, B, C, D, GroupKeyB_> groupKeyBMapping,
+                    QuadConstraintCollector<A, B, C, D, ResultContainerC_, ResultC_> collectorC,
+                    QuadConstraintCollector<A, B, C, D, ResultContainerD_, ResultD_> collectorD) {
+        DroolsGroupingQuadConstraintStream<Solution_, GroupKeyA_, GroupKeyB_, ResultC_, ResultD_> stream =
+                new DroolsGroupingQuadConstraintStream<>(constraintFactory, this, groupKeyAMapping, groupKeyBMapping,
+                        collectorC, collectorD);
         addChildStream(stream);
         return stream;
     }
@@ -247,7 +247,8 @@ public abstract class DroolsAbstractQuadConstraintStream<Solution_, A, B, C, D>
     @Override
     public List<DroolsFromUniConstraintStream<Solution_, Object>> getFromStreamList() {
         if (parent == null) {
-            DroolsJoinQuadConstraintStream<Solution_, A, B, C, D> joinStream = (DroolsJoinQuadConstraintStream<Solution_, A, B, C, D>) this;
+            DroolsJoinQuadConstraintStream<Solution_, A, B, C, D> joinStream =
+                    (DroolsJoinQuadConstraintStream<Solution_, A, B, C, D>) this;
             List<DroolsFromUniConstraintStream<Solution_, Object>> leftParentFromStreamList = joinStream.getLeftParentStream()
                     .getFromStreamList();
             List<DroolsFromUniConstraintStream<Solution_, Object>> rightParentFromStreamList = joinStream.getRightParentStream()

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/quad/DroolsQuadCondition.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/quad/DroolsQuadCondition.java
@@ -89,8 +89,8 @@ public final class DroolsQuadCondition<A, B, C, D, PatternVar> extends
                 bVariable, cVariable, dVariable, newTargetPattern, actualStructure.getShelvedRuleItems(),
                 actualStructure.getPrerequisites(), actualStructure.getDependents(),
                 actualStructure.getVariableIdSupplier());
-        ImmediatelyPreviousFilter<QuadPredicate<A, B, C, D>> newPreviousFilter = new ImmediatelyPreviousFilter<QuadPredicate<A, B, C, D>>(
-                actualStructure, actualPredicate);
+        ImmediatelyPreviousFilter<QuadPredicate<A, B, C, D>> newPreviousFilter =
+                new ImmediatelyPreviousFilter<QuadPredicate<A, B, C, D>>(actualStructure, actualPredicate);
         // Carry forward the information for filter merging.
         return new DroolsQuadCondition<>(newRuleStructure, newPreviousFilter);
     }
@@ -209,10 +209,10 @@ public final class DroolsQuadCondition<A, B, C, D, PatternVar> extends
                 getRuleStructure().getD()));
     }
 
-    public <NewA, NewB, NewC, NewD> DroolsQuadCondition<NewA, NewB, NewC, NewD, QuadTuple<NewA, NewB, NewC, NewD>> andGroupBiWithCollectBi(
-            QuadFunction<A, B, C, D, NewA> groupKeyAMapping,
-            QuadFunction<A, B, C, D, NewB> groupKeyBMapping, QuadConstraintCollector<A, B, C, D, ?, NewC> collectorC,
-            QuadConstraintCollector<A, B, C, D, ?, NewD> collectorD) {
+    public <NewA, NewB, NewC, NewD> DroolsQuadCondition<NewA, NewB, NewC, NewD, QuadTuple<NewA, NewB, NewC, NewD>>
+            andGroupBiWithCollectBi(QuadFunction<A, B, C, D, NewA> groupKeyAMapping,
+                    QuadFunction<A, B, C, D, NewB> groupKeyBMapping, QuadConstraintCollector<A, B, C, D, ?, NewC> collectorC,
+                    QuadConstraintCollector<A, B, C, D, ?, NewD> collectorD) {
         return groupBiWithCollectBi(() -> new DroolsQuadGroupByAccumulator<>(groupKeyAMapping, groupKeyBMapping,
                 collectorC, collectorD, getRuleStructure().getA(), getRuleStructure().getB(), getRuleStructure().getC(),
                 getRuleStructure().getD()));

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/tri/DroolsAbstractTriConstraintStream.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/tri/DroolsAbstractTriConstraintStream.java
@@ -158,22 +158,22 @@ public abstract class DroolsAbstractTriConstraintStream<Solution_, A, B, C>
     public <GroupKeyA_, GroupKeyB_, ResultContainer_, Result_> TriConstraintStream<GroupKeyA_, GroupKeyB_, Result_> groupBy(
             TriFunction<A, B, C, GroupKeyA_> groupKeyAMapping, TriFunction<A, B, C, GroupKeyB_> groupKeyBMapping,
             TriConstraintCollector<A, B, C, ResultContainer_, Result_> collector) {
-        DroolsGroupingTriConstraintStream<Solution_, GroupKeyA_, GroupKeyB_, Result_> stream = new DroolsGroupingTriConstraintStream<>(
-                constraintFactory, this, groupKeyAMapping,
-                groupKeyBMapping, collector);
+        DroolsGroupingTriConstraintStream<Solution_, GroupKeyA_, GroupKeyB_, Result_> stream =
+                new DroolsGroupingTriConstraintStream<>(constraintFactory, this, groupKeyAMapping, groupKeyBMapping, collector);
         addChildStream(stream);
         return stream;
     }
 
     @Override
-    public <GroupKeyA_, GroupKeyB_, ResultContainerC_, ResultC_, ResultContainerD_, ResultD_> QuadConstraintStream<GroupKeyA_, GroupKeyB_, ResultC_, ResultD_> groupBy(
-            TriFunction<A, B, C, GroupKeyA_> groupKeyAMapping,
-            TriFunction<A, B, C, GroupKeyB_> groupKeyBMapping,
-            TriConstraintCollector<A, B, C, ResultContainerC_, ResultC_> collectorC,
-            TriConstraintCollector<A, B, C, ResultContainerD_, ResultD_> collectorD) {
-        DroolsGroupingQuadConstraintStream<Solution_, GroupKeyA_, GroupKeyB_, ResultC_, ResultD_> stream = new DroolsGroupingQuadConstraintStream<>(
-                constraintFactory, this, groupKeyAMapping,
-                groupKeyBMapping, collectorC, collectorD);
+    public <GroupKeyA_, GroupKeyB_, ResultContainerC_, ResultC_, ResultContainerD_, ResultD_>
+            QuadConstraintStream<GroupKeyA_, GroupKeyB_, ResultC_, ResultD_> groupBy(
+                    TriFunction<A, B, C, GroupKeyA_> groupKeyAMapping,
+                    TriFunction<A, B, C, GroupKeyB_> groupKeyBMapping,
+                    TriConstraintCollector<A, B, C, ResultContainerC_, ResultC_> collectorC,
+                    TriConstraintCollector<A, B, C, ResultContainerD_, ResultD_> collectorD) {
+        DroolsGroupingQuadConstraintStream<Solution_, GroupKeyA_, GroupKeyB_, ResultC_, ResultD_> stream =
+                new DroolsGroupingQuadConstraintStream<>(constraintFactory, this, groupKeyAMapping, groupKeyBMapping,
+                        collectorC, collectorD);
         addChildStream(stream);
         return stream;
     }
@@ -261,7 +261,8 @@ public abstract class DroolsAbstractTriConstraintStream<Solution_, A, B, C>
     @Override
     public List<DroolsFromUniConstraintStream<Solution_, Object>> getFromStreamList() {
         if (parent == null) {
-            DroolsJoinTriConstraintStream<Solution_, A, B, C> joinStream = (DroolsJoinTriConstraintStream<Solution_, A, B, C>) this;
+            DroolsJoinTriConstraintStream<Solution_, A, B, C> joinStream =
+                    (DroolsJoinTriConstraintStream<Solution_, A, B, C>) this;
             List<DroolsFromUniConstraintStream<Solution_, Object>> leftParentFromStreamList = joinStream.getLeftParentStream()
                     .getFromStreamList();
             List<DroolsFromUniConstraintStream<Solution_, Object>> rightParentFromStreamList = joinStream.getRightParentStream()

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/tri/DroolsScoringTriConstraintStream.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/tri/DroolsScoringTriConstraintStream.java
@@ -84,7 +84,8 @@ public final class DroolsScoringTriConstraintStream<Solution_, A, B, C>
     @Override
     public List<RuleItemBuilder<?>> createRuleItemBuilders(DroolsConstraint<?> constraint,
             Global<? extends AbstractScoreHolder<?>> scoreHolderGlobal) {
-        DroolsAbstractTriConstraintStream<Solution_, A, B, C> actualParent = (DroolsAbstractTriConstraintStream<Solution_, A, B, C>) parent;
+        DroolsAbstractTriConstraintStream<Solution_, A, B, C> actualParent =
+                (DroolsAbstractTriConstraintStream<Solution_, A, B, C>) parent;
         DroolsTriCondition<A, B, C, ?> condition = actualParent.getCondition();
         if (intMatchWeigher != null) {
             return condition.completeWithScoring(constraint, scoreHolderGlobal, intMatchWeigher);

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/tri/DroolsTriCondition.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/tri/DroolsTriCondition.java
@@ -88,8 +88,8 @@ public final class DroolsTriCondition<A, B, C, PatternVar>
                 cVariable, newTargetPattern,
                 actualStructure.getShelvedRuleItems(), actualStructure.getPrerequisites(),
                 actualStructure.getDependents(), actualStructure.getVariableIdSupplier());
-        ImmediatelyPreviousFilter<TriPredicate<A, B, C>> newPreviousFilter = new ImmediatelyPreviousFilter<TriPredicate<A, B, C>>(
-                actualStructure, actualPredicate);
+        ImmediatelyPreviousFilter<TriPredicate<A, B, C>> newPreviousFilter =
+                new ImmediatelyPreviousFilter<TriPredicate<A, B, C>>(actualStructure, actualPredicate);
         // Carry forward the information for filter merging.
         return new DroolsTriCondition<>(newRuleStructure, newPreviousFilter);
     }
@@ -218,9 +218,9 @@ public final class DroolsTriCondition<A, B, C, PatternVar>
                 getRuleStructure().getA(), getRuleStructure().getB(), getRuleStructure().getC()));
     }
 
-    public <NewA, NewB, NewC, NewD> DroolsQuadCondition<NewA, NewB, NewC, NewD, QuadTuple<NewA, NewB, NewC, NewD>> andGroupBiWithCollectBi(
-            TriFunction<A, B, C, NewA> groupKeyAMapping, TriFunction<A, B, C, NewB> groupKeyBMapping,
-            TriConstraintCollector<A, B, C, ?, NewC> collectorC, TriConstraintCollector<A, B, C, ?, NewD> collectorD) {
+    public <NewA, NewB, NewC, NewD> DroolsQuadCondition<NewA, NewB, NewC, NewD, QuadTuple<NewA, NewB, NewC, NewD>>
+            andGroupBiWithCollectBi(TriFunction<A, B, C, NewA> groupKeyAMapping, TriFunction<A, B, C, NewB> groupKeyBMapping,
+                    TriConstraintCollector<A, B, C, ?, NewC> collectorC, TriConstraintCollector<A, B, C, ?, NewD> collectorD) {
         return groupBiWithCollectBi(() -> new DroolsTriToQuadGroupByAccumulator<>(groupKeyAMapping, groupKeyBMapping,
                 collectorC, collectorD, getRuleStructure().getA(), getRuleStructure().getB(),
                 getRuleStructure().getC()));

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/uni/DroolsAbstractUniConstraintStream.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/uni/DroolsAbstractUniConstraintStream.java
@@ -75,7 +75,8 @@ public abstract class DroolsAbstractUniConstraintStream<Solution_, A> extends Dr
             return join(otherStream)
                     .filter(((FilteringBiJoiner<A, B>) joiner).getFilter());
         }
-        DroolsAbstractUniConstraintStream<Solution_, B> castOtherStream = (DroolsAbstractUniConstraintStream<Solution_, B>) otherStream;
+        DroolsAbstractUniConstraintStream<Solution_, B> castOtherStream =
+                (DroolsAbstractUniConstraintStream<Solution_, B>) otherStream;
         DroolsAbstractBiConstraintStream<Solution_, A, B> stream = new DroolsJoinBiConstraintStream<>(constraintFactory,
                 this, castOtherStream, joiner);
         addChildStream(stream);
@@ -152,21 +153,21 @@ public abstract class DroolsAbstractUniConstraintStream<Solution_, A> extends Dr
     public <GroupKeyA_, GroupKeyB_, ResultContainer_, Result_> TriConstraintStream<GroupKeyA_, GroupKeyB_, Result_> groupBy(
             Function<A, GroupKeyA_> groupKeyAMapping,
             Function<A, GroupKeyB_> groupKeyBMapping, UniConstraintCollector<A, ResultContainer_, Result_> collector) {
-        DroolsGroupingTriConstraintStream<Solution_, GroupKeyA_, GroupKeyB_, Result_> stream = new DroolsGroupingTriConstraintStream<>(
-                constraintFactory, this, groupKeyAMapping, groupKeyBMapping,
-                collector);
+        DroolsGroupingTriConstraintStream<Solution_, GroupKeyA_, GroupKeyB_, Result_> stream =
+                new DroolsGroupingTriConstraintStream<>(constraintFactory, this, groupKeyAMapping, groupKeyBMapping, collector);
         addChildStream(stream);
         return stream;
     }
 
     @Override
-    public <GroupKeyA_, GroupKeyB_, ResultContainerC_, ResultC_, ResultContainerD_, ResultD_> QuadConstraintStream<GroupKeyA_, GroupKeyB_, ResultC_, ResultD_> groupBy(
-            Function<A, GroupKeyA_> groupKeyAMapping,
-            Function<A, GroupKeyB_> groupKeyBMapping, UniConstraintCollector<A, ResultContainerC_, ResultC_> collectorC,
-            UniConstraintCollector<A, ResultContainerD_, ResultD_> collectorD) {
-        DroolsGroupingQuadConstraintStream<Solution_, GroupKeyA_, GroupKeyB_, ResultC_, ResultD_> stream = new DroolsGroupingQuadConstraintStream<>(
-                constraintFactory, this, groupKeyAMapping, groupKeyBMapping,
-                collectorC, collectorD);
+    public <GroupKeyA_, GroupKeyB_, ResultContainerC_, ResultC_, ResultContainerD_, ResultD_>
+            QuadConstraintStream<GroupKeyA_, GroupKeyB_, ResultC_, ResultD_> groupBy(
+                    Function<A, GroupKeyA_> groupKeyAMapping,
+                    Function<A, GroupKeyB_> groupKeyBMapping, UniConstraintCollector<A, ResultContainerC_, ResultC_> collectorC,
+                    UniConstraintCollector<A, ResultContainerD_, ResultD_> collectorD) {
+        DroolsGroupingQuadConstraintStream<Solution_, GroupKeyA_, GroupKeyB_, ResultC_, ResultD_> stream =
+                new DroolsGroupingQuadConstraintStream<>(constraintFactory, this, groupKeyAMapping, groupKeyBMapping,
+                        collectorC, collectorD);
         addChildStream(stream);
         return stream;
     }

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/uni/DroolsUniCondition.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/uni/DroolsUniCondition.java
@@ -170,9 +170,9 @@ public final class DroolsUniCondition<A, PatternVar>
                 collector, getRuleStructure().getA()));
     }
 
-    private <InTuple, OutPatternVar, R extends DroolsRuleStructure<OutPatternVar>, C extends DroolsCondition<OutPatternVar, R>> C universalGroup(
-            BiFunction<PatternDef<PatternVar>, Variable<InTuple>, PatternDef<PatternVar>> bindFunction,
-            Mutator<InTuple, OutPatternVar, R, C> mutator) {
+    private <InTuple, OutPatternVar, R extends DroolsRuleStructure<OutPatternVar>, C extends DroolsCondition<OutPatternVar, R>>
+            C universalGroup(BiFunction<PatternDef<PatternVar>, Variable<InTuple>, PatternDef<PatternVar>> bindFunction,
+                    Mutator<InTuple, OutPatternVar, R, C> mutator) {
         Variable<InTuple> mappedVariable = ruleStructure.createVariable("biMapped");
         PatternDSL.PatternDef<PatternVar> mainAccumulatePattern = ruleStructure.getPrimaryPatternBuilder()
                 .expand(p -> bindFunction.apply(p, mappedVariable))
@@ -188,9 +188,9 @@ public final class DroolsUniCondition<A, PatternVar>
         return mutator.apply(tupleCollection, pattern, accumulate);
     }
 
-    public <NewA, NewB, NewC, NewD> DroolsQuadCondition<NewA, NewB, NewC, NewD, QuadTuple<NewA, NewB, NewC, NewD>> andGroupBiWithCollectBi(
-            Function<A, NewA> groupKeyAMapping, Function<A, NewB> groupKeyBMapping,
-            UniConstraintCollector<A, ?, NewC> collectorC, UniConstraintCollector<A, ?, NewD> collectorD) {
+    public <NewA, NewB, NewC, NewD> DroolsQuadCondition<NewA, NewB, NewC, NewD, QuadTuple<NewA, NewB, NewC, NewD>>
+            andGroupBiWithCollectBi(Function<A, NewA> groupKeyAMapping, Function<A, NewB> groupKeyBMapping,
+                    UniConstraintCollector<A, ?, NewC> collectorC, UniConstraintCollector<A, ?, NewD> collectorD) {
         return groupBiWithCollectBi(() -> new DroolsUniToQuadGroupByAccumulator<>(groupKeyAMapping, groupKeyBMapping,
                 collectorC, collectorD, getRuleStructure().getA()));
     }

--- a/optaplanner-core/src/test/java/org/optaplanner/core/api/score/stream/ConstraintCollectorsTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/api/score/stream/ConstraintCollectorsTest.java
@@ -2236,8 +2236,8 @@ public class ConstraintCollectorsTest {
 
     @Test
     public void toMapQuad() {
-        QuadConstraintCollector<Integer, Integer, Integer, Integer, ?, Map<Integer, Set<Integer>>> collector = ConstraintCollectors
-                .toMap((a, b, c, d) -> a + b + c + d, (a, b, c, d) -> a + b + c + d);
+        QuadConstraintCollector<Integer, Integer, Integer, Integer, ?, Map<Integer, Set<Integer>>> collector =
+                ConstraintCollectors.toMap((a, b, c, d) -> a + b + c + d, (a, b, c, d) -> a + b + c + d);
         Object container = collector.supplier().get();
 
         assertResult(collector, container, emptyMap());
@@ -2468,8 +2468,8 @@ public class ConstraintCollectorsTest {
 
     @Test
     public void toSortedMapQuad() {
-        QuadConstraintCollector<Integer, Integer, Integer, Integer, ?, SortedMap<Integer, Set<Integer>>> collector = ConstraintCollectors
-                .toSortedMap((a, b, c, d) -> a + b + c + d, (a, b, c, d) -> a + b + c + d);
+        QuadConstraintCollector<Integer, Integer, Integer, Integer, ?, SortedMap<Integer, Set<Integer>>> collector =
+                ConstraintCollectors.toSortedMap((a, b, c, d) -> a + b + c + d, (a, b, c, d) -> a + b + c + d);
         Object container = collector.supplier().get();
 
         assertResult(collector, container, emptySortedMap());
@@ -2497,8 +2497,8 @@ public class ConstraintCollectorsTest {
 
     @Test
     public void toSortedMapQuadMerged() {
-        QuadConstraintCollector<Integer, Integer, Integer, Integer, ?, SortedMap<Integer, Integer>> collector = ConstraintCollectors
-                .toSortedMap((a, b, c, d) -> a + b + c + d, (a, b, c, d) -> a + b + c + d, Integer::sum);
+        QuadConstraintCollector<Integer, Integer, Integer, Integer, ?, SortedMap<Integer, Integer>> collector =
+                ConstraintCollectors.toSortedMap((a, b, c, d) -> a + b + c + d, (a, b, c, d) -> a + b + c + d, Integer::sum);
         Object container = collector.supplier().get();
 
         assertResult(collector, container, emptySortedMap());

--- a/optaplanner-core/src/test/java/org/optaplanner/core/api/score/stream/JoinersTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/api/score/stream/JoinersTest.java
@@ -54,8 +54,8 @@ public class JoinersTest {
     public void equalTri() {
         BiFunction<BigInteger, BigInteger, Long> leftMapping = (a, b) -> a.add(b).longValue();
         Function<BigDecimal, Long> rightMapping = BigDecimal::longValue;
-        AbstractTriJoiner<BigInteger, BigInteger, BigDecimal> joiner = (AbstractTriJoiner<BigInteger, BigInteger, BigDecimal>) Joiners
-                .equal(leftMapping, rightMapping);
+        AbstractTriJoiner<BigInteger, BigInteger, BigDecimal> joiner =
+                (AbstractTriJoiner<BigInteger, BigInteger, BigDecimal>) Joiners.equal(leftMapping, rightMapping);
         assertSoftly(softly -> {
             softly.assertThat(joiner.matches(TEN, ZERO, BigDecimal.TEN)).isTrue();
             softly.assertThat(joiner.matches(ONE, ZERO, BigDecimal.ZERO)).isFalse();
@@ -68,8 +68,8 @@ public class JoinersTest {
     public void equalQuad() {
         TriFunction<BigInteger, BigInteger, BigInteger, Long> leftMapping = (a, b, c) -> a.add(b).add(c).longValue();
         Function<BigDecimal, Long> rightMapping = BigDecimal::longValue;
-        AbstractQuadJoiner<BigInteger, BigInteger, BigInteger, BigDecimal> joiner = (AbstractQuadJoiner<BigInteger, BigInteger, BigInteger, BigDecimal>) Joiners
-                .equal(leftMapping, rightMapping);
+        AbstractQuadJoiner<BigInteger, BigInteger, BigInteger, BigDecimal> joiner =
+                (AbstractQuadJoiner<BigInteger, BigInteger, BigInteger, BigDecimal>) Joiners.equal(leftMapping, rightMapping);
         assertSoftly(softly -> {
             softly.assertThat(joiner.matches(TEN, ZERO, ZERO, BigDecimal.TEN)).isTrue();
             softly.assertThat(joiner.matches(ONE, ZERO, ZERO, BigDecimal.ZERO)).isFalse();
@@ -83,8 +83,9 @@ public class JoinersTest {
         QuadFunction<BigInteger, BigInteger, BigInteger, BigInteger, Long> leftMapping = (a, b, c, d) -> a.add(b).add(c).add(d)
                 .longValue();
         Function<BigDecimal, Long> rightMapping = BigDecimal::longValue;
-        AbstractPentaJoiner<BigInteger, BigInteger, BigInteger, BigInteger, BigDecimal> joiner = (AbstractPentaJoiner<BigInteger, BigInteger, BigInteger, BigInteger, BigDecimal>) Joiners
-                .equal(leftMapping, rightMapping);
+        AbstractPentaJoiner<BigInteger, BigInteger, BigInteger, BigInteger, BigDecimal> joiner =
+                (AbstractPentaJoiner<BigInteger, BigInteger, BigInteger, BigInteger, BigDecimal>) Joiners
+                        .equal(leftMapping, rightMapping);
         assertSoftly(softly -> {
             softly.assertThat(joiner.matches(TEN, ZERO, ZERO, ZERO, BigDecimal.TEN)).isTrue();
             softly.assertThat(joiner.matches(ONE, ZERO, ZERO, ZERO, BigDecimal.ZERO)).isFalse();
@@ -112,8 +113,8 @@ public class JoinersTest {
     public void lessThanTri() {
         BiFunction<BigInteger, BigInteger, Long> leftMapping = (a, b) -> a.add(b).longValue();
         Function<BigDecimal, Long> rightMapping = BigDecimal::longValue;
-        AbstractTriJoiner<BigInteger, BigInteger, BigDecimal> joiner = (AbstractTriJoiner<BigInteger, BigInteger, BigDecimal>) Joiners
-                .lessThan(leftMapping, rightMapping);
+        AbstractTriJoiner<BigInteger, BigInteger, BigDecimal> joiner =
+                (AbstractTriJoiner<BigInteger, BigInteger, BigDecimal>) Joiners.lessThan(leftMapping, rightMapping);
         assertSoftly(softly -> {
             softly.assertThat(joiner.matches(TEN, ZERO, BigDecimal.TEN)).isFalse();
             softly.assertThat(joiner.matches(TEN, ZERO, BigDecimal.ONE)).isFalse();
@@ -127,8 +128,9 @@ public class JoinersTest {
     public void lessThanQuad() {
         TriFunction<BigInteger, BigInteger, BigInteger, Long> leftMapping = (a, b, c) -> a.add(b).add(c).longValue();
         Function<BigDecimal, Long> rightMapping = BigDecimal::longValue;
-        AbstractQuadJoiner<BigInteger, BigInteger, BigInteger, BigDecimal> joiner = (AbstractQuadJoiner<BigInteger, BigInteger, BigInteger, BigDecimal>) Joiners
-                .lessThan(leftMapping, rightMapping);
+        AbstractQuadJoiner<BigInteger, BigInteger, BigInteger, BigDecimal> joiner =
+                (AbstractQuadJoiner<BigInteger, BigInteger, BigInteger, BigDecimal>) Joiners
+                        .lessThan(leftMapping, rightMapping);
         assertSoftly(softly -> {
             softly.assertThat(joiner.matches(TEN, ZERO, ZERO, BigDecimal.TEN)).isFalse();
             softly.assertThat(joiner.matches(TEN, ZERO, ZERO, BigDecimal.ONE)).isFalse();
@@ -143,8 +145,9 @@ public class JoinersTest {
         QuadFunction<BigInteger, BigInteger, BigInteger, BigInteger, Long> leftMapping = (a, b, c, d) -> a.add(b).add(c).add(d)
                 .longValue();
         Function<BigDecimal, Long> rightMapping = BigDecimal::longValue;
-        AbstractPentaJoiner<BigInteger, BigInteger, BigInteger, BigInteger, BigDecimal> joiner = (AbstractPentaJoiner<BigInteger, BigInteger, BigInteger, BigInteger, BigDecimal>) Joiners
-                .lessThan(leftMapping, rightMapping);
+        AbstractPentaJoiner<BigInteger, BigInteger, BigInteger, BigInteger, BigDecimal> joiner =
+                (AbstractPentaJoiner<BigInteger, BigInteger, BigInteger, BigInteger, BigDecimal>) Joiners
+                        .lessThan(leftMapping, rightMapping);
         assertSoftly(softly -> {
             softly.assertThat(joiner.matches(TEN, ZERO, ZERO, ZERO, BigDecimal.TEN)).isFalse();
             softly.assertThat(joiner.matches(TEN, ZERO, ZERO, ZERO, BigDecimal.ONE)).isFalse();
@@ -173,8 +176,8 @@ public class JoinersTest {
     public void lessThanOrEqualTri() {
         BiFunction<BigInteger, BigInteger, Long> leftMapping = (a, b) -> a.add(b).longValue();
         Function<BigDecimal, Long> rightMapping = BigDecimal::longValue;
-        AbstractTriJoiner<BigInteger, BigInteger, BigDecimal> joiner = (AbstractTriJoiner<BigInteger, BigInteger, BigDecimal>) Joiners
-                .lessThanOrEqual(leftMapping, rightMapping);
+        AbstractTriJoiner<BigInteger, BigInteger, BigDecimal> joiner =
+                (AbstractTriJoiner<BigInteger, BigInteger, BigDecimal>) Joiners.lessThanOrEqual(leftMapping, rightMapping);
         assertSoftly(softly -> {
             softly.assertThat(joiner.matches(TEN, ZERO, BigDecimal.TEN)).isTrue();
             softly.assertThat(joiner.matches(TEN, ZERO, BigDecimal.ONE)).isFalse();
@@ -188,8 +191,9 @@ public class JoinersTest {
     public void lessThanOrEqualQuad() {
         TriFunction<BigInteger, BigInteger, BigInteger, Long> leftMapping = (a, b, c) -> a.add(b).add(c).longValue();
         Function<BigDecimal, Long> rightMapping = BigDecimal::longValue;
-        AbstractQuadJoiner<BigInteger, BigInteger, BigInteger, BigDecimal> joiner = (AbstractQuadJoiner<BigInteger, BigInteger, BigInteger, BigDecimal>) Joiners
-                .lessThanOrEqual(leftMapping, rightMapping);
+        AbstractQuadJoiner<BigInteger, BigInteger, BigInteger, BigDecimal> joiner =
+                (AbstractQuadJoiner<BigInteger, BigInteger, BigInteger, BigDecimal>) Joiners
+                        .lessThanOrEqual(leftMapping, rightMapping);
         assertSoftly(softly -> {
             softly.assertThat(joiner.matches(TEN, ZERO, ZERO, BigDecimal.TEN)).isTrue();
             softly.assertThat(joiner.matches(TEN, ZERO, ZERO, BigDecimal.ONE)).isFalse();
@@ -204,8 +208,9 @@ public class JoinersTest {
         QuadFunction<BigInteger, BigInteger, BigInteger, BigInteger, Long> leftMapping = (a, b, c, d) -> a.add(b).add(c).add(d)
                 .longValue();
         Function<BigDecimal, Long> rightMapping = BigDecimal::longValue;
-        AbstractPentaJoiner<BigInteger, BigInteger, BigInteger, BigInteger, BigDecimal> joiner = (AbstractPentaJoiner<BigInteger, BigInteger, BigInteger, BigInteger, BigDecimal>) Joiners
-                .lessThanOrEqual(leftMapping, rightMapping);
+        AbstractPentaJoiner<BigInteger, BigInteger, BigInteger, BigInteger, BigDecimal> joiner =
+                (AbstractPentaJoiner<BigInteger, BigInteger, BigInteger, BigInteger, BigDecimal>) Joiners
+                        .lessThanOrEqual(leftMapping, rightMapping);
         assertSoftly(softly -> {
             softly.assertThat(joiner.matches(TEN, ZERO, ZERO, ZERO, BigDecimal.TEN)).isTrue();
             softly.assertThat(joiner.matches(TEN, ZERO, ZERO, ZERO, BigDecimal.ONE)).isFalse();
@@ -234,8 +239,8 @@ public class JoinersTest {
     public void greaterThanTri() {
         BiFunction<BigInteger, BigInteger, Long> leftMapping = (a, b) -> a.add(b).longValue();
         Function<BigDecimal, Long> rightMapping = BigDecimal::longValue;
-        AbstractTriJoiner<BigInteger, BigInteger, BigDecimal> joiner = (AbstractTriJoiner<BigInteger, BigInteger, BigDecimal>) Joiners
-                .greaterThan(leftMapping, rightMapping);
+        AbstractTriJoiner<BigInteger, BigInteger, BigDecimal> joiner =
+                (AbstractTriJoiner<BigInteger, BigInteger, BigDecimal>) Joiners.greaterThan(leftMapping, rightMapping);
         assertSoftly(softly -> {
             softly.assertThat(joiner.matches(TEN, ZERO, BigDecimal.TEN)).isFalse();
             softly.assertThat(joiner.matches(TEN, ZERO, BigDecimal.ONE)).isTrue();
@@ -249,8 +254,9 @@ public class JoinersTest {
     public void greaterThanQuad() {
         TriFunction<BigInteger, BigInteger, BigInteger, Long> leftMapping = (a, b, c) -> a.add(b).add(c).longValue();
         Function<BigDecimal, Long> rightMapping = BigDecimal::longValue;
-        AbstractQuadJoiner<BigInteger, BigInteger, BigInteger, BigDecimal> joiner = (AbstractQuadJoiner<BigInteger, BigInteger, BigInteger, BigDecimal>) Joiners
-                .greaterThan(leftMapping, rightMapping);
+        AbstractQuadJoiner<BigInteger, BigInteger, BigInteger, BigDecimal> joiner =
+                (AbstractQuadJoiner<BigInteger, BigInteger, BigInteger, BigDecimal>) Joiners
+                        .greaterThan(leftMapping, rightMapping);
         assertSoftly(softly -> {
             softly.assertThat(joiner.matches(TEN, ZERO, ZERO, BigDecimal.TEN)).isFalse();
             softly.assertThat(joiner.matches(TEN, ZERO, ZERO, BigDecimal.ONE)).isTrue();
@@ -265,8 +271,9 @@ public class JoinersTest {
         QuadFunction<BigInteger, BigInteger, BigInteger, BigInteger, Long> leftMapping = (a, b, c, d) -> a.add(b).add(c).add(d)
                 .longValue();
         Function<BigDecimal, Long> rightMapping = BigDecimal::longValue;
-        AbstractPentaJoiner<BigInteger, BigInteger, BigInteger, BigInteger, BigDecimal> joiner = (AbstractPentaJoiner<BigInteger, BigInteger, BigInteger, BigInteger, BigDecimal>) Joiners
-                .greaterThan(leftMapping, rightMapping);
+        AbstractPentaJoiner<BigInteger, BigInteger, BigInteger, BigInteger, BigDecimal> joiner =
+                (AbstractPentaJoiner<BigInteger, BigInteger, BigInteger, BigInteger, BigDecimal>) Joiners
+                        .greaterThan(leftMapping, rightMapping);
         assertSoftly(softly -> {
             softly.assertThat(joiner.matches(TEN, ZERO, ZERO, ZERO, BigDecimal.TEN)).isFalse();
             softly.assertThat(joiner.matches(TEN, ZERO, ZERO, ZERO, BigDecimal.ONE)).isTrue();
@@ -295,8 +302,8 @@ public class JoinersTest {
     public void greaterThanOrEqualTri() {
         BiFunction<BigInteger, BigInteger, Long> leftMapping = (a, b) -> a.add(b).longValue();
         Function<BigDecimal, Long> rightMapping = BigDecimal::longValue;
-        AbstractTriJoiner<BigInteger, BigInteger, BigDecimal> joiner = (AbstractTriJoiner<BigInteger, BigInteger, BigDecimal>) Joiners
-                .greaterThanOrEqual(leftMapping, rightMapping);
+        AbstractTriJoiner<BigInteger, BigInteger, BigDecimal> joiner =
+                (AbstractTriJoiner<BigInteger, BigInteger, BigDecimal>) Joiners.greaterThanOrEqual(leftMapping, rightMapping);
         assertSoftly(softly -> {
             softly.assertThat(joiner.matches(TEN, ZERO, BigDecimal.TEN)).isTrue();
             softly.assertThat(joiner.matches(TEN, ZERO, BigDecimal.ONE)).isTrue();
@@ -310,8 +317,9 @@ public class JoinersTest {
     public void greaterThanOrEqualQuad() {
         TriFunction<BigInteger, BigInteger, BigInteger, Long> leftMapping = (a, b, c) -> a.add(b).add(c).longValue();
         Function<BigDecimal, Long> rightMapping = BigDecimal::longValue;
-        AbstractQuadJoiner<BigInteger, BigInteger, BigInteger, BigDecimal> joiner = (AbstractQuadJoiner<BigInteger, BigInteger, BigInteger, BigDecimal>) Joiners
-                .greaterThanOrEqual(leftMapping, rightMapping);
+        AbstractQuadJoiner<BigInteger, BigInteger, BigInteger, BigDecimal> joiner =
+                (AbstractQuadJoiner<BigInteger, BigInteger, BigInteger, BigDecimal>) Joiners
+                        .greaterThanOrEqual(leftMapping, rightMapping);
         assertSoftly(softly -> {
             softly.assertThat(joiner.matches(TEN, ZERO, ZERO, BigDecimal.TEN)).isTrue();
             softly.assertThat(joiner.matches(TEN, ZERO, ZERO, BigDecimal.ONE)).isTrue();
@@ -326,8 +334,9 @@ public class JoinersTest {
         QuadFunction<BigInteger, BigInteger, BigInteger, BigInteger, Long> leftMapping = (a, b, c, d) -> a.add(b).add(c).add(d)
                 .longValue();
         Function<BigDecimal, Long> rightMapping = BigDecimal::longValue;
-        AbstractPentaJoiner<BigInteger, BigInteger, BigInteger, BigInteger, BigDecimal> joiner = (AbstractPentaJoiner<BigInteger, BigInteger, BigInteger, BigInteger, BigDecimal>) Joiners
-                .greaterThanOrEqual(leftMapping, rightMapping);
+        AbstractPentaJoiner<BigInteger, BigInteger, BigInteger, BigInteger, BigDecimal> joiner =
+                (AbstractPentaJoiner<BigInteger, BigInteger, BigInteger, BigInteger, BigDecimal>) Joiners
+                        .greaterThanOrEqual(leftMapping, rightMapping);
         assertSoftly(softly -> {
             softly.assertThat(joiner.matches(TEN, ZERO, ZERO, ZERO, BigDecimal.TEN)).isTrue();
             softly.assertThat(joiner.matches(TEN, ZERO, ZERO, ZERO, BigDecimal.ONE)).isTrue();

--- a/optaplanner-core/src/test/java/org/optaplanner/core/api/score/stream/bi/BiConstraintStreamTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/api/score/stream/bi/BiConstraintStreamTest.java
@@ -861,15 +861,16 @@ public class BiConstraintStreamTest extends AbstractConstraintStreamTest {
         TestdataEntity e2 = new TestdataEntity("e2", v1);
         solution.setEntityList(Arrays.asList(e1, e2));
 
-        ConstraintStreamScoreDirectorFactory<TestdataSolution> scoreDirectorFactory = new ConstraintStreamScoreDirectorFactory<>(
-                TestdataSolution.buildSolutionDescriptor(), (factory) -> new Constraint[] {
-                        factory.from(TestdataEntity.class)
-                                .join(TestdataValue.class, equal(TestdataEntity::getValue, Function.identity()))
-                                .penalize("myConstraint1", SimpleScore.ONE),
-                        factory.from(TestdataEntity.class)
-                                .join(TestdataValue.class, equal(TestdataEntity::getValue, Function.identity()))
-                                .penalize("myConstraint2", SimpleScore.ONE, (entity, value) -> 20)
-                }, constraintStreamImplType);
+        ConstraintStreamScoreDirectorFactory<TestdataSolution> scoreDirectorFactory =
+                new ConstraintStreamScoreDirectorFactory<>(
+                        TestdataSolution.buildSolutionDescriptor(), (factory) -> new Constraint[] {
+                                factory.from(TestdataEntity.class)
+                                        .join(TestdataValue.class, equal(TestdataEntity::getValue, Function.identity()))
+                                        .penalize("myConstraint1", SimpleScore.ONE),
+                                factory.from(TestdataEntity.class)
+                                        .join(TestdataValue.class, equal(TestdataEntity::getValue, Function.identity()))
+                                        .penalize("myConstraint2", SimpleScore.ONE, (entity, value) -> 20)
+                        }, constraintStreamImplType);
         InnerScoreDirector<TestdataSolution> scoreDirector = scoreDirectorFactory.buildScoreDirector(false,
                 constraintMatchEnabled);
 
@@ -886,15 +887,16 @@ public class BiConstraintStreamTest extends AbstractConstraintStreamTest {
         TestdataEntity e2 = new TestdataEntity("e2", v1);
         solution.setEntityList(Arrays.asList(e1, e2));
 
-        ConstraintStreamScoreDirectorFactory<TestdataSimpleLongScoreSolution> scoreDirectorFactory = new ConstraintStreamScoreDirectorFactory<>(
-                TestdataSimpleLongScoreSolution.buildSolutionDescriptor(), (factory) -> new Constraint[] {
-                        factory.from(TestdataEntity.class)
-                                .join(TestdataValue.class, equal(TestdataEntity::getValue, Function.identity()))
-                                .penalize("myConstraint1", SimpleLongScore.ONE),
-                        factory.from(TestdataEntity.class)
-                                .join(TestdataValue.class, equal(TestdataEntity::getValue, Function.identity()))
-                                .penalizeLong("myConstraint2", SimpleLongScore.ONE, (entity, value) -> 20L)
-                }, constraintStreamImplType);
+        ConstraintStreamScoreDirectorFactory<TestdataSimpleLongScoreSolution> scoreDirectorFactory =
+                new ConstraintStreamScoreDirectorFactory<>(
+                        TestdataSimpleLongScoreSolution.buildSolutionDescriptor(), (factory) -> new Constraint[] {
+                                factory.from(TestdataEntity.class)
+                                        .join(TestdataValue.class, equal(TestdataEntity::getValue, Function.identity()))
+                                        .penalize("myConstraint1", SimpleLongScore.ONE),
+                                factory.from(TestdataEntity.class)
+                                        .join(TestdataValue.class, equal(TestdataEntity::getValue, Function.identity()))
+                                        .penalizeLong("myConstraint2", SimpleLongScore.ONE, (entity, value) -> 20L)
+                        }, constraintStreamImplType);
         InnerScoreDirector<TestdataSimpleLongScoreSolution> scoreDirector = scoreDirectorFactory.buildScoreDirector(false,
                 constraintMatchEnabled);
 
@@ -911,16 +913,17 @@ public class BiConstraintStreamTest extends AbstractConstraintStreamTest {
         TestdataEntity e2 = new TestdataEntity("e2", v1);
         solution.setEntityList(Arrays.asList(e1, e2));
 
-        ConstraintStreamScoreDirectorFactory<TestdataSimpleBigDecimalScoreSolution> scoreDirectorFactory = new ConstraintStreamScoreDirectorFactory<>(
-                TestdataSimpleBigDecimalScoreSolution.buildSolutionDescriptor(), (factory) -> new Constraint[] {
-                        factory.from(TestdataEntity.class)
-                                .join(TestdataValue.class, equal(TestdataEntity::getValue, Function.identity()))
-                                .penalize("myConstraint1", SimpleBigDecimalScore.ONE),
-                        factory.from(TestdataEntity.class)
-                                .join(TestdataValue.class, equal(TestdataEntity::getValue, Function.identity()))
-                                .penalizeBigDecimal("myConstraint2", SimpleBigDecimalScore.ONE,
-                                        (entity, value) -> new BigDecimal("0.2"))
-                }, constraintStreamImplType);
+        ConstraintStreamScoreDirectorFactory<TestdataSimpleBigDecimalScoreSolution> scoreDirectorFactory =
+                new ConstraintStreamScoreDirectorFactory<>(
+                        TestdataSimpleBigDecimalScoreSolution.buildSolutionDescriptor(), (factory) -> new Constraint[] {
+                                factory.from(TestdataEntity.class)
+                                        .join(TestdataValue.class, equal(TestdataEntity::getValue, Function.identity()))
+                                        .penalize("myConstraint1", SimpleBigDecimalScore.ONE),
+                                factory.from(TestdataEntity.class)
+                                        .join(TestdataValue.class, equal(TestdataEntity::getValue, Function.identity()))
+                                        .penalizeBigDecimal("myConstraint2", SimpleBigDecimalScore.ONE,
+                                                (entity, value) -> new BigDecimal("0.2"))
+                        }, constraintStreamImplType);
         InnerScoreDirector<TestdataSimpleBigDecimalScoreSolution> scoreDirector = scoreDirectorFactory.buildScoreDirector(false,
                 constraintMatchEnabled);
 
@@ -933,13 +936,14 @@ public class BiConstraintStreamTest extends AbstractConstraintStreamTest {
         TestdataLavishSolution solution = TestdataLavishSolution.generateSolution(1, 1, 1, 1);
 
         String constraintName = "myConstraint";
-        ConstraintStreamScoreDirectorFactory<TestdataLavishSolution> scoreDirectorFactory = new ConstraintStreamScoreDirectorFactory<>(
-                TestdataLavishSolution.buildSolutionDescriptor(),
-                (factory) -> new Constraint[] {
-                        factory.from(TestdataLavishEntity.class)
-                                .join(TestdataLavishValue.class)
-                                .penalize(constraintName, SimpleScore.ONE, (entity, value) -> -1)
-                }, constraintStreamImplType);
+        ConstraintStreamScoreDirectorFactory<TestdataLavishSolution> scoreDirectorFactory =
+                new ConstraintStreamScoreDirectorFactory<>(
+                        TestdataLavishSolution.buildSolutionDescriptor(),
+                        (factory) -> new Constraint[] {
+                                factory.from(TestdataLavishEntity.class)
+                                        .join(TestdataLavishValue.class)
+                                        .penalize(constraintName, SimpleScore.ONE, (entity, value) -> -1)
+                        }, constraintStreamImplType);
         InnerScoreDirector<TestdataLavishSolution> scoreDirector = scoreDirectorFactory.buildScoreDirector(false,
                 constraintMatchEnabled);
 
@@ -956,15 +960,16 @@ public class BiConstraintStreamTest extends AbstractConstraintStreamTest {
         TestdataEntity e2 = new TestdataEntity("e2", v1);
         solution.setEntityList(Arrays.asList(e1, e2));
 
-        ConstraintStreamScoreDirectorFactory<TestdataSolution> scoreDirectorFactory = new ConstraintStreamScoreDirectorFactory<>(
-                TestdataSolution.buildSolutionDescriptor(), (factory) -> new Constraint[] {
-                        factory.from(TestdataEntity.class)
-                                .join(TestdataValue.class, equal(TestdataEntity::getValue, Function.identity()))
-                                .reward("myConstraint1", SimpleScore.ONE),
-                        factory.from(TestdataEntity.class)
-                                .join(TestdataValue.class, equal(TestdataEntity::getValue, Function.identity()))
-                                .reward("myConstraint2", SimpleScore.ONE, (entity, value) -> 20)
-                }, constraintStreamImplType);
+        ConstraintStreamScoreDirectorFactory<TestdataSolution> scoreDirectorFactory =
+                new ConstraintStreamScoreDirectorFactory<>(
+                        TestdataSolution.buildSolutionDescriptor(), (factory) -> new Constraint[] {
+                                factory.from(TestdataEntity.class)
+                                        .join(TestdataValue.class, equal(TestdataEntity::getValue, Function.identity()))
+                                        .reward("myConstraint1", SimpleScore.ONE),
+                                factory.from(TestdataEntity.class)
+                                        .join(TestdataValue.class, equal(TestdataEntity::getValue, Function.identity()))
+                                        .reward("myConstraint2", SimpleScore.ONE, (entity, value) -> 20)
+                        }, constraintStreamImplType);
         InnerScoreDirector<TestdataSolution> scoreDirector = scoreDirectorFactory.buildScoreDirector(false,
                 constraintMatchEnabled);
 
@@ -981,15 +986,16 @@ public class BiConstraintStreamTest extends AbstractConstraintStreamTest {
         TestdataEntity e2 = new TestdataEntity("e2", v1);
         solution.setEntityList(Arrays.asList(e1, e2));
 
-        ConstraintStreamScoreDirectorFactory<TestdataSimpleLongScoreSolution> scoreDirectorFactory = new ConstraintStreamScoreDirectorFactory<>(
-                TestdataSimpleLongScoreSolution.buildSolutionDescriptor(), (factory) -> new Constraint[] {
-                        factory.from(TestdataEntity.class)
-                                .join(TestdataValue.class, equal(TestdataEntity::getValue, Function.identity()))
-                                .reward("myConstraint1", SimpleLongScore.ONE),
-                        factory.from(TestdataEntity.class)
-                                .join(TestdataValue.class, equal(TestdataEntity::getValue, Function.identity()))
-                                .rewardLong("myConstraint2", SimpleLongScore.ONE, (entity, value) -> 20L)
-                }, constraintStreamImplType);
+        ConstraintStreamScoreDirectorFactory<TestdataSimpleLongScoreSolution> scoreDirectorFactory =
+                new ConstraintStreamScoreDirectorFactory<>(
+                        TestdataSimpleLongScoreSolution.buildSolutionDescriptor(), (factory) -> new Constraint[] {
+                                factory.from(TestdataEntity.class)
+                                        .join(TestdataValue.class, equal(TestdataEntity::getValue, Function.identity()))
+                                        .reward("myConstraint1", SimpleLongScore.ONE),
+                                factory.from(TestdataEntity.class)
+                                        .join(TestdataValue.class, equal(TestdataEntity::getValue, Function.identity()))
+                                        .rewardLong("myConstraint2", SimpleLongScore.ONE, (entity, value) -> 20L)
+                        }, constraintStreamImplType);
         InnerScoreDirector<TestdataSimpleLongScoreSolution> scoreDirector = scoreDirectorFactory.buildScoreDirector(false,
                 constraintMatchEnabled);
 
@@ -1006,16 +1012,17 @@ public class BiConstraintStreamTest extends AbstractConstraintStreamTest {
         TestdataEntity e2 = new TestdataEntity("e2", v1);
         solution.setEntityList(Arrays.asList(e1, e2));
 
-        ConstraintStreamScoreDirectorFactory<TestdataSimpleBigDecimalScoreSolution> scoreDirectorFactory = new ConstraintStreamScoreDirectorFactory<>(
-                TestdataSimpleBigDecimalScoreSolution.buildSolutionDescriptor(), (factory) -> new Constraint[] {
-                        factory.from(TestdataEntity.class)
-                                .join(TestdataValue.class, equal(TestdataEntity::getValue, Function.identity()))
-                                .reward("myConstraint1", SimpleBigDecimalScore.ONE),
-                        factory.from(TestdataEntity.class)
-                                .join(TestdataValue.class, equal(TestdataEntity::getValue, Function.identity()))
-                                .rewardBigDecimal("myConstraint2", SimpleBigDecimalScore.ONE,
-                                        (entity, value) -> new BigDecimal("0.2"))
-                }, constraintStreamImplType);
+        ConstraintStreamScoreDirectorFactory<TestdataSimpleBigDecimalScoreSolution> scoreDirectorFactory =
+                new ConstraintStreamScoreDirectorFactory<>(
+                        TestdataSimpleBigDecimalScoreSolution.buildSolutionDescriptor(), (factory) -> new Constraint[] {
+                                factory.from(TestdataEntity.class)
+                                        .join(TestdataValue.class, equal(TestdataEntity::getValue, Function.identity()))
+                                        .reward("myConstraint1", SimpleBigDecimalScore.ONE),
+                                factory.from(TestdataEntity.class)
+                                        .join(TestdataValue.class, equal(TestdataEntity::getValue, Function.identity()))
+                                        .rewardBigDecimal("myConstraint2", SimpleBigDecimalScore.ONE,
+                                                (entity, value) -> new BigDecimal("0.2"))
+                        }, constraintStreamImplType);
         InnerScoreDirector<TestdataSimpleBigDecimalScoreSolution> scoreDirector = scoreDirectorFactory.buildScoreDirector(false,
                 constraintMatchEnabled);
 
@@ -1028,13 +1035,14 @@ public class BiConstraintStreamTest extends AbstractConstraintStreamTest {
         TestdataLavishSolution solution = TestdataLavishSolution.generateSolution(1, 1, 1, 1);
 
         String constraintName = "myConstraint";
-        ConstraintStreamScoreDirectorFactory<TestdataLavishSolution> scoreDirectorFactory = new ConstraintStreamScoreDirectorFactory<>(
-                TestdataLavishSolution.buildSolutionDescriptor(),
-                (factory) -> new Constraint[] {
-                        factory.from(TestdataLavishEntity.class)
-                                .join(TestdataLavishValue.class)
-                                .reward(constraintName, SimpleScore.ONE, (entity, value) -> -1)
-                }, constraintStreamImplType);
+        ConstraintStreamScoreDirectorFactory<TestdataLavishSolution> scoreDirectorFactory =
+                new ConstraintStreamScoreDirectorFactory<>(
+                        TestdataLavishSolution.buildSolutionDescriptor(),
+                        (factory) -> new Constraint[] {
+                                factory.from(TestdataLavishEntity.class)
+                                        .join(TestdataLavishValue.class)
+                                        .reward(constraintName, SimpleScore.ONE, (entity, value) -> -1)
+                        }, constraintStreamImplType);
         InnerScoreDirector<TestdataLavishSolution> scoreDirector = scoreDirectorFactory.buildScoreDirector(false,
                 constraintMatchEnabled);
 

--- a/optaplanner-core/src/test/java/org/optaplanner/core/api/score/stream/quad/QuadConstraintStreamTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/api/score/stream/quad/QuadConstraintStreamTest.java
@@ -645,17 +645,18 @@ public class QuadConstraintStreamTest extends AbstractConstraintStreamTest {
         TestdataEntity e2 = new TestdataEntity("e2", v1);
         solution.setEntityList(Arrays.asList(e1, e2));
 
-        ConstraintStreamScoreDirectorFactory<TestdataSolution> scoreDirectorFactory = new ConstraintStreamScoreDirectorFactory<>(
-                TestdataSolution.buildSolutionDescriptor(), (factory) -> {
-                    QuadConstraintStream<TestdataEntity, TestdataEntity, TestdataValue, TestdataValue> base = factory
-                            .fromUniquePair(TestdataEntity.class)
-                            .join(TestdataValue.class, equal((entity1, entity2) -> e1.getValue(), identity()))
-                            .join(TestdataValue.class);
-                    return new Constraint[] {
-                            base.penalize("myConstraint1", SimpleScore.ONE),
-                            base.penalize("myConstraint2", SimpleScore.ONE, (entity1, entity2, value, extra) -> 20)
-                    };
-                }, constraintStreamImplType);
+        ConstraintStreamScoreDirectorFactory<TestdataSolution> scoreDirectorFactory =
+                new ConstraintStreamScoreDirectorFactory<>(
+                        TestdataSolution.buildSolutionDescriptor(), (factory) -> {
+                            QuadConstraintStream<TestdataEntity, TestdataEntity, TestdataValue, TestdataValue> base = factory
+                                    .fromUniquePair(TestdataEntity.class)
+                                    .join(TestdataValue.class, equal((entity1, entity2) -> e1.getValue(), identity()))
+                                    .join(TestdataValue.class);
+                            return new Constraint[] {
+                                    base.penalize("myConstraint1", SimpleScore.ONE),
+                                    base.penalize("myConstraint2", SimpleScore.ONE, (entity1, entity2, value, extra) -> 20)
+                            };
+                        }, constraintStreamImplType);
         InnerScoreDirector<TestdataSolution> scoreDirector = scoreDirectorFactory.buildScoreDirector(false,
                 constraintMatchEnabled);
 
@@ -673,19 +674,20 @@ public class QuadConstraintStreamTest extends AbstractConstraintStreamTest {
         TestdataEntity e2 = new TestdataEntity("e2", v1);
         solution.setEntityList(Arrays.asList(e1, e2));
 
-        ConstraintStreamScoreDirectorFactory<TestdataSimpleLongScoreSolution> scoreDirectorFactory = new ConstraintStreamScoreDirectorFactory<>(
-                TestdataSimpleLongScoreSolution.buildSolutionDescriptor(),
-                (factory) -> {
-                    QuadConstraintStream<TestdataEntity, TestdataEntity, TestdataValue, TestdataValue> base = factory
-                            .fromUniquePair(TestdataEntity.class)
-                            .join(TestdataValue.class, equal((entity1, entity2) -> e1.getValue(), identity()))
-                            .join(TestdataValue.class);
-                    return new Constraint[] {
-                            base.penalize("myConstraint1", SimpleLongScore.ONE),
-                            base.penalizeLong("myConstraint2", SimpleLongScore.ONE,
-                                    (entity1, entity2, value, extra) -> 20L)
-                    };
-                }, constraintStreamImplType);
+        ConstraintStreamScoreDirectorFactory<TestdataSimpleLongScoreSolution> scoreDirectorFactory =
+                new ConstraintStreamScoreDirectorFactory<>(
+                        TestdataSimpleLongScoreSolution.buildSolutionDescriptor(),
+                        (factory) -> {
+                            QuadConstraintStream<TestdataEntity, TestdataEntity, TestdataValue, TestdataValue> base = factory
+                                    .fromUniquePair(TestdataEntity.class)
+                                    .join(TestdataValue.class, equal((entity1, entity2) -> e1.getValue(), identity()))
+                                    .join(TestdataValue.class);
+                            return new Constraint[] {
+                                    base.penalize("myConstraint1", SimpleLongScore.ONE),
+                                    base.penalizeLong("myConstraint2", SimpleLongScore.ONE,
+                                            (entity1, entity2, value, extra) -> 20L)
+                            };
+                        }, constraintStreamImplType);
         InnerScoreDirector<TestdataSimpleLongScoreSolution> scoreDirector = scoreDirectorFactory.buildScoreDirector(
                 false, constraintMatchEnabled);
 
@@ -703,18 +705,19 @@ public class QuadConstraintStreamTest extends AbstractConstraintStreamTest {
         TestdataEntity e2 = new TestdataEntity("e2", v1);
         solution.setEntityList(Arrays.asList(e1, e2));
 
-        ConstraintStreamScoreDirectorFactory<TestdataSimpleBigDecimalScoreSolution> scoreDirectorFactory = new ConstraintStreamScoreDirectorFactory<>(
-                TestdataSimpleBigDecimalScoreSolution.buildSolutionDescriptor(), (factory) -> {
-                    QuadConstraintStream<TestdataEntity, TestdataEntity, TestdataValue, TestdataValue> base = factory
-                            .fromUniquePair(TestdataEntity.class)
-                            .join(TestdataValue.class, equal((entity1, entity2) -> e1.getValue(), identity()))
-                            .join(TestdataValue.class);
-                    return new Constraint[] {
-                            base.penalize("myConstraint1", SimpleBigDecimalScore.ONE),
-                            base.penalizeBigDecimal("myConstraint2", SimpleBigDecimalScore.ONE,
-                                    (entity1, entity2, value, extra) -> new BigDecimal("0.2"))
-                    };
-                }, constraintStreamImplType);
+        ConstraintStreamScoreDirectorFactory<TestdataSimpleBigDecimalScoreSolution> scoreDirectorFactory =
+                new ConstraintStreamScoreDirectorFactory<>(
+                        TestdataSimpleBigDecimalScoreSolution.buildSolutionDescriptor(), (factory) -> {
+                            QuadConstraintStream<TestdataEntity, TestdataEntity, TestdataValue, TestdataValue> base = factory
+                                    .fromUniquePair(TestdataEntity.class)
+                                    .join(TestdataValue.class, equal((entity1, entity2) -> e1.getValue(), identity()))
+                                    .join(TestdataValue.class);
+                            return new Constraint[] {
+                                    base.penalize("myConstraint1", SimpleBigDecimalScore.ONE),
+                                    base.penalizeBigDecimal("myConstraint2", SimpleBigDecimalScore.ONE,
+                                            (entity1, entity2, value, extra) -> new BigDecimal("0.2"))
+                            };
+                        }, constraintStreamImplType);
         InnerScoreDirector<TestdataSimpleBigDecimalScoreSolution> scoreDirector = scoreDirectorFactory.buildScoreDirector(
                 false, constraintMatchEnabled);
 
@@ -728,14 +731,15 @@ public class QuadConstraintStreamTest extends AbstractConstraintStreamTest {
         TestdataLavishSolution solution = TestdataLavishSolution.generateSolution(1, 1, 1, 2);
 
         String constraintName = "myConstraint";
-        ConstraintStreamScoreDirectorFactory<TestdataLavishSolution> scoreDirectorFactory = new ConstraintStreamScoreDirectorFactory<>(
-                TestdataLavishSolution.buildSolutionDescriptor(),
-                (factory) -> new Constraint[] {
-                        factory.fromUniquePair(TestdataLavishEntity.class)
-                                .join(TestdataLavishEntityGroup.class)
-                                .join(TestdataLavishValue.class)
-                                .penalize(constraintName, SimpleScore.ONE, (entityA, entityB, group, value) -> -1)
-                }, constraintStreamImplType);
+        ConstraintStreamScoreDirectorFactory<TestdataLavishSolution> scoreDirectorFactory =
+                new ConstraintStreamScoreDirectorFactory<>(
+                        TestdataLavishSolution.buildSolutionDescriptor(),
+                        (factory) -> new Constraint[] {
+                                factory.fromUniquePair(TestdataLavishEntity.class)
+                                        .join(TestdataLavishEntityGroup.class)
+                                        .join(TestdataLavishValue.class)
+                                        .penalize(constraintName, SimpleScore.ONE, (entityA, entityB, group, value) -> -1)
+                        }, constraintStreamImplType);
         InnerScoreDirector<TestdataLavishSolution> scoreDirector = scoreDirectorFactory.buildScoreDirector(false,
                 constraintMatchEnabled);
 
@@ -753,17 +757,18 @@ public class QuadConstraintStreamTest extends AbstractConstraintStreamTest {
         TestdataEntity e2 = new TestdataEntity("e2", v1);
         solution.setEntityList(Arrays.asList(e1, e2));
 
-        ConstraintStreamScoreDirectorFactory<TestdataSolution> scoreDirectorFactory = new ConstraintStreamScoreDirectorFactory<>(
-                TestdataSolution.buildSolutionDescriptor(), (factory) -> new Constraint[] {
-                        factory.fromUniquePair(TestdataEntity.class)
-                                .join(TestdataValue.class, equal((entity1, entity2) -> e1.getValue(), identity()))
-                                .join(TestdataValue.class)
-                                .reward("myConstraint1", SimpleScore.ONE),
-                        factory.fromUniquePair(TestdataEntity.class)
-                                .join(TestdataValue.class, equal((entity1, entity2) -> e1.getValue(), identity()))
-                                .join(TestdataValue.class)
-                                .reward("myConstraint2", SimpleScore.ONE, (entity1, entity2, value, extra) -> 20)
-                }, constraintStreamImplType);
+        ConstraintStreamScoreDirectorFactory<TestdataSolution> scoreDirectorFactory =
+                new ConstraintStreamScoreDirectorFactory<>(
+                        TestdataSolution.buildSolutionDescriptor(), (factory) -> new Constraint[] {
+                                factory.fromUniquePair(TestdataEntity.class)
+                                        .join(TestdataValue.class, equal((entity1, entity2) -> e1.getValue(), identity()))
+                                        .join(TestdataValue.class)
+                                        .reward("myConstraint1", SimpleScore.ONE),
+                                factory.fromUniquePair(TestdataEntity.class)
+                                        .join(TestdataValue.class, equal((entity1, entity2) -> e1.getValue(), identity()))
+                                        .join(TestdataValue.class)
+                                        .reward("myConstraint2", SimpleScore.ONE, (entity1, entity2, value, extra) -> 20)
+                        }, constraintStreamImplType);
         InnerScoreDirector<TestdataSolution> scoreDirector = scoreDirectorFactory.buildScoreDirector(false,
                 constraintMatchEnabled);
 
@@ -781,17 +786,19 @@ public class QuadConstraintStreamTest extends AbstractConstraintStreamTest {
         TestdataEntity e2 = new TestdataEntity("e2", v1);
         solution.setEntityList(Arrays.asList(e1, e2));
 
-        ConstraintStreamScoreDirectorFactory<TestdataSimpleLongScoreSolution> scoreDirectorFactory = new ConstraintStreamScoreDirectorFactory<>(
-                TestdataSimpleLongScoreSolution.buildSolutionDescriptor(), (factory) -> new Constraint[] {
-                        factory.fromUniquePair(TestdataEntity.class)
-                                .join(TestdataValue.class, equal((entity1, entity2) -> e1.getValue(), identity()))
-                                .join(TestdataValue.class)
-                                .reward("myConstraint1", SimpleLongScore.ONE),
-                        factory.fromUniquePair(TestdataEntity.class)
-                                .join(TestdataValue.class, equal((entity1, entity2) -> e1.getValue(), identity()))
-                                .join(TestdataValue.class)
-                                .rewardLong("myConstraint2", SimpleLongScore.ONE, (entity1, entity2, value, extra) -> 20L)
-                }, constraintStreamImplType);
+        ConstraintStreamScoreDirectorFactory<TestdataSimpleLongScoreSolution> scoreDirectorFactory =
+                new ConstraintStreamScoreDirectorFactory<>(
+                        TestdataSimpleLongScoreSolution.buildSolutionDescriptor(), (factory) -> new Constraint[] {
+                                factory.fromUniquePair(TestdataEntity.class)
+                                        .join(TestdataValue.class, equal((entity1, entity2) -> e1.getValue(), identity()))
+                                        .join(TestdataValue.class)
+                                        .reward("myConstraint1", SimpleLongScore.ONE),
+                                factory.fromUniquePair(TestdataEntity.class)
+                                        .join(TestdataValue.class, equal((entity1, entity2) -> e1.getValue(), identity()))
+                                        .join(TestdataValue.class)
+                                        .rewardLong("myConstraint2", SimpleLongScore.ONE,
+                                                (entity1, entity2, value, extra) -> 20L)
+                        }, constraintStreamImplType);
         InnerScoreDirector<TestdataSimpleLongScoreSolution> scoreDirector = scoreDirectorFactory.buildScoreDirector(false,
                 constraintMatchEnabled);
 
@@ -809,18 +816,19 @@ public class QuadConstraintStreamTest extends AbstractConstraintStreamTest {
         TestdataEntity e2 = new TestdataEntity("e2", v1);
         solution.setEntityList(Arrays.asList(e1, e2));
 
-        ConstraintStreamScoreDirectorFactory<TestdataSimpleBigDecimalScoreSolution> scoreDirectorFactory = new ConstraintStreamScoreDirectorFactory<>(
-                TestdataSimpleBigDecimalScoreSolution.buildSolutionDescriptor(), (factory) -> new Constraint[] {
-                        factory.fromUniquePair(TestdataEntity.class)
-                                .join(TestdataValue.class, equal((entity1, entity2) -> e1.getValue(), identity()))
-                                .join(TestdataValue.class)
-                                .reward("myConstraint1", SimpleBigDecimalScore.ONE),
-                        factory.fromUniquePair(TestdataEntity.class)
-                                .join(TestdataValue.class, equal((entity1, entity2) -> e1.getValue(), identity()))
-                                .join(TestdataValue.class)
-                                .rewardBigDecimal("myConstraint2", SimpleBigDecimalScore.ONE,
-                                        (entity1, entity2, value, extra) -> new BigDecimal("0.2"))
-                }, constraintStreamImplType);
+        ConstraintStreamScoreDirectorFactory<TestdataSimpleBigDecimalScoreSolution> scoreDirectorFactory =
+                new ConstraintStreamScoreDirectorFactory<>(
+                        TestdataSimpleBigDecimalScoreSolution.buildSolutionDescriptor(), (factory) -> new Constraint[] {
+                                factory.fromUniquePair(TestdataEntity.class)
+                                        .join(TestdataValue.class, equal((entity1, entity2) -> e1.getValue(), identity()))
+                                        .join(TestdataValue.class)
+                                        .reward("myConstraint1", SimpleBigDecimalScore.ONE),
+                                factory.fromUniquePair(TestdataEntity.class)
+                                        .join(TestdataValue.class, equal((entity1, entity2) -> e1.getValue(), identity()))
+                                        .join(TestdataValue.class)
+                                        .rewardBigDecimal("myConstraint2", SimpleBigDecimalScore.ONE,
+                                                (entity1, entity2, value, extra) -> new BigDecimal("0.2"))
+                        }, constraintStreamImplType);
         InnerScoreDirector<TestdataSimpleBigDecimalScoreSolution> scoreDirector = scoreDirectorFactory.buildScoreDirector(false,
                 constraintMatchEnabled);
 
@@ -834,14 +842,15 @@ public class QuadConstraintStreamTest extends AbstractConstraintStreamTest {
         TestdataLavishSolution solution = TestdataLavishSolution.generateSolution(1, 1, 1, 2);
 
         String constraintName = "myConstraint";
-        ConstraintStreamScoreDirectorFactory<TestdataLavishSolution> scoreDirectorFactory = new ConstraintStreamScoreDirectorFactory<>(
-                TestdataLavishSolution.buildSolutionDescriptor(),
-                (factory) -> new Constraint[] {
-                        factory.fromUniquePair(TestdataLavishEntity.class)
-                                .join(TestdataLavishEntityGroup.class)
-                                .join(TestdataLavishValue.class)
-                                .reward(constraintName, SimpleScore.ONE, (entityA, entityB, group, value) -> -1)
-                }, constraintStreamImplType);
+        ConstraintStreamScoreDirectorFactory<TestdataLavishSolution> scoreDirectorFactory =
+                new ConstraintStreamScoreDirectorFactory<>(
+                        TestdataLavishSolution.buildSolutionDescriptor(),
+                        (factory) -> new Constraint[] {
+                                factory.fromUniquePair(TestdataLavishEntity.class)
+                                        .join(TestdataLavishEntityGroup.class)
+                                        .join(TestdataLavishValue.class)
+                                        .reward(constraintName, SimpleScore.ONE, (entityA, entityB, group, value) -> -1)
+                        }, constraintStreamImplType);
         InnerScoreDirector<TestdataLavishSolution> scoreDirector = scoreDirectorFactory.buildScoreDirector(false,
                 constraintMatchEnabled);
 

--- a/optaplanner-core/src/test/java/org/optaplanner/core/api/score/stream/tri/TriConstraintStreamTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/api/score/stream/tri/TriConstraintStreamTest.java
@@ -788,17 +788,18 @@ public class TriConstraintStreamTest extends AbstractConstraintStreamTest {
         TestdataEntity e2 = new TestdataEntity("e2", v1);
         solution.setEntityList(Arrays.asList(e1, e2));
 
-        ConstraintStreamScoreDirectorFactory<TestdataSolution> scoreDirectorFactory = new ConstraintStreamScoreDirectorFactory<>(
-                TestdataSolution.buildSolutionDescriptor(), (factory) -> new Constraint[] {
-                        factory.from(TestdataEntity.class)
-                                .join(TestdataValue.class, equal(TestdataEntity::getValue, identity()))
-                                .join(TestdataValue.class)
-                                .penalize("myConstraint1", SimpleScore.ONE),
-                        factory.from(TestdataEntity.class)
-                                .join(TestdataValue.class, equal(TestdataEntity::getValue, identity()))
-                                .join(TestdataValue.class)
-                                .penalize("myConstraint2", SimpleScore.ONE, (entity, value, extra) -> 20)
-                }, constraintStreamImplType);
+        ConstraintStreamScoreDirectorFactory<TestdataSolution> scoreDirectorFactory =
+                new ConstraintStreamScoreDirectorFactory<>(
+                        TestdataSolution.buildSolutionDescriptor(), (factory) -> new Constraint[] {
+                                factory.from(TestdataEntity.class)
+                                        .join(TestdataValue.class, equal(TestdataEntity::getValue, identity()))
+                                        .join(TestdataValue.class)
+                                        .penalize("myConstraint1", SimpleScore.ONE),
+                                factory.from(TestdataEntity.class)
+                                        .join(TestdataValue.class, equal(TestdataEntity::getValue, identity()))
+                                        .join(TestdataValue.class)
+                                        .penalize("myConstraint2", SimpleScore.ONE, (entity, value, extra) -> 20)
+                        }, constraintStreamImplType);
         InnerScoreDirector<TestdataSolution> scoreDirector = scoreDirectorFactory.buildScoreDirector(false,
                 constraintMatchEnabled);
 
@@ -815,17 +816,18 @@ public class TriConstraintStreamTest extends AbstractConstraintStreamTest {
         TestdataEntity e2 = new TestdataEntity("e2", v1);
         solution.setEntityList(Arrays.asList(e1, e2));
 
-        ConstraintStreamScoreDirectorFactory<TestdataSimpleLongScoreSolution> scoreDirectorFactory = new ConstraintStreamScoreDirectorFactory<>(
-                TestdataSimpleLongScoreSolution.buildSolutionDescriptor(), (factory) -> new Constraint[] {
-                        factory.from(TestdataEntity.class)
-                                .join(TestdataValue.class, equal(TestdataEntity::getValue, identity()))
-                                .join(TestdataValue.class)
-                                .penalize("myConstraint1", SimpleLongScore.ONE),
-                        factory.from(TestdataEntity.class)
-                                .join(TestdataValue.class, equal(TestdataEntity::getValue, identity()))
-                                .join(TestdataValue.class)
-                                .penalizeLong("myConstraint2", SimpleLongScore.ONE, (entity, value, extra) -> 20L)
-                }, constraintStreamImplType);
+        ConstraintStreamScoreDirectorFactory<TestdataSimpleLongScoreSolution> scoreDirectorFactory =
+                new ConstraintStreamScoreDirectorFactory<>(
+                        TestdataSimpleLongScoreSolution.buildSolutionDescriptor(), (factory) -> new Constraint[] {
+                                factory.from(TestdataEntity.class)
+                                        .join(TestdataValue.class, equal(TestdataEntity::getValue, identity()))
+                                        .join(TestdataValue.class)
+                                        .penalize("myConstraint1", SimpleLongScore.ONE),
+                                factory.from(TestdataEntity.class)
+                                        .join(TestdataValue.class, equal(TestdataEntity::getValue, identity()))
+                                        .join(TestdataValue.class)
+                                        .penalizeLong("myConstraint2", SimpleLongScore.ONE, (entity, value, extra) -> 20L)
+                        }, constraintStreamImplType);
         InnerScoreDirector<TestdataSimpleLongScoreSolution> scoreDirector = scoreDirectorFactory.buildScoreDirector(false,
                 constraintMatchEnabled);
 
@@ -842,18 +844,19 @@ public class TriConstraintStreamTest extends AbstractConstraintStreamTest {
         TestdataEntity e2 = new TestdataEntity("e2", v1);
         solution.setEntityList(Arrays.asList(e1, e2));
 
-        ConstraintStreamScoreDirectorFactory<TestdataSimpleBigDecimalScoreSolution> scoreDirectorFactory = new ConstraintStreamScoreDirectorFactory<>(
-                TestdataSimpleBigDecimalScoreSolution.buildSolutionDescriptor(), (factory) -> new Constraint[] {
-                        factory.from(TestdataEntity.class)
-                                .join(TestdataValue.class, equal(TestdataEntity::getValue, identity()))
-                                .join(TestdataValue.class)
-                                .penalize("myConstraint1", SimpleBigDecimalScore.ONE),
-                        factory.from(TestdataEntity.class)
-                                .join(TestdataValue.class, equal(TestdataEntity::getValue, identity()))
-                                .join(TestdataValue.class)
-                                .penalizeBigDecimal("myConstraint2", SimpleBigDecimalScore.ONE,
-                                        (entity, value, extra) -> new BigDecimal("0.2"))
-                }, constraintStreamImplType);
+        ConstraintStreamScoreDirectorFactory<TestdataSimpleBigDecimalScoreSolution> scoreDirectorFactory =
+                new ConstraintStreamScoreDirectorFactory<>(
+                        TestdataSimpleBigDecimalScoreSolution.buildSolutionDescriptor(), (factory) -> new Constraint[] {
+                                factory.from(TestdataEntity.class)
+                                        .join(TestdataValue.class, equal(TestdataEntity::getValue, identity()))
+                                        .join(TestdataValue.class)
+                                        .penalize("myConstraint1", SimpleBigDecimalScore.ONE),
+                                factory.from(TestdataEntity.class)
+                                        .join(TestdataValue.class, equal(TestdataEntity::getValue, identity()))
+                                        .join(TestdataValue.class)
+                                        .penalizeBigDecimal("myConstraint2", SimpleBigDecimalScore.ONE,
+                                                (entity, value, extra) -> new BigDecimal("0.2"))
+                        }, constraintStreamImplType);
         InnerScoreDirector<TestdataSimpleBigDecimalScoreSolution> scoreDirector = scoreDirectorFactory.buildScoreDirector(false,
                 constraintMatchEnabled);
 
@@ -866,14 +869,15 @@ public class TriConstraintStreamTest extends AbstractConstraintStreamTest {
         TestdataLavishSolution solution = TestdataLavishSolution.generateSolution(1, 1, 1, 1);
 
         String constraintName = "myConstraint";
-        ConstraintStreamScoreDirectorFactory<TestdataLavishSolution> scoreDirectorFactory = new ConstraintStreamScoreDirectorFactory<>(
-                TestdataLavishSolution.buildSolutionDescriptor(),
-                (factory) -> new Constraint[] {
-                        factory.from(TestdataLavishEntity.class)
-                                .join(TestdataLavishEntityGroup.class)
-                                .join(TestdataLavishValue.class)
-                                .penalize(constraintName, SimpleScore.ONE, (entity, group, value) -> -1)
-                }, constraintStreamImplType);
+        ConstraintStreamScoreDirectorFactory<TestdataLavishSolution> scoreDirectorFactory =
+                new ConstraintStreamScoreDirectorFactory<>(
+                        TestdataLavishSolution.buildSolutionDescriptor(),
+                        (factory) -> new Constraint[] {
+                                factory.from(TestdataLavishEntity.class)
+                                        .join(TestdataLavishEntityGroup.class)
+                                        .join(TestdataLavishValue.class)
+                                        .penalize(constraintName, SimpleScore.ONE, (entity, group, value) -> -1)
+                        }, constraintStreamImplType);
         InnerScoreDirector<TestdataLavishSolution> scoreDirector = scoreDirectorFactory.buildScoreDirector(false,
                 constraintMatchEnabled);
 
@@ -890,17 +894,18 @@ public class TriConstraintStreamTest extends AbstractConstraintStreamTest {
         TestdataEntity e2 = new TestdataEntity("e2", v1);
         solution.setEntityList(Arrays.asList(e1, e2));
 
-        ConstraintStreamScoreDirectorFactory<TestdataSolution> scoreDirectorFactory = new ConstraintStreamScoreDirectorFactory<>(
-                TestdataSolution.buildSolutionDescriptor(), (factory) -> new Constraint[] {
-                        factory.from(TestdataEntity.class)
-                                .join(TestdataValue.class, equal(TestdataEntity::getValue, identity()))
-                                .join(TestdataValue.class)
-                                .reward("myConstraint1", SimpleScore.ONE),
-                        factory.from(TestdataEntity.class)
-                                .join(TestdataValue.class, equal(TestdataEntity::getValue, identity()))
-                                .join(TestdataValue.class)
-                                .reward("myConstraint2", SimpleScore.ONE, (entity, value, extra) -> 20)
-                }, constraintStreamImplType);
+        ConstraintStreamScoreDirectorFactory<TestdataSolution> scoreDirectorFactory =
+                new ConstraintStreamScoreDirectorFactory<>(
+                        TestdataSolution.buildSolutionDescriptor(), (factory) -> new Constraint[] {
+                                factory.from(TestdataEntity.class)
+                                        .join(TestdataValue.class, equal(TestdataEntity::getValue, identity()))
+                                        .join(TestdataValue.class)
+                                        .reward("myConstraint1", SimpleScore.ONE),
+                                factory.from(TestdataEntity.class)
+                                        .join(TestdataValue.class, equal(TestdataEntity::getValue, identity()))
+                                        .join(TestdataValue.class)
+                                        .reward("myConstraint2", SimpleScore.ONE, (entity, value, extra) -> 20)
+                        }, constraintStreamImplType);
         InnerScoreDirector<TestdataSolution> scoreDirector = scoreDirectorFactory.buildScoreDirector(false,
                 constraintMatchEnabled);
 
@@ -917,17 +922,18 @@ public class TriConstraintStreamTest extends AbstractConstraintStreamTest {
         TestdataEntity e2 = new TestdataEntity("e2", v1);
         solution.setEntityList(Arrays.asList(e1, e2));
 
-        ConstraintStreamScoreDirectorFactory<TestdataSimpleLongScoreSolution> scoreDirectorFactory = new ConstraintStreamScoreDirectorFactory<>(
-                TestdataSimpleLongScoreSolution.buildSolutionDescriptor(), (factory) -> new Constraint[] {
-                        factory.from(TestdataEntity.class)
-                                .join(TestdataValue.class, equal(TestdataEntity::getValue, identity()))
-                                .join(TestdataValue.class)
-                                .reward("myConstraint1", SimpleLongScore.ONE),
-                        factory.from(TestdataEntity.class)
-                                .join(TestdataValue.class, equal(TestdataEntity::getValue, identity()))
-                                .join(TestdataValue.class)
-                                .rewardLong("myConstraint2", SimpleLongScore.ONE, (entity, value, extra) -> 20L)
-                }, constraintStreamImplType);
+        ConstraintStreamScoreDirectorFactory<TestdataSimpleLongScoreSolution> scoreDirectorFactory =
+                new ConstraintStreamScoreDirectorFactory<>(
+                        TestdataSimpleLongScoreSolution.buildSolutionDescriptor(), (factory) -> new Constraint[] {
+                                factory.from(TestdataEntity.class)
+                                        .join(TestdataValue.class, equal(TestdataEntity::getValue, identity()))
+                                        .join(TestdataValue.class)
+                                        .reward("myConstraint1", SimpleLongScore.ONE),
+                                factory.from(TestdataEntity.class)
+                                        .join(TestdataValue.class, equal(TestdataEntity::getValue, identity()))
+                                        .join(TestdataValue.class)
+                                        .rewardLong("myConstraint2", SimpleLongScore.ONE, (entity, value, extra) -> 20L)
+                        }, constraintStreamImplType);
         InnerScoreDirector<TestdataSimpleLongScoreSolution> scoreDirector = scoreDirectorFactory.buildScoreDirector(false,
                 constraintMatchEnabled);
 
@@ -944,18 +950,19 @@ public class TriConstraintStreamTest extends AbstractConstraintStreamTest {
         TestdataEntity e2 = new TestdataEntity("e2", v1);
         solution.setEntityList(Arrays.asList(e1, e2));
 
-        ConstraintStreamScoreDirectorFactory<TestdataSimpleBigDecimalScoreSolution> scoreDirectorFactory = new ConstraintStreamScoreDirectorFactory<>(
-                TestdataSimpleBigDecimalScoreSolution.buildSolutionDescriptor(), (factory) -> new Constraint[] {
-                        factory.from(TestdataEntity.class)
-                                .join(TestdataValue.class, equal(TestdataEntity::getValue, identity()))
-                                .join(TestdataValue.class)
-                                .reward("myConstraint1", SimpleBigDecimalScore.ONE),
-                        factory.from(TestdataEntity.class)
-                                .join(TestdataValue.class, equal(TestdataEntity::getValue, identity()))
-                                .join(TestdataValue.class)
-                                .rewardBigDecimal("myConstraint2", SimpleBigDecimalScore.ONE,
-                                        (entity, value, extra) -> new BigDecimal("0.2"))
-                }, constraintStreamImplType);
+        ConstraintStreamScoreDirectorFactory<TestdataSimpleBigDecimalScoreSolution> scoreDirectorFactory =
+                new ConstraintStreamScoreDirectorFactory<>(
+                        TestdataSimpleBigDecimalScoreSolution.buildSolutionDescriptor(), (factory) -> new Constraint[] {
+                                factory.from(TestdataEntity.class)
+                                        .join(TestdataValue.class, equal(TestdataEntity::getValue, identity()))
+                                        .join(TestdataValue.class)
+                                        .reward("myConstraint1", SimpleBigDecimalScore.ONE),
+                                factory.from(TestdataEntity.class)
+                                        .join(TestdataValue.class, equal(TestdataEntity::getValue, identity()))
+                                        .join(TestdataValue.class)
+                                        .rewardBigDecimal("myConstraint2", SimpleBigDecimalScore.ONE,
+                                                (entity, value, extra) -> new BigDecimal("0.2"))
+                        }, constraintStreamImplType);
         InnerScoreDirector<TestdataSimpleBigDecimalScoreSolution> scoreDirector = scoreDirectorFactory.buildScoreDirector(false,
                 constraintMatchEnabled);
 
@@ -968,14 +975,15 @@ public class TriConstraintStreamTest extends AbstractConstraintStreamTest {
         TestdataLavishSolution solution = TestdataLavishSolution.generateSolution(1, 1, 1, 1);
 
         String constraintName = "myConstraint";
-        ConstraintStreamScoreDirectorFactory<TestdataLavishSolution> scoreDirectorFactory = new ConstraintStreamScoreDirectorFactory<>(
-                TestdataLavishSolution.buildSolutionDescriptor(),
-                (factory) -> new Constraint[] {
-                        factory.from(TestdataLavishEntity.class)
-                                .join(TestdataLavishEntityGroup.class)
-                                .join(TestdataLavishValue.class)
-                                .reward(constraintName, SimpleScore.ONE, (entity, group, value) -> -1)
-                }, constraintStreamImplType);
+        ConstraintStreamScoreDirectorFactory<TestdataLavishSolution> scoreDirectorFactory =
+                new ConstraintStreamScoreDirectorFactory<>(
+                        TestdataLavishSolution.buildSolutionDescriptor(),
+                        (factory) -> new Constraint[] {
+                                factory.from(TestdataLavishEntity.class)
+                                        .join(TestdataLavishEntityGroup.class)
+                                        .join(TestdataLavishValue.class)
+                                        .reward(constraintName, SimpleScore.ONE, (entity, group, value) -> -1)
+                        }, constraintStreamImplType);
         InnerScoreDirector<TestdataLavishSolution> scoreDirector = scoreDirectorFactory.buildScoreDirector(false,
                 constraintMatchEnabled);
 

--- a/optaplanner-core/src/test/java/org/optaplanner/core/api/score/stream/uni/UniConstraintStreamTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/api/score/stream/uni/UniConstraintStreamTest.java
@@ -1185,13 +1185,14 @@ public class UniConstraintStreamTest extends AbstractConstraintStreamTest {
         TestdataEntity e2 = new TestdataEntity("e2", v1);
         solution.setEntityList(Arrays.asList(e1, e2));
 
-        ConstraintStreamScoreDirectorFactory<TestdataSolution> scoreDirectorFactory = new ConstraintStreamScoreDirectorFactory<>(
-                TestdataSolution.buildSolutionDescriptor(), (factory) -> new Constraint[] {
-                        factory.from(TestdataEntity.class)
-                                .penalize("myConstraint1", SimpleScore.ONE),
-                        factory.from(TestdataEntity.class)
-                                .penalize("myConstraint2", SimpleScore.ONE, entity -> 20)
-                }, constraintStreamImplType);
+        ConstraintStreamScoreDirectorFactory<TestdataSolution> scoreDirectorFactory =
+                new ConstraintStreamScoreDirectorFactory<>(
+                        TestdataSolution.buildSolutionDescriptor(), (factory) -> new Constraint[] {
+                                factory.from(TestdataEntity.class)
+                                        .penalize("myConstraint1", SimpleScore.ONE),
+                                factory.from(TestdataEntity.class)
+                                        .penalize("myConstraint2", SimpleScore.ONE, entity -> 20)
+                        }, constraintStreamImplType);
         InnerScoreDirector<TestdataSolution> scoreDirector = scoreDirectorFactory.buildScoreDirector(false,
                 constraintMatchEnabled);
 
@@ -1208,13 +1209,14 @@ public class UniConstraintStreamTest extends AbstractConstraintStreamTest {
         TestdataEntity e2 = new TestdataEntity("e2", v1);
         solution.setEntityList(Arrays.asList(e1, e2));
 
-        ConstraintStreamScoreDirectorFactory<TestdataSimpleLongScoreSolution> scoreDirectorFactory = new ConstraintStreamScoreDirectorFactory<>(
-                TestdataSimpleLongScoreSolution.buildSolutionDescriptor(), (factory) -> new Constraint[] {
-                        factory.from(TestdataEntity.class)
-                                .penalize("myConstraint1", SimpleLongScore.ONE),
-                        factory.from(TestdataEntity.class)
-                                .penalizeLong("myConstraint2", SimpleLongScore.ONE, entity -> 20L)
-                }, constraintStreamImplType);
+        ConstraintStreamScoreDirectorFactory<TestdataSimpleLongScoreSolution> scoreDirectorFactory =
+                new ConstraintStreamScoreDirectorFactory<>(
+                        TestdataSimpleLongScoreSolution.buildSolutionDescriptor(), (factory) -> new Constraint[] {
+                                factory.from(TestdataEntity.class)
+                                        .penalize("myConstraint1", SimpleLongScore.ONE),
+                                factory.from(TestdataEntity.class)
+                                        .penalizeLong("myConstraint2", SimpleLongScore.ONE, entity -> 20L)
+                        }, constraintStreamImplType);
         InnerScoreDirector<TestdataSimpleLongScoreSolution> scoreDirector = scoreDirectorFactory.buildScoreDirector(false,
                 constraintMatchEnabled);
 
@@ -1231,13 +1233,15 @@ public class UniConstraintStreamTest extends AbstractConstraintStreamTest {
         TestdataEntity e2 = new TestdataEntity("e2", v1);
         solution.setEntityList(Arrays.asList(e1, e2));
 
-        ConstraintStreamScoreDirectorFactory<TestdataSimpleBigDecimalScoreSolution> scoreDirectorFactory = new ConstraintStreamScoreDirectorFactory<>(
-                TestdataSimpleBigDecimalScoreSolution.buildSolutionDescriptor(), (factory) -> new Constraint[] {
-                        factory.from(TestdataEntity.class)
-                                .penalize("myConstraint1", SimpleBigDecimalScore.ONE),
-                        factory.from(TestdataEntity.class)
-                                .penalizeBigDecimal("myConstraint2", SimpleBigDecimalScore.ONE, entity -> new BigDecimal("0.2"))
-                }, constraintStreamImplType);
+        ConstraintStreamScoreDirectorFactory<TestdataSimpleBigDecimalScoreSolution> scoreDirectorFactory =
+                new ConstraintStreamScoreDirectorFactory<>(
+                        TestdataSimpleBigDecimalScoreSolution.buildSolutionDescriptor(), (factory) -> new Constraint[] {
+                                factory.from(TestdataEntity.class)
+                                        .penalize("myConstraint1", SimpleBigDecimalScore.ONE),
+                                factory.from(TestdataEntity.class)
+                                        .penalizeBigDecimal("myConstraint2", SimpleBigDecimalScore.ONE,
+                                                entity -> new BigDecimal("0.2"))
+                        }, constraintStreamImplType);
         InnerScoreDirector<TestdataSimpleBigDecimalScoreSolution> scoreDirector = scoreDirectorFactory.buildScoreDirector(false,
                 constraintMatchEnabled);
 
@@ -1250,11 +1254,12 @@ public class UniConstraintStreamTest extends AbstractConstraintStreamTest {
         TestdataLavishSolution solution = TestdataLavishSolution.generateSolution(1, 1, 1, 1);
 
         String constraintName = "myConstraint1";
-        ConstraintStreamScoreDirectorFactory<TestdataLavishSolution> scoreDirectorFactory = new ConstraintStreamScoreDirectorFactory<>(
-                TestdataLavishSolution.buildSolutionDescriptor(),
-                (factory) -> new Constraint[] {
-                        factory.from(TestdataLavishEntity.class).penalize(constraintName, SimpleScore.ONE, e -> -1)
-                }, constraintStreamImplType);
+        ConstraintStreamScoreDirectorFactory<TestdataLavishSolution> scoreDirectorFactory =
+                new ConstraintStreamScoreDirectorFactory<>(
+                        TestdataLavishSolution.buildSolutionDescriptor(),
+                        (factory) -> new Constraint[] {
+                                factory.from(TestdataLavishEntity.class).penalize(constraintName, SimpleScore.ONE, e -> -1)
+                        }, constraintStreamImplType);
         InnerScoreDirector<TestdataLavishSolution> scoreDirector = scoreDirectorFactory.buildScoreDirector(false,
                 constraintMatchEnabled);
 
@@ -1271,13 +1276,14 @@ public class UniConstraintStreamTest extends AbstractConstraintStreamTest {
         TestdataEntity e2 = new TestdataEntity("e2", v1);
         solution.setEntityList(Arrays.asList(e1, e2));
 
-        ConstraintStreamScoreDirectorFactory<TestdataSolution> scoreDirectorFactory = new ConstraintStreamScoreDirectorFactory<>(
-                TestdataSolution.buildSolutionDescriptor(), (factory) -> new Constraint[] {
-                        factory.from(TestdataEntity.class)
-                                .reward("myConstraint1", SimpleScore.ONE),
-                        factory.from(TestdataEntity.class)
-                                .reward("myConstraint2", SimpleScore.ONE, entity -> 20)
-                }, constraintStreamImplType);
+        ConstraintStreamScoreDirectorFactory<TestdataSolution> scoreDirectorFactory =
+                new ConstraintStreamScoreDirectorFactory<>(
+                        TestdataSolution.buildSolutionDescriptor(), (factory) -> new Constraint[] {
+                                factory.from(TestdataEntity.class)
+                                        .reward("myConstraint1", SimpleScore.ONE),
+                                factory.from(TestdataEntity.class)
+                                        .reward("myConstraint2", SimpleScore.ONE, entity -> 20)
+                        }, constraintStreamImplType);
         InnerScoreDirector<TestdataSolution> scoreDirector = scoreDirectorFactory.buildScoreDirector(false,
                 constraintMatchEnabled);
 
@@ -1294,13 +1300,14 @@ public class UniConstraintStreamTest extends AbstractConstraintStreamTest {
         TestdataEntity e2 = new TestdataEntity("e2", v1);
         solution.setEntityList(Arrays.asList(e1, e2));
 
-        ConstraintStreamScoreDirectorFactory<TestdataSimpleLongScoreSolution> scoreDirectorFactory = new ConstraintStreamScoreDirectorFactory<>(
-                TestdataSimpleLongScoreSolution.buildSolutionDescriptor(), (factory) -> new Constraint[] {
-                        factory.from(TestdataEntity.class)
-                                .reward("myConstraint1", SimpleLongScore.ONE),
-                        factory.from(TestdataEntity.class)
-                                .rewardLong("myConstraint2", SimpleLongScore.ONE, entity -> 20L)
-                }, constraintStreamImplType);
+        ConstraintStreamScoreDirectorFactory<TestdataSimpleLongScoreSolution> scoreDirectorFactory =
+                new ConstraintStreamScoreDirectorFactory<>(
+                        TestdataSimpleLongScoreSolution.buildSolutionDescriptor(), (factory) -> new Constraint[] {
+                                factory.from(TestdataEntity.class)
+                                        .reward("myConstraint1", SimpleLongScore.ONE),
+                                factory.from(TestdataEntity.class)
+                                        .rewardLong("myConstraint2", SimpleLongScore.ONE, entity -> 20L)
+                        }, constraintStreamImplType);
         InnerScoreDirector<TestdataSimpleLongScoreSolution> scoreDirector = scoreDirectorFactory.buildScoreDirector(false,
                 constraintMatchEnabled);
 
@@ -1317,13 +1324,15 @@ public class UniConstraintStreamTest extends AbstractConstraintStreamTest {
         TestdataEntity e2 = new TestdataEntity("e2", v1);
         solution.setEntityList(Arrays.asList(e1, e2));
 
-        ConstraintStreamScoreDirectorFactory<TestdataSimpleBigDecimalScoreSolution> scoreDirectorFactory = new ConstraintStreamScoreDirectorFactory<>(
-                TestdataSimpleBigDecimalScoreSolution.buildSolutionDescriptor(), (factory) -> new Constraint[] {
-                        factory.from(TestdataEntity.class)
-                                .reward("myConstraint1", SimpleBigDecimalScore.ONE),
-                        factory.from(TestdataEntity.class)
-                                .rewardBigDecimal("myConstraint2", SimpleBigDecimalScore.ONE, entity -> new BigDecimal("0.2"))
-                }, constraintStreamImplType);
+        ConstraintStreamScoreDirectorFactory<TestdataSimpleBigDecimalScoreSolution> scoreDirectorFactory =
+                new ConstraintStreamScoreDirectorFactory<>(
+                        TestdataSimpleBigDecimalScoreSolution.buildSolutionDescriptor(), (factory) -> new Constraint[] {
+                                factory.from(TestdataEntity.class)
+                                        .reward("myConstraint1", SimpleBigDecimalScore.ONE),
+                                factory.from(TestdataEntity.class)
+                                        .rewardBigDecimal("myConstraint2", SimpleBigDecimalScore.ONE,
+                                                entity -> new BigDecimal("0.2"))
+                        }, constraintStreamImplType);
         InnerScoreDirector<TestdataSimpleBigDecimalScoreSolution> scoreDirector = scoreDirectorFactory.buildScoreDirector(false,
                 constraintMatchEnabled);
 
@@ -1336,11 +1345,12 @@ public class UniConstraintStreamTest extends AbstractConstraintStreamTest {
         TestdataLavishSolution solution = TestdataLavishSolution.generateSolution(1, 1, 1, 1);
 
         String constraintName = "myConstraint1";
-        ConstraintStreamScoreDirectorFactory<TestdataLavishSolution> scoreDirectorFactory = new ConstraintStreamScoreDirectorFactory<>(
-                TestdataLavishSolution.buildSolutionDescriptor(),
-                (factory) -> new Constraint[] {
-                        factory.from(TestdataLavishEntity.class).reward(constraintName, SimpleScore.ONE, e -> -1)
-                }, constraintStreamImplType);
+        ConstraintStreamScoreDirectorFactory<TestdataLavishSolution> scoreDirectorFactory =
+                new ConstraintStreamScoreDirectorFactory<>(
+                        TestdataLavishSolution.buildSolutionDescriptor(),
+                        (factory) -> new Constraint[] {
+                                factory.from(TestdataLavishEntity.class).reward(constraintName, SimpleScore.ONE, e -> -1)
+                        }, constraintStreamImplType);
         InnerScoreDirector<TestdataLavishSolution> scoreDirector = scoreDirectorFactory.buildScoreDirector(false,
                 constraintMatchEnabled);
 
@@ -1419,21 +1429,22 @@ public class UniConstraintStreamTest extends AbstractConstraintStreamTest {
 
         AtomicLong zeroWeightMonitorCount = new AtomicLong(0L);
         AtomicLong oneWeightMonitorCount = new AtomicLong(0L);
-        ConstraintStreamScoreDirectorFactory<TestdataLavishSolution> scoreDirectorFactory = new ConstraintStreamScoreDirectorFactory<>(
-                TestdataLavishSolution.buildSolutionDescriptor(), (factory) -> new Constraint[] {
-                        factory.from(TestdataLavishEntity.class)
-                                .filter(entity -> {
-                                    zeroWeightMonitorCount.getAndIncrement();
-                                    return true;
-                                })
-                                .penalize("myConstraint1", SimpleScore.ZERO),
-                        factory.from(TestdataLavishEntity.class)
-                                .filter(entity -> {
-                                    oneWeightMonitorCount.getAndIncrement();
-                                    return true;
-                                })
-                                .penalize("myConstraint2", SimpleScore.ONE)
-                }, constraintStreamImplType);
+        ConstraintStreamScoreDirectorFactory<TestdataLavishSolution> scoreDirectorFactory =
+                new ConstraintStreamScoreDirectorFactory<>(
+                        TestdataLavishSolution.buildSolutionDescriptor(), (factory) -> new Constraint[] {
+                                factory.from(TestdataLavishEntity.class)
+                                        .filter(entity -> {
+                                            zeroWeightMonitorCount.getAndIncrement();
+                                            return true;
+                                        })
+                                        .penalize("myConstraint1", SimpleScore.ZERO),
+                                factory.from(TestdataLavishEntity.class)
+                                        .filter(entity -> {
+                                            oneWeightMonitorCount.getAndIncrement();
+                                            return true;
+                                        })
+                                        .penalize("myConstraint2", SimpleScore.ONE)
+                        }, constraintStreamImplType);
         InnerScoreDirector<TestdataLavishSolution> scoreDirector = scoreDirectorFactory.buildScoreDirector(false,
                 constraintMatchEnabled);
 
@@ -1466,15 +1477,16 @@ public class UniConstraintStreamTest extends AbstractConstraintStreamTest {
             monitorCount.getAndIncrement();
             return true;
         };
-        ConstraintStreamScoreDirectorFactory<TestdataLavishSolution> scoreDirectorFactory = new ConstraintStreamScoreDirectorFactory<>(
-                TestdataLavishSolution.buildSolutionDescriptor(), (factory) -> new Constraint[] {
-                        factory.from(TestdataLavishEntity.class)
-                                .filter(predicate)
-                                .penalize("myConstraint1", SimpleScore.ONE),
-                        factory.from(TestdataLavishEntity.class)
-                                .filter(predicate)
-                                .penalize("myConstraint2", SimpleScore.ONE)
-                }, constraintStreamImplType);
+        ConstraintStreamScoreDirectorFactory<TestdataLavishSolution> scoreDirectorFactory =
+                new ConstraintStreamScoreDirectorFactory<>(
+                        TestdataLavishSolution.buildSolutionDescriptor(), (factory) -> new Constraint[] {
+                                factory.from(TestdataLavishEntity.class)
+                                        .filter(predicate)
+                                        .penalize("myConstraint1", SimpleScore.ONE),
+                                factory.from(TestdataLavishEntity.class)
+                                        .filter(predicate)
+                                        .penalize("myConstraint2", SimpleScore.ONE)
+                        }, constraintStreamImplType);
         InnerScoreDirector<TestdataLavishSolution> scoreDirector = scoreDirectorFactory.buildScoreDirector(false,
                 constraintMatchEnabled);
 
@@ -1499,15 +1511,16 @@ public class UniConstraintStreamTest extends AbstractConstraintStreamTest {
 
         Predicate<TestdataLavishEntity> predicate = entity -> Objects.equals(entity, entity1);
 
-        ConstraintStreamScoreDirectorFactory<TestdataLavishSolution> scoreDirectorFactory = new ConstraintStreamScoreDirectorFactory<>(
-                TestdataLavishSolution.buildSolutionDescriptor(), (factory) -> {
-                    UniConstraintStream<TestdataLavishEntity> base = factory.from(TestdataLavishEntity.class)
-                            .filter(predicate);
-                    return new Constraint[] {
-                            base.penalize("myConstraint1", SimpleScore.ONE),
-                            base.penalize("myConstraint2", SimpleScore.ONE)
-                    };
-                }, constraintStreamImplType);
+        ConstraintStreamScoreDirectorFactory<TestdataLavishSolution> scoreDirectorFactory =
+                new ConstraintStreamScoreDirectorFactory<>(
+                        TestdataLavishSolution.buildSolutionDescriptor(), (factory) -> {
+                            UniConstraintStream<TestdataLavishEntity> base = factory.from(TestdataLavishEntity.class)
+                                    .filter(predicate);
+                            return new Constraint[] {
+                                    base.penalize("myConstraint1", SimpleScore.ONE),
+                                    base.penalize("myConstraint2", SimpleScore.ONE)
+                            };
+                        }, constraintStreamImplType);
         InnerScoreDirector<TestdataLavishSolution> scoreDirector = scoreDirectorFactory.buildScoreDirector(false,
                 constraintMatchEnabled);
 
@@ -1528,16 +1541,17 @@ public class UniConstraintStreamTest extends AbstractConstraintStreamTest {
         TestdataLavishEntityGroup entityGroup2 = new TestdataLavishEntityGroup("Some Other Group");
         entity2.setEntityGroup(entityGroup2);
 
-        ConstraintStreamScoreDirectorFactory<TestdataLavishSolution> scoreDirectorFactory = new ConstraintStreamScoreDirectorFactory<>(
-                TestdataLavishSolution.buildSolutionDescriptor(), (factory) -> {
-                    UniConstraintStream<TestdataLavishEntityGroup> base = factory.from(TestdataLavishEntity.class)
-                            .groupBy(TestdataLavishEntity::getEntityGroup);
-                    return new Constraint[] {
-                            base.penalize("myConstraint1", SimpleScore.ONE),
-                            base.filter(e -> !Objects.equals(e, entityGroup1))
-                                    .penalize("myConstraint2", SimpleScore.ONE)
-                    };
-                }, constraintStreamImplType);
+        ConstraintStreamScoreDirectorFactory<TestdataLavishSolution> scoreDirectorFactory =
+                new ConstraintStreamScoreDirectorFactory<>(
+                        TestdataLavishSolution.buildSolutionDescriptor(), (factory) -> {
+                            UniConstraintStream<TestdataLavishEntityGroup> base = factory.from(TestdataLavishEntity.class)
+                                    .groupBy(TestdataLavishEntity::getEntityGroup);
+                            return new Constraint[] {
+                                    base.penalize("myConstraint1", SimpleScore.ONE),
+                                    base.filter(e -> !Objects.equals(e, entityGroup1))
+                                            .penalize("myConstraint2", SimpleScore.ONE)
+                            };
+                        }, constraintStreamImplType);
         InnerScoreDirector<TestdataLavishSolution> scoreDirector = scoreDirectorFactory.buildScoreDirector(false,
                 constraintMatchEnabled);
 

--- a/optaplanner-core/src/test/java/org/optaplanner/core/config/score/director/ScoreDirectorFactoryConfigTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/config/score/director/ScoreDirectorFactoryConfigTest.java
@@ -119,8 +119,8 @@ public class ScoreDirectorFactoryConfigTest {
                 .buildScoreDirectorFactory(new SolverConfigContext(), getClass().getClassLoader(),
                         EnvironmentMode.REPRODUCIBLE, TestdataSolution.buildSolutionDescriptor())
                 .buildScoreDirector();
-        TestCustomPropertiesIncrementalScoreCalculator scoreCalculator = (TestCustomPropertiesIncrementalScoreCalculator) scoreDirector
-                .getIncrementalScoreCalculator();
+        TestCustomPropertiesIncrementalScoreCalculator scoreCalculator =
+                (TestCustomPropertiesIncrementalScoreCalculator) scoreDirector.getIncrementalScoreCalculator();
         assertEquals("string 1", scoreCalculator.getStringProperty());
         assertEquals(7, scoreCalculator.getIntProperty());
     }

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/domain/constraintweight/descriptor/ConstraintWeightDescriptorTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/domain/constraintweight/descriptor/ConstraintWeightDescriptorTest.java
@@ -33,17 +33,17 @@ public class ConstraintWeightDescriptorTest {
     public void extractionFunction() {
         SolutionDescriptor<TestdataConstraintConfigurationSolution> solutionDescriptor = TestdataConstraintConfigurationSolution
                 .buildSolutionDescriptor();
-        ConstraintConfigurationDescriptor<TestdataConstraintConfigurationSolution> constraintConfigurationDescriptor = solutionDescriptor
-                .getConstraintConfigurationDescriptor();
+        ConstraintConfigurationDescriptor<TestdataConstraintConfigurationSolution> constraintConfigurationDescriptor =
+                solutionDescriptor.getConstraintConfigurationDescriptor();
 
-        ConstraintWeightDescriptor<TestdataConstraintConfigurationSolution> firstWeightDescriptor = constraintConfigurationDescriptor
-                .getConstraintWeightDescriptor("firstWeight");
+        ConstraintWeightDescriptor<TestdataConstraintConfigurationSolution> firstWeightDescriptor =
+                constraintConfigurationDescriptor.getConstraintWeightDescriptor("firstWeight");
         assertEquals(TestdataConstraintConfigurationSolution.class.getPackage().getName(),
                 firstWeightDescriptor.getConstraintPackage());
         assertEquals("First weight", firstWeightDescriptor.getConstraintName());
 
-        ConstraintWeightDescriptor<TestdataConstraintConfigurationSolution> secondWeightDescriptor = constraintConfigurationDescriptor
-                .getConstraintWeightDescriptor("secondWeight");
+        ConstraintWeightDescriptor<TestdataConstraintConfigurationSolution> secondWeightDescriptor =
+                constraintConfigurationDescriptor.getConstraintWeightDescriptor("secondWeight");
         assertEquals("packageOverwrittenOnField",
                 secondWeightDescriptor.getConstraintPackage());
         assertEquals("Second weight", secondWeightDescriptor.getConstraintName());
@@ -63,25 +63,25 @@ public class ConstraintWeightDescriptorTest {
 
     @Test
     public void extractionFunctionExtended() {
-        SolutionDescriptor<TestdataExtendedConstraintConfigurationSolution> solutionDescriptor = TestdataExtendedConstraintConfigurationSolution
-                .buildExtendedSolutionDescriptor();
-        ConstraintConfigurationDescriptor<TestdataExtendedConstraintConfigurationSolution> constraintConfigurationDescriptor = solutionDescriptor
-                .getConstraintConfigurationDescriptor();
+        SolutionDescriptor<TestdataExtendedConstraintConfigurationSolution> solutionDescriptor =
+                TestdataExtendedConstraintConfigurationSolution.buildExtendedSolutionDescriptor();
+        ConstraintConfigurationDescriptor<TestdataExtendedConstraintConfigurationSolution> constraintConfigurationDescriptor =
+                solutionDescriptor.getConstraintConfigurationDescriptor();
 
-        ConstraintWeightDescriptor<TestdataExtendedConstraintConfigurationSolution> firstWeightDescriptor = constraintConfigurationDescriptor
-                .getConstraintWeightDescriptor("firstWeight");
+        ConstraintWeightDescriptor<TestdataExtendedConstraintConfigurationSolution> firstWeightDescriptor =
+                constraintConfigurationDescriptor.getConstraintWeightDescriptor("firstWeight");
         assertEquals(TestdataConstraintConfigurationSolution.class.getPackage().getName(),
                 firstWeightDescriptor.getConstraintPackage());
         assertEquals("First weight", firstWeightDescriptor.getConstraintName());
 
-        ConstraintWeightDescriptor<TestdataExtendedConstraintConfigurationSolution> secondWeightDescriptor = constraintConfigurationDescriptor
-                .getConstraintWeightDescriptor("secondWeight");
+        ConstraintWeightDescriptor<TestdataExtendedConstraintConfigurationSolution> secondWeightDescriptor =
+                constraintConfigurationDescriptor.getConstraintWeightDescriptor("secondWeight");
         assertEquals("packageOverwrittenOnField",
                 secondWeightDescriptor.getConstraintPackage());
         assertEquals("Second weight", secondWeightDescriptor.getConstraintName());
 
-        ConstraintWeightDescriptor<TestdataExtendedConstraintConfigurationSolution> thirdWeightDescriptor = constraintConfigurationDescriptor
-                .getConstraintWeightDescriptor("thirdWeight");
+        ConstraintWeightDescriptor<TestdataExtendedConstraintConfigurationSolution> thirdWeightDescriptor =
+                constraintConfigurationDescriptor.getConstraintWeightDescriptor("thirdWeight");
         assertEquals(TestdataExtendedConstraintConfigurationSolution.class.getPackage().getName(),
                 thirdWeightDescriptor.getConstraintPackage());
         assertEquals("Third weight", thirdWeightDescriptor.getConstraintName());

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/domain/solution/descriptor/SolutionDescriptorTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/domain/solution/descriptor/SolutionDescriptorTest.java
@@ -75,8 +75,8 @@ public class SolutionDescriptorTest {
 
     @Test
     public void readMethodProblemFactCollectionProperty() {
-        SolutionDescriptor<TestdataReadMethodProblemFactCollectionPropertySolution> solutionDescriptor = TestdataReadMethodProblemFactCollectionPropertySolution
-                .buildSolutionDescriptor();
+        SolutionDescriptor<TestdataReadMethodProblemFactCollectionPropertySolution> solutionDescriptor =
+                TestdataReadMethodProblemFactCollectionPropertySolution.buildSolutionDescriptor();
         assertMapContainsKeysExactly(solutionDescriptor.getProblemFactMemberAccessorMap());
         assertMapContainsKeysExactly(solutionDescriptor.getProblemFactCollectionMemberAccessorMap(),
                 "valueList", "createProblemFacts");
@@ -203,8 +203,8 @@ public class SolutionDescriptorTest {
     @Test
     @Deprecated
     public void extendedAbstractSolutionOverridesGetScore() {
-        SolutionDescriptor<TestdataScoreGetterOverrideExtendedAbstractSolution> solutionDescriptor = TestdataScoreGetterOverrideExtendedAbstractSolution
-                .buildSolutionDescriptor();
+        SolutionDescriptor<TestdataScoreGetterOverrideExtendedAbstractSolution> solutionDescriptor =
+                TestdataScoreGetterOverrideExtendedAbstractSolution.buildSolutionDescriptor();
         assertMapContainsKeysExactly(solutionDescriptor.getProblemFactMemberAccessorMap());
         assertMapContainsKeysExactly(solutionDescriptor.getProblemFactCollectionMemberAccessorMap(),
                 "problemFactList");
@@ -212,7 +212,8 @@ public class SolutionDescriptorTest {
         assertMapContainsKeysExactly(solutionDescriptor.getEntityCollectionMemberAccessorMap(),
                 "entityList");
 
-        TestdataScoreGetterOverrideExtendedAbstractSolution solution = new TestdataScoreGetterOverrideExtendedAbstractSolution();
+        TestdataScoreGetterOverrideExtendedAbstractSolution solution =
+                new TestdataScoreGetterOverrideExtendedAbstractSolution();
         solution.setValueList(Arrays.asList(new TestdataValue("v1"), new TestdataValue("v2")));
         solution.setExtraObject(new TestdataValue("extra"));
         solution.setEntityList(Arrays.asList(new TestdataEntity("e1"), new TestdataEntity("e2")));
@@ -282,8 +283,8 @@ public class SolutionDescriptorTest {
 
     @Test
     public void autoDiscoverFieldsFactCollectionOverridenToSingleProperty() {
-        SolutionDescriptor<TestdataAutoDiscoverFieldOverrideSolution> solutionDescriptor = TestdataAutoDiscoverFieldOverrideSolution
-                .buildSolutionDescriptor();
+        SolutionDescriptor<TestdataAutoDiscoverFieldOverrideSolution> solutionDescriptor =
+                TestdataAutoDiscoverFieldOverrideSolution.buildSolutionDescriptor();
         assertMapContainsKeysExactly(solutionDescriptor.getProblemFactMemberAccessorMap(),
                 "singleProblemFact", "listProblemFact");
         assertMapContainsKeysExactly(solutionDescriptor.getProblemFactCollectionMemberAccessorMap(),
@@ -306,8 +307,8 @@ public class SolutionDescriptorTest {
 
     @Test
     public void autoDiscoverGettersFactCollectionOverridenToSingleProperty() {
-        SolutionDescriptor<TestdataAutoDiscoverGetterOverrideSolution> solutionDescriptor = TestdataAutoDiscoverGetterOverrideSolution
-                .buildSolutionDescriptor();
+        SolutionDescriptor<TestdataAutoDiscoverGetterOverrideSolution> solutionDescriptor =
+                TestdataAutoDiscoverGetterOverrideSolution.buildSolutionDescriptor();
         assertMapContainsKeysExactly(solutionDescriptor.getProblemFactMemberAccessorMap(),
                 "singleProblemFact", "listProblemFact");
         assertMapContainsKeysExactly(solutionDescriptor.getProblemFactCollectionMemberAccessorMap(),
@@ -330,8 +331,8 @@ public class SolutionDescriptorTest {
 
     @Test
     public void autoDiscoverUnannotatedEntitySubclass() {
-        SolutionDescriptor<TestdataAutoDiscoverUnannotatedEntitySolution> solutionDescriptor = TestdataAutoDiscoverUnannotatedEntitySolution
-                .buildSolutionDescriptor();
+        SolutionDescriptor<TestdataAutoDiscoverUnannotatedEntitySolution> solutionDescriptor =
+                TestdataAutoDiscoverUnannotatedEntitySolution.buildSolutionDescriptor();
         assertMapContainsKeysExactly(solutionDescriptor.getProblemFactMemberAccessorMap(), "singleProblemFact");
         assertMapContainsKeysExactly(solutionDescriptor.getProblemFactCollectionMemberAccessorMap(),
                 "problemFactList");
@@ -353,8 +354,8 @@ public class SolutionDescriptorTest {
 
     @Test
     public void autoDiscoverGettersOverriddenInSubclass() {
-        SolutionDescriptor<TestdataExtendedAutoDiscoverGetterSolution> solutionDescriptor = TestdataExtendedAutoDiscoverGetterSolution
-                .buildSubclassSolutionDescriptor();
+        SolutionDescriptor<TestdataExtendedAutoDiscoverGetterSolution> solutionDescriptor =
+                TestdataExtendedAutoDiscoverGetterSolution.buildSubclassSolutionDescriptor();
         assertEquals("constraintConfiguration", solutionDescriptor.getConstraintConfigurationMemberAccessor().getName());
         assertMapContainsKeysExactly(solutionDescriptor.getProblemFactMemberAccessorMap(), "constraintConfiguration",
                 "singleProblemFact", "problemFactList");

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/score/director/incremental/IncrementalScoreDirectorTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/score/director/incremental/IncrementalScoreDirectorTest.java
@@ -68,13 +68,14 @@ public class IncrementalScoreDirectorTest {
         when(scoreDirectorFactory.getSolutionDescriptor()).thenReturn(solutionDescriptor);
         IncrementalScoreCalculator<TestdataShadowingChainedSolution> incrementalScoreCalculator = mock(
                 IncrementalScoreCalculator.class);
-        IncrementalScoreDirector<TestdataShadowingChainedSolution> scoreDirector = new IncrementalScoreDirector<TestdataShadowingChainedSolution>(
-                scoreDirectorFactory, false, false, incrementalScoreCalculator) {
-            @Override
-            public Score calculateScore() {
-                return SimpleScore.of(-100);
-            }
-        };
+        IncrementalScoreDirector<TestdataShadowingChainedSolution> scoreDirector =
+                new IncrementalScoreDirector<TestdataShadowingChainedSolution>(
+                        scoreDirectorFactory, false, false, incrementalScoreCalculator) {
+                    @Override
+                    public Score calculateScore() {
+                        return SimpleScore.of(-100);
+                    }
+                };
         scoreDirector.setWorkingSolution(solution);
         reset(incrementalScoreCalculator);
 

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/testdata/domain/reinitialize/TestdataReinitializeEntity.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/testdata/domain/reinitialize/TestdataReinitializeEntity.java
@@ -51,7 +51,8 @@ public class TestdataReinitializeEntity extends TestdataObject {
         this.initialized = initialized;
     }
 
-    @PlanningVariable(valueRangeProviderRefs = "valueRange", reinitializeVariableEntityFilter = TestdataReinitializeEntityFilter.class)
+    @PlanningVariable(valueRangeProviderRefs = "valueRange",
+            reinitializeVariableEntityFilter = TestdataReinitializeEntityFilter.class)
     public TestdataValue getValue() {
         return value;
     }

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/testdata/domain/shadow/extended/TestdataExtendedShadowedParentEntity.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/testdata/domain/shadow/extended/TestdataExtendedShadowedParentEntity.java
@@ -78,8 +78,9 @@ public class TestdataExtendedShadowedParentEntity extends TestdataObject {
         this.firstShadow = firstShadow;
     }
 
-    @CustomShadowVariable(variableListenerClass = ThirdShadowUpdatingVariableListener.class, sources = {
-            @PlanningVariableReference(entityClass = TestdataExtendedShadowedChildEntity.class, variableName = "secondShadow") })
+    @CustomShadowVariable(variableListenerClass = ThirdShadowUpdatingVariableListener.class,
+            sources = { @PlanningVariableReference(entityClass = TestdataExtendedShadowedChildEntity.class,
+                    variableName = "secondShadow") })
     public String getThirdShadow() {
         return thirdShadow;
     }

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/coachshuttlegathering/app/CoachShuttleGatheringApp.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/coachshuttlegathering/app/CoachShuttleGatheringApp.java
@@ -28,7 +28,8 @@ import org.optaplanner.persistence.xstream.impl.domain.solution.XStreamSolutionF
 
 public class CoachShuttleGatheringApp extends CommonApp<CoachShuttleGatheringSolution> {
 
-    public static final String SOLVER_CONFIG = "org/optaplanner/examples/coachshuttlegathering/solver/coachShuttleGatheringSolverConfig.xml";
+    public static final String SOLVER_CONFIG =
+            "org/optaplanner/examples/coachshuttlegathering/solver/coachShuttleGatheringSolverConfig.xml";
 
     public static final String DATA_DIR_NAME = "coachshuttlegathering";
 

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/coachshuttlegathering/swingui/CoachShuttleGatheringPanel.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/coachshuttlegathering/swingui/CoachShuttleGatheringPanel.java
@@ -25,7 +25,8 @@ import org.optaplanner.examples.common.swingui.SolutionPanel;
 
 public class CoachShuttleGatheringPanel extends SolutionPanel<CoachShuttleGatheringSolution> {
 
-    public static final String LOGO_PATH = "/org/optaplanner/examples/coachshuttlegathering/swingui/coachShuttleGatheringLogo.png";
+    public static final String LOGO_PATH =
+            "/org/optaplanner/examples/coachshuttlegathering/swingui/coachShuttleGatheringLogo.png";
 
     private CoachShuttleGatheringWorldPanel coachShuttleGatheringWorldPanel;
 

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/common/swingui/SolutionPanel.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/common/swingui/SolutionPanel.java
@@ -40,7 +40,8 @@ import org.slf4j.LoggerFactory;
  */
 public abstract class SolutionPanel<Solution_> extends JPanel implements Scrollable {
 
-    protected static final String USAGE_EXPLANATION_PATH = "/org/optaplanner/examples/common/swingui/exampleUsageExplanation.png";
+    protected static final String USAGE_EXPLANATION_PATH =
+            "/org/optaplanner/examples/common/swingui/exampleUsageExplanation.png";
     // Size fits into screen resolution 1024*768
     public static final Dimension PREFERRED_SCROLLABLE_VIEWPORT_SIZE = new Dimension(800, 600);
 

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/conferencescheduling/app/ConferenceSchedulingApp.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/conferencescheduling/app/ConferenceSchedulingApp.java
@@ -25,7 +25,8 @@ import org.optaplanner.persistence.common.api.domain.solution.SolutionFileIO;
 
 public class ConferenceSchedulingApp extends CommonApp<ConferenceSolution> {
 
-    public static final String SOLVER_CONFIG = "org/optaplanner/examples/conferencescheduling/solver/conferenceSchedulingSolverConfig.xml";
+    public static final String SOLVER_CONFIG =
+            "org/optaplanner/examples/conferencescheduling/solver/conferenceSchedulingSolverConfig.xml";
 
     public static final String DATA_DIR_NAME = "conferencescheduling";
 

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/conferencescheduling/persistence/ConferenceSchedulingXlsxFileIO.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/conferencescheduling/persistence/ConferenceSchedulingXlsxFileIO.java
@@ -118,46 +118,82 @@ import org.optaplanner.swing.impl.TangoColorFactory;
 
 public class ConferenceSchedulingXlsxFileIO extends AbstractXlsxSolutionFileIO<ConferenceSolution> {
 
-    private static final String ROOM_UNAVAILABLE_TIMESLOT_DESCRIPTION = "Penalty per talk with an unavailable room in its timeslot, per minute";
-    private static final String ROOM_CONFLICT_DESCRIPTION = "Penalty per 2 talks in the same room and overlapping timeslots, per overlapping minute";
-    private static final String SPEAKER_UNAVAILABLE_TIMESLOT_DESCRIPTION = "Penalty per talk with an unavailable speaker in its timeslot, per minute";
-    private static final String SPEAKER_CONFLICT_DESCRIPTION = "Penalty per 2 talks with the same speaker and overlapping timeslots, per overlapping minute";
-    private static final String TALK_PREREQUISITE_TALKS_DESCRIPTION = "Penalty per prerequisite talk of a talk that doesn't end before the second talk starts, per minute of either talk";
-    private static final String TALK_MUTUALLY_EXCLUSIVE_TALKS_TAGS_DESCRIPTION = "Penalty per common mutually exclusive talks tag of 2 talks with overlapping timeslots, per overlapping minute";
-    private static final String CONSECUTIVE_TALKS_PAUSE_DESCRIPTION = "Penalty per 2 consecutive talks for the same speaker with a pause less than the minimum pause, per minute of either talk";
-    private static final String CROWD_CONTROL_DESCRIPTION = "Penalty per talk with a non-zero crowd control risk that are not in paired with exactly one other such talk, per minute of either talk";
+    private static final String ROOM_UNAVAILABLE_TIMESLOT_DESCRIPTION =
+            "Penalty per talk with an unavailable room in its timeslot, per minute";
+    private static final String ROOM_CONFLICT_DESCRIPTION =
+            "Penalty per 2 talks in the same room and overlapping timeslots, per overlapping minute";
+    private static final String SPEAKER_UNAVAILABLE_TIMESLOT_DESCRIPTION =
+            "Penalty per talk with an unavailable speaker in its timeslot, per minute";
+    private static final String SPEAKER_CONFLICT_DESCRIPTION =
+            "Penalty per 2 talks with the same speaker and overlapping timeslots, per overlapping minute";
+    private static final String TALK_PREREQUISITE_TALKS_DESCRIPTION =
+            "Penalty per prerequisite talk of a talk that doesn't end before the second talk starts, per minute of either talk";
+    private static final String TALK_MUTUALLY_EXCLUSIVE_TALKS_TAGS_DESCRIPTION =
+            "Penalty per common mutually exclusive talks tag of 2 talks with overlapping timeslots, per overlapping minute";
+    private static final String CONSECUTIVE_TALKS_PAUSE_DESCRIPTION =
+            "Penalty per 2 consecutive talks for the same speaker with a pause less than the minimum pause, per minute of either talk";
+    private static final String CROWD_CONTROL_DESCRIPTION =
+            "Penalty per talk with a non-zero crowd control risk that are not in paired with exactly one other such talk, per minute of either talk";
 
-    private static final String SPEAKER_REQUIRED_TIMESLOT_TAGS_DESCRIPTION = "Penalty per missing required tag in a talk's timeslot, per minute";
-    private static final String SPEAKER_PROHIBITED_TIMESLOT_TAGS_DESCRIPTION = "Penalty per prohibited tag in a talk's timeslot, per minute";
-    private static final String TALK_REQUIRED_TIMESLOT_TAGS_DESCRIPTION = "Penalty per missing required tag in a talk's timeslot, per minute";
-    private static final String TALK_PROHIBITED_TIMESLOT_TAGS_DESCRIPTION = "Penalty per prohibited tag in a talk's timeslot, per minute";
-    private static final String SPEAKER_REQUIRED_ROOM_TAGS_DESCRIPTION = "Penalty per missing required tag in a talk's room, per minute";
-    private static final String SPEAKER_PROHIBITED_ROOM_TAGS_DESCRIPTION = "Penalty per prohibited tag in a talk's room, per minute";
-    private static final String TALK_REQUIRED_ROOM_TAGS_DESCRIPTION = "Penalty per missing required tag in a talk's room, per minute";
-    private static final String TALK_PROHIBITED_ROOM_TAGS_DESCRIPTION = "Penalty per prohibited tag in a talk's room, per minute";
+    private static final String SPEAKER_REQUIRED_TIMESLOT_TAGS_DESCRIPTION =
+            "Penalty per missing required tag in a talk's timeslot, per minute";
+    private static final String SPEAKER_PROHIBITED_TIMESLOT_TAGS_DESCRIPTION =
+            "Penalty per prohibited tag in a talk's timeslot, per minute";
+    private static final String TALK_REQUIRED_TIMESLOT_TAGS_DESCRIPTION =
+            "Penalty per missing required tag in a talk's timeslot, per minute";
+    private static final String TALK_PROHIBITED_TIMESLOT_TAGS_DESCRIPTION =
+            "Penalty per prohibited tag in a talk's timeslot, per minute";
+    private static final String SPEAKER_REQUIRED_ROOM_TAGS_DESCRIPTION =
+            "Penalty per missing required tag in a talk's room, per minute";
+    private static final String SPEAKER_PROHIBITED_ROOM_TAGS_DESCRIPTION =
+            "Penalty per prohibited tag in a talk's room, per minute";
+    private static final String TALK_REQUIRED_ROOM_TAGS_DESCRIPTION =
+            "Penalty per missing required tag in a talk's room, per minute";
+    private static final String TALK_PROHIBITED_ROOM_TAGS_DESCRIPTION =
+            "Penalty per prohibited tag in a talk's room, per minute";
 
-    private static final String PUBLISHED_TIMESLOT_DESCRIPTION = "Penalty per published talk with a different timeslot than its published timeslot, per match";
+    private static final String PUBLISHED_TIMESLOT_DESCRIPTION =
+            "Penalty per published talk with a different timeslot than its published timeslot, per match";
 
-    private static final String PUBLISHED_ROOM_DESCRIPTION = "Penalty per published talk with a different room than its published room, per match";
-    private static final String THEME_TRACK_CONFLICT_DESCRIPTION = "Penalty per common theme track of 2 talks with overlapping timeslots, per overlapping minute";
-    private static final String THEME_TRACK_ROOM_STABILITY_DESCRIPTION = "Penalty per common theme track of 2 talks in a different room on the same day, per minute of either talk";
-    private static final String SECTOR_CONFLICT_DESCRIPTION = "Penalty per common sector of 2 talks with overlapping timeslots, per overlapping minute";
-    private static final String AUDIENCE_TYPE_DIVERSITY_DESCRIPTION = "Reward per 2 talks with a different audience type and the same timeslot, per (overlapping) minute";
-    private static final String AUDIENCE_TYPE_THEME_TRACK_CONFLICT_DESCRIPTION = "Penalty per 2 talks with a common audience type, a common theme track and overlapping timeslots, per overlapping minute";
-    private static final String AUDIENCE_LEVEL_DIVERSITY_DESCRIPTION = "Reward per 2 talks with a different audience level and the same timeslot, per (overlapping) minute";
-    private static final String CONTENT_AUDIENCE_LEVEL_FLOW_VIOLATION_DESCRIPTION = "Penalty per common content of 2 talks with a different audience level for which the easier talk isn't scheduled earlier than the other talk, per minute of either talk";
-    private static final String CONTENT_CONFLICT_DESCRIPTION = "Penalty per common content of 2 talks with overlapping timeslots, per overlapping minute";
-    private static final String LANGUAGE_DIVERSITY_DESCRIPTION = "Reward per 2 talks with a different language and the the same timeslot, per (overlapping) minute";
-    private static final String SAME_DAY_TALKS_DESCRIPTION = "Penalty per common content or theme track of 2 talks with a different day, per minute of either talk";
-    private static final String POPULAR_TALKS_DESCRIPTION = "Penalty per 2 talks where the less popular one (has lower favorite count) is assigned a larger room than the more popular talk";
+    private static final String PUBLISHED_ROOM_DESCRIPTION =
+            "Penalty per published talk with a different room than its published room, per match";
+    private static final String THEME_TRACK_CONFLICT_DESCRIPTION =
+            "Penalty per common theme track of 2 talks with overlapping timeslots, per overlapping minute";
+    private static final String THEME_TRACK_ROOM_STABILITY_DESCRIPTION =
+            "Penalty per common theme track of 2 talks in a different room on the same day, per minute of either talk";
+    private static final String SECTOR_CONFLICT_DESCRIPTION =
+            "Penalty per common sector of 2 talks with overlapping timeslots, per overlapping minute";
+    private static final String AUDIENCE_TYPE_DIVERSITY_DESCRIPTION =
+            "Reward per 2 talks with a different audience type and the same timeslot, per (overlapping) minute";
+    private static final String AUDIENCE_TYPE_THEME_TRACK_CONFLICT_DESCRIPTION =
+            "Penalty per 2 talks with a common audience type, a common theme track and overlapping timeslots, per overlapping minute";
+    private static final String AUDIENCE_LEVEL_DIVERSITY_DESCRIPTION =
+            "Reward per 2 talks with a different audience level and the same timeslot, per (overlapping) minute";
+    private static final String CONTENT_AUDIENCE_LEVEL_FLOW_VIOLATION_DESCRIPTION =
+            "Penalty per common content of 2 talks with a different audience level for which the easier talk isn't scheduled earlier than the other talk, per minute of either talk";
+    private static final String CONTENT_CONFLICT_DESCRIPTION =
+            "Penalty per common content of 2 talks with overlapping timeslots, per overlapping minute";
+    private static final String LANGUAGE_DIVERSITY_DESCRIPTION =
+            "Reward per 2 talks with a different language and the the same timeslot, per (overlapping) minute";
+    private static final String SAME_DAY_TALKS_DESCRIPTION =
+            "Penalty per common content or theme track of 2 talks with a different day, per minute of either talk";
+    private static final String POPULAR_TALKS_DESCRIPTION =
+            "Penalty per 2 talks where the less popular one (has lower favorite count) is assigned a larger room than the more popular talk";
 
-    private static final String SPEAKER_PREFERRED_TIMESLOT_TAGS_DESCRIPTION = "Penalty per missing preferred tag in a talk's timeslot, per minute";
-    private static final String SPEAKER_UNDESIRED_TIMESLOT_TAGS_DESCRIPTION = "Penalty per undesired tag in a talk's timeslot, per minute";
-    private static final String TALK_PREFERRED_TIMESLOT_TAGS_DESCRIPTION = "Penalty per missing preferred tag in a talk's timeslot, per minute";
-    private static final String TALK_UNDESIRED_TIMESLOT_TAGS_DESCRIPTION = "Penalty per undesired tag in a talk's timeslot, per minute";
-    private static final String SPEAKER_PREFERRED_ROOM_TAGS_DESCRIPTION = "Penalty per missing preferred tag in a talk's room, per minute";
-    private static final String SPEAKER_UNDESIRED_ROOM_TAGS_DESCRIPTION = "Penalty per undesired tag in a talk's room, per minute";
-    private static final String TALK_PREFERRED_ROOM_TAGS_DESCRIPTION = "Penalty per missing preferred tag in a talk's room, per minute";
+    private static final String SPEAKER_PREFERRED_TIMESLOT_TAGS_DESCRIPTION =
+            "Penalty per missing preferred tag in a talk's timeslot, per minute";
+    private static final String SPEAKER_UNDESIRED_TIMESLOT_TAGS_DESCRIPTION =
+            "Penalty per undesired tag in a talk's timeslot, per minute";
+    private static final String TALK_PREFERRED_TIMESLOT_TAGS_DESCRIPTION =
+            "Penalty per missing preferred tag in a talk's timeslot, per minute";
+    private static final String TALK_UNDESIRED_TIMESLOT_TAGS_DESCRIPTION =
+            "Penalty per undesired tag in a talk's timeslot, per minute";
+    private static final String SPEAKER_PREFERRED_ROOM_TAGS_DESCRIPTION =
+            "Penalty per missing preferred tag in a talk's room, per minute";
+    private static final String SPEAKER_UNDESIRED_ROOM_TAGS_DESCRIPTION =
+            "Penalty per undesired tag in a talk's room, per minute";
+    private static final String TALK_PREFERRED_ROOM_TAGS_DESCRIPTION =
+            "Penalty per missing preferred tag in a talk's room, per minute";
     private static final String TALK_UNDESIRED_ROOM_TAGS_DESCRIPTION = "Penalty per undesired tag in a talk's room, per minute";
 
     private static final Comparator<Timeslot> COMPARATOR = comparing(Timeslot::getStartDateTime)

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/conferencescheduling/swingui/ConferenceSchedulingPanel.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/conferencescheduling/swingui/ConferenceSchedulingPanel.java
@@ -34,7 +34,8 @@ import org.optaplanner.persistence.common.api.domain.solution.SolutionFileIO;
 
 public class ConferenceSchedulingPanel extends SolutionPanel<ConferenceSolution> {
 
-    public static final String LOGO_PATH = "/org/optaplanner/examples/conferencescheduling/swingui/conferenceSchedulingLogo.png";
+    public static final String LOGO_PATH =
+            "/org/optaplanner/examples/conferencescheduling/swingui/conferenceSchedulingLogo.png";
 
     public ConferenceSchedulingPanel() {
         JButton publishButton = new JButton("Publish");

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/curriculumcourse/app/CurriculumCourseApp.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/curriculumcourse/app/CurriculumCourseApp.java
@@ -28,7 +28,8 @@ import org.optaplanner.persistence.xstream.impl.domain.solution.XStreamSolutionF
 
 public class CurriculumCourseApp extends CommonApp<CourseSchedule> {
 
-    public static final String SOLVER_CONFIG = "org/optaplanner/examples/curriculumcourse/solver/curriculumCourseSolverConfig.xml";
+    public static final String SOLVER_CONFIG =
+            "org/optaplanner/examples/curriculumcourse/solver/curriculumCourseSolverConfig.xml";
 
     public static final String DATA_DIR_NAME = "curriculumcourse";
 

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/flightcrewscheduling/app/FlightCrewSchedulingApp.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/flightcrewscheduling/app/FlightCrewSchedulingApp.java
@@ -24,7 +24,8 @@ import org.optaplanner.persistence.common.api.domain.solution.SolutionFileIO;
 
 public class FlightCrewSchedulingApp extends CommonApp<FlightCrewSolution> {
 
-    public static final String SOLVER_CONFIG = "org/optaplanner/examples/flightcrewscheduling/solver/flightCrewSchedulingSolverConfig.xml";
+    public static final String SOLVER_CONFIG =
+            "org/optaplanner/examples/flightcrewscheduling/solver/flightCrewSchedulingSolverConfig.xml";
 
     public static final String DATA_DIR_NAME = "flightcrewscheduling";
 

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/flightcrewscheduling/domain/FlightCrewParametrization.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/flightcrewscheduling/domain/FlightCrewParametrization.java
@@ -25,7 +25,8 @@ public class FlightCrewParametrization extends AbstractPersistable {
     public static final String TRANSFER_BETWEEN_TWO_FLIGHTS = "Transfer between two flights";
     public static final String EMPLOYEE_UNAVAILABILITY = "Employee unavailability";
 
-    public static final String LOAD_BALANCE_FLIGHT_DURATION_TOTAL_PER_EMPLOYEE = "Load balance flight duration total per employee";
+    public static final String LOAD_BALANCE_FLIGHT_DURATION_TOTAL_PER_EMPLOYEE =
+            "Load balance flight duration total per employee";
 
     private long loadBalanceFlightDurationTotalPerEmployee = 1;
 

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/flightcrewscheduling/swingui/FlightCrewSchedulingPanel.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/flightcrewscheduling/swingui/FlightCrewSchedulingPanel.java
@@ -33,7 +33,8 @@ import org.optaplanner.persistence.common.api.domain.solution.SolutionFileIO;
 
 public class FlightCrewSchedulingPanel extends SolutionPanel<FlightCrewSolution> {
 
-    public static final String LOGO_PATH = "/org/optaplanner/examples/flightcrewscheduling/swingui/flightCrewSchedulingLogo.png";
+    public static final String LOGO_PATH =
+            "/org/optaplanner/examples/flightcrewscheduling/swingui/flightCrewSchedulingLogo.png";
 
     private FlightCrewSchedulingWorldPanel flightCrewSchedulingWorldPanel;
 

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/machinereassignment/app/MachineReassignmentApp.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/machinereassignment/app/MachineReassignmentApp.java
@@ -28,7 +28,8 @@ import org.optaplanner.persistence.xstream.impl.domain.solution.XStreamSolutionF
 
 public class MachineReassignmentApp extends CommonApp<MachineReassignment> {
 
-    public static final String SOLVER_CONFIG = "org/optaplanner/examples/machinereassignment/solver/machineReassignmentSolverConfig.xml";
+    public static final String SOLVER_CONFIG =
+            "org/optaplanner/examples/machinereassignment/solver/machineReassignmentSolverConfig.xml";
 
     public static final String DATA_DIR_NAME = "machinereassignment";
 

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/meetingscheduling/app/MeetingSchedulingApp.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/meetingscheduling/app/MeetingSchedulingApp.java
@@ -24,7 +24,8 @@ import org.optaplanner.persistence.common.api.domain.solution.SolutionFileIO;
 
 public class MeetingSchedulingApp extends CommonApp<MeetingSchedule> {
 
-    public static final String SOLVER_CONFIG = "org/optaplanner/examples/meetingscheduling/solver/meetingSchedulingSolverConfig.xml";
+    public static final String SOLVER_CONFIG =
+            "org/optaplanner/examples/meetingscheduling/solver/meetingSchedulingSolverConfig.xml";
 
     public static final String DATA_DIR_NAME = "meetingscheduling";
 

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/meetingscheduling/domain/MeetingConstraintConfiguration.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/meetingscheduling/domain/MeetingConstraintConfiguration.java
@@ -34,7 +34,8 @@ public class MeetingConstraintConfiguration extends AbstractPersistable {
     public static final String PREFERRED_ATTENDANCE_CONFLICT = "Preferred attendance conflict";
 
     public static final String DO_ALL_MEETINGS_AS_SOON_AS_POSSIBLE = "Do all meetings as soon as possible";
-    public static final String ONE_TIME_GRAIN_BREAK_BETWEEN_TWO_CONSECUTIVE_MEETINGS = "One TimeGrain break between two consecutive meetings";
+    public static final String ONE_TIME_GRAIN_BREAK_BETWEEN_TWO_CONSECUTIVE_MEETINGS =
+            "One TimeGrain break between two consecutive meetings";
     public static final String OVERLAPPING_MEETINGS = "Overlapping meetings";
     public static final String ASSIGN_LARGER_ROOMS_FIRST = "Assign larger rooms first";
     public static final String ROOM_STABILITY = "Room stability";

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/nurserostering/domain/ShiftAssignment.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/nurserostering/domain/ShiftAssignment.java
@@ -29,7 +29,8 @@ import org.optaplanner.examples.nurserostering.domain.solver.ShiftAssignmentDiff
 
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 
-@PlanningEntity(movableEntitySelectionFilter = MovableShiftAssignmentSelectionFilter.class, difficultyComparatorClass = ShiftAssignmentDifficultyComparator.class)
+@PlanningEntity(movableEntitySelectionFilter = MovableShiftAssignmentSelectionFilter.class,
+        difficultyComparatorClass = ShiftAssignmentDifficultyComparator.class)
 @XStreamAlias("ShiftAssignment")
 public class ShiftAssignment extends AbstractPersistable implements Comparable<ShiftAssignment> {
 

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/projectjobscheduling/app/ProjectJobSchedulingApp.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/projectjobscheduling/app/ProjectJobSchedulingApp.java
@@ -26,7 +26,8 @@ import org.optaplanner.persistence.xstream.impl.domain.solution.XStreamSolutionF
 
 public class ProjectJobSchedulingApp extends CommonApp<Schedule> {
 
-    public static final String SOLVER_CONFIG = "org/optaplanner/examples/projectjobscheduling/solver/projectJobSchedulingSolverConfig.xml";
+    public static final String SOLVER_CONFIG =
+            "org/optaplanner/examples/projectjobscheduling/solver/projectJobSchedulingSolverConfig.xml";
 
     public static final String DATA_DIR_NAME = "projectjobscheduling";
 

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/projectjobscheduling/swingui/ProjectJobSchedulingPanel.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/projectjobscheduling/swingui/ProjectJobSchedulingPanel.java
@@ -37,7 +37,8 @@ import org.optaplanner.examples.projectjobscheduling.domain.Schedule;
 
 public class ProjectJobSchedulingPanel extends SolutionPanel<Schedule> {
 
-    public static final String LOGO_PATH = "/org/optaplanner/examples/projectjobscheduling/swingui/projectJobSchedulingLogo.png";
+    public static final String LOGO_PATH =
+            "/org/optaplanner/examples/projectjobscheduling/swingui/projectJobSchedulingLogo.png";
 
     public ProjectJobSchedulingPanel() {
         setLayout(new BorderLayout());

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/travelingtournament/app/TravelingTournamentApp.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/travelingtournament/app/TravelingTournamentApp.java
@@ -31,7 +31,8 @@ import org.optaplanner.persistence.xstream.impl.domain.solution.XStreamSolutionF
  */
 public class TravelingTournamentApp extends CommonApp<TravelingTournament> {
 
-    public static final String SOLVER_CONFIG = "org/optaplanner/examples/travelingtournament/solver/travelingTournamentSolverConfig.xml";
+    public static final String SOLVER_CONFIG =
+            "org/optaplanner/examples/travelingtournament/solver/travelingTournamentSolverConfig.xml";
 
     public static final String DATA_DIR_NAME = "travelingtournament";
 

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/tsp/domain/Visit.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/tsp/domain/Visit.java
@@ -44,8 +44,9 @@ public class Visit extends AbstractPersistable implements Standstill {
         this.location = location;
     }
 
-    @PlanningVariable(valueRangeProviderRefs = { "domicileRange",
-            "visitRange" }, graphType = PlanningVariableGraphType.CHAINED, strengthWeightFactoryClass = DomicileDistanceStandstillStrengthWeightFactory.class)
+    @PlanningVariable(valueRangeProviderRefs = { "domicileRange", "visitRange" },
+            graphType = PlanningVariableGraphType.CHAINED,
+            strengthWeightFactoryClass = DomicileDistanceStandstillStrengthWeightFactory.class)
     public Standstill getPreviousStandstill() {
         return previousStandstill;
     }

--- a/optaplanner-examples/src/test/java/org/optaplanner/examples/machinereassignment/solver/score/MachineReassignmentConstraintProviderTest.java
+++ b/optaplanner-examples/src/test/java/org/optaplanner/examples/machinereassignment/solver/score/MachineReassignmentConstraintProviderTest.java
@@ -42,8 +42,9 @@ import org.optaplanner.test.api.score.stream.ConstraintVerifier;
 
 public class MachineReassignmentConstraintProviderTest {
 
-    private final ConstraintVerifier<MachineReassignmentConstraintProvider, MachineReassignment> constraintVerifier = ConstraintVerifier
-            .build(new MachineReassignmentConstraintProvider(), MachineReassignment.class, MrProcessAssignment.class);
+    private final ConstraintVerifier<MachineReassignmentConstraintProvider, MachineReassignment> constraintVerifier =
+            ConstraintVerifier
+                    .build(new MachineReassignmentConstraintProvider(), MachineReassignment.class, MrProcessAssignment.class);
 
     @Test
     public void maximumCapacity() {

--- a/optaplanner-examples/src/test/java/org/optaplanner/examples/vehiclerouting/optional/score/VehicleRoutingConstraintProviderTest.java
+++ b/optaplanner-examples/src/test/java/org/optaplanner/examples/vehiclerouting/optional/score/VehicleRoutingConstraintProviderTest.java
@@ -30,9 +30,9 @@ import org.optaplanner.test.api.score.stream.ConstraintVerifier;
 
 public class VehicleRoutingConstraintProviderTest {
 
-    private final ConstraintVerifier<VehicleRoutingConstraintProvider, VehicleRoutingSolution> constraintVerifier = ConstraintVerifier
-            .build(new VehicleRoutingConstraintProvider(),
-                    VehicleRoutingSolution.class, Standstill.class, Customer.class, TimeWindowedCustomer.class);
+    private final ConstraintVerifier<VehicleRoutingConstraintProvider, VehicleRoutingSolution> constraintVerifier =
+            ConstraintVerifier.build(new VehicleRoutingConstraintProvider(), VehicleRoutingSolution.class, Standstill.class,
+                    Customer.class, TimeWindowedCustomer.class);
 
     private final Location location1 = new AirLocation(1L, 0.0, 0.0);
     private final Location location2 = new AirLocation(2L, 0.0, 4.0);

--- a/optaplanner-persistence/optaplanner-persistence-jpa/src/test/java/org/optaplanner/persistence/jpa/impl/score/buildin/bendablebigdecimal/BendableBigDecimalScoreHibernateTypeTest.java
+++ b/optaplanner-persistence/optaplanner-persistence-jpa/src/test/java/org/optaplanner/persistence/jpa/impl/score/buildin/bendablebigdecimal/BendableBigDecimalScoreHibernateTypeTest.java
@@ -44,8 +44,8 @@ public class BendableBigDecimalScoreHibernateTypeTest extends AbstractScoreHiber
     }
 
     @Entity
-    @TypeDef(defaultForType = BendableBigDecimalScore.class, typeClass = BendableBigDecimalScoreHibernateType.class, parameters = {
-            @Parameter(name = "hardLevelsSize", value = "3"), @Parameter(name = "softLevelsSize", value = "2") })
+    @TypeDef(defaultForType = BendableBigDecimalScore.class, typeClass = BendableBigDecimalScoreHibernateType.class,
+            parameters = { @Parameter(name = "hardLevelsSize", value = "3"), @Parameter(name = "softLevelsSize", value = "2") })
     public static class TestJpaEntity extends AbstractScoreHibernateTypeTest.AbstractTestJpaEntity<BendableBigDecimalScore> {
 
         protected BendableBigDecimalScore score;


### PR DESCRIPTION
There are three rather serious issues with the code style, which are
fixed by this commit:
- inability to wrap around the assignment operator
- annotation parameters must be on a single line
- method declaration must be on a single line

As agreed with @ge0ffrey , I am fixing the code style for this repository first and then bringing the same changes to Quarkus.