### PR TITLE
PLANNER-1997 Spring Boot starter doesn't detect @Planning annotations when they are in abstract classes or interfaces

### DIFF
--- a/optaplanner-integration/optaplanner-spring-boot-autoconfigure/src/test/java/org/optaplanner/spring/boot/autoconfigure/OptaPlannerAutoConfigurationTest.java
+++ b/optaplanner-integration/optaplanner-spring-boot-autoconfigure/src/test/java/org/optaplanner/spring/boot/autoconfigure/OptaPlannerAutoConfigurationTest.java
@@ -33,25 +33,32 @@ import org.optaplanner.core.config.solver.EnvironmentMode;
 import org.optaplanner.core.config.solver.SolverConfig;
 import org.optaplanner.core.config.solver.termination.TerminationConfig;
 import org.optaplanner.core.impl.solver.DefaultSolverManager;
-import org.optaplanner.spring.boot.autoconfigure.solver.TestdataSpringConstraintProvider;
-import org.optaplanner.spring.boot.autoconfigure.testdata.TestdataSpringEntity;
-import org.optaplanner.spring.boot.autoconfigure.testdata.TestdataSpringSolution;
-import org.springframework.boot.autoconfigure.AutoConfigurationPackage;
+import org.optaplanner.spring.boot.autoconfigure.chained.ChainedSpringTestConfiguration;
+import org.optaplanner.spring.boot.autoconfigure.chained.constraints.TestdataChainedSpringConstraintProvider;
+import org.optaplanner.spring.boot.autoconfigure.chained.domain.TestdataChainedSpringEntity;
+import org.optaplanner.spring.boot.autoconfigure.chained.domain.TestdataChainedSpringObject;
+import org.optaplanner.spring.boot.autoconfigure.chained.domain.TestdataChainedSpringSolution;
+import org.optaplanner.spring.boot.autoconfigure.normal.SpringTestConfiguration;
+import org.optaplanner.spring.boot.autoconfigure.normal.constraints.TestdataSpringConstraintProvider;
+import org.optaplanner.spring.boot.autoconfigure.normal.domain.TestdataSpringEntity;
+import org.optaplanner.spring.boot.autoconfigure.normal.domain.TestdataSpringSolution;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
-import org.springframework.boot.autoconfigure.domain.EntityScan;
 import org.springframework.boot.test.context.FilteredClassLoader;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
-import org.springframework.context.annotation.Configuration;
 import org.springframework.core.io.ClassPathResource;
 
 public class OptaPlannerAutoConfigurationTest {
 
     private final ApplicationContextRunner contextRunner;
+    private final ApplicationContextRunner chainedContextRunner;
 
     public OptaPlannerAutoConfigurationTest() {
-        this.contextRunner = new ApplicationContextRunner()
+        contextRunner = new ApplicationContextRunner()
                 .withConfiguration(AutoConfigurations.of(OptaPlannerAutoConfiguration.class))
-                .withUserConfiguration(TestConfiguration.class);
+                .withUserConfiguration(SpringTestConfiguration.class);
+        chainedContextRunner = new ApplicationContextRunner()
+                .withConfiguration(AutoConfigurations.of(OptaPlannerAutoConfiguration.class))
+                .withUserConfiguration(ChainedSpringTestConfiguration.class);
     }
 
     @Test
@@ -203,11 +210,25 @@ public class OptaPlannerAutoConfigurationTest {
                 });
     }
 
-    @Configuration
-    @EntityScan(basePackageClasses = { TestdataSpringSolution.class, TestdataSpringConstraintProvider.class })
-    @AutoConfigurationPackage
-    public static class TestConfiguration {
-
+    @Test
+    public void chained_solverConfigXml_none() {
+        chainedContextRunner
+                .withClassLoader(new FilteredClassLoader(new ClassPathResource("solverConfig.xml")))
+                .run(context -> {
+                    SolverConfig solverConfig = context.getBean(SolverConfig.class);
+                    assertThat(solverConfig).isNotNull();
+                    assertThat(solverConfig.getSolutionClass()).isEqualTo(TestdataChainedSpringSolution.class);
+                    assertThat(solverConfig.getEntityClassList()).containsExactlyInAnyOrder(
+                            TestdataChainedSpringObject.class,
+                            TestdataChainedSpringEntity.class);
+                    assertThat(solverConfig.getScoreDirectorFactoryConfig().getConstraintProviderClass())
+                            .isEqualTo(TestdataChainedSpringConstraintProvider.class);
+                    // No termination defined
+                    assertThat(solverConfig.getTerminationConfig()).isNull();
+                    SolverFactory<TestdataSpringSolution> solverFactory = context.getBean(SolverFactory.class);
+                    assertThat(solverFactory).isNotNull();
+                    assertThat(solverFactory.buildSolver()).isNotNull();
+                });
     }
 
 }

--- a/optaplanner-integration/optaplanner-spring-boot-autoconfigure/src/test/java/org/optaplanner/spring/boot/autoconfigure/chained/ChainedSpringTestConfiguration.java
+++ b/optaplanner-integration/optaplanner-spring-boot-autoconfigure/src/test/java/org/optaplanner/spring/boot/autoconfigure/chained/ChainedSpringTestConfiguration.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.spring.boot.autoconfigure.chained;
+
+import org.optaplanner.spring.boot.autoconfigure.chained.constraints.TestdataChainedSpringConstraintProvider;
+import org.optaplanner.spring.boot.autoconfigure.chained.domain.TestdataChainedSpringSolution;
+import org.springframework.boot.autoconfigure.AutoConfigurationPackage;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EntityScan(basePackageClasses = { TestdataChainedSpringSolution.class, TestdataChainedSpringConstraintProvider.class })
+@AutoConfigurationPackage
+public class ChainedSpringTestConfiguration {
+
+}

