### PR TITLE
PLANNER-1996: Enable dependency check

### DIFF
--- a/optaplanner-benchmark/pom.xml
+++ b/optaplanner-benchmark/pom.xml
@@ -89,6 +89,7 @@
     <dependency>
       <groupId>org.glassfish.jaxb</groupId>
       <artifactId>jaxb-runtime</artifactId>
+      <scope>runtime</scope>
     </dependency>
     <!-- Benchmarker statistics -->
     <dependency>

--- a/optaplanner-build-parent/pom.xml
+++ b/optaplanner-build-parent/pom.xml
@@ -103,7 +103,27 @@
       </dependency>
       <dependency>
         <groupId>org.kie.kogito</groupId>
-        <artifactId>kogito-drools</artifactId>
+        <artifactId>kogito-internal</artifactId>
+        <version>${version.org.kie.kogito}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.kie.kogito</groupId>
+        <artifactId>kogito-drools-model</artifactId>
+        <version>${version.org.kie.kogito}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.kie.kogito</groupId>
+        <artifactId>kogito-ruleunits</artifactId>
+        <version>${version.org.kie.kogito}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.kie.kogito</groupId>
+        <artifactId>drools-core</artifactId>
+        <version>${version.org.kie.kogito}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.kie.kogito</groupId>
+        <artifactId>drools-compiler</artifactId>
         <version>${version.org.kie.kogito}</version>
       </dependency>
       <dependency>
@@ -996,6 +1016,23 @@
       <plugin>
         <groupId>net.revelc.code</groupId>
         <artifactId>impsort-maven-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>analyze-only</id>
+            <goals>
+              <goal>analyze-only</goal>
+            </goals>
+            <configuration>
+              <failOnWarning>true</failOnWarning>
+              <ignoreNonCompile>true</ignoreNonCompile>
+              <verbose>true</verbose>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
       <plugin>
         <artifactId>maven-enforcer-plugin</artifactId>

--- a/optaplanner-core/pom.xml
+++ b/optaplanner-core/pom.xml
@@ -34,11 +34,25 @@
     </dependency>
     <dependency>
       <groupId>org.kie.kogito</groupId>
-      <artifactId>kogito-drools</artifactId>
+      <artifactId>kogito-internal</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.kie.kogito</groupId>
+      <artifactId>kogito-drools-model</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.kie.kogito</groupId>
+      <artifactId>drools-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.kie.kogito</groupId>
+      <artifactId>drools-compiler</artifactId>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.kie.kogito</groupId>
       <artifactId>drools-core-dynamic</artifactId>
+      <scope>runtime</scope>
     </dependency>
     <!-- External dependencies -->
     <!-- Common utils -->
@@ -77,6 +91,7 @@
     <dependency>
       <groupId>org.glassfish.jaxb</groupId>
       <artifactId>jaxb-runtime</artifactId>
+      <scope>runtime</scope>
     </dependency>
     <!-- Testing -->
     <dependency>
@@ -108,6 +123,20 @@
 
   <build>
     <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <configuration>
+          <ignoredUsedUndeclaredDependencies>
+            <!-- TODO Remove this and declare org.drools dependencies once their versions are managed by kogito-bom. -->
+            <dependency>org.drools:*</dependency>
+          </ignoredUsedUndeclaredDependencies>
+          <ignoredUnusedDeclaredDependencies>
+            <!-- Provides org.drools:* dependencies -->
+            <dependency>org.kie.kogito:kogito-drools-model</dependency>
+          </ignoredUnusedDeclaredDependencies>
+        </configuration>
+      </plugin>
       <plugin>
         <groupId>org.revapi</groupId>
         <artifactId>revapi-maven-plugin</artifactId>

--- a/optaplanner-examples/pom.xml
+++ b/optaplanner-examples/pom.xml
@@ -89,18 +89,6 @@
       <groupId>org.optaplanner</groupId>
       <artifactId>optaplanner-persistence-xstream</artifactId>
     </dependency>
-    <dependency><!-- TODO add examples that use the JAXB integration -->
-      <groupId>org.optaplanner</groupId>
-      <artifactId>optaplanner-persistence-jaxb</artifactId>
-    </dependency>
-    <dependency><!-- TODO add examples that use the jackson integration -->
-      <groupId>org.optaplanner</groupId>
-      <artifactId>optaplanner-persistence-jackson</artifactId>
-    </dependency>
-    <dependency><!-- TODO add examples that use the JSON-B integration -->
-      <groupId>org.optaplanner</groupId>
-      <artifactId>optaplanner-persistence-jsonb</artifactId>
-    </dependency>
     <dependency>
       <groupId>org.optaplanner</groupId>
       <artifactId>optaplanner-benchmark</artifactId>
