### PR TITLE
Remove XStream from optaplanner-core

### DIFF
--- a/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/config/PlannerBenchmarkConfig.java
+++ b/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/config/PlannerBenchmarkConfig.java
@@ -140,9 +140,9 @@ public class PlannerBenchmarkConfig {
             return createFromXmlInputStream(in, classLoader);
         } catch (XmlUnmarshallingException e) {
             throw new IllegalArgumentException("Unmarshalling of benchmarkConfigResource (" + benchmarkConfigResource
-                    + ") failed.", e);
+                    + ") fails.", e);
         } catch (IOException e) {
-            throw new IllegalArgumentException("Reading the benchmarkConfigResource (" + benchmarkConfigResource + ") failed.",
+            throw new IllegalArgumentException("Reading the benchmarkConfigResource (" + benchmarkConfigResource + ") fails.",
                     e);
         }
     }
@@ -175,7 +175,7 @@ public class PlannerBenchmarkConfig {
             throw new IllegalArgumentException("The benchmarkConfigFile (" + benchmarkConfigFile
                     + ") was not found.", e);
         } catch (IOException e) {
-            throw new IllegalArgumentException("Reading the benchmarkConfigFile (" + benchmarkConfigFile + ") failed.", e);
+            throw new IllegalArgumentException("Reading the benchmarkConfigFile (" + benchmarkConfigFile + ") fails.", e);
         }
     }
 
@@ -199,7 +199,7 @@ public class PlannerBenchmarkConfig {
         } catch (UnsupportedEncodingException e) {
             throw new IllegalStateException("This vm does not support the charset (" + StandardCharsets.UTF_8 + ").", e);
         } catch (IOException e) {
-            throw new IllegalArgumentException("Reading failed.", e);
+            throw new IllegalArgumentException("Reading fails.", e);
         }
     }
 
@@ -296,7 +296,7 @@ public class PlannerBenchmarkConfig {
             }
             return createFromFreemarkerXmlInputStream(templateIn, model, classLoader);
         } catch (IOException e) {
-            throw new IllegalArgumentException("Reading the templateResource (" + templateResource + ") failed.", e);
+            throw new IllegalArgumentException("Reading the templateResource (" + templateResource + ") fails.", e);
         }
     }
 
@@ -351,7 +351,7 @@ public class PlannerBenchmarkConfig {
         } catch (FileNotFoundException e) {
             throw new IllegalArgumentException("The templateFile (" + templateFile + ") was not found.", e);
         } catch (IOException e) {
-            throw new IllegalArgumentException("Reading the templateFile (" + templateFile + ") failed.", e);
+            throw new IllegalArgumentException("Reading the templateFile (" + templateFile + ") fails.", e);
         }
     }
 
@@ -402,7 +402,7 @@ public class PlannerBenchmarkConfig {
         } catch (UnsupportedEncodingException e) {
             throw new IllegalStateException("This vm does not support the charset (" + StandardCharsets.UTF_8 + ").", e);
         } catch (IOException e) {
-            throw new IllegalArgumentException("Reading failed.", e);
+            throw new IllegalArgumentException("Reading fails.", e);
         }
     }
 

--- a/optaplanner-core/pom.xml
+++ b/optaplanner-core/pom.xml
@@ -81,10 +81,6 @@
     </dependency>
     <!-- XML -->
     <dependency>
-      <groupId>com.thoughtworks.xstream</groupId>
-      <artifactId>xstream</artifactId>
-    </dependency>
-    <dependency>
       <groupId>jakarta.xml.bind</groupId>
       <artifactId>jakarta.xml.bind-api</artifactId>
     </dependency>