--- a/optaplanner-integration/optaplanner-spring-boot-autoconfigure/src/test/java/org/optaplanner/spring/boot/autoconfigure/chained/constraints/TestdataChainedSpringConstraintProvider.java
+++ b/optaplanner-integration/optaplanner-spring-boot-autoconfigure/src/test/java/org/optaplanner/spring/boot/autoconfigure/chained/constraints/TestdataChainedSpringConstraintProvider.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.spring.boot.autoconfigure.chained.constraints;
+
+import org.optaplanner.core.api.score.buildin.simple.SimpleScore;
+import org.optaplanner.core.api.score.stream.Constraint;
+import org.optaplanner.core.api.score.stream.ConstraintFactory;
+import org.optaplanner.core.api.score.stream.ConstraintProvider;
+import org.optaplanner.core.api.score.stream.Joiners;
+import org.optaplanner.spring.boot.autoconfigure.chained.domain.TestdataChainedSpringAnchor;
+import org.optaplanner.spring.boot.autoconfigure.chained.domain.TestdataChainedSpringEntity;
+import org.optaplanner.spring.boot.autoconfigure.chained.domain.TestdataChainedSpringObject;
+
+public class TestdataChainedSpringConstraintProvider implements ConstraintProvider {
+
+    @Override
+    public Constraint[] defineConstraints(ConstraintFactory factory) {
+        return new Constraint[] {
+                factory.from(TestdataChainedSpringAnchor.class)
+                        .ifNotExists(TestdataChainedSpringEntity.class,
+                                Joiners.equal((anchor) -> (TestdataChainedSpringObject) anchor,
+                                        TestdataChainedSpringEntity::getPrevious))
+                        .penalize("Assign at least one entity to each anchor.", SimpleScore.ONE)
+        };
+    }
+
+}

--- a/optaplanner-integration/optaplanner-spring-boot-autoconfigure/src/test/java/org/optaplanner/spring/boot/autoconfigure/chained/domain/TestdataChainedSpringAnchor.java
+++ b/optaplanner-integration/optaplanner-spring-boot-autoconfigure/src/test/java/org/optaplanner/spring/boot/autoconfigure/chained/domain/TestdataChainedSpringAnchor.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.spring.boot.autoconfigure.chained.domain;
+
+public class TestdataChainedSpringAnchor implements TestdataChainedSpringObject {
+
+    private TestdataChainedSpringEntity next;
+
+    // ************************************************************************
+    // Getters/setters
+    // ************************************************************************
+
+    @Override
+    public TestdataChainedSpringEntity getNext() {
+        return next;
+    }
+
+    @Override
+    public void setNext(TestdataChainedSpringEntity next) {
+        this.next = next;
+    }
+
+}

--- a/optaplanner-integration/optaplanner-spring-boot-autoconfigure/src/test/java/org/optaplanner/spring/boot/autoconfigure/chained/domain/TestdataChainedSpringEntity.java
+++ b/optaplanner-integration/optaplanner-spring-boot-autoconfigure/src/test/java/org/optaplanner/spring/boot/autoconfigure/chained/domain/TestdataChainedSpringEntity.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.spring.boot.autoconfigure.chained.domain;
+
+import org.optaplanner.core.api.domain.entity.PlanningEntity;
+import org.optaplanner.core.api.domain.variable.PlanningVariable;
+import org.optaplanner.core.api.domain.variable.PlanningVariableGraphType;
+
+@PlanningEntity
+public class TestdataChainedSpringEntity implements TestdataChainedSpringObject {
+
+    @PlanningVariable(valueRangeProviderRefs = { "chainedAnchorRange",
+            "chainedEntityRange" }, graphType = PlanningVariableGraphType.CHAINED)
+    private TestdataChainedSpringObject previous;
+
+    private TestdataChainedSpringEntity next;
+
+    // ************************************************************************
+    // Getters/setters
+    // ************************************************************************
+
+    public TestdataChainedSpringObject getPrevious() {
+        return previous;
+    }
+
+    public void setPrevious(TestdataChainedSpringObject previous) {
+        this.previous = previous;
+    }
+
+    @Override
+    public TestdataChainedSpringEntity getNext() {
+        return next;
+    }
+
+    @Override
+    public void setNext(TestdataChainedSpringEntity next) {
+        this.next = next;
+    }
+
+}

--- a/optaplanner-integration/optaplanner-spring-boot-autoconfigure/src/test/java/org/optaplanner/spring/boot/autoconfigure/chained/domain/TestdataChainedSpringObject.java
+++ b/optaplanner-integration/optaplanner-spring-boot-autoconfigure/src/test/java/org/optaplanner/spring/boot/autoconfigure/chained/domain/TestdataChainedSpringObject.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.spring.boot.autoconfigure.chained.domain;
+
+import org.optaplanner.core.api.domain.entity.PlanningEntity;
+import org.optaplanner.core.api.domain.variable.InverseRelationShadowVariable;
+
+@PlanningEntity
+public interface TestdataChainedSpringObject {
+
+    @InverseRelationShadowVariable(sourceVariableName = "previous")
+    TestdataChainedSpringEntity getNext();
+
+    void setNext(TestdataChainedSpringEntity next);
+
+}

--- a/optaplanner-integration/optaplanner-spring-boot-autoconfigure/src/test/java/org/optaplanner/spring/boot/autoconfigure/chained/domain/TestdataChainedSpringSolution.java
+++ b/optaplanner-integration/optaplanner-spring-boot-autoconfigure/src/test/java/org/optaplanner/spring/boot/autoconfigure/chained/domain/TestdataChainedSpringSolution.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.spring.boot.autoconfigure.chained.domain;
+
+import java.util.List;
+
+import org.optaplanner.core.api.domain.solution.PlanningEntityCollectionProperty;
+import org.optaplanner.core.api.domain.solution.PlanningScore;
+import org.optaplanner.core.api.domain.solution.PlanningSolution;
+import org.optaplanner.core.api.domain.solution.ProblemFactCollectionProperty;
+import org.optaplanner.core.api.domain.valuerange.ValueRangeProvider;
+import org.optaplanner.core.api.score.buildin.simple.SimpleScore;
+
+@PlanningSolution
+public class TestdataChainedSpringSolution {
+
+    @ProblemFactCollectionProperty
+    @ValueRangeProvider(id = "chainedAnchorRange")
+    private List<TestdataChainedSpringAnchor> chainedAnchorList;
+    @PlanningEntityCollectionProperty
+    @ValueRangeProvider(id = "chainedEntityRange")
+    private List<TestdataChainedSpringEntity> chainedEntityList;
+
+    @PlanningScore
+    private SimpleScore score;
+
+    // ************************************************************************
+    // Getters/setters
+    // ************************************************************************
+
+    public List<TestdataChainedSpringAnchor> getChainedAnchorList() {
+        return chainedAnchorList;
+    }
+
+    public void setChainedAnchorList(List<TestdataChainedSpringAnchor> chainedAnchorList) {
+        this.chainedAnchorList = chainedAnchorList;
+    }
+
+    public List<TestdataChainedSpringEntity> getChainedEntityList() {
+        return chainedEntityList;
+    }
+
+    public void setChainedEntityList(List<TestdataChainedSpringEntity> chainedEntityList) {
+        this.chainedEntityList = chainedEntityList;
+    }
+
+    public SimpleScore getScore() {
+        return score;
+    }
+
+    public void setScore(SimpleScore score) {
+        this.score = score;
+    }
+
+}

