### PR TITLE
Every time a new problem fact change is added, reset is requested. A …

### DIFF
--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/stream/ConstraintStreamScoreDirector.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/stream/ConstraintStreamScoreDirector.java
@@ -58,6 +58,9 @@ public class ConstraintStreamScoreDirector<Solution_>
     }
 
     private void resetConstraintStreamingSession() {
+        if (session != null) {
+            session.close();
+        }
         session = scoreDirectorFactory.newConstraintStreamingSession(constraintMatchEnabledPreference, workingSolution);
         Collection<Object> workingFacts = getSolutionDescriptor().getAllFacts(workingSolution);
         for (Object fact : workingFacts) {


### PR DESCRIPTION
 Every time a new problem fact change is added, reset is requested. An already running session shall be disposed of (also done in DroolsScoreDirector), else originalKieBase and currentKieBase in DroolsConstraintSessionFactory keep accumulating sessions in concurrent hash map leading to memory leaks.