--- a/optaplanner-core/src/main/java/org/optaplanner/core/config/solver/SolverConfig.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/config/solver/SolverConfig.java
@@ -111,10 +111,10 @@ public class SolverConfig extends AbstractConfig<SolverConfig> {
             }
             return createFromXmlInputStream(in, classLoader);
         } catch (XmlUnmarshallingException e) {
-            throw new IllegalArgumentException("Unmarshalling of solverConfigResource (" + solverConfigResource + ") failed.",
+            throw new IllegalArgumentException("Unmarshalling of solverConfigResource (" + solverConfigResource + ") fails.",
                     e);
         } catch (IOException e) {
-            throw new IllegalArgumentException("Reading the solverConfigResource (" + solverConfigResource + ") failed.", e);
+            throw new IllegalArgumentException("Reading the solverConfigResource (" + solverConfigResource + ") fails.", e);
         }
     }
 
@@ -145,7 +145,7 @@ public class SolverConfig extends AbstractConfig<SolverConfig> {
         } catch (FileNotFoundException e) {
             throw new IllegalArgumentException("The solverConfigFile (" + solverConfigFile + ") was not found.", e);
         } catch (IOException e) {
-            throw new IllegalArgumentException("Reading the solverConfigFile (" + solverConfigFile + ") failed.", e);
+            throw new IllegalArgumentException("Reading the solverConfigFile (" + solverConfigFile + ") fails.", e);
         }
     }
 
@@ -171,7 +171,7 @@ public class SolverConfig extends AbstractConfig<SolverConfig> {
         } catch (UnsupportedEncodingException e) {
             throw new IllegalStateException("This vm does not support the charset (" + StandardCharsets.UTF_8 + ").", e);
         } catch (IOException e) {
-            throw new IllegalArgumentException("Reading solverConfigInputStream failed.", e);
+            throw new IllegalArgumentException("Reading solverConfigInputStream fails.", e);
         }
     }
 

--- a/optaplanner-core/src/test/java/org/optaplanner/core/api/score/buildin/bendable/BendableScoreTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/api/score/buildin/bendable/BendableScoreTest.java
@@ -23,7 +23,6 @@ import org.junit.jupiter.api.Test;
 import org.optaplanner.core.api.score.buildin.AbstractScoreTest;
 import org.optaplanner.core.impl.score.buildin.bendable.BendableScoreDefinition;
 import org.optaplanner.core.impl.testdata.util.PlannerAssert;
-import org.optaplanner.core.impl.testdata.util.PlannerTestUtils;
 
 public class BendableScoreTest extends AbstractScoreTest {
 
@@ -298,25 +297,4 @@ public class BendableScoreTest extends AbstractScoreTest {
                 scoreDefinitionHHSSS.createScore(1, Integer.MIN_VALUE, -20, 0, 0),
                 scoreDefinitionHHSSS.createScore(1, -20, Integer.MIN_VALUE, 0, 0));
     }
-
-    @Test
-    public void serializeAndDeserialize() {
-        PlannerTestUtils.serializeAndDeserializeWithXStream(
-                scoreDefinitionHSS.createScore(-12, 3400, -56),
-                output -> {
-                    assertThat(output.getInitScore()).isEqualTo(0);
-                    assertThat(output.getHardScore(0)).isEqualTo(-12);
-                    assertThat(output.getSoftScore(0)).isEqualTo(3400);
-                    assertThat(output.getSoftScore(1)).isEqualTo(-56);
-                });
-        PlannerTestUtils.serializeAndDeserializeWithXStream(
-                scoreDefinitionHSS.createScoreUninitialized(-7, -12, 3400, -56),
-                output -> {
-                    assertThat(output.getInitScore()).isEqualTo(-7);
-                    assertThat(output.getHardScore(0)).isEqualTo(-12);
-                    assertThat(output.getSoftScore(0)).isEqualTo(3400);
-                    assertThat(output.getSoftScore(1)).isEqualTo(-56);
-                });
-    }
-
 }

--- a/optaplanner-core/src/test/java/org/optaplanner/core/api/score/buildin/bendablebigdecimal/BendableBigDecimalScoreTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/api/score/buildin/bendablebigdecimal/BendableBigDecimalScoreTest.java
@@ -26,7 +26,6 @@ import org.junit.jupiter.api.Test;
 import org.optaplanner.core.api.score.buildin.AbstractScoreTest;
 import org.optaplanner.core.impl.score.buildin.bendablebigdecimal.BendableBigDecimalScoreDefinition;
 import org.optaplanner.core.impl.testdata.util.PlannerAssert;