@@ -123,6 +111,10 @@
     <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.glassfish</groupId>
+      <artifactId>jakarta.json</artifactId>
     </dependency>
     <dependency>
       <groupId>org.jfree</groupId>

--- a/optaplanner-examples/src/test/java/org/optaplanner/examples/machinereassignment/solver/score/MachineReassignmentConstraintProviderTest.java
+++ b/optaplanner-examples/src/test/java/org/optaplanner/examples/machinereassignment/solver/score/MachineReassignmentConstraintProviderTest.java
@@ -19,9 +19,9 @@ package org.optaplanner.examples.machinereassignment.solver.score;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.Map;
 
-import org.apache.commons.collections4.map.HashedMap;
 import org.junit.jupiter.api.Test;
 import org.optaplanner.core.api.score.buildin.hardsoftlong.HardSoftLongScore;
 import org.optaplanner.examples.machinereassignment.domain.MachineReassignment;
@@ -257,11 +257,11 @@ public class MachineReassignmentConstraintProviderTest {
         MrMachine machine1 = new MrMachine();
         MrMachine machine2 = new MrMachine();
 
-        Map<MrMachine, Integer> costMapFromMachine1 = new HashedMap<>();
+        Map<MrMachine, Integer> costMapFromMachine1 = new HashMap<>();
         costMapFromMachine1.put(machine2, 20);
         machine1.setMachineMoveCostMap(costMapFromMachine1);
 
-        Map<MrMachine, Integer> costMapFromMachine2 = new HashedMap<>();
+        Map<MrMachine, Integer> costMapFromMachine2 = new HashMap<>();
         costMapFromMachine2.put(machine1, 0);
         machine2.setMachineMoveCostMap(costMapFromMachine2);
 

--- a/optaplanner-integration/optaplanner-spring-boot-autoconfigure/pom.xml
+++ b/optaplanner-integration/optaplanner-spring-boot-autoconfigure/pom.xml
@@ -39,10 +39,6 @@
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-autoconfigure</artifactId>
     </dependency>
-    <dependency>
-      <groupId>org.springframework</groupId>
-      <artifactId>spring-context</artifactId>
-    </dependency>
 
     <dependency>
       <groupId>org.springframework.boot</groupId>
@@ -98,4 +94,21 @@
     </dependency>
   </dependencies>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <configuration>
+          <ignoredUsedUndeclaredDependencies>
+            <dependency>org.springframework.boot:spring-boot</dependency>
+            <dependency>org.springframework:*</dependency>
+          </ignoredUsedUndeclaredDependencies>
+          <ignoredUnusedDeclaredDependencies>
+            <dependency>org.springframework.boot:*</dependency>
+          </ignoredUnusedDeclaredDependencies>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/optaplanner-integration/optaplanner-spring-boot-starter/pom.xml
+++ b/optaplanner-integration/optaplanner-spring-boot-starter/pom.xml
@@ -37,4 +37,19 @@
     </dependency>
   </dependencies>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <executions>
+          <execution>
+            <!-- Starter is essentially a "dependency chain". It has unused dependencies by definition. -->
+            <id>analyze-only</id>
+            <phase>none</phase>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/optaplanner-persistence/optaplanner-persistence-common/pom.xml
+++ b/optaplanner-persistence/optaplanner-persistence-common/pom.xml
@@ -39,4 +39,19 @@
     </dependency>
   </dependencies>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <configuration>
+          <ignoredUnusedDeclaredDependencies>
+            <!-- Uses PlanningEntity in Javadoc. -->
+            <dependency>org.optaplanner:optaplanner-core:jar</dependency>
+          </ignoredUnusedDeclaredDependencies>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
 </project>

--- a/optaplanner-persistence/optaplanner-persistence-jackson/pom.xml
+++ b/optaplanner-persistence/optaplanner-persistence-jackson/pom.xml
@@ -37,10 +37,6 @@
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>org.optaplanner</groupId>
-      <artifactId>optaplanner-persistence-common</artifactId>
-    </dependency>
     <!-- External dependencies -->
     <!-- Logging -->
     <dependency>

--- a/optaplanner-persistence/optaplanner-persistence-jsonb/pom.xml
+++ b/optaplanner-persistence/optaplanner-persistence-jsonb/pom.xml
@@ -37,10 +37,6 @@
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>org.optaplanner</groupId>
-      <artifactId>optaplanner-persistence-common</artifactId>
-    </dependency>
     <!-- External dependencies -->
     <!-- Logging -->
     <dependency>
@@ -56,6 +52,7 @@
     <dependency>
       <groupId>org.glassfish</groupId>
       <artifactId>jakarta.json</artifactId>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.eclipse</groupId>

--- a/optaplanner-quarkus-integration/optaplanner-quarkus-jackson/deployment/pom.xml
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus-jackson/deployment/pom.xml
@@ -25,49 +25,11 @@
     <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-jackson-deployment</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.optaplanner</groupId>
-      <artifactId>optaplanner-quarkus-deployment</artifactId>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.optaplanner</groupId>
       <artifactId>optaplanner-quarkus-jackson</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5-internal</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-resteasy-deployment</artifactId>
-      <exclusions>
-        <!-- Duplicates classes of jakarta.xml.bind:jakarta.xml.bind-api -->
-        <exclusion>
-          <groupId>org.jboss.spec.javax.xml.bind</groupId>
-          <artifactId>jboss-jaxb-api_2.3_spec</artifactId>
-        </exclusion>
-        <!-- Duplicates classes of jakarta.activation:jakarta.activation-api -->
-        <exclusion>
-          <groupId>com.sun.activation</groupId>
-          <artifactId>jakarta.activation</artifactId>
-        </exclusion>
-      </exclusions>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>io.rest-assured</groupId>
-      <artifactId>rest-assured</artifactId>
-      <exclusions>
-        <!-- Duplicates classes of jakarta.activation:jakarta.activation-api -->
-        <exclusion>
-          <groupId>org.apache.sling</groupId>
-          <artifactId>org.apache.sling.javax.activation</artifactId>
-        </exclusion>
-      </exclusions>
-      <scope>test</scope>
     </dependency>
   </dependencies>
 

--- a/optaplanner-quarkus-integration/optaplanner-quarkus-jackson/integration-test/pom.xml
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus-jackson/integration-test/pom.xml
@@ -83,6 +83,17 @@
         </executions>
       </plugin>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <executions>
+          <execution>
+            <!-- Transitive dependencies through quarkus are expected in this module. -->
+            <id>analyze-only</id>
+            <phase>none</phase>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <artifactId>maven-failsafe-plugin</artifactId>
         <configuration>
           <skip>true</skip>

--- a/optaplanner-quarkus-integration/optaplanner-quarkus-jackson/runtime/pom.xml
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus-jackson/runtime/pom.xml
@@ -16,19 +16,19 @@
   <dependencies>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-core</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>io.quarkus</groupId>
       <artifactId>quarkus-jackson</artifactId>
     </dependency>
     <dependency>
       <groupId>org.optaplanner</groupId>
-      <artifactId>optaplanner-quarkus</artifactId>
+      <artifactId>optaplanner-persistence-jackson</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.optaplanner</groupId>
-      <artifactId>optaplanner-persistence-jackson</artifactId>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>jakarta.inject</groupId>
+      <artifactId>jakarta.inject-api</artifactId>
     </dependency>
   </dependencies>
   <build>

--- a/optaplanner-quarkus-integration/optaplanner-quarkus-jsonb/deployment/pom.xml
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus-jsonb/deployment/pom.xml
@@ -25,49 +25,11 @@
     <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-jsonb-deployment</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.optaplanner</groupId>
-      <artifactId>optaplanner-quarkus-deployment</artifactId>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.optaplanner</groupId>
       <artifactId>optaplanner-quarkus-jsonb</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5-internal</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-resteasy-deployment</artifactId>
-      <exclusions>
-        <!-- Duplicates classes of jakarta.xml.bind:jakarta.xml.bind-api -->
-        <exclusion>
-          <groupId>org.jboss.spec.javax.xml.bind</groupId>
-          <artifactId>jboss-jaxb-api_2.3_spec</artifactId>
-        </exclusion>
-        <!-- Duplicates classes of jakarta.activation:jakarta.activation-api -->
-        <exclusion>
-          <groupId>com.sun.activation</groupId>
-          <artifactId>jakarta.activation</artifactId>
-        </exclusion>
-      </exclusions>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>io.rest-assured</groupId>
-      <artifactId>rest-assured</artifactId>
-      <exclusions>
-        <!-- Duplicates classes of jakarta.activation:jakarta.activation-api -->
-        <exclusion>
-          <groupId>org.apache.sling</groupId>
-          <artifactId>org.apache.sling.javax.activation</artifactId>
-        </exclusion>
-      </exclusions>
-      <scope>test</scope>
     </dependency>
   </dependencies>
 

--- a/optaplanner-quarkus-integration/optaplanner-quarkus-jsonb/integration-test/pom.xml
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus-jsonb/integration-test/pom.xml
@@ -69,6 +69,17 @@
         </executions>
       </plugin>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <executions>
+          <execution>
+            <!-- Transitive dependencies through quarkus are expected in this module. -->
+            <id>analyze-only</id>
+            <phase>none</phase>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <artifactId>maven-failsafe-plugin</artifactId>
         <configuration>
           <skip>true</skip>

--- a/optaplanner-quarkus-integration/optaplanner-quarkus-jsonb/runtime/pom.xml
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus-jsonb/runtime/pom.xml
@@ -16,19 +16,19 @@
   <dependencies>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-core</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>io.quarkus</groupId>
       <artifactId>quarkus-jsonb</artifactId>
     </dependency>
     <dependency>
       <groupId>org.optaplanner</groupId>
-      <artifactId>optaplanner-quarkus</artifactId>
+      <artifactId>optaplanner-persistence-jsonb</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.optaplanner</groupId>
-      <artifactId>optaplanner-persistence-jsonb</artifactId>
+      <groupId>jakarta.inject</groupId>
+      <artifactId>jakarta.inject-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>jakarta.json.bind</groupId>
+      <artifactId>jakarta.json.bind-api</artifactId>
     </dependency>
   </dependencies>
 

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/pom.xml
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/pom.xml
@@ -78,6 +78,19 @@
           </annotationProcessorPaths>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <executions>
+          <execution>
+            <!-- TODO enable dependency check later. -->
+            <id>analyze-only</id>
+            <configuration>
+              <failOnWarning>false</failOnWarning>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/runtime/pom.xml
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/runtime/pom.xml
@@ -37,6 +37,10 @@
       <artifactId>drools-core-static</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.kie.kogito</groupId>
+      <artifactId>kogito-ruleunits</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.graalvm.nativeimage</groupId>
       <artifactId>svm</artifactId>
     </dependency>
@@ -59,6 +63,19 @@
             </path>
           </annotationProcessorPaths>
         </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <executions>
+          <execution>
+            <!-- TODO enable dependency check later. -->
+            <id>analyze-only</id>
+            <configuration>
+              <failOnWarning>false</failOnWarning>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>

--- a/optaplanner-quickstarts/quarkus-school-timetabling/src/main/java/org/acme/schooltimetabling/domain/TimeTable.java
+++ b/optaplanner-quickstarts/quarkus-school-timetabling/src/main/java/org/acme/schooltimetabling/domain/TimeTable.java
@@ -21,7 +21,7 @@ import java.util.List;
 import org.optaplanner.core.api.domain.solution.PlanningEntityCollectionProperty;
 import org.optaplanner.core.api.domain.solution.PlanningScore;
 import org.optaplanner.core.api.domain.solution.PlanningSolution;
-import org.optaplanner.core.api.domain.solution.drools.ProblemFactCollectionProperty;
+import org.optaplanner.core.api.domain.solution.ProblemFactCollectionProperty;
 import org.optaplanner.core.api.domain.valuerange.ValueRangeProvider;
 import org.optaplanner.core.api.score.buildin.hardsoft.HardSoftScore;
 import org.optaplanner.core.api.solver.SolverStatus;


### PR DESCRIPTION
Use maven-dependency-plugin to fail the build if any used undeclared
or unused declared dependencies are found.

The plugin is configured to ignore non-compile dependencies. This avoids
having to ignore runtime and test-runtime dependencies individually.

Explanation:
- The plugin cannot detect if a declared runtime dependency is unused.
- The plugin cannot detect if an undeclared runtime dependency is used
  transitively. It is contributor's responsibility to declare runtime
  dependencies even though they are provided transitively.
- Missing runtime dependencies should be detected by tests. It's
  contributor's responsibility to write tests using runtime dependencies
  or to document why a runtine dependency is declared in case it
  cannot be covered by tests.
- The plugin will detect unused declared compile-scope dependencies.
- The plugin will detect used undeclared (transitive) compile-scope
  dependencies.

Exception: Spring Boot Starters are designed to provided transitive
dependencies. So the OptaPlanner Spring Boot Starter is allowed to have
unused declared dependencies and projects depending on Starters are not
checked at all. The same applies for Quarkus integration modules.