--- a/optaplanner-integration/optaplanner-spring-boot-autoconfigure/src/test/java/org/optaplanner/spring/boot/autoconfigure/normal/SpringTestConfiguration.java
+++ b/optaplanner-integration/optaplanner-spring-boot-autoconfigure/src/test/java/org/optaplanner/spring/boot/autoconfigure/normal/SpringTestConfiguration.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.spring.boot.autoconfigure.normal;
+
+import org.springframework.boot.autoconfigure.AutoConfigurationPackage;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@AutoConfigurationPackage
+public class SpringTestConfiguration {
+
+}

--- a/optaplanner-integration/optaplanner-spring-boot-autoconfigure/src/test/java/org/optaplanner/spring/boot/autoconfigure/normal/constraints/TestdataSpringConstraintProvider.java
+++ b/optaplanner-integration/optaplanner-spring-boot-autoconfigure/src/test/java/org/optaplanner/spring/boot/autoconfigure/normal/constraints/TestdataSpringConstraintProvider.java
@@ -14,14 +14,14 @@
  * limitations under the License.
  */
 
-package org.optaplanner.spring.boot.autoconfigure.solver;
+package org.optaplanner.spring.boot.autoconfigure.normal.constraints;
 
 import org.optaplanner.core.api.score.buildin.simple.SimpleScore;
 import org.optaplanner.core.api.score.stream.Constraint;
 import org.optaplanner.core.api.score.stream.ConstraintFactory;
 import org.optaplanner.core.api.score.stream.ConstraintProvider;
 import org.optaplanner.core.api.score.stream.Joiners;
-import org.optaplanner.spring.boot.autoconfigure.testdata.TestdataSpringEntity;
+import org.optaplanner.spring.boot.autoconfigure.normal.domain.TestdataSpringEntity;
 
 public class TestdataSpringConstraintProvider implements ConstraintProvider {
 

--- a/optaplanner-integration/optaplanner-spring-boot-autoconfigure/src/test/java/org/optaplanner/spring/boot/autoconfigure/normal/domain/TestdataSpringEntity.java
+++ b/optaplanner-integration/optaplanner-spring-boot-autoconfigure/src/test/java/org/optaplanner/spring/boot/autoconfigure/normal/domain/TestdataSpringEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,17 +14,21 @@
  * limitations under the License.
  */
 
-package org.optaplanner.quarkus.domain;
+package org.optaplanner.spring.boot.autoconfigure.normal.domain;
 
 import org.optaplanner.core.api.domain.entity.PlanningEntity;
 import org.optaplanner.core.api.domain.variable.PlanningVariable;
 
 @PlanningEntity
-public class TestdataPlanningEntity {
-
-    private String value;
+public class TestdataSpringEntity {
 
     @PlanningVariable(valueRangeProviderRefs = "valueRange")
+    private String value;
+
+    // ************************************************************************
+    // Getters/setters
+    // ************************************************************************
+
     public String getValue() {
         return value;
     }

--- a/optaplanner-integration/optaplanner-spring-boot-autoconfigure/src/test/java/org/optaplanner/spring/boot/autoconfigure/normal/domain/TestdataSpringSolution.java
+++ b/optaplanner-integration/optaplanner-spring-boot-autoconfigure/src/test/java/org/optaplanner/spring/boot/autoconfigure/normal/domain/TestdataSpringSolution.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.spring.boot.autoconfigure.normal.domain;
+
+import java.util.List;
+
+import org.optaplanner.core.api.domain.solution.PlanningEntityCollectionProperty;
+import org.optaplanner.core.api.domain.solution.PlanningScore;
+import org.optaplanner.core.api.domain.solution.PlanningSolution;
+import org.optaplanner.core.api.domain.valuerange.ValueRangeProvider;
+import org.optaplanner.core.api.score.buildin.simple.SimpleScore;
+
+@PlanningSolution
+public class TestdataSpringSolution {
+
+    @ValueRangeProvider(id = "valueRange")
+    private List<String> valueList;
+    @PlanningEntityCollectionProperty
+    private List<TestdataSpringEntity> entityList;
+
+    @PlanningScore
+    private SimpleScore score;
+
+    // ************************************************************************
+    // Getters/setters
+    // ************************************************************************
+
+    public List<String> getValueList() {
+        return valueList;
+    }
+
+    public void setValueList(List<String> valueList) {
+        this.valueList = valueList;
+    }
+
+    public List<TestdataSpringEntity> getEntityList() {
+        return entityList;
+    }
+
+    public void setEntityList(List<TestdataSpringEntity> entityList) {
+        this.entityList = entityList;
+    }
+
+    public SimpleScore getScore() {
+        return score;
+    }
+
+    public void setScore(SimpleScore score) {
+        this.score = score;
+    }
+}

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/pom.xml
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/pom.xml
@@ -33,6 +33,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-resteasy-deployment</artifactId>
       <scope>test</scope>

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/test/java/org/optaplanner/quarkus/OptaPlannerProcessorChainedXMLNoneTest.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/test/java/org/optaplanner/quarkus/OptaPlannerProcessorChainedXMLNoneTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.quarkus;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import javax.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.optaplanner.core.api.solver.SolverFactory;
+import org.optaplanner.core.config.solver.SolverConfig;
+import org.optaplanner.quarkus.testdata.chained.constraints.TestdataChainedQuarkusConstraintProvider;
+import org.optaplanner.quarkus.testdata.chained.domain.TestdataChainedQuarkusAnchor;
+import org.optaplanner.quarkus.testdata.chained.domain.TestdataChainedQuarkusEntity;
+import org.optaplanner.quarkus.testdata.chained.domain.TestdataChainedQuarkusObject;
+import org.optaplanner.quarkus.testdata.chained.domain.TestdataChainedQuarkusSolution;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class OptaPlannerProcessorChainedXMLNoneTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(
+                            TestdataChainedQuarkusObject.class,
+                            TestdataChainedQuarkusAnchor.class,
+                            TestdataChainedQuarkusEntity.class,
+                            TestdataChainedQuarkusSolution.class,
+                            TestdataChainedQuarkusConstraintProvider.class));
+
+    @Inject
+    SolverConfig solverConfig;
+    @Inject
+    SolverFactory<TestdataChainedQuarkusSolution> solverFactory;
+
+    @Test
+    public void solverConfigXml_default() {
+        assertThat(solverConfig).isNotNull();
+        assertThat(solverConfig.getSolutionClass()).isEqualTo(TestdataChainedQuarkusSolution.class);
+        assertThat(solverConfig.getEntityClassList()).containsExactlyInAnyOrder(
+                TestdataChainedQuarkusObject.class,
+                TestdataChainedQuarkusEntity.class);
+        assertThat(solverConfig.getScoreDirectorFactoryConfig().getConstraintProviderClass())
+                .isEqualTo(TestdataChainedQuarkusConstraintProvider.class);
+        // No termination defined (solverConfig.xml isn't included)
+        assertThat(solverConfig.getTerminationConfig().getSecondsSpentLimit()).isNull();
+        assertThat(solverFactory).isNotNull();
+        assertThat(solverFactory.buildSolver()).isNotNull();
+    }
+
+}

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/test/java/org/optaplanner/quarkus/OptaPlannerProcessorSolveTest.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/test/java/org/optaplanner/quarkus/OptaPlannerProcessorSolveTest.java
@@ -35,9 +35,9 @@ import org.optaplanner.core.api.solver.SolverFactory;
 import org.optaplanner.core.api.solver.SolverJob;
 import org.optaplanner.core.api.solver.SolverManager;
 import org.optaplanner.core.impl.solver.DefaultSolverManager;
-import org.optaplanner.quarkus.constraints.TestdataPlanningConstraintProvider;
-import org.optaplanner.quarkus.domain.TestdataPlanningEntity;
-import org.optaplanner.quarkus.domain.TestdataPlanningSolution;
+import org.optaplanner.quarkus.testdata.normal.constraints.TestdataQuarkusConstraintProvider;
+import org.optaplanner.quarkus.testdata.normal.domain.TestdataQuarkusEntity;
+import org.optaplanner.quarkus.testdata.normal.domain.TestdataQuarkusSolution;
 
 import io.quarkus.test.QuarkusUnitTest;
 
@@ -47,15 +47,15 @@ public class OptaPlannerProcessorSolveTest {
     static final QuarkusUnitTest config = new QuarkusUnitTest()
             .overrideConfigKey("quarkus.optaplanner.solver.termination.best-score-limit", "0")
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
-                    .addClasses(TestdataPlanningEntity.class,
-                            TestdataPlanningSolution.class, TestdataPlanningConstraintProvider.class));
+                    .addClasses(TestdataQuarkusEntity.class,
+                            TestdataQuarkusSolution.class, TestdataQuarkusConstraintProvider.class));
 
     @Inject
