### PR TITLE
PLANNER-1960: Use Thread.currentThread().getContextClassLoader() when loading Drools for Quarkus

### DIFF
--- a/optaplanner-core/src/main/java/org/optaplanner/core/config/score/director/ScoreDirectorFactoryConfig.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/config/score/director/ScoreDirectorFactoryConfig.java
@@ -421,8 +421,7 @@ public class ScoreDirectorFactoryConfig extends AbstractConfig<ScoreDirectorFact
             KieResources kieResources = kieServices.getResources();
             KieFileSystem kieFileSystem = kieServices.newKieFileSystem();
             if (!ConfigUtils.isEmptyCollection(scoreDrlList)) {
-                ClassLoader actualClassLoader =
-                        (classLoader != null) ? classLoader : Thread.currentThread().getContextClassLoader();
+                ClassLoader actualClassLoader = (classLoader != null) ? classLoader : getClass().getClassLoader();
                 for (String scoreDrl : scoreDrlList) {
                     if (scoreDrl == null) {
                         throw new IllegalArgumentException("The scoreDrl (" + scoreDrl + ") cannot be null.");
@@ -533,4 +532,5 @@ public class ScoreDirectorFactoryConfig extends AbstractConfig<ScoreDirectorFact
     public ScoreDirectorFactoryConfig copyConfig() {
         return new ScoreDirectorFactoryConfig().inherit(this);
     }
+
 }

--- a/optaplanner-core/src/main/java/org/optaplanner/core/config/score/director/ScoreDirectorFactoryConfig.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/config/score/director/ScoreDirectorFactoryConfig.java
@@ -421,7 +421,8 @@ public class ScoreDirectorFactoryConfig extends AbstractConfig<ScoreDirectorFact
             KieResources kieResources = kieServices.getResources();
             KieFileSystem kieFileSystem = kieServices.newKieFileSystem();
             if (!ConfigUtils.isEmptyCollection(scoreDrlList)) {
-                ClassLoader actualClassLoader = (classLoader != null) ? classLoader : getClass().getClassLoader();
+                ClassLoader actualClassLoader =
+                        (classLoader != null) ? classLoader : Thread.currentThread().getContextClassLoader();
                 for (String scoreDrl : scoreDrlList) {
                     if (scoreDrl == null) {
                         throw new IllegalArgumentException("The scoreDrl (" + scoreDrl + ") cannot be null.");
@@ -532,5 +533,4 @@ public class ScoreDirectorFactoryConfig extends AbstractConfig<ScoreDirectorFact
     public ScoreDirectorFactoryConfig copyConfig() {
         return new ScoreDirectorFactoryConfig().inherit(this);
     }
-
 }

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/runtime/src/main/java/org/optaplanner/quarkus/OptaPlannerBeanProvider.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/runtime/src/main/java/org/optaplanner/quarkus/OptaPlannerBeanProvider.java
@@ -33,7 +33,9 @@ public class OptaPlannerBeanProvider {
     @Singleton
     @Produces
     <Solution_> SolverFactory<Solution_> solverFactory(SolverConfig solverConfig) {
-        return SolverFactory.create(solverConfig);
+        SolverConfig solverConfigWithUpdatedClassloader = solverConfig.copyConfig();
+        solverConfigWithUpdatedClassloader.setClassLoader(Thread.currentThread().getContextClassLoader());
+        return SolverFactory.create(solverConfigWithUpdatedClassloader);
     }
 
     @DefaultBean


### PR DESCRIPTION
See https://github.com/quarkusio/quarkus/issues/2531 for details:
Resources inside the deployment are not on the system class path in dev mode, as we need a new class loader to enable hot deployment.

TODO:
Look for other instances of `getClass().getClassLoader()` and replace with `Thread.currentThread().getContextClassLoader()`