### PR TITLE
Enable GitHub Actions for 7.x branch

### DIFF
--- a/.github/workflows/jpa_integration_ci.yml
+++ b/.github/workflows/jpa_integration_ci.yml
@@ -6,9 +6,11 @@ on:
   push:
     branches:
       - master
+      - 7.x
   pull_request:
     branches:
       - master
+      - 7.x
 
 env:
   # To prevent build failures due to "Connection reset" during artifact download.

--- a/.github/workflows/os_java_ci.yml
+++ b/.github/workflows/os_java_ci.yml
@@ -6,9 +6,11 @@ on:
   push:
     branches:
       - master
+      - 7.x
   pull_request:
     branches:
       - master
+      - 7.x
 
 env:
   # To prevent build failures due to "Connection reset" during artifact download.


### PR DESCRIPTION
As the 7.x branch has become another long-live branch now, we should have the same level of CI there.