### PR TITLE
PLANNER-2069 Add SolutionFileIO for examples

### DIFF
--- a/optaplanner-docs/src/main/asciidoc/BenchmarkingAndTweaking/BenchmarkingAndTweaking-chapter.adoc
+++ b/optaplanner-docs/src/main/asciidoc/BenchmarkingAndTweaking/BenchmarkingAndTweaking-chapter.adoc
@@ -201,8 +201,8 @@ To read and write solutions in the XML format via XStream, extend the `XStreamSo
 
 [source,java,options="nowrap"]
 ----
-public class NQueensSolutionFileIO extends XStreamSolutionFileIO<NQueens> {
-    public NQueensSolutionFileIO() {
+public class NQueensXmlSolutionFileIO extends XStreamSolutionFileIO<NQueens> {
+    public NQueensXmlSolutionFileIO() {
         // NQueens is the @PlanningSolution class.
         super(NQueens.class);
     }
@@ -214,7 +214,7 @@ and use it in the benchmark configuration:
 [source,xml,options="nowrap"]
 ----
     <problemBenchmarks>
-      <solutionFileIOClass>org.optaplanner.examples.nqueens.persistence.NQueensSolutionFileIO</solutionFileIOClass>
+      <solutionFileIOClass>org.optaplanner.examples.nqueens.persistence.NQueensXmlSolutionFileIO</solutionFileIOClass>
       <inputSolutionFile>data/nqueens/unsolved/32queens.xml</inputSolutionFile>
       ...
     </problemBenchmarks>
@@ -327,7 +327,7 @@ To quickly configure and run a benchmark for typical solver configs, use a `solv
 
   <inheritedSolverBenchmark>
     <problemBenchmarks>
-      <solutionFileIOClass>org.optaplanner.examples.nqueens.persistence.NQueensSolutionFileIO</solutionFileIOClass>
+      <solutionFileIOClass>org.optaplanner.examples.nqueens.persistence.NQueensXmlSolutionFileIO</solutionFileIOClass>
       <inputSolutionFile>data/nqueens/unsolved/32queens.xml</inputSolutionFile>
       <inputSolutionFile>data/nqueens/unsolved/64queens.xml</inputSolutionFile>
     </problemBenchmarks>

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/cheaptime/app/CheapTimeApp.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/cheaptime/app/CheapTimeApp.java
@@ -19,12 +19,12 @@ package org.optaplanner.examples.cheaptime.app;
 import org.optaplanner.examples.cheaptime.domain.CheapTimeSolution;
 import org.optaplanner.examples.cheaptime.persistence.CheapTimeExporter;
 import org.optaplanner.examples.cheaptime.persistence.CheapTimeImporter;
+import org.optaplanner.examples.cheaptime.persistence.CheapTimeXmlSolutionFileIO;
 import org.optaplanner.examples.cheaptime.swingui.CheapTimePanel;
 import org.optaplanner.examples.common.app.CommonApp;
 import org.optaplanner.examples.common.persistence.AbstractSolutionExporter;
 import org.optaplanner.examples.common.persistence.AbstractSolutionImporter;
 import org.optaplanner.persistence.common.api.domain.solution.SolutionFileIO;
