### PR TITLE
PLANNER-1921 Increase test coverage for solver configs

### DIFF
--- a/optaplanner-benchmark/src/test/resources/org/optaplanner/benchmark/config/testBenchmarkConfig.xml
+++ b/optaplanner-benchmark/src/test/resources/org/optaplanner/benchmark/config/testBenchmarkConfig.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <plannerBenchmark>
   <benchmarkDirectory>data</benchmarkDirectory>
+  <parallelBenchmarkCount>AUTO</parallelBenchmarkCount>
   <warmUpSecondsSpentLimit>0</warmUpSecondsSpentLimit>
   <inheritedSolverBenchmark>
     <solver>
@@ -8,6 +9,18 @@
         <minutesSpentLimit>5</minutesSpentLimit>
       </termination>
     </solver>
+    <problemBenchmarks>
+      <problemStatisticType>BEST_SCORE</problemStatisticType>
+      <problemStatisticType>STEP_SCORE</problemStatisticType>
+      <problemStatisticType>SCORE_CALCULATION_SPEED</problemStatisticType>
+      <problemStatisticType>BEST_SOLUTION_MUTATION</problemStatisticType>
+      <problemStatisticType>MOVE_COUNT_PER_STEP</problemStatisticType>
+      <problemStatisticType>MEMORY_USE</problemStatisticType>
+      <singleStatisticType>CONSTRAINT_MATCH_TOTAL_BEST_SCORE</singleStatisticType>
+      <singleStatisticType>CONSTRAINT_MATCH_TOTAL_STEP_SCORE</singleStatisticType>
+      <singleStatisticType>PICKED_MOVE_TYPE_BEST_SCORE_DIFF</singleStatisticType>
+      <singleStatisticType>PICKED_MOVE_TYPE_STEP_SCORE_DIFF</singleStatisticType>
+    </problemBenchmarks>
   </inheritedSolverBenchmark>
   <solverBenchmark>
     <name>Entity Tabu Search</name>
@@ -32,7 +45,10 @@
     </solver>
     <problemBenchmarks>
       <xStreamAnnotatedClass>org.optaplanner.core.impl.testdata.domain.TestdataSolution</xStreamAnnotatedClass>
-      <inputSolutionFile>nonExistingDataset.xml</inputSolutionFile>
+      <writeOutputSolutionEnabled>true</writeOutputSolutionEnabled>
+      <inputSolutionFile>nonExistingDataset1.xml</inputSolutionFile>
+      <inputSolutionFile>nonExistingDataset2.xml</inputSolutionFile>
+      <inputSolutionFile>nonExistingDataset3.xml</inputSolutionFile>
     </problemBenchmarks>
     <subSingleCount>2</subSingleCount>
   </solverBenchmark>
@@ -58,7 +74,7 @@
     </solver>
     <problemBenchmarks>
       <xStreamAnnotatedClass>org.optaplanner.core.impl.testdata.domain.TestdataSolution</xStreamAnnotatedClass>
-      <inputSolutionFile>nonExistingDataset.xml</inputSolutionFile>
+      <inputSolutionFile>nonExistingDataset4.xml</inputSolutionFile>
     </problemBenchmarks>
     <subSingleCount>2</subSingleCount>
   </solverBenchmark>

--- a/optaplanner-core/src/test/java/org/optaplanner/core/config/solver/SolverConfigTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/config/solver/SolverConfigTest.java
@@ -25,8 +25,6 @@ import java.io.StringReader;
 import java.io.StringWriter;
 import java.io.Writer;
 import java.nio.charset.StandardCharsets;
-import java.util.Collections;
-import java.util.List;
 
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBException;
@@ -42,14 +40,22 @@ import javax.xml.transform.stream.StreamResult;
 
 import org.apache.commons.io.IOUtils;
 import org.junit.jupiter.api.Test;
-import org.optaplanner.core.api.score.director.ScoreDirector;
+import org.optaplanner.core.api.score.stream.ConstraintProvider;
 import org.optaplanner.core.api.solver.SolverFactory;
 import org.optaplanner.core.config.constructionheuristic.ConstructionHeuristicPhaseConfig;
 import org.optaplanner.core.config.heuristic.selector.move.generic.ChangeMoveSelectorConfig;
 import org.optaplanner.core.config.heuristic.selector.value.ValueSelectorConfig;
+import org.optaplanner.core.impl.heuristic.selector.common.decorator.SelectionFilter;
+import org.optaplanner.core.impl.heuristic.selector.move.factory.MoveIteratorFactory;
+import org.optaplanner.core.impl.heuristic.selector.move.factory.MoveListFactory;
+import org.optaplanner.core.impl.heuristic.selector.move.generic.ChangeMove;
 import org.optaplanner.core.impl.partitionedsearch.partitioner.SolutionPartitioner;