-import org.optaplanner.core.impl.testdata.util.PlannerTestUtils;
 
 public class BendableBigDecimalScoreTest extends AbstractScoreTest {
 
@@ -40,7 +39,6 @@ public class BendableBigDecimalScoreTest extends AbstractScoreTest {
     private static final BigDecimal PLUS_19 = BigDecimal.valueOf(19);
     private static final BigDecimal PLUS_16 = BigDecimal.valueOf(16);
     private static final BigDecimal NINE = BigDecimal.valueOf(9);
-    private static final BigDecimal SIX = BigDecimal.valueOf(6);
     private static final BigDecimal FIVE = BigDecimal.valueOf(5);
     private static final BigDecimal FOUR = BigDecimal.valueOf(4);
     private static final BigDecimal THREE = BigDecimal.valueOf(3);
@@ -354,26 +352,4 @@ public class BendableBigDecimalScoreTest extends AbstractScoreTest {
                 scoreDefinitionHHSSS.createScore(ONE, MIN_INTEGER, MINUS_20, ZERO, ZERO),
                 scoreDefinitionHHSSS.createScore(ONE, MINUS_20, MIN_INTEGER, ZERO, ZERO));
     }
-
-    @Test
-    public void serializeAndDeserialize() {
-        PlannerTestUtils.serializeAndDeserializeWithXStream(
-                scoreDefinitionHSS.createScore(new BigDecimal("-12"), new BigDecimal("3400"), new BigDecimal("-56")),
-                output -> {
-                    assertThat(output.getInitScore()).isEqualTo(0);
-                    assertThat(output.getHardScore(0)).isEqualTo(new BigDecimal("-12"));
-                    assertThat(output.getSoftScore(0)).isEqualTo(new BigDecimal("3400"));
-                    assertThat(output.getSoftScore(1)).isEqualTo(new BigDecimal("-56"));
-                });
-        PlannerTestUtils.serializeAndDeserializeWithXStream(
-                scoreDefinitionHSS.createScoreUninitialized(-7, new BigDecimal("-12"), new BigDecimal("3400"),
-                        new BigDecimal("-56")),
-                output -> {
-                    assertThat(output.getInitScore()).isEqualTo(-7);
-                    assertThat(output.getHardScore(0)).isEqualTo(new BigDecimal("-12"));
-                    assertThat(output.getSoftScore(0)).isEqualTo(new BigDecimal("3400"));
-                    assertThat(output.getSoftScore(1)).isEqualTo(new BigDecimal("-56"));
-                });
-    }
-
 }

--- a/optaplanner-core/src/test/java/org/optaplanner/core/api/score/buildin/bendablelong/BendableLongScoreTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/api/score/buildin/bendablelong/BendableLongScoreTest.java
@@ -23,7 +23,6 @@ import org.junit.jupiter.api.Test;
 import org.optaplanner.core.api.score.buildin.AbstractScoreTest;
 import org.optaplanner.core.impl.score.buildin.bendablelong.BendableLongScoreDefinition;
 import org.optaplanner.core.impl.testdata.util.PlannerAssert;
-import org.optaplanner.core.impl.testdata.util.PlannerTestUtils;
 
 public class BendableLongScoreTest extends AbstractScoreTest {
 
@@ -300,25 +299,4 @@ public class BendableLongScoreTest extends AbstractScoreTest {
                 scoreDefinitionHHSSS.createScore(1L, Long.MIN_VALUE, -20L, 0L, 0L),
                 scoreDefinitionHHSSS.createScore(1L, -20L, Long.MIN_VALUE, 0L, 0L));
     }
