### PR TITLE
DO NOT MERGE - Branch OptaPlanner 8 test Jenkins CI cross repo PR

### DIFF
--- a/optaplanner-core/pom.xml
+++ b/optaplanner-core/pom.xml
@@ -27,6 +27,12 @@
   </properties>
 
   <dependencies>
+    <!-- DO NOT MERGE THIS -->
+    <!-- Test CI for Cross repository PR's over build-boostrap master and optaplanner 7.x -->
+    <dependency>
+      <groupId>org.guvnor</groupId>
+      <artifactId>guvnor-project-api</artifactId>
+    </dependency>
     <!-- Internal dependencies -->
     <dependency>
       <groupId>org.kie</groupId>


### PR DESCRIPTION
This tests a cross repo PR towards build-bootstrap master and optaplanner 7.x. Do not merge. We'll close it when we're done.

PR's involved:

* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1379
* https://github.com/kiegroup/optaplanner/pull/818