### PR TITLE
Align Asciidoctor plugin Netty dependencies to kie-parent

### DIFF
--- a/optaplanner-docs/pom.xml
+++ b/optaplanner-docs/pom.xml
@@ -44,6 +44,13 @@
         <plugin>
           <groupId>org.asciidoctor</groupId>
           <artifactId>asciidoctor-maven-plugin</artifactId>
+          <dependencies>
+            <dependency>
+              <groupId>io.netty</groupId>
+              <artifactId>netty-codec-http</artifactId>
+              <version>${version.io.netty}</version>
+            </dependency>
+          </dependencies>
           <configuration>
             <imagesDir>.</imagesDir>
             <attributes>


### PR DESCRIPTION
Signed-off-by: Alberto Morales Pérez <almorale@redhat.com>

The Asciidoctor plugin mojo that uses the Netty dependency is actually not used in the project so the change should be safe.