-
-    @Test
-    public void serializeAndDeserialize() {
-        PlannerTestUtils.serializeAndDeserializeWithXStream(
-                scoreDefinitionHSS.createScore(-12L, 3400L, -56L),
-                output -> {
-                    assertThat(output.getInitScore()).isEqualTo(0);
-                    assertThat(output.getHardScore(0)).isEqualTo(-12L);
-                    assertThat(output.getSoftScore(0)).isEqualTo(3400L);
-                    assertThat(output.getSoftScore(1)).isEqualTo(-56L);
-                });
-        PlannerTestUtils.serializeAndDeserializeWithXStream(
-                scoreDefinitionHSS.createScoreUninitialized(-7, -12L, 3400L, -56L),
-                output -> {
-                    assertThat(output.getInitScore()).isEqualTo(-7);
-                    assertThat(output.getHardScore(0)).isEqualTo(-12L);
-                    assertThat(output.getSoftScore(0)).isEqualTo(3400L);
-                    assertThat(output.getSoftScore(1)).isEqualTo(-56L);
-                });
-    }
-
 }

--- a/optaplanner-core/src/test/java/org/optaplanner/core/api/score/buildin/hardmediumsoft/HardMediumSoftScoreTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/api/score/buildin/hardmediumsoft/HardMediumSoftScoreTest.java
@@ -22,7 +22,6 @@ import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException
 import org.junit.jupiter.api.Test;
 import org.optaplanner.core.api.score.buildin.AbstractScoreTest;
 import org.optaplanner.core.impl.testdata.util.PlannerAssert;
-import org.optaplanner.core.impl.testdata.util.PlannerTestUtils;
 
 public class HardMediumSoftScoreTest extends AbstractScoreTest {
 
@@ -180,25 +179,4 @@ public class HardMediumSoftScoreTest extends AbstractScoreTest {
                 HardMediumSoftScore.of(1, Integer.MIN_VALUE, -20),
                 HardMediumSoftScore.of(1, -20, Integer.MIN_VALUE));
     }
-
-    @Test
-    public void serializeAndDeserialize() {
-        PlannerTestUtils.serializeAndDeserializeWithXStream(
-                HardMediumSoftScore.of(-12, 3400, -56),
-                output -> {
-                    assertThat(output.getInitScore()).isEqualTo(0);
-                    assertThat(output.getHardScore()).isEqualTo(-12);
-                    assertThat(output.getMediumScore()).isEqualTo(3400);
-                    assertThat(output.getSoftScore()).isEqualTo(-56);
-                });
-        PlannerTestUtils.serializeAndDeserializeWithXStream(
-                HardMediumSoftScore.ofUninitialized(-7, -12, 3400, -56),
-                output -> {
-                    assertThat(output.getInitScore()).isEqualTo(-7);
-                    assertThat(output.getHardScore()).isEqualTo(-12);
-                    assertThat(output.getMediumScore()).isEqualTo(3400);
-                    assertThat(output.getSoftScore()).isEqualTo(-56);
-                });
-    }
-
 }

--- a/optaplanner-core/src/test/java/org/optaplanner/core/api/score/buildin/hardmediumsoftbigdecimal/HardMediumSoftBigDecimalScoreTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/api/score/buildin/hardmediumsoftbigdecimal/HardMediumSoftBigDecimalScoreTest.java
@@ -24,7 +24,6 @@ import java.math.BigDecimal;
 import org.junit.jupiter.api.Test;
 import org.optaplanner.core.api.score.buildin.AbstractScoreTest;
 import org.optaplanner.core.impl.testdata.util.PlannerAssert;
-import org.optaplanner.core.impl.testdata.util.PlannerTestUtils;
 
 public class HardMediumSoftBigDecimalScoreTest extends AbstractScoreTest {
 
@@ -270,26 +269,4 @@ public class HardMediumSoftBigDecimalScoreTest extends AbstractScoreTest {
                 HardMediumSoftBigDecimalScore.of(new BigDecimal("0"), new BigDecimal("0"), new BigDecimal("0")),
                 HardMediumSoftBigDecimalScore.of(new BigDecimal("0"), new BigDecimal("0"), new BigDecimal("1")));
     }