-import org.optaplanner.persistence.xstream.impl.domain.solution.XStreamSolutionFileIO;
 
 public class CheapTimeApp extends CommonApp<CheapTimeSolution> {
 
@@ -55,7 +55,7 @@ public class CheapTimeApp extends CommonApp<CheapTimeSolution> {
 
     @Override
     public SolutionFileIO<CheapTimeSolution> createSolutionFileIO() {
-        return new XStreamSolutionFileIO<>(CheapTimeSolution.class);
+        return new CheapTimeXmlSolutionFileIO();
     }
 
     @Override

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/cheaptime/persistence/CheapTimeXmlSolutionFileIO.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/cheaptime/persistence/CheapTimeXmlSolutionFileIO.java
@@ -14,14 +14,14 @@
  * limitations under the License.
  */
 
-package org.optaplanner.examples.pas.persistence;
+package org.optaplanner.examples.cheaptime.persistence;
 
-import org.optaplanner.examples.pas.domain.PatientAdmissionSchedule;
+import org.optaplanner.examples.cheaptime.domain.CheapTimeSolution;
 import org.optaplanner.persistence.xstream.impl.domain.solution.XStreamSolutionFileIO;
 
-public class PatientAdmissionScheduleSolutionFileIO extends XStreamSolutionFileIO<PatientAdmissionSchedule> {
+public class CheapTimeXmlSolutionFileIO extends XStreamSolutionFileIO<CheapTimeSolution> {
 
-    public PatientAdmissionScheduleSolutionFileIO() {
-        super(PatientAdmissionSchedule.class);
+    public CheapTimeXmlSolutionFileIO() {
+        super(CheapTimeSolution.class);
     }
 }

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/cloudbalancing/app/CloudBalancingApp.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/cloudbalancing/app/CloudBalancingApp.java
@@ -17,10 +17,10 @@
 package org.optaplanner.examples.cloudbalancing.app;
 
 import org.optaplanner.examples.cloudbalancing.domain.CloudBalance;
+import org.optaplanner.examples.cloudbalancing.persistence.CloudBalanceXmlSolutionFileIO;
 import org.optaplanner.examples.cloudbalancing.swingui.CloudBalancingPanel;
 import org.optaplanner.examples.common.app.CommonApp;
 import org.optaplanner.persistence.common.api.domain.solution.SolutionFileIO;
-import org.optaplanner.persistence.xstream.impl.domain.solution.XStreamSolutionFileIO;
 
 /**
  * For an easy example, look at {@link CloudBalancingHelloWorld} instead.
@@ -52,7 +52,7 @@ public class CloudBalancingApp extends CommonApp<CloudBalance> {
 
     @Override
     public SolutionFileIO<CloudBalance> createSolutionFileIO() {
-        return new XStreamSolutionFileIO<>(CloudBalance.class);
+        return new CloudBalanceXmlSolutionFileIO();
     }
 
 }

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/cloudbalancing/persistence/CloudBalanceXmlSolutionFileIO.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/cloudbalancing/persistence/CloudBalanceXmlSolutionFileIO.java
@@ -14,14 +14,14 @@
  * limitations under the License.
  */
 
-package org.optaplanner.examples.projectjobscheduling.persistence;
+package org.optaplanner.examples.cloudbalancing.persistence;
 
-import org.optaplanner.examples.projectjobscheduling.domain.Project;
+import org.optaplanner.examples.cloudbalancing.domain.CloudBalance;
 import org.optaplanner.persistence.xstream.impl.domain.solution.XStreamSolutionFileIO;
 
-public class ProjectJobSchedulingSolutionFileIO extends XStreamSolutionFileIO<Project> {
+public class CloudBalanceXmlSolutionFileIO extends XStreamSolutionFileIO<CloudBalance> {
 
-    public ProjectJobSchedulingSolutionFileIO() {
-        super(Project.class);
+    public CloudBalanceXmlSolutionFileIO() {
+        super(CloudBalance.class);
     }
 }

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/coachshuttlegathering/app/CoachShuttleGatheringApp.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/coachshuttlegathering/app/CoachShuttleGatheringApp.java
@@ -19,12 +19,12 @@ package org.optaplanner.examples.coachshuttlegathering.app;
 import org.optaplanner.examples.coachshuttlegathering.domain.CoachShuttleGatheringSolution;
 import org.optaplanner.examples.coachshuttlegathering.persistence.CoachShuttleGatheringExporter;
 import org.optaplanner.examples.coachshuttlegathering.persistence.CoachShuttleGatheringImporter;
+import org.optaplanner.examples.coachshuttlegathering.persistence.CoachShuttleGatheringXmlSolutionFileIO;
 import org.optaplanner.examples.coachshuttlegathering.swingui.CoachShuttleGatheringPanel;
 import org.optaplanner.examples.common.app.CommonApp;
 import org.optaplanner.examples.common.persistence.AbstractSolutionExporter;
 import org.optaplanner.examples.common.persistence.AbstractSolutionImporter;
 import org.optaplanner.persistence.common.api.domain.solution.SolutionFileIO;
-import org.optaplanner.persistence.xstream.impl.domain.solution.XStreamSolutionFileIO;
 
 public class CoachShuttleGatheringApp extends CommonApp<CoachShuttleGatheringSolution> {
 
@@ -52,7 +52,7 @@ public class CoachShuttleGatheringApp extends CommonApp<CoachShuttleGatheringSol
 
     @Override
     public SolutionFileIO<CoachShuttleGatheringSolution> createSolutionFileIO() {
-        return new XStreamSolutionFileIO<>(CoachShuttleGatheringSolution.class);
+        return new CoachShuttleGatheringXmlSolutionFileIO();
     }
 
     @Override

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/coachshuttlegathering/persistence/CoachShuttleGatheringXmlSolutionFileIO.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/coachshuttlegathering/persistence/CoachShuttleGatheringXmlSolutionFileIO.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.examples.coachshuttlegathering.persistence;
+
+import org.optaplanner.examples.coachshuttlegathering.domain.CoachShuttleGatheringSolution;
+import org.optaplanner.persistence.xstream.impl.domain.solution.XStreamSolutionFileIO;
+
+public class CoachShuttleGatheringXmlSolutionFileIO extends XStreamSolutionFileIO<CoachShuttleGatheringSolution> {
+
+    public CoachShuttleGatheringXmlSolutionFileIO() {
+        super(CoachShuttleGatheringSolution.class);
+    }
+}

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/curriculumcourse/app/CurriculumCourseApp.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/curriculumcourse/app/CurriculumCourseApp.java
@@ -20,11 +20,11 @@ import org.optaplanner.examples.common.app.CommonApp;
 import org.optaplanner.examples.common.persistence.AbstractSolutionExporter;
 import org.optaplanner.examples.common.persistence.AbstractSolutionImporter;
 import org.optaplanner.examples.curriculumcourse.domain.CourseSchedule;
+import org.optaplanner.examples.curriculumcourse.persistence.CourseScheduleXmlSolutionFileIO;
 import org.optaplanner.examples.curriculumcourse.persistence.CurriculumCourseExporter;
 import org.optaplanner.examples.curriculumcourse.persistence.CurriculumCourseImporter;
 import org.optaplanner.examples.curriculumcourse.swingui.CurriculumCoursePanel;
 import org.optaplanner.persistence.common.api.domain.solution.SolutionFileIO;
-import org.optaplanner.persistence.xstream.impl.domain.solution.XStreamSolutionFileIO;
 
 public class CurriculumCourseApp extends CommonApp<CourseSchedule> {
 
@@ -53,7 +53,7 @@ public class CurriculumCourseApp extends CommonApp<CourseSchedule> {
 
     @Override
     public SolutionFileIO<CourseSchedule> createSolutionFileIO() {
-        return new XStreamSolutionFileIO<>(CourseSchedule.class);
+        return new CourseScheduleXmlSolutionFileIO();
     }
 
     @Override

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/curriculumcourse/persistence/CourseScheduleXmlSolutionFileIO.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/curriculumcourse/persistence/CourseScheduleXmlSolutionFileIO.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.examples.curriculumcourse.persistence;
+
+import org.optaplanner.examples.curriculumcourse.domain.CourseSchedule;
+import org.optaplanner.persistence.xstream.impl.domain.solution.XStreamSolutionFileIO;
+
+public class CourseScheduleXmlSolutionFileIO extends XStreamSolutionFileIO<CourseSchedule> {
+
+    public CourseScheduleXmlSolutionFileIO() {
+        super(CourseSchedule.class);
+    }
+}

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/dinnerparty/app/DinnerPartyApp.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/dinnerparty/app/DinnerPartyApp.java
@@ -20,9 +20,9 @@ import org.optaplanner.examples.common.app.CommonApp;
 import org.optaplanner.examples.common.persistence.AbstractSolutionImporter;
 import org.optaplanner.examples.dinnerparty.domain.DinnerParty;
 import org.optaplanner.examples.dinnerparty.persistence.DinnerPartyImporter;
+import org.optaplanner.examples.dinnerparty.persistence.DinnerPartyXmlSolutionFileIO;
 import org.optaplanner.examples.dinnerparty.swingui.DinnerPartyPanel;
 import org.optaplanner.persistence.common.api.domain.solution.SolutionFileIO;
-import org.optaplanner.persistence.xstream.impl.domain.solution.XStreamSolutionFileIO;
 
 public class DinnerPartyApp extends CommonApp<DinnerParty> {
 
@@ -50,7 +50,7 @@ public class DinnerPartyApp extends CommonApp<DinnerParty> {
 
     @Override
     public SolutionFileIO<DinnerParty> createSolutionFileIO() {
-        return new XStreamSolutionFileIO<>(DinnerParty.class);
+        return new DinnerPartyXmlSolutionFileIO();
     }
 
     @Override

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/dinnerparty/persistence/DinnerPartyXmlSolutionFileIO.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/dinnerparty/persistence/DinnerPartyXmlSolutionFileIO.java
@@ -14,14 +14,14 @@
  * limitations under the License.
  */
 
-package org.optaplanner.examples.travelingtournament.persistence;
+package org.optaplanner.examples.dinnerparty.persistence;
 
-import org.optaplanner.examples.travelingtournament.domain.TravelingTournament;
+import org.optaplanner.examples.dinnerparty.domain.DinnerParty;
 import org.optaplanner.persistence.xstream.impl.domain.solution.XStreamSolutionFileIO;
 
-public class TravelingTournamentSolutionFileIO extends XStreamSolutionFileIO<TravelingTournament> {
+public class DinnerPartyXmlSolutionFileIO extends XStreamSolutionFileIO<DinnerParty> {
 
-    public TravelingTournamentSolutionFileIO() {
-        super(TravelingTournament.class);
+    public DinnerPartyXmlSolutionFileIO() {
+        super(DinnerParty.class);
     }
 }

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/examination/app/ExaminationApp.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/examination/app/ExaminationApp.java
@@ -23,9 +23,9 @@ import org.optaplanner.examples.curriculumcourse.app.CurriculumCourseApp;
 import org.optaplanner.examples.examination.domain.Examination;
 import org.optaplanner.examples.examination.persistence.ExaminationExporter;
 import org.optaplanner.examples.examination.persistence.ExaminationImporter;
+import org.optaplanner.examples.examination.persistence.ExaminationXmlSolutionFileIO;
 import org.optaplanner.examples.examination.swingui.ExaminationPanel;
 import org.optaplanner.persistence.common.api.domain.solution.SolutionFileIO;
-import org.optaplanner.persistence.xstream.impl.domain.solution.XStreamSolutionFileIO;
 
 /**
  * Examination is super optimized and a bit complex.
@@ -57,7 +57,7 @@ public class ExaminationApp extends CommonApp<Examination> {
 
     @Override
     public SolutionFileIO<Examination> createSolutionFileIO() {
-        return new XStreamSolutionFileIO<>(Examination.class);
+        return new ExaminationXmlSolutionFileIO();
     }
 
     @Override

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/examination/persistence/ExaminationXmlSolutionFileIO.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/examination/persistence/ExaminationXmlSolutionFileIO.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.examples.examination.persistence;
+
+import org.optaplanner.examples.examination.domain.Examination;
+import org.optaplanner.persistence.xstream.impl.domain.solution.XStreamSolutionFileIO;
+
+public class ExaminationXmlSolutionFileIO extends XStreamSolutionFileIO<Examination> {
+
+    public ExaminationXmlSolutionFileIO() {
+        super(Examination.class);
+    }
+}

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/investment/app/InvestmentApp.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/investment/app/InvestmentApp.java
@@ -20,9 +20,9 @@ import org.optaplanner.examples.common.app.CommonApp;
 import org.optaplanner.examples.common.persistence.AbstractSolutionImporter;
 import org.optaplanner.examples.investment.domain.InvestmentSolution;
 import org.optaplanner.examples.investment.persistence.InvestmentImporter;
+import org.optaplanner.examples.investment.persistence.InvestmentXmlSolutionFileIO;
 import org.optaplanner.examples.investment.swingui.InvestmentPanel;
 import org.optaplanner.persistence.common.api.domain.solution.SolutionFileIO;
-import org.optaplanner.persistence.xstream.impl.domain.solution.XStreamSolutionFileIO;
 
 public class InvestmentApp extends CommonApp<InvestmentSolution> {
 
@@ -50,7 +50,7 @@ public class InvestmentApp extends CommonApp<InvestmentSolution> {
 
     @Override
     public SolutionFileIO<InvestmentSolution> createSolutionFileIO() {
-        return new XStreamSolutionFileIO<>(InvestmentSolution.class);
+        return new InvestmentXmlSolutionFileIO();
     }
 
     @Override

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/investment/persistence/InvestmentXmlSolutionFileIO.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/investment/persistence/InvestmentXmlSolutionFileIO.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.examples.investment.persistence;
+
+import org.optaplanner.examples.investment.domain.InvestmentSolution;
+import org.optaplanner.persistence.xstream.impl.domain.solution.XStreamSolutionFileIO;
+
+public class InvestmentXmlSolutionFileIO extends XStreamSolutionFileIO<InvestmentSolution> {
+
+    public InvestmentXmlSolutionFileIO() {
+        super(InvestmentSolution.class);
+    }
+}

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/machinereassignment/app/MachineReassignmentApp.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/machinereassignment/app/MachineReassignmentApp.java
@@ -22,9 +22,9 @@ import org.optaplanner.examples.common.persistence.AbstractSolutionImporter;
 import org.optaplanner.examples.machinereassignment.domain.MachineReassignment;
 import org.optaplanner.examples.machinereassignment.persistence.MachineReassignmentExporter;
 import org.optaplanner.examples.machinereassignment.persistence.MachineReassignmentImporter;
+import org.optaplanner.examples.machinereassignment.persistence.MachineReassignmentXmlSolutionFileIO;
 import org.optaplanner.examples.machinereassignment.swingui.MachineReassignmentPanel;
 import org.optaplanner.persistence.common.api.domain.solution.SolutionFileIO;
-import org.optaplanner.persistence.xstream.impl.domain.solution.XStreamSolutionFileIO;
 
 public class MachineReassignmentApp extends CommonApp<MachineReassignment> {
 
@@ -53,7 +53,7 @@ public class MachineReassignmentApp extends CommonApp<MachineReassignment> {
 
     @Override
     public SolutionFileIO<MachineReassignment> createSolutionFileIO() {
-        return new XStreamSolutionFileIO<>(MachineReassignment.class);
+        return new MachineReassignmentXmlSolutionFileIO();
     }
 
     @Override

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/machinereassignment/persistence/MachineReassignmentXmlSolutionFileIO.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/machinereassignment/persistence/MachineReassignmentXmlSolutionFileIO.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2020 Red Hat, Inc. and/or its affiliates.
- *  
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *  
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- *  
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -14,14 +14,14 @@
  * limitations under the License.
  */
 
-package org.optaplanner.examples.curriculumcourse.persistence;
+package org.optaplanner.examples.machinereassignment.persistence;
 
-import org.optaplanner.examples.curriculumcourse.domain.CourseSchedule;
+import org.optaplanner.examples.machinereassignment.domain.MachineReassignment;
 import org.optaplanner.persistence.xstream.impl.domain.solution.XStreamSolutionFileIO;
 
-public class CourseScheduleSolutionFileIO extends XStreamSolutionFileIO<CourseSchedule> {
+public class MachineReassignmentXmlSolutionFileIO extends XStreamSolutionFileIO<MachineReassignment> {
 
-    public CourseScheduleSolutionFileIO() {
-        super(CourseSchedule.class);
+    public MachineReassignmentXmlSolutionFileIO() {
+        super(MachineReassignment.class);
     }
 }

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/nqueens/app/NQueensApp.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/nqueens/app/NQueensApp.java
@@ -36,9 +36,9 @@ import org.optaplanner.core.config.solver.termination.TerminationConfig;
 import org.optaplanner.examples.common.app.CommonApp;
 import org.optaplanner.examples.nqueens.domain.NQueens;
 import org.optaplanner.examples.nqueens.domain.Queen;
+import org.optaplanner.examples.nqueens.persistence.NQueensXmlSolutionFileIO;
 import org.optaplanner.examples.nqueens.swingui.NQueensPanel;
 import org.optaplanner.persistence.common.api.domain.solution.SolutionFileIO;
-import org.optaplanner.persistence.xstream.impl.domain.solution.XStreamSolutionFileIO;
 
 /**
  * For an easy example, look at {@link NQueensHelloWorld} instead.
@@ -120,7 +120,7 @@ public class NQueensApp extends CommonApp<NQueens> {
 
     @Override
     public SolutionFileIO<NQueens> createSolutionFileIO() {
-        return new XStreamSolutionFileIO<>(NQueens.class);
+        return new NQueensXmlSolutionFileIO();
     }
 
 }

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/nqueens/persistence/NQueensXmlSolutionFileIO.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/nqueens/persistence/NQueensXmlSolutionFileIO.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.examples.nqueens.persistence;
+
+import org.optaplanner.examples.nqueens.domain.NQueens;
+import org.optaplanner.persistence.xstream.impl.domain.solution.XStreamSolutionFileIO;
+
+public class NQueensXmlSolutionFileIO extends XStreamSolutionFileIO<NQueens> {
+
+    public NQueensXmlSolutionFileIO() {
+        super(NQueens.class);
+    }
+}

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/nurserostering/app/NurseRosteringApp.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/nurserostering/app/NurseRosteringApp.java
@@ -20,11 +20,11 @@ import org.optaplanner.examples.common.app.CommonApp;
 import org.optaplanner.examples.common.persistence.AbstractSolutionExporter;
 import org.optaplanner.examples.common.persistence.AbstractSolutionImporter;
 import org.optaplanner.examples.nurserostering.domain.NurseRoster;
+import org.optaplanner.examples.nurserostering.persistence.NurseRosterXmlSolutionFileIO;
 import org.optaplanner.examples.nurserostering.persistence.NurseRosteringExporter;
 import org.optaplanner.examples.nurserostering.persistence.NurseRosteringImporter;
 import org.optaplanner.examples.nurserostering.swingui.NurseRosteringPanel;
 import org.optaplanner.persistence.common.api.domain.solution.SolutionFileIO;
-import org.optaplanner.persistence.xstream.impl.domain.solution.XStreamSolutionFileIO;
 
 public class NurseRosteringApp extends CommonApp<NurseRoster> {
 
@@ -52,7 +52,7 @@ public class NurseRosteringApp extends CommonApp<NurseRoster> {
 
     @Override
     public SolutionFileIO<NurseRoster> createSolutionFileIO() {
-        return new XStreamSolutionFileIO<>(NurseRoster.class);
+        return new NurseRosterXmlSolutionFileIO();
     }
 
     @Override

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/nurserostering/persistence/NurseRosterXmlSolutionFileIO.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/nurserostering/persistence/NurseRosterXmlSolutionFileIO.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.examples.nurserostering.persistence;
+
+import org.optaplanner.examples.nurserostering.domain.NurseRoster;
+import org.optaplanner.persistence.xstream.impl.domain.solution.XStreamSolutionFileIO;
+
+public class NurseRosterXmlSolutionFileIO extends XStreamSolutionFileIO<NurseRoster> {
+
+    public NurseRosterXmlSolutionFileIO() {
+        super(NurseRoster.class);
+    }
+}

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/pas/app/PatientAdmissionScheduleApp.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/pas/app/PatientAdmissionScheduleApp.java
@@ -22,9 +22,9 @@ import org.optaplanner.examples.common.persistence.AbstractSolutionImporter;
 import org.optaplanner.examples.pas.domain.PatientAdmissionSchedule;
 import org.optaplanner.examples.pas.persistence.PatientAdmissionScheduleExporter;
 import org.optaplanner.examples.pas.persistence.PatientAdmissionScheduleImporter;
+import org.optaplanner.examples.pas.persistence.PatientAdmissionScheduleXmlSolutionFileIO;
 import org.optaplanner.examples.pas.swingui.PatientAdmissionSchedulePanel;
 import org.optaplanner.persistence.common.api.domain.solution.SolutionFileIO;
-import org.optaplanner.persistence.xstream.impl.domain.solution.XStreamSolutionFileIO;
 
 public class PatientAdmissionScheduleApp extends CommonApp<PatientAdmissionSchedule> {
 
@@ -52,7 +52,7 @@ public class PatientAdmissionScheduleApp extends CommonApp<PatientAdmissionSched
 
     @Override
     public SolutionFileIO<PatientAdmissionSchedule> createSolutionFileIO() {
-        return new XStreamSolutionFileIO<>(PatientAdmissionSchedule.class);
+        return new PatientAdmissionScheduleXmlSolutionFileIO();
     }
 
     @Override

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/pas/persistence/PatientAdmissionScheduleXmlSolutionFileIO.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/pas/persistence/PatientAdmissionScheduleXmlSolutionFileIO.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.examples.pas.persistence;
+
+import org.optaplanner.examples.pas.domain.PatientAdmissionSchedule;
+import org.optaplanner.persistence.xstream.impl.domain.solution.XStreamSolutionFileIO;
+
+public class PatientAdmissionScheduleXmlSolutionFileIO extends XStreamSolutionFileIO<PatientAdmissionSchedule> {
+
+    public PatientAdmissionScheduleXmlSolutionFileIO() {
+        super(PatientAdmissionSchedule.class);
+    }
+}

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/projectjobscheduling/app/ProjectJobSchedulingApp.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/projectjobscheduling/app/ProjectJobSchedulingApp.java
@@ -20,9 +20,9 @@ import org.optaplanner.examples.common.app.CommonApp;
 import org.optaplanner.examples.common.persistence.AbstractSolutionImporter;
 import org.optaplanner.examples.projectjobscheduling.domain.Schedule;
 import org.optaplanner.examples.projectjobscheduling.persistence.ProjectJobSchedulingImporter;
+import org.optaplanner.examples.projectjobscheduling.persistence.ProjectJobSchedulingXmlSolutionFileIO;
 import org.optaplanner.examples.projectjobscheduling.swingui.ProjectJobSchedulingPanel;
 import org.optaplanner.persistence.common.api.domain.solution.SolutionFileIO;
-import org.optaplanner.persistence.xstream.impl.domain.solution.XStreamSolutionFileIO;
 
 public class ProjectJobSchedulingApp extends CommonApp<Schedule> {
 
@@ -53,7 +53,7 @@ public class ProjectJobSchedulingApp extends CommonApp<Schedule> {
 
     @Override
     public SolutionFileIO<Schedule> createSolutionFileIO() {
-        return new XStreamSolutionFileIO<>(Schedule.class);
+        return new ProjectJobSchedulingXmlSolutionFileIO();
     }
 
     @Override

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/projectjobscheduling/persistence/ProjectJobSchedulingXmlSolutionFileIO.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/projectjobscheduling/persistence/ProjectJobSchedulingXmlSolutionFileIO.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.examples.projectjobscheduling.persistence;
+
+import org.optaplanner.examples.projectjobscheduling.domain.Schedule;
+import org.optaplanner.persistence.xstream.impl.domain.solution.XStreamSolutionFileIO;
+
+public class ProjectJobSchedulingXmlSolutionFileIO extends XStreamSolutionFileIO<Schedule> {
+
+    public ProjectJobSchedulingXmlSolutionFileIO() {
+        super(Schedule.class);
+    }
+}

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/scrabble/app/ScrabbleApp.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/scrabble/app/ScrabbleApp.java
@@ -18,9 +18,9 @@ package org.optaplanner.examples.scrabble.app;
 
 import org.optaplanner.examples.common.app.CommonApp;
 import org.optaplanner.examples.scrabble.domain.ScrabbleSolution;
+import org.optaplanner.examples.scrabble.persistence.ScrabbleXmlSolutionFileIO;
 import org.optaplanner.examples.scrabble.swingui.ScrabblePanel;
 import org.optaplanner.persistence.common.api.domain.solution.SolutionFileIO;
-import org.optaplanner.persistence.xstream.impl.domain.solution.XStreamSolutionFileIO;
 
 public class ScrabbleApp extends CommonApp<ScrabbleSolution> {
 
@@ -47,7 +47,7 @@ public class ScrabbleApp extends CommonApp<ScrabbleSolution> {
 
     @Override
     public SolutionFileIO<ScrabbleSolution> createSolutionFileIO() {
-        return new XStreamSolutionFileIO<>(ScrabbleSolution.class);
+        return new ScrabbleXmlSolutionFileIO();
     }
 
 }

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/scrabble/persistence/ScrabbleXmlSolutionFileIO.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/scrabble/persistence/ScrabbleXmlSolutionFileIO.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.examples.scrabble.persistence;
+
+import org.optaplanner.examples.scrabble.domain.ScrabbleSolution;
+import org.optaplanner.persistence.xstream.impl.domain.solution.XStreamSolutionFileIO;
+
+public class ScrabbleXmlSolutionFileIO extends XStreamSolutionFileIO<ScrabbleSolution> {
+
+    public ScrabbleXmlSolutionFileIO() {
+        super(ScrabbleSolution.class);
+    }
+}

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/taskassigning/app/TaskAssigningApp.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/taskassigning/app/TaskAssigningApp.java
@@ -18,9 +18,9 @@ package org.optaplanner.examples.taskassigning.app;
 
 import org.optaplanner.examples.common.app.CommonApp;
 import org.optaplanner.examples.taskassigning.domain.TaskAssigningSolution;
+import org.optaplanner.examples.taskassigning.persistence.TaskAssigningXmlSolutionFileIO;
 import org.optaplanner.examples.taskassigning.swingui.TaskAssigningPanel;
 import org.optaplanner.persistence.common.api.domain.solution.SolutionFileIO;
-import org.optaplanner.persistence.xstream.impl.domain.solution.XStreamSolutionFileIO;
 
 public class TaskAssigningApp extends CommonApp<TaskAssigningSolution> {
 
@@ -50,7 +50,7 @@ public class TaskAssigningApp extends CommonApp<TaskAssigningSolution> {
 
     @Override
     public SolutionFileIO<TaskAssigningSolution> createSolutionFileIO() {
-        return new XStreamSolutionFileIO<>(TaskAssigningSolution.class);
+        return new TaskAssigningXmlSolutionFileIO();
     }
 
 }

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/taskassigning/persistence/TaskAssigningXmlSolutionFileIO.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/taskassigning/persistence/TaskAssigningXmlSolutionFileIO.java
@@ -14,14 +14,14 @@
  * limitations under the License.
  */
 
-package org.optaplanner.examples.nqueens.persistence;
+package org.optaplanner.examples.taskassigning.persistence;
 
-import org.optaplanner.examples.nqueens.domain.NQueens;
+import org.optaplanner.examples.taskassigning.domain.TaskAssigningSolution;
 import org.optaplanner.persistence.xstream.impl.domain.solution.XStreamSolutionFileIO;
 
-public class NQueensSolutionFileIO extends XStreamSolutionFileIO<NQueens> {
+public class TaskAssigningXmlSolutionFileIO extends XStreamSolutionFileIO<TaskAssigningSolution> {
 
-    public NQueensSolutionFileIO() {
-        super(NQueens.class);
+    public TaskAssigningXmlSolutionFileIO() {
+        super(TaskAssigningSolution.class);
     }
 }

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/tennis/app/TennisApp.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/tennis/app/TennisApp.java
@@ -18,9 +18,9 @@ package org.optaplanner.examples.tennis.app;
 
 import org.optaplanner.examples.common.app.CommonApp;
 import org.optaplanner.examples.tennis.domain.TennisSolution;
+import org.optaplanner.examples.tennis.persistence.TennisXmlSolutionFileIO;
 import org.optaplanner.examples.tennis.swingui.TennisPanel;
 import org.optaplanner.persistence.common.api.domain.solution.SolutionFileIO;
-import org.optaplanner.persistence.xstream.impl.domain.solution.XStreamSolutionFileIO;
 
 public class TennisApp extends CommonApp<TennisSolution> {
 
@@ -49,7 +49,7 @@ public class TennisApp extends CommonApp<TennisSolution> {
 
     @Override
     public SolutionFileIO<TennisSolution> createSolutionFileIO() {
-        return new XStreamSolutionFileIO<>(TennisSolution.class);
+        return new TennisXmlSolutionFileIO();
     }
 
 }

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/tennis/persistence/TennisXmlSolutionFileIO.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/tennis/persistence/TennisXmlSolutionFileIO.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2020 Red Hat, Inc. and/or its affiliates.
- *  
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *  
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- *  
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -14,14 +14,14 @@
  * limitations under the License.
  */
 
-package org.optaplanner.examples.nurserostering.persistence;
+package org.optaplanner.examples.tennis.persistence;
 
-import org.optaplanner.examples.nurserostering.domain.NurseRoster;
+import org.optaplanner.examples.tennis.domain.TennisSolution;
 import org.optaplanner.persistence.xstream.impl.domain.solution.XStreamSolutionFileIO;
 
-public class NurseRosterSolutionFileIO extends XStreamSolutionFileIO<NurseRoster> {
+public class TennisXmlSolutionFileIO extends XStreamSolutionFileIO<TennisSolution> {
 
-    public NurseRosterSolutionFileIO() {
-        super(NurseRoster.class);
+    public TennisXmlSolutionFileIO() {
+        super(TennisSolution.class);
     }
 }

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/travelingtournament/app/TravelingTournamentApp.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/travelingtournament/app/TravelingTournamentApp.java
@@ -22,9 +22,9 @@ import org.optaplanner.examples.common.persistence.AbstractSolutionImporter;
 import org.optaplanner.examples.travelingtournament.domain.TravelingTournament;
 import org.optaplanner.examples.travelingtournament.persistence.TravelingTournamentExporter;
 import org.optaplanner.examples.travelingtournament.persistence.TravelingTournamentImporter;
+import org.optaplanner.examples.travelingtournament.persistence.TravelingTournamentXmlSolutionFileIO;
 import org.optaplanner.examples.travelingtournament.swingui.TravelingTournamentPanel;
 import org.optaplanner.persistence.common.api.domain.solution.SolutionFileIO;
-import org.optaplanner.persistence.xstream.impl.domain.solution.XStreamSolutionFileIO;
 
 /**
  * WARNING: This is an old, complex, tailored example. You're probably better off with one of the other examples.
@@ -56,7 +56,7 @@ public class TravelingTournamentApp extends CommonApp<TravelingTournament> {
 
     @Override
     public SolutionFileIO<TravelingTournament> createSolutionFileIO() {
-        return new XStreamSolutionFileIO<>(TravelingTournament.class);
+        return new TravelingTournamentXmlSolutionFileIO();
     }
 
     @Override

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/travelingtournament/persistence/TravelingTournamentXmlSolutionFileIO.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/travelingtournament/persistence/TravelingTournamentXmlSolutionFileIO.java
@@ -14,14 +14,14 @@
  * limitations under the License.
  */
 
-package org.optaplanner.examples.taskassigning.persistence;
+package org.optaplanner.examples.travelingtournament.persistence;
 
-import org.optaplanner.examples.taskassigning.domain.TaskAssigningSolution;
+import org.optaplanner.examples.travelingtournament.domain.TravelingTournament;
 import org.optaplanner.persistence.xstream.impl.domain.solution.XStreamSolutionFileIO;
 
-public class TaskAssigningSolutionFileIO extends XStreamSolutionFileIO<TaskAssigningSolution> {
+public class TravelingTournamentXmlSolutionFileIO extends XStreamSolutionFileIO<TravelingTournament> {
 
-    public TaskAssigningSolutionFileIO() {
-        super(TaskAssigningSolution.class);
+    public TravelingTournamentXmlSolutionFileIO() {
+        super(TravelingTournament.class);
     }
 }

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/tsp/app/TspApp.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/tsp/app/TspApp.java
@@ -23,9 +23,9 @@ import org.optaplanner.examples.tsp.domain.TspSolution;
 import org.optaplanner.examples.tsp.persistence.TspExporter;
 import org.optaplanner.examples.tsp.persistence.TspImageStipplerImporter;
 import org.optaplanner.examples.tsp.persistence.TspImporter;
+import org.optaplanner.examples.tsp.persistence.TspXmlSolutionFileIO;
 import org.optaplanner.examples.tsp.swingui.TspPanel;
 import org.optaplanner.persistence.common.api.domain.solution.SolutionFileIO;
-import org.optaplanner.persistence.xstream.impl.domain.solution.XStreamSolutionFileIO;
 
 public class TspApp extends CommonApp<TspSolution> {
 
@@ -54,7 +54,7 @@ public class TspApp extends CommonApp<TspSolution> {
 
     @Override
     public SolutionFileIO<TspSolution> createSolutionFileIO() {
-        return new XStreamSolutionFileIO<>(TspSolution.class);
+        return new TspXmlSolutionFileIO();
     }
 
     @Override

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/tsp/persistence/TspXmlSolutionFileIO.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/tsp/persistence/TspXmlSolutionFileIO.java
@@ -14,13 +14,14 @@
  * limitations under the License.
  */
 
-package org.optaplanner.examples.cloudbalancing.persistence;
+package org.optaplanner.examples.tsp.persistence;
 
-import org.optaplanner.examples.cloudbalancing.domain.CloudBalance;
+import org.optaplanner.examples.tsp.domain.TspSolution;
 import org.optaplanner.persistence.xstream.impl.domain.solution.XStreamSolutionFileIO;
 
-public class CloudBalanceSolutionFileIO extends XStreamSolutionFileIO<CloudBalance> {
-    public CloudBalanceSolutionFileIO() {
-        super(CloudBalance.class);
+public class TspXmlSolutionFileIO extends XStreamSolutionFileIO<TspSolution> {
+
+    public TspXmlSolutionFileIO() {
+        super(TspSolution.class);
     }
 }

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/vehiclerouting/app/VehicleRoutingApp.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/vehiclerouting/app/VehicleRoutingApp.java
@@ -20,9 +20,9 @@ import org.optaplanner.examples.common.app.CommonApp;
 import org.optaplanner.examples.common.persistence.AbstractSolutionImporter;
 import org.optaplanner.examples.vehiclerouting.domain.VehicleRoutingSolution;
 import org.optaplanner.examples.vehiclerouting.persistence.VehicleRoutingImporter;
+import org.optaplanner.examples.vehiclerouting.persistence.VehicleRoutingXmlSolutionFileIO;
 import org.optaplanner.examples.vehiclerouting.swingui.VehicleRoutingPanel;
 import org.optaplanner.persistence.common.api.domain.solution.SolutionFileIO;
-import org.optaplanner.persistence.xstream.impl.domain.solution.XStreamSolutionFileIO;
 
 public class VehicleRoutingApp extends CommonApp<VehicleRoutingSolution> {
 
@@ -54,7 +54,7 @@ public class VehicleRoutingApp extends CommonApp<VehicleRoutingSolution> {
 
     @Override
     public SolutionFileIO<VehicleRoutingSolution> createSolutionFileIO() {
-        return new XStreamSolutionFileIO<>(VehicleRoutingSolution.class);
+        return new VehicleRoutingXmlSolutionFileIO();
     }
 
     @Override

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/vehiclerouting/persistence/VehicleRoutingXmlSolutionFileIO.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/vehiclerouting/persistence/VehicleRoutingXmlSolutionFileIO.java
@@ -14,14 +14,14 @@
  * limitations under the License.
  */
 
-package org.optaplanner.examples.examination.persistence;
+package org.optaplanner.examples.vehiclerouting.persistence;
 
-import org.optaplanner.examples.examination.domain.Examination;
+import org.optaplanner.examples.vehiclerouting.domain.VehicleRoutingSolution;
 import org.optaplanner.persistence.xstream.impl.domain.solution.XStreamSolutionFileIO;
 
-public class ExaminationSolutionFileIO extends XStreamSolutionFileIO<Examination> {
+public class VehicleRoutingXmlSolutionFileIO extends XStreamSolutionFileIO<VehicleRoutingSolution> {
 
-    public ExaminationSolutionFileIO() {
-        super(Examination.class);
+    public VehicleRoutingXmlSolutionFileIO() {
+        super(VehicleRoutingSolution.class);
     }
 }

--- a/optaplanner-examples/src/main/resources/org/optaplanner/examples/app/benchmark/generalOptaPlannerBenchmarkConfig.xml
+++ b/optaplanner-examples/src/main/resources/org/optaplanner/examples/app/benchmark/generalOptaPlannerBenchmarkConfig.xml
@@ -16,7 +16,7 @@
   <solverBenchmark>
     <name>Cloud Balancing Late Acceptance</name>
     <problemBenchmarks>
-      <solutionFileIOClass>org.optaplanner.examples.cloudbalancing.persistence.CloudBalanceSolutionFileIO</solutionFileIOClass>
+      <solutionFileIOClass>org.optaplanner.examples.cloudbalancing.persistence.CloudBalanceXmlSolutionFileIO</solutionFileIOClass>
       <inputSolutionFile>data/cloudbalancing/unsolved/200computers-600processes.xml</inputSolutionFile>
       <inputSolutionFile>data/cloudbalancing/unsolved/800computers-2400processes.xml</inputSolutionFile>
     </problemBenchmarks>
@@ -77,7 +77,7 @@
   <solverBenchmark>
     <name>Course Scheduling Late Acceptance</name>
     <problemBenchmarks>
-      <solutionFileIOClass>org.optaplanner.examples.curriculumcourse.persistence.CourseScheduleSolutionFileIO</solutionFileIOClass>
+      <solutionFileIOClass>org.optaplanner.examples.curriculumcourse.persistence.CourseScheduleXmlSolutionFileIO</solutionFileIOClass>
       <inputSolutionFile>data/curriculumcourse/unsolved/comp07.xml</inputSolutionFile>
       <inputSolutionFile>data/curriculumcourse/unsolved/comp08.xml</inputSolutionFile>
     </problemBenchmarks>
@@ -109,7 +109,7 @@
   <solverBenchmark>
     <name>Examination Tabu Search</name>
     <problemBenchmarks>
-      <solutionFileIOClass>org.optaplanner.examples.examination.persistence.ExaminationSolutionFileIO</solutionFileIOClass>
+      <solutionFileIOClass>org.optaplanner.examples.examination.persistence.ExaminationXmlSolutionFileIO</solutionFileIOClass>
       <inputSolutionFile>data/examination/unsolved/exam_comp_set2.xml</inputSolutionFile>
       <inputSolutionFile>data/examination/unsolved/exam_comp_set3.xml</inputSolutionFile>
     </problemBenchmarks>
@@ -184,7 +184,7 @@
   <solverBenchmark>
     <name>Nurse Rostering Tabu Search</name>
     <problemBenchmarks>
-      <solutionFileIOClass>org.optaplanner.examples.nurserostering.persistence.NurseRosterSolutionFileIO</solutionFileIOClass>
+      <solutionFileIOClass>org.optaplanner.examples.nurserostering.persistence.NurseRosterXmlSolutionFileIO</solutionFileIOClass>
       <inputSolutionFile>data/nurserostering/unsolved/medium01.xml</inputSolutionFile>
       <inputSolutionFile>data/nurserostering/unsolved/medium_hint01.xml</inputSolutionFile>
     </problemBenchmarks>
@@ -242,7 +242,7 @@
   <solverBenchmark>
     <name>TravelingTournament Tabu Search</name>
     <problemBenchmarks>
-      <solutionFileIOClass>org.optaplanner.examples.travelingtournament.persistence.TravelingTournamentSolutionFileIO</solutionFileIOClass>
+      <solutionFileIOClass>org.optaplanner.examples.travelingtournament.persistence.TravelingTournamentXmlSolutionFileIO</solutionFileIOClass>
       <inputSolutionFile>data/travelingtournament/unsolved/1-nl14.xml</inputSolutionFile>
     </problemBenchmarks>
     <solver>

--- a/optaplanner-examples/src/main/resources/org/optaplanner/examples/app/benchmark/generalOptaPlannerBenchmarkConfigTemplate.xml.ftl
+++ b/optaplanner-examples/src/main/resources/org/optaplanner/examples/app/benchmark/generalOptaPlannerBenchmarkConfigTemplate.xml.ftl
@@ -15,7 +15,7 @@
   <solverBenchmark>
     <name>Cloud Balancing Late Acceptance ${randomType}</name>
     <problemBenchmarks>
-      <solutionFileIOClass>org.optaplanner.examples.cloudbalancing.persistence.CloudBalanceSolutionFileIO</solutionFileIOClass>
+      <solutionFileIOClass>org.optaplanner.examples.cloudbalancing.persistence.CloudBalanceXmlSolutionFileIO</solutionFileIOClass>
       <inputSolutionFile>data/cloudbalancing/unsolved/200computers-600processes.xml</inputSolutionFile>
       <inputSolutionFile>data/cloudbalancing/unsolved/800computers-2400processes.xml</inputSolutionFile>
     </problemBenchmarks>
@@ -78,7 +78,7 @@
   <solverBenchmark>
     <name>Course Scheduling Late Acceptance ${randomType}</name>
     <problemBenchmarks>
-      <solutionFileIOClass>org.optaplanner.examples.curriculumcourse.persistence.CourseScheduleSolutionFileIO</solutionFileIOClass>
+      <solutionFileIOClass>org.optaplanner.examples.curriculumcourse.persistence.CourseScheduleXmlSolutionFileIO</solutionFileIOClass>
       <inputSolutionFile>data/curriculumcourse/unsolved/comp07.xml</inputSolutionFile>
       <inputSolutionFile>data/curriculumcourse/unsolved/comp08.xml</inputSolutionFile>
     </problemBenchmarks>
@@ -111,7 +111,7 @@
   <solverBenchmark>
     <name>Examination Tabu Search ${randomType}</name>
     <problemBenchmarks>
-      <solutionFileIOClass>org.optaplanner.examples.examination.persistence.ExaminationSolutionFileIO</solutionFileIOClass>
+      <solutionFileIOClass>org.optaplanner.examples.examination.persistence.ExaminationXmlSolutionFileIO</solutionFileIOClass>
       <inputSolutionFile>data/examination/unsolved/exam_comp_set2.xml</inputSolutionFile>
       <inputSolutionFile>data/examination/unsolved/exam_comp_set3.xml</inputSolutionFile>
     </problemBenchmarks>
@@ -187,7 +187,7 @@
   <solverBenchmark>
     <name>Nurse Rostering Tabu Search ${randomType}</name>
     <problemBenchmarks>
-      <solutionFileIOClass>org.optaplanner.examples.nurserostering.persistence.NurseRosterSolutionFileIO</solutionFileIOClass>
+      <solutionFileIOClass>org.optaplanner.examples.nurserostering.persistence.NurseRosterXmlSolutionFileIO</solutionFileIOClass>
       <inputSolutionFile>data/nurserostering/unsolved/medium01.xml</inputSolutionFile>
       <inputSolutionFile>data/nurserostering/unsolved/medium_hint01.xml</inputSolutionFile>
     </problemBenchmarks>
@@ -246,7 +246,7 @@
   <solverBenchmark>
     <name>TravelingTournament Tabu Search ${randomType}</name>
     <problemBenchmarks>
-      <solutionFileIOClass>org.optaplanner.examples.travelingtournament.persistence.TravelingTournamentSolutionFileIO</solutionFileIOClass>
+      <solutionFileIOClass>org.optaplanner.examples.travelingtournament.persistence.TravelingTournamentXmlSolutionFileIO</solutionFileIOClass>
       <inputSolutionFile>data/travelingtournament/unsolved/1-nl14.xml</inputSolutionFile>
     </problemBenchmarks>
     <solver>

--- a/optaplanner-examples/src/main/resources/org/optaplanner/examples/cloudbalancing/optional/benchmark/cloudBalancingBenchmarkConfig.xml
+++ b/optaplanner-examples/src/main/resources/org/optaplanner/examples/cloudbalancing/optional/benchmark/cloudBalancingBenchmarkConfig.xml
@@ -5,7 +5,7 @@
 
   <inheritedSolverBenchmark>
     <problemBenchmarks>
-      <solutionFileIOClass>org.optaplanner.examples.cloudbalancing.persistence.CloudBalanceSolutionFileIO</solutionFileIOClass>
+      <solutionFileIOClass>org.optaplanner.examples.cloudbalancing.persistence.CloudBalanceXmlSolutionFileIO</solutionFileIOClass>
       <!--<inputSolutionFile>data/cloudbalancing/unsolved/2computers-6processes.xml</inputSolutionFile>-->
       <!--<inputSolutionFile>data/cloudbalancing/unsolved/3computers-9processes.xml</inputSolutionFile>-->
       <!--<inputSolutionFile>data/cloudbalancing/unsolved/4computers-12processes.xml</inputSolutionFile>-->

--- a/optaplanner-examples/src/main/resources/org/optaplanner/examples/cloudbalancing/optional/benchmark/cloudBalancingBenchmarkConfigTemplate.xml.ftl
+++ b/optaplanner-examples/src/main/resources/org/optaplanner/examples/cloudbalancing/optional/benchmark/cloudBalancingBenchmarkConfigTemplate.xml.ftl
@@ -5,7 +5,7 @@
 
   <inheritedSolverBenchmark>
     <problemBenchmarks>
-      <solutionFileIOClass>org.optaplanner.examples.cloudbalancing.persistence.CloudBalanceSolutionFileIO</solutionFileIOClass>
+      <solutionFileIOClass>org.optaplanner.examples.cloudbalancing.persistence.CloudBalanceXmlSolutionFileIO</solutionFileIOClass>
       <!--<inputSolutionFile>data/cloudbalancing/unsolved/2computers-6processes.xml</inputSolutionFile>-->
       <!--<inputSolutionFile>data/cloudbalancing/unsolved/3computers-9processes.xml</inputSolutionFile>-->
       <!--<inputSolutionFile>data/cloudbalancing/unsolved/4computers-12processes.xml</inputSolutionFile>-->

--- a/optaplanner-examples/src/main/resources/org/optaplanner/examples/cloudbalancing/optional/benchmark/cloudBalancingScoreDirectorBenchmarkConfig.xml
+++ b/optaplanner-examples/src/main/resources/org/optaplanner/examples/cloudbalancing/optional/benchmark/cloudBalancingScoreDirectorBenchmarkConfig.xml
@@ -21,7 +21,7 @@
 
   <inheritedSolverBenchmark>
     <problemBenchmarks>
-      <solutionFileIOClass>org.optaplanner.examples.cloudbalancing.persistence.CloudBalanceSolutionFileIO</solutionFileIOClass>
+      <solutionFileIOClass>org.optaplanner.examples.cloudbalancing.persistence.CloudBalanceXmlSolutionFileIO</solutionFileIOClass>
       <inputSolutionFile>data/cloudbalancing/unsolved/100computers-300processes.xml</inputSolutionFile>
       <inputSolutionFile>data/cloudbalancing/unsolved/200computers-600processes.xml</inputSolutionFile>
       <inputSolutionFile>data/cloudbalancing/unsolved/400computers-1200processes.xml</inputSolutionFile>

--- a/optaplanner-examples/src/main/resources/org/optaplanner/examples/cloudbalancing/optional/benchmark/cloudBalancingStepLimitBenchmarkConfig.xml
+++ b/optaplanner-examples/src/main/resources/org/optaplanner/examples/cloudbalancing/optional/benchmark/cloudBalancingStepLimitBenchmarkConfig.xml
@@ -5,7 +5,7 @@
 
   <inheritedSolverBenchmark>
     <problemBenchmarks>
-      <solutionFileIOClass>org.optaplanner.examples.cloudbalancing.persistence.CloudBalanceSolutionFileIO</solutionFileIOClass>
+      <solutionFileIOClass>org.optaplanner.examples.cloudbalancing.persistence.CloudBalanceXmlSolutionFileIO</solutionFileIOClass>
       <inputSolutionFile>data/cloudbalancing/unsolved/100computers-300processes.xml</inputSolutionFile>
     </problemBenchmarks>
 

--- a/optaplanner-examples/src/main/resources/org/optaplanner/examples/curriculumcourse/benchmark/curriculumCourseBenchmarkConfig.xml
+++ b/optaplanner-examples/src/main/resources/org/optaplanner/examples/curriculumcourse/benchmark/curriculumCourseBenchmarkConfig.xml
@@ -5,7 +5,7 @@
 
   <inheritedSolverBenchmark>
     <problemBenchmarks>
-      <solutionFileIOClass>org.optaplanner.examples.curriculumcourse.persistence.CourseScheduleSolutionFileIO</solutionFileIOClass>
+      <solutionFileIOClass>org.optaplanner.examples.curriculumcourse.persistence.CourseScheduleXmlSolutionFileIO</solutionFileIOClass>
       <inputSolutionFile>data/curriculumcourse/unsolved/comp01.xml</inputSolutionFile>
       <inputSolutionFile>data/curriculumcourse/unsolved/comp02.xml</inputSolutionFile>
       <inputSolutionFile>data/curriculumcourse/unsolved/comp03.xml</inputSolutionFile>

--- a/optaplanner-examples/src/main/resources/org/optaplanner/examples/curriculumcourse/benchmark/curriculumCourseBenchmarkConfigTemplate.xml.ftl
+++ b/optaplanner-examples/src/main/resources/org/optaplanner/examples/curriculumcourse/benchmark/curriculumCourseBenchmarkConfigTemplate.xml.ftl
@@ -5,7 +5,7 @@
 
   <inheritedSolverBenchmark>
     <problemBenchmarks>
-      <solutionFileIOClass>org.optaplanner.examples.curriculumcourse.persistence.CourseScheduleSolutionFileIO</solutionFileIOClass>
+      <solutionFileIOClass>org.optaplanner.examples.curriculumcourse.persistence.CourseScheduleXmlSolutionFileIO</solutionFileIOClass>
       <inputSolutionFile>data/curriculumcourse/unsolved/comp01.xml</inputSolutionFile>
       <inputSolutionFile>data/curriculumcourse/unsolved/comp02.xml</inputSolutionFile>
       <inputSolutionFile>data/curriculumcourse/unsolved/comp03.xml</inputSolutionFile>

--- a/optaplanner-examples/src/main/resources/org/optaplanner/examples/curriculumcourse/benchmark/curriculumCourseStepLimitBenchmarkConfig.xml
+++ b/optaplanner-examples/src/main/resources/org/optaplanner/examples/curriculumcourse/benchmark/curriculumCourseStepLimitBenchmarkConfig.xml
@@ -5,7 +5,7 @@
 
   <inheritedSolverBenchmark>
     <problemBenchmarks>
-      <solutionFileIOClass>org.optaplanner.examples.curriculumcourse.persistence.CourseScheduleSolutionFileIO</solutionFileIOClass>
+      <solutionFileIOClass>org.optaplanner.examples.curriculumcourse.persistence.CourseScheduleXmlSolutionFileIO</solutionFileIOClass>
       <inputSolutionFile>data/curriculumcourse/unsolved/comp01_initialized.xml</inputSolutionFile>
     </problemBenchmarks>
 

--- a/optaplanner-examples/src/main/resources/org/optaplanner/examples/examination/benchmark/examinationBenchmarkConfig.xml
+++ b/optaplanner-examples/src/main/resources/org/optaplanner/examples/examination/benchmark/examinationBenchmarkConfig.xml
@@ -5,7 +5,7 @@
 
   <inheritedSolverBenchmark>
     <problemBenchmarks>
-      <solutionFileIOClass>org.optaplanner.examples.examination.persistence.ExaminationSolutionFileIO</solutionFileIOClass>
+      <solutionFileIOClass>org.optaplanner.examples.examination.persistence.ExaminationXmlSolutionFileIO</solutionFileIOClass>
       <inputSolutionFile>data/examination/unsolved/exam_comp_set1.xml</inputSolutionFile>
       <inputSolutionFile>data/examination/unsolved/exam_comp_set2.xml</inputSolutionFile>
       <inputSolutionFile>data/examination/unsolved/exam_comp_set3.xml</inputSolutionFile>

--- a/optaplanner-examples/src/main/resources/org/optaplanner/examples/examination/benchmark/examinationStepLimitBenchmarkConfig.xml
+++ b/optaplanner-examples/src/main/resources/org/optaplanner/examples/examination/benchmark/examinationStepLimitBenchmarkConfig.xml
@@ -5,7 +5,7 @@
 
   <inheritedSolverBenchmark>
     <problemBenchmarks>
-      <solutionFileIOClass>org.optaplanner.examples.examination.persistence.ExaminationSolutionFileIO</solutionFileIOClass>
+      <solutionFileIOClass>org.optaplanner.examples.examination.persistence.ExaminationXmlSolutionFileIO</solutionFileIOClass>
       <inputSolutionFile>data/examination/unsolved/exam_comp_set1_initialized.xml</inputSolutionFile>
     </problemBenchmarks>
 

--- a/optaplanner-examples/src/main/resources/org/optaplanner/examples/nqueens/benchmark/nqueensBenchmarkConfig.xml
+++ b/optaplanner-examples/src/main/resources/org/optaplanner/examples/nqueens/benchmark/nqueensBenchmarkConfig.xml
@@ -5,7 +5,7 @@
 
   <inheritedSolverBenchmark>
     <problemBenchmarks>
-      <solutionFileIOClass>org.optaplanner.examples.nqueens.persistence.NQueensSolutionFileIO</solutionFileIOClass>
+      <solutionFileIOClass>org.optaplanner.examples.nqueens.persistence.NQueensXmlSolutionFileIO</solutionFileIOClass>
       <inputSolutionFile>data/nqueens/unsolved/32queens.xml</inputSolutionFile>
       <inputSolutionFile>data/nqueens/unsolved/64queens.xml</inputSolutionFile>
       <writeOutputSolutionEnabled>true</writeOutputSolutionEnabled>

--- a/optaplanner-examples/src/main/resources/org/optaplanner/examples/nqueens/benchmark/nqueensScoreDirectorBenchmarkConfig.xml
+++ b/optaplanner-examples/src/main/resources/org/optaplanner/examples/nqueens/benchmark/nqueensScoreDirectorBenchmarkConfig.xml
@@ -5,7 +5,7 @@
 
   <inheritedSolverBenchmark>
     <problemBenchmarks>
-      <solutionFileIOClass>org.optaplanner.examples.nqueens.persistence.NQueensSolutionFileIO</solutionFileIOClass>
+      <solutionFileIOClass>org.optaplanner.examples.nqueens.persistence.NQueensXmlSolutionFileIO</solutionFileIOClass>
       <inputSolutionFile>data/nqueens/unsolved/32queens.xml</inputSolutionFile>
       <inputSolutionFile>data/nqueens/unsolved/64queens.xml</inputSolutionFile>
       <inputSolutionFile>data/nqueens/unsolved/256queens.xml</inputSolutionFile>

--- a/optaplanner-examples/src/main/resources/org/optaplanner/examples/nqueens/benchmark/nqueensStepLimitBenchmarkConfig.xml
+++ b/optaplanner-examples/src/main/resources/org/optaplanner/examples/nqueens/benchmark/nqueensStepLimitBenchmarkConfig.xml
@@ -5,7 +5,7 @@
 
   <inheritedSolverBenchmark>
     <problemBenchmarks>
-      <solutionFileIOClass>org.optaplanner.examples.nqueens.persistence.NQueensSolutionFileIO</solutionFileIOClass>
+      <solutionFileIOClass>org.optaplanner.examples.nqueens.persistence.NQueensXmlSolutionFileIO</solutionFileIOClass>
       <inputSolutionFile>data/nqueens/unsolved/256queens.xml</inputSolutionFile>
     </problemBenchmarks>
     <solver>

--- a/optaplanner-examples/src/main/resources/org/optaplanner/examples/nurserostering/benchmark/nurseRosteringLongBenchmarkConfig.xml
+++ b/optaplanner-examples/src/main/resources/org/optaplanner/examples/nurserostering/benchmark/nurseRosteringLongBenchmarkConfig.xml
@@ -5,7 +5,7 @@
 
   <inheritedSolverBenchmark>
     <problemBenchmarks>
-      <solutionFileIOClass>org.optaplanner.examples.nurserostering.persistence.NurseRosterSolutionFileIO</solutionFileIOClass>
+      <solutionFileIOClass>org.optaplanner.examples.nurserostering.persistence.NurseRosterXmlSolutionFileIO</solutionFileIOClass>
       <inputSolutionFile>data/nurserostering/unsolved/long01.xml</inputSolutionFile>
       <inputSolutionFile>data/nurserostering/unsolved/long02.xml</inputSolutionFile>
       <!--<inputSolutionFile>data/nurserostering/unsolved/long03.xml</inputSolutionFile>-->

--- a/optaplanner-examples/src/main/resources/org/optaplanner/examples/nurserostering/benchmark/nurseRosteringMediumBenchmarkConfig.xml
+++ b/optaplanner-examples/src/main/resources/org/optaplanner/examples/nurserostering/benchmark/nurseRosteringMediumBenchmarkConfig.xml
@@ -5,7 +5,7 @@
 
   <inheritedSolverBenchmark>
     <problemBenchmarks>
-      <solutionFileIOClass>org.optaplanner.examples.nurserostering.persistence.NurseRosterSolutionFileIO</solutionFileIOClass>
+      <solutionFileIOClass>org.optaplanner.examples.nurserostering.persistence.NurseRosterXmlSolutionFileIO</solutionFileIOClass>
       <inputSolutionFile>data/nurserostering/unsolved/medium01.xml</inputSolutionFile>
       <inputSolutionFile>data/nurserostering/unsolved/medium02.xml</inputSolutionFile>
       <inputSolutionFile>data/nurserostering/unsolved/medium03.xml</inputSolutionFile>

--- a/optaplanner-examples/src/main/resources/org/optaplanner/examples/nurserostering/benchmark/nurseRosteringSprintBenchmarkConfig.xml
+++ b/optaplanner-examples/src/main/resources/org/optaplanner/examples/nurserostering/benchmark/nurseRosteringSprintBenchmarkConfig.xml
@@ -6,7 +6,7 @@
 
   <inheritedSolverBenchmark>
     <problemBenchmarks>
-      <solutionFileIOClass>org.optaplanner.examples.nurserostering.persistence.NurseRosterSolutionFileIO</solutionFileIOClass>
+      <solutionFileIOClass>org.optaplanner.examples.nurserostering.persistence.NurseRosterXmlSolutionFileIO</solutionFileIOClass>
       <inputSolutionFile>data/nurserostering/unsolved/sprint01.xml</inputSolutionFile>
       <inputSolutionFile>data/nurserostering/unsolved/sprint02.xml</inputSolutionFile>
       <!--<inputSolutionFile>data/nurserostering/unsolved/sprint03.xml</inputSolutionFile>-->

--- a/optaplanner-examples/src/main/resources/org/optaplanner/examples/nurserostering/benchmark/nurseRosteringStepLimitBenchmarkConfig.xml
+++ b/optaplanner-examples/src/main/resources/org/optaplanner/examples/nurserostering/benchmark/nurseRosteringStepLimitBenchmarkConfig.xml
@@ -5,7 +5,7 @@
 
   <inheritedSolverBenchmark>
     <problemBenchmarks>
-      <solutionFileIOClass>org.optaplanner.examples.nurserostering.persistence.NurseRosterSolutionFileIO</solutionFileIOClass>
+      <solutionFileIOClass>org.optaplanner.examples.nurserostering.persistence.NurseRosterXmlSolutionFileIO</solutionFileIOClass>
       <inputSolutionFile>data/nurserostering/unsolved/medium_late01_initialized.xml</inputSolutionFile>
     </problemBenchmarks>
 

--- a/optaplanner-examples/src/main/resources/org/optaplanner/examples/pas/benchmark/patientAdmissionScheduleBenchmarkConfig.xml
+++ b/optaplanner-examples/src/main/resources/org/optaplanner/examples/pas/benchmark/patientAdmissionScheduleBenchmarkConfig.xml
@@ -5,7 +5,7 @@
 
   <inheritedSolverBenchmark>
     <problemBenchmarks>
-      <solutionFileIOClass>org.optaplanner.examples.pas.persistence.PatientAdmissionScheduleSolutionFileIO</solutionFileIOClass>
+      <solutionFileIOClass>org.optaplanner.examples.pas.persistence.PatientAdmissionScheduleXmlSolutionFileIO</solutionFileIOClass>
       <inputSolutionFile>data/pas/unsolved/testdata01.xml</inputSolutionFile>
       <inputSolutionFile>data/pas/unsolved/testdata02.xml</inputSolutionFile>
       <inputSolutionFile>data/pas/unsolved/testdata03.xml</inputSolutionFile>

--- a/optaplanner-examples/src/main/resources/org/optaplanner/examples/projectjobscheduling/benchmark/projectJobSchedulingBenchmarkConfigTemplate.xml.ftl
+++ b/optaplanner-examples/src/main/resources/org/optaplanner/examples/projectjobscheduling/benchmark/projectJobSchedulingBenchmarkConfigTemplate.xml.ftl
@@ -5,7 +5,7 @@
 
   <inheritedSolverBenchmark>
     <problemBenchmarks>
-      <solutionFileIOClass>org.optaplanner.examples.projectjobscheduling.persistence.ProjectJobSchedulingSolutionFileIO</solutionFileIOClass>
+      <solutionFileIOClass>org.optaplanner.examples.projectjobscheduling.persistence.ProjectJobSchedulingXmlSolutionFileIO</solutionFileIOClass>
       <inputSolutionFile>data/projectjobscheduling/unsolved/A-1.xml</inputSolutionFile>
       <inputSolutionFile>data/projectjobscheduling/unsolved/A-2.xml</inputSolutionFile>
       <inputSolutionFile>data/projectjobscheduling/unsolved/A-3.xml</inputSolutionFile>

--- a/optaplanner-examples/src/main/resources/org/optaplanner/examples/taskassigning/benchmark/taskAssigningBenchmarkConfig.xml
+++ b/optaplanner-examples/src/main/resources/org/optaplanner/examples/taskassigning/benchmark/taskAssigningBenchmarkConfig.xml
@@ -5,7 +5,7 @@
 
   <inheritedSolverBenchmark>
     <problemBenchmarks>
-      <solutionFileIOClass>org.optaplanner.examples.taskassigning.persistence.TaskAssigningSolutionFileIO</solutionFileIOClass>
+      <solutionFileIOClass>org.optaplanner.examples.taskassigning.persistence.TaskAssigningXmlSolutionFileIO</solutionFileIOClass>
       <inputSolutionFile>data/taskassigning/unsolved/24tasks-8employees.xml</inputSolutionFile>
       <inputSolutionFile>data/taskassigning/unsolved/50tasks-5employees.xml</inputSolutionFile>
       <inputSolutionFile>data/taskassigning/unsolved/100tasks-5employees.xml</inputSolutionFile>

--- a/optaplanner-examples/src/main/resources/org/optaplanner/examples/taskassigning/benchmark/taskAssigningScoreDirectorBenchmarkConfig.xml
+++ b/optaplanner-examples/src/main/resources/org/optaplanner/examples/taskassigning/benchmark/taskAssigningScoreDirectorBenchmarkConfig.xml
@@ -5,7 +5,7 @@
 
   <inheritedSolverBenchmark>
     <problemBenchmarks>
-      <solutionFileIOClass>org.optaplanner.examples.taskassigning.persistence.TaskAssigningSolutionFileIO</solutionFileIOClass>
+      <solutionFileIOClass>org.optaplanner.examples.taskassigning.persistence.TaskAssigningXmlSolutionFileIO</solutionFileIOClass>
       <inputSolutionFile>data/taskassigning/unsolved/24tasks-8employees.xml</inputSolutionFile>
       <inputSolutionFile>data/taskassigning/unsolved/50tasks-5employees.xml</inputSolutionFile>
       <inputSolutionFile>data/taskassigning/unsolved/100tasks-5employees.xml</inputSolutionFile>

--- a/optaplanner-examples/src/main/resources/org/optaplanner/examples/travelingtournament/benchmark/travelingTournamentBenchmarkConfig.xml
+++ b/optaplanner-examples/src/main/resources/org/optaplanner/examples/travelingtournament/benchmark/travelingTournamentBenchmarkConfig.xml
@@ -5,7 +5,7 @@
 
   <inheritedSolverBenchmark>
     <problemBenchmarks>
-      <solutionFileIOClass>org.optaplanner.examples.travelingtournament.persistence.TravelingTournamentSolutionFileIO</solutionFileIOClass>
+      <solutionFileIOClass>org.optaplanner.examples.travelingtournament.persistence.TravelingTournamentXmlSolutionFileIO</solutionFileIOClass>
       <inputSolutionFile>data/travelingtournament/unsolved/1-nl14.xml</inputSolutionFile>
       <!--<problemStatisticType>BEST_SCORE</problemStatisticType>-->
       <!--<problemStatisticType>STEP_SCORE</problemStatisticType>-->

--- a/optaplanner-examples/src/main/resources/org/optaplanner/examples/travelingtournament/benchmark/travelingTournamentStepLimitBenchmarkConfig.xml
+++ b/optaplanner-examples/src/main/resources/org/optaplanner/examples/travelingtournament/benchmark/travelingTournamentStepLimitBenchmarkConfig.xml
@@ -5,7 +5,7 @@
 
   <inheritedSolverBenchmark>
     <problemBenchmarks>
-      <solutionFileIOClass>org.optaplanner.examples.travelingtournament.persistence.TravelingTournamentSolutionFileIO</solutionFileIOClass>
+      <solutionFileIOClass>org.optaplanner.examples.travelingtournament.persistence.TravelingTournamentXmlSolutionFileIO</solutionFileIOClass>
       <inputSolutionFile>data/travelingtournament/unsolved/1-nl14.xml</inputSolutionFile>
     </problemBenchmarks>
   </inheritedSolverBenchmark>


### PR DESCRIPTION
The Investment and Scrabble examples relied on `<xstreamAnnotatedClass/>` configuration option, which was removed.

This PR adds `SolutionFileIO` implementation (still using XStream) for these examples together with basic benchmark configurations that show usage of the new `SolutionFileIO`s.