+import org.optaplanner.core.impl.score.director.easy.EasyScoreCalculator;
+import org.optaplanner.core.impl.score.director.incremental.IncrementalScoreCalculator;
 import org.optaplanner.core.impl.solver.io.XStreamConfigReader;
+import org.optaplanner.core.impl.testdata.domain.TestdataEntity;
 import org.optaplanner.core.impl.testdata.domain.TestdataSolution;
+import org.optaplanner.core.impl.testdata.domain.TestdataValue;
 
 import com.thoughtworks.xstream.XStream;
 
@@ -165,12 +171,32 @@ public class SolverConfigTest {
         assertThat(savedXml.trim()).isEqualTo(originalXml.trim());
     }
 
-    private static class DummySolutionPartitioner implements SolutionPartitioner<TestdataSolution> {
+    /* Dummy classes below are referenced from the testSolverConfig.xml used in this test case. */
 
-        @Override
-        public List<TestdataSolution> splitWorkingSolution(ScoreDirector<TestdataSolution> scoreDirector,
-                Integer runnablePartThreadLimit) {
-            return Collections.emptyList(); // noop
-        }
+    private static abstract class DummySolutionPartitioner implements SolutionPartitioner<TestdataSolution> {
+    }
+
+    private static abstract class DummyEasyScoreCalculator implements EasyScoreCalculator<TestdataSolution> {
+    }
+
+    private static abstract class DummyIncrementalScoreCalculator implements IncrementalScoreCalculator<TestdataSolution> {
+    }
+
+    private static abstract class DummyConstraintProvider implements ConstraintProvider {
+    }
+
+    private abstract class DummyValueFilter implements SelectionFilter<TestdataSolution, TestdataValue> {
+    }
+
+    private abstract class DummyEntityFilter implements SelectionFilter<TestdataSolution, TestdataEntity> {
+    }
+
+    private abstract class DummyChangeMoveFilter implements SelectionFilter<TestdataSolution, ChangeMove> {
+    }
+
+    private abstract class DummyMoveIteratorFactory implements MoveIteratorFactory<TestdataSolution> {
+    }
+
+    private abstract class DummyMoveListFactory implements MoveListFactory<TestdataSolution> {
     }
 }

--- a/optaplanner-core/src/test/resources/org/optaplanner/core/config/solver/testSolverConfig.xml
+++ b/optaplanner-core/src/test/resources/org/optaplanner/core/config/solver/testSolverConfig.xml
@@ -1,35 +1,15 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!--
-  ~ Copyright 2020 Red Hat, Inc. and/or its affiliates.
-  ~
-  ~ Licensed under the Apache License, Version 2.0 (the "License");
-  ~ you may not use this file except in compliance with the License.
-  ~ You may obtain a copy of the License at
-  ~
-  ~      http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing, software
-  ~ distributed under the License is distributed on an "AS IS" BASIS,
-  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~ See the License for the specific language governing permissions and
-  ~ limitations under the License.
-  -->
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <solver>
   <environmentMode>FULL_ASSERT</environmentMode>
   <solutionClass>org.optaplanner.core.impl.testdata.domain.TestdataSolution</solutionClass>
   <entityClass>org.optaplanner.core.impl.testdata.domain.TestdataEntity</entityClass>
-
   <scoreDirectorFactory>
     <scoreDrl>org/optaplanner/config/first-non-existing-constraints.drl</scoreDrl>
     <scoreDrl>org/optaplanner/config/second-non-existing-constraints.drl</scoreDrl>
     <initializingScoreTrend>ONLY_DOWN</initializingScoreTrend>
   </scoreDirectorFactory>
-
   <constructionHeuristic>
     <constructionHeuristicType>FIRST_FIT_DECREASING</constructionHeuristicType>
-    <forager>
-      <pickEarlyType>FIRST_FEASIBLE_SCORE_OR_NON_DETERIORATING_HARD</pickEarlyType>
-    </forager>
     <queuedEntityPlacer>
       <entitySelector id="placerEntitySelector">
         <entityClass>org.optaplanner.core.impl.testdata.domain.TestdataEntity</entityClass>
@@ -63,29 +43,29 @@
         <variableNameInclude>variableB</variableNameInclude>
       </variableNameIncludes>
     </swapMoveSelector>
+    <forager>
+      <pickEarlyType>FIRST_FEASIBLE_SCORE_OR_NON_DETERIORATING_HARD</pickEarlyType>
+    </forager>
   </constructionHeuristic>
-
   <customPhase>
     <customPhaseCommandClass>org.optaplanner.core.impl.phase.custom.AbstractCustomPhaseCommand</customPhaseCommandClass>
   </customPhase>