-
-    @Test
-    public void serializeAndDeserialize() {
-        PlannerTestUtils.serializeAndDeserializeWithXStream(
-                HardMediumSoftBigDecimalScore.of(new BigDecimal("-12.3"), new BigDecimal("-43.3"), new BigDecimal("3400.5")),
-                output -> {
-                    assertThat(output.getInitScore()).isEqualTo(0);
-                    assertThat(output.getHardScore()).isEqualTo(new BigDecimal("-12.3"));
-                    assertThat(output.getMediumScore()).isEqualTo(new BigDecimal("-43.3"));
-                    assertThat(output.getSoftScore()).isEqualTo(new BigDecimal("3400.5"));
-                });
-        PlannerTestUtils.serializeAndDeserializeWithXStream(
-                HardMediumSoftBigDecimalScore.ofUninitialized(-7, new BigDecimal("-12.3"), new BigDecimal("-43.3"),
-                        new BigDecimal("3400.5")),
-                output -> {
-                    assertThat(output.getInitScore()).isEqualTo(-7);
-                    assertThat(output.getHardScore()).isEqualTo(new BigDecimal("-12.3"));
-                    assertThat(output.getMediumScore()).isEqualTo(new BigDecimal("-43.3"));
-                    assertThat(output.getSoftScore()).isEqualTo(new BigDecimal("3400.5"));
-                });
-    }
-
 }

--- a/optaplanner-core/src/test/java/org/optaplanner/core/api/score/buildin/hardmediumsoftlong/HardMediumSoftLongScoreTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/api/score/buildin/hardmediumsoftlong/HardMediumSoftLongScoreTest.java
@@ -22,7 +22,6 @@ import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException
 import org.junit.jupiter.api.Test;
 import org.optaplanner.core.api.score.buildin.AbstractScoreTest;
 import org.optaplanner.core.impl.testdata.util.PlannerAssert;
-import org.optaplanner.core.impl.testdata.util.PlannerTestUtils;
 
 public class HardMediumSoftLongScoreTest extends AbstractScoreTest {
 
@@ -180,25 +179,4 @@ public class HardMediumSoftLongScoreTest extends AbstractScoreTest {
                 HardMediumSoftLongScore.of(1L, Long.MIN_VALUE, -20L),
                 HardMediumSoftLongScore.of(1L, -20L, Long.MIN_VALUE));
     }
-
-    @Test
-    public void serializeAndDeserialize() {
-        PlannerTestUtils.serializeAndDeserializeWithXStream(
-                HardMediumSoftLongScore.of(-12L, 3400L, -56L),
-                output -> {
-                    assertThat(output.getInitScore()).isEqualTo(0);
-                    assertThat(output.getHardScore()).isEqualTo(-12L);
-                    assertThat(output.getMediumScore()).isEqualTo(3400L);
-                    assertThat(output.getSoftScore()).isEqualTo(-56L);
-                });
-        PlannerTestUtils.serializeAndDeserializeWithXStream(
-                HardMediumSoftLongScore.ofUninitialized(-7, -12L, 3400L, -56L),
-                output -> {
-                    assertThat(output.getInitScore()).isEqualTo(-7);
-                    assertThat(output.getHardScore()).isEqualTo(-12L);
-                    assertThat(output.getMediumScore()).isEqualTo(3400L);
-                    assertThat(output.getSoftScore()).isEqualTo(-56L);
-                });
-    }
-
 }

--- a/optaplanner-core/src/test/java/org/optaplanner/core/api/score/buildin/hardsoft/HardSoftScoreTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/api/score/buildin/hardsoft/HardSoftScoreTest.java
@@ -22,7 +22,6 @@ import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException
 import org.junit.jupiter.api.Test;
 import org.optaplanner.core.api.score.buildin.AbstractScoreTest;
 import org.optaplanner.core.impl.testdata.util.PlannerAssert;
