### PR TITLE
Build optaplanner-core in optaplanner-persistence-jpa CI

### DIFF
--- a/.github/workflows/jpa_integration_ci.yml
+++ b/.github/workflows/jpa_integration_ci.yml
@@ -49,4 +49,4 @@ jobs:
 
       # Builds the JPA module and runs tests in a PostgreSQL container
       - name: Build with Maven
-        run: cd optaplanner-persistence/optaplanner-persistence-jpa && mvn -B clean install -Ppostgresql ${{ env.MVN_CONNECTION_PROPS }}
+        run: mvn -B clean install -pl :optaplanner-persistence-jpa -am -Ppostgresql ${{ env.MVN_CONNECTION_PROPS }}


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/PLANNER-2049

Accounts for `optaplanner-core` api and version changes by building it before running `optaplanner-persistence-jpa` CI container tests.