-
   <exhaustiveSearch>
     <exhaustiveSearchType>BRANCH_AND_BOUND</exhaustiveSearchType>
     <nodeExplorationType>BREADTH_FIRST</nodeExplorationType>
     <changeMoveSelector/>
   </exhaustiveSearch>
-
   <localSearch>
-    <localSearchType>TABU_SEARCH</localSearchType>
     <termination>
       <terminationCompositionStyle>AND</terminationCompositionStyle>
       <unimprovedSecondsSpentLimit>10</unimprovedSecondsSpentLimit>
       <termination>
         <terminationCompositionStyle>OR</terminationCompositionStyle>
-        <unimprovedStepCountLimit>1000</unimprovedStepCountLimit>
         <secondsSpentLimit>20</secondsSpentLimit>
+        <unimprovedStepCountLimit>1000</unimprovedStepCountLimit>
       </termination>
     </termination>
+    <localSearchType>TABU_SEARCH</localSearchType>
     <unionMoveSelector>
       <pillarChangeMoveSelector/>
       <pillarSwapMoveSelector/>
@@ -94,24 +74,22 @@
       <acceptorType>ENTITY_TABU</acceptorType>
       <acceptorType>STEP_COUNTING_HILL_CLIMBING</acceptorType>
       <entityTabuRatio>2.0</entityTabuRatio>
-      <stepCountingHillClimbingType>EQUAL_OR_IMPROVING_STEP</stepCountingHillClimbingType>
       <stepCountingHillClimbingSize>10</stepCountingHillClimbingSize>
+      <stepCountingHillClimbingType>EQUAL_OR_IMPROVING_STEP</stepCountingHillClimbingType>
     </acceptor>
     <forager>
+      <pickEarlyType>FIRST_LAST_STEP_SCORE_IMPROVING</pickEarlyType>
       <acceptedCountLimit>1000</acceptedCountLimit>
       <finalistPodiumType>STRATEGIC_OSCILLATION</finalistPodiumType>
-      <pickEarlyType>FIRST_LAST_STEP_SCORE_IMPROVING</pickEarlyType>
       <breakTieRandomly>true</breakTieRandomly>
     </forager>
   </localSearch>
-
   <noChangePhase/>
-
   <partitionedSearch>
     <solutionPartitionerClass>org.optaplanner.core.config.solver.SolverConfigTest$DummySolutionPartitioner</solutionPartitionerClass>
     <solutionPartitionerCustomProperties>
-      <property name="partCount" value="4"/>
       <property name="minimumProcessListSize" value="300"/>
+      <property name="partCount" value="4"/>
     </solutionPartitionerCustomProperties>
     <constructionHeuristic>
       <pooledEntityPlacer>

--- a/optaplanner-core/src/test/resources/org/optaplanner/core/config/solver/testSolverConfig.xml
+++ b/optaplanner-core/src/test/resources/org/optaplanner/core/config/solver/testSolverConfig.xml
@@ -1,11 +1,16 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <solver>
   <environmentMode>FULL_ASSERT</environmentMode>
+  <moveThreadCount>AUTO</moveThreadCount>
   <solutionClass>org.optaplanner.core.impl.testdata.domain.TestdataSolution</solutionClass>
   <entityClass>org.optaplanner.core.impl.testdata.domain.TestdataEntity</entityClass>
+  <entityClass>org.optaplanner.core.impl.testdata.domain.extended.TestdataAnnotatedExtendedEntity</entityClass>
   <scoreDirectorFactory>
-    <scoreDrl>org/optaplanner/config/first-non-existing-constraints.drl</scoreDrl>
-    <scoreDrl>org/optaplanner/config/second-non-existing-constraints.drl</scoreDrl>
+    <easyScoreCalculatorClass>org.optaplanner.core.config.solver.SolverConfigTest$DummyEasyScoreCalculator</easyScoreCalculatorClass>
+    <constraintProviderClass>org.optaplanner.core.config.solver.SolverConfigTest$DummyConstraintProvider</constraintProviderClass>
+    <incrementalScoreCalculatorClass>org.optaplanner.core.config.solver.SolverConfigTest$DummyIncrementalScoreCalculator</incrementalScoreCalculatorClass>
+    <scoreDrl>org/optaplanner/config/firstNonExistingConstraints.drl</scoreDrl>
+    <scoreDrl>org/optaplanner/config/secondNonExistingConstraints.drl</scoreDrl>
     <initializingScoreTrend>ONLY_DOWN</initializingScoreTrend>
   </scoreDirectorFactory>
   <constructionHeuristic>
@@ -15,6 +20,7 @@
         <entityClass>org.optaplanner.core.impl.testdata.domain.TestdataEntity</entityClass>
         <cacheType>PHASE</cacheType>
         <selectionOrder>SORTED</selectionOrder>