-import org.optaplanner.core.impl.testdata.util.PlannerTestUtils;
 
 public class HardSoftScoreTest extends AbstractScoreTest {
 
@@ -158,23 +157,4 @@ public class HardSoftScoreTest extends AbstractScoreTest {
                 HardSoftScore.of(0, 0),
                 HardSoftScore.of(0, 1));
     }
-
-    @Test
-    public void serializeAndDeserialize() {
-        PlannerTestUtils.serializeAndDeserializeWithXStream(
-                HardSoftScore.of(-12, 3400),
-                output -> {
-                    assertThat(output.getInitScore()).isEqualTo(0);
-                    assertThat(output.getHardScore()).isEqualTo(-12);
-                    assertThat(output.getSoftScore()).isEqualTo(3400);
-                });
-        PlannerTestUtils.serializeAndDeserializeWithXStream(
-                HardSoftScore.ofUninitialized(-7, -12, 3400),
-                output -> {
-                    assertThat(output.getInitScore()).isEqualTo(-7);
-                    assertThat(output.getHardScore()).isEqualTo(-12);
-                    assertThat(output.getSoftScore()).isEqualTo(3400);
-                });
-    }
-
 }

--- a/optaplanner-core/src/test/java/org/optaplanner/core/api/score/buildin/hardsoftbigdecimal/HardSoftBigDecimalScoreTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/api/score/buildin/hardsoftbigdecimal/HardSoftBigDecimalScoreTest.java
@@ -24,7 +24,6 @@ import java.math.BigDecimal;
 import org.junit.jupiter.api.Test;
 import org.optaplanner.core.api.score.buildin.AbstractScoreTest;
 import org.optaplanner.core.impl.testdata.util.PlannerAssert;
-import org.optaplanner.core.impl.testdata.util.PlannerTestUtils;
 
 public class HardSoftBigDecimalScoreTest extends AbstractScoreTest {
 
@@ -193,23 +192,4 @@ public class HardSoftBigDecimalScoreTest extends AbstractScoreTest {
                 HardSoftBigDecimalScore.of(new BigDecimal("0"), new BigDecimal("0")),
                 HardSoftBigDecimalScore.of(new BigDecimal("0"), new BigDecimal("1")));
     }
-
-    @Test
-    public void serializeAndDeserialize() {
-        PlannerTestUtils.serializeAndDeserializeWithXStream(
-                HardSoftBigDecimalScore.of(new BigDecimal("-12.3"), new BigDecimal("3400.5")),
-                output -> {
-                    assertThat(output.getInitScore()).isEqualTo(0);
-                    assertThat(output.getHardScore()).isEqualTo(new BigDecimal("-12.3"));
-                    assertThat(output.getSoftScore()).isEqualTo(new BigDecimal("3400.5"));
-                });
-        PlannerTestUtils.serializeAndDeserializeWithXStream(
-                HardSoftBigDecimalScore.ofUninitialized(-7, new BigDecimal("-12.3"), new BigDecimal("3400.5")),
-                output -> {
-                    assertThat(output.getInitScore()).isEqualTo(-7);
-                    assertThat(output.getHardScore()).isEqualTo(new BigDecimal("-12.3"));
-                    assertThat(output.getSoftScore()).isEqualTo(new BigDecimal("3400.5"));
-                });
-    }
-
 }

--- a/optaplanner-core/src/test/java/org/optaplanner/core/api/score/buildin/hardsoftlong/HardSoftLongScoreTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/api/score/buildin/hardsoftlong/HardSoftLongScoreTest.java
@@ -22,7 +22,6 @@ import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException
 import org.junit.jupiter.api.Test;
 import org.optaplanner.core.api.score.buildin.AbstractScoreTest;
 import org.optaplanner.core.impl.testdata.util.PlannerAssert;