-    SolverFactory<TestdataPlanningSolution> solverFactory;
+    SolverFactory<TestdataQuarkusSolution> solverFactory;
     @Inject
-    SolverManager<TestdataPlanningSolution, Long> solverManager;
+    SolverManager<TestdataQuarkusSolution, Long> solverManager;
     @Inject
-    ScoreManager<TestdataPlanningSolution> scoreManager;
+    ScoreManager<TestdataQuarkusSolution> scoreManager;
 
     @Test
     public void singletonSolverFactory() {
@@ -65,20 +65,20 @@ public class OptaPlannerProcessorSolveTest {
         // assertSame(solverFactory.getScoreDirectorFactory(), ((DefaultScoreManager<TestdataPlanningSolution>) scoreManager).getScoreDirectorFactory());
         assertNotNull(solverManager);
         // There is only one SolverFactory instance
-        assertSame(solverFactory, ((DefaultSolverManager<TestdataPlanningSolution, Long>) solverManager).getSolverFactory());
+        assertSame(solverFactory, ((DefaultSolverManager<TestdataQuarkusSolution, Long>) solverManager).getSolverFactory());
     }
 
     @Test
     public void solve() throws ExecutionException, InterruptedException {
-        TestdataPlanningSolution problem = new TestdataPlanningSolution();
+        TestdataQuarkusSolution problem = new TestdataQuarkusSolution();
         problem.setValueList(IntStream.range(1, 3)
                 .mapToObj(i -> "v" + i)
                 .collect(Collectors.toList()));
         problem.setEntityList(IntStream.range(1, 3)
-                .mapToObj(i -> new TestdataPlanningEntity())
+                .mapToObj(i -> new TestdataQuarkusEntity())
                 .collect(Collectors.toList()));
-        SolverJob<TestdataPlanningSolution, Long> solverJob = solverManager.solve(1L, problem);
-        TestdataPlanningSolution solution = solverJob.getFinalBestSolution();
+        SolverJob<TestdataQuarkusSolution, Long> solverJob = solverManager.solve(1L, problem);
+        TestdataQuarkusSolution solution = solverJob.getFinalBestSolution();
         assertNotNull(solution);
         assertTrue(solution.getScore().getScore() >= 0);
     }

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/test/java/org/optaplanner/quarkus/OptaPlannerProcessorSolverPropertiesTest.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/test/java/org/optaplanner/quarkus/OptaPlannerProcessorSolverPropertiesTest.java
@@ -31,9 +31,9 @@ import org.optaplanner.core.api.score.buildin.simple.SimpleScore;
 import org.optaplanner.core.api.solver.SolverFactory;
 import org.optaplanner.core.config.solver.EnvironmentMode;
 import org.optaplanner.core.config.solver.SolverConfig;
-import org.optaplanner.quarkus.constraints.TestdataPlanningConstraintProvider;
-import org.optaplanner.quarkus.domain.TestdataPlanningEntity;
-import org.optaplanner.quarkus.domain.TestdataPlanningSolution;
+import org.optaplanner.quarkus.testdata.normal.constraints.TestdataQuarkusConstraintProvider;
+import org.optaplanner.quarkus.testdata.normal.domain.TestdataQuarkusEntity;
+import org.optaplanner.quarkus.testdata.normal.domain.TestdataQuarkusSolution;
 
 import io.quarkus.test.QuarkusUnitTest;
 
@@ -48,13 +48,13 @@ public class OptaPlannerProcessorSolverPropertiesTest {
             .overrideConfigKey("quarkus.optaplanner.solver.termination.unimproved-spent-limit", "5h")
             .overrideConfigKey("quarkus.optaplanner.solver.termination.best-score-limit", "0")
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
-                    .addClasses(TestdataPlanningEntity.class, TestdataPlanningSolution.class,
-                            TestdataPlanningConstraintProvider.class));
+                    .addClasses(TestdataQuarkusEntity.class, TestdataQuarkusSolution.class,
+                            TestdataQuarkusConstraintProvider.class));
 
     @Inject
     SolverConfig solverConfig;
     @Inject