+        <filterClass>org.optaplanner.core.config.solver.SolverConfigTest$DummyEntityFilter</filterClass>
         <sorterManner>DECREASING_DIFFICULTY</sorterManner>
       </entitySelector>
       <cartesianProductMoveSelector>
@@ -28,10 +34,12 @@
           </valueSelector>
         </changeMoveSelector>
         <changeMoveSelector>
+          <filterClass>org.optaplanner.core.config.solver.SolverConfigTest$DummyChangeMoveFilter</filterClass>
           <entitySelector mimicSelectorRef="placerEntitySelector"/>
           <valueSelector variableName="value">
             <cacheType>PHASE</cacheType>
             <selectionOrder>SORTED</selectionOrder>
+            <filterClass>org.optaplanner.core.config.solver.SolverConfigTest$DummyValueFilter</filterClass>
             <sorterManner>INCREASING_STRENGTH</sorterManner>
           </valueSelector>
         </changeMoveSelector>
@@ -67,12 +75,37 @@
     </termination>
     <localSearchType>TABU_SEARCH</localSearchType>
     <unionMoveSelector>
-      <pillarChangeMoveSelector/>
-      <pillarSwapMoveSelector/>
+      <pillarChangeMoveSelector>
+        <subPillarType>SEQUENCE</subPillarType>
+      </pillarChangeMoveSelector>
+      <pillarSwapMoveSelector>
+        <pillarSelector>
+          <entitySelector>
+            <filterClass>org.optaplanner.core.config.solver.SolverConfigTest$DummyEntityFilter</filterClass>
+          </entitySelector>
+          <minimumSubPillarSize>5</minimumSubPillarSize>
+          <maximumSubPillarSize>10</maximumSubPillarSize>
+        </pillarSelector>
+      </pillarSwapMoveSelector>
+      <moveIteratorFactory>
+        <fixedProbabilityWeight>30.0</fixedProbabilityWeight>
+        <moveIteratorFactoryClass>org.optaplanner.core.config.solver.SolverConfigTest$DummyMoveIteratorFactory</moveIteratorFactoryClass>
+        <moveIteratorFactoryCustomProperties>
+          <property name="moveIteratorProperty" value="moveIteratorPropertyValue"/>
+        </moveIteratorFactoryCustomProperties>
+      </moveIteratorFactory>
+      <moveListFactory>
+        <selectedCountLimit>500</selectedCountLimit>
+        <moveListFactoryClass>org.optaplanner.core.config.solver.SolverConfigTest$DummyMoveListFactory</moveListFactoryClass>
+        <moveListFactoryCustomProperties>
+          <property name="moveListProperty" value="moveListPropertyValue"/>
+        </moveListFactoryCustomProperties>
+      </moveListFactory>
     </unionMoveSelector>
     <acceptor>
       <acceptorType>ENTITY_TABU</acceptorType>
       <acceptorType>STEP_COUNTING_HILL_CLIMBING</acceptorType>
+      <entityTabuSize>5</entityTabuSize>
       <entityTabuRatio>2.0</entityTabuRatio>
       <stepCountingHillClimbingSize>10</stepCountingHillClimbingSize>
       <stepCountingHillClimbingType>EQUAL_OR_IMPROVING_STEP</stepCountingHillClimbingType>
@@ -96,6 +129,26 @@
         <changeMoveSelector/>
       </pooledEntityPlacer>
     </constructionHeuristic>
-    <localSearch/>
+    <localSearch>
+      <termination>
+        <minutesSpentLimit>5</minutesSpentLimit>
+        <bestScoreLimit>0hard/0soft</bestScoreLimit>
+      </termination>
+      <unionMoveSelector>
+        <subChainChangeMoveSelector>
+          <subChainSelector>
+            <maximumSubChainSize>50</maximumSubChainSize>
+          </subChainSelector>
+          <selectReversingMoveToo>true</selectReversingMoveToo>
+        </subChainChangeMoveSelector>
+        <subChainSwapMoveSelector>
+          <selectReversingMoveToo>false</selectReversingMoveToo>
+        </subChainSwapMoveSelector>
+        <tailChainSwapMoveSelector/>
+      </unionMoveSelector>
+      <acceptor>
+        <simulatedAnnealingStartingTemperature>2hard/10000soft</simulatedAnnealingStartingTemperature>
+      </acceptor>
+    </localSearch>
   </partitionedSearch>
 </solver>


### PR DESCRIPTION
Please note that JAXB changes the order of sibling elements - based on the position of corresponding fields in the class. It matters only for serialization. During deserialization, JAXB does not care about the order of sibling elements (unless told otherwise).