-import org.optaplanner.core.impl.testdata.util.PlannerTestUtils;
 
 public class HardSoftLongScoreTest extends AbstractScoreTest {
 
@@ -163,23 +162,4 @@ public class HardSoftLongScoreTest extends AbstractScoreTest {
                 HardSoftLongScore.of(0L, 0L),
                 HardSoftLongScore.of(0L, 1L));
     }
-
-    @Test
-    public void serializeAndDeserialize() {
-        PlannerTestUtils.serializeAndDeserializeWithXStream(
-                HardSoftLongScore.of(-12, 3400L),
-                output -> {
-                    assertThat(output.getInitScore()).isEqualTo(0);
-                    assertThat(output.getHardScore()).isEqualTo(-12L);
-                    assertThat(output.getSoftScore()).isEqualTo(3400L);
-                });
-        PlannerTestUtils.serializeAndDeserializeWithXStream(
-                HardSoftLongScore.ofUninitialized(-7, -12L, 3400L),
-                output -> {
-                    assertThat(output.getInitScore()).isEqualTo(-7);
-                    assertThat(output.getHardScore()).isEqualTo(-12L);
-                    assertThat(output.getSoftScore()).isEqualTo(3400L);
-                });
-    }
-
 }

--- a/optaplanner-core/src/test/java/org/optaplanner/core/api/score/buildin/simple/SimpleScoreTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/api/score/buildin/simple/SimpleScoreTest.java
@@ -22,7 +22,6 @@ import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException
 import org.junit.jupiter.api.Test;
 import org.optaplanner.core.api.score.buildin.AbstractScoreTest;
 import org.optaplanner.core.impl.testdata.util.PlannerAssert;
-import org.optaplanner.core.impl.testdata.util.PlannerTestUtils;
 
 public class SimpleScoreTest extends AbstractScoreTest {
 
@@ -132,21 +131,4 @@ public class SimpleScoreTest extends AbstractScoreTest {
                 SimpleScore.of(0),
                 SimpleScore.of(1));
     }
-
-    @Test
-    public void serializeAndDeserialize() {
-        PlannerTestUtils.serializeAndDeserializeWithXStream(
-                SimpleScore.of(123),
-                output -> {
-                    assertThat(output.getInitScore()).isEqualTo(0);
-                    assertThat(output.getScore()).isEqualTo(123);
-                });
-        PlannerTestUtils.serializeAndDeserializeWithXStream(
-                SimpleScore.ofUninitialized(-7, 123),
-                output -> {
-                    assertThat(output.getInitScore()).isEqualTo(-7);
-                    assertThat(output.getScore()).isEqualTo(123);
-                });
-    }
-
 }

--- a/optaplanner-core/src/test/java/org/optaplanner/core/api/score/buildin/simplebigdecimal/SimpleBigDecimalScoreTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/api/score/buildin/simplebigdecimal/SimpleBigDecimalScoreTest.java
@@ -24,7 +24,6 @@ import java.math.BigDecimal;
 import org.junit.jupiter.api.Test;
 import org.optaplanner.core.api.score.buildin.AbstractScoreTest;
 import org.optaplanner.core.impl.testdata.util.PlannerAssert;
-import org.optaplanner.core.impl.testdata.util.PlannerTestUtils;
 
 public class SimpleBigDecimalScoreTest extends AbstractScoreTest {
 
@@ -153,21 +152,4 @@ public class SimpleBigDecimalScoreTest extends AbstractScoreTest {
                 SimpleBigDecimalScore.of(new BigDecimal("0")),
                 SimpleBigDecimalScore.of(new BigDecimal("1")));
     }
-
-    @Test
-    public void serializeAndDeserialize() {
-        PlannerTestUtils.serializeAndDeserializeWithXStream(
-                SimpleBigDecimalScore.of(new BigDecimal("123.4")),
-                output -> {
-                    assertThat(output.getInitScore()).isEqualTo(0);
-                    assertThat(output.getScore()).isEqualTo(new BigDecimal("123.4"));
-                });
-        PlannerTestUtils.serializeAndDeserializeWithXStream(
-                SimpleBigDecimalScore.ofUninitialized(-7, new BigDecimal("123.4")),
-                output -> {
-                    assertThat(output.getInitScore()).isEqualTo(-7);
-                    assertThat(output.getScore()).isEqualTo(new BigDecimal("123.4"));
-                });
-    }
-
 }