-    SolverFactory<TestdataPlanningSolution> solverFactory;
+    SolverFactory<TestdataQuarkusSolution> solverFactory;
 
     @Test
     public void solverProperties() {

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/test/java/org/optaplanner/quarkus/OptaPlannerProcessorXMLDefaultTest.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/test/java/org/optaplanner/quarkus/OptaPlannerProcessorXMLDefaultTest.java
@@ -29,9 +29,9 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.optaplanner.core.api.solver.SolverFactory;
 import org.optaplanner.core.config.solver.SolverConfig;
-import org.optaplanner.quarkus.constraints.TestdataPlanningConstraintProvider;
-import org.optaplanner.quarkus.domain.TestdataPlanningEntity;
-import org.optaplanner.quarkus.domain.TestdataPlanningSolution;
+import org.optaplanner.quarkus.testdata.normal.constraints.TestdataQuarkusConstraintProvider;
+import org.optaplanner.quarkus.testdata.normal.domain.TestdataQuarkusEntity;
+import org.optaplanner.quarkus.testdata.normal.domain.TestdataQuarkusSolution;
 
 import io.quarkus.test.QuarkusUnitTest;
 
@@ -40,21 +40,21 @@ public class OptaPlannerProcessorXMLDefaultTest {
     @RegisterExtension
     static final QuarkusUnitTest config = new QuarkusUnitTest()
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
-                    .addClasses(TestdataPlanningEntity.class,
-                            TestdataPlanningSolution.class, TestdataPlanningConstraintProvider.class)
+                    .addClasses(TestdataQuarkusEntity.class,
+                            TestdataQuarkusSolution.class, TestdataQuarkusConstraintProvider.class)
                     .addAsResource("solverConfig.xml"));
 
     @Inject
     SolverConfig solverConfig;
     @Inject
-    SolverFactory<TestdataPlanningSolution> solverFactory;
+    SolverFactory<TestdataQuarkusSolution> solverFactory;
 
     @Test
     public void solverConfigXml_default() {
         assertNotNull(solverConfig);
-        assertEquals(TestdataPlanningSolution.class, solverConfig.getSolutionClass());
-        assertEquals(Collections.singletonList(TestdataPlanningEntity.class), solverConfig.getEntityClassList());
-        assertEquals(TestdataPlanningConstraintProvider.class,
+        assertEquals(TestdataQuarkusSolution.class, solverConfig.getSolutionClass());
+        assertEquals(Collections.singletonList(TestdataQuarkusEntity.class), solverConfig.getEntityClassList());
+        assertEquals(TestdataQuarkusConstraintProvider.class,
                 solverConfig.getScoreDirectorFactoryConfig().getConstraintProviderClass());
         // Properties defined in solverConfig.xml
         assertEquals(2L, solverConfig.getTerminationConfig().getSecondsSpentLimit().longValue());

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/test/java/org/optaplanner/quarkus/OptaPlannerProcessorXMLNoneTest.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/test/java/org/optaplanner/quarkus/OptaPlannerProcessorXMLNoneTest.java
@@ -30,9 +30,9 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.optaplanner.core.api.solver.SolverFactory;
 import org.optaplanner.core.config.solver.SolverConfig;
-import org.optaplanner.quarkus.constraints.TestdataPlanningConstraintProvider;
-import org.optaplanner.quarkus.domain.TestdataPlanningEntity;
-import org.optaplanner.quarkus.domain.TestdataPlanningSolution;
+import org.optaplanner.quarkus.testdata.normal.constraints.TestdataQuarkusConstraintProvider;
+import org.optaplanner.quarkus.testdata.normal.domain.TestdataQuarkusEntity;
+import org.optaplanner.quarkus.testdata.normal.domain.TestdataQuarkusSolution;
 
 import io.quarkus.test.QuarkusUnitTest;
 
@@ -41,20 +41,20 @@ public class OptaPlannerProcessorXMLNoneTest {
     @RegisterExtension
     static final QuarkusUnitTest config = new QuarkusUnitTest()
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
-                    .addClasses(TestdataPlanningEntity.class,
-                            TestdataPlanningSolution.class, TestdataPlanningConstraintProvider.class));
+                    .addClasses(TestdataQuarkusEntity.class,
+                            TestdataQuarkusSolution.class, TestdataQuarkusConstraintProvider.class));
 
     @Inject
     SolverConfig solverConfig;
     @Inject
-    SolverFactory<TestdataPlanningSolution> solverFactory;
+    SolverFactory<TestdataQuarkusSolution> solverFactory;
 
     @Test
     public void solverConfigXml_default() {
         assertNotNull(solverConfig);
-        assertEquals(TestdataPlanningSolution.class, solverConfig.getSolutionClass());
-        assertEquals(Collections.singletonList(TestdataPlanningEntity.class), solverConfig.getEntityClassList());
-        assertEquals(TestdataPlanningConstraintProvider.class,
+        assertEquals(TestdataQuarkusSolution.class, solverConfig.getSolutionClass());
+        assertEquals(Collections.singletonList(TestdataQuarkusEntity.class), solverConfig.getEntityClassList());
+        assertEquals(TestdataQuarkusConstraintProvider.class,
                 solverConfig.getScoreDirectorFactoryConfig().getConstraintProviderClass());
         // No termination defined (solverConfig.xml isn't included)
         assertNull(solverConfig.getTerminationConfig().getSecondsSpentLimit());

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/test/java/org/optaplanner/quarkus/OptaPlannerProcessorXMLPropertyTest.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/test/java/org/optaplanner/quarkus/OptaPlannerProcessorXMLPropertyTest.java
@@ -29,9 +29,9 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.optaplanner.core.api.solver.SolverFactory;
 import org.optaplanner.core.config.solver.SolverConfig;
-import org.optaplanner.quarkus.constraints.TestdataPlanningConstraintProvider;
-import org.optaplanner.quarkus.domain.TestdataPlanningEntity;
-import org.optaplanner.quarkus.domain.TestdataPlanningSolution;
+import org.optaplanner.quarkus.testdata.normal.constraints.TestdataQuarkusConstraintProvider;
+import org.optaplanner.quarkus.testdata.normal.domain.TestdataQuarkusEntity;
+import org.optaplanner.quarkus.testdata.normal.domain.TestdataQuarkusSolution;
 
 import io.quarkus.test.QuarkusUnitTest;
 
@@ -41,21 +41,21 @@ public class OptaPlannerProcessorXMLPropertyTest {
     static final QuarkusUnitTest config = new QuarkusUnitTest()
             .overrideConfigKey("quarkus.optaplanner.solver-config-xml", "org/optaplanner/quarkus/customSolverConfig.xml")
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
-                    .addClasses(TestdataPlanningEntity.class,
-                            TestdataPlanningSolution.class, TestdataPlanningConstraintProvider.class)
+                    .addClasses(TestdataQuarkusEntity.class,
+                            TestdataQuarkusSolution.class, TestdataQuarkusConstraintProvider.class)
                     .addAsResource("org/optaplanner/quarkus/customSolverConfig.xml"));
 
     @Inject
     SolverConfig solverConfig;
     @Inject
-    SolverFactory<TestdataPlanningSolution> solverFactory;
+    SolverFactory<TestdataQuarkusSolution> solverFactory;
 
     @Test
     public void solverConfigXml_property() {
         assertNotNull(solverConfig);
-        assertEquals(TestdataPlanningSolution.class, solverConfig.getSolutionClass());
-        assertEquals(Collections.singletonList(TestdataPlanningEntity.class), solverConfig.getEntityClassList());
-        assertEquals(TestdataPlanningConstraintProvider.class,
+        assertEquals(TestdataQuarkusSolution.class, solverConfig.getSolutionClass());
+        assertEquals(Collections.singletonList(TestdataQuarkusEntity.class), solverConfig.getEntityClassList());
+        assertEquals(TestdataQuarkusConstraintProvider.class,
                 solverConfig.getScoreDirectorFactoryConfig().getConstraintProviderClass());
         // Properties defined in solverConfig.xml
         assertEquals(3L, solverConfig.getTerminationConfig().getSecondsSpentLimit().longValue());

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/test/java/org/optaplanner/quarkus/constraints/OptaPlannerProcessorConstraintProviderTest.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/test/java/org/optaplanner/quarkus/constraints/OptaPlannerProcessorConstraintProviderTest.java
@@ -27,8 +27,9 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.optaplanner.core.api.solver.SolverFactory;
 import org.optaplanner.core.config.solver.SolverConfig;
-import org.optaplanner.quarkus.domain.TestdataPlanningEntity;
-import org.optaplanner.quarkus.domain.TestdataPlanningSolution;
+import org.optaplanner.quarkus.testdata.normal.constraints.TestdataQuarkusConstraintProvider;
+import org.optaplanner.quarkus.testdata.normal.domain.TestdataQuarkusEntity;
+import org.optaplanner.quarkus.testdata.normal.domain.TestdataQuarkusSolution;
 
 import io.quarkus.test.QuarkusUnitTest;
 
@@ -37,17 +38,17 @@ public class OptaPlannerProcessorConstraintProviderTest {
     @RegisterExtension
     static final QuarkusUnitTest config = new QuarkusUnitTest()
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
-                    .addClasses(TestdataPlanningEntity.class,
-                            TestdataPlanningSolution.class, TestdataPlanningConstraintProvider.class));
+                    .addClasses(TestdataQuarkusEntity.class,
+                            TestdataQuarkusSolution.class, TestdataQuarkusConstraintProvider.class));
 
     @Inject
     SolverConfig solverConfig;
     @Inject
-    SolverFactory<TestdataPlanningSolution> solverFactory;
+    SolverFactory<TestdataQuarkusSolution> solverFactory;
 
     @Test
     public void solverConfigXml_default() {
-        assertEquals(TestdataPlanningConstraintProvider.class,
+        assertEquals(TestdataQuarkusConstraintProvider.class,
                 solverConfig.getScoreDirectorFactoryConfig().getConstraintProviderClass());
         assertNotNull(solverFactory.buildSolver());
     }

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/test/java/org/optaplanner/quarkus/constraints/OptaPlannerProcessorScoreDrlDefaultTest.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/test/java/org/optaplanner/quarkus/constraints/OptaPlannerProcessorScoreDrlDefaultTest.java
@@ -29,8 +29,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.optaplanner.core.api.solver.SolverFactory;
 import org.optaplanner.core.config.solver.SolverConfig;
-import org.optaplanner.quarkus.domain.TestdataPlanningEntity;
-import org.optaplanner.quarkus.domain.TestdataPlanningSolution;
+import org.optaplanner.quarkus.testdata.normal.domain.TestdataQuarkusEntity;
+import org.optaplanner.quarkus.testdata.normal.domain.TestdataQuarkusSolution;
 
 import io.quarkus.test.QuarkusUnitTest;
 
@@ -39,14 +39,14 @@ public class OptaPlannerProcessorScoreDrlDefaultTest {
     @RegisterExtension
     static final QuarkusUnitTest config = new QuarkusUnitTest()
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
-                    .addClasses(TestdataPlanningEntity.class,
-                            TestdataPlanningSolution.class)
+                    .addClasses(TestdataQuarkusEntity.class,
+                            TestdataQuarkusSolution.class)
                     .addAsResource("org/optaplanner/quarkus/constraints/defaultConstraints.drl", "constraints.drl"));
 
     @Inject
     SolverConfig solverConfig;
     @Inject
-    SolverFactory<TestdataPlanningSolution> solverFactory;
+    SolverFactory<TestdataQuarkusSolution> solverFactory;
 
     @Test
     public void solverConfigXml_default() {

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/test/java/org/optaplanner/quarkus/rest/OptaPlannerProcessorHotReloadTest.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/test/java/org/optaplanner/quarkus/rest/OptaPlannerProcessorHotReloadTest.java
@@ -21,9 +21,9 @@ import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
-import org.optaplanner.quarkus.constraints.TestdataPlanningConstraintProvider;
-import org.optaplanner.quarkus.domain.TestdataPlanningEntity;
-import org.optaplanner.quarkus.domain.TestdataPlanningSolution;
+import org.optaplanner.quarkus.testdata.normal.constraints.TestdataQuarkusConstraintProvider;
+import org.optaplanner.quarkus.testdata.normal.domain.TestdataQuarkusEntity;
+import org.optaplanner.quarkus.testdata.normal.domain.TestdataQuarkusSolution;
 
 import io.quarkus.test.QuarkusDevModeTest;
 import io.restassured.RestAssured;
@@ -34,8 +34,8 @@ public class OptaPlannerProcessorHotReloadTest {
     @RegisterExtension
     static final QuarkusDevModeTest test = new QuarkusDevModeTest()
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
-                    .addClasses(TestdataPlanningEntity.class,
-                            TestdataPlanningSolution.class, TestdataPlanningConstraintProvider.class,
+                    .addClasses(TestdataQuarkusEntity.class,
+                            TestdataQuarkusSolution.class, TestdataQuarkusConstraintProvider.class,
                             SolverConfigTestResource.class)
                     .addAsResource("solverConfig.xml"));
 

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/test/java/org/optaplanner/quarkus/testdata/chained/constraints/TestdataChainedQuarkusConstraintProvider.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/test/java/org/optaplanner/quarkus/testdata/chained/constraints/TestdataChainedQuarkusConstraintProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,24 +14,27 @@
  * limitations under the License.
  */
 
-package org.optaplanner.quarkus.constraints;
+package org.optaplanner.quarkus.testdata.chained.constraints;
 
 import org.optaplanner.core.api.score.buildin.simple.SimpleScore;
 import org.optaplanner.core.api.score.stream.Constraint;
 import org.optaplanner.core.api.score.stream.ConstraintFactory;
 import org.optaplanner.core.api.score.stream.ConstraintProvider;
 import org.optaplanner.core.api.score.stream.Joiners;
-import org.optaplanner.quarkus.domain.TestdataPlanningEntity;
+import org.optaplanner.quarkus.testdata.chained.domain.TestdataChainedQuarkusAnchor;
+import org.optaplanner.quarkus.testdata.chained.domain.TestdataChainedQuarkusEntity;
+import org.optaplanner.quarkus.testdata.chained.domain.TestdataChainedQuarkusObject;
 
-public class TestdataPlanningConstraintProvider implements ConstraintProvider {
+public class TestdataChainedQuarkusConstraintProvider implements ConstraintProvider {
 
     @Override
     public Constraint[] defineConstraints(ConstraintFactory factory) {
         return new Constraint[] {
-                factory.from(TestdataPlanningEntity.class)
-                        .join(TestdataPlanningEntity.class, Joiners.equal(TestdataPlanningEntity::getValue))
-                        .filter((a, b) -> a != b)
-                        .penalize("Don't assign 2 entities the same value.", SimpleScore.ONE)
+                factory.from(TestdataChainedQuarkusAnchor.class)
+                        .ifNotExists(TestdataChainedQuarkusEntity.class,
+                                Joiners.equal((anchor) -> (TestdataChainedQuarkusObject) anchor,
+                                        TestdataChainedQuarkusEntity::getPrevious))
+                        .penalize("Assign at least one entity to each anchor.", SimpleScore.ONE)
         };
     }
 

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/test/java/org/optaplanner/quarkus/testdata/chained/domain/TestdataChainedQuarkusAnchor.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/test/java/org/optaplanner/quarkus/testdata/chained/domain/TestdataChainedQuarkusAnchor.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.quarkus.testdata.chained.domain;
+
+public class TestdataChainedQuarkusAnchor implements TestdataChainedQuarkusObject {
+
+    private TestdataChainedQuarkusEntity next;
+
+    // ************************************************************************
+    // Getters/setters
+    // ************************************************************************
+
+    @Override
+    public TestdataChainedQuarkusEntity getNext() {
+        return next;
+    }
+
+    @Override
+    public void setNext(TestdataChainedQuarkusEntity next) {
+        this.next = next;
+    }
+
+}

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/test/java/org/optaplanner/quarkus/testdata/chained/domain/TestdataChainedQuarkusEntity.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/test/java/org/optaplanner/quarkus/testdata/chained/domain/TestdataChainedQuarkusEntity.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.quarkus.testdata.chained.domain;
+
+import org.optaplanner.core.api.domain.entity.PlanningEntity;
+import org.optaplanner.core.api.domain.variable.PlanningVariable;
+import org.optaplanner.core.api.domain.variable.PlanningVariableGraphType;
+
+@PlanningEntity
+public class TestdataChainedQuarkusEntity implements TestdataChainedQuarkusObject {
+
+    @PlanningVariable(valueRangeProviderRefs = { "chainedAnchorRange",
+            "chainedEntityRange" }, graphType = PlanningVariableGraphType.CHAINED)
+    private TestdataChainedQuarkusObject previous;
+
+    private TestdataChainedQuarkusEntity next;
+
+    // ************************************************************************
+    // Getters/setters
+    // ************************************************************************
+
+    public TestdataChainedQuarkusObject getPrevious() {
+        return previous;
+    }
+
+    public void setPrevious(TestdataChainedQuarkusObject previous) {
+        this.previous = previous;
+    }
+
+    @Override
+    public TestdataChainedQuarkusEntity getNext() {
+        return next;
+    }
+
+    @Override
+    public void setNext(TestdataChainedQuarkusEntity next) {
+        this.next = next;
+    }
+
+}

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/test/java/org/optaplanner/quarkus/testdata/chained/domain/TestdataChainedQuarkusObject.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/test/java/org/optaplanner/quarkus/testdata/chained/domain/TestdataChainedQuarkusObject.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.quarkus.testdata.chained.domain;
+
+import org.optaplanner.core.api.domain.entity.PlanningEntity;
+import org.optaplanner.core.api.domain.variable.InverseRelationShadowVariable;
+
+@PlanningEntity
+public interface TestdataChainedQuarkusObject {
+
+    @InverseRelationShadowVariable(sourceVariableName = "previous")
+    TestdataChainedQuarkusEntity getNext();
+
+    void setNext(TestdataChainedQuarkusEntity next);
+
+}

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/test/java/org/optaplanner/quarkus/testdata/chained/domain/TestdataChainedQuarkusSolution.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/test/java/org/optaplanner/quarkus/testdata/chained/domain/TestdataChainedQuarkusSolution.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.optaplanner.quarkus.domain;
+package org.optaplanner.quarkus.testdata.chained.domain;
 
 import java.util.List;
 
@@ -26,33 +26,38 @@ import org.optaplanner.core.api.domain.valuerange.ValueRangeProvider;
 import org.optaplanner.core.api.score.buildin.simple.SimpleScore;
 
 @PlanningSolution
-public class TestdataPlanningSolution {
+public class TestdataChainedQuarkusSolution {
 
-    private List<String> valueList;
-    private List<TestdataPlanningEntity> entityList;
-
-    private SimpleScore score;
-
-    @ValueRangeProvider(id = "valueRange")
     @ProblemFactCollectionProperty
-    public List<String> getValueList() {
-        return valueList;
-    }
-
-    public void setValueList(List<String> valueList) {
-        this.valueList = valueList;
-    }
-
+    @ValueRangeProvider(id = "chainedAnchorRange")
+    private List<TestdataChainedQuarkusAnchor> chainedAnchorList;
     @PlanningEntityCollectionProperty
-    public List<TestdataPlanningEntity> getEntityList() {
-        return entityList;
-    }
-
-    public void setEntityList(List<TestdataPlanningEntity> entityList) {
-        this.entityList = entityList;
-    }
+    @ValueRangeProvider(id = "chainedEntityRange")
+    private List<TestdataChainedQuarkusEntity> chainedEntityList;
 
     @PlanningScore
+    private SimpleScore score;
+
+    // ************************************************************************
+    // Getters/setters
+    // ************************************************************************
+
+    public List<TestdataChainedQuarkusAnchor> getChainedAnchorList() {
+        return chainedAnchorList;
+    }
+
+    public void setChainedAnchorList(List<TestdataChainedQuarkusAnchor> chainedAnchorList) {
+        this.chainedAnchorList = chainedAnchorList;
+    }
+
+    public List<TestdataChainedQuarkusEntity> getChainedEntityList() {
+        return chainedEntityList;
+    }
+
+    public void setChainedEntityList(List<TestdataChainedQuarkusEntity> chainedEntityList) {
+        this.chainedEntityList = chainedEntityList;
+    }
+
     public SimpleScore getScore() {
         return score;
     }

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/test/java/org/optaplanner/quarkus/testdata/normal/constraints/TestdataQuarkusConstraintProvider.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/test/java/org/optaplanner/quarkus/testdata/normal/constraints/TestdataQuarkusConstraintProvider.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.quarkus.testdata.normal.constraints;
+
+import org.optaplanner.core.api.score.buildin.simple.SimpleScore;
+import org.optaplanner.core.api.score.stream.Constraint;
+import org.optaplanner.core.api.score.stream.ConstraintFactory;
+import org.optaplanner.core.api.score.stream.ConstraintProvider;
+import org.optaplanner.core.api.score.stream.Joiners;
+import org.optaplanner.quarkus.testdata.normal.domain.TestdataQuarkusEntity;
+
+public class TestdataQuarkusConstraintProvider implements ConstraintProvider {
+
+    @Override
+    public Constraint[] defineConstraints(ConstraintFactory factory) {
+        return new Constraint[] {
+                factory.from(TestdataQuarkusEntity.class)
+                        .join(TestdataQuarkusEntity.class, Joiners.equal(TestdataQuarkusEntity::getValue))
+                        .filter((a, b) -> a != b)
+                        .penalize("Don't assign 2 entities the same value.", SimpleScore.ONE)
+        };
+    }
+
+}

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/test/java/org/optaplanner/quarkus/testdata/normal/domain/TestdataQuarkusEntity.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/test/java/org/optaplanner/quarkus/testdata/normal/domain/TestdataQuarkusEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,21 +14,17 @@
  * limitations under the License.
  */
 
-package org.optaplanner.spring.boot.autoconfigure.testdata;
+package org.optaplanner.quarkus.testdata.normal.domain;
 
 import org.optaplanner.core.api.domain.entity.PlanningEntity;
 import org.optaplanner.core.api.domain.variable.PlanningVariable;
 
 @PlanningEntity
-public class TestdataSpringEntity {
+public class TestdataQuarkusEntity {
 
-    @PlanningVariable(valueRangeProviderRefs = "valueRange")
     private String value;
 
-    // ************************************************************************
-    // Getters/setters
-    // ************************************************************************
-
+    @PlanningVariable(valueRangeProviderRefs = "valueRange")
     public String getValue() {
         return value;
     }

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/test/java/org/optaplanner/quarkus/testdata/normal/domain/TestdataQuarkusSolution.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/test/java/org/optaplanner/quarkus/testdata/normal/domain/TestdataQuarkusSolution.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,31 +14,27 @@
  * limitations under the License.
  */
 
-package org.optaplanner.spring.boot.autoconfigure.testdata;
+package org.optaplanner.quarkus.testdata.normal.domain;
 
 import java.util.List;
 
 import org.optaplanner.core.api.domain.solution.PlanningEntityCollectionProperty;
 import org.optaplanner.core.api.domain.solution.PlanningScore;
 import org.optaplanner.core.api.domain.solution.PlanningSolution;
+import org.optaplanner.core.api.domain.solution.ProblemFactCollectionProperty;
 import org.optaplanner.core.api.domain.valuerange.ValueRangeProvider;
 import org.optaplanner.core.api.score.buildin.simple.SimpleScore;
 
 @PlanningSolution
-public class TestdataSpringSolution {
+public class TestdataQuarkusSolution {
 
-    @ValueRangeProvider(id = "valueRange")
     private List<String> valueList;
-    @PlanningEntityCollectionProperty
-    private List<TestdataSpringEntity> entityList;
+    private List<TestdataQuarkusEntity> entityList;
 
-    @PlanningScore
     private SimpleScore score;
 
-    // ************************************************************************
-    // Getters/setters
-    // ************************************************************************
-
+    @ValueRangeProvider(id = "valueRange")
+    @ProblemFactCollectionProperty
     public List<String> getValueList() {
         return valueList;
     }
@@ -47,14 +43,16 @@ public class TestdataSpringSolution {
         this.valueList = valueList;
     }
 
-    public List<TestdataSpringEntity> getEntityList() {
+    @PlanningEntityCollectionProperty
+    public List<TestdataQuarkusEntity> getEntityList() {
         return entityList;
     }
 
-    public void setEntityList(List<TestdataSpringEntity> entityList) {
+    public void setEntityList(List<TestdataQuarkusEntity> entityList) {
         this.entityList = entityList;
     }
 
+    @PlanningScore
     public SimpleScore getScore() {
         return score;
     }
@@ -62,4 +60,5 @@ public class TestdataSpringSolution {
     public void setScore(SimpleScore score) {
         this.score = score;
     }
+
 }

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/test/resources/org/optaplanner/quarkus/constraints/defaultConstraints.drl
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/test/resources/org/optaplanner/quarkus/constraints/defaultConstraints.drl
@@ -3,13 +3,13 @@ package org.optaplanner.quarkus.constraints;
 
 import org.optaplanner.core.api.score.buildin.simple.SimpleScoreHolder;
 
-import org.optaplanner.quarkus.domain.TestdataPlanningEntity;
+import org.optaplanner.quarkus.testdata.normal.domain.TestdataQuarkusEntity;
 
 global SimpleScoreHolder scoreHolder;
 
 rule "Don't assign 2 entities the same value."
     when
-        TestdataPlanningEntity()
+        TestdataQuarkusEntity()
         // TODO Fix UnsupportedOperationException with kogito-drools
 //        $a : TestdataPlanningEntity(value != null, $v : value)
 //        TestdataPlanningEntity(value == $v, this != $a)


### PR DESCRIPTION
Also adds test coverage for this bug, both for our Spring Boot Starter and our Quarkus Extension.