### PR TITLE
Fix examples tests: JUnit 5 does not support forkCount

### DIFF
--- a/optaplanner-build-parent/pom.xml
+++ b/optaplanner-build-parent/pom.xml
@@ -50,6 +50,7 @@
     <!-- ************************************************************************ -->
 
     <maven.min.version>3.6.2</maven.min.version>
+    <version.surefire.plugin>2.22.2</version.surefire.plugin>
     <!-- This property needs to be defined in all modules that use the packaging 'jar'.
          It is used by different plugins to make sure the module/bundle names are consistent. -->
     <java.module.name/>

--- a/optaplanner-examples/pom.xml
+++ b/optaplanner-examples/pom.xml
@@ -51,7 +51,6 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
           <configuration>
-            <forkCount>0.5C</forkCount>
             <systemPropertyVariables>
               <java.awt.headless>true</java.awt.headless>
             </systemPropertyVariables>


### PR DESCRIPTION
At least so, it says here:
  https://maven.apache.org/surefire/maven-surefire-plugin/examples/junit-platform.html
If that forkCount is there and junit 4 is not in the classpath, the tests don't run.