--- a/optaplanner-core/src/test/java/org/optaplanner/core/api/score/buildin/simplelong/SimpleLongScoreTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/api/score/buildin/simplelong/SimpleLongScoreTest.java
@@ -22,7 +22,6 @@ import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException
 import org.junit.jupiter.api.Test;
 import org.optaplanner.core.api.score.buildin.AbstractScoreTest;
 import org.optaplanner.core.impl.testdata.util.PlannerAssert;
-import org.optaplanner.core.impl.testdata.util.PlannerTestUtils;
 
 public class SimpleLongScoreTest extends AbstractScoreTest {
 
@@ -134,21 +133,4 @@ public class SimpleLongScoreTest extends AbstractScoreTest {
                 SimpleLongScore.of(1L),
                 SimpleLongScore.of(((long) Integer.MAX_VALUE) + 4000L));
     }
-
-    @Test
-    public void serializeAndDeserialize() {
-        PlannerTestUtils.serializeAndDeserializeWithXStream(
-                SimpleLongScore.of(123L),
-                output -> {
-                    assertThat(output.getInitScore()).isEqualTo(0);
-                    assertThat(output.getScore()).isEqualTo(123L);
-                });
-        PlannerTestUtils.serializeAndDeserializeWithXStream(
-                SimpleLongScore.ofUninitialized(-7, 123L),
-                output -> {
-                    assertThat(output.getInitScore()).isEqualTo(-7);
-                    assertThat(output.getScore()).isEqualTo(123L);
-                });
-    }
-
 }

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/testdata/util/PlannerTestUtils.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/testdata/util/PlannerTestUtils.java
@@ -33,7 +33,6 @@ import java.util.SortedMap;
 import java.util.SortedSet;
 import java.util.TreeMap;
 import java.util.TreeSet;
-import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -55,9 +54,6 @@ import org.optaplanner.core.impl.score.trend.InitializingScoreTrend;
 import org.optaplanner.core.impl.testdata.domain.TestdataEntity;
 import org.optaplanner.core.impl.testdata.domain.TestdataSolution;
 import org.optaplanner.core.impl.testdata.domain.TestdataValue;
-
-import com.thoughtworks.xstream.XStream;
-import com.thoughtworks.xstream.security.AnyTypePermission;
 
 /**
  * @see PlannerAssert
@@ -158,22 +154,6 @@ public class PlannerTestUtils {
             throw new IllegalStateException("No method mocked for parameter (" + externalObject + ").");
         });
         return scoreDirector;
-    }
-
-    // ************************************************************************
-    // Serialization methods
-    // ************************************************************************
-
-    public static <T> void serializeAndDeserializeWithXStream(T input, Consumer<T> outputAsserter) {
-        XStream xStream = new XStream();
-        xStream.setMode(XStream.ID_REFERENCES);
-        if (input != null) {
-            xStream.processAnnotations(input.getClass());
-        }
-        XStream.setupDefaultSecurity(xStream);
-        xStream.addPermission(new AnyTypePermission());
-        String xmlString = xStream.toXML(input);
-        outputAsserter.accept((T) xStream.fromXML(xmlString));
     }
 
     // ************************************************************************


### PR DESCRIPTION
This PR removes the remaining usage of XStream from optaplanner-core.

It removes tests of Score (de)serialization, as these are duplicate to tests of optaplanner-persistance-xstream [1]. Test coverage measured after removing these tests shows no differences compared to coverage of the master branch.

[1] https://github.com/kiegroup/optaplanner/tree/master/optaplanner-persistence/optaplanner-persistence-xstream/src/test/java/org/optaplanner/persistence/xstream/api/score/buildin