### PR TITLE
PLANNER-1816 Fix constraint provider for Course Scheduling

### DIFF
--- a/optaplanner-examples/data/curriculumcourse/unsolved/200lectures-32periods-12rooms.xml
+++ b/optaplanner-examples/data/curriculumcourse/unsolved/200lectures-32periods-12rooms.xml
@@ -107,7 +107,7 @@
       <teacher reference="3"/>
       <lectureSize>4</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="30"/>
+      <curriculumSet id="30"/>
       <studentSize>0</studentSize>
     </Course>
     <Course id="31">
@@ -116,9 +116,9 @@
       <teacher reference="4"/>
       <lectureSize>7</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="32">
+      <curriculumSet id="32">
         <Curriculum reference="25"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>15</studentSize>
     </Course>
     <Course id="33">
@@ -127,10 +127,10 @@
       <teacher reference="5"/>
       <lectureSize>5</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="34">
+      <curriculumSet id="34">
         <Curriculum reference="20"/>
         <Curriculum reference="24"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>32</studentSize>
     </Course>
     <Course id="35">
@@ -139,7 +139,7 @@
       <teacher reference="6"/>
       <lectureSize>4</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="36"/>
+      <curriculumSet id="36"/>
       <studentSize>0</studentSize>
     </Course>
     <Course id="37">
@@ -148,10 +148,10 @@
       <teacher reference="7"/>
       <lectureSize>2</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="38">
+      <curriculumSet id="38">
         <Curriculum reference="21"/>
         <Curriculum reference="22"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>35</studentSize>
     </Course>
     <Course id="39">
@@ -160,10 +160,10 @@
       <teacher reference="8"/>
       <lectureSize>4</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="40">
+      <curriculumSet id="40">
         <Curriculum reference="22"/>
         <Curriculum reference="23"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>31</studentSize>
     </Course>
     <Course id="41">
@@ -172,10 +172,10 @@
       <teacher reference="9"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="42">
+      <curriculumSet id="42">
         <Curriculum reference="25"/>
         <Curriculum reference="27"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>22</studentSize>
     </Course>
     <Course id="43">
@@ -184,9 +184,9 @@
       <teacher reference="10"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="44">
+      <curriculumSet id="44">
         <Curriculum reference="21"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>15</studentSize>
     </Course>
     <Course id="45">
@@ -195,10 +195,10 @@
       <teacher reference="11"/>
       <lectureSize>2</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="46">
+      <curriculumSet id="46">
         <Curriculum reference="20"/>
         <Curriculum reference="25"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>29</studentSize>
     </Course>
     <Course id="47">
@@ -207,9 +207,9 @@
       <teacher reference="12"/>
       <lectureSize>4</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="48">
+      <curriculumSet id="48">
         <Curriculum reference="23"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>11</studentSize>
     </Course>
     <Course id="49">
@@ -218,7 +218,7 @@
       <teacher reference="13"/>
       <lectureSize>4</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="50"/>
+      <curriculumSet id="50"/>
       <studentSize>0</studentSize>
     </Course>
     <Course id="51">
@@ -227,10 +227,10 @@
       <teacher reference="14"/>
       <lectureSize>7</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="52">
+      <curriculumSet id="52">
         <Curriculum reference="21"/>
         <Curriculum reference="24"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>33</studentSize>
     </Course>
     <Course id="53">
@@ -239,10 +239,10 @@
       <teacher reference="15"/>
       <lectureSize>6</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="54">
+      <curriculumSet id="54">
         <Curriculum reference="21"/>
         <Curriculum reference="22"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>35</studentSize>
     </Course>
     <Course id="55">
@@ -251,7 +251,7 @@
       <teacher reference="16"/>
       <lectureSize>2</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="56"/>
+      <curriculumSet id="56"/>
       <studentSize>0</studentSize>
     </Course>
     <Course id="57">
@@ -260,7 +260,7 @@
       <teacher reference="17"/>
       <lectureSize>5</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="58"/>
+      <curriculumSet id="58"/>
       <studentSize>0</studentSize>
     </Course>
     <Course id="59">
@@ -269,10 +269,10 @@
       <teacher reference="18"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="60">
+      <curriculumSet id="60">
         <Curriculum reference="20"/>
         <Curriculum reference="26"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>35</studentSize>
     </Course>
     <Course id="61">
@@ -281,9 +281,9 @@
       <teacher reference="3"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="62">
+      <curriculumSet id="62">
         <Curriculum reference="20"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>14</studentSize>
     </Course>
     <Course id="63">
@@ -292,9 +292,9 @@
       <teacher reference="4"/>
       <lectureSize>6</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="64">
+      <curriculumSet id="64">
         <Curriculum reference="23"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>11</studentSize>
     </Course>
     <Course id="65">
@@ -303,10 +303,10 @@
       <teacher reference="5"/>
       <lectureSize>5</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="66">
+      <curriculumSet id="66">
         <Curriculum reference="24"/>
         <Curriculum reference="27"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>25</studentSize>
     </Course>
     <Course id="67">
@@ -315,7 +315,7 @@
       <teacher reference="6"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="68"/>
+      <curriculumSet id="68"/>
       <studentSize>0</studentSize>
     </Course>
     <Course id="69">
@@ -324,10 +324,10 @@
       <teacher reference="7"/>
       <lectureSize>6</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="70">
+      <curriculumSet id="70">
         <Curriculum reference="23"/>
         <Curriculum reference="27"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>18</studentSize>
     </Course>
     <Course id="71">
@@ -336,9 +336,9 @@
       <teacher reference="8"/>
       <lectureSize>7</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="72">
+      <curriculumSet id="72">
         <Curriculum reference="20"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>14</studentSize>
     </Course>
     <Course id="73">
@@ -347,9 +347,9 @@
       <teacher reference="9"/>
       <lectureSize>6</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="74">
+      <curriculumSet id="74">
         <Curriculum reference="24"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>18</studentSize>
     </Course>
     <Course id="75">
@@ -358,9 +358,9 @@
       <teacher reference="10"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="76">
+      <curriculumSet id="76">
         <Curriculum reference="26"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>21</studentSize>
     </Course>
     <Course id="77">
@@ -369,9 +369,9 @@
       <teacher reference="11"/>
       <lectureSize>7</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="78">
+      <curriculumSet id="78">
         <Curriculum reference="25"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>15</studentSize>
     </Course>
     <Course id="79">
@@ -380,7 +380,7 @@
       <teacher reference="12"/>
       <lectureSize>4</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="80"/>
+      <curriculumSet id="80"/>
       <studentSize>0</studentSize>
     </Course>
     <Course id="81">
@@ -389,9 +389,9 @@
       <teacher reference="13"/>
       <lectureSize>2</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="82">
+      <curriculumSet id="82">
         <Curriculum reference="26"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>21</studentSize>
     </Course>
     <Course id="83">
@@ -400,10 +400,10 @@
       <teacher reference="14"/>
       <lectureSize>2</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="84">
+      <curriculumSet id="84">
         <Curriculum reference="20"/>
         <Curriculum reference="25"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>29</studentSize>
     </Course>
     <Course id="85">
@@ -412,9 +412,9 @@
       <teacher reference="15"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="86">
+      <curriculumSet id="86">
         <Curriculum reference="21"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>15</studentSize>
     </Course>
     <Course id="87">
@@ -423,9 +423,9 @@
       <teacher reference="16"/>
       <lectureSize>5</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="88">
+      <curriculumSet id="88">
         <Curriculum reference="26"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>21</studentSize>
     </Course>
     <Course id="89">
@@ -434,9 +434,9 @@
       <teacher reference="17"/>
       <lectureSize>5</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="90">
+      <curriculumSet id="90">
         <Curriculum reference="22"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>20</studentSize>
     </Course>
     <Course id="91">
@@ -445,7 +445,7 @@
       <teacher reference="18"/>
       <lectureSize>6</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="92"/>
+      <curriculumSet id="92"/>
       <studentSize>0</studentSize>
     </Course>
     <Course id="93">
@@ -454,10 +454,10 @@
       <teacher reference="6"/>
       <lectureSize>6</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="94">
+      <curriculumSet id="94">
         <Curriculum reference="25"/>
         <Curriculum reference="26"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>36</studentSize>
     </Course>
     <Course id="95">
@@ -466,10 +466,10 @@
       <teacher reference="6"/>
       <lectureSize>6</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="96">
+      <curriculumSet id="96">
         <Curriculum reference="21"/>
         <Curriculum reference="22"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>35</studentSize>
     </Course>
     <Course id="97">
@@ -478,10 +478,10 @@
       <teacher reference="5"/>
       <lectureSize>6</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="98">
+      <curriculumSet id="98">
         <Curriculum reference="26"/>
         <Curriculum reference="27"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>28</studentSize>
     </Course>
     <Course id="99">
@@ -490,11 +490,11 @@
       <teacher reference="5"/>
       <lectureSize>6</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="100">
+      <curriculumSet id="100">
         <Curriculum reference="23"/>
         <Curriculum reference="24"/>
         <Curriculum reference="27"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>36</studentSize>
     </Course>
     <Course id="101">
@@ -503,7 +503,7 @@
       <teacher reference="11"/>
       <lectureSize>7</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="102"/>
+      <curriculumSet id="102"/>
       <studentSize>0</studentSize>
     </Course>
     <Course id="103">
@@ -512,9 +512,9 @@
       <teacher reference="16"/>
       <lectureSize>4</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="104">
+      <curriculumSet id="104">
         <Curriculum reference="27"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>7</studentSize>
     </Course>
     <Course id="105">
@@ -523,10 +523,10 @@
       <teacher reference="4"/>
       <lectureSize>4</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="106">
+      <curriculumSet id="106">
         <Curriculum reference="20"/>
         <Curriculum reference="25"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>29</studentSize>
     </Course>
     <Course id="107">
@@ -535,9 +535,9 @@
       <teacher reference="16"/>
       <lectureSize>5</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="108">
+      <curriculumSet id="108">
         <Curriculum reference="22"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>20</studentSize>
     </Course>
     <Course id="109">
@@ -546,9 +546,9 @@
       <teacher reference="13"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="110">
+      <curriculumSet id="110">
         <Curriculum reference="24"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>18</studentSize>
     </Course>
     <Course id="111">
@@ -557,10 +557,10 @@
       <teacher reference="11"/>
       <lectureSize>5</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="112">
+      <curriculumSet id="112">
         <Curriculum reference="23"/>
         <Curriculum reference="26"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>32</studentSize>
     </Course>
     <Course id="113">
@@ -569,10 +569,10 @@
       <teacher reference="13"/>
       <lectureSize>4</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="114">
+      <curriculumSet id="114">
         <Curriculum reference="21"/>
         <Curriculum reference="22"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>35</studentSize>
     </Course>
     <Course id="115">
@@ -581,10 +581,10 @@
       <teacher reference="7"/>
       <lectureSize>2</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="116">
+      <curriculumSet id="116">
         <Curriculum reference="20"/>
         <Curriculum reference="26"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>35</studentSize>
     </Course>
     <Course id="117">
@@ -593,9 +593,9 @@
       <teacher reference="17"/>
       <lectureSize>4</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="118">
+      <curriculumSet id="118">
         <Curriculum reference="20"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>14</studentSize>
     </Course>
   </courseList>

--- a/optaplanner-examples/data/curriculumcourse/unsolved/400lectures-32periods-25rooms.xml
+++ b/optaplanner-examples/data/curriculumcourse/unsolved/400lectures-32periods-25rooms.xml
@@ -195,11 +195,11 @@
       <teacher reference="3"/>
       <lectureSize>4</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="52">
+      <curriculumSet id="52">
         <Curriculum reference="34"/>
         <Curriculum reference="44"/>
         <Curriculum reference="48"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>49</studentSize>
     </Course>
     <Course id="53">
@@ -208,7 +208,7 @@
       <teacher reference="4"/>
       <lectureSize>6</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="54"/>
+      <curriculumSet id="54"/>
       <studentSize>0</studentSize>
     </Course>
     <Course id="55">
@@ -217,9 +217,9 @@
       <teacher reference="5"/>
       <lectureSize>4</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="56">
+      <curriculumSet id="56">
         <Curriculum reference="39"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>18</studentSize>
     </Course>
     <Course id="57">
@@ -228,9 +228,9 @@
       <teacher reference="6"/>
       <lectureSize>2</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="58">
+      <curriculumSet id="58">
         <Curriculum reference="48"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>14</studentSize>
     </Course>
     <Course id="59">
@@ -239,10 +239,10 @@
       <teacher reference="7"/>
       <lectureSize>4</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="60">
+      <curriculumSet id="60">
         <Curriculum reference="39"/>
         <Curriculum reference="49"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>36</studentSize>
     </Course>
     <Course id="61">
@@ -251,9 +251,9 @@
       <teacher reference="8"/>
       <lectureSize>10</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="62">
+      <curriculumSet id="62">
         <Curriculum reference="49"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>18</studentSize>
     </Course>
     <Course id="63">
@@ -262,9 +262,9 @@
       <teacher reference="9"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="64">
+      <curriculumSet id="64">
         <Curriculum reference="36"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>14</studentSize>
     </Course>
     <Course id="65">
@@ -273,9 +273,9 @@
       <teacher reference="10"/>
       <lectureSize>5</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="66">
+      <curriculumSet id="66">
         <Curriculum reference="39"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>18</studentSize>
     </Course>
     <Course id="67">
@@ -284,7 +284,7 @@
       <teacher reference="11"/>
       <lectureSize>5</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="68"/>
+      <curriculumSet id="68"/>
       <studentSize>0</studentSize>
     </Course>
     <Course id="69">
@@ -293,10 +293,10 @@
       <teacher reference="12"/>
       <lectureSize>5</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="70">
+      <curriculumSet id="70">
         <Curriculum reference="40"/>
         <Curriculum reference="49"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>36</studentSize>
     </Course>
     <Course id="71">
@@ -305,10 +305,10 @@
       <teacher reference="13"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="72">
+      <curriculumSet id="72">
         <Curriculum reference="43"/>
         <Curriculum reference="46"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>25</studentSize>
     </Course>
     <Course id="73">
@@ -317,7 +317,7 @@
       <teacher reference="14"/>
       <lectureSize>6</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="74"/>
+      <curriculumSet id="74"/>
       <studentSize>0</studentSize>
     </Course>
     <Course id="75">
@@ -326,9 +326,9 @@
       <teacher reference="15"/>
       <lectureSize>4</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="76">
+      <curriculumSet id="76">
         <Curriculum reference="48"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>14</studentSize>
     </Course>
     <Course id="77">
@@ -337,10 +337,10 @@
       <teacher reference="16"/>
       <lectureSize>6</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="78">
+      <curriculumSet id="78">
         <Curriculum reference="37"/>
         <Curriculum reference="42"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>31</studentSize>
     </Course>
     <Course id="79">
@@ -349,10 +349,10 @@
       <teacher reference="17"/>
       <lectureSize>5</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="80">
+      <curriculumSet id="80">
         <Curriculum reference="35"/>
         <Curriculum reference="41"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>23</studentSize>
     </Course>
     <Course id="81">
@@ -361,9 +361,9 @@
       <teacher reference="18"/>
       <lectureSize>4</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="82">
+      <curriculumSet id="82">
         <Curriculum reference="41"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>13</studentSize>
     </Course>
     <Course id="83">
@@ -372,11 +372,11 @@
       <teacher reference="19"/>
       <lectureSize>5</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="84">
+      <curriculumSet id="84">
         <Curriculum reference="43"/>
         <Curriculum reference="47"/>
         <Curriculum reference="48"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>44</studentSize>
     </Course>
     <Course id="85">
@@ -385,9 +385,9 @@
       <teacher reference="20"/>
       <lectureSize>7</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="86">
+      <curriculumSet id="86">
         <Curriculum reference="45"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>14</studentSize>
     </Course>
     <Course id="87">
@@ -396,10 +396,10 @@
       <teacher reference="21"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="88">
+      <curriculumSet id="88">
         <Curriculum reference="42"/>
         <Curriculum reference="44"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>38</studentSize>
     </Course>
     <Course id="89">
@@ -408,10 +408,10 @@
       <teacher reference="22"/>
       <lectureSize>2</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="90">
+      <curriculumSet id="90">
         <Curriculum reference="37"/>
         <Curriculum reference="48"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>26</studentSize>
     </Course>
     <Course id="91">
@@ -420,9 +420,9 @@
       <teacher reference="23"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="92">
+      <curriculumSet id="92">
         <Curriculum reference="38"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>19</studentSize>
     </Course>
     <Course id="93">
@@ -431,9 +431,9 @@
       <teacher reference="24"/>
       <lectureSize>5</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="94">
+      <curriculumSet id="94">
         <Curriculum reference="45"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>14</studentSize>
     </Course>
     <Course id="95">
@@ -442,7 +442,7 @@
       <teacher reference="25"/>
       <lectureSize>5</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="96"/>
+      <curriculumSet id="96"/>
       <studentSize>0</studentSize>
     </Course>
     <Course id="97">
@@ -451,10 +451,10 @@
       <teacher reference="26"/>
       <lectureSize>5</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="98">
+      <curriculumSet id="98">
         <Curriculum reference="36"/>
         <Curriculum reference="37"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>26</studentSize>
     </Course>
     <Course id="99">
@@ -463,10 +463,10 @@
       <teacher reference="27"/>
       <lectureSize>4</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="100">
+      <curriculumSet id="100">
         <Curriculum reference="34"/>
         <Curriculum reference="49"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>34</studentSize>
     </Course>
     <Course id="101">
@@ -475,10 +475,10 @@
       <teacher reference="28"/>
       <lectureSize>5</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="102">
+      <curriculumSet id="102">
         <Curriculum reference="34"/>
         <Curriculum reference="38"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>35</studentSize>
     </Course>
     <Course id="103">
@@ -487,7 +487,7 @@
       <teacher reference="29"/>
       <lectureSize>7</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="104"/>
+      <curriculumSet id="104"/>
       <studentSize>0</studentSize>
     </Course>
     <Course id="105">
@@ -496,9 +496,9 @@
       <teacher reference="30"/>
       <lectureSize>5</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="106">
+      <curriculumSet id="106">
         <Curriculum reference="45"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>14</studentSize>
     </Course>
     <Course id="107">
@@ -507,7 +507,7 @@
       <teacher reference="31"/>
       <lectureSize>4</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="108"/>
+      <curriculumSet id="108"/>
       <studentSize>0</studentSize>
     </Course>
     <Course id="109">
@@ -516,9 +516,9 @@
       <teacher reference="32"/>
       <lectureSize>6</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="110">
+      <curriculumSet id="110">
         <Curriculum reference="43"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>13</studentSize>
     </Course>
     <Course id="111">
@@ -527,9 +527,9 @@
       <teacher reference="3"/>
       <lectureSize>5</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="112">
+      <curriculumSet id="112">
         <Curriculum reference="41"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>13</studentSize>
     </Course>
     <Course id="113">
@@ -538,11 +538,11 @@
       <teacher reference="4"/>
       <lectureSize>5</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="114">
+      <curriculumSet id="114">
         <Curriculum reference="42"/>
         <Curriculum reference="45"/>
         <Curriculum reference="46"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>45</studentSize>
     </Course>
     <Course id="115">
@@ -551,7 +551,7 @@
       <teacher reference="5"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="116"/>
+      <curriculumSet id="116"/>
       <studentSize>0</studentSize>
     </Course>
     <Course id="117">
@@ -560,10 +560,10 @@
       <teacher reference="6"/>
       <lectureSize>4</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="118">
+      <curriculumSet id="118">
         <Curriculum reference="36"/>
         <Curriculum reference="46"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>26</studentSize>
     </Course>
     <Course id="119">
@@ -572,9 +572,9 @@
       <teacher reference="7"/>
       <lectureSize>7</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="120">
+      <curriculumSet id="120">
         <Curriculum reference="39"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>18</studentSize>
     </Course>
     <Course id="121">
@@ -583,10 +583,10 @@
       <teacher reference="8"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="122">
+      <curriculumSet id="122">
         <Curriculum reference="34"/>
         <Curriculum reference="39"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>34</studentSize>
     </Course>
     <Course id="123">
@@ -595,9 +595,9 @@
       <teacher reference="9"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="124">
+      <curriculumSet id="124">
         <Curriculum reference="46"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>12</studentSize>
     </Course>
     <Course id="125">
@@ -606,7 +606,7 @@
       <teacher reference="10"/>
       <lectureSize>5</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="126"/>
+      <curriculumSet id="126"/>
       <studentSize>0</studentSize>
     </Course>
     <Course id="127">
@@ -615,9 +615,9 @@
       <teacher reference="11"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="128">
+      <curriculumSet id="128">
         <Curriculum reference="44"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>19</studentSize>
     </Course>
     <Course id="129">
@@ -626,9 +626,9 @@
       <teacher reference="12"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="130">
+      <curriculumSet id="130">
         <Curriculum reference="37"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>12</studentSize>
     </Course>
     <Course id="131">
@@ -637,9 +637,9 @@
       <teacher reference="13"/>
       <lectureSize>7</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="132">
+      <curriculumSet id="132">
         <Curriculum reference="34"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>16</studentSize>
     </Course>
     <Course id="133">
@@ -648,9 +648,9 @@
       <teacher reference="14"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="134">
+      <curriculumSet id="134">
         <Curriculum reference="35"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>10</studentSize>
     </Course>
     <Course id="135">
@@ -659,10 +659,10 @@
       <teacher reference="15"/>
       <lectureSize>2</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="136">
+      <curriculumSet id="136">
         <Curriculum reference="35"/>
         <Curriculum reference="41"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>23</studentSize>
     </Course>
     <Course id="137">
@@ -671,7 +671,7 @@
       <teacher reference="16"/>
       <lectureSize>4</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="138"/>
+      <curriculumSet id="138"/>
       <studentSize>0</studentSize>
     </Course>
     <Course id="139">
@@ -680,7 +680,7 @@
       <teacher reference="17"/>
       <lectureSize>5</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="140"/>
+      <curriculumSet id="140"/>
       <studentSize>0</studentSize>
     </Course>
     <Course id="141">
@@ -689,10 +689,10 @@
       <teacher reference="18"/>
       <lectureSize>7</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="142">
+      <curriculumSet id="142">
         <Curriculum reference="34"/>
         <Curriculum reference="40"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>34</studentSize>
     </Course>
     <Course id="143">
@@ -701,9 +701,9 @@
       <teacher reference="19"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="144">
+      <curriculumSet id="144">
         <Curriculum reference="36"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>14</studentSize>
     </Course>
     <Course id="145">
@@ -712,9 +712,9 @@
       <teacher reference="20"/>
       <lectureSize>5</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="146">
+      <curriculumSet id="146">
         <Curriculum reference="38"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>19</studentSize>
     </Course>
     <Course id="147">
@@ -723,7 +723,7 @@
       <teacher reference="21"/>
       <lectureSize>4</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="148"/>
+      <curriculumSet id="148"/>
       <studentSize>0</studentSize>
     </Course>
     <Course id="149">
@@ -732,7 +732,7 @@
       <teacher reference="22"/>
       <lectureSize>4</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="150"/>
+      <curriculumSet id="150"/>
       <studentSize>0</studentSize>
     </Course>
     <Course id="151">
@@ -741,7 +741,7 @@
       <teacher reference="23"/>
       <lectureSize>9</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="152"/>
+      <curriculumSet id="152"/>
       <studentSize>0</studentSize>
     </Course>
     <Course id="153">
@@ -750,9 +750,9 @@
       <teacher reference="24"/>
       <lectureSize>4</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="154">
+      <curriculumSet id="154">
         <Curriculum reference="40"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>18</studentSize>
     </Course>
     <Course id="155">
@@ -761,10 +761,10 @@
       <teacher reference="25"/>
       <lectureSize>6</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="156">
+      <curriculumSet id="156">
         <Curriculum reference="36"/>
         <Curriculum reference="43"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>27</studentSize>
     </Course>
     <Course id="157">
@@ -773,10 +773,10 @@
       <teacher reference="26"/>
       <lectureSize>5</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="158">
+      <curriculumSet id="158">
         <Curriculum reference="35"/>
         <Curriculum reference="47"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>27</studentSize>
     </Course>
     <Course id="159">
@@ -785,10 +785,10 @@
       <teacher reference="27"/>
       <lectureSize>4</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="160">
+      <curriculumSet id="160">
         <Curriculum reference="36"/>
         <Curriculum reference="46"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>26</studentSize>
     </Course>
     <Course id="161">
@@ -797,10 +797,10 @@
       <teacher reference="28"/>
       <lectureSize>6</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="162">
+      <curriculumSet id="162">
         <Curriculum reference="48"/>
         <Curriculum reference="49"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>32</studentSize>
     </Course>
     <Course id="163">
@@ -809,9 +809,9 @@
       <teacher reference="29"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="164">
+      <curriculumSet id="164">
         <Curriculum reference="37"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>12</studentSize>
     </Course>
     <Course id="165">
@@ -820,9 +820,9 @@
       <teacher reference="30"/>
       <lectureSize>6</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="166">
+      <curriculumSet id="166">
         <Curriculum reference="38"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>19</studentSize>
     </Course>
     <Course id="167">
@@ -831,10 +831,10 @@
       <teacher reference="31"/>
       <lectureSize>4</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="168">
+      <curriculumSet id="168">
         <Curriculum reference="44"/>
         <Curriculum reference="45"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>33</studentSize>
     </Course>
     <Course id="169">
@@ -843,10 +843,10 @@
       <teacher reference="32"/>
       <lectureSize>4</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="170">
+      <curriculumSet id="170">
         <Curriculum reference="44"/>
         <Curriculum reference="48"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>33</studentSize>
     </Course>
     <Course id="171">
@@ -855,7 +855,7 @@
       <teacher reference="10"/>
       <lectureSize>4</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="172"/>
+      <curriculumSet id="172"/>
       <studentSize>0</studentSize>
     </Course>
     <Course id="173">
@@ -864,9 +864,9 @@
       <teacher reference="9"/>
       <lectureSize>4</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="174">
+      <curriculumSet id="174">
         <Curriculum reference="41"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>13</studentSize>
     </Course>
     <Course id="175">
@@ -875,9 +875,9 @@
       <teacher reference="15"/>
       <lectureSize>4</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="176">
+      <curriculumSet id="176">
         <Curriculum reference="42"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>19</studentSize>
     </Course>
     <Course id="177">
@@ -886,9 +886,9 @@
       <teacher reference="17"/>
       <lectureSize>4</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="178">
+      <curriculumSet id="178">
         <Curriculum reference="38"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>19</studentSize>
     </Course>
     <Course id="179">
@@ -897,11 +897,11 @@
       <teacher reference="28"/>
       <lectureSize>5</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="180">
+      <curriculumSet id="180">
         <Curriculum reference="36"/>
         <Curriculum reference="41"/>
         <Curriculum reference="43"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>40</studentSize>
     </Course>
     <Course id="181">
@@ -910,7 +910,7 @@
       <teacher reference="32"/>
       <lectureSize>6</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="182"/>
+      <curriculumSet id="182"/>
       <studentSize>0</studentSize>
     </Course>
     <Course id="183">
@@ -919,10 +919,10 @@
       <teacher reference="32"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="184">
+      <curriculumSet id="184">
         <Curriculum reference="43"/>
         <Curriculum reference="44"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>32</studentSize>
     </Course>
     <Course id="185">
@@ -931,7 +931,7 @@
       <teacher reference="6"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="186"/>
+      <curriculumSet id="186"/>
       <studentSize>0</studentSize>
     </Course>
     <Course id="187">
@@ -940,9 +940,9 @@
       <teacher reference="27"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="188">
+      <curriculumSet id="188">
         <Curriculum reference="44"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>19</studentSize>
     </Course>
     <Course id="189">
@@ -951,7 +951,7 @@
       <teacher reference="18"/>
       <lectureSize>2</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="190"/>
+      <curriculumSet id="190"/>
       <studentSize>0</studentSize>
     </Course>
     <Course id="191">
@@ -960,7 +960,7 @@
       <teacher reference="18"/>
       <lectureSize>4</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="192"/>
+      <curriculumSet id="192"/>
       <studentSize>0</studentSize>
     </Course>
     <Course id="193">
@@ -969,10 +969,10 @@
       <teacher reference="10"/>
       <lectureSize>4</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="194">
+      <curriculumSet id="194">
         <Curriculum reference="43"/>
         <Curriculum reference="47"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>30</studentSize>
     </Course>
     <Course id="195">
@@ -981,9 +981,9 @@
       <teacher reference="26"/>
       <lectureSize>4</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="196">
+      <curriculumSet id="196">
         <Curriculum reference="46"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>12</studentSize>
     </Course>
     <Course id="197">
@@ -992,9 +992,9 @@
       <teacher reference="28"/>
       <lectureSize>4</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="198">
+      <curriculumSet id="198">
         <Curriculum reference="46"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>12</studentSize>
     </Course>
     <Course id="199">
@@ -1003,10 +1003,10 @@
       <teacher reference="29"/>
       <lectureSize>4</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="200">
+      <curriculumSet id="200">
         <Curriculum reference="38"/>
         <Curriculum reference="47"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>36</studentSize>
     </Course>
     <Course id="201">
@@ -1015,10 +1015,10 @@
       <teacher reference="30"/>
       <lectureSize>5</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="202">
+      <curriculumSet id="202">
         <Curriculum reference="35"/>
         <Curriculum reference="39"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>28</studentSize>
     </Course>
     <Course id="203">
@@ -1027,10 +1027,10 @@
       <teacher reference="19"/>
       <lectureSize>2</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="204">
+      <curriculumSet id="204">
         <Curriculum reference="39"/>
         <Curriculum reference="40"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>36</studentSize>
     </Course>
     <Course id="205">
@@ -1039,11 +1039,11 @@
       <teacher reference="17"/>
       <lectureSize>6</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="206">
+      <curriculumSet id="206">
         <Curriculum reference="35"/>
         <Curriculum reference="40"/>
         <Curriculum reference="47"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>45</studentSize>
     </Course>
     <Course id="207">
@@ -1052,9 +1052,9 @@
       <teacher reference="26"/>
       <lectureSize>8</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="208">
+      <curriculumSet id="208">
         <Curriculum reference="42"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>19</studentSize>
     </Course>
     <Course id="209">
@@ -1063,9 +1063,9 @@
       <teacher reference="23"/>
       <lectureSize>5</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="210">
+      <curriculumSet id="210">
         <Curriculum reference="35"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>10</studentSize>
     </Course>
     <Course id="211">
@@ -1074,9 +1074,9 @@
       <teacher reference="20"/>
       <lectureSize>5</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="212">
+      <curriculumSet id="212">
         <Curriculum reference="40"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>18</studentSize>
     </Course>
     <Course id="213">
@@ -1085,9 +1085,9 @@
       <teacher reference="5"/>
       <lectureSize>5</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="214">
+      <curriculumSet id="214">
         <Curriculum reference="37"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>12</studentSize>
     </Course>
     <Course id="215">
@@ -1096,10 +1096,10 @@
       <teacher reference="21"/>
       <lectureSize>4</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="216">
+      <curriculumSet id="216">
         <Curriculum reference="37"/>
         <Curriculum reference="46"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>24</studentSize>
     </Course>
     <Course id="217">
@@ -1108,10 +1108,10 @@
       <teacher reference="24"/>
       <lectureSize>4</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="218">
+      <curriculumSet id="218">
         <Curriculum reference="37"/>
         <Curriculum reference="41"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>25</studentSize>
     </Course>
     <Course id="219">
@@ -1120,9 +1120,9 @@
       <teacher reference="22"/>
       <lectureSize>5</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="220">
+      <curriculumSet id="220">
         <Curriculum reference="44"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>19</studentSize>
     </Course>
     <Course id="221">
@@ -1131,9 +1131,9 @@
       <teacher reference="27"/>
       <lectureSize>4</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="222">
+      <curriculumSet id="222">
         <Curriculum reference="38"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>19</studentSize>
     </Course>
     <Course id="223">
@@ -1142,11 +1142,11 @@
       <teacher reference="6"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="224">
+      <curriculumSet id="224">
         <Curriculum reference="41"/>
         <Curriculum reference="42"/>
         <Curriculum reference="45"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>46</studentSize>
     </Course>
     <Course id="225">
@@ -1155,7 +1155,7 @@
       <teacher reference="27"/>
       <lectureSize>4</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="226"/>
+      <curriculumSet id="226"/>
       <studentSize>0</studentSize>
     </Course>
     <Course id="227">
@@ -1164,7 +1164,7 @@
       <teacher reference="4"/>
       <lectureSize>4</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="228"/>
+      <curriculumSet id="228"/>
       <studentSize>0</studentSize>
     </Course>
   </courseList>

--- a/optaplanner-examples/data/curriculumcourse/unsolved/800lectures-32periods-50rooms.xml
+++ b/optaplanner-examples/data/curriculumcourse/unsolved/800lectures-32periods-50rooms.xml
@@ -379,9 +379,9 @@
       <teacher reference="3"/>
       <lectureSize>6</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="98">
+      <curriculumSet id="98">
         <Curriculum reference="93"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>8</studentSize>
     </Course>
     <Course id="99">
@@ -390,7 +390,7 @@
       <teacher reference="4"/>
       <lectureSize>4</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="100"/>
+      <curriculumSet id="100"/>
       <studentSize>0</studentSize>
     </Course>
     <Course id="101">
@@ -399,10 +399,10 @@
       <teacher reference="5"/>
       <lectureSize>5</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="102">
+      <curriculumSet id="102">
         <Curriculum reference="85"/>
         <Curriculum reference="86"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>27</studentSize>
     </Course>
     <Course id="103">
@@ -411,10 +411,10 @@
       <teacher reference="6"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="104">
+      <curriculumSet id="104">
         <Curriculum reference="75"/>
         <Curriculum reference="94"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>22</studentSize>
     </Course>
     <Course id="105">
@@ -423,10 +423,10 @@
       <teacher reference="7"/>
       <lectureSize>2</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="106">
+      <curriculumSet id="106">
         <Curriculum reference="64"/>
         <Curriculum reference="65"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>28</studentSize>
     </Course>
     <Course id="107">
@@ -435,10 +435,10 @@
       <teacher reference="8"/>
       <lectureSize>5</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="108">
+      <curriculumSet id="108">
         <Curriculum reference="93"/>
         <Curriculum reference="94"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>21</studentSize>
     </Course>
     <Course id="109">
@@ -447,7 +447,7 @@
       <teacher reference="9"/>
       <lectureSize>5</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="110"/>
+      <curriculumSet id="110"/>
       <studentSize>0</studentSize>
     </Course>
     <Course id="111">
@@ -456,9 +456,9 @@
       <teacher reference="10"/>
       <lectureSize>5</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="112">
+      <curriculumSet id="112">
         <Curriculum reference="68"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>14</studentSize>
     </Course>
     <Course id="113">
@@ -467,9 +467,9 @@
       <teacher reference="11"/>
       <lectureSize>6</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="114">
+      <curriculumSet id="114">
         <Curriculum reference="64"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>18</studentSize>
     </Course>
     <Course id="115">
@@ -478,9 +478,9 @@
       <teacher reference="12"/>
       <lectureSize>4</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="116">
+      <curriculumSet id="116">
         <Curriculum reference="84"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>9</studentSize>
     </Course>
     <Course id="117">
@@ -489,11 +489,11 @@
       <teacher reference="13"/>
       <lectureSize>4</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="118">
+      <curriculumSet id="118">
         <Curriculum reference="81"/>
         <Curriculum reference="86"/>
         <Curriculum reference="88"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>41</studentSize>
     </Course>
     <Course id="119">
@@ -502,7 +502,7 @@
       <teacher reference="14"/>
       <lectureSize>4</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="120"/>
+      <curriculumSet id="120"/>
       <studentSize>0</studentSize>
     </Course>
     <Course id="121">
@@ -511,10 +511,10 @@
       <teacher reference="15"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="122">
+      <curriculumSet id="122">
         <Curriculum reference="67"/>
         <Curriculum reference="93"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>21</studentSize>
     </Course>
     <Course id="123">
@@ -523,7 +523,7 @@
       <teacher reference="16"/>
       <lectureSize>4</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="124"/>
+      <curriculumSet id="124"/>
       <studentSize>0</studentSize>
     </Course>
     <Course id="125">
@@ -532,9 +532,9 @@
       <teacher reference="17"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="126">
+      <curriculumSet id="126">
         <Curriculum reference="78"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>6</studentSize>
     </Course>
     <Course id="127">
@@ -543,10 +543,10 @@
       <teacher reference="18"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="128">
+      <curriculumSet id="128">
         <Curriculum reference="93"/>
         <Curriculum reference="95"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>25</studentSize>
     </Course>
     <Course id="129">
@@ -555,12 +555,12 @@
       <teacher reference="19"/>
       <lectureSize>5</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="130">
+      <curriculumSet id="130">
         <Curriculum reference="70"/>
         <Curriculum reference="75"/>
         <Curriculum reference="78"/>
         <Curriculum reference="79"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>49</studentSize>
     </Course>
     <Course id="131">
@@ -569,9 +569,9 @@
       <teacher reference="20"/>
       <lectureSize>7</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="132">
+      <curriculumSet id="132">
         <Curriculum reference="72"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>16</studentSize>
     </Course>
     <Course id="133">
@@ -580,7 +580,7 @@
       <teacher reference="21"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="134"/>
+      <curriculumSet id="134"/>
       <studentSize>0</studentSize>
     </Course>
     <Course id="135">
@@ -589,10 +589,10 @@
       <teacher reference="22"/>
       <lectureSize>6</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="136">
+      <curriculumSet id="136">
         <Curriculum reference="68"/>
         <Curriculum reference="77"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>22</studentSize>
     </Course>
     <Course id="137">
@@ -601,7 +601,7 @@
       <teacher reference="23"/>
       <lectureSize>5</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="138"/>
+      <curriculumSet id="138"/>
       <studentSize>0</studentSize>
     </Course>
     <Course id="139">
@@ -610,11 +610,11 @@
       <teacher reference="24"/>
       <lectureSize>5</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="140">
+      <curriculumSet id="140">
         <Curriculum reference="77"/>
         <Curriculum reference="93"/>
         <Curriculum reference="95"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>33</studentSize>
     </Course>
     <Course id="141">
@@ -623,9 +623,9 @@
       <teacher reference="25"/>
       <lectureSize>6</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="142">
+      <curriculumSet id="142">
         <Curriculum reference="72"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>16</studentSize>
     </Course>
     <Course id="143">
@@ -634,10 +634,10 @@
       <teacher reference="26"/>
       <lectureSize>2</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="144">
+      <curriculumSet id="144">
         <Curriculum reference="69"/>
         <Curriculum reference="95"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>30</studentSize>
     </Course>
     <Course id="145">
@@ -646,7 +646,7 @@
       <teacher reference="27"/>
       <lectureSize>4</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="146"/>
+      <curriculumSet id="146"/>
       <studentSize>0</studentSize>
     </Course>
     <Course id="147">
@@ -655,9 +655,9 @@
       <teacher reference="28"/>
       <lectureSize>6</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="148">
+      <curriculumSet id="148">
         <Curriculum reference="66"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>22</studentSize>
     </Course>
     <Course id="149">
@@ -666,9 +666,9 @@
       <teacher reference="29"/>
       <lectureSize>5</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="150">
+      <curriculumSet id="150">
         <Curriculum reference="67"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>13</studentSize>
     </Course>
     <Course id="151">
@@ -677,7 +677,7 @@
       <teacher reference="30"/>
       <lectureSize>4</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="152"/>
+      <curriculumSet id="152"/>
       <studentSize>0</studentSize>
     </Course>
     <Course id="153">
@@ -686,7 +686,7 @@
       <teacher reference="31"/>
       <lectureSize>4</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="154"/>
+      <curriculumSet id="154"/>
       <studentSize>0</studentSize>
     </Course>
     <Course id="155">
@@ -695,11 +695,11 @@
       <teacher reference="32"/>
       <lectureSize>6</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="156">
+      <curriculumSet id="156">
         <Curriculum reference="64"/>
         <Curriculum reference="69"/>
         <Curriculum reference="88"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>43</studentSize>
     </Course>
     <Course id="157">
@@ -708,7 +708,7 @@
       <teacher reference="33"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="158"/>
+      <curriculumSet id="158"/>
       <studentSize>0</studentSize>
     </Course>
     <Course id="159">
@@ -717,10 +717,10 @@
       <teacher reference="34"/>
       <lectureSize>5</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="160">
+      <curriculumSet id="160">
         <Curriculum reference="71"/>
         <Curriculum reference="85"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>23</studentSize>
     </Course>
     <Course id="161">
@@ -729,7 +729,7 @@
       <teacher reference="35"/>
       <lectureSize>6</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="162"/>
+      <curriculumSet id="162"/>
       <studentSize>0</studentSize>
     </Course>
     <Course id="163">
@@ -738,10 +738,10 @@
       <teacher reference="36"/>
       <lectureSize>4</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="164">
+      <curriculumSet id="164">
         <Curriculum reference="70"/>
         <Curriculum reference="94"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>28</studentSize>
     </Course>
     <Course id="165">
@@ -750,10 +750,10 @@
       <teacher reference="37"/>
       <lectureSize>6</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="166">
+      <curriculumSet id="166">
         <Curriculum reference="74"/>
         <Curriculum reference="76"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>31</studentSize>
     </Course>
     <Course id="167">
@@ -762,9 +762,9 @@
       <teacher reference="38"/>
       <lectureSize>5</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="168">
+      <curriculumSet id="168">
         <Curriculum reference="92"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>19</studentSize>
     </Course>
     <Course id="169">
@@ -773,9 +773,9 @@
       <teacher reference="39"/>
       <lectureSize>5</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="170">
+      <curriculumSet id="170">
         <Curriculum reference="64"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>18</studentSize>
     </Course>
     <Course id="171">
@@ -784,7 +784,7 @@
       <teacher reference="40"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="172"/>
+      <curriculumSet id="172"/>
       <studentSize>0</studentSize>
     </Course>
     <Course id="173">
@@ -793,10 +793,10 @@
       <teacher reference="41"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="174">
+      <curriculumSet id="174">
         <Curriculum reference="73"/>
         <Curriculum reference="84"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>30</studentSize>
     </Course>
     <Course id="175">
@@ -805,11 +805,11 @@
       <teacher reference="42"/>
       <lectureSize>2</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="176">
+      <curriculumSet id="176">
         <Curriculum reference="69"/>
         <Curriculum reference="78"/>
         <Curriculum reference="87"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>28</studentSize>
     </Course>
     <Course id="177">
@@ -818,11 +818,11 @@
       <teacher reference="43"/>
       <lectureSize>5</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="178">
+      <curriculumSet id="178">
         <Curriculum reference="74"/>
         <Curriculum reference="77"/>
         <Curriculum reference="78"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>32</studentSize>
     </Course>
     <Course id="179">
@@ -831,11 +831,11 @@
       <teacher reference="44"/>
       <lectureSize>2</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="180">
+      <curriculumSet id="180">
         <Curriculum reference="76"/>
         <Curriculum reference="87"/>
         <Curriculum reference="92"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>41</studentSize>
     </Course>
     <Course id="181">
@@ -844,7 +844,7 @@
       <teacher reference="45"/>
       <lectureSize>2</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="182"/>
+      <curriculumSet id="182"/>
       <studentSize>0</studentSize>
     </Course>
     <Course id="183">
@@ -853,7 +853,7 @@
       <teacher reference="46"/>
       <lectureSize>2</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="184"/>
+      <curriculumSet id="184"/>
       <studentSize>0</studentSize>
     </Course>
     <Course id="185">
@@ -862,10 +862,10 @@
       <teacher reference="47"/>
       <lectureSize>5</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="186">
+      <curriculumSet id="186">
         <Curriculum reference="66"/>
         <Curriculum reference="88"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>34</studentSize>
     </Course>
     <Course id="187">
@@ -874,10 +874,10 @@
       <teacher reference="48"/>
       <lectureSize>6</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="188">
+      <curriculumSet id="188">
         <Curriculum reference="78"/>
         <Curriculum reference="81"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>19</studentSize>
     </Course>
     <Course id="189">
@@ -886,9 +886,9 @@
       <teacher reference="49"/>
       <lectureSize>4</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="190">
+      <curriculumSet id="190">
         <Curriculum reference="81"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>13</studentSize>
     </Course>
     <Course id="191">
@@ -897,9 +897,9 @@
       <teacher reference="50"/>
       <lectureSize>6</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="192">
+      <curriculumSet id="192">
         <Curriculum reference="80"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>12</studentSize>
     </Course>
     <Course id="193">
@@ -908,9 +908,9 @@
       <teacher reference="51"/>
       <lectureSize>4</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="194">
+      <curriculumSet id="194">
         <Curriculum reference="88"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>12</studentSize>
     </Course>
     <Course id="195">
@@ -919,9 +919,9 @@
       <teacher reference="52"/>
       <lectureSize>5</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="196">
+      <curriculumSet id="196">
         <Curriculum reference="81"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>13</studentSize>
     </Course>
     <Course id="197">
@@ -930,10 +930,10 @@
       <teacher reference="53"/>
       <lectureSize>6</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="198">
+      <curriculumSet id="198">
         <Curriculum reference="74"/>
         <Curriculum reference="88"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>30</studentSize>
     </Course>
     <Course id="199">
@@ -942,9 +942,9 @@
       <teacher reference="54"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="200">
+      <curriculumSet id="200">
         <Curriculum reference="81"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>13</studentSize>
     </Course>
     <Course id="201">
@@ -953,11 +953,11 @@
       <teacher reference="55"/>
       <lectureSize>4</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="202">
+      <curriculumSet id="202">
         <Curriculum reference="69"/>
         <Curriculum reference="82"/>
         <Curriculum reference="92"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>49</studentSize>
     </Course>
     <Course id="203">
@@ -966,7 +966,7 @@
       <teacher reference="56"/>
       <lectureSize>7</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="204"/>
+      <curriculumSet id="204"/>
       <studentSize>0</studentSize>
     </Course>
     <Course id="205">
@@ -975,9 +975,9 @@
       <teacher reference="57"/>
       <lectureSize>6</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="206">
+      <curriculumSet id="206">
         <Curriculum reference="79"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>19</studentSize>
     </Course>
     <Course id="207">
@@ -986,10 +986,10 @@
       <teacher reference="58"/>
       <lectureSize>7</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="208">
+      <curriculumSet id="208">
         <Curriculum reference="66"/>
         <Curriculum reference="81"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>35</studentSize>
     </Course>
     <Course id="209">
@@ -998,9 +998,9 @@
       <teacher reference="59"/>
       <lectureSize>2</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="210">
+      <curriculumSet id="210">
         <Curriculum reference="95"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>17</studentSize>
     </Course>
     <Course id="211">
@@ -1009,9 +1009,9 @@
       <teacher reference="60"/>
       <lectureSize>5</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="212">
+      <curriculumSet id="212">
         <Curriculum reference="64"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>18</studentSize>
     </Course>
     <Course id="213">
@@ -1020,9 +1020,9 @@
       <teacher reference="61"/>
       <lectureSize>4</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="214">
+      <curriculumSet id="214">
         <Curriculum reference="80"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>12</studentSize>
     </Course>
     <Course id="215">
@@ -1031,7 +1031,7 @@
       <teacher reference="62"/>
       <lectureSize>5</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="216"/>
+      <curriculumSet id="216"/>
       <studentSize>0</studentSize>
     </Course>
     <Course id="217">
@@ -1040,9 +1040,9 @@
       <teacher reference="3"/>
       <lectureSize>5</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="218">
+      <curriculumSet id="218">
         <Curriculum reference="74"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>18</studentSize>
     </Course>
     <Course id="219">
@@ -1051,10 +1051,10 @@
       <teacher reference="4"/>
       <lectureSize>4</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="220">
+      <curriculumSet id="220">
         <Curriculum reference="73"/>
         <Curriculum reference="83"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>37</studentSize>
     </Course>
     <Course id="221">
@@ -1063,9 +1063,9 @@
       <teacher reference="5"/>
       <lectureSize>6</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="222">
+      <curriculumSet id="222">
         <Curriculum reference="89"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>19</studentSize>
     </Course>
     <Course id="223">
@@ -1074,10 +1074,10 @@
       <teacher reference="6"/>
       <lectureSize>5</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="224">
+      <curriculumSet id="224">
         <Curriculum reference="87"/>
         <Curriculum reference="92"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>28</studentSize>
     </Course>
     <Course id="225">
@@ -1086,7 +1086,7 @@
       <teacher reference="7"/>
       <lectureSize>6</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="226"/>
+      <curriculumSet id="226"/>
       <studentSize>0</studentSize>
     </Course>
     <Course id="227">
@@ -1095,9 +1095,9 @@
       <teacher reference="8"/>
       <lectureSize>9</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="228">
+      <curriculumSet id="228">
         <Curriculum reference="91"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>21</studentSize>
     </Course>
     <Course id="229">
@@ -1106,7 +1106,7 @@
       <teacher reference="9"/>
       <lectureSize>5</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="230"/>
+      <curriculumSet id="230"/>
       <studentSize>0</studentSize>
     </Course>
     <Course id="231">
@@ -1115,10 +1115,10 @@
       <teacher reference="10"/>
       <lectureSize>5</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="232">
+      <curriculumSet id="232">
         <Curriculum reference="79"/>
         <Curriculum reference="86"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>35</studentSize>
     </Course>
     <Course id="233">
@@ -1127,10 +1127,10 @@
       <teacher reference="11"/>
       <lectureSize>4</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="234">
+      <curriculumSet id="234">
         <Curriculum reference="66"/>
         <Curriculum reference="82"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>39</studentSize>
     </Course>
     <Course id="235">
@@ -1139,9 +1139,9 @@
       <teacher reference="12"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="236">
+      <curriculumSet id="236">
         <Curriculum reference="94"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>13</studentSize>
     </Course>
     <Course id="237">
@@ -1150,7 +1150,7 @@
       <teacher reference="13"/>
       <lectureSize>5</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="238"/>
+      <curriculumSet id="238"/>
       <studentSize>0</studentSize>
     </Course>
     <Course id="239">
@@ -1159,11 +1159,11 @@
       <teacher reference="14"/>
       <lectureSize>4</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="240">
+      <curriculumSet id="240">
         <Curriculum reference="71"/>
         <Curriculum reference="75"/>
         <Curriculum reference="82"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>38</studentSize>
     </Course>
     <Course id="241">
@@ -1172,9 +1172,9 @@
       <teacher reference="15"/>
       <lectureSize>2</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="242">
+      <curriculumSet id="242">
         <Curriculum reference="76"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>13</studentSize>
     </Course>
     <Course id="243">
@@ -1183,9 +1183,9 @@
       <teacher reference="16"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="244">
+      <curriculumSet id="244">
         <Curriculum reference="70"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>15</studentSize>
     </Course>
     <Course id="245">
@@ -1194,7 +1194,7 @@
       <teacher reference="17"/>
       <lectureSize>5</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="246"/>
+      <curriculumSet id="246"/>
       <studentSize>0</studentSize>
     </Course>
     <Course id="247">
@@ -1203,7 +1203,7 @@
       <teacher reference="18"/>
       <lectureSize>4</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="248"/>
+      <curriculumSet id="248"/>
       <studentSize>0</studentSize>
     </Course>
     <Course id="249">
@@ -1212,9 +1212,9 @@
       <teacher reference="19"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="250">
+      <curriculumSet id="250">
         <Curriculum reference="69"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>13</studentSize>
     </Course>
     <Course id="251">
@@ -1223,7 +1223,7 @@
       <teacher reference="20"/>
       <lectureSize>7</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="252"/>
+      <curriculumSet id="252"/>
       <studentSize>0</studentSize>
     </Course>
     <Course id="253">
@@ -1232,11 +1232,11 @@
       <teacher reference="21"/>
       <lectureSize>2</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="254">
+      <curriculumSet id="254">
         <Curriculum reference="79"/>
         <Curriculum reference="82"/>
         <Curriculum reference="88"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>48</studentSize>
     </Course>
     <Course id="255">
@@ -1245,9 +1245,9 @@
       <teacher reference="22"/>
       <lectureSize>7</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="256">
+      <curriculumSet id="256">
         <Curriculum reference="75"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>9</studentSize>
     </Course>
     <Course id="257">
@@ -1256,9 +1256,9 @@
       <teacher reference="23"/>
       <lectureSize>8</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="258">
+      <curriculumSet id="258">
         <Curriculum reference="77"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>8</studentSize>
     </Course>
     <Course id="259">
@@ -1267,10 +1267,10 @@
       <teacher reference="24"/>
       <lectureSize>7</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="260">
+      <curriculumSet id="260">
         <Curriculum reference="83"/>
         <Curriculum reference="85"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>27</studentSize>
     </Course>
     <Course id="261">
@@ -1279,7 +1279,7 @@
       <teacher reference="25"/>
       <lectureSize>2</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="262"/>
+      <curriculumSet id="262"/>
       <studentSize>0</studentSize>
     </Course>
     <Course id="263">
@@ -1288,11 +1288,11 @@
       <teacher reference="26"/>
       <lectureSize>4</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="264">
+      <curriculumSet id="264">
         <Curriculum reference="66"/>
         <Curriculum reference="75"/>
         <Curriculum reference="85"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>42</studentSize>
     </Course>
     <Course id="265">
@@ -1301,7 +1301,7 @@
       <teacher reference="27"/>
       <lectureSize>4</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="266"/>
+      <curriculumSet id="266"/>
       <studentSize>0</studentSize>
     </Course>
     <Course id="267">
@@ -1310,9 +1310,9 @@
       <teacher reference="28"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="268">
+      <curriculumSet id="268">
         <Curriculum reference="78"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>6</studentSize>
     </Course>
     <Course id="269">
@@ -1321,9 +1321,9 @@
       <teacher reference="29"/>
       <lectureSize>4</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="270">
+      <curriculumSet id="270">
         <Curriculum reference="65"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>10</studentSize>
     </Course>
     <Course id="271">
@@ -1332,7 +1332,7 @@
       <teacher reference="30"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="272"/>
+      <curriculumSet id="272"/>
       <studentSize>0</studentSize>
     </Course>
     <Course id="273">
@@ -1341,7 +1341,7 @@
       <teacher reference="31"/>
       <lectureSize>4</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="274"/>
+      <curriculumSet id="274"/>
       <studentSize>0</studentSize>
     </Course>
     <Course id="275">
@@ -1350,7 +1350,7 @@
       <teacher reference="32"/>
       <lectureSize>4</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="276"/>
+      <curriculumSet id="276"/>
       <studentSize>0</studentSize>
     </Course>
     <Course id="277">
@@ -1359,7 +1359,7 @@
       <teacher reference="33"/>
       <lectureSize>7</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="278"/>
+      <curriculumSet id="278"/>
       <studentSize>0</studentSize>
     </Course>
     <Course id="279">
@@ -1368,10 +1368,10 @@
       <teacher reference="34"/>
       <lectureSize>7</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="280">
+      <curriculumSet id="280">
         <Curriculum reference="73"/>
         <Curriculum reference="76"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>34</studentSize>
     </Course>
     <Course id="281">
@@ -1380,10 +1380,10 @@
       <teacher reference="35"/>
       <lectureSize>4</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="282">
+      <curriculumSet id="282">
         <Curriculum reference="89"/>
         <Curriculum reference="92"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>38</studentSize>
     </Course>
     <Course id="283">
@@ -1392,9 +1392,9 @@
       <teacher reference="36"/>
       <lectureSize>5</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="284">
+      <curriculumSet id="284">
         <Curriculum reference="70"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>15</studentSize>
     </Course>
     <Course id="285">
@@ -1403,10 +1403,10 @@
       <teacher reference="37"/>
       <lectureSize>8</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="286">
+      <curriculumSet id="286">
         <Curriculum reference="71"/>
         <Curriculum reference="73"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>33</studentSize>
     </Course>
     <Course id="287">
@@ -1415,9 +1415,9 @@
       <teacher reference="38"/>
       <lectureSize>4</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="288">
+      <curriculumSet id="288">
         <Curriculum reference="76"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>13</studentSize>
     </Course>
     <Course id="289">
@@ -1426,10 +1426,10 @@
       <teacher reference="39"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="290">
+      <curriculumSet id="290">
         <Curriculum reference="79"/>
         <Curriculum reference="88"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>31</studentSize>
     </Course>
     <Course id="291">
@@ -1438,7 +1438,7 @@
       <teacher reference="40"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="292"/>
+      <curriculumSet id="292"/>
       <studentSize>0</studentSize>
     </Course>
     <Course id="293">
@@ -1447,10 +1447,10 @@
       <teacher reference="41"/>
       <lectureSize>6</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="294">
+      <curriculumSet id="294">
         <Curriculum reference="78"/>
         <Curriculum reference="86"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>22</studentSize>
     </Course>
     <Course id="295">
@@ -1459,7 +1459,7 @@
       <teacher reference="42"/>
       <lectureSize>5</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="296"/>
+      <curriculumSet id="296"/>
       <studentSize>0</studentSize>
     </Course>
     <Course id="297">
@@ -1468,10 +1468,10 @@
       <teacher reference="43"/>
       <lectureSize>4</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="298">
+      <curriculumSet id="298">
         <Curriculum reference="82"/>
         <Curriculum reference="94"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>30</studentSize>
     </Course>
     <Course id="299">
@@ -1480,9 +1480,9 @@
       <teacher reference="44"/>
       <lectureSize>5</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="300">
+      <curriculumSet id="300">
         <Curriculum reference="87"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>9</studentSize>
     </Course>
     <Course id="301">
@@ -1491,7 +1491,7 @@
       <teacher reference="45"/>
       <lectureSize>4</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="302"/>
+      <curriculumSet id="302"/>
       <studentSize>0</studentSize>
     </Course>
     <Course id="303">
@@ -1500,10 +1500,10 @@
       <teacher reference="46"/>
       <lectureSize>2</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="304">
+      <curriculumSet id="304">
         <Curriculum reference="67"/>
         <Curriculum reference="87"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>22</studentSize>
     </Course>
     <Course id="305">
@@ -1512,9 +1512,9 @@
       <teacher reference="47"/>
       <lectureSize>5</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="306">
+      <curriculumSet id="306">
         <Curriculum reference="75"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>9</studentSize>
     </Course>
     <Course id="307">
@@ -1523,9 +1523,9 @@
       <teacher reference="48"/>
       <lectureSize>2</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="308">
+      <curriculumSet id="308">
         <Curriculum reference="65"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>10</studentSize>
     </Course>
     <Course id="309">
@@ -1534,9 +1534,9 @@
       <teacher reference="49"/>
       <lectureSize>5</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="310">
+      <curriculumSet id="310">
         <Curriculum reference="95"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>17</studentSize>
     </Course>
     <Course id="311">
@@ -1545,9 +1545,9 @@
       <teacher reference="50"/>
       <lectureSize>4</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="312">
+      <curriculumSet id="312">
         <Curriculum reference="94"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>13</studentSize>
     </Course>
     <Course id="313">
@@ -1556,9 +1556,9 @@
       <teacher reference="51"/>
       <lectureSize>4</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="314">
+      <curriculumSet id="314">
         <Curriculum reference="65"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>10</studentSize>
     </Course>
     <Course id="315">
@@ -1567,10 +1567,10 @@
       <teacher reference="52"/>
       <lectureSize>6</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="316">
+      <curriculumSet id="316">
         <Curriculum reference="66"/>
         <Curriculum reference="84"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>31</studentSize>
     </Course>
     <Course id="317">
@@ -1579,7 +1579,7 @@
       <teacher reference="53"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="318"/>
+      <curriculumSet id="318"/>
       <studentSize>0</studentSize>
     </Course>
     <Course id="319">
@@ -1588,10 +1588,10 @@
       <teacher reference="54"/>
       <lectureSize>5</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="320">
+      <curriculumSet id="320">
         <Curriculum reference="65"/>
         <Curriculum reference="72"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>26</studentSize>
     </Course>
     <Course id="321">
@@ -1600,10 +1600,10 @@
       <teacher reference="55"/>
       <lectureSize>7</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="322">
+      <curriculumSet id="322">
         <Curriculum reference="89"/>
         <Curriculum reference="95"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>36</studentSize>
     </Course>
     <Course id="323">
@@ -1612,9 +1612,9 @@
       <teacher reference="56"/>
       <lectureSize>5</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="324">
+      <curriculumSet id="324">
         <Curriculum reference="86"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>16</studentSize>
     </Course>
     <Course id="325">
@@ -1623,9 +1623,9 @@
       <teacher reference="57"/>
       <lectureSize>6</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="326">
+      <curriculumSet id="326">
         <Curriculum reference="89"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>19</studentSize>
     </Course>
     <Course id="327">
@@ -1634,9 +1634,9 @@
       <teacher reference="58"/>
       <lectureSize>5</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="328">
+      <curriculumSet id="328">
         <Curriculum reference="83"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>16</studentSize>
     </Course>
     <Course id="329">
@@ -1645,10 +1645,10 @@
       <teacher reference="59"/>
       <lectureSize>6</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="330">
+      <curriculumSet id="330">
         <Curriculum reference="69"/>
         <Curriculum reference="83"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>29</studentSize>
     </Course>
     <Course id="331">
@@ -1657,9 +1657,9 @@
       <teacher reference="60"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="332">
+      <curriculumSet id="332">
         <Curriculum reference="83"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>16</studentSize>
     </Course>
     <Course id="333">
@@ -1668,9 +1668,9 @@
       <teacher reference="61"/>
       <lectureSize>7</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="334">
+      <curriculumSet id="334">
         <Curriculum reference="68"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>14</studentSize>
     </Course>
     <Course id="335">
@@ -1679,10 +1679,10 @@
       <teacher reference="62"/>
       <lectureSize>6</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="336">
+      <curriculumSet id="336">
         <Curriculum reference="80"/>
         <Curriculum reference="94"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>25</studentSize>
     </Course>
     <Course id="337">
@@ -1691,9 +1691,9 @@
       <teacher reference="12"/>
       <lectureSize>4</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="338">
+      <curriculumSet id="338">
         <Curriculum reference="90"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>12</studentSize>
     </Course>
     <Course id="339">
@@ -1702,10 +1702,10 @@
       <teacher reference="40"/>
       <lectureSize>2</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="340">
+      <curriculumSet id="340">
         <Curriculum reference="64"/>
         <Curriculum reference="95"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>35</studentSize>
     </Course>
     <Course id="341">
@@ -1714,7 +1714,7 @@
       <teacher reference="44"/>
       <lectureSize>4</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="342"/>
+      <curriculumSet id="342"/>
       <studentSize>0</studentSize>
     </Course>
     <Course id="343">
@@ -1723,11 +1723,11 @@
       <teacher reference="20"/>
       <lectureSize>4</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="344">
+      <curriculumSet id="344">
         <Curriculum reference="72"/>
         <Curriculum reference="82"/>
         <Curriculum reference="85"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>44</studentSize>
     </Course>
     <Course id="345">
@@ -1736,7 +1736,7 @@
       <teacher reference="52"/>
       <lectureSize>5</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="346"/>
+      <curriculumSet id="346"/>
       <studentSize>0</studentSize>
     </Course>
     <Course id="347">
@@ -1745,9 +1745,9 @@
       <teacher reference="44"/>
       <lectureSize>6</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="348">
+      <curriculumSet id="348">
         <Curriculum reference="79"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>19</studentSize>
     </Course>
     <Course id="349">
@@ -1756,10 +1756,10 @@
       <teacher reference="50"/>
       <lectureSize>5</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="350">
+      <curriculumSet id="350">
         <Curriculum reference="84"/>
         <Curriculum reference="91"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>30</studentSize>
     </Course>
     <Course id="351">
@@ -1768,9 +1768,9 @@
       <teacher reference="9"/>
       <lectureSize>5</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="352">
+      <curriculumSet id="352">
         <Curriculum reference="95"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>17</studentSize>
     </Course>
     <Course id="353">
@@ -1779,10 +1779,10 @@
       <teacher reference="23"/>
       <lectureSize>4</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="354">
+      <curriculumSet id="354">
         <Curriculum reference="67"/>
         <Curriculum reference="90"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>25</studentSize>
     </Course>
     <Course id="355">
@@ -1791,9 +1791,9 @@
       <teacher reference="41"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="356">
+      <curriculumSet id="356">
         <Curriculum reference="76"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>13</studentSize>
     </Course>
     <Course id="357">
@@ -1802,7 +1802,7 @@
       <teacher reference="40"/>
       <lectureSize>6</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="358"/>
+      <curriculumSet id="358"/>
       <studentSize>0</studentSize>
     </Course>
     <Course id="359">
@@ -1811,7 +1811,7 @@
       <teacher reference="42"/>
       <lectureSize>4</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="360"/>
+      <curriculumSet id="360"/>
       <studentSize>0</studentSize>
     </Course>
     <Course id="361">
@@ -1820,12 +1820,12 @@
       <teacher reference="24"/>
       <lectureSize>5</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="362">
+      <curriculumSet id="362">
         <Curriculum reference="76"/>
         <Curriculum reference="80"/>
         <Curriculum reference="87"/>
         <Curriculum reference="90"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>46</studentSize>
     </Course>
     <Course id="363">
@@ -1834,7 +1834,7 @@
       <teacher reference="53"/>
       <lectureSize>4</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="364"/>
+      <curriculumSet id="364"/>
       <studentSize>0</studentSize>
     </Course>
     <Course id="365">
@@ -1843,7 +1843,7 @@
       <teacher reference="44"/>
       <lectureSize>5</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="366"/>
+      <curriculumSet id="366"/>
       <studentSize>0</studentSize>
     </Course>
     <Course id="367">
@@ -1852,10 +1852,10 @@
       <teacher reference="42"/>
       <lectureSize>4</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="368">
+      <curriculumSet id="368">
         <Curriculum reference="74"/>
         <Curriculum reference="90"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>30</studentSize>
     </Course>
     <Course id="369">
@@ -1864,10 +1864,10 @@
       <teacher reference="55"/>
       <lectureSize>6</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="370">
+      <curriculumSet id="370">
         <Curriculum reference="80"/>
         <Curriculum reference="93"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>20</studentSize>
     </Course>
     <Course id="371">
@@ -1876,10 +1876,10 @@
       <teacher reference="51"/>
       <lectureSize>4</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="372">
+      <curriculumSet id="372">
         <Curriculum reference="69"/>
         <Curriculum reference="91"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>34</studentSize>
     </Course>
     <Course id="373">
@@ -1888,7 +1888,7 @@
       <teacher reference="49"/>
       <lectureSize>4</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="374"/>
+      <curriculumSet id="374"/>
       <studentSize>0</studentSize>
     </Course>
     <Course id="375">
@@ -1897,9 +1897,9 @@
       <teacher reference="57"/>
       <lectureSize>7</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="376">
+      <curriculumSet id="376">
         <Curriculum reference="68"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>14</studentSize>
     </Course>
     <Course id="377">
@@ -1908,10 +1908,10 @@
       <teacher reference="38"/>
       <lectureSize>6</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="378">
+      <curriculumSet id="378">
         <Curriculum reference="67"/>
         <Curriculum reference="92"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>32</studentSize>
     </Course>
     <Course id="379">
@@ -1920,10 +1920,10 @@
       <teacher reference="35"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="380">
+      <curriculumSet id="380">
         <Curriculum reference="70"/>
         <Curriculum reference="72"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>31</studentSize>
     </Course>
     <Course id="381">
@@ -1932,9 +1932,9 @@
       <teacher reference="57"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="382">
+      <curriculumSet id="382">
         <Curriculum reference="69"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>13</studentSize>
     </Course>
     <Course id="383">
@@ -1943,10 +1943,10 @@
       <teacher reference="17"/>
       <lectureSize>2</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="384">
+      <curriculumSet id="384">
         <Curriculum reference="69"/>
         <Curriculum reference="92"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>32</studentSize>
     </Course>
     <Course id="385">
@@ -1955,9 +1955,9 @@
       <teacher reference="39"/>
       <lectureSize>4</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="386">
+      <curriculumSet id="386">
         <Curriculum reference="82"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>17</studentSize>
     </Course>
     <Course id="387">
@@ -1966,11 +1966,11 @@
       <teacher reference="53"/>
       <lectureSize>4</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="388">
+      <curriculumSet id="388">
         <Curriculum reference="73"/>
         <Curriculum reference="84"/>
         <Curriculum reference="87"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>39</studentSize>
     </Course>
     <Course id="389">
@@ -1979,9 +1979,9 @@
       <teacher reference="19"/>
       <lectureSize>5</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="390">
+      <curriculumSet id="390">
         <Curriculum reference="68"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>14</studentSize>
     </Course>
     <Course id="391">
@@ -1990,11 +1990,11 @@
       <teacher reference="21"/>
       <lectureSize>6</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="392">
+      <curriculumSet id="392">
         <Curriculum reference="65"/>
         <Curriculum reference="71"/>
         <Curriculum reference="90"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>34</studentSize>
     </Course>
     <Course id="393">
@@ -2003,9 +2003,9 @@
       <teacher reference="11"/>
       <lectureSize>4</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="394">
+      <curriculumSet id="394">
         <Curriculum reference="83"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>16</studentSize>
     </Course>
     <Course id="395">
@@ -2014,10 +2014,10 @@
       <teacher reference="50"/>
       <lectureSize>2</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="396">
+      <curriculumSet id="396">
         <Curriculum reference="73"/>
         <Curriculum reference="79"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>40</studentSize>
     </Course>
     <Course id="397">
@@ -2026,7 +2026,7 @@
       <teacher reference="29"/>
       <lectureSize>5</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="398"/>
+      <curriculumSet id="398"/>
       <studentSize>0</studentSize>
     </Course>
     <Course id="399">
@@ -2035,10 +2035,10 @@
       <teacher reference="26"/>
       <lectureSize>4</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="400">
+      <curriculumSet id="400">
         <Curriculum reference="64"/>
         <Curriculum reference="70"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>33</studentSize>
     </Course>
     <Course id="401">
@@ -2047,9 +2047,9 @@
       <teacher reference="17"/>
       <lectureSize>4</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="402">
+      <curriculumSet id="402">
         <Curriculum reference="72"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>16</studentSize>
     </Course>
     <Course id="403">
@@ -2058,7 +2058,7 @@
       <teacher reference="60"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="404"/>
+      <curriculumSet id="404"/>
       <studentSize>0</studentSize>
     </Course>
     <Course id="405">
@@ -2067,7 +2067,7 @@
       <teacher reference="62"/>
       <lectureSize>7</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="406"/>
+      <curriculumSet id="406"/>
       <studentSize>0</studentSize>
     </Course>
     <Course id="407">
@@ -2076,7 +2076,7 @@
       <teacher reference="8"/>
       <lectureSize>5</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="408"/>
+      <curriculumSet id="408"/>
       <studentSize>0</studentSize>
     </Course>
     <Course id="409">
@@ -2085,7 +2085,7 @@
       <teacher reference="33"/>
       <lectureSize>6</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="410"/>
+      <curriculumSet id="410"/>
       <studentSize>0</studentSize>
     </Course>
     <Course id="411">
@@ -2094,10 +2094,10 @@
       <teacher reference="10"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="412">
+      <curriculumSet id="412">
         <Curriculum reference="81"/>
         <Curriculum reference="91"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>34</studentSize>
     </Course>
     <Course id="413">
@@ -2106,7 +2106,7 @@
       <teacher reference="16"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="414"/>
+      <curriculumSet id="414"/>
       <studentSize>0</studentSize>
     </Course>
     <Course id="415">
@@ -2115,9 +2115,9 @@
       <teacher reference="45"/>
       <lectureSize>2</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="416">
+      <curriculumSet id="416">
         <Curriculum reference="87"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>9</studentSize>
     </Course>
     <Course id="417">
@@ -2126,7 +2126,7 @@
       <teacher reference="33"/>
       <lectureSize>5</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="418"/>
+      <curriculumSet id="418"/>
       <studentSize>0</studentSize>
     </Course>
     <Course id="419">
@@ -2135,9 +2135,9 @@
       <teacher reference="17"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="420">
+      <curriculumSet id="420">
         <Curriculum reference="93"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>8</studentSize>
     </Course>
     <Course id="421">
@@ -2146,10 +2146,10 @@
       <teacher reference="15"/>
       <lectureSize>2</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="422">
+      <curriculumSet id="422">
         <Curriculum reference="72"/>
         <Curriculum reference="73"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>37</studentSize>
     </Course>
     <Course id="423">
@@ -2158,9 +2158,9 @@
       <teacher reference="62"/>
       <lectureSize>5</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="424">
+      <curriculumSet id="424">
         <Curriculum reference="77"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>8</studentSize>
     </Course>
     <Course id="425">
@@ -2169,7 +2169,7 @@
       <teacher reference="38"/>
       <lectureSize>5</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="426"/>
+      <curriculumSet id="426"/>
       <studentSize>0</studentSize>
     </Course>
     <Course id="427">
@@ -2178,11 +2178,11 @@
       <teacher reference="53"/>
       <lectureSize>6</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="428">
+      <curriculumSet id="428">
         <Curriculum reference="65"/>
         <Curriculum reference="67"/>
         <Curriculum reference="91"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>44</studentSize>
     </Course>
     <Course id="429">
@@ -2191,10 +2191,10 @@
       <teacher reference="56"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="430">
+      <curriculumSet id="430">
         <Curriculum reference="80"/>
         <Curriculum reference="86"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>28</studentSize>
     </Course>
     <Course id="431">
@@ -2203,10 +2203,10 @@
       <teacher reference="44"/>
       <lectureSize>9</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="432">
+      <curriculumSet id="432">
         <Curriculum reference="84"/>
         <Curriculum reference="90"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>21</studentSize>
     </Course>
     <Course id="433">
@@ -2215,9 +2215,9 @@
       <teacher reference="3"/>
       <lectureSize>7</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="434">
+      <curriculumSet id="434">
         <Curriculum reference="85"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>11</studentSize>
     </Course>
     <Course id="435">
@@ -2226,10 +2226,10 @@
       <teacher reference="29"/>
       <lectureSize>2</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="436">
+      <curriculumSet id="436">
         <Curriculum reference="80"/>
         <Curriculum reference="89"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>31</studentSize>
     </Course>
     <Course id="437">
@@ -2238,7 +2238,7 @@
       <teacher reference="11"/>
       <lectureSize>4</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="438"/>
+      <curriculumSet id="438"/>
       <studentSize>0</studentSize>
     </Course>
     <Course id="439">
@@ -2247,7 +2247,7 @@
       <teacher reference="20"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="440"/>
+      <curriculumSet id="440"/>
       <studentSize>0</studentSize>
     </Course>
     <Course id="441">
@@ -2256,11 +2256,11 @@
       <teacher reference="60"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="442">
+      <curriculumSet id="442">
         <Curriculum reference="71"/>
         <Curriculum reference="75"/>
         <Curriculum reference="92"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>40</studentSize>
     </Course>
     <Course id="443">
@@ -2269,10 +2269,10 @@
       <teacher reference="25"/>
       <lectureSize>4</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="444">
+      <curriculumSet id="444">
         <Curriculum reference="67"/>
         <Curriculum reference="82"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>30</studentSize>
     </Course>
     <Course id="445">
@@ -2281,7 +2281,7 @@
       <teacher reference="9"/>
       <lectureSize>4</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="446"/>
+      <curriculumSet id="446"/>
       <studentSize>0</studentSize>
     </Course>
     <Course id="447">
@@ -2290,9 +2290,9 @@
       <teacher reference="6"/>
       <lectureSize>6</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="448">
+      <curriculumSet id="448">
         <Curriculum reference="89"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>19</studentSize>
     </Course>
     <Course id="449">
@@ -2301,10 +2301,10 @@
       <teacher reference="52"/>
       <lectureSize>4</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="450">
+      <curriculumSet id="450">
         <Curriculum reference="74"/>
         <Curriculum reference="91"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>39</studentSize>
     </Course>
     <Course id="451">
@@ -2313,10 +2313,10 @@
       <teacher reference="3"/>
       <lectureSize>4</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="452">
+      <curriculumSet id="452">
         <Curriculum reference="70"/>
         <Curriculum reference="86"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>31</studentSize>
     </Course>
   </courseList>

--- a/optaplanner-examples/data/curriculumcourse/unsolved/comp01.xml
+++ b/optaplanner-examples/data/curriculumcourse/unsolved/comp01.xml
@@ -164,10 +164,10 @@
       <teacher reference="7"/>
       <lectureSize>6</lectureSize>
       <minWorkingDaySize>4</minWorkingDaySize>
-      <curriculumList id="44">
+      <curriculumSet id="44">
         <Curriculum reference="28"/>
         <Curriculum reference="30"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>130</studentSize>
     </Course>
     <Course id="45">
@@ -176,9 +176,9 @@
       <teacher reference="8"/>
       <lectureSize>6</lectureSize>
       <minWorkingDaySize>4</minWorkingDaySize>
-      <curriculumList id="46">
+      <curriculumSet id="46">
         <Curriculum reference="28"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>75</studentSize>
     </Course>
     <Course id="47">
@@ -187,10 +187,10 @@
       <teacher reference="4"/>
       <lectureSize>7</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="48">
+      <curriculumSet id="48">
         <Curriculum reference="28"/>
         <Curriculum reference="40"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>117</studentSize>
     </Course>
     <Course id="49">
@@ -199,9 +199,9 @@
       <teacher reference="6"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="50">
+      <curriculumSet id="50">
         <Curriculum reference="28"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>75</studentSize>
     </Course>
     <Course id="51">
@@ -210,9 +210,9 @@
       <teacher reference="19"/>
       <lectureSize>1</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="52">
+      <curriculumSet id="52">
         <Curriculum reference="29"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>65</studentSize>
     </Course>
     <Course id="53">
@@ -221,9 +221,9 @@
       <teacher reference="17"/>
       <lectureSize>8</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="54">
+      <curriculumSet id="54">
         <Curriculum reference="29"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>65</studentSize>
     </Course>
     <Course id="55">
@@ -232,9 +232,9 @@
       <teacher reference="23"/>
       <lectureSize>7</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="56">
+      <curriculumSet id="56">
         <Curriculum reference="29"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>65</studentSize>
     </Course>
     <Course id="57">
@@ -243,9 +243,9 @@
       <teacher reference="21"/>
       <lectureSize>2</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="58">
+      <curriculumSet id="58">
         <Curriculum reference="29"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>65</studentSize>
     </Course>
     <Course id="59">
@@ -254,9 +254,9 @@
       <teacher reference="25"/>
       <lectureSize>4</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="60">
+      <curriculumSet id="60">
         <Curriculum reference="30"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>55</studentSize>
     </Course>
     <Course id="61">
@@ -265,9 +265,9 @@
       <teacher reference="24"/>
       <lectureSize>8</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="62">
+      <curriculumSet id="62">
         <Curriculum reference="30"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>55</studentSize>
     </Course>
     <Course id="63">
@@ -276,9 +276,9 @@
       <teacher reference="9"/>
       <lectureSize>5</lectureSize>
       <minWorkingDaySize>4</minWorkingDaySize>
-      <curriculumList id="64">
+      <curriculumSet id="64">
         <Curriculum reference="30"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>55</studentSize>
     </Course>
     <Course id="65">
@@ -287,9 +287,9 @@
       <teacher reference="10"/>
       <lectureSize>5</lectureSize>
       <minWorkingDaySize>4</minWorkingDaySize>
-      <curriculumList id="66">
+      <curriculumSet id="66">
         <Curriculum reference="31"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>20</studentSize>
     </Course>
     <Course id="67">
@@ -298,9 +298,9 @@
       <teacher reference="11"/>
       <lectureSize>5</lectureSize>
       <minWorkingDaySize>4</minWorkingDaySize>
-      <curriculumList id="68">
+      <curriculumSet id="68">
         <Curriculum reference="32"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>11</studentSize>
     </Course>
     <Course id="69">
@@ -309,10 +309,10 @@
       <teacher reference="13"/>
       <lectureSize>1</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="70">
+      <curriculumSet id="70">
         <Curriculum reference="31"/>
         <Curriculum reference="32"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>31</studentSize>
     </Course>
     <Course id="71">
@@ -321,10 +321,10 @@
       <teacher reference="15"/>
       <lectureSize>6</lectureSize>
       <minWorkingDaySize>4</minWorkingDaySize>
-      <curriculumList id="72">
+      <curriculumSet id="72">
         <Curriculum reference="31"/>
         <Curriculum reference="32"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>31</studentSize>
     </Course>
     <Course id="73">
@@ -333,9 +333,9 @@
       <teacher reference="22"/>
       <lectureSize>5</lectureSize>
       <minWorkingDaySize>4</minWorkingDaySize>
-      <curriculumList id="74">
+      <curriculumSet id="74">
         <Curriculum reference="34"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>2</studentSize>
     </Course>
     <Course id="75">
@@ -344,9 +344,9 @@
       <teacher reference="20"/>
       <lectureSize>5</lectureSize>
       <minWorkingDaySize>4</minWorkingDaySize>
-      <curriculumList id="76">
+      <curriculumSet id="76">
         <Curriculum reference="38"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>2</studentSize>
     </Course>
     <Course id="77">
@@ -355,10 +355,10 @@
       <teacher reference="18"/>
       <lectureSize>6</lectureSize>
       <minWorkingDaySize>4</minWorkingDaySize>
-      <curriculumList id="78">
+      <curriculumSet id="78">
         <Curriculum reference="34"/>
         <Curriculum reference="36"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>7</studentSize>
     </Course>
     <Course id="79">
@@ -367,9 +367,9 @@
       <teacher reference="16"/>
       <lectureSize>6</lectureSize>
       <minWorkingDaySize>4</minWorkingDaySize>
-      <curriculumList id="80">
+      <curriculumSet id="80">
         <Curriculum reference="35"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>6</studentSize>
     </Course>
     <Course id="81">
@@ -378,10 +378,10 @@
       <teacher reference="26"/>
       <lectureSize>5</lectureSize>
       <minWorkingDaySize>4</minWorkingDaySize>
-      <curriculumList id="82">
+      <curriculumSet id="82">
         <Curriculum reference="35"/>
         <Curriculum reference="41"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>10</studentSize>
     </Course>
     <Course id="83">
@@ -390,10 +390,10 @@
       <teacher reference="3"/>
       <lectureSize>6</lectureSize>
       <minWorkingDaySize>4</minWorkingDaySize>
-      <curriculumList id="84">
+      <curriculumSet id="84">
         <Curriculum reference="37"/>
         <Curriculum reference="38"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>8</studentSize>
     </Course>
     <Course id="85">
@@ -402,9 +402,9 @@
       <teacher reference="3"/>
       <lectureSize>6</lectureSize>
       <minWorkingDaySize>4</minWorkingDaySize>
-      <curriculumList id="86">
+      <curriculumSet id="86">
         <Curriculum reference="37"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>6</studentSize>
     </Course>
     <Course id="87">
@@ -413,9 +413,9 @@
       <teacher reference="5"/>
       <lectureSize>6</lectureSize>
       <minWorkingDaySize>4</minWorkingDaySize>
-      <curriculumList id="88">
+      <curriculumSet id="88">
         <Curriculum reference="36"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>5</studentSize>
     </Course>
     <Course id="89">
@@ -424,11 +424,11 @@
       <teacher reference="25"/>
       <lectureSize>6</lectureSize>
       <minWorkingDaySize>4</minWorkingDaySize>
-      <curriculumList id="90">
+      <curriculumSet id="90">
         <Curriculum reference="33"/>
         <Curriculum reference="37"/>
         <Curriculum reference="41"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>14</studentSize>
     </Course>
     <Course id="91">
@@ -437,9 +437,9 @@
       <teacher reference="12"/>
       <lectureSize>5</lectureSize>
       <minWorkingDaySize>4</minWorkingDaySize>
-      <curriculumList id="92">
+      <curriculumSet id="92">
         <Curriculum reference="39"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>7</studentSize>
     </Course>
     <Course id="93">
@@ -448,10 +448,10 @@
       <teacher reference="14"/>
       <lectureSize>6</lectureSize>
       <minWorkingDaySize>4</minWorkingDaySize>
-      <curriculumList id="94">
+      <curriculumSet id="94">
         <Curriculum reference="38"/>
         <Curriculum reference="39"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>9</studentSize>
     </Course>
     <Course id="95">
@@ -460,9 +460,9 @@
       <teacher reference="21"/>
       <lectureSize>6</lectureSize>
       <minWorkingDaySize>4</minWorkingDaySize>
-      <curriculumList id="96">
+      <curriculumSet id="96">
         <Curriculum reference="39"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>7</studentSize>
     </Course>
     <Course id="97">
@@ -471,9 +471,9 @@
       <teacher reference="4"/>
       <lectureSize>6</lectureSize>
       <minWorkingDaySize>4</minWorkingDaySize>
-      <curriculumList id="98">
+      <curriculumSet id="98">
         <Curriculum reference="33"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>4</studentSize>
     </Course>
     <Course id="99">
@@ -482,10 +482,10 @@
       <teacher reference="8"/>
       <lectureSize>6</lectureSize>
       <minWorkingDaySize>4</minWorkingDaySize>
-      <curriculumList id="100">
+      <curriculumSet id="100">
         <Curriculum reference="37"/>
         <Curriculum reference="41"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>10</studentSize>
     </Course>
     <Course id="101">
@@ -494,10 +494,10 @@
       <teacher reference="6"/>
       <lectureSize>6</lectureSize>
       <minWorkingDaySize>4</minWorkingDaySize>
-      <curriculumList id="102">
+      <curriculumSet id="102">
         <Curriculum reference="33"/>
         <Curriculum reference="36"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>9</studentSize>
     </Course>
   </courseList>

--- a/optaplanner-examples/data/curriculumcourse/unsolved/comp01_initialized.xml
+++ b/optaplanner-examples/data/curriculumcourse/unsolved/comp01_initialized.xml
@@ -164,10 +164,10 @@
       <teacher reference="7"/>
       <lectureSize>6</lectureSize>
       <minWorkingDaySize>4</minWorkingDaySize>
-      <curriculumList id="44">
+      <curriculumSet id="44">
         <Curriculum reference="28"/>
         <Curriculum reference="30"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>130</studentSize>
     </Course>
     <Course id="45">
@@ -176,9 +176,9 @@
       <teacher reference="8"/>
       <lectureSize>6</lectureSize>
       <minWorkingDaySize>4</minWorkingDaySize>
-      <curriculumList id="46">
+      <curriculumSet id="46">
         <Curriculum reference="28"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>75</studentSize>
     </Course>
     <Course id="47">
@@ -187,10 +187,10 @@
       <teacher reference="4"/>
       <lectureSize>7</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="48">
+      <curriculumSet id="48">
         <Curriculum reference="28"/>
         <Curriculum reference="40"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>117</studentSize>
     </Course>
     <Course id="49">
@@ -199,9 +199,9 @@
       <teacher reference="6"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="50">
+      <curriculumSet id="50">
         <Curriculum reference="28"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>75</studentSize>
     </Course>
     <Course id="51">
@@ -210,9 +210,9 @@
       <teacher reference="19"/>
       <lectureSize>1</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="52">
+      <curriculumSet id="52">
         <Curriculum reference="29"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>65</studentSize>
     </Course>
     <Course id="53">
@@ -221,9 +221,9 @@
       <teacher reference="17"/>
       <lectureSize>8</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="54">
+      <curriculumSet id="54">
         <Curriculum reference="29"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>65</studentSize>
     </Course>
     <Course id="55">
@@ -232,9 +232,9 @@
       <teacher reference="23"/>
       <lectureSize>7</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="56">
+      <curriculumSet id="56">
         <Curriculum reference="29"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>65</studentSize>
     </Course>
     <Course id="57">
@@ -243,9 +243,9 @@
       <teacher reference="21"/>
       <lectureSize>2</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="58">
+      <curriculumSet id="58">
         <Curriculum reference="29"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>65</studentSize>
     </Course>
     <Course id="59">
@@ -254,9 +254,9 @@
       <teacher reference="25"/>
       <lectureSize>4</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="60">
+      <curriculumSet id="60">
         <Curriculum reference="30"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>55</studentSize>
     </Course>
     <Course id="61">
@@ -265,9 +265,9 @@
       <teacher reference="24"/>
       <lectureSize>8</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="62">
+      <curriculumSet id="62">
         <Curriculum reference="30"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>55</studentSize>
     </Course>
     <Course id="63">
@@ -276,9 +276,9 @@
       <teacher reference="9"/>
       <lectureSize>5</lectureSize>
       <minWorkingDaySize>4</minWorkingDaySize>
-      <curriculumList id="64">
+      <curriculumSet id="64">
         <Curriculum reference="30"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>55</studentSize>
     </Course>
     <Course id="65">
@@ -287,9 +287,9 @@
       <teacher reference="10"/>
       <lectureSize>5</lectureSize>
       <minWorkingDaySize>4</minWorkingDaySize>
-      <curriculumList id="66">
+      <curriculumSet id="66">
         <Curriculum reference="31"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>20</studentSize>
     </Course>
     <Course id="67">
@@ -298,9 +298,9 @@
       <teacher reference="11"/>
       <lectureSize>5</lectureSize>
       <minWorkingDaySize>4</minWorkingDaySize>
-      <curriculumList id="68">
+      <curriculumSet id="68">
         <Curriculum reference="32"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>11</studentSize>
     </Course>
     <Course id="69">
@@ -309,10 +309,10 @@
       <teacher reference="13"/>
       <lectureSize>1</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="70">
+      <curriculumSet id="70">
         <Curriculum reference="31"/>
         <Curriculum reference="32"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>31</studentSize>
     </Course>
     <Course id="71">
@@ -321,10 +321,10 @@
       <teacher reference="15"/>
       <lectureSize>6</lectureSize>
       <minWorkingDaySize>4</minWorkingDaySize>
-      <curriculumList id="72">
+      <curriculumSet id="72">
         <Curriculum reference="31"/>
         <Curriculum reference="32"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>31</studentSize>
     </Course>
     <Course id="73">
@@ -333,9 +333,9 @@
       <teacher reference="22"/>
       <lectureSize>5</lectureSize>
       <minWorkingDaySize>4</minWorkingDaySize>
-      <curriculumList id="74">
+      <curriculumSet id="74">
         <Curriculum reference="34"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>2</studentSize>
     </Course>
     <Course id="75">
@@ -344,9 +344,9 @@
       <teacher reference="20"/>
       <lectureSize>5</lectureSize>
       <minWorkingDaySize>4</minWorkingDaySize>
-      <curriculumList id="76">
+      <curriculumSet id="76">
         <Curriculum reference="38"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>2</studentSize>
     </Course>
     <Course id="77">
@@ -355,10 +355,10 @@
       <teacher reference="18"/>
       <lectureSize>6</lectureSize>
       <minWorkingDaySize>4</minWorkingDaySize>
-      <curriculumList id="78">
+      <curriculumSet id="78">
         <Curriculum reference="34"/>
         <Curriculum reference="36"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>7</studentSize>
     </Course>
     <Course id="79">
@@ -367,9 +367,9 @@
       <teacher reference="16"/>
       <lectureSize>6</lectureSize>
       <minWorkingDaySize>4</minWorkingDaySize>
-      <curriculumList id="80">
+      <curriculumSet id="80">
         <Curriculum reference="35"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>6</studentSize>
     </Course>
     <Course id="81">
@@ -378,10 +378,10 @@
       <teacher reference="26"/>
       <lectureSize>5</lectureSize>
       <minWorkingDaySize>4</minWorkingDaySize>
-      <curriculumList id="82">
+      <curriculumSet id="82">
         <Curriculum reference="35"/>
         <Curriculum reference="41"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>10</studentSize>
     </Course>
     <Course id="83">
@@ -390,10 +390,10 @@
       <teacher reference="3"/>
       <lectureSize>6</lectureSize>
       <minWorkingDaySize>4</minWorkingDaySize>
-      <curriculumList id="84">
+      <curriculumSet id="84">
         <Curriculum reference="37"/>
         <Curriculum reference="38"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>8</studentSize>
     </Course>
     <Course id="85">
@@ -402,9 +402,9 @@
       <teacher reference="3"/>
       <lectureSize>6</lectureSize>
       <minWorkingDaySize>4</minWorkingDaySize>
-      <curriculumList id="86">
+      <curriculumSet id="86">
         <Curriculum reference="37"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>6</studentSize>
     </Course>
     <Course id="87">
@@ -413,9 +413,9 @@
       <teacher reference="5"/>
       <lectureSize>6</lectureSize>
       <minWorkingDaySize>4</minWorkingDaySize>
-      <curriculumList id="88">
+      <curriculumSet id="88">
         <Curriculum reference="36"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>5</studentSize>
     </Course>
     <Course id="89">
@@ -424,11 +424,11 @@
       <teacher reference="25"/>
       <lectureSize>6</lectureSize>
       <minWorkingDaySize>4</minWorkingDaySize>
-      <curriculumList id="90">
+      <curriculumSet id="90">
         <Curriculum reference="33"/>
         <Curriculum reference="37"/>
         <Curriculum reference="41"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>14</studentSize>
     </Course>
     <Course id="91">
@@ -437,9 +437,9 @@
       <teacher reference="12"/>
       <lectureSize>5</lectureSize>
       <minWorkingDaySize>4</minWorkingDaySize>
-      <curriculumList id="92">
+      <curriculumSet id="92">
         <Curriculum reference="39"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>7</studentSize>
     </Course>
     <Course id="93">
@@ -448,10 +448,10 @@
       <teacher reference="14"/>
       <lectureSize>6</lectureSize>
       <minWorkingDaySize>4</minWorkingDaySize>
-      <curriculumList id="94">
+      <curriculumSet id="94">
         <Curriculum reference="38"/>
         <Curriculum reference="39"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>9</studentSize>
     </Course>
     <Course id="95">
@@ -460,9 +460,9 @@
       <teacher reference="21"/>
       <lectureSize>6</lectureSize>
       <minWorkingDaySize>4</minWorkingDaySize>
-      <curriculumList id="96">
+      <curriculumSet id="96">
         <Curriculum reference="39"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>7</studentSize>
     </Course>
     <Course id="97">
@@ -471,9 +471,9 @@
       <teacher reference="4"/>
       <lectureSize>6</lectureSize>
       <minWorkingDaySize>4</minWorkingDaySize>
-      <curriculumList id="98">
+      <curriculumSet id="98">
         <Curriculum reference="33"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>4</studentSize>
     </Course>
     <Course id="99">
@@ -482,10 +482,10 @@
       <teacher reference="8"/>
       <lectureSize>6</lectureSize>
       <minWorkingDaySize>4</minWorkingDaySize>
-      <curriculumList id="100">
+      <curriculumSet id="100">
         <Curriculum reference="37"/>
         <Curriculum reference="41"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>10</studentSize>
     </Course>
     <Course id="101">
@@ -494,10 +494,10 @@
       <teacher reference="6"/>
       <lectureSize>6</lectureSize>
       <minWorkingDaySize>4</minWorkingDaySize>
-      <curriculumList id="102">
+      <curriculumSet id="102">
         <Curriculum reference="33"/>
         <Curriculum reference="36"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>9</studentSize>
     </Course>
   </courseList>

--- a/optaplanner-examples/data/curriculumcourse/unsolved/comp02.xml
+++ b/optaplanner-examples/data/curriculumcourse/unsolved/comp02.xml
@@ -576,11 +576,11 @@
       <teacher reference="60"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="147">
+      <curriculumSet id="147">
         <Curriculum reference="75"/>
         <Curriculum reference="76"/>
         <Curriculum reference="77"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>150</studentSize>
     </Course>
     <Course id="148">
@@ -589,9 +589,9 @@
       <teacher reference="61"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="149">
+      <curriculumSet id="149">
         <Curriculum reference="78"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>147</studentSize>
     </Course>
     <Course id="150">
@@ -600,9 +600,9 @@
       <teacher reference="58"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="151">
+      <curriculumSet id="151">
         <Curriculum reference="101"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>89</studentSize>
     </Course>
     <Course id="152">
@@ -611,11 +611,11 @@
       <teacher reference="59"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="153">
+      <curriculumSet id="153">
         <Curriculum reference="75"/>
         <Curriculum reference="76"/>
         <Curriculum reference="77"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>150</studentSize>
     </Course>
     <Course id="154">
@@ -624,9 +624,9 @@
       <teacher reference="20"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="155">
+      <curriculumSet id="155">
         <Curriculum reference="102"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>114</studentSize>
     </Course>
     <Course id="156">
@@ -635,9 +635,9 @@
       <teacher reference="19"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="157">
+      <curriculumSet id="157">
         <Curriculum reference="102"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>114</studentSize>
     </Course>
     <Course id="158">
@@ -646,11 +646,11 @@
       <teacher reference="22"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="159">
+      <curriculumSet id="159">
         <Curriculum reference="102"/>
         <Curriculum reference="103"/>
         <Curriculum reference="104"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>234</studentSize>
     </Course>
     <Course id="160">
@@ -659,7 +659,7 @@
       <teacher reference="21"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="161">
+      <curriculumSet id="161">
         <Curriculum reference="103"/>
         <Curriculum reference="104"/>
         <Curriculum reference="121"/>
@@ -668,7 +668,7 @@
         <Curriculum reference="129"/>
         <Curriculum reference="141"/>
         <Curriculum reference="142"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>302</studentSize>
     </Course>
     <Course id="162">
@@ -677,9 +677,9 @@
       <teacher reference="24"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="163">
+      <curriculumSet id="163">
         <Curriculum reference="104"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>60</studentSize>
     </Course>
     <Course id="164">
@@ -688,9 +688,9 @@
       <teacher reference="23"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="165">
+      <curriculumSet id="165">
         <Curriculum reference="101"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>89</studentSize>
     </Course>
     <Course id="166">
@@ -699,9 +699,9 @@
       <teacher reference="3"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="167">
+      <curriculumSet id="167">
         <Curriculum reference="80"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>17</studentSize>
     </Course>
     <Course id="168">
@@ -710,9 +710,9 @@
       <teacher reference="4"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="169">
+      <curriculumSet id="169">
         <Curriculum reference="82"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>23</studentSize>
     </Course>
     <Course id="170">
@@ -721,10 +721,10 @@
       <teacher reference="5"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="171">
+      <curriculumSet id="171">
         <Curriculum reference="81"/>
         <Curriculum reference="82"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>46</studentSize>
     </Course>
     <Course id="172">
@@ -733,9 +733,9 @@
       <teacher reference="7"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="173">
+      <curriculumSet id="173">
         <Curriculum reference="82"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>23</studentSize>
     </Course>
     <Course id="174">
@@ -744,11 +744,11 @@
       <teacher reference="8"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="175">
+      <curriculumSet id="175">
         <Curriculum reference="79"/>
         <Curriculum reference="80"/>
         <Curriculum reference="83"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>124</studentSize>
     </Course>
     <Course id="176">
@@ -757,9 +757,9 @@
       <teacher reference="45"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="177">
+      <curriculumSet id="177">
         <Curriculum reference="81"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>23</studentSize>
     </Course>
     <Course id="178">
@@ -768,7 +768,7 @@
       <teacher reference="44"/>
       <lectureSize>5</lectureSize>
       <minWorkingDaySize>4</minWorkingDaySize>
-      <curriculumList id="179">
+      <curriculumSet id="179">
         <Curriculum reference="81"/>
         <Curriculum reference="84"/>
         <Curriculum reference="108"/>
@@ -780,7 +780,7 @@
         <Curriculum reference="114"/>
         <Curriculum reference="115"/>
         <Curriculum reference="116"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>144</studentSize>
     </Course>
     <Course id="180">
@@ -789,9 +789,9 @@
       <teacher reference="43"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="181">
+      <curriculumSet id="181">
         <Curriculum reference="86"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>86</studentSize>
     </Course>
     <Course id="182">
@@ -800,10 +800,10 @@
       <teacher reference="42"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="183">
+      <curriculumSet id="183">
         <Curriculum reference="93"/>
         <Curriculum reference="102"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>195</studentSize>
     </Course>
     <Course id="184">
@@ -812,10 +812,10 @@
       <teacher reference="42"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="185">
+      <curriculumSet id="185">
         <Curriculum reference="87"/>
         <Curriculum reference="97"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>149</studentSize>
     </Course>
     <Course id="186">
@@ -824,14 +824,14 @@
       <teacher reference="46"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="187">
+      <curriculumSet id="187">
         <Curriculum reference="88"/>
         <Curriculum reference="89"/>
         <Curriculum reference="90"/>
         <Curriculum reference="91"/>
         <Curriculum reference="117"/>
         <Curriculum reference="122"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>201</studentSize>
     </Course>
     <Course id="188">
@@ -840,12 +840,12 @@
       <teacher reference="25"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="189">
+      <curriculumSet id="189">
         <Curriculum reference="88"/>
         <Curriculum reference="132"/>
         <Curriculum reference="133"/>
         <Curriculum reference="134"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>33</studentSize>
     </Course>
     <Course id="190">
@@ -854,12 +854,12 @@
       <teacher reference="26"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="191">
+      <curriculumSet id="191">
         <Curriculum reference="89"/>
         <Curriculum reference="118"/>
         <Curriculum reference="119"/>
         <Curriculum reference="120"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>75</studentSize>
     </Course>
     <Course id="192">
@@ -868,9 +868,9 @@
       <teacher reference="31"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="193">
+      <curriculumSet id="193">
         <Curriculum reference="78"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>147</studentSize>
     </Course>
     <Course id="194">
@@ -879,9 +879,9 @@
       <teacher reference="32"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="195">
+      <curriculumSet id="195">
         <Curriculum reference="83"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>90</studentSize>
     </Course>
     <Course id="196">
@@ -890,9 +890,9 @@
       <teacher reference="28"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="197">
+      <curriculumSet id="197">
         <Curriculum reference="92"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>159</studentSize>
     </Course>
     <Course id="198">
@@ -901,14 +901,14 @@
       <teacher reference="30"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="199">
+      <curriculumSet id="199">
         <Curriculum reference="94"/>
         <Curriculum reference="95"/>
         <Curriculum reference="96"/>
         <Curriculum reference="98"/>
         <Curriculum reference="99"/>
         <Curriculum reference="100"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>175</studentSize>
     </Course>
     <Course id="200">
@@ -917,10 +917,10 @@
       <teacher reference="54"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="201">
+      <curriculumSet id="201">
         <Curriculum reference="93"/>
         <Curriculum reference="135"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>84</studentSize>
     </Course>
     <Course id="202">
@@ -929,9 +929,9 @@
       <teacher reference="55"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="203">
+      <curriculumSet id="203">
         <Curriculum reference="101"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>89</studentSize>
     </Course>
     <Course id="204">
@@ -940,9 +940,9 @@
       <teacher reference="55"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="205">
+      <curriculumSet id="205">
         <Curriculum reference="86"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>86</studentSize>
     </Course>
     <Course id="206">
@@ -951,9 +951,9 @@
       <teacher reference="55"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="207">
+      <curriculumSet id="207">
         <Curriculum reference="92"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>159</studentSize>
     </Course>
     <Course id="208">
@@ -962,9 +962,9 @@
       <teacher reference="56"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="209">
+      <curriculumSet id="209">
         <Curriculum reference="92"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>159</studentSize>
     </Course>
     <Course id="210">
@@ -973,11 +973,11 @@
       <teacher reference="57"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="211">
+      <curriculumSet id="211">
         <Curriculum reference="95"/>
         <Curriculum reference="139"/>
         <Curriculum reference="142"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>37</studentSize>
     </Course>
     <Course id="212">
@@ -986,11 +986,11 @@
       <teacher reference="51"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="213">
+      <curriculumSet id="213">
         <Curriculum reference="75"/>
         <Curriculum reference="76"/>
         <Curriculum reference="77"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>150</studentSize>
     </Course>
     <Course id="214">
@@ -999,9 +999,9 @@
       <teacher reference="53"/>
       <lectureSize>7</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="215">
+      <curriculumSet id="215">
         <Curriculum reference="76"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>50</studentSize>
     </Course>
     <Course id="216">
@@ -1010,9 +1010,9 @@
       <teacher reference="52"/>
       <lectureSize>7</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="217">
+      <curriculumSet id="217">
         <Curriculum reference="77"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>50</studentSize>
     </Course>
     <Course id="218">
@@ -1021,9 +1021,9 @@
       <teacher reference="48"/>
       <lectureSize>7</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="219">
+      <curriculumSet id="219">
         <Curriculum reference="75"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>50</studentSize>
     </Course>
     <Course id="220">
@@ -1032,10 +1032,10 @@
       <teacher reference="47"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="221">
+      <curriculumSet id="221">
         <Curriculum reference="93"/>
         <Curriculum reference="97"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>138</studentSize>
     </Course>
     <Course id="222">
@@ -1044,11 +1044,11 @@
       <teacher reference="50"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="223">
+      <curriculumSet id="223">
         <Curriculum reference="87"/>
         <Curriculum reference="97"/>
         <Curriculum reference="129"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>169</studentSize>
     </Course>
     <Course id="224">
@@ -1057,9 +1057,9 @@
       <teacher reference="49"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="225">
+      <curriculumSet id="225">
         <Curriculum reference="78"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>147</studentSize>
     </Course>
     <Course id="226">
@@ -1068,7 +1068,7 @@
       <teacher reference="49"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="227">
+      <curriculumSet id="227">
         <Curriculum reference="100"/>
         <Curriculum reference="119"/>
         <Curriculum reference="120"/>
@@ -1080,7 +1080,7 @@
         <Curriculum reference="141"/>
         <Curriculum reference="142"/>
         <Curriculum reference="144"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>128</studentSize>
     </Course>
     <Course id="228">
@@ -1089,11 +1089,11 @@
       <teacher reference="71"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="229">
+      <curriculumSet id="229">
         <Curriculum reference="90"/>
         <Curriculum reference="120"/>
         <Curriculum reference="134"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>46</studentSize>
     </Course>
     <Course id="230">
@@ -1102,10 +1102,10 @@
       <teacher reference="71"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="231">
+      <curriculumSet id="231">
         <Curriculum reference="99"/>
         <Curriculum reference="143"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>16</studentSize>
     </Course>
     <Course id="232">
@@ -1114,9 +1114,9 @@
       <teacher reference="72"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="233">
+      <curriculumSet id="233">
         <Curriculum reference="80"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>17</studentSize>
     </Course>
     <Course id="234">
@@ -1125,10 +1125,10 @@
       <teacher reference="72"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="235">
+      <curriculumSet id="235">
         <Curriculum reference="79"/>
         <Curriculum reference="83"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>107</studentSize>
     </Course>
     <Course id="236">
@@ -1137,11 +1137,11 @@
       <teacher reference="70"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="237">
+      <curriculumSet id="237">
         <Curriculum reference="79"/>
         <Curriculum reference="80"/>
         <Curriculum reference="83"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>124</studentSize>
     </Course>
     <Course id="238">
@@ -1150,14 +1150,14 @@
       <teacher reference="69"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="239">
+      <curriculumSet id="239">
         <Curriculum reference="94"/>
         <Curriculum reference="95"/>
         <Curriculum reference="96"/>
         <Curriculum reference="98"/>
         <Curriculum reference="99"/>
         <Curriculum reference="100"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>175</studentSize>
     </Course>
     <Course id="240">
@@ -1166,9 +1166,9 @@
       <teacher reference="68"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="241">
+      <curriculumSet id="241">
         <Curriculum reference="139"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>1</studentSize>
     </Course>
     <Course id="242">
@@ -1177,11 +1177,11 @@
       <teacher reference="67"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="243">
+      <curriculumSet id="243">
         <Curriculum reference="119"/>
         <Curriculum reference="120"/>
         <Curriculum reference="133"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>31</studentSize>
     </Course>
     <Course id="244">
@@ -1190,14 +1190,14 @@
       <teacher reference="66"/>
       <lectureSize>5</lectureSize>
       <minWorkingDaySize>4</minWorkingDaySize>
-      <curriculumList id="245">
+      <curriculumSet id="245">
         <Curriculum reference="87"/>
         <Curriculum reference="97"/>
         <Curriculum reference="125"/>
         <Curriculum reference="132"/>
         <Curriculum reference="133"/>
         <Curriculum reference="134"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>168</studentSize>
     </Course>
     <Course id="246">
@@ -1206,12 +1206,12 @@
       <teacher reference="65"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="247">
+      <curriculumSet id="247">
         <Curriculum reference="141"/>
         <Curriculum reference="142"/>
         <Curriculum reference="143"/>
         <Curriculum reference="144"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>4</studentSize>
     </Course>
     <Course id="248">
@@ -1220,10 +1220,10 @@
       <teacher reference="64"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="249">
+      <curriculumSet id="249">
         <Curriculum reference="143"/>
         <Curriculum reference="144"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>2</studentSize>
     </Course>
     <Course id="250">
@@ -1232,9 +1232,9 @@
       <teacher reference="63"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="251">
+      <curriculumSet id="251">
         <Curriculum reference="139"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>1</studentSize>
     </Course>
     <Course id="252">
@@ -1243,9 +1243,9 @@
       <teacher reference="62"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="253">
+      <curriculumSet id="253">
         <Curriculum reference="86"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>86</studentSize>
     </Course>
     <Course id="254">
@@ -1254,9 +1254,9 @@
       <teacher reference="17"/>
       <lectureSize>5</lectureSize>
       <minWorkingDaySize>4</minWorkingDaySize>
-      <curriculumList id="255">
+      <curriculumSet id="255">
         <Curriculum reference="113"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>4</studentSize>
     </Course>
     <Course id="256">
@@ -1265,7 +1265,7 @@
       <teacher reference="18"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="257">
+      <curriculumSet id="257">
         <Curriculum reference="108"/>
         <Curriculum reference="109"/>
         <Curriculum reference="110"/>
@@ -1277,7 +1277,7 @@
         <Curriculum reference="116"/>
         <Curriculum reference="138"/>
         <Curriculum reference="140"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>58</studentSize>
     </Course>
     <Course id="258">
@@ -1286,10 +1286,10 @@
       <teacher reference="6"/>
       <lectureSize>5</lectureSize>
       <minWorkingDaySize>4</minWorkingDaySize>
-      <curriculumList id="259">
+      <curriculumSet id="259">
         <Curriculum reference="111"/>
         <Curriculum reference="114"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>11</studentSize>
     </Course>
     <Course id="260">
@@ -1298,10 +1298,10 @@
       <teacher reference="10"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="261">
+      <curriculumSet id="261">
         <Curriculum reference="84"/>
         <Curriculum reference="108"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>72</studentSize>
     </Course>
     <Course id="262">
@@ -1310,9 +1310,9 @@
       <teacher reference="72"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="263">
+      <curriculumSet id="263">
         <Curriculum reference="107"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>21</studentSize>
     </Course>
     <Course id="264">
@@ -1321,11 +1321,11 @@
       <teacher reference="9"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="265">
+      <curriculumSet id="265">
         <Curriculum reference="108"/>
         <Curriculum reference="109"/>
         <Curriculum reference="115"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>18</studentSize>
     </Course>
     <Course id="266">
@@ -1334,9 +1334,9 @@
       <teacher reference="12"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="267">
+      <curriculumSet id="267">
         <Curriculum reference="116"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>4</studentSize>
     </Course>
     <Course id="268">
@@ -1345,14 +1345,14 @@
       <teacher reference="11"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="269">
+      <curriculumSet id="269">
         <Curriculum reference="81"/>
         <Curriculum reference="84"/>
         <Curriculum reference="85"/>
         <Curriculum reference="105"/>
         <Curriculum reference="106"/>
         <Curriculum reference="107"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>237</studentSize>
     </Course>
     <Course id="270">
@@ -1361,13 +1361,13 @@
       <teacher reference="11"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="271">
+      <curriculumSet id="271">
         <Curriculum reference="110"/>
         <Curriculum reference="113"/>
         <Curriculum reference="114"/>
         <Curriculum reference="115"/>
         <Curriculum reference="116"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>23</studentSize>
     </Course>
     <Course id="272">
@@ -1376,13 +1376,13 @@
       <teacher reference="70"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="273">
+      <curriculumSet id="273">
         <Curriculum reference="109"/>
         <Curriculum reference="112"/>
         <Curriculum reference="127"/>
         <Curriculum reference="131"/>
         <Curriculum reference="136"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>45</studentSize>
     </Course>
     <Course id="274">
@@ -1391,9 +1391,9 @@
       <teacher reference="14"/>
       <lectureSize>5</lectureSize>
       <minWorkingDaySize>4</minWorkingDaySize>
-      <curriculumList id="275">
+      <curriculumSet id="275">
         <Curriculum reference="85"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>86</studentSize>
     </Course>
     <Course id="276">
@@ -1402,11 +1402,11 @@
       <teacher reference="13"/>
       <lectureSize>5</lectureSize>
       <minWorkingDaySize>4</minWorkingDaySize>
-      <curriculumList id="277">
+      <curriculumSet id="277">
         <Curriculum reference="105"/>
         <Curriculum reference="138"/>
         <Curriculum reference="140"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>23</studentSize>
     </Course>
     <Course id="278">
@@ -1415,7 +1415,7 @@
       <teacher reference="16"/>
       <lectureSize>5</lectureSize>
       <minWorkingDaySize>4</minWorkingDaySize>
-      <curriculumList id="279">
+      <curriculumSet id="279">
         <Curriculum reference="93"/>
         <Curriculum reference="121"/>
         <Curriculum reference="122"/>
@@ -1424,7 +1424,7 @@
         <Curriculum reference="135"/>
         <Curriculum reference="136"/>
         <Curriculum reference="137"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>270</studentSize>
     </Course>
     <Course id="280">
@@ -1433,13 +1433,13 @@
       <teacher reference="69"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="281">
+      <curriculumSet id="281">
         <Curriculum reference="124"/>
         <Curriculum reference="125"/>
         <Curriculum reference="126"/>
         <Curriculum reference="127"/>
         <Curriculum reference="128"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>80</studentSize>
     </Course>
     <Course id="282">
@@ -1448,12 +1448,12 @@
       <teacher reference="15"/>
       <lectureSize>5</lectureSize>
       <minWorkingDaySize>4</minWorkingDaySize>
-      <curriculumList id="283">
+      <curriculumSet id="283">
         <Curriculum reference="128"/>
         <Curriculum reference="135"/>
         <Curriculum reference="136"/>
         <Curriculum reference="137"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>41</studentSize>
     </Course>
     <Course id="284">
@@ -1462,10 +1462,10 @@
       <teacher reference="41"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="285">
+      <curriculumSet id="285">
         <Curriculum reference="103"/>
         <Curriculum reference="123"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>100</studentSize>
     </Course>
     <Course id="286">
@@ -1474,7 +1474,7 @@
       <teacher reference="29"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="287">
+      <curriculumSet id="287">
         <Curriculum reference="96"/>
         <Curriculum reference="103"/>
         <Curriculum reference="104"/>
@@ -1486,7 +1486,7 @@
         <Curriculum reference="130"/>
         <Curriculum reference="131"/>
         <Curriculum reference="141"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>296</studentSize>
     </Course>
     <Course id="288">
@@ -1495,7 +1495,7 @@
       <teacher reference="27"/>
       <lectureSize>4</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="289">
+      <curriculumSet id="289">
         <Curriculum reference="94"/>
         <Curriculum reference="95"/>
         <Curriculum reference="96"/>
@@ -1507,7 +1507,7 @@
         <Curriculum reference="130"/>
         <Curriculum reference="131"/>
         <Curriculum reference="135"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>273</studentSize>
     </Course>
     <Course id="290">
@@ -1516,9 +1516,9 @@
       <teacher reference="36"/>
       <lectureSize>5</lectureSize>
       <minWorkingDaySize>4</minWorkingDaySize>
-      <curriculumList id="291">
+      <curriculumSet id="291">
         <Curriculum reference="117"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>61</studentSize>
     </Course>
     <Course id="292">
@@ -1527,7 +1527,7 @@
       <teacher reference="35"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="293">
+      <curriculumSet id="293">
         <Curriculum reference="88"/>
         <Curriculum reference="89"/>
         <Curriculum reference="90"/>
@@ -1535,7 +1535,7 @@
         <Curriculum reference="118"/>
         <Curriculum reference="119"/>
         <Curriculum reference="120"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>165</studentSize>
     </Course>
     <Course id="294">
@@ -1544,14 +1544,14 @@
       <teacher reference="34"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="295">
+      <curriculumSet id="295">
         <Curriculum reference="91"/>
         <Curriculum reference="98"/>
         <Curriculum reference="99"/>
         <Curriculum reference="100"/>
         <Curriculum reference="118"/>
         <Curriculum reference="132"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>91</studentSize>
     </Course>
     <Course id="296">
@@ -1560,14 +1560,14 @@
       <teacher reference="63"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="297">
+      <curriculumSet id="297">
         <Curriculum reference="88"/>
         <Curriculum reference="89"/>
         <Curriculum reference="90"/>
         <Curriculum reference="91"/>
         <Curriculum reference="118"/>
         <Curriculum reference="120"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>150</studentSize>
     </Course>
     <Course id="298">
@@ -1576,14 +1576,14 @@
       <teacher reference="33"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="299">
+      <curriculumSet id="299">
         <Curriculum reference="117"/>
         <Curriculum reference="132"/>
         <Curriculum reference="133"/>
         <Curriculum reference="134"/>
         <Curriculum reference="143"/>
         <Curriculum reference="144"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>66</studentSize>
     </Course>
     <Course id="300">
@@ -1592,12 +1592,12 @@
       <teacher reference="40"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="301">
+      <curriculumSet id="301">
         <Curriculum reference="117"/>
         <Curriculum reference="132"/>
         <Curriculum reference="133"/>
         <Curriculum reference="134"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>64</studentSize>
     </Course>
     <Course id="302">
@@ -1606,11 +1606,11 @@
       <teacher reference="39"/>
       <lectureSize>5</lectureSize>
       <minWorkingDaySize>4</minWorkingDaySize>
-      <curriculumList id="303">
+      <curriculumSet id="303">
         <Curriculum reference="106"/>
         <Curriculum reference="139"/>
         <Curriculum reference="140"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>23</studentSize>
     </Course>
     <Course id="304">
@@ -1619,13 +1619,13 @@
       <teacher reference="38"/>
       <lectureSize>5</lectureSize>
       <minWorkingDaySize>4</minWorkingDaySize>
-      <curriculumList id="305">
+      <curriculumSet id="305">
         <Curriculum reference="84"/>
         <Curriculum reference="85"/>
         <Curriculum reference="105"/>
         <Curriculum reference="106"/>
         <Curriculum reference="107"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>214</studentSize>
     </Course>
     <Course id="306">
@@ -1634,10 +1634,10 @@
       <teacher reference="37"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="307">
+      <curriculumSet id="307">
         <Curriculum reference="82"/>
         <Curriculum reference="126"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>31</studentSize>
     </Course>
     <Course id="308">
@@ -1646,13 +1646,13 @@
       <teacher reference="73"/>
       <lectureSize>5</lectureSize>
       <minWorkingDaySize>4</minWorkingDaySize>
-      <curriculumList id="309">
+      <curriculumSet id="309">
         <Curriculum reference="130"/>
         <Curriculum reference="131"/>
         <Curriculum reference="135"/>
         <Curriculum reference="136"/>
         <Curriculum reference="137"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>69</studentSize>
     </Course>
   </courseList>

--- a/optaplanner-examples/data/curriculumcourse/unsolved/comp03.xml
+++ b/optaplanner-examples/data/curriculumcourse/unsolved/comp03.xml
@@ -528,10 +528,10 @@
       <teacher reference="51"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="135">
+      <curriculumSet id="135">
         <Curriculum reference="69"/>
         <Curriculum reference="72"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>150</studentSize>
     </Course>
     <Course id="136">
@@ -540,13 +540,13 @@
       <teacher reference="52"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="137">
+      <curriculumSet id="137">
         <Curriculum reference="69"/>
         <Curriculum reference="73"/>
         <Curriculum reference="113"/>
         <Curriculum reference="114"/>
         <Curriculum reference="115"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>160</studentSize>
     </Course>
     <Course id="138">
@@ -555,10 +555,10 @@
       <teacher reference="49"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="139">
+      <curriculumSet id="139">
         <Curriculum reference="70"/>
         <Curriculum reference="94"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>24</studentSize>
     </Course>
     <Course id="140">
@@ -567,11 +567,11 @@
       <teacher reference="50"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="141">
+      <curriculumSet id="141">
         <Curriculum reference="70"/>
         <Curriculum reference="86"/>
         <Curriculum reference="110"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>49</studentSize>
     </Course>
     <Course id="142">
@@ -580,12 +580,12 @@
       <teacher reference="20"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="143">
+      <curriculumSet id="143">
         <Curriculum reference="71"/>
         <Curriculum reference="113"/>
         <Curriculum reference="114"/>
         <Curriculum reference="115"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>100</studentSize>
     </Course>
     <Course id="144">
@@ -594,10 +594,10 @@
       <teacher reference="19"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="145">
+      <curriculumSet id="145">
         <Curriculum reference="70"/>
         <Curriculum reference="94"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>24</studentSize>
     </Course>
     <Course id="146">
@@ -606,9 +606,9 @@
       <teacher reference="22"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="147">
+      <curriculumSet id="147">
         <Curriculum reference="70"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>20</studentSize>
     </Course>
     <Course id="148">
@@ -617,9 +617,9 @@
       <teacher reference="21"/>
       <lectureSize>5</lectureSize>
       <minWorkingDaySize>4</minWorkingDaySize>
-      <curriculumList id="149">
+      <curriculumSet id="149">
         <Curriculum reference="68"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>170</studentSize>
     </Course>
     <Course id="150">
@@ -628,10 +628,10 @@
       <teacher reference="24"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="151">
+      <curriculumSet id="151">
         <Curriculum reference="69"/>
         <Curriculum reference="72"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>150</studentSize>
     </Course>
     <Course id="152">
@@ -640,10 +640,10 @@
       <teacher reference="23"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="153">
+      <curriculumSet id="153">
         <Curriculum reference="69"/>
         <Curriculum reference="72"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>150</studentSize>
     </Course>
     <Course id="154">
@@ -652,9 +652,9 @@
       <teacher reference="3"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="155">
+      <curriculumSet id="155">
         <Curriculum reference="72"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>110</studentSize>
     </Course>
     <Course id="156">
@@ -663,10 +663,10 @@
       <teacher reference="4"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="157">
+      <curriculumSet id="157">
         <Curriculum reference="73"/>
         <Curriculum reference="74"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>80</studentSize>
     </Course>
     <Course id="158">
@@ -675,10 +675,10 @@
       <teacher reference="23"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="159">
+      <curriculumSet id="159">
         <Curriculum reference="74"/>
         <Curriculum reference="95"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>44</studentSize>
     </Course>
     <Course id="160">
@@ -687,11 +687,11 @@
       <teacher reference="5"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="161">
+      <curriculumSet id="161">
         <Curriculum reference="71"/>
         <Curriculum reference="73"/>
         <Curriculum reference="97"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>64</studentSize>
     </Course>
     <Course id="162">
@@ -700,9 +700,9 @@
       <teacher reference="7"/>
       <lectureSize>5</lectureSize>
       <minWorkingDaySize>4</minWorkingDaySize>
-      <curriculumList id="163">
+      <curriculumSet id="163">
         <Curriculum reference="75"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>100</studentSize>
     </Course>
     <Course id="164">
@@ -711,10 +711,10 @@
       <teacher reference="8"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="165">
+      <curriculumSet id="165">
         <Curriculum reference="76"/>
         <Curriculum reference="81"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>130</studentSize>
     </Course>
     <Course id="166">
@@ -723,10 +723,10 @@
       <teacher reference="36"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="167">
+      <curriculumSet id="167">
         <Curriculum reference="76"/>
         <Curriculum reference="81"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>130</studentSize>
     </Course>
     <Course id="168">
@@ -735,12 +735,12 @@
       <teacher reference="35"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="169">
+      <curriculumSet id="169">
         <Curriculum reference="76"/>
         <Curriculum reference="106"/>
         <Curriculum reference="107"/>
         <Curriculum reference="108"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>92</studentSize>
     </Course>
     <Course id="170">
@@ -749,10 +749,10 @@
       <teacher reference="34"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="171">
+      <curriculumSet id="171">
         <Curriculum reference="76"/>
         <Curriculum reference="81"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>130</studentSize>
     </Course>
     <Course id="172">
@@ -761,13 +761,13 @@
       <teacher reference="33"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="173">
+      <curriculumSet id="173">
         <Curriculum reference="77"/>
         <Curriculum reference="78"/>
         <Curriculum reference="79"/>
         <Curriculum reference="120"/>
         <Curriculum reference="126"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>130</studentSize>
     </Course>
     <Course id="174">
@@ -776,14 +776,14 @@
       <teacher reference="37"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="175">
+      <curriculumSet id="175">
         <Curriculum reference="77"/>
         <Curriculum reference="78"/>
         <Curriculum reference="79"/>
         <Curriculum reference="121"/>
         <Curriculum reference="122"/>
         <Curriculum reference="123"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>105</studentSize>
     </Course>
     <Course id="176">
@@ -792,12 +792,12 @@
       <teacher reference="24"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="177">
+      <curriculumSet id="177">
         <Curriculum reference="79"/>
         <Curriculum reference="101"/>
         <Curriculum reference="102"/>
         <Curriculum reference="105"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>32</studentSize>
     </Course>
     <Course id="178">
@@ -806,7 +806,7 @@
       <teacher reference="25"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="179">
+      <curriculumSet id="179">
         <Curriculum reference="78"/>
         <Curriculum reference="82"/>
         <Curriculum reference="83"/>
@@ -821,7 +821,7 @@
         <Curriculum reference="127"/>
         <Curriculum reference="128"/>
         <Curriculum reference="129"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>205</studentSize>
     </Course>
     <Course id="180">
@@ -830,9 +830,9 @@
       <teacher reference="26"/>
       <lectureSize>5</lectureSize>
       <minWorkingDaySize>4</minWorkingDaySize>
-      <curriculumList id="181">
+      <curriculumSet id="181">
         <Curriculum reference="80"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>170</studentSize>
     </Course>
     <Course id="182">
@@ -841,10 +841,10 @@
       <teacher reference="51"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="183">
+      <curriculumSet id="183">
         <Curriculum reference="85"/>
         <Curriculum reference="90"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>210</studentSize>
     </Course>
     <Course id="184">
@@ -853,9 +853,9 @@
       <teacher reference="30"/>
       <lectureSize>1</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="185">
+      <curriculumSet id="185">
         <Curriculum reference="85"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>100</studentSize>
     </Course>
     <Course id="186">
@@ -864,10 +864,10 @@
       <teacher reference="31"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="187">
+      <curriculumSet id="187">
         <Curriculum reference="85"/>
         <Curriculum reference="90"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>210</studentSize>
     </Course>
     <Course id="188">
@@ -876,9 +876,9 @@
       <teacher reference="27"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="189">
+      <curriculumSet id="189">
         <Curriculum reference="85"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>100</studentSize>
     </Course>
     <Course id="190">
@@ -887,12 +887,12 @@
       <teacher reference="29"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="191">
+      <curriculumSet id="191">
         <Curriculum reference="84"/>
         <Curriculum reference="88"/>
         <Curriculum reference="108"/>
         <Curriculum reference="111"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>48</studentSize>
     </Course>
     <Course id="192">
@@ -901,9 +901,9 @@
       <teacher reference="45"/>
       <lectureSize>5</lectureSize>
       <minWorkingDaySize>4</minWorkingDaySize>
-      <curriculumList id="193">
+      <curriculumSet id="193">
         <Curriculum reference="89"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>100</studentSize>
     </Course>
     <Course id="194">
@@ -912,10 +912,10 @@
       <teacher reference="30"/>
       <lectureSize>2</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="195">
+      <curriculumSet id="195">
         <Curriculum reference="85"/>
         <Curriculum reference="90"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>210</studentSize>
     </Course>
     <Course id="196">
@@ -924,9 +924,9 @@
       <teacher reference="30"/>
       <lectureSize>1</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="197">
+      <curriculumSet id="197">
         <Curriculum reference="90"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>110</studentSize>
     </Course>
     <Course id="198">
@@ -935,9 +935,9 @@
       <teacher reference="46"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="199">
+      <curriculumSet id="199">
         <Curriculum reference="90"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>110</studentSize>
     </Course>
     <Course id="200">
@@ -946,9 +946,9 @@
       <teacher reference="47"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="201">
+      <curriculumSet id="201">
         <Curriculum reference="91"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>110</studentSize>
     </Course>
     <Course id="202">
@@ -957,9 +957,9 @@
       <teacher reference="48"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="203">
+      <curriculumSet id="203">
         <Curriculum reference="91"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>110</studentSize>
     </Course>
     <Course id="204">
@@ -968,7 +968,7 @@
       <teacher reference="42"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="205">
+      <curriculumSet id="205">
         <Curriculum reference="86"/>
         <Curriculum reference="87"/>
         <Curriculum reference="88"/>
@@ -977,7 +977,7 @@
         <Curriculum reference="125"/>
         <Curriculum reference="126"/>
         <Curriculum reference="130"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>325</studentSize>
     </Course>
     <Course id="206">
@@ -986,11 +986,11 @@
       <teacher reference="44"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="207">
+      <curriculumSet id="207">
         <Curriculum reference="65"/>
         <Curriculum reference="66"/>
         <Curriculum reference="67"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>150</studentSize>
     </Course>
     <Course id="208">
@@ -999,11 +999,11 @@
       <teacher reference="43"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="209">
+      <curriculumSet id="209">
         <Curriculum reference="65"/>
         <Curriculum reference="66"/>
         <Curriculum reference="67"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>150</studentSize>
     </Course>
     <Course id="210">
@@ -1012,9 +1012,9 @@
       <teacher reference="39"/>
       <lectureSize>7</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="211">
+      <curriculumSet id="211">
         <Curriculum reference="65"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>50</studentSize>
     </Course>
     <Course id="212">
@@ -1023,9 +1023,9 @@
       <teacher reference="38"/>
       <lectureSize>7</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="213">
+      <curriculumSet id="213">
         <Curriculum reference="66"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>50</studentSize>
     </Course>
     <Course id="214">
@@ -1034,9 +1034,9 @@
       <teacher reference="41"/>
       <lectureSize>7</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="215">
+      <curriculumSet id="215">
         <Curriculum reference="67"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>50</studentSize>
     </Course>
     <Course id="216">
@@ -1045,11 +1045,11 @@
       <teacher reference="40"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="217">
+      <curriculumSet id="217">
         <Curriculum reference="92"/>
         <Curriculum reference="93"/>
         <Curriculum reference="94"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>12</studentSize>
     </Course>
     <Course id="218">
@@ -1058,11 +1058,11 @@
       <teacher reference="62"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="219">
+      <curriculumSet id="219">
         <Curriculum reference="92"/>
         <Curriculum reference="93"/>
         <Curriculum reference="94"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>12</studentSize>
     </Course>
     <Course id="220">
@@ -1071,9 +1071,9 @@
       <teacher reference="52"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="221">
+      <curriculumSet id="221">
         <Curriculum reference="93"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>4</studentSize>
     </Course>
     <Course id="222">
@@ -1082,9 +1082,9 @@
       <teacher reference="63"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="223">
+      <curriculumSet id="223">
         <Curriculum reference="94"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>4</studentSize>
     </Course>
     <Course id="224">
@@ -1093,10 +1093,10 @@
       <teacher reference="20"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="225">
+      <curriculumSet id="225">
         <Curriculum reference="92"/>
         <Curriculum reference="93"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>8</studentSize>
     </Course>
     <Course id="226">
@@ -1105,11 +1105,11 @@
       <teacher reference="29"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="227">
+      <curriculumSet id="227">
         <Curriculum reference="92"/>
         <Curriculum reference="93"/>
         <Curriculum reference="94"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>12</studentSize>
     </Course>
     <Course id="228">
@@ -1118,11 +1118,11 @@
       <teacher reference="4"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="229">
+      <curriculumSet id="229">
         <Curriculum reference="97"/>
         <Curriculum reference="98"/>
         <Curriculum reference="99"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>16</studentSize>
     </Course>
     <Course id="230">
@@ -1131,7 +1131,7 @@
       <teacher reference="61"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="231">
+      <curriculumSet id="231">
         <Curriculum reference="83"/>
         <Curriculum reference="100"/>
         <Curriculum reference="101"/>
@@ -1142,7 +1142,7 @@
         <Curriculum reference="106"/>
         <Curriculum reference="122"/>
         <Curriculum reference="123"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>73</studentSize>
     </Course>
     <Course id="232">
@@ -1151,11 +1151,11 @@
       <teacher reference="60"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="233">
+      <curriculumSet id="233">
         <Curriculum reference="104"/>
         <Curriculum reference="105"/>
         <Curriculum reference="123"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>23</studentSize>
     </Course>
     <Course id="234">
@@ -1164,12 +1164,12 @@
       <teacher reference="59"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="235">
+      <curriculumSet id="235">
         <Curriculum reference="91"/>
         <Curriculum reference="109"/>
         <Curriculum reference="110"/>
         <Curriculum reference="111"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>122</studentSize>
     </Course>
     <Course id="236">
@@ -1178,11 +1178,11 @@
       <teacher reference="25"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="237">
+      <curriculumSet id="237">
         <Curriculum reference="106"/>
         <Curriculum reference="107"/>
         <Curriculum reference="108"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>12</studentSize>
     </Course>
     <Course id="238">
@@ -1191,14 +1191,14 @@
       <teacher reference="58"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="239">
+      <curriculumSet id="239">
         <Curriculum reference="71"/>
         <Curriculum reference="73"/>
         <Curriculum reference="74"/>
         <Curriculum reference="113"/>
         <Curriculum reference="114"/>
         <Curriculum reference="115"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>180</studentSize>
     </Course>
     <Course id="240">
@@ -1207,11 +1207,11 @@
       <teacher reference="57"/>
       <lectureSize>5</lectureSize>
       <minWorkingDaySize>4</minWorkingDaySize>
-      <curriculumList id="241">
+      <curriculumSet id="241">
         <Curriculum reference="99"/>
         <Curriculum reference="113"/>
         <Curriculum reference="114"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>48</studentSize>
     </Course>
     <Course id="242">
@@ -1220,11 +1220,11 @@
       <teacher reference="56"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="243">
+      <curriculumSet id="243">
         <Curriculum reference="95"/>
         <Curriculum reference="96"/>
         <Curriculum reference="113"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>28</studentSize>
     </Course>
     <Course id="244">
@@ -1233,12 +1233,12 @@
       <teacher reference="55"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="245">
+      <curriculumSet id="245">
         <Curriculum reference="95"/>
         <Curriculum reference="96"/>
         <Curriculum reference="98"/>
         <Curriculum reference="113"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>32</studentSize>
     </Course>
     <Course id="246">
@@ -1247,11 +1247,11 @@
       <teacher reference="54"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="247">
+      <curriculumSet id="247">
         <Curriculum reference="74"/>
         <Curriculum reference="116"/>
         <Curriculum reference="117"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>70</studentSize>
     </Course>
     <Course id="248">
@@ -1260,13 +1260,13 @@
       <teacher reference="53"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="249">
+      <curriculumSet id="249">
         <Curriculum reference="96"/>
         <Curriculum reference="97"/>
         <Curriculum reference="98"/>
         <Curriculum reference="99"/>
         <Curriculum reference="116"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>35</studentSize>
     </Course>
     <Course id="250">
@@ -1275,10 +1275,10 @@
       <teacher reference="58"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="251">
+      <curriculumSet id="251">
         <Curriculum reference="116"/>
         <Curriculum reference="118"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>30</studentSize>
     </Course>
     <Course id="252">
@@ -1287,7 +1287,7 @@
       <teacher reference="17"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="253">
+      <curriculumSet id="253">
         <Curriculum reference="87"/>
         <Curriculum reference="109"/>
         <Curriculum reference="112"/>
@@ -1295,7 +1295,7 @@
         <Curriculum reference="119"/>
         <Curriculum reference="128"/>
         <Curriculum reference="132"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>98</studentSize>
     </Course>
     <Course id="254">
@@ -1304,10 +1304,10 @@
       <teacher reference="18"/>
       <lectureSize>5</lectureSize>
       <minWorkingDaySize>4</minWorkingDaySize>
-      <curriculumList id="255">
+      <curriculumSet id="255">
         <Curriculum reference="118"/>
         <Curriculum reference="119"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>30</studentSize>
     </Course>
     <Course id="256">
@@ -1316,10 +1316,10 @@
       <teacher reference="6"/>
       <lectureSize>5</lectureSize>
       <minWorkingDaySize>4</minWorkingDaySize>
-      <curriculumList id="257">
+      <curriculumSet id="257">
         <Curriculum reference="118"/>
         <Curriculum reference="119"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>30</studentSize>
     </Course>
     <Course id="258">
@@ -1328,7 +1328,7 @@
       <teacher reference="10"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="259">
+      <curriculumSet id="259">
         <Curriculum reference="82"/>
         <Curriculum reference="100"/>
         <Curriculum reference="101"/>
@@ -1338,7 +1338,7 @@
         <Curriculum reference="105"/>
         <Curriculum reference="107"/>
         <Curriculum reference="120"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>93</studentSize>
     </Course>
     <Course id="260">
@@ -1347,12 +1347,12 @@
       <teacher reference="9"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="261">
+      <curriculumSet id="261">
         <Curriculum reference="77"/>
         <Curriculum reference="78"/>
         <Curriculum reference="79"/>
         <Curriculum reference="120"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>110</studentSize>
     </Course>
     <Course id="262">
@@ -1361,7 +1361,7 @@
       <teacher reference="12"/>
       <lectureSize>5</lectureSize>
       <minWorkingDaySize>4</minWorkingDaySize>
-      <curriculumList id="263">
+      <curriculumSet id="263">
         <Curriculum reference="77"/>
         <Curriculum reference="100"/>
         <Curriculum reference="102"/>
@@ -1369,7 +1369,7 @@
         <Curriculum reference="121"/>
         <Curriculum reference="122"/>
         <Curriculum reference="129"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>82</studentSize>
     </Course>
     <Course id="264">
@@ -1378,7 +1378,7 @@
       <teacher reference="11"/>
       <lectureSize>5</lectureSize>
       <minWorkingDaySize>4</minWorkingDaySize>
-      <curriculumList id="265">
+      <curriculumSet id="265">
         <Curriculum reference="82"/>
         <Curriculum reference="83"/>
         <Curriculum reference="84"/>
@@ -1394,7 +1394,7 @@
         <Curriculum reference="124"/>
         <Curriculum reference="125"/>
         <Curriculum reference="126"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>224</studentSize>
     </Course>
     <Course id="266">
@@ -1403,11 +1403,11 @@
       <teacher reference="14"/>
       <lectureSize>5</lectureSize>
       <minWorkingDaySize>4</minWorkingDaySize>
-      <curriculumList id="267">
+      <curriculumSet id="267">
         <Curriculum reference="70"/>
         <Curriculum reference="94"/>
         <Curriculum reference="124"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>44</studentSize>
     </Course>
     <Course id="268">
@@ -1416,7 +1416,7 @@
       <teacher reference="13"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="269">
+      <curriculumSet id="269">
         <Curriculum reference="82"/>
         <Curriculum reference="83"/>
         <Curriculum reference="84"/>
@@ -1426,7 +1426,7 @@
         <Curriculum reference="127"/>
         <Curriculum reference="128"/>
         <Curriculum reference="129"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>210</studentSize>
     </Course>
     <Course id="270">
@@ -1435,11 +1435,11 @@
       <teacher reference="16"/>
       <lectureSize>5</lectureSize>
       <minWorkingDaySize>4</minWorkingDaySize>
-      <curriculumList id="271">
+      <curriculumSet id="271">
         <Curriculum reference="124"/>
         <Curriculum reference="125"/>
         <Curriculum reference="130"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>120</studentSize>
     </Course>
     <Course id="272">
@@ -1448,10 +1448,10 @@
       <teacher reference="15"/>
       <lectureSize>5</lectureSize>
       <minWorkingDaySize>4</minWorkingDaySize>
-      <curriculumList id="273">
+      <curriculumSet id="273">
         <Curriculum reference="112"/>
         <Curriculum reference="130"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>64</studentSize>
     </Course>
     <Course id="274">
@@ -1460,10 +1460,10 @@
       <teacher reference="32"/>
       <lectureSize>5</lectureSize>
       <minWorkingDaySize>4</minWorkingDaySize>
-      <curriculumList id="275">
+      <curriculumSet id="275">
         <Curriculum reference="131"/>
         <Curriculum reference="132"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>65</studentSize>
     </Course>
     <Course id="276">
@@ -1472,10 +1472,10 @@
       <teacher reference="28"/>
       <lectureSize>5</lectureSize>
       <minWorkingDaySize>5</minWorkingDaySize>
-      <curriculumList id="277">
+      <curriculumSet id="277">
         <Curriculum reference="131"/>
         <Curriculum reference="132"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>65</studentSize>
     </Course>
   </courseList>

--- a/optaplanner-examples/data/curriculumcourse/unsolved/comp04.xml
+++ b/optaplanner-examples/data/curriculumcourse/unsolved/comp04.xml
@@ -520,10 +520,10 @@
       <teacher reference="60"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="133">
+      <curriculumSet id="133">
         <Curriculum reference="79"/>
         <Curriculum reference="80"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>20</studentSize>
     </Course>
     <Course id="134">
@@ -532,10 +532,10 @@
       <teacher reference="61"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="135">
+      <curriculumSet id="135">
         <Curriculum reference="79"/>
         <Curriculum reference="81"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>25</studentSize>
     </Course>
     <Course id="136">
@@ -544,13 +544,13 @@
       <teacher reference="58"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="137">
+      <curriculumSet id="137">
         <Curriculum reference="79"/>
         <Curriculum reference="81"/>
         <Curriculum reference="83"/>
         <Curriculum reference="126"/>
         <Curriculum reference="127"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>41</studentSize>
     </Course>
     <Course id="138">
@@ -559,10 +559,10 @@
       <teacher reference="59"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="139">
+      <curriculumSet id="139">
         <Curriculum reference="82"/>
         <Curriculum reference="125"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>13</studentSize>
     </Course>
     <Course id="140">
@@ -571,10 +571,10 @@
       <teacher reference="20"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="141">
+      <curriculumSet id="141">
         <Curriculum reference="82"/>
         <Curriculum reference="125"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>13</studentSize>
     </Course>
     <Course id="142">
@@ -583,9 +583,9 @@
       <teacher reference="19"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="143">
+      <curriculumSet id="143">
         <Curriculum reference="84"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>76</studentSize>
     </Course>
     <Course id="144">
@@ -594,12 +594,12 @@
       <teacher reference="22"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="145">
+      <curriculumSet id="145">
         <Curriculum reference="85"/>
         <Curriculum reference="104"/>
         <Curriculum reference="123"/>
         <Curriculum reference="124"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>119</studentSize>
     </Course>
     <Course id="146">
@@ -608,9 +608,9 @@
       <teacher reference="21"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="147">
+      <curriculumSet id="147">
         <Curriculum reference="85"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>63</studentSize>
     </Course>
     <Course id="148">
@@ -619,9 +619,9 @@
       <teacher reference="24"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="149">
+      <curriculumSet id="149">
         <Curriculum reference="85"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>63</studentSize>
     </Course>
     <Course id="150">
@@ -630,9 +630,9 @@
       <teacher reference="23"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="151">
+      <curriculumSet id="151">
         <Curriculum reference="84"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>76</studentSize>
     </Course>
     <Course id="152">
@@ -641,10 +641,10 @@
       <teacher reference="3"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="153">
+      <curriculumSet id="153">
         <Curriculum reference="85"/>
         <Curriculum reference="104"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>89</studentSize>
     </Course>
     <Course id="154">
@@ -653,9 +653,9 @@
       <teacher reference="4"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="155">
+      <curriculumSet id="155">
         <Curriculum reference="74"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>70</studentSize>
     </Course>
     <Course id="156">
@@ -664,9 +664,9 @@
       <teacher reference="5"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="157">
+      <curriculumSet id="157">
         <Curriculum reference="75"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>92</studentSize>
     </Course>
     <Course id="158">
@@ -675,9 +675,9 @@
       <teacher reference="7"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="159">
+      <curriculumSet id="159">
         <Curriculum reference="75"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>92</studentSize>
     </Course>
     <Course id="160">
@@ -686,9 +686,9 @@
       <teacher reference="8"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="161">
+      <curriculumSet id="161">
         <Curriculum reference="74"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>70</studentSize>
     </Course>
     <Course id="162">
@@ -697,9 +697,9 @@
       <teacher reference="45"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="163">
+      <curriculumSet id="163">
         <Curriculum reference="74"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>70</studentSize>
     </Course>
     <Course id="164">
@@ -708,9 +708,9 @@
       <teacher reference="44"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="165">
+      <curriculumSet id="165">
         <Curriculum reference="75"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>92</studentSize>
     </Course>
     <Course id="166">
@@ -719,11 +719,11 @@
       <teacher reference="22"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="167">
+      <curriculumSet id="167">
         <Curriculum reference="76"/>
         <Curriculum reference="123"/>
         <Curriculum reference="124"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>120</studentSize>
     </Course>
     <Course id="168">
@@ -732,11 +732,11 @@
       <teacher reference="43"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="169">
+      <curriculumSet id="169">
         <Curriculum reference="76"/>
         <Curriculum reference="123"/>
         <Curriculum reference="124"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>120</studentSize>
     </Course>
     <Course id="170">
@@ -745,11 +745,11 @@
       <teacher reference="42"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="171">
+      <curriculumSet id="171">
         <Curriculum reference="94"/>
         <Curriculum reference="95"/>
         <Curriculum reference="96"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>124</studentSize>
     </Course>
     <Course id="172">
@@ -758,12 +758,12 @@
       <teacher reference="46"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="173">
+      <curriculumSet id="173">
         <Curriculum reference="97"/>
         <Curriculum reference="98"/>
         <Curriculum reference="99"/>
         <Curriculum reference="100"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>121</studentSize>
     </Course>
     <Course id="174">
@@ -772,12 +772,12 @@
       <teacher reference="25"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="175">
+      <curriculumSet id="175">
         <Curriculum reference="97"/>
         <Curriculum reference="98"/>
         <Curriculum reference="99"/>
         <Curriculum reference="100"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>121</studentSize>
     </Course>
     <Course id="176">
@@ -786,12 +786,12 @@
       <teacher reference="26"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="177">
+      <curriculumSet id="177">
         <Curriculum reference="97"/>
         <Curriculum reference="98"/>
         <Curriculum reference="99"/>
         <Curriculum reference="100"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>121</studentSize>
     </Course>
     <Course id="178">
@@ -800,11 +800,11 @@
       <teacher reference="31"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="179">
+      <curriculumSet id="179">
         <Curriculum reference="101"/>
         <Curriculum reference="102"/>
         <Curriculum reference="103"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>130</studentSize>
     </Course>
     <Course id="180">
@@ -813,12 +813,12 @@
       <teacher reference="32"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="181">
+      <curriculumSet id="181">
         <Curriculum reference="78"/>
         <Curriculum reference="101"/>
         <Curriculum reference="102"/>
         <Curriculum reference="103"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>145</studentSize>
     </Course>
     <Course id="182">
@@ -827,9 +827,9 @@
       <teacher reference="4"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="183">
+      <curriculumSet id="183">
         <Curriculum reference="91"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>113</studentSize>
     </Course>
     <Course id="184">
@@ -838,9 +838,9 @@
       <teacher reference="19"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="185">
+      <curriculumSet id="185">
         <Curriculum reference="91"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>113</studentSize>
     </Course>
     <Course id="186">
@@ -849,9 +849,9 @@
       <teacher reference="28"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="187">
+      <curriculumSet id="187">
         <Curriculum reference="91"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>113</studentSize>
     </Course>
     <Course id="188">
@@ -860,9 +860,9 @@
       <teacher reference="30"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="189">
+      <curriculumSet id="189">
         <Curriculum reference="92"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>88</studentSize>
     </Course>
     <Course id="190">
@@ -871,10 +871,10 @@
       <teacher reference="54"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="191">
+      <curriculumSet id="191">
         <Curriculum reference="77"/>
         <Curriculum reference="78"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>125</studentSize>
     </Course>
     <Course id="192">
@@ -883,10 +883,10 @@
       <teacher reference="55"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="193">
+      <curriculumSet id="193">
         <Curriculum reference="77"/>
         <Curriculum reference="78"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>125</studentSize>
     </Course>
     <Course id="194">
@@ -895,10 +895,10 @@
       <teacher reference="56"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="195">
+      <curriculumSet id="195">
         <Curriculum reference="80"/>
         <Curriculum reference="87"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>80</studentSize>
     </Course>
     <Course id="196">
@@ -907,10 +907,10 @@
       <teacher reference="61"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="197">
+      <curriculumSet id="197">
         <Curriculum reference="80"/>
         <Curriculum reference="87"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>80</studentSize>
     </Course>
     <Course id="198">
@@ -919,13 +919,13 @@
       <teacher reference="57"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="199">
+      <curriculumSet id="199">
         <Curriculum reference="79"/>
         <Curriculum reference="80"/>
         <Curriculum reference="81"/>
         <Curriculum reference="87"/>
         <Curriculum reference="88"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>115</studentSize>
     </Course>
     <Course id="200">
@@ -934,9 +934,9 @@
       <teacher reference="51"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="201">
+      <curriculumSet id="201">
         <Curriculum reference="77"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>110</studentSize>
     </Course>
     <Course id="202">
@@ -945,12 +945,12 @@
       <teacher reference="53"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="203">
+      <curriculumSet id="203">
         <Curriculum reference="89"/>
         <Curriculum reference="90"/>
         <Curriculum reference="113"/>
         <Curriculum reference="115"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>90</studentSize>
     </Course>
     <Course id="204">
@@ -959,13 +959,13 @@
       <teacher reference="52"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="205">
+      <curriculumSet id="205">
         <Curriculum reference="89"/>
         <Curriculum reference="113"/>
         <Curriculum reference="114"/>
         <Curriculum reference="129"/>
         <Curriculum reference="130"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>66</studentSize>
     </Course>
     <Course id="206">
@@ -974,11 +974,11 @@
       <teacher reference="48"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="207">
+      <curriculumSet id="207">
         <Curriculum reference="90"/>
         <Curriculum reference="112"/>
         <Curriculum reference="115"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>70</studentSize>
     </Course>
     <Course id="208">
@@ -987,10 +987,10 @@
       <teacher reference="47"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="209">
+      <curriculumSet id="209">
         <Curriculum reference="92"/>
         <Curriculum reference="104"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>114</studentSize>
     </Course>
     <Course id="210">
@@ -999,10 +999,10 @@
       <teacher reference="50"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="211">
+      <curriculumSet id="211">
         <Curriculum reference="92"/>
         <Curriculum reference="104"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>114</studentSize>
     </Course>
     <Course id="212">
@@ -1011,10 +1011,10 @@
       <teacher reference="49"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="213">
+      <curriculumSet id="213">
         <Curriculum reference="112"/>
         <Curriculum reference="113"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>30</studentSize>
     </Course>
     <Course id="214">
@@ -1023,10 +1023,10 @@
       <teacher reference="52"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="215">
+      <curriculumSet id="215">
         <Curriculum reference="112"/>
         <Curriculum reference="130"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>23</studentSize>
     </Course>
     <Course id="216">
@@ -1035,11 +1035,11 @@
       <teacher reference="71"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="217">
+      <curriculumSet id="217">
         <Curriculum reference="112"/>
         <Curriculum reference="114"/>
         <Curriculum reference="115"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>50</studentSize>
     </Course>
     <Course id="218">
@@ -1048,12 +1048,12 @@
       <teacher reference="72"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="219">
+      <curriculumSet id="219">
         <Curriculum reference="83"/>
         <Curriculum reference="114"/>
         <Curriculum reference="126"/>
         <Curriculum reference="127"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>36</studentSize>
     </Course>
     <Course id="220">
@@ -1062,10 +1062,10 @@
       <teacher reference="72"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="221">
+      <curriculumSet id="221">
         <Curriculum reference="116"/>
         <Curriculum reference="127"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>43</studentSize>
     </Course>
     <Course id="222">
@@ -1074,12 +1074,12 @@
       <teacher reference="70"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="223">
+      <curriculumSet id="223">
         <Curriculum reference="106"/>
         <Curriculum reference="107"/>
         <Curriculum reference="108"/>
         <Curriculum reference="109"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>70</studentSize>
     </Course>
     <Course id="224">
@@ -1088,11 +1088,11 @@
       <teacher reference="69"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="225">
+      <curriculumSet id="225">
         <Curriculum reference="109"/>
         <Curriculum reference="120"/>
         <Curriculum reference="122"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>50</studentSize>
     </Course>
     <Course id="226">
@@ -1101,11 +1101,11 @@
       <teacher reference="68"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="227">
+      <curriculumSet id="227">
         <Curriculum reference="108"/>
         <Curriculum reference="110"/>
         <Curriculum reference="111"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>70</studentSize>
     </Course>
     <Course id="228">
@@ -1114,11 +1114,11 @@
       <teacher reference="67"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="229">
+      <curriculumSet id="229">
         <Curriculum reference="117"/>
         <Curriculum reference="118"/>
         <Curriculum reference="119"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>15</studentSize>
     </Course>
     <Course id="230">
@@ -1127,9 +1127,9 @@
       <teacher reference="66"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="231">
+      <curriculumSet id="231">
         <Curriculum reference="120"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>5</studentSize>
     </Course>
     <Course id="232">
@@ -1138,11 +1138,11 @@
       <teacher reference="65"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="233">
+      <curriculumSet id="233">
         <Curriculum reference="108"/>
         <Curriculum reference="111"/>
         <Curriculum reference="121"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>25</studentSize>
     </Course>
     <Course id="234">
@@ -1151,9 +1151,9 @@
       <teacher reference="64"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="235">
+      <curriculumSet id="235">
         <Curriculum reference="122"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>5</studentSize>
     </Course>
     <Course id="236">
@@ -1162,9 +1162,9 @@
       <teacher reference="63"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="237">
+      <curriculumSet id="237">
         <Curriculum reference="119"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>5</studentSize>
     </Course>
     <Course id="238">
@@ -1173,10 +1173,10 @@
       <teacher reference="62"/>
       <lectureSize>6</lectureSize>
       <minWorkingDaySize>4</minWorkingDaySize>
-      <curriculumList id="239">
+      <curriculumSet id="239">
         <Curriculum reference="123"/>
         <Curriculum reference="124"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>30</studentSize>
     </Course>
     <Course id="240">
@@ -1185,10 +1185,10 @@
       <teacher reference="17"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="241">
+      <curriculumSet id="241">
         <Curriculum reference="124"/>
         <Curriculum reference="128"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>13</studentSize>
     </Course>
     <Course id="242">
@@ -1197,10 +1197,10 @@
       <teacher reference="25"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="243">
+      <curriculumSet id="243">
         <Curriculum reference="112"/>
         <Curriculum reference="113"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>30</studentSize>
     </Course>
     <Course id="244">
@@ -1209,10 +1209,10 @@
       <teacher reference="18"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="245">
+      <curriculumSet id="245">
         <Curriculum reference="117"/>
         <Curriculum reference="121"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>10</studentSize>
     </Course>
     <Course id="246">
@@ -1221,13 +1221,13 @@
       <teacher reference="6"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="247">
+      <curriculumSet id="247">
         <Curriculum reference="105"/>
         <Curriculum reference="106"/>
         <Curriculum reference="117"/>
         <Curriculum reference="118"/>
         <Curriculum reference="119"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>30</studentSize>
     </Course>
     <Course id="248">
@@ -1236,10 +1236,10 @@
       <teacher reference="10"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="249">
+      <curriculumSet id="249">
         <Curriculum reference="81"/>
         <Curriculum reference="88"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>15</studentSize>
     </Course>
     <Course id="250">
@@ -1248,9 +1248,9 @@
       <teacher reference="9"/>
       <lectureSize>5</lectureSize>
       <minWorkingDaySize>4</minWorkingDaySize>
-      <curriculumList id="251">
+      <curriculumSet id="251">
         <Curriculum reference="126"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>3</studentSize>
     </Course>
     <Course id="252">
@@ -1259,9 +1259,9 @@
       <teacher reference="12"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="253">
+      <curriculumSet id="253">
         <Curriculum reference="130"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>3</studentSize>
     </Course>
     <Course id="254">
@@ -1270,9 +1270,9 @@
       <teacher reference="11"/>
       <lectureSize>7</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="255">
+      <curriculumSet id="255">
         <Curriculum reference="97"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>18</studentSize>
     </Course>
     <Course id="256">
@@ -1281,9 +1281,9 @@
       <teacher reference="14"/>
       <lectureSize>7</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="257">
+      <curriculumSet id="257">
         <Curriculum reference="100"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>53</studentSize>
     </Course>
     <Course id="258">
@@ -1292,10 +1292,10 @@
       <teacher reference="13"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="259">
+      <curriculumSet id="259">
         <Curriculum reference="88"/>
         <Curriculum reference="99"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>14</studentSize>
     </Course>
     <Course id="260">
@@ -1304,11 +1304,11 @@
       <teacher reference="16"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="261">
+      <curriculumSet id="261">
         <Curriculum reference="94"/>
         <Curriculum reference="95"/>
         <Curriculum reference="96"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>124</studentSize>
     </Course>
     <Course id="262">
@@ -1317,10 +1317,10 @@
       <teacher reference="15"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="263">
+      <curriculumSet id="263">
         <Curriculum reference="114"/>
         <Curriculum reference="115"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>30</studentSize>
     </Course>
     <Course id="264">
@@ -1329,9 +1329,9 @@
       <teacher reference="41"/>
       <lectureSize>7</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="265">
+      <curriculumSet id="265">
         <Curriculum reference="101"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>30</studentSize>
     </Course>
     <Course id="266">
@@ -1340,9 +1340,9 @@
       <teacher reference="29"/>
       <lectureSize>7</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="267">
+      <curriculumSet id="267">
         <Curriculum reference="95"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>46</studentSize>
     </Course>
     <Course id="268">
@@ -1351,9 +1351,9 @@
       <teacher reference="27"/>
       <lectureSize>7</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="269">
+      <curriculumSet id="269">
         <Curriculum reference="98"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>46</studentSize>
     </Course>
     <Course id="270">
@@ -1362,9 +1362,9 @@
       <teacher reference="36"/>
       <lectureSize>7</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="271">
+      <curriculumSet id="271">
         <Curriculum reference="94"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>18</studentSize>
     </Course>
     <Course id="272">
@@ -1373,9 +1373,9 @@
       <teacher reference="35"/>
       <lectureSize>7</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="273">
+      <curriculumSet id="273">
         <Curriculum reference="96"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>60</studentSize>
     </Course>
     <Course id="274">
@@ -1384,9 +1384,9 @@
       <teacher reference="34"/>
       <lectureSize>7</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="275">
+      <curriculumSet id="275">
         <Curriculum reference="102"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>40</studentSize>
     </Course>
     <Course id="276">
@@ -1395,10 +1395,10 @@
       <teacher reference="61"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="277">
+      <curriculumSet id="277">
         <Curriculum reference="127"/>
         <Curriculum reference="129"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>6</studentSize>
     </Course>
     <Course id="278">
@@ -1407,9 +1407,9 @@
       <teacher reference="33"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="279">
+      <curriculumSet id="279">
         <Curriculum reference="84"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>76</studentSize>
     </Course>
     <Course id="280">
@@ -1418,11 +1418,11 @@
       <teacher reference="40"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="281">
+      <curriculumSet id="281">
         <Curriculum reference="101"/>
         <Curriculum reference="102"/>
         <Curriculum reference="103"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>130</studentSize>
     </Course>
     <Course id="282">
@@ -1431,9 +1431,9 @@
       <teacher reference="40"/>
       <lectureSize>7</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="283">
+      <curriculumSet id="283">
         <Curriculum reference="103"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>60</studentSize>
     </Course>
     <Course id="284">
@@ -1442,14 +1442,14 @@
       <teacher reference="39"/>
       <lectureSize>6</lectureSize>
       <minWorkingDaySize>4</minWorkingDaySize>
-      <curriculumList id="285">
+      <curriculumSet id="285">
         <Curriculum reference="86"/>
         <Curriculum reference="106"/>
         <Curriculum reference="107"/>
         <Curriculum reference="117"/>
         <Curriculum reference="118"/>
         <Curriculum reference="119"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>110</studentSize>
     </Course>
     <Course id="286">
@@ -1458,10 +1458,10 @@
       <teacher reference="38"/>
       <lectureSize>6</lectureSize>
       <minWorkingDaySize>4</minWorkingDaySize>
-      <curriculumList id="287">
+      <curriculumSet id="287">
         <Curriculum reference="93"/>
         <Curriculum reference="109"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>100</studentSize>
     </Course>
     <Course id="288">
@@ -1470,9 +1470,9 @@
       <teacher reference="37"/>
       <lectureSize>5</lectureSize>
       <minWorkingDaySize>4</minWorkingDaySize>
-      <curriculumList id="289">
+      <curriculumSet id="289">
         <Curriculum reference="125"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>3</studentSize>
     </Course>
   </courseList>

--- a/optaplanner-examples/data/curriculumcourse/unsolved/comp05.xml
+++ b/optaplanner-examples/data/curriculumcourse/unsolved/comp05.xml
@@ -756,9 +756,9 @@
       <teacher reference="29"/>
       <lectureSize>1</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="192">
+      <curriculumSet id="192">
         <Curriculum reference="55"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>10</studentSize>
     </Course>
     <Course id="193">
@@ -767,9 +767,9 @@
       <teacher reference="30"/>
       <lectureSize>1</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="194">
+      <curriculumSet id="194">
         <Curriculum reference="55"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>10</studentSize>
     </Course>
     <Course id="195">
@@ -778,7 +778,7 @@
       <teacher reference="25"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="196">
+      <curriculumSet id="196">
         <Curriculum reference="51"/>
         <Curriculum reference="56"/>
         <Curriculum reference="66"/>
@@ -807,7 +807,7 @@
         <Curriculum reference="107"/>
         <Curriculum reference="108"/>
         <Curriculum reference="134"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>300</studentSize>
     </Course>
     <Course id="197">
@@ -816,7 +816,7 @@
       <teacher reference="27"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="198">
+      <curriculumSet id="198">
         <Curriculum reference="168"/>
         <Curriculum reference="169"/>
         <Curriculum reference="170"/>
@@ -827,7 +827,7 @@
         <Curriculum reference="175"/>
         <Curriculum reference="176"/>
         <Curriculum reference="177"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>100</studentSize>
     </Course>
     <Course id="199">
@@ -836,12 +836,12 @@
       <teacher reference="20"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="200">
+      <curriculumSet id="200">
         <Curriculum reference="56"/>
         <Curriculum reference="78"/>
         <Curriculum reference="79"/>
         <Curriculum reference="80"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>50</studentSize>
     </Course>
     <Course id="201">
@@ -850,12 +850,12 @@
       <teacher reference="19"/>
       <lectureSize>2</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="202">
+      <curriculumSet id="202">
         <Curriculum reference="51"/>
         <Curriculum reference="56"/>
         <Curriculum reference="66"/>
         <Curriculum reference="71"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>60</studentSize>
     </Course>
     <Course id="203">
@@ -864,7 +864,7 @@
       <teacher reference="22"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="204">
+      <curriculumSet id="204">
         <Curriculum reference="57"/>
         <Curriculum reference="59"/>
         <Curriculum reference="94"/>
@@ -882,7 +882,7 @@
         <Curriculum reference="128"/>
         <Curriculum reference="129"/>
         <Curriculum reference="130"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>170</studentSize>
     </Course>
     <Course id="205">
@@ -891,7 +891,7 @@
       <teacher reference="21"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="206">
+      <curriculumSet id="206">
         <Curriculum reference="52"/>
         <Curriculum reference="53"/>
         <Curriculum reference="54"/>
@@ -923,7 +923,7 @@
         <Curriculum reference="178"/>
         <Curriculum reference="179"/>
         <Curriculum reference="181"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>350</studentSize>
     </Course>
     <Course id="207">
@@ -932,13 +932,13 @@
       <teacher reference="24"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="208">
+      <curriculumSet id="208">
         <Curriculum reference="58"/>
         <Curriculum reference="61"/>
         <Curriculum reference="72"/>
         <Curriculum reference="179"/>
         <Curriculum reference="180"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>80</studentSize>
     </Course>
     <Course id="209">
@@ -947,7 +947,7 @@
       <teacher reference="23"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="210">
+      <curriculumSet id="210">
         <Curriculum reference="58"/>
         <Curriculum reference="60"/>
         <Curriculum reference="61"/>
@@ -967,7 +967,7 @@
         <Curriculum reference="180"/>
         <Curriculum reference="181"/>
         <Curriculum reference="182"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>230</studentSize>
     </Course>
     <Course id="211">
@@ -976,14 +976,14 @@
       <teacher reference="3"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="212">
+      <curriculumSet id="212">
         <Curriculum reference="60"/>
         <Curriculum reference="61"/>
         <Curriculum reference="62"/>
         <Curriculum reference="63"/>
         <Curriculum reference="179"/>
         <Curriculum reference="181"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>80</studentSize>
     </Course>
     <Course id="213">
@@ -992,7 +992,7 @@
       <teacher reference="4"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="214">
+      <curriculumSet id="214">
         <Curriculum reference="52"/>
         <Curriculum reference="53"/>
         <Curriculum reference="54"/>
@@ -1035,7 +1035,7 @@
         <Curriculum reference="138"/>
         <Curriculum reference="144"/>
         <Curriculum reference="151"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>440</studentSize>
     </Course>
     <Course id="215">
@@ -1044,7 +1044,7 @@
       <teacher reference="5"/>
       <lectureSize>2</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="216">
+      <curriculumSet id="216">
         <Curriculum reference="55"/>
         <Curriculum reference="65"/>
         <Curriculum reference="68"/>
@@ -1084,7 +1084,7 @@
         <Curriculum reference="141"/>
         <Curriculum reference="145"/>
         <Curriculum reference="152"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>400</studentSize>
     </Course>
     <Course id="217">
@@ -1093,10 +1093,10 @@
       <teacher reference="6"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="218">
+      <curriculumSet id="218">
         <Curriculum reference="67"/>
         <Curriculum reference="69"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>20</studentSize>
     </Course>
     <Course id="219">
@@ -1105,7 +1105,7 @@
       <teacher reference="7"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="220">
+      <curriculumSet id="220">
         <Curriculum reference="64"/>
         <Curriculum reference="66"/>
         <Curriculum reference="67"/>
@@ -1135,7 +1135,7 @@
         <Curriculum reference="187"/>
         <Curriculum reference="188"/>
         <Curriculum reference="189"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>370</studentSize>
     </Course>
     <Course id="221">
@@ -1144,14 +1144,14 @@
       <teacher reference="48"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="222">
+      <curriculumSet id="222">
         <Curriculum reference="51"/>
         <Curriculum reference="56"/>
         <Curriculum reference="66"/>
         <Curriculum reference="71"/>
         <Curriculum reference="140"/>
         <Curriculum reference="165"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>80</studentSize>
     </Course>
     <Course id="223">
@@ -1160,14 +1160,14 @@
       <teacher reference="47"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="224">
+      <curriculumSet id="224">
         <Curriculum reference="63"/>
         <Curriculum reference="65"/>
         <Curriculum reference="72"/>
         <Curriculum reference="82"/>
         <Curriculum reference="83"/>
         <Curriculum reference="183"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>60</studentSize>
     </Course>
     <Course id="225">
@@ -1176,13 +1176,13 @@
       <teacher reference="46"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="226">
+      <curriculumSet id="226">
         <Curriculum reference="65"/>
         <Curriculum reference="68"/>
         <Curriculum reference="69"/>
         <Curriculum reference="70"/>
         <Curriculum reference="72"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>50</studentSize>
     </Course>
     <Course id="227">
@@ -1191,9 +1191,9 @@
       <teacher reference="45"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="228">
+      <curriculumSet id="228">
         <Curriculum reference="77"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>10</studentSize>
     </Course>
     <Course id="229">
@@ -1202,7 +1202,7 @@
       <teacher reference="49"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="230">
+      <curriculumSet id="230">
         <Curriculum reference="57"/>
         <Curriculum reference="59"/>
         <Curriculum reference="77"/>
@@ -1212,7 +1212,7 @@
         <Curriculum reference="162"/>
         <Curriculum reference="163"/>
         <Curriculum reference="164"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>130</studentSize>
     </Course>
     <Course id="231">
@@ -1221,11 +1221,11 @@
       <teacher reference="26"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="232">
+      <curriculumSet id="232">
         <Curriculum reference="77"/>
         <Curriculum reference="86"/>
         <Curriculum reference="134"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>30</studentSize>
     </Course>
     <Course id="233">
@@ -1234,14 +1234,14 @@
       <teacher reference="28"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="234">
+      <curriculumSet id="234">
         <Curriculum reference="62"/>
         <Curriculum reference="78"/>
         <Curriculum reference="79"/>
         <Curriculum reference="80"/>
         <Curriculum reference="181"/>
         <Curriculum reference="183"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>60</studentSize>
     </Course>
     <Course id="235">
@@ -1250,12 +1250,12 @@
       <teacher reference="33"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="236">
+      <curriculumSet id="236">
         <Curriculum reference="79"/>
         <Curriculum reference="148"/>
         <Curriculum reference="149"/>
         <Curriculum reference="181"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>40</studentSize>
     </Course>
     <Course id="237">
@@ -1264,12 +1264,12 @@
       <teacher reference="34"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="238">
+      <curriculumSet id="238">
         <Curriculum reference="59"/>
         <Curriculum reference="80"/>
         <Curriculum reference="146"/>
         <Curriculum reference="147"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>40</studentSize>
     </Course>
     <Course id="239">
@@ -1278,13 +1278,13 @@
       <teacher reference="31"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="240">
+      <curriculumSet id="240">
         <Curriculum reference="83"/>
         <Curriculum reference="85"/>
         <Curriculum reference="146"/>
         <Curriculum reference="148"/>
         <Curriculum reference="181"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>50</studentSize>
     </Course>
     <Course id="241">
@@ -1293,13 +1293,13 @@
       <teacher reference="34"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="242">
+      <curriculumSet id="242">
         <Curriculum reference="82"/>
         <Curriculum reference="83"/>
         <Curriculum reference="84"/>
         <Curriculum reference="85"/>
         <Curriculum reference="180"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>50</studentSize>
     </Course>
     <Course id="243">
@@ -1308,7 +1308,7 @@
       <teacher reference="32"/>
       <lectureSize>2</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="244">
+      <curriculumSet id="244">
         <Curriculum reference="81"/>
         <Curriculum reference="82"/>
         <Curriculum reference="83"/>
@@ -1323,7 +1323,7 @@
         <Curriculum reference="143"/>
         <Curriculum reference="144"/>
         <Curriculum reference="145"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>170</studentSize>
     </Course>
     <Course id="245">
@@ -1332,7 +1332,7 @@
       <teacher reference="15"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="246">
+      <curriculumSet id="246">
         <Curriculum reference="53"/>
         <Curriculum reference="86"/>
         <Curriculum reference="168"/>
@@ -1340,7 +1340,7 @@
         <Curriculum reference="170"/>
         <Curriculum reference="171"/>
         <Curriculum reference="172"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>70</studentSize>
     </Course>
     <Course id="247">
@@ -1349,9 +1349,9 @@
       <teacher reference="16"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="248">
+      <curriculumSet id="248">
         <Curriculum reference="86"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>10</studentSize>
     </Course>
     <Course id="249">
@@ -1360,7 +1360,7 @@
       <teacher reference="17"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="250">
+      <curriculumSet id="250">
         <Curriculum reference="91"/>
         <Curriculum reference="92"/>
         <Curriculum reference="93"/>
@@ -1376,7 +1376,7 @@
         <Curriculum reference="129"/>
         <Curriculum reference="131"/>
         <Curriculum reference="133"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>150</studentSize>
     </Course>
     <Course id="251">
@@ -1385,7 +1385,7 @@
       <teacher reference="18"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="252">
+      <curriculumSet id="252">
         <Curriculum reference="109"/>
         <Curriculum reference="114"/>
         <Curriculum reference="115"/>
@@ -1395,7 +1395,7 @@
         <Curriculum reference="125"/>
         <Curriculum reference="126"/>
         <Curriculum reference="127"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>90</studentSize>
     </Course>
     <Course id="253">
@@ -1404,7 +1404,7 @@
       <teacher reference="12"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="254">
+      <curriculumSet id="254">
         <Curriculum reference="113"/>
         <Curriculum reference="117"/>
         <Curriculum reference="120"/>
@@ -1414,7 +1414,7 @@
         <Curriculum reference="130"/>
         <Curriculum reference="132"/>
         <Curriculum reference="133"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>90</studentSize>
     </Course>
     <Course id="255">
@@ -1423,7 +1423,7 @@
       <teacher reference="14"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="256">
+      <curriculumSet id="256">
         <Curriculum reference="51"/>
         <Curriculum reference="73"/>
         <Curriculum reference="75"/>
@@ -1438,7 +1438,7 @@
         <Curriculum reference="168"/>
         <Curriculum reference="173"/>
         <Curriculum reference="184"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>150</studentSize>
     </Course>
     <Course id="257">
@@ -1447,7 +1447,7 @@
       <teacher reference="13"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="258">
+      <curriculumSet id="258">
         <Curriculum reference="134"/>
         <Curriculum reference="136"/>
         <Curriculum reference="159"/>
@@ -1457,7 +1457,7 @@
         <Curriculum reference="171"/>
         <Curriculum reference="176"/>
         <Curriculum reference="187"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>100</studentSize>
     </Course>
     <Course id="259">
@@ -1466,14 +1466,14 @@
       <teacher reference="13"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="260">
+      <curriculumSet id="260">
         <Curriculum reference="159"/>
         <Curriculum reference="160"/>
         <Curriculum reference="162"/>
         <Curriculum reference="172"/>
         <Curriculum reference="177"/>
         <Curriculum reference="188"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>100</studentSize>
     </Course>
     <Course id="261">
@@ -1482,7 +1482,7 @@
       <teacher reference="9"/>
       <lectureSize>2</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="262">
+      <curriculumSet id="262">
         <Curriculum reference="52"/>
         <Curriculum reference="53"/>
         <Curriculum reference="54"/>
@@ -1503,7 +1503,7 @@
         <Curriculum reference="169"/>
         <Curriculum reference="174"/>
         <Curriculum reference="185"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>200</studentSize>
     </Course>
     <Course id="263">
@@ -1512,13 +1512,13 @@
       <teacher reference="8"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="264">
+      <curriculumSet id="264">
         <Curriculum reference="137"/>
         <Curriculum reference="159"/>
         <Curriculum reference="161"/>
         <Curriculum reference="162"/>
         <Curriculum reference="164"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>70</studentSize>
     </Course>
     <Course id="265">
@@ -1527,7 +1527,7 @@
       <teacher reference="11"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="266">
+      <curriculumSet id="266">
         <Curriculum reference="138"/>
         <Curriculum reference="140"/>
         <Curriculum reference="141"/>
@@ -1537,7 +1537,7 @@
         <Curriculum reference="163"/>
         <Curriculum reference="164"/>
         <Curriculum reference="189"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>170</studentSize>
     </Course>
     <Course id="267">
@@ -1546,7 +1546,7 @@
       <teacher reference="10"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="268">
+      <curriculumSet id="268">
         <Curriculum reference="55"/>
         <Curriculum reference="65"/>
         <Curriculum reference="90"/>
@@ -1562,7 +1562,7 @@
         <Curriculum reference="170"/>
         <Curriculum reference="175"/>
         <Curriculum reference="186"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>150</studentSize>
     </Course>
     <Course id="269">
@@ -1571,13 +1571,13 @@
       <teacher reference="43"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="270">
+      <curriculumSet id="270">
         <Curriculum reference="68"/>
         <Curriculum reference="69"/>
         <Curriculum reference="70"/>
         <Curriculum reference="141"/>
         <Curriculum reference="166"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>50</studentSize>
     </Course>
     <Course id="271">
@@ -1586,7 +1586,7 @@
       <teacher reference="44"/>
       <lectureSize>1</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="272">
+      <curriculumSet id="272">
         <Curriculum reference="81"/>
         <Curriculum reference="82"/>
         <Curriculum reference="83"/>
@@ -1621,7 +1621,7 @@
         <Curriculum reference="140"/>
         <Curriculum reference="141"/>
         <Curriculum reference="167"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>340</studentSize>
     </Course>
     <Course id="273">
@@ -1630,11 +1630,11 @@
       <teacher reference="25"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="274">
+      <curriculumSet id="274">
         <Curriculum reference="154"/>
         <Curriculum reference="157"/>
         <Curriculum reference="178"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>30</studentSize>
     </Course>
     <Course id="275">
@@ -1643,14 +1643,14 @@
       <teacher reference="42"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="276">
+      <curriculumSet id="276">
         <Curriculum reference="146"/>
         <Curriculum reference="147"/>
         <Curriculum reference="148"/>
         <Curriculum reference="149"/>
         <Curriculum reference="179"/>
         <Curriculum reference="182"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>60</studentSize>
     </Course>
     <Course id="277">
@@ -1659,7 +1659,7 @@
       <teacher reference="41"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="278">
+      <curriculumSet id="278">
         <Curriculum reference="168"/>
         <Curriculum reference="169"/>
         <Curriculum reference="170"/>
@@ -1671,7 +1671,7 @@
         <Curriculum reference="176"/>
         <Curriculum reference="177"/>
         <Curriculum reference="183"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>110</studentSize>
     </Course>
     <Course id="279">
@@ -1680,12 +1680,12 @@
       <teacher reference="40"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="280">
+      <curriculumSet id="280">
         <Curriculum reference="146"/>
         <Curriculum reference="147"/>
         <Curriculum reference="148"/>
         <Curriculum reference="149"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>40</studentSize>
     </Course>
     <Course id="281">
@@ -1694,9 +1694,9 @@
       <teacher reference="40"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="282">
+      <curriculumSet id="282">
         <Curriculum reference="150"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>10</studentSize>
     </Course>
     <Course id="283">
@@ -1705,7 +1705,7 @@
       <teacher reference="32"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="284">
+      <curriculumSet id="284">
         <Curriculum reference="151"/>
         <Curriculum reference="152"/>
         <Curriculum reference="158"/>
@@ -1715,7 +1715,7 @@
         <Curriculum reference="162"/>
         <Curriculum reference="163"/>
         <Curriculum reference="164"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>140</studentSize>
     </Course>
     <Course id="285">
@@ -1724,14 +1724,14 @@
       <teacher reference="14"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="286">
+      <curriculumSet id="286">
         <Curriculum reference="159"/>
         <Curriculum reference="160"/>
         <Curriculum reference="161"/>
         <Curriculum reference="162"/>
         <Curriculum reference="163"/>
         <Curriculum reference="164"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>100</studentSize>
     </Course>
     <Course id="287">
@@ -1740,10 +1740,10 @@
       <teacher reference="39"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="288">
+      <curriculumSet id="288">
         <Curriculum reference="165"/>
         <Curriculum reference="166"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>20</studentSize>
     </Course>
     <Course id="289">
@@ -1752,9 +1752,9 @@
       <teacher reference="49"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="290">
+      <curriculumSet id="290">
         <Curriculum reference="142"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>10</studentSize>
     </Course>
     <Course id="291">
@@ -1763,11 +1763,11 @@
       <teacher reference="38"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="292">
+      <curriculumSet id="292">
         <Curriculum reference="143"/>
         <Curriculum reference="144"/>
         <Curriculum reference="145"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>60</studentSize>
     </Course>
     <Course id="293">
@@ -1776,7 +1776,7 @@
       <teacher reference="37"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="294">
+      <curriculumSet id="294">
         <Curriculum reference="64"/>
         <Curriculum reference="66"/>
         <Curriculum reference="72"/>
@@ -1784,7 +1784,7 @@
         <Curriculum reference="74"/>
         <Curriculum reference="75"/>
         <Curriculum reference="76"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>70</studentSize>
     </Course>
     <Course id="295">
@@ -1793,7 +1793,7 @@
       <teacher reference="36"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="296">
+      <curriculumSet id="296">
         <Curriculum reference="54"/>
         <Curriculum reference="87"/>
         <Curriculum reference="88"/>
@@ -1822,7 +1822,7 @@
         <Curriculum reference="175"/>
         <Curriculum reference="176"/>
         <Curriculum reference="177"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>280</studentSize>
     </Course>
     <Course id="297">
@@ -1831,13 +1831,13 @@
       <teacher reference="35"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="298">
+      <curriculumSet id="298">
         <Curriculum reference="151"/>
         <Curriculum reference="152"/>
         <Curriculum reference="155"/>
         <Curriculum reference="156"/>
         <Curriculum reference="157"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>60</studentSize>
     </Course>
   </courseList>

--- a/optaplanner-examples/data/curriculumcourse/unsolved/comp06.xml
+++ b/optaplanner-examples/data/curriculumcourse/unsolved/comp06.xml
@@ -640,12 +640,12 @@
       <teacher reference="67"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="163">
+      <curriculumSet id="163">
         <Curriculum reference="95"/>
         <Curriculum reference="96"/>
         <Curriculum reference="97"/>
         <Curriculum reference="106"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>145</studentSize>
     </Course>
     <Course id="164">
@@ -654,10 +654,10 @@
       <teacher reference="68"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="165">
+      <curriculumSet id="165">
         <Curriculum reference="98"/>
         <Curriculum reference="100"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>25</studentSize>
     </Course>
     <Course id="166">
@@ -666,11 +666,11 @@
       <teacher reference="65"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="167">
+      <curriculumSet id="167">
         <Curriculum reference="98"/>
         <Curriculum reference="113"/>
         <Curriculum reference="131"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>42</studentSize>
     </Course>
     <Course id="168">
@@ -679,11 +679,11 @@
       <teacher reference="66"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="169">
+      <curriculumSet id="169">
         <Curriculum reference="98"/>
         <Curriculum reference="135"/>
         <Curriculum reference="154"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>45</studentSize>
     </Course>
     <Course id="170">
@@ -692,11 +692,11 @@
       <teacher reference="20"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="171">
+      <curriculumSet id="171">
         <Curriculum reference="98"/>
         <Curriculum reference="135"/>
         <Curriculum reference="154"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>45</studentSize>
     </Course>
     <Course id="172">
@@ -705,10 +705,10 @@
       <teacher reference="19"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="173">
+      <curriculumSet id="173">
         <Curriculum reference="103"/>
         <Curriculum reference="124"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>75</studentSize>
     </Course>
     <Course id="174">
@@ -717,11 +717,11 @@
       <teacher reference="22"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="175">
+      <curriculumSet id="175">
         <Curriculum reference="103"/>
         <Curriculum reference="104"/>
         <Curriculum reference="105"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>67</studentSize>
     </Course>
     <Course id="176">
@@ -730,10 +730,10 @@
       <teacher reference="21"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="177">
+      <curriculumSet id="177">
         <Curriculum reference="102"/>
         <Curriculum reference="124"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>128</studentSize>
     </Course>
     <Course id="178">
@@ -742,10 +742,10 @@
       <teacher reference="24"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="179">
+      <curriculumSet id="179">
         <Curriculum reference="102"/>
         <Curriculum reference="124"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>128</studentSize>
     </Course>
     <Course id="180">
@@ -754,11 +754,11 @@
       <teacher reference="23"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="181">
+      <curriculumSet id="181">
         <Curriculum reference="103"/>
         <Curriculum reference="104"/>
         <Curriculum reference="105"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>67</studentSize>
     </Course>
     <Course id="182">
@@ -767,12 +767,12 @@
       <teacher reference="3"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="183">
+      <curriculumSet id="183">
         <Curriculum reference="104"/>
         <Curriculum reference="132"/>
         <Curriculum reference="143"/>
         <Curriculum reference="145"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>68</studentSize>
     </Course>
     <Course id="184">
@@ -781,11 +781,11 @@
       <teacher reference="4"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="185">
+      <curriculumSet id="185">
         <Curriculum reference="99"/>
         <Curriculum reference="157"/>
         <Curriculum reference="158"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>30</studentSize>
     </Course>
     <Course id="186">
@@ -794,14 +794,14 @@
       <teacher reference="5"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="187">
+      <curriculumSet id="187">
         <Curriculum reference="96"/>
         <Curriculum reference="107"/>
         <Curriculum reference="139"/>
         <Curriculum reference="140"/>
         <Curriculum reference="141"/>
         <Curriculum reference="142"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>67</studentSize>
     </Course>
     <Course id="188">
@@ -810,9 +810,9 @@
       <teacher reference="5"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="189">
+      <curriculumSet id="189">
         <Curriculum reference="99"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>20</studentSize>
     </Course>
     <Course id="190">
@@ -821,9 +821,9 @@
       <teacher reference="7"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="191">
+      <curriculumSet id="191">
         <Curriculum reference="92"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>100</studentSize>
     </Course>
     <Course id="192">
@@ -832,10 +832,10 @@
       <teacher reference="8"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="193">
+      <curriculumSet id="193">
         <Curriculum reference="93"/>
         <Curriculum reference="134"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>130</studentSize>
     </Course>
     <Course id="194">
@@ -844,9 +844,9 @@
       <teacher reference="45"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="195">
+      <curriculumSet id="195">
         <Curriculum reference="92"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>100</studentSize>
     </Course>
     <Course id="196">
@@ -855,12 +855,12 @@
       <teacher reference="44"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="197">
+      <curriculumSet id="197">
         <Curriculum reference="93"/>
         <Curriculum reference="112"/>
         <Curriculum reference="113"/>
         <Curriculum reference="114"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>182</studentSize>
     </Course>
     <Course id="198">
@@ -869,9 +869,9 @@
       <teacher reference="43"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="199">
+      <curriculumSet id="199">
         <Curriculum reference="92"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>100</studentSize>
     </Course>
     <Course id="200">
@@ -880,12 +880,12 @@
       <teacher reference="42"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="201">
+      <curriculumSet id="201">
         <Curriculum reference="118"/>
         <Curriculum reference="119"/>
         <Curriculum reference="120"/>
         <Curriculum reference="121"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>130</studentSize>
     </Course>
     <Course id="202">
@@ -894,13 +894,13 @@
       <teacher reference="46"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="203">
+      <curriculumSet id="203">
         <Curriculum reference="107"/>
         <Curriculum reference="108"/>
         <Curriculum reference="109"/>
         <Curriculum reference="122"/>
         <Curriculum reference="123"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>200</studentSize>
     </Course>
     <Course id="204">
@@ -909,12 +909,12 @@
       <teacher reference="25"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="205">
+      <curriculumSet id="205">
         <Curriculum reference="118"/>
         <Curriculum reference="119"/>
         <Curriculum reference="120"/>
         <Curriculum reference="121"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>130</studentSize>
     </Course>
     <Course id="206">
@@ -923,10 +923,10 @@
       <teacher reference="26"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="207">
+      <curriculumSet id="207">
         <Curriculum reference="122"/>
         <Curriculum reference="123"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>120</studentSize>
     </Course>
     <Course id="208">
@@ -935,11 +935,11 @@
       <teacher reference="31"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="209">
+      <curriculumSet id="209">
         <Curriculum reference="115"/>
         <Curriculum reference="116"/>
         <Curriculum reference="117"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>150</studentSize>
     </Course>
     <Course id="210">
@@ -948,10 +948,10 @@
       <teacher reference="67"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="211">
+      <curriculumSet id="211">
         <Curriculum reference="92"/>
         <Curriculum reference="111"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>190</studentSize>
     </Course>
     <Course id="212">
@@ -960,14 +960,14 @@
       <teacher reference="32"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="213">
+      <curriculumSet id="213">
         <Curriculum reference="112"/>
         <Curriculum reference="113"/>
         <Curriculum reference="114"/>
         <Curriculum reference="125"/>
         <Curriculum reference="126"/>
         <Curriculum reference="127"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>119</studentSize>
     </Course>
     <Course id="214">
@@ -976,14 +976,14 @@
       <teacher reference="28"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="215">
+      <curriculumSet id="215">
         <Curriculum reference="112"/>
         <Curriculum reference="113"/>
         <Curriculum reference="114"/>
         <Curriculum reference="125"/>
         <Curriculum reference="126"/>
         <Curriculum reference="127"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>119</studentSize>
     </Course>
     <Course id="216">
@@ -992,11 +992,11 @@
       <teacher reference="30"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="217">
+      <curriculumSet id="217">
         <Curriculum reference="128"/>
         <Curriculum reference="129"/>
         <Curriculum reference="147"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>38</studentSize>
     </Course>
     <Course id="218">
@@ -1005,9 +1005,9 @@
       <teacher reference="57"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="219">
+      <curriculumSet id="219">
         <Curriculum reference="141"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>3</studentSize>
     </Course>
     <Course id="220">
@@ -1016,10 +1016,10 @@
       <teacher reference="58"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="221">
+      <curriculumSet id="221">
         <Curriculum reference="149"/>
         <Curriculum reference="150"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>70</studentSize>
     </Course>
     <Course id="222">
@@ -1028,9 +1028,9 @@
       <teacher reference="20"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="223">
+      <curriculumSet id="223">
         <Curriculum reference="154"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>10</studentSize>
     </Course>
     <Course id="224">
@@ -1039,10 +1039,10 @@
       <teacher reference="43"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="225">
+      <curriculumSet id="225">
         <Curriculum reference="135"/>
         <Curriculum reference="157"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>25</studentSize>
     </Course>
     <Course id="226">
@@ -1051,9 +1051,9 @@
       <teacher reference="59"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="227">
+      <curriculumSet id="227">
         <Curriculum reference="157"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>5</studentSize>
     </Course>
     <Course id="228">
@@ -1062,11 +1062,11 @@
       <teacher reference="60"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="229">
+      <curriculumSet id="229">
         <Curriculum reference="138"/>
         <Curriculum reference="140"/>
         <Curriculum reference="155"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>28</studentSize>
     </Course>
     <Course id="230">
@@ -1075,10 +1075,10 @@
       <teacher reference="60"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="231">
+      <curriculumSet id="231">
         <Curriculum reference="155"/>
         <Curriculum reference="156"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>20</studentSize>
     </Course>
     <Course id="232">
@@ -1087,10 +1087,10 @@
       <teacher reference="51"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="233">
+      <curriculumSet id="233">
         <Curriculum reference="158"/>
         <Curriculum reference="159"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>10</studentSize>
     </Course>
     <Course id="234">
@@ -1099,11 +1099,11 @@
       <teacher reference="53"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="235">
+      <curriculumSet id="235">
         <Curriculum reference="100"/>
         <Curriculum reference="158"/>
         <Curriculum reference="159"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>20</studentSize>
     </Course>
     <Course id="236">
@@ -1112,10 +1112,10 @@
       <teacher reference="51"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="237">
+      <curriculumSet id="237">
         <Curriculum reference="158"/>
         <Curriculum reference="159"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>10</studentSize>
     </Course>
     <Course id="238">
@@ -1124,11 +1124,11 @@
       <teacher reference="53"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="239">
+      <curriculumSet id="239">
         <Curriculum reference="100"/>
         <Curriculum reference="158"/>
         <Curriculum reference="159"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>20</studentSize>
     </Course>
     <Course id="240">
@@ -1137,9 +1137,9 @@
       <teacher reference="52"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="241">
+      <curriculumSet id="241">
         <Curriculum reference="111"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>90</studentSize>
     </Course>
     <Course id="242">
@@ -1148,9 +1148,9 @@
       <teacher reference="48"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="243">
+      <curriculumSet id="243">
         <Curriculum reference="111"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>90</studentSize>
     </Course>
     <Course id="244">
@@ -1159,9 +1159,9 @@
       <teacher reference="47"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="245">
+      <curriculumSet id="245">
         <Curriculum reference="111"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>90</studentSize>
     </Course>
     <Course id="246">
@@ -1170,14 +1170,14 @@
       <teacher reference="50"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="247">
+      <curriculumSet id="247">
         <Curriculum reference="112"/>
         <Curriculum reference="125"/>
         <Curriculum reference="128"/>
         <Curriculum reference="129"/>
         <Curriculum reference="130"/>
         <Curriculum reference="131"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>158</studentSize>
     </Course>
     <Course id="248">
@@ -1186,12 +1186,12 @@
       <teacher reference="49"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="249">
+      <curriculumSet id="249">
         <Curriculum reference="95"/>
         <Curriculum reference="96"/>
         <Curriculum reference="97"/>
         <Curriculum reference="106"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>145</studentSize>
     </Course>
     <Course id="250">
@@ -1200,12 +1200,12 @@
       <teacher reference="84"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="251">
+      <curriculumSet id="251">
         <Curriculum reference="95"/>
         <Curriculum reference="96"/>
         <Curriculum reference="97"/>
         <Curriculum reference="106"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>145</studentSize>
     </Course>
     <Course id="252">
@@ -1214,12 +1214,12 @@
       <teacher reference="86"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="253">
+      <curriculumSet id="253">
         <Curriculum reference="99"/>
         <Curriculum reference="107"/>
         <Curriculum reference="108"/>
         <Curriculum reference="109"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>100</studentSize>
     </Course>
     <Course id="254">
@@ -1228,9 +1228,9 @@
       <teacher reference="82"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="255">
+      <curriculumSet id="255">
         <Curriculum reference="106"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>100</studentSize>
     </Course>
     <Course id="256">
@@ -1239,11 +1239,11 @@
       <teacher reference="76"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="257">
+      <curriculumSet id="257">
         <Curriculum reference="99"/>
         <Curriculum reference="107"/>
         <Curriculum reference="137"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>85</studentSize>
     </Course>
     <Course id="258">
@@ -1252,10 +1252,10 @@
       <teacher reference="84"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="259">
+      <curriculumSet id="259">
         <Curriculum reference="108"/>
         <Curriculum reference="136"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>65</studentSize>
     </Course>
     <Course id="260">
@@ -1264,11 +1264,11 @@
       <teacher reference="75"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="261">
+      <curriculumSet id="261">
         <Curriculum reference="108"/>
         <Curriculum reference="109"/>
         <Curriculum reference="138"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>60</studentSize>
     </Course>
     <Course id="262">
@@ -1277,7 +1277,7 @@
       <teacher reference="74"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="263">
+      <curriculumSet id="263">
         <Curriculum reference="105"/>
         <Curriculum reference="125"/>
         <Curriculum reference="126"/>
@@ -1286,7 +1286,7 @@
         <Curriculum reference="131"/>
         <Curriculum reference="143"/>
         <Curriculum reference="144"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>142</studentSize>
     </Course>
     <Course id="264">
@@ -1295,13 +1295,13 @@
       <teacher reference="73"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="265">
+      <curriculumSet id="265">
         <Curriculum reference="127"/>
         <Curriculum reference="129"/>
         <Curriculum reference="143"/>
         <Curriculum reference="144"/>
         <Curriculum reference="145"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>90</studentSize>
     </Course>
     <Course id="266">
@@ -1310,9 +1310,9 @@
       <teacher reference="72"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="267">
+      <curriculumSet id="267">
         <Curriculum reference="136"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>30</studentSize>
     </Course>
     <Course id="268">
@@ -1321,13 +1321,13 @@
       <teacher reference="86"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="269">
+      <curriculumSet id="269">
         <Curriculum reference="138"/>
         <Curriculum reference="139"/>
         <Curriculum reference="140"/>
         <Curriculum reference="141"/>
         <Curriculum reference="142"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>27</studentSize>
     </Course>
     <Course id="270">
@@ -1336,7 +1336,7 @@
       <teacher reference="71"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="271">
+      <curriculumSet id="271">
         <Curriculum reference="97"/>
         <Curriculum reference="99"/>
         <Curriculum reference="109"/>
@@ -1344,7 +1344,7 @@
         <Curriculum reference="142"/>
         <Curriculum reference="155"/>
         <Curriculum reference="156"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>78</studentSize>
     </Course>
     <Course id="272">
@@ -1353,7 +1353,7 @@
       <teacher reference="70"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="273">
+      <curriculumSet id="273">
         <Curriculum reference="114"/>
         <Curriculum reference="130"/>
         <Curriculum reference="138"/>
@@ -1362,7 +1362,7 @@
         <Curriculum reference="141"/>
         <Curriculum reference="142"/>
         <Curriculum reference="150"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>122</studentSize>
     </Course>
     <Course id="274">
@@ -1371,9 +1371,9 @@
       <teacher reference="46"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="275">
+      <curriculumSet id="275">
         <Curriculum reference="137"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>30</studentSize>
     </Course>
     <Course id="276">
@@ -1382,10 +1382,10 @@
       <teacher reference="69"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="277">
+      <curriculumSet id="277">
         <Curriculum reference="136"/>
         <Curriculum reference="137"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>60</studentSize>
     </Course>
     <Course id="278">
@@ -1394,9 +1394,9 @@
       <teacher reference="17"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="279">
+      <curriculumSet id="279">
         <Curriculum reference="137"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>30</studentSize>
     </Course>
     <Course id="280">
@@ -1405,9 +1405,9 @@
       <teacher reference="18"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="281">
+      <curriculumSet id="281">
         <Curriculum reference="137"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>30</studentSize>
     </Course>
     <Course id="282">
@@ -1416,9 +1416,9 @@
       <teacher reference="6"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="283">
+      <curriculumSet id="283">
         <Curriculum reference="139"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>3</studentSize>
     </Course>
     <Course id="284">
@@ -1427,11 +1427,11 @@
       <teacher reference="10"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="285">
+      <curriculumSet id="285">
         <Curriculum reference="102"/>
         <Curriculum reference="128"/>
         <Curriculum reference="129"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>113</studentSize>
     </Course>
     <Course id="286">
@@ -1440,12 +1440,12 @@
       <teacher reference="9"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="287">
+      <curriculumSet id="287">
         <Curriculum reference="102"/>
         <Curriculum reference="143"/>
         <Curriculum reference="144"/>
         <Curriculum reference="145"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>150</studentSize>
     </Course>
     <Course id="288">
@@ -1454,10 +1454,10 @@
       <teacher reference="12"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="289">
+      <curriculumSet id="289">
         <Curriculum reference="98"/>
         <Curriculum reference="154"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>25</studentSize>
     </Course>
     <Course id="290">
@@ -1466,9 +1466,9 @@
       <teacher reference="11"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="291">
+      <curriculumSet id="291">
         <Curriculum reference="94"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>50</studentSize>
     </Course>
     <Course id="292">
@@ -1477,9 +1477,9 @@
       <teacher reference="14"/>
       <lectureSize>5</lectureSize>
       <minWorkingDaySize>4</minWorkingDaySize>
-      <curriculumList id="293">
+      <curriculumSet id="293">
         <Curriculum reference="101"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>50</studentSize>
     </Course>
     <Course id="294">
@@ -1488,9 +1488,9 @@
       <teacher reference="14"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="295">
+      <curriculumSet id="295">
         <Curriculum reference="101"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>50</studentSize>
     </Course>
     <Course id="296">
@@ -1499,9 +1499,9 @@
       <teacher reference="13"/>
       <lectureSize>5</lectureSize>
       <minWorkingDaySize>4</minWorkingDaySize>
-      <curriculumList id="297">
+      <curriculumSet id="297">
         <Curriculum reference="110"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>50</studentSize>
     </Course>
     <Course id="298">
@@ -1510,9 +1510,9 @@
       <teacher reference="13"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="299">
+      <curriculumSet id="299">
         <Curriculum reference="110"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>50</studentSize>
     </Course>
     <Course id="300">
@@ -1521,9 +1521,9 @@
       <teacher reference="16"/>
       <lectureSize>5</lectureSize>
       <minWorkingDaySize>4</minWorkingDaySize>
-      <curriculumList id="301">
+      <curriculumSet id="301">
         <Curriculum reference="91"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>50</studentSize>
     </Course>
     <Course id="302">
@@ -1532,9 +1532,9 @@
       <teacher reference="16"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="303">
+      <curriculumSet id="303">
         <Curriculum reference="91"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>50</studentSize>
     </Course>
     <Course id="304">
@@ -1543,9 +1543,9 @@
       <teacher reference="72"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="305">
+      <curriculumSet id="305">
         <Curriculum reference="122"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>110</studentSize>
     </Course>
     <Course id="306">
@@ -1554,12 +1554,12 @@
       <teacher reference="32"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="307">
+      <curriculumSet id="307">
         <Curriculum reference="128"/>
         <Curriculum reference="129"/>
         <Curriculum reference="130"/>
         <Curriculum reference="131"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>83</studentSize>
     </Course>
     <Course id="308">
@@ -1568,10 +1568,10 @@
       <teacher reference="15"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="309">
+      <curriculumSet id="309">
         <Curriculum reference="130"/>
         <Curriculum reference="131"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>60</studentSize>
     </Course>
     <Course id="310">
@@ -1580,12 +1580,12 @@
       <teacher reference="41"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="311">
+      <curriculumSet id="311">
         <Curriculum reference="132"/>
         <Curriculum reference="133"/>
         <Curriculum reference="134"/>
         <Curriculum reference="135"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>68</studentSize>
     </Course>
     <Course id="312">
@@ -1594,12 +1594,12 @@
       <teacher reference="29"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="313">
+      <curriculumSet id="313">
         <Curriculum reference="132"/>
         <Curriculum reference="133"/>
         <Curriculum reference="134"/>
         <Curriculum reference="135"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>68</studentSize>
     </Course>
     <Course id="314">
@@ -1608,14 +1608,14 @@
       <teacher reference="27"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="315">
+      <curriculumSet id="315">
         <Curriculum reference="126"/>
         <Curriculum reference="128"/>
         <Curriculum reference="133"/>
         <Curriculum reference="143"/>
         <Curriculum reference="144"/>
         <Curriculum reference="145"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>80</studentSize>
     </Course>
     <Course id="316">
@@ -1624,11 +1624,11 @@
       <teacher reference="36"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="317">
+      <curriculumSet id="317">
         <Curriculum reference="146"/>
         <Curriculum reference="147"/>
         <Curriculum reference="148"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>45</studentSize>
     </Course>
     <Course id="318">
@@ -1637,10 +1637,10 @@
       <teacher reference="10"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="319">
+      <curriculumSet id="319">
         <Curriculum reference="133"/>
         <Curriculum reference="146"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>30</studentSize>
     </Course>
     <Course id="320">
@@ -1649,10 +1649,10 @@
       <teacher reference="35"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="321">
+      <curriculumSet id="321">
         <Curriculum reference="132"/>
         <Curriculum reference="144"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>23</studentSize>
     </Course>
     <Course id="322">
@@ -1661,10 +1661,10 @@
       <teacher reference="58"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="323">
+      <curriculumSet id="323">
         <Curriculum reference="149"/>
         <Curriculum reference="150"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>70</studentSize>
     </Course>
     <Course id="324">
@@ -1673,9 +1673,9 @@
       <teacher reference="34"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="325">
+      <curriculumSet id="325">
         <Curriculum reference="149"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>40</studentSize>
     </Course>
     <Course id="326">
@@ -1684,11 +1684,11 @@
       <teacher reference="33"/>
       <lectureSize>2</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="327">
+      <curriculumSet id="327">
         <Curriculum reference="151"/>
         <Curriculum reference="152"/>
         <Curriculum reference="153"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>60</studentSize>
     </Course>
     <Course id="328">
@@ -1697,11 +1697,11 @@
       <teacher reference="33"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="329">
+      <curriculumSet id="329">
         <Curriculum reference="151"/>
         <Curriculum reference="152"/>
         <Curriculum reference="153"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>60</studentSize>
     </Course>
     <Course id="330">
@@ -1710,10 +1710,10 @@
       <teacher reference="7"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="331">
+      <curriculumSet id="331">
         <Curriculum reference="148"/>
         <Curriculum reference="151"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>45</studentSize>
     </Course>
     <Course id="332">
@@ -1722,10 +1722,10 @@
       <teacher reference="40"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="333">
+      <curriculumSet id="333">
         <Curriculum reference="152"/>
         <Curriculum reference="157"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>25</studentSize>
     </Course>
     <Course id="334">
@@ -1734,9 +1734,9 @@
       <teacher reference="39"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="335">
+      <curriculumSet id="335">
         <Curriculum reference="153"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>10</studentSize>
     </Course>
     <Course id="336">
@@ -1745,12 +1745,12 @@
       <teacher reference="38"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="337">
+      <curriculumSet id="337">
         <Curriculum reference="100"/>
         <Curriculum reference="154"/>
         <Curriculum reference="155"/>
         <Curriculum reference="156"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>40</studentSize>
     </Course>
     <Course id="338">
@@ -1759,12 +1759,12 @@
       <teacher reference="37"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="339">
+      <curriculumSet id="339">
         <Curriculum reference="136"/>
         <Curriculum reference="137"/>
         <Curriculum reference="155"/>
         <Curriculum reference="156"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>80</studentSize>
     </Course>
     <Course id="340">
@@ -1773,9 +1773,9 @@
       <teacher reference="89"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="341">
+      <curriculumSet id="341">
         <Curriculum reference="160"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>100</studentSize>
     </Course>
     <Course id="342">
@@ -1784,9 +1784,9 @@
       <teacher reference="89"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="343">
+      <curriculumSet id="343">
         <Curriculum reference="160"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>100</studentSize>
     </Course>
     <Course id="344">
@@ -1795,9 +1795,9 @@
       <teacher reference="87"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="345">
+      <curriculumSet id="345">
         <Curriculum reference="160"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>100</studentSize>
     </Course>
     <Course id="346">
@@ -1806,9 +1806,9 @@
       <teacher reference="88"/>
       <lectureSize>7</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="347">
+      <curriculumSet id="347">
         <Curriculum reference="160"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>100</studentSize>
     </Course>
     <Course id="348">
@@ -1817,11 +1817,11 @@
       <teacher reference="79"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="349">
+      <curriculumSet id="349">
         <Curriculum reference="118"/>
         <Curriculum reference="119"/>
         <Curriculum reference="121"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>120</studentSize>
     </Course>
     <Course id="350">
@@ -1830,11 +1830,11 @@
       <teacher reference="80"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="351">
+      <curriculumSet id="351">
         <Curriculum reference="115"/>
         <Curriculum reference="116"/>
         <Curriculum reference="117"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>150</studentSize>
     </Course>
     <Course id="352">
@@ -1843,10 +1843,10 @@
       <teacher reference="77"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="353">
+      <curriculumSet id="353">
         <Curriculum reference="100"/>
         <Curriculum reference="120"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>20</studentSize>
     </Course>
     <Course id="354">
@@ -1855,9 +1855,9 @@
       <teacher reference="78"/>
       <lectureSize>5</lectureSize>
       <minWorkingDaySize>4</minWorkingDaySize>
-      <curriculumList id="355">
+      <curriculumSet id="355">
         <Curriculum reference="93"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>100</studentSize>
     </Course>
     <Course id="356">
@@ -1866,9 +1866,9 @@
       <teacher reference="83"/>
       <lectureSize>7</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="357">
+      <curriculumSet id="357">
         <Curriculum reference="121"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>40</studentSize>
     </Course>
     <Course id="358">
@@ -1877,9 +1877,9 @@
       <teacher reference="85"/>
       <lectureSize>7</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="359">
+      <curriculumSet id="359">
         <Curriculum reference="118"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>40</studentSize>
     </Course>
     <Course id="360">
@@ -1888,9 +1888,9 @@
       <teacher reference="81"/>
       <lectureSize>7</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="361">
+      <curriculumSet id="361">
         <Curriculum reference="116"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>50</studentSize>
     </Course>
     <Course id="362">
@@ -1899,9 +1899,9 @@
       <teacher reference="61"/>
       <lectureSize>7</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="363">
+      <curriculumSet id="363">
         <Curriculum reference="117"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>50</studentSize>
     </Course>
     <Course id="364">
@@ -1910,9 +1910,9 @@
       <teacher reference="62"/>
       <lectureSize>7</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="365">
+      <curriculumSet id="365">
         <Curriculum reference="115"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>50</studentSize>
     </Course>
     <Course id="366">
@@ -1921,9 +1921,9 @@
       <teacher reference="63"/>
       <lectureSize>7</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="367">
+      <curriculumSet id="367">
         <Curriculum reference="119"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>40</studentSize>
     </Course>
     <Course id="368">
@@ -1932,9 +1932,9 @@
       <teacher reference="43"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="369">
+      <curriculumSet id="369">
         <Curriculum reference="152"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>20</studentSize>
     </Course>
     <Course id="370">
@@ -1943,11 +1943,11 @@
       <teacher reference="64"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="371">
+      <curriculumSet id="371">
         <Curriculum reference="103"/>
         <Curriculum reference="104"/>
         <Curriculum reference="105"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>67</studentSize>
     </Course>
     <Course id="372">
@@ -1956,9 +1956,9 @@
       <teacher reference="54"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="373">
+      <curriculumSet id="373">
         <Curriculum reference="147"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>15</studentSize>
     </Course>
     <Course id="374">
@@ -1967,11 +1967,11 @@
       <teacher reference="55"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="375">
+      <curriculumSet id="375">
         <Curriculum reference="146"/>
         <Curriculum reference="147"/>
         <Curriculum reference="148"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>45</studentSize>
     </Course>
     <Course id="376">
@@ -1980,9 +1980,9 @@
       <teacher reference="56"/>
       <lectureSize>5</lectureSize>
       <minWorkingDaySize>4</minWorkingDaySize>
-      <curriculumList id="377">
+      <curriculumSet id="377">
         <Curriculum reference="94"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>50</studentSize>
     </Course>
   </courseList>

--- a/optaplanner-examples/data/curriculumcourse/unsolved/comp07.xml
+++ b/optaplanner-examples/data/curriculumcourse/unsolved/comp07.xml
@@ -716,9 +716,9 @@
       <teacher reference="79"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="182">
+      <curriculumSet id="182">
         <Curriculum reference="109"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>12</studentSize>
     </Course>
     <Course id="183">
@@ -727,10 +727,10 @@
       <teacher reference="80"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="184">
+      <curriculumSet id="184">
         <Curriculum reference="109"/>
         <Curriculum reference="111"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>16</studentSize>
     </Course>
     <Course id="185">
@@ -739,10 +739,10 @@
       <teacher reference="77"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="186">
+      <curriculumSet id="186">
         <Curriculum reference="112"/>
         <Curriculum reference="114"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>15</studentSize>
     </Course>
     <Course id="187">
@@ -751,11 +751,11 @@
       <teacher reference="78"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="188">
+      <curriculumSet id="188">
         <Curriculum reference="111"/>
         <Curriculum reference="112"/>
         <Curriculum reference="113"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>31</studentSize>
     </Course>
     <Course id="189">
@@ -764,9 +764,9 @@
       <teacher reference="20"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="190">
+      <curriculumSet id="190">
         <Curriculum reference="112"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>12</studentSize>
     </Course>
     <Course id="191">
@@ -775,12 +775,12 @@
       <teacher reference="19"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="192">
+      <curriculumSet id="192">
         <Curriculum reference="109"/>
         <Curriculum reference="110"/>
         <Curriculum reference="111"/>
         <Curriculum reference="121"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>111</studentSize>
     </Course>
     <Course id="193">
@@ -789,10 +789,10 @@
       <teacher reference="22"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="194">
+      <curriculumSet id="194">
         <Curriculum reference="112"/>
         <Curriculum reference="166"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>38</studentSize>
     </Course>
     <Course id="195">
@@ -801,9 +801,9 @@
       <teacher reference="21"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="196">
+      <curriculumSet id="196">
         <Curriculum reference="115"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>110</studentSize>
     </Course>
     <Course id="197">
@@ -812,10 +812,10 @@
       <teacher reference="24"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="198">
+      <curriculumSet id="198">
         <Curriculum reference="116"/>
         <Curriculum reference="140"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>100</studentSize>
     </Course>
     <Course id="199">
@@ -824,12 +824,12 @@
       <teacher reference="23"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="200">
+      <curriculumSet id="200">
         <Curriculum reference="117"/>
         <Curriculum reference="118"/>
         <Curriculum reference="119"/>
         <Curriculum reference="120"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>55</studentSize>
     </Course>
     <Course id="201">
@@ -838,9 +838,9 @@
       <teacher reference="3"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="202">
+      <curriculumSet id="202">
         <Curriculum reference="116"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>60</studentSize>
     </Course>
     <Course id="203">
@@ -849,9 +849,9 @@
       <teacher reference="4"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="204">
+      <curriculumSet id="204">
         <Curriculum reference="115"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>110</studentSize>
     </Course>
     <Course id="205">
@@ -860,10 +860,10 @@
       <teacher reference="5"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="206">
+      <curriculumSet id="206">
         <Curriculum reference="116"/>
         <Curriculum reference="140"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>100</studentSize>
     </Course>
     <Course id="207">
@@ -872,12 +872,12 @@
       <teacher reference="7"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="208">
+      <curriculumSet id="208">
         <Curriculum reference="117"/>
         <Curriculum reference="118"/>
         <Curriculum reference="119"/>
         <Curriculum reference="120"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>55</studentSize>
     </Course>
     <Course id="209">
@@ -886,12 +886,12 @@
       <teacher reference="8"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="210">
+      <curriculumSet id="210">
         <Curriculum reference="117"/>
         <Curriculum reference="118"/>
         <Curriculum reference="119"/>
         <Curriculum reference="120"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>55</studentSize>
     </Course>
     <Course id="211">
@@ -900,9 +900,9 @@
       <teacher reference="3"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="212">
+      <curriculumSet id="212">
         <Curriculum reference="115"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>110</studentSize>
     </Course>
     <Course id="213">
@@ -911,7 +911,7 @@
       <teacher reference="53"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="214">
+      <curriculumSet id="214">
         <Curriculum reference="120"/>
         <Curriculum reference="141"/>
         <Curriculum reference="142"/>
@@ -919,7 +919,7 @@
         <Curriculum reference="150"/>
         <Curriculum reference="158"/>
         <Curriculum reference="165"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>127</studentSize>
     </Course>
     <Course id="215">
@@ -928,10 +928,10 @@
       <teacher reference="51"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="216">
+      <curriculumSet id="216">
         <Curriculum reference="118"/>
         <Curriculum reference="156"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>13</studentSize>
     </Course>
     <Course id="217">
@@ -940,12 +940,12 @@
       <teacher reference="49"/>
       <lectureSize>5</lectureSize>
       <minWorkingDaySize>4</minWorkingDaySize>
-      <curriculumList id="218">
+      <curriculumSet id="218">
         <Curriculum reference="113"/>
         <Curriculum reference="123"/>
         <Curriculum reference="152"/>
         <Curriculum reference="153"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>85</studentSize>
     </Course>
     <Course id="219">
@@ -954,9 +954,9 @@
       <teacher reference="47"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="220">
+      <curriculumSet id="220">
         <Curriculum reference="103"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>90</studentSize>
     </Course>
     <Course id="221">
@@ -965,9 +965,9 @@
       <teacher reference="55"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="222">
+      <curriculumSet id="222">
         <Curriculum reference="104"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>80</studentSize>
     </Course>
     <Course id="223">
@@ -976,13 +976,13 @@
       <teacher reference="25"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="224">
+      <curriculumSet id="224">
         <Curriculum reference="105"/>
         <Curriculum reference="106"/>
         <Curriculum reference="107"/>
         <Curriculum reference="130"/>
         <Curriculum reference="146"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>147</studentSize>
     </Course>
     <Course id="225">
@@ -991,9 +991,9 @@
       <teacher reference="26"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="226">
+      <curriculumSet id="226">
         <Curriculum reference="103"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>90</studentSize>
     </Course>
     <Course id="227">
@@ -1002,10 +1002,10 @@
       <teacher reference="5"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="228">
+      <curriculumSet id="228">
         <Curriculum reference="104"/>
         <Curriculum reference="127"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>160</studentSize>
     </Course>
     <Course id="229">
@@ -1014,10 +1014,10 @@
       <teacher reference="31"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="230">
+      <curriculumSet id="230">
         <Curriculum reference="104"/>
         <Curriculum reference="150"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>125</studentSize>
     </Course>
     <Course id="231">
@@ -1026,13 +1026,13 @@
       <teacher reference="32"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="232">
+      <curriculumSet id="232">
         <Curriculum reference="105"/>
         <Curriculum reference="106"/>
         <Curriculum reference="107"/>
         <Curriculum reference="146"/>
         <Curriculum reference="147"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>136</studentSize>
     </Course>
     <Course id="233">
@@ -1041,9 +1041,9 @@
       <teacher reference="28"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="234">
+      <curriculumSet id="234">
         <Curriculum reference="105"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>33</studentSize>
     </Course>
     <Course id="235">
@@ -1052,9 +1052,9 @@
       <teacher reference="30"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="236">
+      <curriculumSet id="236">
         <Curriculum reference="103"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>90</studentSize>
     </Course>
     <Course id="237">
@@ -1063,11 +1063,11 @@
       <teacher reference="68"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="238">
+      <curriculumSet id="238">
         <Curriculum reference="131"/>
         <Curriculum reference="132"/>
         <Curriculum reference="133"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>105</studentSize>
     </Course>
     <Course id="239">
@@ -1076,11 +1076,11 @@
       <teacher reference="70"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="240">
+      <curriculumSet id="240">
         <Curriculum reference="131"/>
         <Curriculum reference="132"/>
         <Curriculum reference="133"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>105</studentSize>
     </Course>
     <Course id="241">
@@ -1089,12 +1089,12 @@
       <teacher reference="70"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="242">
+      <curriculumSet id="242">
         <Curriculum reference="134"/>
         <Curriculum reference="135"/>
         <Curriculum reference="136"/>
         <Curriculum reference="137"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>105</studentSize>
     </Course>
     <Course id="243">
@@ -1103,11 +1103,11 @@
       <teacher reference="71"/>
       <lectureSize>5</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="244">
+      <curriculumSet id="244">
         <Curriculum reference="134"/>
         <Curriculum reference="135"/>
         <Curriculum reference="137"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>100</studentSize>
     </Course>
     <Course id="245">
@@ -1116,11 +1116,11 @@
       <teacher reference="72"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="246">
+      <curriculumSet id="246">
         <Curriculum reference="131"/>
         <Curriculum reference="132"/>
         <Curriculum reference="133"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>105</studentSize>
     </Course>
     <Course id="247">
@@ -1129,12 +1129,12 @@
       <teacher reference="60"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="248">
+      <curriculumSet id="248">
         <Curriculum reference="134"/>
         <Curriculum reference="135"/>
         <Curriculum reference="136"/>
         <Curriculum reference="137"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>105</studentSize>
     </Course>
     <Course id="249">
@@ -1143,10 +1143,10 @@
       <teacher reference="62"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="250">
+      <curriculumSet id="250">
         <Curriculum reference="138"/>
         <Curriculum reference="139"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>102</studentSize>
     </Course>
     <Course id="251">
@@ -1155,9 +1155,9 @@
       <teacher reference="61"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="252">
+      <curriculumSet id="252">
         <Curriculum reference="126"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>90</studentSize>
     </Course>
     <Course id="253">
@@ -1166,9 +1166,9 @@
       <teacher reference="57"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="254">
+      <curriculumSet id="254">
         <Curriculum reference="127"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>80</studentSize>
     </Course>
     <Course id="255">
@@ -1177,10 +1177,10 @@
       <teacher reference="56"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="256">
+      <curriculumSet id="256">
         <Curriculum reference="127"/>
         <Curriculum reference="162"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>106</studentSize>
     </Course>
     <Course id="257">
@@ -1189,9 +1189,9 @@
       <teacher reference="4"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="258">
+      <curriculumSet id="258">
         <Curriculum reference="126"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>90</studentSize>
     </Course>
     <Course id="259">
@@ -1200,14 +1200,14 @@
       <teacher reference="59"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="260">
+      <curriculumSet id="260">
         <Curriculum reference="128"/>
         <Curriculum reference="129"/>
         <Curriculum reference="130"/>
         <Curriculum reference="141"/>
         <Curriculum reference="142"/>
         <Curriculum reference="143"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>105</studentSize>
     </Course>
     <Course id="261">
@@ -1216,10 +1216,10 @@
       <teacher reference="72"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="262">
+      <curriculumSet id="262">
         <Curriculum reference="128"/>
         <Curriculum reference="141"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>75</studentSize>
     </Course>
     <Course id="263">
@@ -1228,9 +1228,9 @@
       <teacher reference="58"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="264">
+      <curriculumSet id="264">
         <Curriculum reference="126"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>90</studentSize>
     </Course>
     <Course id="265">
@@ -1239,9 +1239,9 @@
       <teacher reference="96"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="266">
+      <curriculumSet id="266">
         <Curriculum reference="108"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>130</studentSize>
     </Course>
     <Course id="267">
@@ -1250,9 +1250,9 @@
       <teacher reference="98"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="268">
+      <curriculumSet id="268">
         <Curriculum reference="108"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>130</studentSize>
     </Course>
     <Course id="269">
@@ -1261,11 +1261,11 @@
       <teacher reference="80"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="270">
+      <curriculumSet id="270">
         <Curriculum reference="110"/>
         <Curriculum reference="121"/>
         <Curriculum reference="122"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>98</studentSize>
     </Course>
     <Course id="271">
@@ -1274,10 +1274,10 @@
       <teacher reference="94"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="272">
+      <curriculumSet id="272">
         <Curriculum reference="121"/>
         <Curriculum reference="122"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>83</studentSize>
     </Course>
     <Course id="273">
@@ -1286,12 +1286,12 @@
       <teacher reference="62"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="274">
+      <curriculumSet id="274">
         <Curriculum reference="113"/>
         <Curriculum reference="123"/>
         <Curriculum reference="124"/>
         <Curriculum reference="125"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>98</studentSize>
     </Course>
     <Course id="275">
@@ -1300,11 +1300,11 @@
       <teacher reference="88"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="276">
+      <curriculumSet id="276">
         <Curriculum reference="123"/>
         <Curriculum reference="124"/>
         <Curriculum reference="125"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>83</studentSize>
     </Course>
     <Course id="277">
@@ -1313,13 +1313,13 @@
       <teacher reference="87"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="278">
+      <curriculumSet id="278">
         <Curriculum reference="109"/>
         <Curriculum reference="110"/>
         <Curriculum reference="114"/>
         <Curriculum reference="121"/>
         <Curriculum reference="122"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>113</studentSize>
     </Course>
     <Course id="279">
@@ -1328,10 +1328,10 @@
       <teacher reference="86"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="280">
+      <curriculumSet id="280">
         <Curriculum reference="123"/>
         <Curriculum reference="153"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>50</studentSize>
     </Course>
     <Course id="281">
@@ -1340,9 +1340,9 @@
       <teacher reference="85"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="282">
+      <curriculumSet id="282">
         <Curriculum reference="108"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>130</studentSize>
     </Course>
     <Course id="283">
@@ -1351,10 +1351,10 @@
       <teacher reference="84"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="284">
+      <curriculumSet id="284">
         <Curriculum reference="127"/>
         <Curriculum reference="140"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>120</studentSize>
     </Course>
     <Course id="285">
@@ -1363,11 +1363,11 @@
       <teacher reference="83"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="286">
+      <curriculumSet id="286">
         <Curriculum reference="113"/>
         <Curriculum reference="124"/>
         <Curriculum reference="154"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>85</studentSize>
     </Course>
     <Course id="287">
@@ -1376,7 +1376,7 @@
       <teacher reference="82"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="288">
+      <curriculumSet id="288">
         <Curriculum reference="128"/>
         <Curriculum reference="129"/>
         <Curriculum reference="130"/>
@@ -1385,7 +1385,7 @@
         <Curriculum reference="143"/>
         <Curriculum reference="165"/>
         <Curriculum reference="166"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>157</studentSize>
     </Course>
     <Course id="289">
@@ -1394,7 +1394,7 @@
       <teacher reference="81"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="290">
+      <curriculumSet id="290">
         <Curriculum reference="143"/>
         <Curriculum reference="145"/>
         <Curriculum reference="146"/>
@@ -1402,7 +1402,7 @@
         <Curriculum reference="148"/>
         <Curriculum reference="160"/>
         <Curriculum reference="161"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>105</studentSize>
     </Course>
     <Course id="291">
@@ -1411,12 +1411,12 @@
       <teacher reference="17"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="292">
+      <curriculumSet id="292">
         <Curriculum reference="152"/>
         <Curriculum reference="153"/>
         <Curriculum reference="169"/>
         <Curriculum reference="170"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>57</studentSize>
     </Course>
     <Course id="293">
@@ -1425,9 +1425,9 @@
       <teacher reference="18"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="294">
+      <curriculumSet id="294">
         <Curriculum reference="152"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>20</studentSize>
     </Course>
     <Course id="295">
@@ -1436,10 +1436,10 @@
       <teacher reference="17"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="296">
+      <curriculumSet id="296">
         <Curriculum reference="154"/>
         <Curriculum reference="155"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>40</studentSize>
     </Course>
     <Course id="297">
@@ -1448,9 +1448,9 @@
       <teacher reference="60"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="298">
+      <curriculumSet id="298">
         <Curriculum reference="154"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>20</studentSize>
     </Course>
     <Course id="299">
@@ -1459,11 +1459,11 @@
       <teacher reference="87"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="300">
+      <curriculumSet id="300">
         <Curriculum reference="154"/>
         <Curriculum reference="155"/>
         <Curriculum reference="163"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>68</studentSize>
     </Course>
     <Course id="301">
@@ -1472,10 +1472,10 @@
       <teacher reference="6"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="302">
+      <curriculumSet id="302">
         <Curriculum reference="153"/>
         <Curriculum reference="154"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>40</studentSize>
     </Course>
     <Course id="303">
@@ -1484,9 +1484,9 @@
       <teacher reference="10"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="304">
+      <curriculumSet id="304">
         <Curriculum reference="153"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>20</studentSize>
     </Course>
     <Course id="305">
@@ -1495,9 +1495,9 @@
       <teacher reference="9"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="306">
+      <curriculumSet id="306">
         <Curriculum reference="155"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>20</studentSize>
     </Course>
     <Course id="307">
@@ -1506,9 +1506,9 @@
       <teacher reference="83"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="308">
+      <curriculumSet id="308">
         <Curriculum reference="155"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>20</studentSize>
     </Course>
     <Course id="309">
@@ -1517,12 +1517,12 @@
       <teacher reference="12"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="310">
+      <curriculumSet id="310">
         <Curriculum reference="144"/>
         <Curriculum reference="145"/>
         <Curriculum reference="146"/>
         <Curriculum reference="147"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>65</studentSize>
     </Course>
     <Course id="311">
@@ -1531,12 +1531,12 @@
       <teacher reference="11"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="312">
+      <curriculumSet id="312">
         <Curriculum reference="148"/>
         <Curriculum reference="149"/>
         <Curriculum reference="150"/>
         <Curriculum reference="151"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>65</studentSize>
     </Course>
     <Course id="313">
@@ -1545,11 +1545,11 @@
       <teacher reference="14"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="314">
+      <curriculumSet id="314">
         <Curriculum reference="129"/>
         <Curriculum reference="147"/>
         <Curriculum reference="168"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>15</studentSize>
     </Course>
     <Course id="315">
@@ -1558,13 +1558,13 @@
       <teacher reference="60"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="316">
+      <curriculumSet id="316">
         <Curriculum reference="144"/>
         <Curriculum reference="145"/>
         <Curriculum reference="156"/>
         <Curriculum reference="157"/>
         <Curriculum reference="158"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>53</studentSize>
     </Course>
     <Course id="317">
@@ -1573,11 +1573,11 @@
       <teacher reference="23"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="318">
+      <curriculumSet id="318">
         <Curriculum reference="156"/>
         <Curriculum reference="157"/>
         <Curriculum reference="158"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>37</studentSize>
     </Course>
     <Course id="319">
@@ -1586,11 +1586,11 @@
       <teacher reference="13"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="320">
+      <curriculumSet id="320">
         <Curriculum reference="159"/>
         <Curriculum reference="160"/>
         <Curriculum reference="161"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>38</studentSize>
     </Course>
     <Course id="321">
@@ -1599,10 +1599,10 @@
       <teacher reference="16"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="322">
+      <curriculumSet id="322">
         <Curriculum reference="149"/>
         <Curriculum reference="159"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>23</studentSize>
     </Course>
     <Course id="323">
@@ -1611,11 +1611,11 @@
       <teacher reference="15"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="324">
+      <curriculumSet id="324">
         <Curriculum reference="148"/>
         <Curriculum reference="149"/>
         <Curriculum reference="160"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>31</studentSize>
     </Course>
     <Course id="325">
@@ -1624,9 +1624,9 @@
       <teacher reference="41"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="326">
+      <curriculumSet id="326">
         <Curriculum reference="157"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>15</studentSize>
     </Course>
     <Course id="327">
@@ -1635,11 +1635,11 @@
       <teacher reference="29"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="328">
+      <curriculumSet id="328">
         <Curriculum reference="144"/>
         <Curriculum reference="145"/>
         <Curriculum reference="161"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>31</studentSize>
     </Course>
     <Course id="329">
@@ -1648,9 +1648,9 @@
       <teacher reference="27"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="330">
+      <curriculumSet id="330">
         <Curriculum reference="161"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>15</studentSize>
     </Course>
     <Course id="331">
@@ -1659,11 +1659,11 @@
       <teacher reference="36"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="332">
+      <curriculumSet id="332">
         <Curriculum reference="162"/>
         <Curriculum reference="163"/>
         <Curriculum reference="164"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>69</studentSize>
     </Course>
     <Course id="333">
@@ -1672,12 +1672,12 @@
       <teacher reference="35"/>
       <lectureSize>4</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="334">
+      <curriculumSet id="334">
         <Curriculum reference="128"/>
         <Curriculum reference="129"/>
         <Curriculum reference="130"/>
         <Curriculum reference="162"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>99</studentSize>
     </Course>
     <Course id="335">
@@ -1686,12 +1686,12 @@
       <teacher reference="25"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="336">
+      <curriculumSet id="336">
         <Curriculum reference="150"/>
         <Curriculum reference="165"/>
         <Curriculum reference="166"/>
         <Curriculum reference="167"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>112</studentSize>
     </Course>
     <Course id="337">
@@ -1700,9 +1700,9 @@
       <teacher reference="31"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="338">
+      <curriculumSet id="338">
         <Curriculum reference="165"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>26</studentSize>
     </Course>
     <Course id="339">
@@ -1711,9 +1711,9 @@
       <teacher reference="36"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="340">
+      <curriculumSet id="340">
         <Curriculum reference="163"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>28</studentSize>
     </Course>
     <Course id="341">
@@ -1722,9 +1722,9 @@
       <teacher reference="34"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="342">
+      <curriculumSet id="342">
         <Curriculum reference="166"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>26</studentSize>
     </Course>
     <Course id="343">
@@ -1733,9 +1733,9 @@
       <teacher reference="33"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="344">
+      <curriculumSet id="344">
         <Curriculum reference="167"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>15</studentSize>
     </Course>
     <Course id="345">
@@ -1744,9 +1744,9 @@
       <teacher reference="40"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="346">
+      <curriculumSet id="346">
         <Curriculum reference="164"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>15</studentSize>
     </Course>
     <Course id="347">
@@ -1755,9 +1755,9 @@
       <teacher reference="39"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="348">
+      <curriculumSet id="348">
         <Curriculum reference="167"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>15</studentSize>
     </Course>
     <Course id="349">
@@ -1766,9 +1766,9 @@
       <teacher reference="39"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="350">
+      <curriculumSet id="350">
         <Curriculum reference="167"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>15</studentSize>
     </Course>
     <Course id="351">
@@ -1777,9 +1777,9 @@
       <teacher reference="38"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="352">
+      <curriculumSet id="352">
         <Curriculum reference="164"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>15</studentSize>
     </Course>
     <Course id="353">
@@ -1788,9 +1788,9 @@
       <teacher reference="60"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="354">
+      <curriculumSet id="354">
         <Curriculum reference="151"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>4</studentSize>
     </Course>
     <Course id="355">
@@ -1799,13 +1799,13 @@
       <teacher reference="37"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="356">
+      <curriculumSet id="356">
         <Curriculum reference="144"/>
         <Curriculum reference="145"/>
         <Curriculum reference="168"/>
         <Curriculum reference="169"/>
         <Curriculum reference="170"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>41</studentSize>
     </Course>
     <Course id="357">
@@ -1814,9 +1814,9 @@
       <teacher reference="101"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="358">
+      <curriculumSet id="358">
         <Curriculum reference="104"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>80</studentSize>
     </Course>
     <Course id="359">
@@ -1825,9 +1825,9 @@
       <teacher reference="99"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="360">
+      <curriculumSet id="360">
         <Curriculum reference="107"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>10</studentSize>
     </Course>
     <Course id="361">
@@ -1836,11 +1836,11 @@
       <teacher reference="38"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="362">
+      <curriculumSet id="362">
         <Curriculum reference="162"/>
         <Curriculum reference="163"/>
         <Curriculum reference="164"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>69</studentSize>
     </Course>
     <Course id="363">
@@ -1849,9 +1849,9 @@
       <teacher reference="24"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="364">
+      <curriculumSet id="364">
         <Curriculum reference="159"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>8</studentSize>
     </Course>
     <Course id="365">
@@ -1860,11 +1860,11 @@
       <teacher reference="56"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="366">
+      <curriculumSet id="366">
         <Curriculum reference="158"/>
         <Curriculum reference="159"/>
         <Curriculum reference="160"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>37</studentSize>
     </Course>
     <Course id="367">
@@ -1873,9 +1873,9 @@
       <teacher reference="100"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="368">
+      <curriculumSet id="368">
         <Curriculum reference="117"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>35</studentSize>
     </Course>
     <Course id="369">
@@ -1884,10 +1884,10 @@
       <teacher reference="15"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="370">
+      <curriculumSet id="370">
         <Curriculum reference="116"/>
         <Curriculum reference="140"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>100</studentSize>
     </Course>
     <Course id="371">
@@ -1896,9 +1896,9 @@
       <teacher reference="91"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="372">
+      <curriculumSet id="372">
         <Curriculum reference="173"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>12</studentSize>
     </Course>
     <Course id="373">
@@ -1907,9 +1907,9 @@
       <teacher reference="92"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="374">
+      <curriculumSet id="374">
         <Curriculum reference="168"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>8</studentSize>
     </Course>
     <Course id="375">
@@ -1918,11 +1918,11 @@
       <teacher reference="91"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="376">
+      <curriculumSet id="376">
         <Curriculum reference="114"/>
         <Curriculum reference="168"/>
         <Curriculum reference="170"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>23</studentSize>
     </Course>
     <Course id="377">
@@ -1931,9 +1931,9 @@
       <teacher reference="89"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="378">
+      <curriculumSet id="378">
         <Curriculum reference="171"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>8</studentSize>
     </Course>
     <Course id="379">
@@ -1942,9 +1942,9 @@
       <teacher reference="90"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="380">
+      <curriculumSet id="380">
         <Curriculum reference="171"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>8</studentSize>
     </Course>
     <Course id="381">
@@ -1953,11 +1953,11 @@
       <teacher reference="95"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="382">
+      <curriculumSet id="382">
         <Curriculum reference="171"/>
         <Curriculum reference="172"/>
         <Curriculum reference="173"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>24</studentSize>
     </Course>
     <Course id="383">
@@ -1966,10 +1966,10 @@
       <teacher reference="97"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="384">
+      <curriculumSet id="384">
         <Curriculum reference="169"/>
         <Curriculum reference="170"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>17</studentSize>
     </Course>
     <Course id="385">
@@ -1978,10 +1978,10 @@
       <teacher reference="97"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="386">
+      <curriculumSet id="386">
         <Curriculum reference="169"/>
         <Curriculum reference="170"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>17</studentSize>
     </Course>
     <Course id="387">
@@ -1990,9 +1990,9 @@
       <teacher reference="93"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="388">
+      <curriculumSet id="388">
         <Curriculum reference="172"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>4</studentSize>
     </Course>
     <Course id="389">
@@ -2001,11 +2001,11 @@
       <teacher reference="78"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="390">
+      <curriculumSet id="390">
         <Curriculum reference="168"/>
         <Curriculum reference="169"/>
         <Curriculum reference="170"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>25</studentSize>
     </Course>
     <Course id="391">
@@ -2014,11 +2014,11 @@
       <teacher reference="73"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="392">
+      <curriculumSet id="392">
         <Curriculum reference="174"/>
         <Curriculum reference="175"/>
         <Curriculum reference="176"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>60</studentSize>
     </Course>
     <Course id="393">
@@ -2027,11 +2027,11 @@
       <teacher reference="74"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="394">
+      <curriculumSet id="394">
         <Curriculum reference="177"/>
         <Curriculum reference="178"/>
         <Curriculum reference="179"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>20</studentSize>
     </Course>
     <Course id="395">
@@ -2040,9 +2040,9 @@
       <teacher reference="94"/>
       <lectureSize>7</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="396">
+      <curriculumSet id="396">
         <Curriculum reference="178"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>10</studentSize>
     </Course>
     <Course id="397">
@@ -2051,9 +2051,9 @@
       <teacher reference="73"/>
       <lectureSize>7</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="398">
+      <curriculumSet id="398">
         <Curriculum reference="177"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>5</studentSize>
     </Course>
     <Course id="399">
@@ -2062,9 +2062,9 @@
       <teacher reference="75"/>
       <lectureSize>7</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="400">
+      <curriculumSet id="400">
         <Curriculum reference="134"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>10</studentSize>
     </Course>
     <Course id="401">
@@ -2073,13 +2073,13 @@
       <teacher reference="76"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="402">
+      <curriculumSet id="402">
         <Curriculum reference="114"/>
         <Curriculum reference="122"/>
         <Curriculum reference="136"/>
         <Curriculum reference="174"/>
         <Curriculum reference="175"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>51</studentSize>
     </Course>
     <Course id="403">
@@ -2088,11 +2088,11 @@
       <teacher reference="63"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="404">
+      <curriculumSet id="404">
         <Curriculum reference="165"/>
         <Curriculum reference="166"/>
         <Curriculum reference="167"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>67</studentSize>
     </Course>
     <Course id="405">
@@ -2101,11 +2101,11 @@
       <teacher reference="64"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="406">
+      <curriculumSet id="406">
         <Curriculum reference="124"/>
         <Curriculum reference="152"/>
         <Curriculum reference="153"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>90</studentSize>
     </Course>
     <Course id="407">
@@ -2114,10 +2114,10 @@
       <teacher reference="101"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="408">
+      <curriculumSet id="408">
         <Curriculum reference="162"/>
         <Curriculum reference="164"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>41</studentSize>
     </Course>
     <Course id="409">
@@ -2126,9 +2126,9 @@
       <teacher reference="8"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="410">
+      <curriculumSet id="410">
         <Curriculum reference="168"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>8</studentSize>
     </Course>
     <Course id="411">
@@ -2137,9 +2137,9 @@
       <teacher reference="65"/>
       <lectureSize>7</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="412">
+      <curriculumSet id="412">
         <Curriculum reference="132"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>40</studentSize>
     </Course>
     <Course id="413">
@@ -2148,10 +2148,10 @@
       <teacher reference="66"/>
       <lectureSize>7</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="414">
+      <curriculumSet id="414">
         <Curriculum reference="136"/>
         <Curriculum reference="137"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>55</studentSize>
     </Course>
     <Course id="415">
@@ -2160,9 +2160,9 @@
       <teacher reference="67"/>
       <lectureSize>7</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="416">
+      <curriculumSet id="416">
         <Curriculum reference="131"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>15</studentSize>
     </Course>
     <Course id="417">
@@ -2171,10 +2171,10 @@
       <teacher reference="69"/>
       <lectureSize>7</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="418">
+      <curriculumSet id="418">
         <Curriculum reference="135"/>
         <Curriculum reference="174"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>60</studentSize>
     </Course>
     <Course id="419">
@@ -2183,9 +2183,9 @@
       <teacher reference="54"/>
       <lectureSize>7</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="420">
+      <curriculumSet id="420">
         <Curriculum reference="133"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>50</studentSize>
     </Course>
     <Course id="421">
@@ -2194,11 +2194,11 @@
       <teacher reference="50"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="422">
+      <curriculumSet id="422">
         <Curriculum reference="105"/>
         <Curriculum reference="106"/>
         <Curriculum reference="107"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>87</studentSize>
     </Course>
     <Course id="423">
@@ -2207,12 +2207,12 @@
       <teacher reference="52"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="424">
+      <curriculumSet id="424">
         <Curriculum reference="138"/>
         <Curriculum reference="174"/>
         <Curriculum reference="175"/>
         <Curriculum reference="176"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>160</studentSize>
     </Course>
     <Course id="425">
@@ -2221,10 +2221,10 @@
       <teacher reference="46"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="426">
+      <curriculumSet id="426">
         <Curriculum reference="159"/>
         <Curriculum reference="160"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>23</studentSize>
     </Course>
     <Course id="427">
@@ -2233,10 +2233,10 @@
       <teacher reference="48"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="428">
+      <curriculumSet id="428">
         <Curriculum reference="175"/>
         <Curriculum reference="176"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>40</studentSize>
     </Course>
     <Course id="429">
@@ -2245,9 +2245,9 @@
       <teacher reference="44"/>
       <lectureSize>7</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="430">
+      <curriculumSet id="430">
         <Curriculum reference="179"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>5</studentSize>
     </Course>
     <Course id="431">
@@ -2256,11 +2256,11 @@
       <teacher reference="72"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="432">
+      <curriculumSet id="432">
         <Curriculum reference="177"/>
         <Curriculum reference="178"/>
         <Curriculum reference="179"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>20</studentSize>
     </Course>
     <Course id="433">
@@ -2269,9 +2269,9 @@
       <teacher reference="45"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="434">
+      <curriculumSet id="434">
         <Curriculum reference="176"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>20</studentSize>
     </Course>
     <Course id="435">
@@ -2280,10 +2280,10 @@
       <teacher reference="41"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="436">
+      <curriculumSet id="436">
         <Curriculum reference="119"/>
         <Curriculum reference="157"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>20</studentSize>
     </Course>
     <Course id="437">
@@ -2292,11 +2292,11 @@
       <teacher reference="42"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="438">
+      <curriculumSet id="438">
         <Curriculum reference="174"/>
         <Curriculum reference="175"/>
         <Curriculum reference="176"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>60</studentSize>
     </Course>
     <Course id="439">
@@ -2305,9 +2305,9 @@
       <teacher reference="43"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="440">
+      <curriculumSet id="440">
         <Curriculum reference="152"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>20</studentSize>
     </Course>
     <Course id="441">
@@ -2316,9 +2316,9 @@
       <teacher reference="40"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="442">
+      <curriculumSet id="442">
         <Curriculum reference="106"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>44</studentSize>
     </Course>
   </courseList>

--- a/optaplanner-examples/data/curriculumcourse/unsolved/comp08.xml
+++ b/optaplanner-examples/data/curriculumcourse/unsolved/comp08.xml
@@ -560,13 +560,13 @@
       <teacher reference="60"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="143">
+      <curriculumSet id="143">
         <Curriculum reference="85"/>
         <Curriculum reference="86"/>
         <Curriculum reference="130"/>
         <Curriculum reference="131"/>
         <Curriculum reference="132"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>52</studentSize>
     </Course>
     <Course id="144">
@@ -575,10 +575,10 @@
       <teacher reference="61"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="145">
+      <curriculumSet id="145">
         <Curriculum reference="85"/>
         <Curriculum reference="87"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>16</studentSize>
     </Course>
     <Course id="146">
@@ -587,13 +587,13 @@
       <teacher reference="58"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="147">
+      <curriculumSet id="147">
         <Curriculum reference="85"/>
         <Curriculum reference="87"/>
         <Curriculum reference="89"/>
         <Curriculum reference="131"/>
         <Curriculum reference="132"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>45</studentSize>
     </Course>
     <Course id="148">
@@ -602,10 +602,10 @@
       <teacher reference="58"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="149">
+      <curriculumSet id="149">
         <Curriculum reference="88"/>
         <Curriculum reference="130"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>20</studentSize>
     </Course>
     <Course id="150">
@@ -614,11 +614,11 @@
       <teacher reference="59"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="151">
+      <curriculumSet id="151">
         <Curriculum reference="88"/>
         <Curriculum reference="90"/>
         <Curriculum reference="130"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>23</studentSize>
     </Course>
     <Course id="152">
@@ -627,10 +627,10 @@
       <teacher reference="20"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="153">
+      <curriculumSet id="153">
         <Curriculum reference="91"/>
         <Curriculum reference="111"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>110</studentSize>
     </Course>
     <Course id="154">
@@ -639,12 +639,12 @@
       <teacher reference="19"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="155">
+      <curriculumSet id="155">
         <Curriculum reference="92"/>
         <Curriculum reference="112"/>
         <Curriculum reference="128"/>
         <Curriculum reference="129"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>169</studentSize>
     </Course>
     <Course id="156">
@@ -653,9 +653,9 @@
       <teacher reference="22"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="157">
+      <curriculumSet id="157">
         <Curriculum reference="92"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>60</studentSize>
     </Course>
     <Course id="158">
@@ -664,9 +664,9 @@
       <teacher reference="21"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="159">
+      <curriculumSet id="159">
         <Curriculum reference="91"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>60</studentSize>
     </Course>
     <Course id="160">
@@ -675,10 +675,10 @@
       <teacher reference="24"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="161">
+      <curriculumSet id="161">
         <Curriculum reference="92"/>
         <Curriculum reference="112"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>100</studentSize>
     </Course>
     <Course id="162">
@@ -687,9 +687,9 @@
       <teacher reference="23"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="163">
+      <curriculumSet id="163">
         <Curriculum reference="80"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>90</studentSize>
     </Course>
     <Course id="164">
@@ -698,9 +698,9 @@
       <teacher reference="3"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="165">
+      <curriculumSet id="165">
         <Curriculum reference="81"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>80</studentSize>
     </Course>
     <Course id="166">
@@ -709,9 +709,9 @@
       <teacher reference="4"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="167">
+      <curriculumSet id="167">
         <Curriculum reference="81"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>80</studentSize>
     </Course>
     <Course id="168">
@@ -720,9 +720,9 @@
       <teacher reference="5"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="169">
+      <curriculumSet id="169">
         <Curriculum reference="80"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>90</studentSize>
     </Course>
     <Course id="170">
@@ -731,9 +731,9 @@
       <teacher reference="7"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="171">
+      <curriculumSet id="171">
         <Curriculum reference="80"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>90</studentSize>
     </Course>
     <Course id="172">
@@ -742,9 +742,9 @@
       <teacher reference="8"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="173">
+      <curriculumSet id="173">
         <Curriculum reference="81"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>80</studentSize>
     </Course>
     <Course id="174">
@@ -753,11 +753,11 @@
       <teacher reference="19"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="175">
+      <curriculumSet id="175">
         <Curriculum reference="82"/>
         <Curriculum reference="128"/>
         <Curriculum reference="129"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>139</studentSize>
     </Course>
     <Course id="176">
@@ -766,11 +766,11 @@
       <teacher reference="45"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="177">
+      <curriculumSet id="177">
         <Curriculum reference="82"/>
         <Curriculum reference="128"/>
         <Curriculum reference="129"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>139</studentSize>
     </Course>
     <Course id="178">
@@ -779,11 +779,11 @@
       <teacher reference="44"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="179">
+      <curriculumSet id="179">
         <Curriculum reference="101"/>
         <Curriculum reference="102"/>
         <Curriculum reference="103"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>105</studentSize>
     </Course>
     <Course id="180">
@@ -792,12 +792,12 @@
       <teacher reference="43"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="181">
+      <curriculumSet id="181">
         <Curriculum reference="104"/>
         <Curriculum reference="105"/>
         <Curriculum reference="106"/>
         <Curriculum reference="107"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>105</studentSize>
     </Course>
     <Course id="182">
@@ -806,12 +806,12 @@
       <teacher reference="42"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="183">
+      <curriculumSet id="183">
         <Curriculum reference="104"/>
         <Curriculum reference="105"/>
         <Curriculum reference="106"/>
         <Curriculum reference="107"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>105</studentSize>
     </Course>
     <Course id="184">
@@ -820,12 +820,12 @@
       <teacher reference="46"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="185">
+      <curriculumSet id="185">
         <Curriculum reference="104"/>
         <Curriculum reference="105"/>
         <Curriculum reference="106"/>
         <Curriculum reference="107"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>105</studentSize>
     </Course>
     <Course id="186">
@@ -834,12 +834,12 @@
       <teacher reference="25"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="187">
+      <curriculumSet id="187">
         <Curriculum reference="84"/>
         <Curriculum reference="108"/>
         <Curriculum reference="109"/>
         <Curriculum reference="110"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>115</studentSize>
     </Course>
     <Course id="188">
@@ -848,9 +848,9 @@
       <teacher reference="26"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="189">
+      <curriculumSet id="189">
         <Curriculum reference="98"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>80</studentSize>
     </Course>
     <Course id="190">
@@ -859,9 +859,9 @@
       <teacher reference="31"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="191">
+      <curriculumSet id="191">
         <Curriculum reference="98"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>80</studentSize>
     </Course>
     <Course id="192">
@@ -870,10 +870,10 @@
       <teacher reference="32"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="193">
+      <curriculumSet id="193">
         <Curriculum reference="98"/>
         <Curriculum reference="111"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>130</studentSize>
     </Course>
     <Course id="194">
@@ -882,9 +882,9 @@
       <teacher reference="28"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="195">
+      <curriculumSet id="195">
         <Curriculum reference="99"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>80</studentSize>
     </Course>
     <Course id="196">
@@ -893,10 +893,10 @@
       <teacher reference="23"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="197">
+      <curriculumSet id="197">
         <Curriculum reference="83"/>
         <Curriculum reference="84"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>130</studentSize>
     </Course>
     <Course id="198">
@@ -905,10 +905,10 @@
       <teacher reference="30"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="199">
+      <curriculumSet id="199">
         <Curriculum reference="83"/>
         <Curriculum reference="84"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>130</studentSize>
     </Course>
     <Course id="200">
@@ -917,12 +917,12 @@
       <teacher reference="54"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="201">
+      <curriculumSet id="201">
         <Curriculum reference="86"/>
         <Curriculum reference="94"/>
         <Curriculum reference="131"/>
         <Curriculum reference="132"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>122</studentSize>
     </Course>
     <Course id="202">
@@ -931,10 +931,10 @@
       <teacher reference="61"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="203">
+      <curriculumSet id="203">
         <Curriculum reference="86"/>
         <Curriculum reference="94"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>105</studentSize>
     </Course>
     <Course id="204">
@@ -943,13 +943,13 @@
       <teacher reference="55"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="205">
+      <curriculumSet id="205">
         <Curriculum reference="85"/>
         <Curriculum reference="86"/>
         <Curriculum reference="87"/>
         <Curriculum reference="94"/>
         <Curriculum reference="95"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>126</studentSize>
     </Course>
     <Course id="206">
@@ -958,9 +958,9 @@
       <teacher reference="56"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="207">
+      <curriculumSet id="207">
         <Curriculum reference="83"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>120</studentSize>
     </Course>
     <Course id="208">
@@ -969,10 +969,10 @@
       <teacher reference="57"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="209">
+      <curriculumSet id="209">
         <Curriculum reference="96"/>
         <Curriculum reference="97"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>80</studentSize>
     </Course>
     <Course id="210">
@@ -981,11 +981,11 @@
       <teacher reference="51"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="211">
+      <curriculumSet id="211">
         <Curriculum reference="96"/>
         <Curriculum reference="134"/>
         <Curriculum reference="135"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>46</studentSize>
     </Course>
     <Course id="212">
@@ -994,9 +994,9 @@
       <teacher reference="53"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="213">
+      <curriculumSet id="213">
         <Curriculum reference="97"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>50</studentSize>
     </Course>
     <Course id="214">
@@ -1005,10 +1005,10 @@
       <teacher reference="52"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="215">
+      <curriculumSet id="215">
         <Curriculum reference="99"/>
         <Curriculum reference="112"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>120</studentSize>
     </Course>
     <Course id="216">
@@ -1017,10 +1017,10 @@
       <teacher reference="48"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="217">
+      <curriculumSet id="217">
         <Curriculum reference="99"/>
         <Curriculum reference="112"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>120</studentSize>
     </Course>
     <Course id="218">
@@ -1029,9 +1029,9 @@
       <teacher reference="47"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="219">
+      <curriculumSet id="219">
         <Curriculum reference="119"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>25</studentSize>
     </Course>
     <Course id="220">
@@ -1040,9 +1040,9 @@
       <teacher reference="51"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="221">
+      <curriculumSet id="221">
         <Curriculum reference="135"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>12</studentSize>
     </Course>
     <Course id="222">
@@ -1051,10 +1051,10 @@
       <teacher reference="50"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="223">
+      <curriculumSet id="223">
         <Curriculum reference="119"/>
         <Curriculum reference="120"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>50</studentSize>
     </Course>
     <Course id="224">
@@ -1063,12 +1063,12 @@
       <teacher reference="49"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="225">
+      <curriculumSet id="225">
         <Curriculum reference="89"/>
         <Curriculum reference="120"/>
         <Curriculum reference="131"/>
         <Curriculum reference="132"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>54</studentSize>
     </Course>
     <Course id="226">
@@ -1077,10 +1077,10 @@
       <teacher reference="49"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="227">
+      <curriculumSet id="227">
         <Curriculum reference="121"/>
         <Curriculum reference="132"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>32</studentSize>
     </Course>
     <Course id="228">
@@ -1089,11 +1089,11 @@
       <teacher reference="74"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="229">
+      <curriculumSet id="229">
         <Curriculum reference="114"/>
         <Curriculum reference="115"/>
         <Curriculum reference="116"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>66</studentSize>
     </Course>
     <Course id="230">
@@ -1102,11 +1102,11 @@
       <teacher reference="75"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="231">
+      <curriculumSet id="231">
         <Curriculum reference="116"/>
         <Curriculum reference="125"/>
         <Curriculum reference="127"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>73</studentSize>
     </Course>
     <Course id="232">
@@ -1115,10 +1115,10 @@
       <teacher reference="73"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="233">
+      <curriculumSet id="233">
         <Curriculum reference="117"/>
         <Curriculum reference="118"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>66</studentSize>
     </Course>
     <Course id="234">
@@ -1127,11 +1127,11 @@
       <teacher reference="69"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="235">
+      <curriculumSet id="235">
         <Curriculum reference="122"/>
         <Curriculum reference="123"/>
         <Curriculum reference="124"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>37</studentSize>
     </Course>
     <Course id="236">
@@ -1140,9 +1140,9 @@
       <teacher reference="68"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="237">
+      <curriculumSet id="237">
         <Curriculum reference="125"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>8</studentSize>
     </Course>
     <Course id="238">
@@ -1151,10 +1151,10 @@
       <teacher reference="67"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="239">
+      <curriculumSet id="239">
         <Curriculum reference="118"/>
         <Curriculum reference="126"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>30</studentSize>
     </Course>
     <Course id="240">
@@ -1163,9 +1163,9 @@
       <teacher reference="66"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="241">
+      <curriculumSet id="241">
         <Curriculum reference="127"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>15</studentSize>
     </Course>
     <Course id="242">
@@ -1174,9 +1174,9 @@
       <teacher reference="65"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="243">
+      <curriculumSet id="243">
         <Curriculum reference="124"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>14</studentSize>
     </Course>
     <Course id="244">
@@ -1185,10 +1185,10 @@
       <teacher reference="64"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="245">
+      <curriculumSet id="245">
         <Curriculum reference="129"/>
         <Curriculum reference="133"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>36</studentSize>
     </Course>
     <Course id="246">
@@ -1197,10 +1197,10 @@
       <teacher reference="63"/>
       <lectureSize>5</lectureSize>
       <minWorkingDaySize>4</minWorkingDaySize>
-      <curriculumList id="247">
+      <curriculumSet id="247">
         <Curriculum reference="128"/>
         <Curriculum reference="129"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>69</studentSize>
     </Course>
     <Course id="248">
@@ -1209,9 +1209,9 @@
       <teacher reference="62"/>
       <lectureSize>5</lectureSize>
       <minWorkingDaySize>4</minWorkingDaySize>
-      <curriculumList id="249">
+      <curriculumSet id="249">
         <Curriculum reference="130"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>8</studentSize>
     </Course>
     <Course id="250">
@@ -1220,9 +1220,9 @@
       <teacher reference="54"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="251">
+      <curriculumSet id="251">
         <Curriculum reference="119"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>25</studentSize>
     </Course>
     <Course id="252">
@@ -1231,10 +1231,10 @@
       <teacher reference="17"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="253">
+      <curriculumSet id="253">
         <Curriculum reference="122"/>
         <Curriculum reference="126"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>23</studentSize>
     </Course>
     <Course id="254">
@@ -1243,13 +1243,13 @@
       <teacher reference="18"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="255">
+      <curriculumSet id="255">
         <Curriculum reference="113"/>
         <Curriculum reference="114"/>
         <Curriculum reference="122"/>
         <Curriculum reference="123"/>
         <Curriculum reference="124"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>40</studentSize>
     </Course>
     <Course id="256">
@@ -1258,10 +1258,10 @@
       <teacher reference="6"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="257">
+      <curriculumSet id="257">
         <Curriculum reference="87"/>
         <Curriculum reference="95"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>9</studentSize>
     </Course>
     <Course id="258">
@@ -1270,9 +1270,9 @@
       <teacher reference="10"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="259">
+      <curriculumSet id="259">
         <Curriculum reference="131"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>5</studentSize>
     </Course>
     <Course id="260">
@@ -1281,9 +1281,9 @@
       <teacher reference="10"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="261">
+      <curriculumSet id="261">
         <Curriculum reference="131"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>5</studentSize>
     </Course>
     <Course id="262">
@@ -1292,10 +1292,10 @@
       <teacher reference="9"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="263">
+      <curriculumSet id="263">
         <Curriculum reference="132"/>
         <Curriculum reference="134"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>16</studentSize>
     </Course>
     <Course id="264">
@@ -1304,10 +1304,10 @@
       <teacher reference="12"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="265">
+      <curriculumSet id="265">
         <Curriculum reference="139"/>
         <Curriculum reference="140"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>20</studentSize>
     </Course>
     <Course id="266">
@@ -1316,14 +1316,14 @@
       <teacher reference="11"/>
       <lectureSize>6</lectureSize>
       <minWorkingDaySize>4</minWorkingDaySize>
-      <curriculumList id="267">
+      <curriculumSet id="267">
         <Curriculum reference="93"/>
         <Curriculum reference="114"/>
         <Curriculum reference="115"/>
         <Curriculum reference="122"/>
         <Curriculum reference="123"/>
         <Curriculum reference="124"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>113</studentSize>
     </Course>
     <Course id="268">
@@ -1332,11 +1332,11 @@
       <teacher reference="14"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="269">
+      <curriculumSet id="269">
         <Curriculum reference="136"/>
         <Curriculum reference="137"/>
         <Curriculum reference="138"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>60</studentSize>
     </Course>
     <Course id="270">
@@ -1345,11 +1345,11 @@
       <teacher reference="13"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="271">
+      <curriculumSet id="271">
         <Curriculum reference="136"/>
         <Curriculum reference="137"/>
         <Curriculum reference="138"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>60</studentSize>
     </Course>
     <Course id="272">
@@ -1358,10 +1358,10 @@
       <teacher reference="16"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="273">
+      <curriculumSet id="273">
         <Curriculum reference="139"/>
         <Curriculum reference="140"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>20</studentSize>
     </Course>
     <Course id="274">
@@ -1370,9 +1370,9 @@
       <teacher reference="15"/>
       <lectureSize>7</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="275">
+      <curriculumSet id="275">
         <Curriculum reference="139"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>15</studentSize>
     </Course>
     <Course id="276">
@@ -1381,9 +1381,9 @@
       <teacher reference="41"/>
       <lectureSize>7</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="277">
+      <curriculumSet id="277">
         <Curriculum reference="136"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>20</studentSize>
     </Course>
     <Course id="278">
@@ -1392,9 +1392,9 @@
       <teacher reference="29"/>
       <lectureSize>7</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="279">
+      <curriculumSet id="279">
         <Curriculum reference="140"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>5</studentSize>
     </Course>
     <Course id="280">
@@ -1403,9 +1403,9 @@
       <teacher reference="27"/>
       <lectureSize>7</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="281">
+      <curriculumSet id="281">
         <Curriculum reference="137"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>20</studentSize>
     </Course>
     <Course id="282">
@@ -1414,9 +1414,9 @@
       <teacher reference="36"/>
       <lectureSize>7</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="283">
+      <curriculumSet id="283">
         <Curriculum reference="138"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>20</studentSize>
     </Course>
     <Course id="284">
@@ -1425,9 +1425,9 @@
       <teacher reference="35"/>
       <lectureSize>7</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="285">
+      <curriculumSet id="285">
         <Curriculum reference="104"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>10</studentSize>
     </Course>
     <Course id="286">
@@ -1436,9 +1436,9 @@
       <teacher reference="34"/>
       <lectureSize>7</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="287">
+      <curriculumSet id="287">
         <Curriculum reference="107"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>50</studentSize>
     </Course>
     <Course id="288">
@@ -1447,10 +1447,10 @@
       <teacher reference="33"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="289">
+      <curriculumSet id="289">
         <Curriculum reference="90"/>
         <Curriculum reference="106"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>8</studentSize>
     </Course>
     <Course id="290">
@@ -1459,11 +1459,11 @@
       <teacher reference="40"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="291">
+      <curriculumSet id="291">
         <Curriculum reference="101"/>
         <Curriculum reference="102"/>
         <Curriculum reference="103"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>105</studentSize>
     </Course>
     <Course id="292">
@@ -1472,9 +1472,9 @@
       <teacher reference="39"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="293">
+      <curriculumSet id="293">
         <Curriculum reference="120"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>25</studentSize>
     </Course>
     <Course id="294">
@@ -1483,9 +1483,9 @@
       <teacher reference="38"/>
       <lectureSize>7</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="295">
+      <curriculumSet id="295">
         <Curriculum reference="108"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>10</studentSize>
     </Course>
     <Course id="296">
@@ -1494,9 +1494,9 @@
       <teacher reference="48"/>
       <lectureSize>7</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="297">
+      <curriculumSet id="297">
         <Curriculum reference="102"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>40</studentSize>
     </Course>
     <Course id="298">
@@ -1505,9 +1505,9 @@
       <teacher reference="37"/>
       <lectureSize>7</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="299">
+      <curriculumSet id="299">
         <Curriculum reference="105"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>40</studentSize>
     </Course>
     <Course id="300">
@@ -1516,9 +1516,9 @@
       <teacher reference="78"/>
       <lectureSize>7</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="301">
+      <curriculumSet id="301">
         <Curriculum reference="101"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>15</studentSize>
     </Course>
     <Course id="302">
@@ -1527,9 +1527,9 @@
       <teacher reference="76"/>
       <lectureSize>7</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="303">
+      <curriculumSet id="303">
         <Curriculum reference="103"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>50</studentSize>
     </Course>
     <Course id="304">
@@ -1538,9 +1538,9 @@
       <teacher reference="16"/>
       <lectureSize>7</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="305">
+      <curriculumSet id="305">
         <Curriculum reference="109"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>40</studentSize>
     </Course>
     <Course id="306">
@@ -1549,10 +1549,10 @@
       <teacher reference="77"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="307">
+      <curriculumSet id="307">
         <Curriculum reference="91"/>
         <Curriculum reference="111"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>110</studentSize>
     </Course>
     <Course id="308">
@@ -1561,9 +1561,9 @@
       <teacher reference="71"/>
       <lectureSize>7</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="309">
+      <curriculumSet id="309">
         <Curriculum reference="110"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>55</studentSize>
     </Course>
     <Course id="310">
@@ -1572,9 +1572,9 @@
       <teacher reference="72"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="311">
+      <curriculumSet id="311">
         <Curriculum reference="132"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>12</studentSize>
     </Course>
     <Course id="312">
@@ -1583,10 +1583,10 @@
       <teacher reference="70"/>
       <lectureSize>6</lectureSize>
       <minWorkingDaySize>4</minWorkingDaySize>
-      <curriculumList id="313">
+      <curriculumSet id="313">
         <Curriculum reference="100"/>
         <Curriculum reference="116"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>105</studentSize>
     </Course>
   </courseList>

--- a/optaplanner-examples/data/curriculumcourse/unsolved/comp09.xml
+++ b/optaplanner-examples/data/curriculumcourse/unsolved/comp09.xml
@@ -584,10 +584,10 @@
       <teacher reference="58"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="149">
+      <curriculumSet id="149">
         <Curriculum reference="74"/>
         <Curriculum reference="75"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>36</studentSize>
     </Course>
     <Course id="150">
@@ -596,9 +596,9 @@
       <teacher reference="59"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="151">
+      <curriculumSet id="151">
         <Curriculum reference="74"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>18</studentSize>
     </Course>
     <Course id="152">
@@ -607,10 +607,10 @@
       <teacher reference="56"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="153">
+      <curriculumSet id="153">
         <Curriculum reference="76"/>
         <Curriculum reference="78"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>17</studentSize>
     </Course>
     <Course id="154">
@@ -619,10 +619,10 @@
       <teacher reference="57"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="155">
+      <curriculumSet id="155">
         <Curriculum reference="76"/>
         <Curriculum reference="78"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>17</studentSize>
     </Course>
     <Course id="156">
@@ -631,9 +631,9 @@
       <teacher reference="20"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="157">
+      <curriculumSet id="157">
         <Curriculum reference="103"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>90</studentSize>
     </Course>
     <Course id="158">
@@ -642,13 +642,13 @@
       <teacher reference="19"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="159">
+      <curriculumSet id="159">
         <Curriculum reference="104"/>
         <Curriculum reference="116"/>
         <Curriculum reference="123"/>
         <Curriculum reference="124"/>
         <Curriculum reference="125"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>170</studentSize>
     </Course>
     <Course id="160">
@@ -657,9 +657,9 @@
       <teacher reference="22"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="161">
+      <curriculumSet id="161">
         <Curriculum reference="104"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>85</studentSize>
     </Course>
     <Course id="162">
@@ -668,9 +668,9 @@
       <teacher reference="21"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="163">
+      <curriculumSet id="163">
         <Curriculum reference="104"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>85</studentSize>
     </Course>
     <Course id="164">
@@ -679,9 +679,9 @@
       <teacher reference="24"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="165">
+      <curriculumSet id="165">
         <Curriculum reference="103"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>90</studentSize>
     </Course>
     <Course id="166">
@@ -690,10 +690,10 @@
       <teacher reference="23"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="167">
+      <curriculumSet id="167">
         <Curriculum reference="104"/>
         <Curriculum reference="116"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>140</studentSize>
     </Course>
     <Course id="168">
@@ -702,9 +702,9 @@
       <teacher reference="3"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="169">
+      <curriculumSet id="169">
         <Curriculum reference="120"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>100</studentSize>
     </Course>
     <Course id="170">
@@ -713,9 +713,9 @@
       <teacher reference="4"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="171">
+      <curriculumSet id="171">
         <Curriculum reference="121"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>85</studentSize>
     </Course>
     <Course id="172">
@@ -724,9 +724,9 @@
       <teacher reference="5"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="173">
+      <curriculumSet id="173">
         <Curriculum reference="121"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>85</studentSize>
     </Course>
     <Course id="174">
@@ -735,9 +735,9 @@
       <teacher reference="7"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="175">
+      <curriculumSet id="175">
         <Curriculum reference="120"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>100</studentSize>
     </Course>
     <Course id="176">
@@ -746,9 +746,9 @@
       <teacher reference="8"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="177">
+      <curriculumSet id="177">
         <Curriculum reference="120"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>100</studentSize>
     </Course>
     <Course id="178">
@@ -757,9 +757,9 @@
       <teacher reference="43"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="179">
+      <curriculumSet id="179">
         <Curriculum reference="121"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>85</studentSize>
     </Course>
     <Course id="180">
@@ -768,12 +768,12 @@
       <teacher reference="19"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="181">
+      <curriculumSet id="181">
         <Curriculum reference="122"/>
         <Curriculum reference="123"/>
         <Curriculum reference="124"/>
         <Curriculum reference="125"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>120</studentSize>
     </Course>
     <Course id="182">
@@ -782,12 +782,12 @@
       <teacher reference="42"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="183">
+      <curriculumSet id="183">
         <Curriculum reference="122"/>
         <Curriculum reference="123"/>
         <Curriculum reference="124"/>
         <Curriculum reference="125"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>120</studentSize>
     </Course>
     <Course id="184">
@@ -796,11 +796,11 @@
       <teacher reference="41"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="185">
+      <curriculumSet id="185">
         <Curriculum reference="84"/>
         <Curriculum reference="85"/>
         <Curriculum reference="86"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>135</studentSize>
     </Course>
     <Course id="186">
@@ -809,11 +809,11 @@
       <teacher reference="40"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="187">
+      <curriculumSet id="187">
         <Curriculum reference="87"/>
         <Curriculum reference="88"/>
         <Curriculum reference="89"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>120</studentSize>
     </Course>
     <Course id="188">
@@ -822,11 +822,11 @@
       <teacher reference="44"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="189">
+      <curriculumSet id="189">
         <Curriculum reference="87"/>
         <Curriculum reference="88"/>
         <Curriculum reference="89"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>120</studentSize>
     </Course>
     <Course id="190">
@@ -835,11 +835,11 @@
       <teacher reference="25"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="191">
+      <curriculumSet id="191">
         <Curriculum reference="87"/>
         <Curriculum reference="88"/>
         <Curriculum reference="89"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>120</studentSize>
     </Course>
     <Course id="192">
@@ -848,11 +848,11 @@
       <teacher reference="3"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="193">
+      <curriculumSet id="193">
         <Curriculum reference="72"/>
         <Curriculum reference="73"/>
         <Curriculum reference="112"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>133</studentSize>
     </Course>
     <Course id="194">
@@ -861,10 +861,10 @@
       <teacher reference="26"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="195">
+      <curriculumSet id="195">
         <Curriculum reference="112"/>
         <Curriculum reference="115"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>140</studentSize>
     </Course>
     <Course id="196">
@@ -873,10 +873,10 @@
       <teacher reference="31"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="197">
+      <curriculumSet id="197">
         <Curriculum reference="112"/>
         <Curriculum reference="115"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>140</studentSize>
     </Course>
     <Course id="198">
@@ -885,9 +885,9 @@
       <teacher reference="32"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="199">
+      <curriculumSet id="199">
         <Curriculum reference="113"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>90</studentSize>
     </Course>
     <Course id="200">
@@ -896,10 +896,10 @@
       <teacher reference="28"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="201">
+      <curriculumSet id="201">
         <Curriculum reference="90"/>
         <Curriculum reference="91"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>100</studentSize>
     </Course>
     <Course id="202">
@@ -908,12 +908,12 @@
       <teacher reference="30"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="203">
+      <curriculumSet id="203">
         <Curriculum reference="72"/>
         <Curriculum reference="73"/>
         <Curriculum reference="90"/>
         <Curriculum reference="91"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>143</studentSize>
     </Course>
     <Course id="204">
@@ -922,10 +922,10 @@
       <teacher reference="52"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="205">
+      <curriculumSet id="205">
         <Curriculum reference="75"/>
         <Curriculum reference="92"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>138</studentSize>
     </Course>
     <Course id="206">
@@ -934,10 +934,10 @@
       <teacher reference="59"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="207">
+      <curriculumSet id="207">
         <Curriculum reference="75"/>
         <Curriculum reference="92"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>138</studentSize>
     </Course>
     <Course id="208">
@@ -946,11 +946,11 @@
       <teacher reference="25"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="209">
+      <curriculumSet id="209">
         <Curriculum reference="74"/>
         <Curriculum reference="75"/>
         <Curriculum reference="92"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>156</studentSize>
     </Course>
     <Course id="210">
@@ -959,10 +959,10 @@
       <teacher reference="53"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="211">
+      <curriculumSet id="211">
         <Curriculum reference="72"/>
         <Curriculum reference="90"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>110</studentSize>
     </Course>
     <Course id="212">
@@ -971,12 +971,12 @@
       <teacher reference="54"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="213">
+      <curriculumSet id="213">
         <Curriculum reference="93"/>
         <Curriculum reference="94"/>
         <Curriculum reference="97"/>
         <Curriculum reference="101"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>72</studentSize>
     </Course>
     <Course id="214">
@@ -985,14 +985,14 @@
       <teacher reference="55"/>
       <lectureSize>5</lectureSize>
       <minWorkingDaySize>4</minWorkingDaySize>
-      <curriculumList id="215">
+      <curriculumSet id="215">
         <Curriculum reference="77"/>
         <Curriculum reference="79"/>
         <Curriculum reference="81"/>
         <Curriculum reference="100"/>
         <Curriculum reference="102"/>
         <Curriculum reference="130"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>30</studentSize>
     </Course>
     <Course id="216">
@@ -1001,11 +1001,11 @@
       <teacher reference="49"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="217">
+      <curriculumSet id="217">
         <Curriculum reference="94"/>
         <Curriculum reference="95"/>
         <Curriculum reference="98"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>42</studentSize>
     </Course>
     <Course id="218">
@@ -1014,10 +1014,10 @@
       <teacher reference="51"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="219">
+      <curriculumSet id="219">
         <Curriculum reference="113"/>
         <Curriculum reference="116"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>145</studentSize>
     </Course>
     <Course id="220">
@@ -1026,10 +1026,10 @@
       <teacher reference="50"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="221">
+      <curriculumSet id="221">
         <Curriculum reference="113"/>
         <Curriculum reference="116"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>145</studentSize>
     </Course>
     <Course id="222">
@@ -1038,11 +1038,11 @@
       <teacher reference="46"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="223">
+      <curriculumSet id="223">
         <Curriculum reference="111"/>
         <Curriculum reference="132"/>
         <Curriculum reference="134"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>47</studentSize>
     </Course>
     <Course id="224">
@@ -1051,14 +1051,14 @@
       <teacher reference="45"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="225">
+      <curriculumSet id="225">
         <Curriculum reference="109"/>
         <Curriculum reference="110"/>
         <Curriculum reference="111"/>
         <Curriculum reference="132"/>
         <Curriculum reference="133"/>
         <Curriculum reference="134"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>75</studentSize>
     </Course>
     <Course id="226">
@@ -1067,7 +1067,7 @@
       <teacher reference="48"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="227">
+      <curriculumSet id="227">
         <Curriculum reference="135"/>
         <Curriculum reference="136"/>
         <Curriculum reference="137"/>
@@ -1076,7 +1076,7 @@
         <Curriculum reference="140"/>
         <Curriculum reference="141"/>
         <Curriculum reference="142"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>132</studentSize>
     </Course>
     <Course id="228">
@@ -1085,11 +1085,11 @@
       <teacher reference="47"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="229">
+      <curriculumSet id="229">
         <Curriculum reference="95"/>
         <Curriculum reference="96"/>
         <Curriculum reference="97"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>3</studentSize>
     </Course>
     <Course id="230">
@@ -1098,7 +1098,7 @@
       <teacher reference="69"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="231">
+      <curriculumSet id="231">
         <Curriculum reference="79"/>
         <Curriculum reference="80"/>
         <Curriculum reference="81"/>
@@ -1112,7 +1112,7 @@
         <Curriculum reference="129"/>
         <Curriculum reference="130"/>
         <Curriculum reference="131"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>126</studentSize>
     </Course>
     <Course id="232">
@@ -1121,11 +1121,11 @@
       <teacher reference="70"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="233">
+      <curriculumSet id="233">
         <Curriculum reference="109"/>
         <Curriculum reference="111"/>
         <Curriculum reference="118"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>7</studentSize>
     </Course>
     <Course id="234">
@@ -1134,9 +1134,9 @@
       <teacher reference="21"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="235">
+      <curriculumSet id="235">
         <Curriculum reference="107"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>5</studentSize>
     </Course>
     <Course id="236">
@@ -1145,13 +1145,13 @@
       <teacher reference="68"/>
       <lectureSize>5</lectureSize>
       <minWorkingDaySize>4</minWorkingDaySize>
-      <curriculumList id="237">
+      <curriculumSet id="237">
         <Curriculum reference="111"/>
         <Curriculum reference="117"/>
         <Curriculum reference="126"/>
         <Curriculum reference="132"/>
         <Curriculum reference="143"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>57</studentSize>
     </Course>
     <Course id="238">
@@ -1160,10 +1160,10 @@
       <teacher reference="67"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="239">
+      <curriculumSet id="239">
         <Curriculum reference="108"/>
         <Curriculum reference="132"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>29</studentSize>
     </Course>
     <Course id="240">
@@ -1172,10 +1172,10 @@
       <teacher reference="66"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="241">
+      <curriculumSet id="241">
         <Curriculum reference="82"/>
         <Curriculum reference="124"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>11</studentSize>
     </Course>
     <Course id="242">
@@ -1184,12 +1184,12 @@
       <teacher reference="32"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="243">
+      <curriculumSet id="243">
         <Curriculum reference="127"/>
         <Curriculum reference="141"/>
         <Curriculum reference="142"/>
         <Curriculum reference="145"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>46</studentSize>
     </Course>
     <Course id="244">
@@ -1198,10 +1198,10 @@
       <teacher reference="65"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="245">
+      <curriculumSet id="245">
         <Curriculum reference="128"/>
         <Curriculum reference="146"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>26</studentSize>
     </Course>
     <Course id="246">
@@ -1210,13 +1210,13 @@
       <teacher reference="64"/>
       <lectureSize>5</lectureSize>
       <minWorkingDaySize>4</minWorkingDaySize>
-      <curriculumList id="247">
+      <curriculumSet id="247">
         <Curriculum reference="119"/>
         <Curriculum reference="135"/>
         <Curriculum reference="137"/>
         <Curriculum reference="139"/>
         <Curriculum reference="141"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>67</studentSize>
     </Course>
     <Course id="248">
@@ -1225,11 +1225,11 @@
       <teacher reference="63"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="249">
+      <curriculumSet id="249">
         <Curriculum reference="106"/>
         <Curriculum reference="107"/>
         <Curriculum reference="108"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>15</studentSize>
     </Course>
     <Course id="250">
@@ -1238,10 +1238,10 @@
       <teacher reference="62"/>
       <lectureSize>4</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="251">
+      <curriculumSet id="251">
         <Curriculum reference="73"/>
         <Curriculum reference="91"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>33</studentSize>
     </Course>
     <Course id="252">
@@ -1250,9 +1250,9 @@
       <teacher reference="61"/>
       <lectureSize>7</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="253">
+      <curriculumSet id="253">
         <Curriculum reference="87"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>40</studentSize>
     </Course>
     <Course id="254">
@@ -1261,9 +1261,9 @@
       <teacher reference="60"/>
       <lectureSize>7</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="255">
+      <curriculumSet id="255">
         <Curriculum reference="89"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>40</studentSize>
     </Course>
     <Course id="256">
@@ -1272,11 +1272,11 @@
       <teacher reference="17"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="257">
+      <curriculumSet id="257">
         <Curriculum reference="84"/>
         <Curriculum reference="85"/>
         <Curriculum reference="86"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>135</studentSize>
     </Course>
     <Course id="258">
@@ -1285,12 +1285,12 @@
       <teacher reference="18"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="259">
+      <curriculumSet id="259">
         <Curriculum reference="109"/>
         <Curriculum reference="110"/>
         <Curriculum reference="111"/>
         <Curriculum reference="133"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>29</studentSize>
     </Course>
     <Course id="260">
@@ -1299,10 +1299,10 @@
       <teacher reference="6"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="261">
+      <curriculumSet id="261">
         <Curriculum reference="109"/>
         <Curriculum reference="133"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>27</studentSize>
     </Course>
     <Course id="262">
@@ -1311,12 +1311,12 @@
       <teacher reference="10"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="263">
+      <curriculumSet id="263">
         <Curriculum reference="98"/>
         <Curriculum reference="99"/>
         <Curriculum reference="100"/>
         <Curriculum reference="101"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>4</studentSize>
     </Course>
     <Course id="264">
@@ -1325,9 +1325,9 @@
       <teacher reference="65"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="265">
+      <curriculumSet id="265">
         <Curriculum reference="146"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>25</studentSize>
     </Course>
     <Course id="266">
@@ -1336,9 +1336,9 @@
       <teacher reference="9"/>
       <lectureSize>7</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="267">
+      <curriculumSet id="267">
         <Curriculum reference="85"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>50</studentSize>
     </Course>
     <Course id="268">
@@ -1347,9 +1347,9 @@
       <teacher reference="12"/>
       <lectureSize>7</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="269">
+      <curriculumSet id="269">
         <Curriculum reference="88"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>40</studentSize>
     </Course>
     <Course id="270">
@@ -1358,9 +1358,9 @@
       <teacher reference="11"/>
       <lectureSize>7</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="271">
+      <curriculumSet id="271">
         <Curriculum reference="84"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>15</studentSize>
     </Course>
     <Course id="272">
@@ -1369,9 +1369,9 @@
       <teacher reference="14"/>
       <lectureSize>7</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="273">
+      <curriculumSet id="273">
         <Curriculum reference="86"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>70</studentSize>
     </Course>
     <Course id="274">
@@ -1380,10 +1380,10 @@
       <teacher reference="13"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="275">
+      <curriculumSet id="275">
         <Curriculum reference="109"/>
         <Curriculum reference="110"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>2</studentSize>
     </Course>
     <Course id="276">
@@ -1392,10 +1392,10 @@
       <teacher reference="16"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="277">
+      <curriculumSet id="277">
         <Curriculum reference="103"/>
         <Curriculum reference="115"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>140</studentSize>
     </Course>
     <Course id="278">
@@ -1404,10 +1404,10 @@
       <teacher reference="17"/>
       <lectureSize>5</lectureSize>
       <minWorkingDaySize>4</minWorkingDaySize>
-      <curriculumList id="279">
+      <curriculumSet id="279">
         <Curriculum reference="137"/>
         <Curriculum reference="138"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>40</studentSize>
     </Course>
     <Course id="280">
@@ -1416,11 +1416,11 @@
       <teacher reference="15"/>
       <lectureSize>5</lectureSize>
       <minWorkingDaySize>4</minWorkingDaySize>
-      <curriculumList id="281">
+      <curriculumSet id="281">
         <Curriculum reference="78"/>
         <Curriculum reference="135"/>
         <Curriculum reference="136"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>21</studentSize>
     </Course>
     <Course id="282">
@@ -1429,14 +1429,14 @@
       <teacher reference="39"/>
       <lectureSize>5</lectureSize>
       <minWorkingDaySize>4</minWorkingDaySize>
-      <curriculumList id="283">
+      <curriculumSet id="283">
         <Curriculum reference="105"/>
         <Curriculum reference="106"/>
         <Curriculum reference="107"/>
         <Curriculum reference="108"/>
         <Curriculum reference="117"/>
         <Curriculum reference="143"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>105</studentSize>
     </Course>
     <Course id="284">
@@ -1445,10 +1445,10 @@
       <teacher reference="29"/>
       <lectureSize>5</lectureSize>
       <minWorkingDaySize>4</minWorkingDaySize>
-      <curriculumList id="285">
+      <curriculumSet id="285">
         <Curriculum reference="114"/>
         <Curriculum reference="118"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>60</studentSize>
     </Course>
     <Course id="286">
@@ -1457,13 +1457,13 @@
       <teacher reference="27"/>
       <lectureSize>5</lectureSize>
       <minWorkingDaySize>4</minWorkingDaySize>
-      <curriculumList id="287">
+      <curriculumSet id="287">
         <Curriculum reference="74"/>
         <Curriculum reference="77"/>
         <Curriculum reference="79"/>
         <Curriculum reference="81"/>
         <Curriculum reference="131"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>51</studentSize>
     </Course>
     <Course id="288">
@@ -1472,7 +1472,7 @@
       <teacher reference="36"/>
       <lectureSize>5</lectureSize>
       <minWorkingDaySize>4</minWorkingDaySize>
-      <curriculumList id="289">
+      <curriculumSet id="289">
         <Curriculum reference="83"/>
         <Curriculum reference="93"/>
         <Curriculum reference="96"/>
@@ -1480,7 +1480,7 @@
         <Curriculum reference="129"/>
         <Curriculum reference="130"/>
         <Curriculum reference="131"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>151</studentSize>
     </Course>
     <Course id="290">
@@ -1489,12 +1489,12 @@
       <teacher reference="35"/>
       <lectureSize>5</lectureSize>
       <minWorkingDaySize>4</minWorkingDaySize>
-      <curriculumList id="291">
+      <curriculumSet id="291">
         <Curriculum reference="80"/>
         <Curriculum reference="81"/>
         <Curriculum reference="83"/>
         <Curriculum reference="131"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>19</studentSize>
     </Course>
     <Course id="292">
@@ -1503,14 +1503,14 @@
       <teacher reference="34"/>
       <lectureSize>5</lectureSize>
       <minWorkingDaySize>4</minWorkingDaySize>
-      <curriculumList id="293">
+      <curriculumSet id="293">
         <Curriculum reference="117"/>
         <Curriculum reference="118"/>
         <Curriculum reference="136"/>
         <Curriculum reference="138"/>
         <Curriculum reference="140"/>
         <Curriculum reference="142"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>76</studentSize>
     </Course>
     <Course id="294">
@@ -1519,12 +1519,12 @@
       <teacher reference="33"/>
       <lectureSize>5</lectureSize>
       <minWorkingDaySize>4</minWorkingDaySize>
-      <curriculumList id="295">
+      <curriculumSet id="295">
         <Curriculum reference="125"/>
         <Curriculum reference="137"/>
         <Curriculum reference="138"/>
         <Curriculum reference="146"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>75</studentSize>
     </Course>
     <Course id="296">
@@ -1533,12 +1533,12 @@
       <teacher reference="38"/>
       <lectureSize>5</lectureSize>
       <minWorkingDaySize>4</minWorkingDaySize>
-      <curriculumList id="297">
+      <curriculumSet id="297">
         <Curriculum reference="123"/>
         <Curriculum reference="124"/>
         <Curriculum reference="125"/>
         <Curriculum reference="144"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>55</studentSize>
     </Course>
     <Course id="298">
@@ -1547,11 +1547,11 @@
       <teacher reference="37"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="299">
+      <curriculumSet id="299">
         <Curriculum reference="141"/>
         <Curriculum reference="142"/>
         <Curriculum reference="145"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>45</studentSize>
     </Course>
   </courseList>

--- a/optaplanner-examples/data/curriculumcourse/unsolved/comp10.xml
+++ b/optaplanner-examples/data/curriculumcourse/unsolved/comp10.xml
@@ -632,11 +632,11 @@
       <teacher reference="68"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="161">
+      <curriculumSet id="161">
         <Curriculum reference="150"/>
         <Curriculum reference="151"/>
         <Curriculum reference="152"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>38</studentSize>
     </Course>
     <Course id="162">
@@ -645,9 +645,9 @@
       <teacher reference="69"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="163">
+      <curriculumSet id="163">
         <Curriculum reference="153"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>3</studentSize>
     </Course>
     <Course id="164">
@@ -656,9 +656,9 @@
       <teacher reference="66"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="165">
+      <curriculumSet id="165">
         <Curriculum reference="93"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>92</studentSize>
     </Course>
     <Course id="166">
@@ -667,10 +667,10 @@
       <teacher reference="67"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="167">
+      <curriculumSet id="167">
         <Curriculum reference="144"/>
         <Curriculum reference="145"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>15</studentSize>
     </Course>
     <Course id="168">
@@ -679,13 +679,13 @@
       <teacher reference="20"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="169">
+      <curriculumSet id="169">
         <Curriculum reference="94"/>
         <Curriculum reference="95"/>
         <Curriculum reference="96"/>
         <Curriculum reference="117"/>
         <Curriculum reference="131"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>108</studentSize>
     </Course>
     <Course id="170">
@@ -694,9 +694,9 @@
       <teacher reference="19"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="171">
+      <curriculumSet id="171">
         <Curriculum reference="92"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>70</studentSize>
     </Course>
     <Course id="172">
@@ -705,10 +705,10 @@
       <teacher reference="22"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="173">
+      <curriculumSet id="173">
         <Curriculum reference="93"/>
         <Curriculum reference="114"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>180</studentSize>
     </Course>
     <Course id="174">
@@ -717,10 +717,10 @@
       <teacher reference="21"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="175">
+      <curriculumSet id="175">
         <Curriculum reference="93"/>
         <Curriculum reference="135"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>117</studentSize>
     </Course>
     <Course id="176">
@@ -729,13 +729,13 @@
       <teacher reference="24"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="177">
+      <curriculumSet id="177">
         <Curriculum reference="94"/>
         <Curriculum reference="95"/>
         <Curriculum reference="96"/>
         <Curriculum reference="131"/>
         <Curriculum reference="132"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>95</studentSize>
     </Course>
     <Course id="178">
@@ -744,9 +744,9 @@
       <teacher reference="23"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="179">
+      <curriculumSet id="179">
         <Curriculum reference="94"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>20</studentSize>
     </Course>
     <Course id="180">
@@ -755,9 +755,9 @@
       <teacher reference="3"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="181">
+      <curriculumSet id="181">
         <Curriculum reference="95"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>35</studentSize>
     </Course>
     <Course id="182">
@@ -766,9 +766,9 @@
       <teacher reference="4"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="183">
+      <curriculumSet id="183">
         <Curriculum reference="92"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>70</studentSize>
     </Course>
     <Course id="184">
@@ -777,11 +777,11 @@
       <teacher reference="5"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="185">
+      <curriculumSet id="185">
         <Curriculum reference="118"/>
         <Curriculum reference="119"/>
         <Curriculum reference="120"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>124</studentSize>
     </Course>
     <Course id="186">
@@ -790,11 +790,11 @@
       <teacher reference="7"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="187">
+      <curriculumSet id="187">
         <Curriculum reference="118"/>
         <Curriculum reference="119"/>
         <Curriculum reference="120"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>124</studentSize>
     </Course>
     <Course id="188">
@@ -803,12 +803,12 @@
       <teacher reference="7"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="189">
+      <curriculumSet id="189">
         <Curriculum reference="121"/>
         <Curriculum reference="122"/>
         <Curriculum reference="123"/>
         <Curriculum reference="124"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>121</studentSize>
     </Course>
     <Course id="190">
@@ -817,12 +817,12 @@
       <teacher reference="8"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="191">
+      <curriculumSet id="191">
         <Curriculum reference="121"/>
         <Curriculum reference="122"/>
         <Curriculum reference="123"/>
         <Curriculum reference="124"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>121</studentSize>
     </Course>
     <Course id="192">
@@ -831,9 +831,9 @@
       <teacher reference="45"/>
       <lectureSize>2</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="193">
+      <curriculumSet id="193">
         <Curriculum reference="101"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>15</studentSize>
     </Course>
     <Course id="194">
@@ -842,11 +842,11 @@
       <teacher reference="44"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="195">
+      <curriculumSet id="195">
         <Curriculum reference="118"/>
         <Curriculum reference="119"/>
         <Curriculum reference="120"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>124</studentSize>
     </Course>
     <Course id="196">
@@ -855,12 +855,12 @@
       <teacher reference="43"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="197">
+      <curriculumSet id="197">
         <Curriculum reference="121"/>
         <Curriculum reference="122"/>
         <Curriculum reference="123"/>
         <Curriculum reference="124"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>121</studentSize>
     </Course>
     <Course id="198">
@@ -869,11 +869,11 @@
       <teacher reference="42"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="199">
+      <curriculumSet id="199">
         <Curriculum reference="100"/>
         <Curriculum reference="101"/>
         <Curriculum reference="102"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>38</studentSize>
     </Course>
     <Course id="200">
@@ -882,9 +882,9 @@
       <teacher reference="46"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="201">
+      <curriculumSet id="201">
         <Curriculum reference="114"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>88</studentSize>
     </Course>
     <Course id="202">
@@ -893,10 +893,10 @@
       <teacher reference="25"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="203">
+      <curriculumSet id="203">
         <Curriculum reference="114"/>
         <Curriculum reference="147"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>103</studentSize>
     </Course>
     <Course id="204">
@@ -905,9 +905,9 @@
       <teacher reference="26"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="205">
+      <curriculumSet id="205">
         <Curriculum reference="113"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>113</studentSize>
     </Course>
     <Course id="206">
@@ -916,9 +916,9 @@
       <teacher reference="31"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="207">
+      <curriculumSet id="207">
         <Curriculum reference="101"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>15</studentSize>
     </Course>
     <Course id="208">
@@ -927,14 +927,14 @@
       <teacher reference="32"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="209">
+      <curriculumSet id="209">
         <Curriculum reference="115"/>
         <Curriculum reference="116"/>
         <Curriculum reference="117"/>
         <Curriculum reference="126"/>
         <Curriculum reference="127"/>
         <Curriculum reference="128"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>130</studentSize>
     </Course>
     <Course id="210">
@@ -943,14 +943,14 @@
       <teacher reference="28"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="211">
+      <curriculumSet id="211">
         <Curriculum reference="115"/>
         <Curriculum reference="126"/>
         <Curriculum reference="129"/>
         <Curriculum reference="130"/>
         <Curriculum reference="131"/>
         <Curriculum reference="132"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>132</studentSize>
     </Course>
     <Course id="212">
@@ -959,9 +959,9 @@
       <teacher reference="30"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="213">
+      <curriculumSet id="213">
         <Curriculum reference="113"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>113</studentSize>
     </Course>
     <Course id="214">
@@ -970,9 +970,9 @@
       <teacher reference="58"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="215">
+      <curriculumSet id="215">
         <Curriculum reference="97"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>110</studentSize>
     </Course>
     <Course id="216">
@@ -981,9 +981,9 @@
       <teacher reference="59"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="217">
+      <curriculumSet id="217">
         <Curriculum reference="97"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>110</studentSize>
     </Course>
     <Course id="218">
@@ -992,11 +992,11 @@
       <teacher reference="60"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="219">
+      <curriculumSet id="219">
         <Curriculum reference="99"/>
         <Curriculum reference="109"/>
         <Curriculum reference="110"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>110</studentSize>
     </Course>
     <Course id="220">
@@ -1005,10 +1005,10 @@
       <teacher reference="61"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="221">
+      <curriculumSet id="221">
         <Curriculum reference="109"/>
         <Curriculum reference="110"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>90</studentSize>
     </Course>
     <Course id="222">
@@ -1017,11 +1017,11 @@
       <teacher reference="51"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="223">
+      <curriculumSet id="223">
         <Curriculum reference="102"/>
         <Curriculum reference="111"/>
         <Curriculum reference="112"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>95</studentSize>
     </Course>
     <Course id="224">
@@ -1030,10 +1030,10 @@
       <teacher reference="53"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="225">
+      <curriculumSet id="225">
         <Curriculum reference="111"/>
         <Curriculum reference="112"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>75</studentSize>
     </Course>
     <Course id="226">
@@ -1042,12 +1042,12 @@
       <teacher reference="52"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="227">
+      <curriculumSet id="227">
         <Curriculum reference="98"/>
         <Curriculum reference="99"/>
         <Curriculum reference="100"/>
         <Curriculum reference="109"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>123</studentSize>
     </Course>
     <Course id="228">
@@ -1056,12 +1056,12 @@
       <teacher reference="48"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="229">
+      <curriculumSet id="229">
         <Curriculum reference="98"/>
         <Curriculum reference="99"/>
         <Curriculum reference="109"/>
         <Curriculum reference="110"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>130</studentSize>
     </Course>
     <Course id="230">
@@ -1070,10 +1070,10 @@
       <teacher reference="47"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="231">
+      <curriculumSet id="231">
         <Curriculum reference="111"/>
         <Curriculum reference="138"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>35</studentSize>
     </Course>
     <Course id="232">
@@ -1082,9 +1082,9 @@
       <teacher reference="50"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="233">
+      <curriculumSet id="233">
         <Curriculum reference="97"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>110</studentSize>
     </Course>
     <Course id="234">
@@ -1093,10 +1093,10 @@
       <teacher reference="49"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="235">
+      <curriculumSet id="235">
         <Curriculum reference="101"/>
         <Curriculum reference="151"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>35</studentSize>
     </Course>
     <Course id="236">
@@ -1105,10 +1105,10 @@
       <teacher reference="85"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="237">
+      <curriculumSet id="237">
         <Curriculum reference="114"/>
         <Curriculum reference="125"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>114</studentSize>
     </Course>
     <Course id="238">
@@ -1117,11 +1117,11 @@
       <teacher reference="87"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="239">
+      <curriculumSet id="239">
         <Curriculum reference="102"/>
         <Curriculum reference="112"/>
         <Curriculum reference="139"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>60</studentSize>
     </Course>
     <Course id="240">
@@ -1130,7 +1130,7 @@
       <teacher reference="83"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="241">
+      <curriculumSet id="241">
         <Curriculum reference="115"/>
         <Curriculum reference="116"/>
         <Curriculum reference="117"/>
@@ -1139,7 +1139,7 @@
         <Curriculum reference="128"/>
         <Curriculum reference="150"/>
         <Curriculum reference="151"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>160</studentSize>
     </Course>
     <Course id="242">
@@ -1148,7 +1148,7 @@
       <teacher reference="50"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="243">
+      <curriculumSet id="243">
         <Curriculum reference="128"/>
         <Curriculum reference="130"/>
         <Curriculum reference="131"/>
@@ -1156,7 +1156,7 @@
         <Curriculum reference="133"/>
         <Curriculum reference="145"/>
         <Curriculum reference="146"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>78</studentSize>
     </Course>
     <Course id="244">
@@ -1165,12 +1165,12 @@
       <teacher reference="77"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="245">
+      <curriculumSet id="245">
         <Curriculum reference="137"/>
         <Curriculum reference="138"/>
         <Curriculum reference="154"/>
         <Curriculum reference="155"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>6</studentSize>
     </Course>
     <Course id="246">
@@ -1179,9 +1179,9 @@
       <teacher reference="76"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="247">
+      <curriculumSet id="247">
         <Curriculum reference="137"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>0</studentSize>
     </Course>
     <Course id="248">
@@ -1190,9 +1190,9 @@
       <teacher reference="60"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="249">
+      <curriculumSet id="249">
         <Curriculum reference="137"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>0</studentSize>
     </Course>
     <Course id="250">
@@ -1201,10 +1201,10 @@
       <teacher reference="75"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="251">
+      <curriculumSet id="251">
         <Curriculum reference="139"/>
         <Curriculum reference="140"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>0</studentSize>
     </Course>
     <Course id="252">
@@ -1213,9 +1213,9 @@
       <teacher reference="76"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="253">
+      <curriculumSet id="253">
         <Curriculum reference="139"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>0</studentSize>
     </Course>
     <Course id="254">
@@ -1224,11 +1224,11 @@
       <teacher reference="48"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="255">
+      <curriculumSet id="255">
         <Curriculum reference="139"/>
         <Curriculum reference="140"/>
         <Curriculum reference="148"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>15</studentSize>
     </Course>
     <Course id="256">
@@ -1237,10 +1237,10 @@
       <teacher reference="53"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="257">
+      <curriculumSet id="257">
         <Curriculum reference="138"/>
         <Curriculum reference="139"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>0</studentSize>
     </Course>
     <Course id="258">
@@ -1249,10 +1249,10 @@
       <teacher reference="74"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="259">
+      <curriculumSet id="259">
         <Curriculum reference="103"/>
         <Curriculum reference="113"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>189</studentSize>
     </Course>
     <Course id="260">
@@ -1261,9 +1261,9 @@
       <teacher reference="5"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="261">
+      <curriculumSet id="261">
         <Curriculum reference="138"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>0</studentSize>
     </Course>
     <Course id="262">
@@ -1272,9 +1272,9 @@
       <teacher reference="73"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="263">
+      <curriculumSet id="263">
         <Curriculum reference="140"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>0</studentSize>
     </Course>
     <Course id="264">
@@ -1283,9 +1283,9 @@
       <teacher reference="87"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="265">
+      <curriculumSet id="265">
         <Curriculum reference="140"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>0</studentSize>
     </Course>
     <Course id="266">
@@ -1294,12 +1294,12 @@
       <teacher reference="72"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="267">
+      <curriculumSet id="267">
         <Curriculum reference="129"/>
         <Curriculum reference="130"/>
         <Curriculum reference="131"/>
         <Curriculum reference="132"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>50</studentSize>
     </Course>
     <Course id="268">
@@ -1308,12 +1308,12 @@
       <teacher reference="71"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="269">
+      <curriculumSet id="269">
         <Curriculum reference="133"/>
         <Curriculum reference="134"/>
         <Curriculum reference="135"/>
         <Curriculum reference="136"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>66</studentSize>
     </Course>
     <Course id="270">
@@ -1322,11 +1322,11 @@
       <teacher reference="70"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="271">
+      <curriculumSet id="271">
         <Curriculum reference="116"/>
         <Curriculum reference="132"/>
         <Curriculum reference="153"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>23</studentSize>
     </Course>
     <Course id="272">
@@ -1335,10 +1335,10 @@
       <teacher reference="17"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="273">
+      <curriculumSet id="273">
         <Curriculum reference="104"/>
         <Curriculum reference="125"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>89</studentSize>
     </Course>
     <Course id="274">
@@ -1347,13 +1347,13 @@
       <teacher reference="18"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="275">
+      <curriculumSet id="275">
         <Curriculum reference="129"/>
         <Curriculum reference="130"/>
         <Curriculum reference="141"/>
         <Curriculum reference="142"/>
         <Curriculum reference="143"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>35</studentSize>
     </Course>
     <Course id="276">
@@ -1362,11 +1362,11 @@
       <teacher reference="6"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="277">
+      <curriculumSet id="277">
         <Curriculum reference="141"/>
         <Curriculum reference="142"/>
         <Curriculum reference="143"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>15</studentSize>
     </Course>
     <Course id="278">
@@ -1375,11 +1375,11 @@
       <teacher reference="10"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="279">
+      <curriculumSet id="279">
         <Curriculum reference="144"/>
         <Curriculum reference="145"/>
         <Curriculum reference="146"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>24</studentSize>
     </Course>
     <Course id="280">
@@ -1388,12 +1388,12 @@
       <teacher reference="6"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="281">
+      <curriculumSet id="281">
         <Curriculum reference="105"/>
         <Curriculum reference="106"/>
         <Curriculum reference="107"/>
         <Curriculum reference="108"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>73</studentSize>
     </Course>
     <Course id="282">
@@ -1402,9 +1402,9 @@
       <teacher reference="9"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="283">
+      <curriculumSet id="283">
         <Curriculum reference="142"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>5</studentSize>
     </Course>
     <Course id="284">
@@ -1413,11 +1413,11 @@
       <teacher reference="12"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="285">
+      <curriculumSet id="285">
         <Curriculum reference="129"/>
         <Curriculum reference="130"/>
         <Curriculum reference="146"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>29</studentSize>
     </Course>
     <Course id="286">
@@ -1426,9 +1426,9 @@
       <teacher reference="11"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="287">
+      <curriculumSet id="287">
         <Curriculum reference="143"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>5</studentSize>
     </Course>
     <Course id="288">
@@ -1437,11 +1437,11 @@
       <teacher reference="14"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="289">
+      <curriculumSet id="289">
         <Curriculum reference="147"/>
         <Curriculum reference="148"/>
         <Curriculum reference="149"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>45</studentSize>
     </Course>
     <Course id="290">
@@ -1450,12 +1450,12 @@
       <teacher reference="13"/>
       <lectureSize>4</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="291">
+      <curriculumSet id="291">
         <Curriculum reference="115"/>
         <Curriculum reference="116"/>
         <Curriculum reference="117"/>
         <Curriculum reference="147"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>105</studentSize>
     </Course>
     <Course id="292">
@@ -1464,12 +1464,12 @@
       <teacher reference="20"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="293">
+      <curriculumSet id="293">
         <Curriculum reference="135"/>
         <Curriculum reference="150"/>
         <Curriculum reference="151"/>
         <Curriculum reference="152"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>63</studentSize>
     </Course>
     <Course id="294">
@@ -1478,9 +1478,9 @@
       <teacher reference="21"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="295">
+      <curriculumSet id="295">
         <Curriculum reference="150"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>10</studentSize>
     </Course>
     <Course id="296">
@@ -1489,9 +1489,9 @@
       <teacher reference="14"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="297">
+      <curriculumSet id="297">
         <Curriculum reference="148"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>15</studentSize>
     </Course>
     <Course id="298">
@@ -1500,9 +1500,9 @@
       <teacher reference="68"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="299">
+      <curriculumSet id="299">
         <Curriculum reference="151"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>20</studentSize>
     </Course>
     <Course id="300">
@@ -1511,9 +1511,9 @@
       <teacher reference="16"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="301">
+      <curriculumSet id="301">
         <Curriculum reference="152"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>8</studentSize>
     </Course>
     <Course id="302">
@@ -1522,9 +1522,9 @@
       <teacher reference="3"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="303">
+      <curriculumSet id="303">
         <Curriculum reference="149"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>15</studentSize>
     </Course>
     <Course id="304">
@@ -1533,9 +1533,9 @@
       <teacher reference="15"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="305">
+      <curriculumSet id="305">
         <Curriculum reference="152"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>8</studentSize>
     </Course>
     <Course id="306">
@@ -1544,9 +1544,9 @@
       <teacher reference="15"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="307">
+      <curriculumSet id="307">
         <Curriculum reference="152"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>8</studentSize>
     </Course>
     <Course id="308">
@@ -1555,9 +1555,9 @@
       <teacher reference="41"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="309">
+      <curriculumSet id="309">
         <Curriculum reference="149"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>15</studentSize>
     </Course>
     <Course id="310">
@@ -1566,9 +1566,9 @@
       <teacher reference="31"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="311">
+      <curriculumSet id="311">
         <Curriculum reference="136"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>25</studentSize>
     </Course>
     <Course id="312">
@@ -1577,9 +1577,9 @@
       <teacher reference="26"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="313">
+      <curriculumSet id="313">
         <Curriculum reference="103"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>76</studentSize>
     </Course>
     <Course id="314">
@@ -1588,10 +1588,10 @@
       <teacher reference="22"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="315">
+      <curriculumSet id="315">
         <Curriculum reference="104"/>
         <Curriculum reference="125"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>89</studentSize>
     </Course>
     <Course id="316">
@@ -1600,13 +1600,13 @@
       <teacher reference="29"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="317">
+      <curriculumSet id="317">
         <Curriculum reference="129"/>
         <Curriculum reference="130"/>
         <Curriculum reference="153"/>
         <Curriculum reference="154"/>
         <Curriculum reference="155"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>29</studentSize>
     </Course>
     <Course id="318">
@@ -1615,12 +1615,12 @@
       <teacher reference="27"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="319">
+      <curriculumSet id="319">
         <Curriculum reference="105"/>
         <Curriculum reference="106"/>
         <Curriculum reference="107"/>
         <Curriculum reference="108"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>73</studentSize>
     </Course>
     <Course id="320">
@@ -1629,12 +1629,12 @@
       <teacher reference="69"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="321">
+      <curriculumSet id="321">
         <Curriculum reference="105"/>
         <Curriculum reference="106"/>
         <Curriculum reference="107"/>
         <Curriculum reference="108"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>73</studentSize>
     </Course>
     <Course id="322">
@@ -1643,9 +1643,9 @@
       <teacher reference="36"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="323">
+      <curriculumSet id="323">
         <Curriculum reference="103"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>76</studentSize>
     </Course>
     <Course id="324">
@@ -1654,9 +1654,9 @@
       <teacher reference="35"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="325">
+      <curriculumSet id="325">
         <Curriculum reference="98"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>20</studentSize>
     </Course>
     <Course id="326">
@@ -1665,7 +1665,7 @@
       <teacher reference="34"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="327">
+      <curriculumSet id="327">
         <Curriculum reference="108"/>
         <Curriculum reference="126"/>
         <Curriculum reference="127"/>
@@ -1673,7 +1673,7 @@
         <Curriculum reference="135"/>
         <Curriculum reference="143"/>
         <Curriculum reference="150"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>95</studentSize>
     </Course>
     <Course id="328">
@@ -1682,9 +1682,9 @@
       <teacher reference="33"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="329">
+      <curriculumSet id="329">
         <Curriculum reference="96"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>10</studentSize>
     </Course>
     <Course id="330">
@@ -1693,9 +1693,9 @@
       <teacher reference="17"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="331">
+      <curriculumSet id="331">
         <Curriculum reference="144"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>6</studentSize>
     </Course>
     <Course id="332">
@@ -1704,11 +1704,11 @@
       <teacher reference="25"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="333">
+      <curriculumSet id="333">
         <Curriculum reference="144"/>
         <Curriculum reference="145"/>
         <Curriculum reference="146"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>24</studentSize>
     </Course>
     <Course id="334">
@@ -1717,10 +1717,10 @@
       <teacher reference="40"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="335">
+      <curriculumSet id="335">
         <Curriculum reference="106"/>
         <Curriculum reference="141"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>17</studentSize>
     </Course>
     <Course id="336">
@@ -1729,12 +1729,12 @@
       <teacher reference="39"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="337">
+      <curriculumSet id="337">
         <Curriculum reference="105"/>
         <Curriculum reference="141"/>
         <Curriculum reference="142"/>
         <Curriculum reference="143"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>55</studentSize>
     </Course>
     <Course id="338">
@@ -1743,10 +1743,10 @@
       <teacher reference="38"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="339">
+      <curriculumSet id="339">
         <Curriculum reference="104"/>
         <Curriculum reference="125"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>89</studentSize>
     </Course>
     <Course id="340">
@@ -1755,12 +1755,12 @@
       <teacher reference="9"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="341">
+      <curriculumSet id="341">
         <Curriculum reference="107"/>
         <Curriculum reference="133"/>
         <Curriculum reference="134"/>
         <Curriculum reference="142"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>27</studentSize>
     </Course>
     <Course id="342">
@@ -1769,12 +1769,12 @@
       <teacher reference="37"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="343">
+      <curriculumSet id="343">
         <Curriculum reference="93"/>
         <Curriculum reference="147"/>
         <Curriculum reference="148"/>
         <Curriculum reference="149"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>137</studentSize>
     </Course>
     <Course id="344">
@@ -1783,9 +1783,9 @@
       <teacher reference="90"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="345">
+      <curriculumSet id="345">
         <Curriculum reference="158"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>3</studentSize>
     </Course>
     <Course id="346">
@@ -1794,9 +1794,9 @@
       <teacher reference="88"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="347">
+      <curriculumSet id="347">
         <Curriculum reference="153"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>3</studentSize>
     </Course>
     <Course id="348">
@@ -1805,10 +1805,10 @@
       <teacher reference="90"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="349">
+      <curriculumSet id="349">
         <Curriculum reference="153"/>
         <Curriculum reference="155"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>6</studentSize>
     </Course>
     <Course id="350">
@@ -1817,9 +1817,9 @@
       <teacher reference="89"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="351">
+      <curriculumSet id="351">
         <Curriculum reference="156"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>3</studentSize>
     </Course>
     <Course id="352">
@@ -1828,9 +1828,9 @@
       <teacher reference="80"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="353">
+      <curriculumSet id="353">
         <Curriculum reference="156"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>3</studentSize>
     </Course>
     <Course id="354">
@@ -1839,11 +1839,11 @@
       <teacher reference="81"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="355">
+      <curriculumSet id="355">
         <Curriculum reference="156"/>
         <Curriculum reference="157"/>
         <Curriculum reference="158"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>9</studentSize>
     </Course>
     <Course id="356">
@@ -1852,10 +1852,10 @@
       <teacher reference="78"/>
       <lectureSize>5</lectureSize>
       <minWorkingDaySize>4</minWorkingDaySize>
-      <curriculumList id="357">
+      <curriculumSet id="357">
         <Curriculum reference="154"/>
         <Curriculum reference="155"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>6</studentSize>
     </Course>
     <Course id="358">
@@ -1864,9 +1864,9 @@
       <teacher reference="79"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="359">
+      <curriculumSet id="359">
         <Curriculum reference="157"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>3</studentSize>
     </Course>
     <Course id="360">
@@ -1875,11 +1875,11 @@
       <teacher reference="84"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="361">
+      <curriculumSet id="361">
         <Curriculum reference="153"/>
         <Curriculum reference="154"/>
         <Curriculum reference="155"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>9</studentSize>
     </Course>
     <Course id="362">
@@ -1888,12 +1888,12 @@
       <teacher reference="45"/>
       <lectureSize>4</lectureSize>
       <minWorkingDaySize>4</minWorkingDaySize>
-      <curriculumList id="363">
+      <curriculumSet id="363">
         <Curriculum reference="102"/>
         <Curriculum reference="111"/>
         <Curriculum reference="137"/>
         <Curriculum reference="138"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>55</studentSize>
     </Course>
     <Course id="364">
@@ -1902,13 +1902,13 @@
       <teacher reference="45"/>
       <lectureSize>1</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="365">
+      <curriculumSet id="365">
         <Curriculum reference="101"/>
         <Curriculum reference="102"/>
         <Curriculum reference="111"/>
         <Curriculum reference="137"/>
         <Curriculum reference="138"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>70</studentSize>
     </Course>
     <Course id="366">
@@ -1917,10 +1917,10 @@
       <teacher reference="86"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="367">
+      <curriculumSet id="367">
         <Curriculum reference="110"/>
         <Curriculum reference="123"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>14</studentSize>
     </Course>
     <Course id="368">
@@ -1929,10 +1929,10 @@
       <teacher reference="60"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="369">
+      <curriculumSet id="369">
         <Curriculum reference="98"/>
         <Curriculum reference="100"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>23</studentSize>
     </Course>
     <Course id="370">
@@ -1941,10 +1941,10 @@
       <teacher reference="82"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="371">
+      <curriculumSet id="371">
         <Curriculum reference="112"/>
         <Curriculum reference="137"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>40</studentSize>
     </Course>
     <Course id="372">
@@ -1953,10 +1953,10 @@
       <teacher reference="37"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="373">
+      <curriculumSet id="373">
         <Curriculum reference="147"/>
         <Curriculum reference="149"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>30</studentSize>
     </Course>
     <Course id="374">
@@ -1965,9 +1965,9 @@
       <teacher reference="62"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="375">
+      <curriculumSet id="375">
         <Curriculum reference="92"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>70</studentSize>
     </Course>
     <Course id="376">
@@ -1976,9 +1976,9 @@
       <teacher reference="63"/>
       <lectureSize>7</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="377">
+      <curriculumSet id="377">
         <Curriculum reference="119"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>46</studentSize>
     </Course>
     <Course id="378">
@@ -1987,10 +1987,10 @@
       <teacher reference="64"/>
       <lectureSize>7</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="379">
+      <curriculumSet id="379">
         <Curriculum reference="123"/>
         <Curriculum reference="124"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>57</studentSize>
     </Course>
     <Course id="380">
@@ -1999,9 +1999,9 @@
       <teacher reference="65"/>
       <lectureSize>7</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="381">
+      <curriculumSet id="381">
         <Curriculum reference="121"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>18</studentSize>
     </Course>
     <Course id="382">
@@ -2010,9 +2010,9 @@
       <teacher reference="54"/>
       <lectureSize>7</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="383">
+      <curriculumSet id="383">
         <Curriculum reference="118"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>18</studentSize>
     </Course>
     <Course id="384">
@@ -2021,9 +2021,9 @@
       <teacher reference="55"/>
       <lectureSize>7</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="385">
+      <curriculumSet id="385">
         <Curriculum reference="122"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>46</studentSize>
     </Course>
     <Course id="386">
@@ -2032,9 +2032,9 @@
       <teacher reference="56"/>
       <lectureSize>7</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="387">
+      <curriculumSet id="387">
         <Curriculum reference="120"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>60</studentSize>
     </Course>
     <Course id="388">
@@ -2043,11 +2043,11 @@
       <teacher reference="57"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="389">
+      <curriculumSet id="389">
         <Curriculum reference="94"/>
         <Curriculum reference="95"/>
         <Curriculum reference="96"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>65</studentSize>
     </Course>
   </courseList>

--- a/optaplanner-examples/data/curriculumcourse/unsolved/comp11.xml
+++ b/optaplanner-examples/data/curriculumcourse/unsolved/comp11.xml
@@ -160,9 +160,9 @@
       <teacher reference="7"/>
       <lectureSize>2</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="43">
+      <curriculumSet id="43">
         <Curriculum reference="28"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>75</studentSize>
     </Course>
     <Course id="44">
@@ -171,9 +171,9 @@
       <teacher reference="8"/>
       <lectureSize>2</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="45">
+      <curriculumSet id="45">
         <Curriculum reference="28"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>75</studentSize>
     </Course>
     <Course id="46">
@@ -182,9 +182,9 @@
       <teacher reference="4"/>
       <lectureSize>9</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="47">
+      <curriculumSet id="47">
         <Curriculum reference="28"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>75</studentSize>
     </Course>
     <Course id="48">
@@ -193,9 +193,9 @@
       <teacher reference="6"/>
       <lectureSize>7</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="49">
+      <curriculumSet id="49">
         <Curriculum reference="28"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>75</studentSize>
     </Course>
     <Course id="50">
@@ -204,9 +204,9 @@
       <teacher reference="19"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="51">
+      <curriculumSet id="51">
         <Curriculum reference="29"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>65</studentSize>
     </Course>
     <Course id="52">
@@ -215,9 +215,9 @@
       <teacher reference="17"/>
       <lectureSize>9</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="53">
+      <curriculumSet id="53">
         <Curriculum reference="29"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>65</studentSize>
     </Course>
     <Course id="54">
@@ -226,9 +226,9 @@
       <teacher reference="23"/>
       <lectureSize>8</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="55">
+      <curriculumSet id="55">
         <Curriculum reference="29"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>65</studentSize>
     </Course>
     <Course id="56">
@@ -237,9 +237,9 @@
       <teacher reference="21"/>
       <lectureSize>6</lectureSize>
       <minWorkingDaySize>4</minWorkingDaySize>
-      <curriculumList id="57">
+      <curriculumSet id="57">
         <Curriculum reference="30"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>11</studentSize>
     </Course>
     <Course id="58">
@@ -248,9 +248,9 @@
       <teacher reference="25"/>
       <lectureSize>6</lectureSize>
       <minWorkingDaySize>4</minWorkingDaySize>
-      <curriculumList id="59">
+      <curriculumSet id="59">
         <Curriculum reference="33"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>8</studentSize>
     </Course>
     <Course id="60">
@@ -259,9 +259,9 @@
       <teacher reference="24"/>
       <lectureSize>5</lectureSize>
       <minWorkingDaySize>4</minWorkingDaySize>
-      <curriculumList id="61">
+      <curriculumSet id="61">
         <Curriculum reference="34"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>11</studentSize>
     </Course>
     <Course id="62">
@@ -270,9 +270,9 @@
       <teacher reference="9"/>
       <lectureSize>5</lectureSize>
       <minWorkingDaySize>4</minWorkingDaySize>
-      <curriculumList id="63">
+      <curriculumSet id="63">
         <Curriculum reference="32"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>11</studentSize>
     </Course>
     <Course id="64">
@@ -281,9 +281,9 @@
       <teacher reference="10"/>
       <lectureSize>5</lectureSize>
       <minWorkingDaySize>4</minWorkingDaySize>
-      <curriculumList id="65">
+      <curriculumSet id="65">
         <Curriculum reference="31"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>11</studentSize>
     </Course>
     <Course id="66">
@@ -292,13 +292,13 @@
       <teacher reference="11"/>
       <lectureSize>6</lectureSize>
       <minWorkingDaySize>4</minWorkingDaySize>
-      <curriculumList id="67">
+      <curriculumSet id="67">
         <Curriculum reference="30"/>
         <Curriculum reference="31"/>
         <Curriculum reference="32"/>
         <Curriculum reference="33"/>
         <Curriculum reference="34"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>52</studentSize>
     </Course>
     <Course id="68">
@@ -307,13 +307,13 @@
       <teacher reference="13"/>
       <lectureSize>6</lectureSize>
       <minWorkingDaySize>4</minWorkingDaySize>
-      <curriculumList id="69">
+      <curriculumSet id="69">
         <Curriculum reference="30"/>
         <Curriculum reference="31"/>
         <Curriculum reference="32"/>
         <Curriculum reference="33"/>
         <Curriculum reference="34"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>52</studentSize>
     </Course>
     <Course id="70">
@@ -322,13 +322,13 @@
       <teacher reference="15"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="71">
+      <curriculumSet id="71">
         <Curriculum reference="30"/>
         <Curriculum reference="31"/>
         <Curriculum reference="32"/>
         <Curriculum reference="33"/>
         <Curriculum reference="34"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>52</studentSize>
     </Course>
     <Course id="72">
@@ -337,9 +337,9 @@
       <teacher reference="22"/>
       <lectureSize>6</lectureSize>
       <minWorkingDaySize>4</minWorkingDaySize>
-      <curriculumList id="73">
+      <curriculumSet id="73">
         <Curriculum reference="36"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>11</studentSize>
     </Course>
     <Course id="74">
@@ -348,9 +348,9 @@
       <teacher reference="20"/>
       <lectureSize>6</lectureSize>
       <minWorkingDaySize>4</minWorkingDaySize>
-      <curriculumList id="75">
+      <curriculumSet id="75">
         <Curriculum reference="37"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>11</studentSize>
     </Course>
     <Course id="76">
@@ -359,11 +359,11 @@
       <teacher reference="18"/>
       <lectureSize>6</lectureSize>
       <minWorkingDaySize>4</minWorkingDaySize>
-      <curriculumList id="77">
+      <curriculumSet id="77">
         <Curriculum reference="35"/>
         <Curriculum reference="36"/>
         <Curriculum reference="37"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>33</studentSize>
     </Course>
     <Course id="78">
@@ -372,11 +372,11 @@
       <teacher reference="16"/>
       <lectureSize>5</lectureSize>
       <minWorkingDaySize>4</minWorkingDaySize>
-      <curriculumList id="79">
+      <curriculumSet id="79">
         <Curriculum reference="35"/>
         <Curriculum reference="36"/>
         <Curriculum reference="37"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>33</studentSize>
     </Course>
     <Course id="80">
@@ -385,9 +385,9 @@
       <teacher reference="8"/>
       <lectureSize>5</lectureSize>
       <minWorkingDaySize>4</minWorkingDaySize>
-      <curriculumList id="81">
+      <curriculumSet id="81">
         <Curriculum reference="36"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>11</studentSize>
     </Course>
     <Course id="82">
@@ -396,9 +396,9 @@
       <teacher reference="4"/>
       <lectureSize>5</lectureSize>
       <minWorkingDaySize>4</minWorkingDaySize>
-      <curriculumList id="83">
+      <curriculumSet id="83">
         <Curriculum reference="35"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>11</studentSize>
     </Course>
     <Course id="84">
@@ -407,11 +407,11 @@
       <teacher reference="26"/>
       <lectureSize>6</lectureSize>
       <minWorkingDaySize>4</minWorkingDaySize>
-      <curriculumList id="85">
+      <curriculumSet id="85">
         <Curriculum reference="35"/>
         <Curriculum reference="36"/>
         <Curriculum reference="37"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>33</studentSize>
     </Course>
     <Course id="86">
@@ -420,9 +420,9 @@
       <teacher reference="3"/>
       <lectureSize>6</lectureSize>
       <minWorkingDaySize>4</minWorkingDaySize>
-      <curriculumList id="87">
+      <curriculumSet id="87">
         <Curriculum reference="38"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>20</studentSize>
     </Course>
     <Course id="88">
@@ -431,9 +431,9 @@
       <teacher reference="19"/>
       <lectureSize>9</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="89">
+      <curriculumSet id="89">
         <Curriculum reference="38"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>20</studentSize>
     </Course>
     <Course id="90">
@@ -442,9 +442,9 @@
       <teacher reference="5"/>
       <lectureSize>4</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="91">
+      <curriculumSet id="91">
         <Curriculum reference="39"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>20</studentSize>
     </Course>
     <Course id="92">
@@ -453,9 +453,9 @@
       <teacher reference="7"/>
       <lectureSize>7</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="93">
+      <curriculumSet id="93">
         <Curriculum reference="40"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>25</studentSize>
     </Course>
     <Course id="94">
@@ -464,9 +464,9 @@
       <teacher reference="12"/>
       <lectureSize>2</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="95">
+      <curriculumSet id="95">
         <Curriculum reference="40"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>25</studentSize>
     </Course>
     <Course id="96">
@@ -475,9 +475,9 @@
       <teacher reference="6"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="97">
+      <curriculumSet id="97">
         <Curriculum reference="40"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>50</studentSize>
     </Course>
     <Course id="98">
@@ -486,9 +486,9 @@
       <teacher reference="6"/>
       <lectureSize>6</lectureSize>
       <minWorkingDaySize>4</minWorkingDaySize>
-      <curriculumList id="99">
+      <curriculumSet id="99">
         <Curriculum reference="39"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>20</studentSize>
     </Course>
     <Course id="100">
@@ -497,9 +497,9 @@
       <teacher reference="14"/>
       <lectureSize>4</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="101">
+      <curriculumSet id="101">
         <Curriculum reference="39"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>20</studentSize>
     </Course>
   </courseList>

--- a/optaplanner-examples/data/curriculumcourse/unsolved/comp12.xml
+++ b/optaplanner-examples/data/curriculumcourse/unsolved/comp12.xml
@@ -908,7 +908,7 @@
       <teacher reference="60"/>
       <lectureSize>2</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="230">
+      <curriculumSet id="230">
         <Curriculum reference="92"/>
         <Curriculum reference="93"/>
         <Curriculum reference="95"/>
@@ -924,7 +924,7 @@
         <Curriculum reference="157"/>
         <Curriculum reference="208"/>
         <Curriculum reference="209"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>170</studentSize>
     </Course>
     <Course id="231">
@@ -933,9 +933,9 @@
       <teacher reference="61"/>
       <lectureSize>2</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="232">
+      <curriculumSet id="232">
         <Curriculum reference="213"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>4</studentSize>
     </Course>
     <Course id="233">
@@ -944,12 +944,12 @@
       <teacher reference="58"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="234">
+      <curriculumSet id="234">
         <Curriculum reference="85"/>
         <Curriculum reference="87"/>
         <Curriculum reference="123"/>
         <Curriculum reference="209"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>31</studentSize>
     </Course>
     <Course id="235">
@@ -958,7 +958,7 @@
       <teacher reference="61"/>
       <lectureSize>2</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="236">
+      <curriculumSet id="236">
         <Curriculum reference="124"/>
         <Curriculum reference="198"/>
         <Curriculum reference="199"/>
@@ -967,7 +967,7 @@
         <Curriculum reference="203"/>
         <Curriculum reference="204"/>
         <Curriculum reference="209"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>16</studentSize>
     </Course>
     <Course id="237">
@@ -976,12 +976,12 @@
       <teacher reference="59"/>
       <lectureSize>2</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="238">
+      <curriculumSet id="238">
         <Curriculum reference="102"/>
         <Curriculum reference="103"/>
         <Curriculum reference="125"/>
         <Curriculum reference="209"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>24</studentSize>
     </Course>
     <Course id="239">
@@ -990,7 +990,7 @@
       <teacher reference="20"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="240">
+      <curriculumSet id="240">
         <Curriculum reference="126"/>
         <Curriculum reference="198"/>
         <Curriculum reference="199"/>
@@ -998,7 +998,7 @@
         <Curriculum reference="202"/>
         <Curriculum reference="203"/>
         <Curriculum reference="205"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>13</studentSize>
     </Course>
     <Course id="241">
@@ -1007,7 +1007,7 @@
       <teacher reference="19"/>
       <lectureSize>2</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="242">
+      <curriculumSet id="242">
         <Curriculum reference="107"/>
         <Curriculum reference="108"/>
         <Curriculum reference="115"/>
@@ -1015,7 +1015,7 @@
         <Curriculum reference="207"/>
         <Curriculum reference="210"/>
         <Curriculum reference="212"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>60</studentSize>
     </Course>
     <Course id="243">
@@ -1024,9 +1024,9 @@
       <teacher reference="59"/>
       <lectureSize>2</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="244">
+      <curriculumSet id="244">
         <Curriculum reference="213"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>4</studentSize>
     </Course>
     <Course id="245">
@@ -1035,7 +1035,7 @@
       <teacher reference="22"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="246">
+      <curriculumSet id="246">
         <Curriculum reference="79"/>
         <Curriculum reference="98"/>
         <Curriculum reference="135"/>
@@ -1047,7 +1047,7 @@
         <Curriculum reference="176"/>
         <Curriculum reference="177"/>
         <Curriculum reference="178"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>36</studentSize>
     </Course>
     <Course id="247">
@@ -1056,14 +1056,14 @@
       <teacher reference="22"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="248">
+      <curriculumSet id="248">
         <Curriculum reference="215"/>
         <Curriculum reference="216"/>
         <Curriculum reference="218"/>
         <Curriculum reference="219"/>
         <Curriculum reference="220"/>
         <Curriculum reference="221"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>6</studentSize>
     </Course>
     <Course id="249">
@@ -1072,10 +1072,10 @@
       <teacher reference="21"/>
       <lectureSize>2</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="250">
+      <curriculumSet id="250">
         <Curriculum reference="213"/>
         <Curriculum reference="214"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>8</studentSize>
     </Course>
     <Course id="251">
@@ -1084,9 +1084,9 @@
       <teacher reference="24"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="252">
+      <curriculumSet id="252">
         <Curriculum reference="83"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>5</studentSize>
     </Course>
     <Course id="253">
@@ -1095,12 +1095,12 @@
       <teacher reference="23"/>
       <lectureSize>2</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="254">
+      <curriculumSet id="254">
         <Curriculum reference="220"/>
         <Curriculum reference="224"/>
         <Curriculum reference="226"/>
         <Curriculum reference="227"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>4</studentSize>
     </Course>
     <Course id="255">
@@ -1109,14 +1109,14 @@
       <teacher reference="3"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="256">
+      <curriculumSet id="256">
         <Curriculum reference="80"/>
         <Curriculum reference="145"/>
         <Curriculum reference="146"/>
         <Curriculum reference="147"/>
         <Curriculum reference="151"/>
         <Curriculum reference="152"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>8</studentSize>
     </Course>
     <Course id="257">
@@ -1125,14 +1125,14 @@
       <teacher reference="3"/>
       <lectureSize>2</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="258">
+      <curriculumSet id="258">
         <Curriculum reference="216"/>
         <Curriculum reference="217"/>
         <Curriculum reference="221"/>
         <Curriculum reference="222"/>
         <Curriculum reference="223"/>
         <Curriculum reference="224"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>6</studentSize>
     </Course>
     <Course id="259">
@@ -1141,11 +1141,11 @@
       <teacher reference="4"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="260">
+      <curriculumSet id="260">
         <Curriculum reference="155"/>
         <Curriculum reference="158"/>
         <Curriculum reference="159"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>104</studentSize>
     </Course>
     <Course id="261">
@@ -1154,12 +1154,12 @@
       <teacher reference="5"/>
       <lectureSize>2</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="262">
+      <curriculumSet id="262">
         <Curriculum reference="109"/>
         <Curriculum reference="111"/>
         <Curriculum reference="113"/>
         <Curriculum reference="115"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>24</studentSize>
     </Course>
     <Course id="263">
@@ -1168,12 +1168,12 @@
       <teacher reference="7"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="264">
+      <curriculumSet id="264">
         <Curriculum reference="110"/>
         <Curriculum reference="112"/>
         <Curriculum reference="114"/>
         <Curriculum reference="116"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>24</studentSize>
     </Course>
     <Course id="265">
@@ -1182,7 +1182,7 @@
       <teacher reference="8"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="266">
+      <curriculumSet id="266">
         <Curriculum reference="88"/>
         <Curriculum reference="89"/>
         <Curriculum reference="90"/>
@@ -1193,7 +1193,7 @@
         <Curriculum reference="191"/>
         <Curriculum reference="192"/>
         <Curriculum reference="193"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>16</studentSize>
     </Course>
     <Course id="267">
@@ -1202,7 +1202,7 @@
       <teacher reference="45"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="268">
+      <curriculumSet id="268">
         <Curriculum reference="83"/>
         <Curriculum reference="102"/>
         <Curriculum reference="120"/>
@@ -1211,7 +1211,7 @@
         <Curriculum reference="160"/>
         <Curriculum reference="161"/>
         <Curriculum reference="162"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>74</studentSize>
     </Course>
     <Course id="269">
@@ -1220,7 +1220,7 @@
       <teacher reference="44"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="270">
+      <curriculumSet id="270">
         <Curriculum reference="127"/>
         <Curriculum reference="128"/>
         <Curriculum reference="129"/>
@@ -1236,7 +1236,7 @@
         <Curriculum reference="204"/>
         <Curriculum reference="205"/>
         <Curriculum reference="213"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>26</studentSize>
     </Course>
     <Course id="271">
@@ -1245,7 +1245,7 @@
       <teacher reference="43"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="272">
+      <curriculumSet id="272">
         <Curriculum reference="86"/>
         <Curriculum reference="90"/>
         <Curriculum reference="91"/>
@@ -1256,7 +1256,7 @@
         <Curriculum reference="199"/>
         <Curriculum reference="200"/>
         <Curriculum reference="201"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>14</studentSize>
     </Course>
     <Course id="273">
@@ -1265,11 +1265,11 @@
       <teacher reference="42"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="274">
+      <curriculumSet id="274">
         <Curriculum reference="160"/>
         <Curriculum reference="161"/>
         <Curriculum reference="162"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>33</studentSize>
     </Course>
     <Course id="275">
@@ -1278,11 +1278,11 @@
       <teacher reference="46"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="276">
+      <curriculumSet id="276">
         <Curriculum reference="92"/>
         <Curriculum reference="101"/>
         <Curriculum reference="103"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>41</studentSize>
     </Course>
     <Course id="277">
@@ -1291,11 +1291,11 @@
       <teacher reference="25"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="278">
+      <curriculumSet id="278">
         <Curriculum reference="155"/>
         <Curriculum reference="158"/>
         <Curriculum reference="159"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>104</studentSize>
     </Course>
     <Course id="279">
@@ -1304,7 +1304,7 @@
       <teacher reference="26"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="280">
+      <curriculumSet id="280">
         <Curriculum reference="78"/>
         <Curriculum reference="84"/>
         <Curriculum reference="92"/>
@@ -1315,7 +1315,7 @@
         <Curriculum reference="108"/>
         <Curriculum reference="123"/>
         <Curriculum reference="135"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>139</studentSize>
     </Course>
     <Course id="281">
@@ -1324,7 +1324,7 @@
       <teacher reference="31"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="282">
+      <curriculumSet id="282">
         <Curriculum reference="85"/>
         <Curriculum reference="88"/>
         <Curriculum reference="89"/>
@@ -1336,7 +1336,7 @@
         <Curriculum reference="203"/>
         <Curriculum reference="204"/>
         <Curriculum reference="205"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>18</studentSize>
     </Course>
     <Course id="283">
@@ -1345,7 +1345,7 @@
       <teacher reference="32"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="284">
+      <curriculumSet id="284">
         <Curriculum reference="129"/>
         <Curriculum reference="130"/>
         <Curriculum reference="133"/>
@@ -1362,7 +1362,7 @@
         <Curriculum reference="154"/>
         <Curriculum reference="156"/>
         <Curriculum reference="157"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>121</studentSize>
     </Course>
     <Course id="285">
@@ -1371,7 +1371,7 @@
       <teacher reference="28"/>
       <lectureSize>2</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="286">
+      <curriculumSet id="286">
         <Curriculum reference="79"/>
         <Curriculum reference="80"/>
         <Curriculum reference="81"/>
@@ -1382,7 +1382,7 @@
         <Curriculum reference="98"/>
         <Curriculum reference="102"/>
         <Curriculum reference="103"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>67</studentSize>
     </Course>
     <Course id="287">
@@ -1391,9 +1391,9 @@
       <teacher reference="28"/>
       <lectureSize>1</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="288">
+      <curriculumSet id="288">
         <Curriculum reference="83"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>5</studentSize>
     </Course>
     <Course id="289">
@@ -1402,7 +1402,7 @@
       <teacher reference="30"/>
       <lectureSize>2</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="290">
+      <curriculumSet id="290">
         <Curriculum reference="155"/>
         <Curriculum reference="158"/>
         <Curriculum reference="159"/>
@@ -1410,7 +1410,7 @@
         <Curriculum reference="215"/>
         <Curriculum reference="216"/>
         <Curriculum reference="217"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>110</studentSize>
     </Course>
     <Course id="291">
@@ -1419,7 +1419,7 @@
       <teacher reference="54"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="292">
+      <curriculumSet id="292">
         <Curriculum reference="86"/>
         <Curriculum reference="88"/>
         <Curriculum reference="90"/>
@@ -1435,7 +1435,7 @@
         <Curriculum reference="196"/>
         <Curriculum reference="197"/>
         <Curriculum reference="207"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>69</studentSize>
     </Course>
     <Course id="293">
@@ -1444,7 +1444,7 @@
       <teacher reference="55"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="294">
+      <curriculumSet id="294">
         <Curriculum reference="85"/>
         <Curriculum reference="87"/>
         <Curriculum reference="139"/>
@@ -1455,7 +1455,7 @@
         <Curriculum reference="149"/>
         <Curriculum reference="151"/>
         <Curriculum reference="153"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>14</studentSize>
     </Course>
     <Course id="295">
@@ -1464,13 +1464,13 @@
       <teacher reference="56"/>
       <lectureSize>2</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="296">
+      <curriculumSet id="296">
         <Curriculum reference="190"/>
         <Curriculum reference="192"/>
         <Curriculum reference="193"/>
         <Curriculum reference="194"/>
         <Curriculum reference="195"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>6</studentSize>
     </Course>
     <Course id="297">
@@ -1479,7 +1479,7 @@
       <teacher reference="56"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="298">
+      <curriculumSet id="298">
         <Curriculum reference="86"/>
         <Curriculum reference="187"/>
         <Curriculum reference="188"/>
@@ -1496,7 +1496,7 @@
         <Curriculum reference="203"/>
         <Curriculum reference="204"/>
         <Curriculum reference="205"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>27</studentSize>
     </Course>
     <Course id="299">
@@ -1505,12 +1505,12 @@
       <teacher reference="57"/>
       <lectureSize>2</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="300">
+      <curriculumSet id="300">
         <Curriculum reference="84"/>
         <Curriculum reference="124"/>
         <Curriculum reference="125"/>
         <Curriculum reference="126"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>26</studentSize>
     </Course>
     <Course id="301">
@@ -1519,11 +1519,11 @@
       <teacher reference="51"/>
       <lectureSize>2</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="302">
+      <curriculumSet id="302">
         <Curriculum reference="78"/>
         <Curriculum reference="84"/>
         <Curriculum reference="92"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>53</studentSize>
     </Course>
     <Course id="303">
@@ -1532,7 +1532,7 @@
       <teacher reference="53"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="304">
+      <curriculumSet id="304">
         <Curriculum reference="104"/>
         <Curriculum reference="105"/>
         <Curriculum reference="106"/>
@@ -1540,7 +1540,7 @@
         <Curriculum reference="108"/>
         <Curriculum reference="123"/>
         <Curriculum reference="135"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>86</studentSize>
     </Course>
     <Course id="305">
@@ -1549,11 +1549,11 @@
       <teacher reference="52"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="306">
+      <curriculumSet id="306">
         <Curriculum reference="78"/>
         <Curriculum reference="84"/>
         <Curriculum reference="92"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>53</studentSize>
     </Course>
     <Course id="307">
@@ -1562,7 +1562,7 @@
       <teacher reference="48"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="308">
+      <curriculumSet id="308">
         <Curriculum reference="79"/>
         <Curriculum reference="80"/>
         <Curriculum reference="81"/>
@@ -1571,7 +1571,7 @@
         <Curriculum reference="95"/>
         <Curriculum reference="96"/>
         <Curriculum reference="97"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>32</studentSize>
     </Course>
     <Course id="309">
@@ -1580,11 +1580,11 @@
       <teacher reference="47"/>
       <lectureSize>2</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="310">
+      <curriculumSet id="310">
         <Curriculum reference="160"/>
         <Curriculum reference="161"/>
         <Curriculum reference="162"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>33</studentSize>
     </Course>
     <Course id="311">
@@ -1593,12 +1593,12 @@
       <teacher reference="50"/>
       <lectureSize>2</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="312">
+      <curriculumSet id="312">
         <Curriculum reference="131"/>
         <Curriculum reference="132"/>
         <Curriculum reference="133"/>
         <Curriculum reference="134"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>8</studentSize>
     </Course>
     <Course id="313">
@@ -1607,7 +1607,7 @@
       <teacher reference="49"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="314">
+      <curriculumSet id="314">
         <Curriculum reference="117"/>
         <Curriculum reference="118"/>
         <Curriculum reference="119"/>
@@ -1618,7 +1618,7 @@
         <Curriculum reference="128"/>
         <Curriculum reference="129"/>
         <Curriculum reference="130"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>56</studentSize>
     </Course>
     <Course id="315">
@@ -1627,12 +1627,12 @@
       <teacher reference="72"/>
       <lectureSize>2</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="316">
+      <curriculumSet id="316">
         <Curriculum reference="109"/>
         <Curriculum reference="110"/>
         <Curriculum reference="210"/>
         <Curriculum reference="212"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>18</studentSize>
     </Course>
     <Course id="317">
@@ -1641,9 +1641,9 @@
       <teacher reference="73"/>
       <lectureSize>2</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="318">
+      <curriculumSet id="318">
         <Curriculum reference="213"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>4</studentSize>
     </Course>
     <Course id="319">
@@ -1652,9 +1652,9 @@
       <teacher reference="71"/>
       <lectureSize>2</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="320">
+      <curriculumSet id="320">
         <Curriculum reference="213"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>4</studentSize>
     </Course>
     <Course id="321">
@@ -1663,9 +1663,9 @@
       <teacher reference="21"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="322">
+      <curriculumSet id="322">
         <Curriculum reference="123"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>22</studentSize>
     </Course>
     <Course id="323">
@@ -1674,7 +1674,7 @@
       <teacher reference="69"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="324">
+      <curriculumSet id="324">
         <Curriculum reference="81"/>
         <Curriculum reference="98"/>
         <Curriculum reference="136"/>
@@ -1700,7 +1700,7 @@
         <Curriculum reference="191"/>
         <Curriculum reference="192"/>
         <Curriculum reference="193"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>45</studentSize>
     </Course>
     <Course id="325">
@@ -1709,7 +1709,7 @@
       <teacher reference="68"/>
       <lectureSize>2</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="326">
+      <curriculumSet id="326">
         <Curriculum reference="194"/>
         <Curriculum reference="195"/>
         <Curriculum reference="196"/>
@@ -1720,7 +1720,7 @@
         <Curriculum reference="223"/>
         <Curriculum reference="225"/>
         <Curriculum reference="227"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>13</studentSize>
     </Course>
     <Course id="327">
@@ -1729,9 +1729,9 @@
       <teacher reference="67"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="328">
+      <curriculumSet id="328">
         <Curriculum reference="213"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>4</studentSize>
     </Course>
     <Course id="329">
@@ -1740,11 +1740,11 @@
       <teacher reference="66"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="330">
+      <curriculumSet id="330">
         <Curriculum reference="154"/>
         <Curriculum reference="156"/>
         <Curriculum reference="157"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>104</studentSize>
     </Course>
     <Course id="331">
@@ -1753,11 +1753,11 @@
       <teacher reference="46"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="332">
+      <curriculumSet id="332">
         <Curriculum reference="117"/>
         <Curriculum reference="118"/>
         <Curriculum reference="119"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>24</studentSize>
     </Course>
     <Course id="333">
@@ -1766,7 +1766,7 @@
       <teacher reference="46"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="334">
+      <curriculumSet id="334">
         <Curriculum reference="93"/>
         <Curriculum reference="94"/>
         <Curriculum reference="96"/>
@@ -1774,7 +1774,7 @@
         <Curriculum reference="156"/>
         <Curriculum reference="157"/>
         <Curriculum reference="208"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>143</studentSize>
     </Course>
     <Course id="335">
@@ -1783,7 +1783,7 @@
       <teacher reference="65"/>
       <lectureSize>2</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="336">
+      <curriculumSet id="336">
         <Curriculum reference="165"/>
         <Curriculum reference="169"/>
         <Curriculum reference="173"/>
@@ -1791,7 +1791,7 @@
         <Curriculum reference="181"/>
         <Curriculum reference="185"/>
         <Curriculum reference="207"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>15</studentSize>
     </Course>
     <Course id="337">
@@ -1800,7 +1800,7 @@
       <teacher reference="64"/>
       <lectureSize>2</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="338">
+      <curriculumSet id="338">
         <Curriculum reference="166"/>
         <Curriculum reference="170"/>
         <Curriculum reference="174"/>
@@ -1809,7 +1809,7 @@
         <Curriculum reference="186"/>
         <Curriculum reference="207"/>
         <Curriculum reference="208"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>24</studentSize>
     </Course>
     <Course id="339">
@@ -1818,7 +1818,7 @@
       <teacher reference="63"/>
       <lectureSize>2</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="340">
+      <curriculumSet id="340">
         <Curriculum reference="111"/>
         <Curriculum reference="112"/>
         <Curriculum reference="155"/>
@@ -1827,7 +1827,7 @@
         <Curriculum reference="208"/>
         <Curriculum reference="210"/>
         <Curriculum reference="212"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>131</studentSize>
     </Course>
     <Course id="341">
@@ -1836,12 +1836,12 @@
       <teacher reference="62"/>
       <lectureSize>2</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="342">
+      <curriculumSet id="342">
         <Curriculum reference="113"/>
         <Curriculum reference="114"/>
         <Curriculum reference="210"/>
         <Curriculum reference="212"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>18</studentSize>
     </Course>
     <Course id="343">
@@ -1850,7 +1850,7 @@
       <teacher reference="17"/>
       <lectureSize>2</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="344">
+      <curriculumSet id="344">
         <Curriculum reference="164"/>
         <Curriculum reference="168"/>
         <Curriculum reference="172"/>
@@ -1859,7 +1859,7 @@
         <Curriculum reference="184"/>
         <Curriculum reference="207"/>
         <Curriculum reference="208"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>24</studentSize>
     </Course>
     <Course id="345">
@@ -1868,7 +1868,7 @@
       <teacher reference="18"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="346">
+      <curriculumSet id="346">
         <Curriculum reference="82"/>
         <Curriculum reference="142"/>
         <Curriculum reference="143"/>
@@ -1887,7 +1887,7 @@
         <Curriculum reference="184"/>
         <Curriculum reference="185"/>
         <Curriculum reference="186"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>20</studentSize>
     </Course>
     <Course id="347">
@@ -1896,14 +1896,14 @@
       <teacher reference="6"/>
       <lectureSize>2</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="348">
+      <curriculumSet id="348">
         <Curriculum reference="215"/>
         <Curriculum reference="217"/>
         <Curriculum reference="218"/>
         <Curriculum reference="222"/>
         <Curriculum reference="225"/>
         <Curriculum reference="226"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>6</studentSize>
     </Course>
     <Course id="349">
@@ -1912,14 +1912,14 @@
       <teacher reference="10"/>
       <lectureSize>2</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="350">
+      <curriculumSet id="350">
         <Curriculum reference="215"/>
         <Curriculum reference="217"/>
         <Curriculum reference="218"/>
         <Curriculum reference="222"/>
         <Curriculum reference="225"/>
         <Curriculum reference="226"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>6</studentSize>
     </Course>
     <Course id="351">
@@ -1928,7 +1928,7 @@
       <teacher reference="9"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="352">
+      <curriculumSet id="352">
         <Curriculum reference="109"/>
         <Curriculum reference="110"/>
         <Curriculum reference="111"/>
@@ -1937,7 +1937,7 @@
         <Curriculum reference="114"/>
         <Curriculum reference="115"/>
         <Curriculum reference="116"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>48</studentSize>
     </Course>
     <Course id="353">
@@ -1946,9 +1946,9 @@
       <teacher reference="58"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="354">
+      <curriculumSet id="354">
         <Curriculum reference="154"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>14</studentSize>
     </Course>
     <Course id="355">
@@ -1957,7 +1957,7 @@
       <teacher reference="12"/>
       <lectureSize>2</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="356">
+      <curriculumSet id="356">
         <Curriculum reference="117"/>
         <Curriculum reference="118"/>
         <Curriculum reference="119"/>
@@ -1967,7 +1967,7 @@
         <Curriculum reference="208"/>
         <Curriculum reference="210"/>
         <Curriculum reference="212"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>63</studentSize>
     </Course>
     <Course id="357">
@@ -1976,14 +1976,14 @@
       <teacher reference="11"/>
       <lectureSize>2</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="358">
+      <curriculumSet id="358">
         <Curriculum reference="104"/>
         <Curriculum reference="105"/>
         <Curriculum reference="208"/>
         <Curriculum reference="210"/>
         <Curriculum reference="211"/>
         <Curriculum reference="212"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>33</studentSize>
     </Course>
     <Course id="359">
@@ -1992,10 +1992,10 @@
       <teacher reference="14"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="360">
+      <curriculumSet id="360">
         <Curriculum reference="156"/>
         <Curriculum reference="157"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>90</studentSize>
     </Course>
     <Course id="361">
@@ -2004,7 +2004,7 @@
       <teacher reference="13"/>
       <lectureSize>2</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="362">
+      <curriculumSet id="362">
         <Curriculum reference="109"/>
         <Curriculum reference="110"/>
         <Curriculum reference="111"/>
@@ -2015,7 +2015,7 @@
         <Curriculum reference="116"/>
         <Curriculum reference="209"/>
         <Curriculum reference="211"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>54</studentSize>
     </Course>
     <Course id="363">
@@ -2024,7 +2024,7 @@
       <teacher reference="16"/>
       <lectureSize>2</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="364">
+      <curriculumSet id="364">
         <Curriculum reference="175"/>
         <Curriculum reference="176"/>
         <Curriculum reference="177"/>
@@ -2038,7 +2038,7 @@
         <Curriculum reference="185"/>
         <Curriculum reference="186"/>
         <Curriculum reference="207"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>21</studentSize>
     </Course>
     <Course id="365">
@@ -2047,7 +2047,7 @@
       <teacher reference="15"/>
       <lectureSize>2</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="366">
+      <curriculumSet id="366">
         <Curriculum reference="163"/>
         <Curriculum reference="164"/>
         <Curriculum reference="165"/>
@@ -2063,7 +2063,7 @@
         <Curriculum reference="194"/>
         <Curriculum reference="196"/>
         <Curriculum reference="207"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>23</studentSize>
     </Course>
     <Course id="367">
@@ -2072,7 +2072,7 @@
       <teacher reference="48"/>
       <lectureSize>2</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="368">
+      <curriculumSet id="368">
         <Curriculum reference="163"/>
         <Curriculum reference="164"/>
         <Curriculum reference="165"/>
@@ -2097,7 +2097,7 @@
         <Curriculum reference="184"/>
         <Curriculum reference="185"/>
         <Curriculum reference="186"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>24</studentSize>
     </Course>
     <Course id="369">
@@ -2106,7 +2106,7 @@
       <teacher reference="41"/>
       <lectureSize>2</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="370">
+      <curriculumSet id="370">
         <Curriculum reference="83"/>
         <Curriculum reference="94"/>
         <Curriculum reference="95"/>
@@ -2117,7 +2117,7 @@
         <Curriculum reference="142"/>
         <Curriculum reference="207"/>
         <Curriculum reference="211"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>51</studentSize>
     </Course>
     <Course id="371">
@@ -2126,12 +2126,12 @@
       <teacher reference="29"/>
       <lectureSize>2</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="372">
+      <curriculumSet id="372">
         <Curriculum reference="106"/>
         <Curriculum reference="208"/>
         <Curriculum reference="210"/>
         <Curriculum reference="212"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>33</studentSize>
     </Course>
     <Course id="373">
@@ -2140,10 +2140,10 @@
       <teacher reference="27"/>
       <lectureSize>2</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="374">
+      <curriculumSet id="374">
         <Curriculum reference="209"/>
         <Curriculum reference="211"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>6</studentSize>
     </Course>
     <Course id="375">
@@ -2152,10 +2152,10 @@
       <teacher reference="36"/>
       <lectureSize>2</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="376">
+      <curriculumSet id="376">
         <Curriculum reference="209"/>
         <Curriculum reference="211"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>6</studentSize>
     </Course>
     <Course id="377">
@@ -2164,13 +2164,13 @@
       <teacher reference="7"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="378">
+      <curriculumSet id="378">
         <Curriculum reference="147"/>
         <Curriculum reference="149"/>
         <Curriculum reference="150"/>
         <Curriculum reference="152"/>
         <Curriculum reference="153"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>5</studentSize>
     </Course>
     <Course id="379">
@@ -2179,11 +2179,11 @@
       <teacher reference="35"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="380">
+      <curriculumSet id="380">
         <Curriculum reference="104"/>
         <Curriculum reference="106"/>
         <Curriculum reference="107"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>36</studentSize>
     </Course>
     <Course id="381">
@@ -2192,10 +2192,10 @@
       <teacher reference="34"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="382">
+      <curriculumSet id="382">
         <Curriculum reference="105"/>
         <Curriculum reference="108"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>18</studentSize>
     </Course>
     <Course id="383">
@@ -2204,10 +2204,10 @@
       <teacher reference="33"/>
       <lectureSize>2</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="384">
+      <curriculumSet id="384">
         <Curriculum reference="210"/>
         <Curriculum reference="211"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>6</studentSize>
     </Course>
     <Course id="385">
@@ -2216,7 +2216,7 @@
       <teacher reference="40"/>
       <lectureSize>2</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="386">
+      <curriculumSet id="386">
         <Curriculum reference="96"/>
         <Curriculum reference="97"/>
         <Curriculum reference="117"/>
@@ -2250,7 +2250,7 @@
         <Curriculum reference="186"/>
         <Curriculum reference="207"/>
         <Curriculum reference="211"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>65</studentSize>
     </Course>
     <Course id="387">
@@ -2259,7 +2259,7 @@
       <teacher reference="39"/>
       <lectureSize>2</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="388">
+      <curriculumSet id="388">
         <Curriculum reference="118"/>
         <Curriculum reference="121"/>
         <Curriculum reference="138"/>
@@ -2269,7 +2269,7 @@
         <Curriculum reference="158"/>
         <Curriculum reference="159"/>
         <Curriculum reference="211"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>126</studentSize>
     </Course>
     <Course id="389">
@@ -2278,12 +2278,12 @@
       <teacher reference="38"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="390">
+      <curriculumSet id="390">
         <Curriculum reference="85"/>
         <Curriculum reference="87"/>
         <Curriculum reference="123"/>
         <Curriculum reference="160"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>39</studentSize>
     </Course>
     <Course id="391">
@@ -2292,13 +2292,13 @@
       <teacher reference="37"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="392">
+      <curriculumSet id="392">
         <Curriculum reference="99"/>
         <Curriculum reference="100"/>
         <Curriculum reference="156"/>
         <Curriculum reference="158"/>
         <Curriculum reference="162"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>115</studentSize>
     </Course>
     <Course id="393">
@@ -2307,7 +2307,7 @@
       <teacher reference="76"/>
       <lectureSize>2</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="394">
+      <curriculumSet id="394">
         <Curriculum reference="163"/>
         <Curriculum reference="167"/>
         <Curriculum reference="171"/>
@@ -2315,7 +2315,7 @@
         <Curriculum reference="179"/>
         <Curriculum reference="183"/>
         <Curriculum reference="208"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>15</studentSize>
     </Course>
     <Course id="395">
@@ -2324,12 +2324,12 @@
       <teacher reference="17"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="396">
+      <curriculumSet id="396">
         <Curriculum reference="99"/>
         <Curriculum reference="100"/>
         <Curriculum reference="157"/>
         <Curriculum reference="159"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>104</studentSize>
     </Course>
     <Course id="397">
@@ -2338,7 +2338,7 @@
       <teacher reference="74"/>
       <lectureSize>2</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="398">
+      <curriculumSet id="398">
         <Curriculum reference="86"/>
         <Curriculum reference="87"/>
         <Curriculum reference="99"/>
@@ -2356,7 +2356,7 @@
         <Curriculum reference="204"/>
         <Curriculum reference="205"/>
         <Curriculum reference="207"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>76</studentSize>
     </Course>
     <Course id="399">
@@ -2365,7 +2365,7 @@
       <teacher reference="74"/>
       <lectureSize>2</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="400">
+      <curriculumSet id="400">
         <Curriculum reference="188"/>
         <Curriculum reference="189"/>
         <Curriculum reference="190"/>
@@ -2374,7 +2374,7 @@
         <Curriculum reference="193"/>
         <Curriculum reference="206"/>
         <Curriculum reference="213"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>15</studentSize>
     </Course>
     <Course id="401">
@@ -2383,11 +2383,11 @@
       <teacher reference="75"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="402">
+      <curriculumSet id="402">
         <Curriculum reference="195"/>
         <Curriculum reference="197"/>
         <Curriculum reference="206"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>3</studentSize>
     </Course>
     <Course id="403">
@@ -2396,7 +2396,7 @@
       <teacher reference="70"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="404">
+      <curriculumSet id="404">
         <Curriculum reference="89"/>
         <Curriculum reference="91"/>
         <Curriculum reference="124"/>
@@ -2408,7 +2408,7 @@
         <Curriculum reference="203"/>
         <Curriculum reference="204"/>
         <Curriculum reference="205"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>29</studentSize>
     </Course>
   </courseList>

--- a/optaplanner-examples/data/curriculumcourse/unsolved/comp13.xml
+++ b/optaplanner-examples/data/curriculumcourse/unsolved/comp13.xml
@@ -584,10 +584,10 @@
       <teacher reference="60"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="149">
+      <curriculumSet id="149">
         <Curriculum reference="86"/>
         <Curriculum reference="87"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>40</studentSize>
     </Course>
     <Course id="150">
@@ -596,10 +596,10 @@
       <teacher reference="61"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="151">
+      <curriculumSet id="151">
         <Curriculum reference="86"/>
         <Curriculum reference="88"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>23</studentSize>
     </Course>
     <Course id="152">
@@ -608,13 +608,13 @@
       <teacher reference="58"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="153">
+      <curriculumSet id="153">
         <Curriculum reference="86"/>
         <Curriculum reference="88"/>
         <Curriculum reference="90"/>
         <Curriculum reference="138"/>
         <Curriculum reference="140"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>42</studentSize>
     </Course>
     <Course id="154">
@@ -623,10 +623,10 @@
       <teacher reference="59"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="155">
+      <curriculumSet id="155">
         <Curriculum reference="89"/>
         <Curriculum reference="137"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>20</studentSize>
     </Course>
     <Course id="156">
@@ -635,11 +635,11 @@
       <teacher reference="20"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="157">
+      <curriculumSet id="157">
         <Curriculum reference="89"/>
         <Curriculum reference="91"/>
         <Curriculum reference="137"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>23</studentSize>
     </Course>
     <Course id="158">
@@ -648,9 +648,9 @@
       <teacher reference="19"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="159">
+      <curriculumSet id="159">
         <Curriculum reference="92"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>120</studentSize>
     </Course>
     <Course id="160">
@@ -659,12 +659,12 @@
       <teacher reference="22"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="161">
+      <curriculumSet id="161">
         <Curriculum reference="93"/>
         <Curriculum reference="112"/>
         <Curriculum reference="135"/>
         <Curriculum reference="136"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>230</studentSize>
     </Course>
     <Course id="162">
@@ -673,9 +673,9 @@
       <teacher reference="21"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="163">
+      <curriculumSet id="163">
         <Curriculum reference="93"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>90</studentSize>
     </Course>
     <Course id="164">
@@ -684,9 +684,9 @@
       <teacher reference="24"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="165">
+      <curriculumSet id="165">
         <Curriculum reference="93"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>90</studentSize>
     </Course>
     <Course id="166">
@@ -695,9 +695,9 @@
       <teacher reference="23"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="167">
+      <curriculumSet id="167">
         <Curriculum reference="92"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>120</studentSize>
     </Course>
     <Course id="168">
@@ -706,10 +706,10 @@
       <teacher reference="3"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="169">
+      <curriculumSet id="169">
         <Curriculum reference="93"/>
         <Curriculum reference="112"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>130</studentSize>
     </Course>
     <Course id="170">
@@ -718,9 +718,9 @@
       <teacher reference="4"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="171">
+      <curriculumSet id="171">
         <Curriculum reference="81"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>100</studentSize>
     </Course>
     <Course id="172">
@@ -729,9 +729,9 @@
       <teacher reference="5"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="173">
+      <curriculumSet id="173">
         <Curriculum reference="82"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>100</studentSize>
     </Course>
     <Course id="174">
@@ -740,9 +740,9 @@
       <teacher reference="7"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="175">
+      <curriculumSet id="175">
         <Curriculum reference="82"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>100</studentSize>
     </Course>
     <Course id="176">
@@ -751,9 +751,9 @@
       <teacher reference="8"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="177">
+      <curriculumSet id="177">
         <Curriculum reference="81"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>100</studentSize>
     </Course>
     <Course id="178">
@@ -762,9 +762,9 @@
       <teacher reference="45"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="179">
+      <curriculumSet id="179">
         <Curriculum reference="81"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>100</studentSize>
     </Course>
     <Course id="180">
@@ -773,9 +773,9 @@
       <teacher reference="44"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="181">
+      <curriculumSet id="181">
         <Curriculum reference="82"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>100</studentSize>
     </Course>
     <Course id="182">
@@ -784,10 +784,10 @@
       <teacher reference="22"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="183">
+      <curriculumSet id="183">
         <Curriculum reference="83"/>
         <Curriculum reference="135"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>145</studentSize>
     </Course>
     <Course id="184">
@@ -796,10 +796,10 @@
       <teacher reference="43"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="185">
+      <curriculumSet id="185">
         <Curriculum reference="83"/>
         <Curriculum reference="135"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>145</studentSize>
     </Course>
     <Course id="186">
@@ -808,11 +808,11 @@
       <teacher reference="42"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="187">
+      <curriculumSet id="187">
         <Curriculum reference="102"/>
         <Curriculum reference="103"/>
         <Curriculum reference="104"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>153</studentSize>
     </Course>
     <Course id="188">
@@ -821,12 +821,12 @@
       <teacher reference="46"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="189">
+      <curriculumSet id="189">
         <Curriculum reference="105"/>
         <Curriculum reference="106"/>
         <Curriculum reference="107"/>
         <Curriculum reference="108"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>123</studentSize>
     </Course>
     <Course id="190">
@@ -835,12 +835,12 @@
       <teacher reference="25"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="191">
+      <curriculumSet id="191">
         <Curriculum reference="105"/>
         <Curriculum reference="106"/>
         <Curriculum reference="107"/>
         <Curriculum reference="108"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>123</studentSize>
     </Course>
     <Course id="192">
@@ -849,12 +849,12 @@
       <teacher reference="26"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="193">
+      <curriculumSet id="193">
         <Curriculum reference="105"/>
         <Curriculum reference="106"/>
         <Curriculum reference="107"/>
         <Curriculum reference="108"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>123</studentSize>
     </Course>
     <Course id="194">
@@ -863,11 +863,11 @@
       <teacher reference="31"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="195">
+      <curriculumSet id="195">
         <Curriculum reference="109"/>
         <Curriculum reference="110"/>
         <Curriculum reference="111"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>123</studentSize>
     </Course>
     <Course id="196">
@@ -876,12 +876,12 @@
       <teacher reference="32"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="197">
+      <curriculumSet id="197">
         <Curriculum reference="85"/>
         <Curriculum reference="109"/>
         <Curriculum reference="110"/>
         <Curriculum reference="111"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>131</studentSize>
     </Course>
     <Course id="198">
@@ -890,9 +890,9 @@
       <teacher reference="4"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="199">
+      <curriculumSet id="199">
         <Curriculum reference="99"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>90</studentSize>
     </Course>
     <Course id="200">
@@ -901,9 +901,9 @@
       <teacher reference="28"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="201">
+      <curriculumSet id="201">
         <Curriculum reference="99"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>90</studentSize>
     </Course>
     <Course id="202">
@@ -912,9 +912,9 @@
       <teacher reference="30"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="203">
+      <curriculumSet id="203">
         <Curriculum reference="99"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>90</studentSize>
     </Course>
     <Course id="204">
@@ -923,9 +923,9 @@
       <teacher reference="54"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="205">
+      <curriculumSet id="205">
         <Curriculum reference="100"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>90</studentSize>
     </Course>
     <Course id="206">
@@ -934,10 +934,10 @@
       <teacher reference="55"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="207">
+      <curriculumSet id="207">
         <Curriculum reference="84"/>
         <Curriculum reference="85"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>133</studentSize>
     </Course>
     <Course id="208">
@@ -946,10 +946,10 @@
       <teacher reference="56"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="209">
+      <curriculumSet id="209">
         <Curriculum reference="84"/>
         <Curriculum reference="85"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>133</studentSize>
     </Course>
     <Course id="210">
@@ -958,10 +958,10 @@
       <teacher reference="57"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="211">
+      <curriculumSet id="211">
         <Curriculum reference="87"/>
         <Curriculum reference="95"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>110</studentSize>
     </Course>
     <Course id="212">
@@ -970,10 +970,10 @@
       <teacher reference="61"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="213">
+      <curriculumSet id="213">
         <Curriculum reference="87"/>
         <Curriculum reference="95"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>110</studentSize>
     </Course>
     <Course id="214">
@@ -982,13 +982,13 @@
       <teacher reference="51"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="215">
+      <curriculumSet id="215">
         <Curriculum reference="86"/>
         <Curriculum reference="87"/>
         <Curriculum reference="88"/>
         <Curriculum reference="95"/>
         <Curriculum reference="96"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>138</studentSize>
     </Course>
     <Course id="216">
@@ -997,9 +997,9 @@
       <teacher reference="53"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="217">
+      <curriculumSet id="217">
         <Curriculum reference="84"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>125</studentSize>
     </Course>
     <Course id="218">
@@ -1008,12 +1008,12 @@
       <teacher reference="52"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="219">
+      <curriculumSet id="219">
         <Curriculum reference="97"/>
         <Curriculum reference="98"/>
         <Curriculum reference="121"/>
         <Curriculum reference="123"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>105</studentSize>
     </Course>
     <Course id="220">
@@ -1022,13 +1022,13 @@
       <teacher reference="48"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="221">
+      <curriculumSet id="221">
         <Curriculum reference="97"/>
         <Curriculum reference="121"/>
         <Curriculum reference="122"/>
         <Curriculum reference="142"/>
         <Curriculum reference="143"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>78</studentSize>
     </Course>
     <Course id="222">
@@ -1037,11 +1037,11 @@
       <teacher reference="47"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="223">
+      <curriculumSet id="223">
         <Curriculum reference="98"/>
         <Curriculum reference="120"/>
         <Curriculum reference="122"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>70</studentSize>
     </Course>
     <Course id="224">
@@ -1050,10 +1050,10 @@
       <teacher reference="50"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="225">
+      <curriculumSet id="225">
         <Curriculum reference="100"/>
         <Curriculum reference="112"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>130</studentSize>
     </Course>
     <Course id="226">
@@ -1062,10 +1062,10 @@
       <teacher reference="49"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="227">
+      <curriculumSet id="227">
         <Curriculum reference="100"/>
         <Curriculum reference="112"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>130</studentSize>
     </Course>
     <Course id="228">
@@ -1074,10 +1074,10 @@
       <teacher reference="75"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="229">
+      <curriculumSet id="229">
         <Curriculum reference="120"/>
         <Curriculum reference="121"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>40</studentSize>
     </Course>
     <Course id="230">
@@ -1086,10 +1086,10 @@
       <teacher reference="48"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="231">
+      <curriculumSet id="231">
         <Curriculum reference="120"/>
         <Curriculum reference="143"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>24</studentSize>
     </Course>
     <Course id="232">
@@ -1098,11 +1098,11 @@
       <teacher reference="76"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="233">
+      <curriculumSet id="233">
         <Curriculum reference="120"/>
         <Curriculum reference="122"/>
         <Curriculum reference="123"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>50</studentSize>
     </Course>
     <Course id="234">
@@ -1111,14 +1111,14 @@
       <teacher reference="74"/>
       <lectureSize>5</lectureSize>
       <minWorkingDaySize>4</minWorkingDaySize>
-      <curriculumList id="235">
+      <curriculumSet id="235">
         <Curriculum reference="90"/>
         <Curriculum reference="122"/>
         <Curriculum reference="124"/>
         <Curriculum reference="138"/>
         <Curriculum reference="139"/>
         <Curriculum reference="140"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>62</studentSize>
     </Course>
     <Course id="236">
@@ -1127,12 +1127,12 @@
       <teacher reference="69"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="237">
+      <curriculumSet id="237">
         <Curriculum reference="114"/>
         <Curriculum reference="115"/>
         <Curriculum reference="116"/>
         <Curriculum reference="117"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>77</studentSize>
     </Course>
     <Course id="238">
@@ -1141,11 +1141,11 @@
       <teacher reference="68"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="239">
+      <curriculumSet id="239">
         <Curriculum reference="117"/>
         <Curriculum reference="131"/>
         <Curriculum reference="134"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>65</studentSize>
     </Course>
     <Course id="240">
@@ -1154,11 +1154,11 @@
       <teacher reference="67"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="241">
+      <curriculumSet id="241">
         <Curriculum reference="116"/>
         <Curriculum reference="118"/>
         <Curriculum reference="119"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>94</studentSize>
     </Course>
     <Course id="242">
@@ -1167,14 +1167,14 @@
       <teacher reference="66"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="243">
+      <curriculumSet id="243">
         <Curriculum reference="125"/>
         <Curriculum reference="126"/>
         <Curriculum reference="127"/>
         <Curriculum reference="128"/>
         <Curriculum reference="129"/>
         <Curriculum reference="130"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>80</studentSize>
     </Course>
     <Course id="244">
@@ -1183,9 +1183,9 @@
       <teacher reference="65"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="245">
+      <curriculumSet id="245">
         <Curriculum reference="131"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>10</studentSize>
     </Course>
     <Course id="246">
@@ -1194,11 +1194,11 @@
       <teacher reference="64"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="247">
+      <curriculumSet id="247">
         <Curriculum reference="116"/>
         <Curriculum reference="119"/>
         <Curriculum reference="132"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>47</studentSize>
     </Course>
     <Course id="248">
@@ -1207,10 +1207,10 @@
       <teacher reference="63"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="249">
+      <curriculumSet id="249">
         <Curriculum reference="133"/>
         <Curriculum reference="134"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>25</studentSize>
     </Course>
     <Course id="250">
@@ -1219,10 +1219,10 @@
       <teacher reference="62"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="251">
+      <curriculumSet id="251">
         <Curriculum reference="129"/>
         <Curriculum reference="130"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>35</studentSize>
     </Course>
     <Course id="252">
@@ -1231,10 +1231,10 @@
       <teacher reference="17"/>
       <lectureSize>6</lectureSize>
       <minWorkingDaySize>4</minWorkingDaySize>
-      <curriculumList id="253">
+      <curriculumSet id="253">
         <Curriculum reference="135"/>
         <Curriculum reference="136"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>100</studentSize>
     </Course>
     <Course id="254">
@@ -1243,10 +1243,10 @@
       <teacher reference="18"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="255">
+      <curriculumSet id="255">
         <Curriculum reference="136"/>
         <Curriculum reference="141"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>29</studentSize>
     </Course>
     <Course id="256">
@@ -1255,10 +1255,10 @@
       <teacher reference="25"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="257">
+      <curriculumSet id="257">
         <Curriculum reference="120"/>
         <Curriculum reference="121"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>40</studentSize>
     </Course>
     <Course id="258">
@@ -1267,11 +1267,11 @@
       <teacher reference="6"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="259">
+      <curriculumSet id="259">
         <Curriculum reference="125"/>
         <Curriculum reference="126"/>
         <Curriculum reference="132"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>40</studentSize>
     </Course>
     <Course id="260">
@@ -1280,7 +1280,7 @@
       <teacher reference="10"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="261">
+      <curriculumSet id="261">
         <Curriculum reference="113"/>
         <Curriculum reference="114"/>
         <Curriculum reference="125"/>
@@ -1289,7 +1289,7 @@
         <Curriculum reference="128"/>
         <Curriculum reference="129"/>
         <Curriculum reference="130"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>97</studentSize>
     </Course>
     <Course id="262">
@@ -1298,10 +1298,10 @@
       <teacher reference="9"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="263">
+      <curriculumSet id="263">
         <Curriculum reference="88"/>
         <Curriculum reference="96"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>8</studentSize>
     </Course>
     <Course id="264">
@@ -1310,9 +1310,9 @@
       <teacher reference="12"/>
       <lectureSize>5</lectureSize>
       <minWorkingDaySize>4</minWorkingDaySize>
-      <curriculumList id="265">
+      <curriculumSet id="265">
         <Curriculum reference="138"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>3</studentSize>
     </Course>
     <Course id="266">
@@ -1321,9 +1321,9 @@
       <teacher reference="11"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="267">
+      <curriculumSet id="267">
         <Curriculum reference="139"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>3</studentSize>
     </Course>
     <Course id="268">
@@ -1332,11 +1332,11 @@
       <teacher reference="14"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="269">
+      <curriculumSet id="269">
         <Curriculum reference="139"/>
         <Curriculum reference="140"/>
         <Curriculum reference="142"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>10</studentSize>
     </Course>
     <Course id="270">
@@ -1345,11 +1345,11 @@
       <teacher reference="13"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="271">
+      <curriculumSet id="271">
         <Curriculum reference="144"/>
         <Curriculum reference="145"/>
         <Curriculum reference="146"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>45</studentSize>
     </Course>
     <Course id="272">
@@ -1358,11 +1358,11 @@
       <teacher reference="16"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="273">
+      <curriculumSet id="273">
         <Curriculum reference="144"/>
         <Curriculum reference="145"/>
         <Curriculum reference="146"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>45</studentSize>
     </Course>
     <Course id="274">
@@ -1371,9 +1371,9 @@
       <teacher reference="15"/>
       <lectureSize>7</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="275">
+      <curriculumSet id="275">
         <Curriculum reference="144"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>15</studentSize>
     </Course>
     <Course id="276">
@@ -1382,9 +1382,9 @@
       <teacher reference="41"/>
       <lectureSize>7</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="277">
+      <curriculumSet id="277">
         <Curriculum reference="145"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>15</studentSize>
     </Course>
     <Course id="278">
@@ -1393,9 +1393,9 @@
       <teacher reference="29"/>
       <lectureSize>7</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="279">
+      <curriculumSet id="279">
         <Curriculum reference="146"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>15</studentSize>
     </Course>
     <Course id="280">
@@ -1404,9 +1404,9 @@
       <teacher reference="27"/>
       <lectureSize>7</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="281">
+      <curriculumSet id="281">
         <Curriculum reference="105"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>40</studentSize>
     </Course>
     <Course id="282">
@@ -1415,9 +1415,9 @@
       <teacher reference="36"/>
       <lectureSize>7</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="283">
+      <curriculumSet id="283">
         <Curriculum reference="108"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>40</studentSize>
     </Course>
     <Course id="284">
@@ -1426,14 +1426,14 @@
       <teacher reference="35"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="285">
+      <curriculumSet id="285">
         <Curriculum reference="91"/>
         <Curriculum reference="96"/>
         <Curriculum reference="107"/>
         <Curriculum reference="144"/>
         <Curriculum reference="145"/>
         <Curriculum reference="146"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>56</studentSize>
     </Course>
     <Course id="286">
@@ -1442,11 +1442,11 @@
       <teacher reference="34"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="287">
+      <curriculumSet id="287">
         <Curriculum reference="102"/>
         <Curriculum reference="103"/>
         <Curriculum reference="104"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>153</studentSize>
     </Course>
     <Course id="288">
@@ -1455,10 +1455,10 @@
       <teacher reference="33"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="289">
+      <curriculumSet id="289">
         <Curriculum reference="122"/>
         <Curriculum reference="123"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>30</studentSize>
     </Course>
     <Course id="290">
@@ -1467,9 +1467,9 @@
       <teacher reference="40"/>
       <lectureSize>7</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="291">
+      <curriculumSet id="291">
         <Curriculum reference="109"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>40</studentSize>
     </Course>
     <Course id="292">
@@ -1478,9 +1478,9 @@
       <teacher reference="39"/>
       <lectureSize>7</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="293">
+      <curriculumSet id="293">
         <Curriculum reference="103"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>50</studentSize>
     </Course>
     <Course id="294">
@@ -1489,9 +1489,9 @@
       <teacher reference="38"/>
       <lectureSize>7</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="295">
+      <curriculumSet id="295">
         <Curriculum reference="106"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>40</studentSize>
     </Course>
     <Course id="296">
@@ -1500,9 +1500,9 @@
       <teacher reference="37"/>
       <lectureSize>7</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="297">
+      <curriculumSet id="297">
         <Curriculum reference="102"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>50</studentSize>
     </Course>
     <Course id="298">
@@ -1511,9 +1511,9 @@
       <teacher reference="79"/>
       <lectureSize>7</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="299">
+      <curriculumSet id="299">
         <Curriculum reference="104"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>53</studentSize>
     </Course>
     <Course id="300">
@@ -1522,9 +1522,9 @@
       <teacher reference="77"/>
       <lectureSize>7</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="301">
+      <curriculumSet id="301">
         <Curriculum reference="110"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>40</studentSize>
     </Course>
     <Course id="302">
@@ -1533,9 +1533,9 @@
       <teacher reference="78"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="303">
+      <curriculumSet id="303">
         <Curriculum reference="92"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>120</studentSize>
     </Course>
     <Course id="304">
@@ -1544,9 +1544,9 @@
       <teacher reference="72"/>
       <lectureSize>7</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="305">
+      <curriculumSet id="305">
         <Curriculum reference="111"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>43</studentSize>
     </Course>
     <Course id="306">
@@ -1555,9 +1555,9 @@
       <teacher reference="73"/>
       <lectureSize>5</lectureSize>
       <minWorkingDaySize>4</minWorkingDaySize>
-      <curriculumList id="307">
+      <curriculumSet id="307">
         <Curriculum reference="137"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>5</studentSize>
     </Course>
     <Course id="308">
@@ -1566,14 +1566,14 @@
       <teacher reference="70"/>
       <lectureSize>6</lectureSize>
       <minWorkingDaySize>4</minWorkingDaySize>
-      <curriculumList id="309">
+      <curriculumSet id="309">
         <Curriculum reference="94"/>
         <Curriculum reference="114"/>
         <Curriculum reference="115"/>
         <Curriculum reference="126"/>
         <Curriculum reference="128"/>
         <Curriculum reference="129"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>147</studentSize>
     </Course>
     <Course id="310">
@@ -1582,10 +1582,10 @@
       <teacher reference="71"/>
       <lectureSize>5</lectureSize>
       <minWorkingDaySize>4</minWorkingDaySize>
-      <curriculumList id="311">
+      <curriculumSet id="311">
         <Curriculum reference="101"/>
         <Curriculum reference="117"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>105</studentSize>
     </Course>
   </courseList>

--- a/optaplanner-examples/data/curriculumcourse/unsolved/comp14.xml
+++ b/optaplanner-examples/data/curriculumcourse/unsolved/comp14.xml
@@ -524,10 +524,10 @@
       <teacher reference="58"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="134">
+      <curriculumSet id="134">
         <Curriculum reference="80"/>
         <Curriculum reference="87"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>6</studentSize>
     </Course>
     <Course id="135">
@@ -536,9 +536,9 @@
       <teacher reference="58"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="136">
+      <curriculumSet id="136">
         <Curriculum reference="126"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>10</studentSize>
     </Course>
     <Course id="137">
@@ -547,10 +547,10 @@
       <teacher reference="59"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="138">
+      <curriculumSet id="138">
         <Curriculum reference="107"/>
         <Curriculum reference="129"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>20</studentSize>
     </Course>
     <Course id="139">
@@ -559,9 +559,9 @@
       <teacher reference="56"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="140">
+      <curriculumSet id="140">
         <Curriculum reference="129"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>10</studentSize>
     </Course>
     <Course id="141">
@@ -570,11 +570,11 @@
       <teacher reference="57"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="142">
+      <curriculumSet id="142">
         <Curriculum reference="110"/>
         <Curriculum reference="112"/>
         <Curriculum reference="127"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>24</studentSize>
     </Course>
     <Course id="143">
@@ -583,10 +583,10 @@
       <teacher reference="57"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="144">
+      <curriculumSet id="144">
         <Curriculum reference="127"/>
         <Curriculum reference="128"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>16</studentSize>
     </Course>
     <Course id="145">
@@ -595,10 +595,10 @@
       <teacher reference="56"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="146">
+      <curriculumSet id="146">
         <Curriculum reference="130"/>
         <Curriculum reference="131"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>16</studentSize>
     </Course>
     <Course id="147">
@@ -607,11 +607,11 @@
       <teacher reference="20"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="148">
+      <curriculumSet id="148">
         <Curriculum reference="80"/>
         <Curriculum reference="130"/>
         <Curriculum reference="131"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>19</studentSize>
     </Course>
     <Course id="149">
@@ -620,10 +620,10 @@
       <teacher reference="56"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="150">
+      <curriculumSet id="150">
         <Curriculum reference="130"/>
         <Curriculum reference="131"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>16</studentSize>
     </Course>
     <Course id="151">
@@ -632,11 +632,11 @@
       <teacher reference="20"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="152">
+      <curriculumSet id="152">
         <Curriculum reference="80"/>
         <Curriculum reference="130"/>
         <Curriculum reference="131"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>19</studentSize>
     </Course>
     <Course id="153">
@@ -645,12 +645,12 @@
       <teacher reference="19"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="154">
+      <curriculumSet id="154">
         <Curriculum reference="80"/>
         <Curriculum reference="126"/>
         <Curriculum reference="127"/>
         <Curriculum reference="128"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>29</studentSize>
     </Course>
     <Course id="155">
@@ -659,12 +659,12 @@
       <teacher reference="22"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="156">
+      <curriculumSet id="156">
         <Curriculum reference="108"/>
         <Curriculum reference="109"/>
         <Curriculum reference="127"/>
         <Curriculum reference="128"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>46</studentSize>
     </Course>
     <Course id="157">
@@ -673,9 +673,9 @@
       <teacher reference="21"/>
       <lectureSize>6</lectureSize>
       <minWorkingDaySize>4</minWorkingDaySize>
-      <curriculumList id="158">
+      <curriculumSet id="158">
         <Curriculum reference="74"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>80</studentSize>
     </Course>
     <Course id="159">
@@ -684,11 +684,11 @@
       <teacher reference="58"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="160">
+      <curriculumSet id="160">
         <Curriculum reference="82"/>
         <Curriculum reference="100"/>
         <Curriculum reference="101"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>82</studentSize>
     </Course>
     <Course id="161">
@@ -697,9 +697,9 @@
       <teacher reference="24"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="162">
+      <curriculumSet id="162">
         <Curriculum reference="82"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>60</studentSize>
     </Course>
     <Course id="163">
@@ -708,9 +708,9 @@
       <teacher reference="23"/>
       <lectureSize>6</lectureSize>
       <minWorkingDaySize>5</minWorkingDaySize>
-      <curriculumList id="164">
+      <curriculumSet id="164">
         <Curriculum reference="81"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>115</studentSize>
     </Course>
     <Course id="165">
@@ -719,9 +719,9 @@
       <teacher reference="3"/>
       <lectureSize>6</lectureSize>
       <minWorkingDaySize>5</minWorkingDaySize>
-      <curriculumList id="166">
+      <curriculumSet id="166">
         <Curriculum reference="91"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>90</studentSize>
     </Course>
     <Course id="167">
@@ -730,9 +730,9 @@
       <teacher reference="4"/>
       <lectureSize>6</lectureSize>
       <minWorkingDaySize>5</minWorkingDaySize>
-      <curriculumList id="168">
+      <curriculumSet id="168">
         <Curriculum reference="72"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>90</studentSize>
     </Course>
     <Course id="169">
@@ -741,9 +741,9 @@
       <teacher reference="59"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="170">
+      <curriculumSet id="170">
         <Curriculum reference="124"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>30</studentSize>
     </Course>
     <Course id="171">
@@ -752,9 +752,9 @@
       <teacher reference="5"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="172">
+      <curriculumSet id="172">
         <Curriculum reference="119"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>15</studentSize>
     </Course>
     <Course id="173">
@@ -763,11 +763,11 @@
       <teacher reference="7"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="174">
+      <curriculumSet id="174">
         <Curriculum reference="118"/>
         <Curriculum reference="119"/>
         <Curriculum reference="120"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>38</studentSize>
     </Course>
     <Course id="175">
@@ -776,9 +776,9 @@
       <teacher reference="8"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="176">
+      <curriculumSet id="176">
         <Curriculum reference="108"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>15</studentSize>
     </Course>
     <Course id="177">
@@ -787,10 +787,10 @@
       <teacher reference="43"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="178">
+      <curriculumSet id="178">
         <Curriculum reference="76"/>
         <Curriculum reference="77"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>29</studentSize>
     </Course>
     <Course id="179">
@@ -799,10 +799,10 @@
       <teacher reference="22"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="180">
+      <curriculumSet id="180">
         <Curriculum reference="78"/>
         <Curriculum reference="80"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>18</studentSize>
     </Course>
     <Course id="181">
@@ -811,11 +811,11 @@
       <teacher reference="42"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="182">
+      <curriculumSet id="182">
         <Curriculum reference="78"/>
         <Curriculum reference="94"/>
         <Curriculum reference="103"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>28</studentSize>
     </Course>
     <Course id="183">
@@ -824,11 +824,11 @@
       <teacher reference="41"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="184">
+      <curriculumSet id="184">
         <Curriculum reference="78"/>
         <Curriculum reference="107"/>
         <Curriculum reference="126"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>35</studentSize>
     </Course>
     <Course id="185">
@@ -837,10 +837,10 @@
       <teacher reference="40"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="186">
+      <curriculumSet id="186">
         <Curriculum reference="78"/>
         <Curriculum reference="107"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>25</studentSize>
     </Course>
     <Course id="187">
@@ -849,10 +849,10 @@
       <teacher reference="44"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="188">
+      <curriculumSet id="188">
         <Curriculum reference="83"/>
         <Curriculum reference="96"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>79</studentSize>
     </Course>
     <Course id="189">
@@ -861,11 +861,11 @@
       <teacher reference="25"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="190">
+      <curriculumSet id="190">
         <Curriculum reference="83"/>
         <Curriculum reference="84"/>
         <Curriculum reference="85"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>55</studentSize>
     </Course>
     <Course id="191">
@@ -874,10 +874,10 @@
       <teacher reference="26"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="192">
+      <curriculumSet id="192">
         <Curriculum reference="82"/>
         <Curriculum reference="96"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>104</studentSize>
     </Course>
     <Course id="193">
@@ -886,10 +886,10 @@
       <teacher reference="31"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="194">
+      <curriculumSet id="194">
         <Curriculum reference="82"/>
         <Curriculum reference="96"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>104</studentSize>
     </Course>
     <Course id="195">
@@ -898,11 +898,11 @@
       <teacher reference="32"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="196">
+      <curriculumSet id="196">
         <Curriculum reference="83"/>
         <Curriculum reference="84"/>
         <Curriculum reference="85"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>55</studentSize>
     </Course>
     <Course id="197">
@@ -911,12 +911,12 @@
       <teacher reference="28"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="198">
+      <curriculumSet id="198">
         <Curriculum reference="84"/>
         <Curriculum reference="104"/>
         <Curriculum reference="115"/>
         <Curriculum reference="117"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>42</studentSize>
     </Course>
     <Course id="199">
@@ -925,11 +925,11 @@
       <teacher reference="30"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="200">
+      <curriculumSet id="200">
         <Curriculum reference="79"/>
         <Curriculum reference="129"/>
         <Curriculum reference="130"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>31</studentSize>
     </Course>
     <Course id="201">
@@ -938,9 +938,9 @@
       <teacher reference="52"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="202">
+      <curriculumSet id="202">
         <Curriculum reference="79"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>17</studentSize>
     </Course>
     <Course id="203">
@@ -949,9 +949,9 @@
       <teacher reference="53"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="204">
+      <curriculumSet id="204">
         <Curriculum reference="73"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>80</studentSize>
     </Course>
     <Course id="205">
@@ -960,10 +960,10 @@
       <teacher reference="54"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="206">
+      <curriculumSet id="206">
         <Curriculum reference="74"/>
         <Curriculum reference="106"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>130</studentSize>
     </Course>
     <Course id="207">
@@ -972,9 +972,9 @@
       <teacher reference="55"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="208">
+      <curriculumSet id="208">
         <Curriculum reference="73"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>80</studentSize>
     </Course>
     <Course id="209">
@@ -983,12 +983,12 @@
       <teacher reference="49"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="210">
+      <curriculumSet id="210">
         <Curriculum reference="74"/>
         <Curriculum reference="93"/>
         <Curriculum reference="94"/>
         <Curriculum reference="95"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>153</studentSize>
     </Course>
     <Course id="211">
@@ -997,9 +997,9 @@
       <teacher reference="59"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="212">
+      <curriculumSet id="212">
         <Curriculum reference="73"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>80</studentSize>
     </Course>
     <Course id="213">
@@ -1008,10 +1008,10 @@
       <teacher reference="51"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="214">
+      <curriculumSet id="214">
         <Curriculum reference="73"/>
         <Curriculum reference="92"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>160</studentSize>
     </Course>
     <Course id="215">
@@ -1020,14 +1020,14 @@
       <teacher reference="50"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="216">
+      <curriculumSet id="216">
         <Curriculum reference="93"/>
         <Curriculum reference="94"/>
         <Curriculum reference="95"/>
         <Curriculum reference="97"/>
         <Curriculum reference="98"/>
         <Curriculum reference="99"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>105</studentSize>
     </Course>
     <Course id="217">
@@ -1036,14 +1036,14 @@
       <teacher reference="46"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="218">
+      <curriculumSet id="218">
         <Curriculum reference="93"/>
         <Curriculum reference="94"/>
         <Curriculum reference="95"/>
         <Curriculum reference="97"/>
         <Curriculum reference="98"/>
         <Curriculum reference="99"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>105</studentSize>
     </Course>
     <Course id="219">
@@ -1052,9 +1052,9 @@
       <teacher reference="45"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="220">
+      <curriculumSet id="220">
         <Curriculum reference="92"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>80</studentSize>
     </Course>
     <Course id="221">
@@ -1063,9 +1063,9 @@
       <teacher reference="48"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="222">
+      <curriculumSet id="222">
         <Curriculum reference="92"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>80</studentSize>
     </Course>
     <Course id="223">
@@ -1074,9 +1074,9 @@
       <teacher reference="47"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="224">
+      <curriculumSet id="224">
         <Curriculum reference="92"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>80</studentSize>
     </Course>
     <Course id="225">
@@ -1085,12 +1085,12 @@
       <teacher reference="69"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="226">
+      <curriculumSet id="226">
         <Curriculum reference="76"/>
         <Curriculum reference="77"/>
         <Curriculum reference="86"/>
         <Curriculum reference="87"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>112</studentSize>
     </Course>
     <Course id="227">
@@ -1099,10 +1099,10 @@
       <teacher reference="70"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="228">
+      <curriculumSet id="228">
         <Curriculum reference="86"/>
         <Curriculum reference="87"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>83</studentSize>
     </Course>
     <Course id="229">
@@ -1111,12 +1111,12 @@
       <teacher reference="68"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="230">
+      <curriculumSet id="230">
         <Curriculum reference="76"/>
         <Curriculum reference="77"/>
         <Curriculum reference="86"/>
         <Curriculum reference="87"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>112</studentSize>
     </Course>
     <Course id="231">
@@ -1125,12 +1125,12 @@
       <teacher reference="67"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="232">
+      <curriculumSet id="232">
         <Curriculum reference="79"/>
         <Curriculum reference="88"/>
         <Curriculum reference="89"/>
         <Curriculum reference="90"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>80</studentSize>
     </Course>
     <Course id="233">
@@ -1139,10 +1139,10 @@
       <teacher reference="66"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="234">
+      <curriculumSet id="234">
         <Curriculum reference="86"/>
         <Curriculum reference="87"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>83</studentSize>
     </Course>
     <Course id="235">
@@ -1151,12 +1151,12 @@
       <teacher reference="65"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="236">
+      <curriculumSet id="236">
         <Curriculum reference="79"/>
         <Curriculum reference="88"/>
         <Curriculum reference="108"/>
         <Curriculum reference="109"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>67</studentSize>
     </Course>
     <Course id="237">
@@ -1165,10 +1165,10 @@
       <teacher reference="68"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="238">
+      <curriculumSet id="238">
         <Curriculum reference="89"/>
         <Curriculum reference="108"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>55</studentSize>
     </Course>
     <Course id="239">
@@ -1177,7 +1177,7 @@
       <teacher reference="64"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="240">
+      <curriculumSet id="240">
         <Curriculum reference="89"/>
         <Curriculum reference="90"/>
         <Curriculum reference="110"/>
@@ -1185,7 +1185,7 @@
         <Curriculum reference="112"/>
         <Curriculum reference="113"/>
         <Curriculum reference="114"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>78</studentSize>
     </Course>
     <Course id="241">
@@ -1194,7 +1194,7 @@
       <teacher reference="63"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="242">
+      <curriculumSet id="242">
         <Curriculum reference="85"/>
         <Curriculum reference="97"/>
         <Curriculum reference="98"/>
@@ -1203,7 +1203,7 @@
         <Curriculum reference="103"/>
         <Curriculum reference="115"/>
         <Curriculum reference="116"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>125</studentSize>
     </Course>
     <Course id="243">
@@ -1212,13 +1212,13 @@
       <teacher reference="62"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="244">
+      <curriculumSet id="244">
         <Curriculum reference="99"/>
         <Curriculum reference="101"/>
         <Curriculum reference="115"/>
         <Curriculum reference="116"/>
         <Curriculum reference="117"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>74</studentSize>
     </Course>
     <Course id="245">
@@ -1227,13 +1227,13 @@
       <teacher reference="67"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="246">
+      <curriculumSet id="246">
         <Curriculum reference="110"/>
         <Curriculum reference="111"/>
         <Curriculum reference="112"/>
         <Curriculum reference="113"/>
         <Curriculum reference="114"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>35</studentSize>
     </Course>
     <Course id="247">
@@ -1242,7 +1242,7 @@
       <teacher reference="61"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="248">
+      <curriculumSet id="248">
         <Curriculum reference="77"/>
         <Curriculum reference="79"/>
         <Curriculum reference="90"/>
@@ -1250,7 +1250,7 @@
         <Curriculum reference="114"/>
         <Curriculum reference="127"/>
         <Curriculum reference="128"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>60</studentSize>
     </Course>
     <Course id="249">
@@ -1259,7 +1259,7 @@
       <teacher reference="60"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="250">
+      <curriculumSet id="250">
         <Curriculum reference="95"/>
         <Curriculum reference="102"/>
         <Curriculum reference="110"/>
@@ -1268,7 +1268,7 @@
         <Curriculum reference="113"/>
         <Curriculum reference="114"/>
         <Curriculum reference="122"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>130</studentSize>
     </Course>
     <Course id="251">
@@ -1277,9 +1277,9 @@
       <teacher reference="17"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="252">
+      <curriculumSet id="252">
         <Curriculum reference="109"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>15</studentSize>
     </Course>
     <Course id="253">
@@ -1288,10 +1288,10 @@
       <teacher reference="18"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="254">
+      <curriculumSet id="254">
         <Curriculum reference="108"/>
         <Curriculum reference="109"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>30</studentSize>
     </Course>
     <Course id="255">
@@ -1300,9 +1300,9 @@
       <teacher reference="6"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="256">
+      <curriculumSet id="256">
         <Curriculum reference="109"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>15</studentSize>
     </Course>
     <Course id="257">
@@ -1311,9 +1311,9 @@
       <teacher reference="10"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="258">
+      <curriculumSet id="258">
         <Curriculum reference="109"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>15</studentSize>
     </Course>
     <Course id="259">
@@ -1322,9 +1322,9 @@
       <teacher reference="9"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="260">
+      <curriculumSet id="260">
         <Curriculum reference="111"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>5</studentSize>
     </Course>
     <Course id="261">
@@ -1333,12 +1333,12 @@
       <teacher reference="12"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="262">
+      <curriculumSet id="262">
         <Curriculum reference="100"/>
         <Curriculum reference="101"/>
         <Curriculum reference="102"/>
         <Curriculum reference="103"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>82</studentSize>
     </Course>
     <Course id="263">
@@ -1347,10 +1347,10 @@
       <teacher reference="11"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="264">
+      <curriculumSet id="264">
         <Curriculum reference="102"/>
         <Curriculum reference="103"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>60</studentSize>
     </Course>
     <Course id="265">
@@ -1359,9 +1359,9 @@
       <teacher reference="14"/>
       <lectureSize>6</lectureSize>
       <minWorkingDaySize>5</minWorkingDaySize>
-      <curriculumList id="266">
+      <curriculumSet id="266">
         <Curriculum reference="75"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>130</studentSize>
     </Course>
     <Course id="267">
@@ -1370,12 +1370,12 @@
       <teacher reference="13"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="268">
+      <curriculumSet id="268">
         <Curriculum reference="104"/>
         <Curriculum reference="105"/>
         <Curriculum reference="106"/>
         <Curriculum reference="107"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>81</studentSize>
     </Course>
     <Course id="269">
@@ -1384,12 +1384,12 @@
       <teacher reference="16"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="270">
+      <curriculumSet id="270">
         <Curriculum reference="104"/>
         <Curriculum reference="105"/>
         <Curriculum reference="106"/>
         <Curriculum reference="107"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>81</studentSize>
     </Course>
     <Course id="271">
@@ -1398,14 +1398,14 @@
       <teacher reference="15"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="272">
+      <curriculumSet id="272">
         <Curriculum reference="98"/>
         <Curriculum reference="100"/>
         <Curriculum reference="105"/>
         <Curriculum reference="115"/>
         <Curriculum reference="116"/>
         <Curriculum reference="117"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>68</studentSize>
     </Course>
     <Course id="273">
@@ -1414,11 +1414,11 @@
       <teacher reference="39"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="274">
+      <curriculumSet id="274">
         <Curriculum reference="118"/>
         <Curriculum reference="119"/>
         <Curriculum reference="120"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>38</studentSize>
     </Course>
     <Course id="275">
@@ -1427,10 +1427,10 @@
       <teacher reference="29"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="276">
+      <curriculumSet id="276">
         <Curriculum reference="104"/>
         <Curriculum reference="116"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>19</studentSize>
     </Course>
     <Course id="277">
@@ -1439,9 +1439,9 @@
       <teacher reference="49"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="278">
+      <curriculumSet id="278">
         <Curriculum reference="121"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>40</studentSize>
     </Course>
     <Course id="279">
@@ -1450,11 +1450,11 @@
       <teacher reference="27"/>
       <lectureSize>5</lectureSize>
       <minWorkingDaySize>5</minWorkingDaySize>
-      <curriculumList id="280">
+      <curriculumSet id="280">
         <Curriculum reference="123"/>
         <Curriculum reference="124"/>
         <Curriculum reference="125"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>75</studentSize>
     </Course>
     <Course id="281">
@@ -1463,10 +1463,10 @@
       <teacher reference="53"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>2</minWorkingDaySize>
-      <curriculumList id="282">
+      <curriculumSet id="282">
         <Curriculum reference="120"/>
         <Curriculum reference="123"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>45</studentSize>
     </Course>
     <Course id="283">
@@ -1475,10 +1475,10 @@
       <teacher reference="36"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="284">
+      <curriculumSet id="284">
         <Curriculum reference="124"/>
         <Curriculum reference="129"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>40</studentSize>
     </Course>
     <Course id="285">
@@ -1487,9 +1487,9 @@
       <teacher reference="35"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="286">
+      <curriculumSet id="286">
         <Curriculum reference="125"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>15</studentSize>
     </Course>
     <Course id="287">
@@ -1498,11 +1498,11 @@
       <teacher reference="34"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="288">
+      <curriculumSet id="288">
         <Curriculum reference="100"/>
         <Curriculum reference="101"/>
         <Curriculum reference="119"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>37</studentSize>
     </Course>
     <Course id="289">
@@ -1511,9 +1511,9 @@
       <teacher reference="33"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="290">
+      <curriculumSet id="290">
         <Curriculum reference="113"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>5</studentSize>
     </Course>
     <Course id="291">
@@ -1522,10 +1522,10 @@
       <teacher reference="38"/>
       <lectureSize>6</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="292">
+      <curriculumSet id="292">
         <Curriculum reference="121"/>
         <Curriculum reference="122"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>70</studentSize>
     </Course>
     <Course id="293">
@@ -1534,11 +1534,11 @@
       <teacher reference="33"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="294">
+      <curriculumSet id="294">
         <Curriculum reference="88"/>
         <Curriculum reference="89"/>
         <Curriculum reference="90"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>63</studentSize>
     </Course>
     <Course id="295">
@@ -1547,10 +1547,10 @@
       <teacher reference="37"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="296">
+      <curriculumSet id="296">
         <Curriculum reference="93"/>
         <Curriculum reference="97"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>75</studentSize>
     </Course>
     <Course id="297">
@@ -1559,10 +1559,10 @@
       <teacher reference="5"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="298">
+      <curriculumSet id="298">
         <Curriculum reference="78"/>
         <Curriculum reference="126"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>25</studentSize>
     </Course>
     <Course id="299">
@@ -1571,11 +1571,11 @@
       <teacher reference="39"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="300">
+      <curriculumSet id="300">
         <Curriculum reference="83"/>
         <Curriculum reference="84"/>
         <Curriculum reference="85"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>55</studentSize>
     </Course>
     <Course id="301">
@@ -1584,13 +1584,13 @@
       <teacher reference="52"/>
       <lectureSize>3</lectureSize>
       <minWorkingDaySize>3</minWorkingDaySize>
-      <curriculumList id="302">
+      <curriculumSet id="302">
         <Curriculum reference="88"/>
         <Curriculum reference="111"/>
         <Curriculum reference="112"/>
         <Curriculum reference="113"/>
         <Curriculum reference="114"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>40</studentSize>
     </Course>
   </courseList>

--- a/optaplanner-examples/data/curriculumcourse/unsolved/toy01.xml
+++ b/optaplanner-examples/data/curriculumcourse/unsolved/toy01.xml
@@ -28,10 +28,10 @@
       <teacher reference="4"/>
       <lectureSize>2</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="10">
+      <curriculumSet id="10">
         <Curriculum reference="6"/>
         <Curriculum reference="7"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>100</studentSize>
     </Course>
     <Course id="11">
@@ -40,9 +40,9 @@
       <teacher reference="4"/>
       <lectureSize>1</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="12">
+      <curriculumSet id="12">
         <Curriculum reference="7"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>80</studentSize>
     </Course>
     <Course id="13">
@@ -51,9 +51,9 @@
       <teacher reference="3"/>
       <lectureSize>1</lectureSize>
       <minWorkingDaySize>1</minWorkingDaySize>
-      <curriculumList id="14">
+      <curriculumSet id="14">
         <Curriculum reference="6"/>
-      </curriculumList>
+      </curriculumSet>
       <studentSize>20</studentSize>
     </Course>
   </courseList>

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/curriculumcourse/app/CurriculumCourseApp.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/curriculumcourse/app/CurriculumCourseApp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +20,7 @@ import org.optaplanner.examples.common.app.CommonApp;
 import org.optaplanner.examples.common.persistence.AbstractSolutionExporter;
 import org.optaplanner.examples.common.persistence.AbstractSolutionImporter;
 import org.optaplanner.examples.curriculumcourse.domain.CourseSchedule;
-import org.optaplanner.examples.curriculumcourse.persistence.CourseScheduleXmlSolutionFileIO;
+import org.optaplanner.examples.curriculumcourse.persistence.CurriculumCourseXmlSolutionFileIO;
 import org.optaplanner.examples.curriculumcourse.persistence.CurriculumCourseExporter;
 import org.optaplanner.examples.curriculumcourse.persistence.CurriculumCourseImporter;
 import org.optaplanner.examples.curriculumcourse.swingui.CurriculumCoursePanel;
@@ -53,7 +53,7 @@ public class CurriculumCourseApp extends CommonApp<CourseSchedule> {
 
     @Override
     public SolutionFileIO<CourseSchedule> createSolutionFileIO() {
-        return new CourseScheduleXmlSolutionFileIO();
+        return new CurriculumCourseXmlSolutionFileIO();
     }
 
     @Override

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/curriculumcourse/app/CurriculumCourseApp.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/curriculumcourse/app/CurriculumCourseApp.java
@@ -20,9 +20,9 @@ import org.optaplanner.examples.common.app.CommonApp;
 import org.optaplanner.examples.common.persistence.AbstractSolutionExporter;
 import org.optaplanner.examples.common.persistence.AbstractSolutionImporter;
 import org.optaplanner.examples.curriculumcourse.domain.CourseSchedule;
-import org.optaplanner.examples.curriculumcourse.persistence.CurriculumCourseXmlSolutionFileIO;
 import org.optaplanner.examples.curriculumcourse.persistence.CurriculumCourseExporter;
 import org.optaplanner.examples.curriculumcourse.persistence.CurriculumCourseImporter;
+import org.optaplanner.examples.curriculumcourse.persistence.CurriculumCourseXmlSolutionFileIO;
 import org.optaplanner.examples.curriculumcourse.swingui.CurriculumCoursePanel;
 import org.optaplanner.persistence.common.api.domain.solution.SolutionFileIO;
 

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/curriculumcourse/domain/Course.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/curriculumcourse/domain/Course.java
@@ -16,16 +16,15 @@
 
 package org.optaplanner.examples.curriculumcourse.domain;
 
-import static java.util.Objects.requireNonNull;
-
 import java.util.Arrays;
 import java.util.LinkedHashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import com.thoughtworks.xstream.annotations.XStreamAlias;
 import org.optaplanner.examples.common.domain.AbstractPersistable;
 
-import com.thoughtworks.xstream.annotations.XStreamAlias;
+import static java.util.Objects.requireNonNull;
 
 @XStreamAlias("Course")
 public class Course extends AbstractPersistable {
@@ -40,7 +39,6 @@ public class Course extends AbstractPersistable {
     private int studentSize;
 
     public Course() {
-
     }
 
     public Course(int id, String code, Teacher teacher, int lectureSize, int studentSize, int minWorkingDaySize,

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/curriculumcourse/domain/Course.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/curriculumcourse/domain/Course.java
@@ -16,15 +16,16 @@
 
 package org.optaplanner.examples.curriculumcourse.domain;
 
+import static java.util.Objects.requireNonNull;
+
 import java.util.Arrays;
 import java.util.LinkedHashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import com.thoughtworks.xstream.annotations.XStreamAlias;
 import org.optaplanner.examples.common.domain.AbstractPersistable;
 
-import static java.util.Objects.requireNonNull;
+import com.thoughtworks.xstream.annotations.XStreamAlias;
 
 @XStreamAlias("Course")
 public class Course extends AbstractPersistable {

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/curriculumcourse/domain/Course.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/curriculumcourse/domain/Course.java
@@ -16,10 +16,15 @@
 
 package org.optaplanner.examples.curriculumcourse.domain;
 
+import java.util.Arrays;
+import java.util.LinkedHashSet;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 import org.optaplanner.examples.common.domain.AbstractPersistable;
+
+import static java.util.Objects.requireNonNull;
 
 @XStreamAlias("Course")
 public class Course extends AbstractPersistable {
@@ -32,6 +37,21 @@ public class Course extends AbstractPersistable {
 
     private Set<Curriculum> curriculumSet;
     private int studentSize;
+
+    public Course() {
+
+    }
+
+    public Course(int id, String code, Teacher teacher, int lectureSize, int studentSize, int minWorkingDaySize,
+            Curriculum... curricula) {
+        super(id);
+        this.code = requireNonNull(code);
+        this.teacher = requireNonNull(teacher);
+        this.lectureSize = lectureSize;
+        this.minWorkingDaySize = minWorkingDaySize;
+        this.curriculumSet = Arrays.stream(curricula).collect(Collectors.toCollection(LinkedHashSet::new));
+        this.studentSize = studentSize;
+    }
 
     public String getCode() {
         return code;

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/curriculumcourse/domain/Course.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/curriculumcourse/domain/Course.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,11 +16,10 @@
 
 package org.optaplanner.examples.curriculumcourse.domain;
 
-import java.util.List;
-
-import org.optaplanner.examples.common.domain.AbstractPersistable;
+import java.util.Set;
 
 import com.thoughtworks.xstream.annotations.XStreamAlias;
+import org.optaplanner.examples.common.domain.AbstractPersistable;
 
 @XStreamAlias("Course")
 public class Course extends AbstractPersistable {
@@ -31,7 +30,7 @@ public class Course extends AbstractPersistable {
     private int lectureSize;
     private int minWorkingDaySize;
 
-    private List<Curriculum> curriculumList;
+    private Set<Curriculum> curriculumSet;
     private int studentSize;
 
     public String getCode() {
@@ -66,12 +65,12 @@ public class Course extends AbstractPersistable {
         this.minWorkingDaySize = minWorkingDaySize;
     }
 
-    public List<Curriculum> getCurriculumList() {
-        return curriculumList;
+    public Set<Curriculum> getCurriculumSet() {
+        return curriculumSet;
     }
 
-    public void setCurriculumList(List<Curriculum> curriculumList) {
-        this.curriculumList = curriculumList;
+    public void setCurriculumSet(Set<Curriculum> curriculumSet) {
+        this.curriculumSet = curriculumSet;
     }
 
     public int getStudentSize() {

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/curriculumcourse/domain/CourseSchedule.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/curriculumcourse/domain/CourseSchedule.java
@@ -167,8 +167,8 @@ public class CourseSchedule extends AbstractPersistable {
                     if (leftCourse.getTeacher().equals(rightCourse.getTeacher())) {
                         conflictCount++;
                     }
-                    for (Curriculum curriculum : leftCourse.getCurriculumList()) {
-                        if (rightCourse.getCurriculumList().contains(curriculum)) {
+                    for (Curriculum curriculum : leftCourse.getCurriculumSet()) {
+                        if (rightCourse.getCurriculumSet().contains(curriculum)) {
                             conflictCount++;
                         }
                     }

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/curriculumcourse/domain/Curriculum.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/curriculumcourse/domain/Curriculum.java
@@ -16,11 +16,10 @@
 
 package org.optaplanner.examples.curriculumcourse.domain;
 
-import static java.util.Objects.requireNonNull;
-
+import com.thoughtworks.xstream.annotations.XStreamAlias;
 import org.optaplanner.examples.common.domain.AbstractPersistable;
 
-import com.thoughtworks.xstream.annotations.XStreamAlias;
+import static java.util.Objects.requireNonNull;
 
 @XStreamAlias("Curriculum")
 public class Curriculum extends AbstractPersistable {
@@ -28,7 +27,6 @@ public class Curriculum extends AbstractPersistable {
     private String code;
 
     public Curriculum() {
-
     }
 
     public Curriculum(int id, String code) {

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/curriculumcourse/domain/Curriculum.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/curriculumcourse/domain/Curriculum.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,14 +16,24 @@
 
 package org.optaplanner.examples.curriculumcourse.domain;
 
+import com.thoughtworks.xstream.annotations.XStreamAlias;
 import org.optaplanner.examples.common.domain.AbstractPersistable;
 
-import com.thoughtworks.xstream.annotations.XStreamAlias;
+import static java.util.Objects.requireNonNull;
 
 @XStreamAlias("Curriculum")
 public class Curriculum extends AbstractPersistable {
 
     private String code;
+
+    public Curriculum() {
+
+    }
+
+    public Curriculum(int id, String code) {
+        super(id);
+        this.code = requireNonNull(code);
+    }
 
     public String getCode() {
         return code;

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/curriculumcourse/domain/Curriculum.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/curriculumcourse/domain/Curriculum.java
@@ -16,10 +16,11 @@
 
 package org.optaplanner.examples.curriculumcourse.domain;
 
-import com.thoughtworks.xstream.annotations.XStreamAlias;
+import static java.util.Objects.requireNonNull;
+
 import org.optaplanner.examples.common.domain.AbstractPersistable;
 
-import static java.util.Objects.requireNonNull;
+import com.thoughtworks.xstream.annotations.XStreamAlias;
 
 @XStreamAlias("Curriculum")
 public class Curriculum extends AbstractPersistable {

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/curriculumcourse/domain/Day.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/curriculumcourse/domain/Day.java
@@ -34,7 +34,6 @@ public class Day extends AbstractPersistable {
     private List<Period> periodList;
 
     public Day() {
-
     }
 
     public Day(int dayIndex, Period... periods) {

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/curriculumcourse/domain/Day.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/curriculumcourse/domain/Day.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,9 @@
 
 package org.optaplanner.examples.curriculumcourse.domain;
 
+import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import org.optaplanner.examples.common.domain.AbstractPersistable;
 
@@ -30,6 +32,17 @@ public class Day extends AbstractPersistable {
     private int dayIndex;
 
     private List<Period> periodList;
+
+    public Day() {
+
+    }
+
+    public Day(int dayIndex, Period... periods) {
+        super(dayIndex);
+        this.dayIndex = dayIndex;
+        this.periodList = Arrays.stream(periods)
+                .collect(Collectors.toList());
+    }
 
     public int getDayIndex() {
         return dayIndex;

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/curriculumcourse/domain/Lecture.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/curriculumcourse/domain/Lecture.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 
 package org.optaplanner.examples.curriculumcourse.domain;
 
-import java.util.List;
+import java.util.Set;
 
 import org.optaplanner.core.api.domain.entity.PlanningEntity;
 import org.optaplanner.core.api.domain.entity.PlanningPin;
@@ -96,8 +96,8 @@ public class Lecture extends AbstractPersistable {
         return course.getStudentSize();
     }
 
-    public List<Curriculum> getCurriculumList() {
-        return course.getCurriculumList();
+    public Set<Curriculum> getCurriculumSet() {
+        return course.getCurriculumSet();
     }
 
     public Day getDay() {

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/curriculumcourse/domain/Lecture.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/curriculumcourse/domain/Lecture.java
@@ -41,7 +41,6 @@ public class Lecture extends AbstractPersistable {
     private Room room;
 
     public Lecture() {
-
     }
 
     public Lecture(int id, Course course, Period period, Room room) {

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/curriculumcourse/domain/Lecture.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/curriculumcourse/domain/Lecture.java
@@ -40,6 +40,17 @@ public class Lecture extends AbstractPersistable {
     private Period period;
     private Room room;
 
+    public Lecture() {
+
+    }
+
+    public Lecture(int id, Course course, Period period, Room room) {
+        super(id);
+        this.course = course;
+        this.period = period;
+        this.room = room;
+    }
+
     public Course getCourse() {
         return course;
     }

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/curriculumcourse/domain/Period.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/curriculumcourse/domain/Period.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,16 +16,28 @@
 
 package org.optaplanner.examples.curriculumcourse.domain;
 
+import com.thoughtworks.xstream.annotations.XStreamAlias;
 import org.optaplanner.examples.common.domain.AbstractPersistable;
 import org.optaplanner.examples.common.swingui.components.Labeled;
 
-import com.thoughtworks.xstream.annotations.XStreamAlias;
+import static java.util.Objects.requireNonNull;
 
 @XStreamAlias("Period")
 public class Period extends AbstractPersistable implements Labeled {
 
     private Day day;
     private Timeslot timeslot;
+
+    public Period() {
+
+    }
+
+    public Period(int id, Day day, Timeslot timeslot) {
+        super(id);
+        this.day = requireNonNull(day);
+        day.getPeriodList().add(this);
+        this.timeslot = requireNonNull(timeslot);
+    }
 
     public Day getDay() {
         return day;

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/curriculumcourse/domain/Period.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/curriculumcourse/domain/Period.java
@@ -16,11 +16,12 @@
 
 package org.optaplanner.examples.curriculumcourse.domain;
 
-import com.thoughtworks.xstream.annotations.XStreamAlias;
+import static java.util.Objects.requireNonNull;
+
 import org.optaplanner.examples.common.domain.AbstractPersistable;
 import org.optaplanner.examples.common.swingui.components.Labeled;
 
-import static java.util.Objects.requireNonNull;
+import com.thoughtworks.xstream.annotations.XStreamAlias;
 
 @XStreamAlias("Period")
 public class Period extends AbstractPersistable implements Labeled {

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/curriculumcourse/domain/Period.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/curriculumcourse/domain/Period.java
@@ -16,12 +16,11 @@
 
 package org.optaplanner.examples.curriculumcourse.domain;
 
-import static java.util.Objects.requireNonNull;
-
+import com.thoughtworks.xstream.annotations.XStreamAlias;
 import org.optaplanner.examples.common.domain.AbstractPersistable;
 import org.optaplanner.examples.common.swingui.components.Labeled;
 
-import com.thoughtworks.xstream.annotations.XStreamAlias;
+import static java.util.Objects.requireNonNull;
 
 @XStreamAlias("Period")
 public class Period extends AbstractPersistable implements Labeled {
@@ -30,7 +29,6 @@ public class Period extends AbstractPersistable implements Labeled {
     private Timeslot timeslot;
 
     public Period() {
-
     }
 
     public Period(int id, Day day, Timeslot timeslot) {

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/curriculumcourse/domain/Room.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/curriculumcourse/domain/Room.java
@@ -30,7 +30,6 @@ public class Room extends AbstractPersistable implements Labeled {
     private int capacity;
 
     public Room() {
-
     }
 
     public Room(int id, String code, int capacity) {

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/curriculumcourse/domain/Room.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/curriculumcourse/domain/Room.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,8 @@
 
 package org.optaplanner.examples.curriculumcourse.domain;
 
+import java.util.Objects;
+
 import org.optaplanner.examples.common.domain.AbstractPersistable;
 import org.optaplanner.examples.common.swingui.components.Labeled;
 
@@ -26,6 +28,16 @@ public class Room extends AbstractPersistable implements Labeled {
 
     private String code;
     private int capacity;
+
+    public Room() {
+
+    }
+
+    public Room(int id, String code, int capacity) {
+        super(id);
+        this.code = Objects.requireNonNull(code);
+        this.capacity = capacity;
+    }
 
     public String getCode() {
         return code;

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/curriculumcourse/domain/Teacher.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/curriculumcourse/domain/Teacher.java
@@ -16,11 +16,10 @@
 
 package org.optaplanner.examples.curriculumcourse.domain;
 
-import static java.util.Objects.requireNonNull;
-
+import com.thoughtworks.xstream.annotations.XStreamAlias;
 import org.optaplanner.examples.common.domain.AbstractPersistable;
 
-import com.thoughtworks.xstream.annotations.XStreamAlias;
+import static java.util.Objects.requireNonNull;
 
 @XStreamAlias("Teacher")
 public class Teacher extends AbstractPersistable {
@@ -28,7 +27,6 @@ public class Teacher extends AbstractPersistable {
     private String code;
 
     public Teacher() {
-
     }
 
     public Teacher(int id, String code) {

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/curriculumcourse/domain/Teacher.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/curriculumcourse/domain/Teacher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,10 +20,21 @@ import org.optaplanner.examples.common.domain.AbstractPersistable;
 
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 
+import static java.util.Objects.requireNonNull;
+
 @XStreamAlias("Teacher")
 public class Teacher extends AbstractPersistable {
 
     private String code;
+
+    public Teacher() {
+
+    }
+
+    public Teacher(int id, String code) {
+        super(id);
+        this.code = requireNonNull(code);
+    }
 
     public String getCode() {
         return code;

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/curriculumcourse/domain/Teacher.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/curriculumcourse/domain/Teacher.java
@@ -16,10 +16,11 @@
 
 package org.optaplanner.examples.curriculumcourse.domain;
 
-import com.thoughtworks.xstream.annotations.XStreamAlias;
+import static java.util.Objects.requireNonNull;
+
 import org.optaplanner.examples.common.domain.AbstractPersistable;
 
-import static java.util.Objects.requireNonNull;
+import com.thoughtworks.xstream.annotations.XStreamAlias;
 
 @XStreamAlias("Teacher")
 public class Teacher extends AbstractPersistable {

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/curriculumcourse/domain/Teacher.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/curriculumcourse/domain/Teacher.java
@@ -16,11 +16,11 @@
 
 package org.optaplanner.examples.curriculumcourse.domain;
 
+import static java.util.Objects.requireNonNull;
+
 import org.optaplanner.examples.common.domain.AbstractPersistable;
 
 import com.thoughtworks.xstream.annotations.XStreamAlias;
-
-import static java.util.Objects.requireNonNull;
 
 @XStreamAlias("Teacher")
 public class Teacher extends AbstractPersistable {

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/curriculumcourse/domain/Timeslot.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/curriculumcourse/domain/Timeslot.java
@@ -16,8 +16,9 @@
 
 package org.optaplanner.examples.curriculumcourse.domain;
 
-import com.thoughtworks.xstream.annotations.XStreamAlias;
 import org.optaplanner.examples.common.domain.AbstractPersistable;
+
+import com.thoughtworks.xstream.annotations.XStreamAlias;
 
 @XStreamAlias("Timeslot")
 public class Timeslot extends AbstractPersistable {

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/curriculumcourse/domain/Timeslot.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/curriculumcourse/domain/Timeslot.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,9 +16,8 @@
 
 package org.optaplanner.examples.curriculumcourse.domain;
 
-import org.optaplanner.examples.common.domain.AbstractPersistable;
-
 import com.thoughtworks.xstream.annotations.XStreamAlias;
+import org.optaplanner.examples.common.domain.AbstractPersistable;
 
 @XStreamAlias("Timeslot")
 public class Timeslot extends AbstractPersistable {
@@ -27,6 +26,11 @@ public class Timeslot extends AbstractPersistable {
             "18:00" };
 
     private int timeslotIndex;
+
+    public Timeslot(int timeslotIndex) {
+        super(timeslotIndex);
+        this.timeslotIndex = timeslotIndex;
+    }
 
     public int getTimeslotIndex() {
         return timeslotIndex;

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/curriculumcourse/domain/UnavailablePeriodPenalty.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/curriculumcourse/domain/UnavailablePeriodPenalty.java
@@ -16,10 +16,11 @@
 
 package org.optaplanner.examples.curriculumcourse.domain;
 
-import com.thoughtworks.xstream.annotations.XStreamAlias;
+import static java.util.Objects.requireNonNull;
+
 import org.optaplanner.examples.common.domain.AbstractPersistable;
 
-import static java.util.Objects.requireNonNull;
+import com.thoughtworks.xstream.annotations.XStreamAlias;
 
 @XStreamAlias("UnavailablePeriodPenalty")
 public class UnavailablePeriodPenalty extends AbstractPersistable {

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/curriculumcourse/domain/UnavailablePeriodPenalty.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/curriculumcourse/domain/UnavailablePeriodPenalty.java
@@ -16,11 +16,11 @@
 
 package org.optaplanner.examples.curriculumcourse.domain;
 
+import static java.util.Objects.requireNonNull;
+
 import org.optaplanner.examples.common.domain.AbstractPersistable;
 
 import com.thoughtworks.xstream.annotations.XStreamAlias;
-
-import static java.util.Objects.requireNonNull;
 
 @XStreamAlias("UnavailablePeriodPenalty")
 public class UnavailablePeriodPenalty extends AbstractPersistable {

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/curriculumcourse/domain/UnavailablePeriodPenalty.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/curriculumcourse/domain/UnavailablePeriodPenalty.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,11 +20,23 @@ import org.optaplanner.examples.common.domain.AbstractPersistable;
 
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 
+import static java.util.Objects.requireNonNull;
+
 @XStreamAlias("UnavailablePeriodPenalty")
 public class UnavailablePeriodPenalty extends AbstractPersistable {
 
     private Course course;
     private Period period;
+
+    public UnavailablePeriodPenalty() {
+
+    }
+
+    public UnavailablePeriodPenalty(int id, Course course, Period period) {
+        super(id);
+        this.course = requireNonNull(course);
+        this.period = requireNonNull(period);
+    }
 
     public Course getCourse() {
         return course;

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/curriculumcourse/domain/UnavailablePeriodPenalty.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/curriculumcourse/domain/UnavailablePeriodPenalty.java
@@ -16,11 +16,10 @@
 
 package org.optaplanner.examples.curriculumcourse.domain;
 
-import static java.util.Objects.requireNonNull;
-
+import com.thoughtworks.xstream.annotations.XStreamAlias;
 import org.optaplanner.examples.common.domain.AbstractPersistable;
 
-import com.thoughtworks.xstream.annotations.XStreamAlias;
+import static java.util.Objects.requireNonNull;
 
 @XStreamAlias("UnavailablePeriodPenalty")
 public class UnavailablePeriodPenalty extends AbstractPersistable {
@@ -29,7 +28,6 @@ public class UnavailablePeriodPenalty extends AbstractPersistable {
     private Period period;
 
     public UnavailablePeriodPenalty() {
-
     }
 
     public UnavailablePeriodPenalty(int id, Course course, Period period) {

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/curriculumcourse/domain/solver/LectureDifficultyWeightFactory.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/curriculumcourse/domain/solver/LectureDifficultyWeightFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -44,7 +44,7 @@ public class LectureDifficultyWeightFactory implements SelectionSorterWeightFact
     public static class LectureDifficultyWeight implements Comparable<LectureDifficultyWeight> {
 
         private static final Comparator<LectureDifficultyWeight> COMPARATOR = comparingInt(
-                (LectureDifficultyWeight c) -> c.lecture.getCurriculumList().size())
+                (LectureDifficultyWeight c) -> c.lecture.getCurriculumSet().size())
                         .thenComparing(c -> c.unavailablePeriodPenaltyCount)
                         .thenComparingInt(c -> c.lecture.getCourse().getLectureSize())
                         .thenComparingInt(c -> c.lecture.getCourse().getStudentSize())

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/curriculumcourse/optional/score/CourseScheduleConstraintProvider.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/curriculumcourse/optional/score/CourseScheduleConstraintProvider.java
@@ -16,6 +16,13 @@
 
 package org.optaplanner.examples.curriculumcourse.optional.score;
 
+import static org.optaplanner.core.api.score.buildin.hardsoft.HardSoftScore.ONE_HARD;
+import static org.optaplanner.core.api.score.buildin.hardsoft.HardSoftScore.ofHard;
+import static org.optaplanner.core.api.score.buildin.hardsoft.HardSoftScore.ofSoft;
+import static org.optaplanner.core.api.score.stream.ConstraintCollectors.countDistinct;
+import static org.optaplanner.core.api.score.stream.Joiners.equal;
+import static org.optaplanner.core.api.score.stream.Joiners.filtering;
+
 import org.optaplanner.core.api.score.stream.Constraint;
 import org.optaplanner.core.api.score.stream.ConstraintFactory;
 import org.optaplanner.core.api.score.stream.ConstraintProvider;
@@ -23,13 +30,6 @@ import org.optaplanner.examples.curriculumcourse.domain.Curriculum;
 import org.optaplanner.examples.curriculumcourse.domain.Lecture;
 import org.optaplanner.examples.curriculumcourse.domain.UnavailablePeriodPenalty;
 import org.optaplanner.examples.curriculumcourse.domain.solver.CourseConflict;
-
-import static org.optaplanner.core.api.score.buildin.hardsoft.HardSoftScore.ONE_HARD;
-import static org.optaplanner.core.api.score.buildin.hardsoft.HardSoftScore.ofHard;
-import static org.optaplanner.core.api.score.buildin.hardsoft.HardSoftScore.ofSoft;
-import static org.optaplanner.core.api.score.stream.ConstraintCollectors.countDistinct;
-import static org.optaplanner.core.api.score.stream.Joiners.equal;
-import static org.optaplanner.core.api.score.stream.Joiners.filtering;
 
 public class CourseScheduleConstraintProvider implements ConstraintProvider {
 

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/curriculumcourse/optional/score/CourseScheduleConstraintProvider.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/curriculumcourse/optional/score/CourseScheduleConstraintProvider.java
@@ -69,7 +69,7 @@ public class CourseScheduleConstraintProvider implements ConstraintProvider {
                 equal(Lecture::getPeriod),
                 equal(Lecture::getCourse))
                 .penalize("conflictingLecturesSameCourseInSamePeriod", ONE_HARD,
-                        (lecture1, lecture2) -> 1 + lecture1.getCurriculumList().size());
+                        (lecture1, lecture2) -> 1 + lecture1.getCurriculumSet().size());
     }
 
     Constraint roomOccupancy(ConstraintFactory factory) {
@@ -110,15 +110,15 @@ public class CourseScheduleConstraintProvider implements ConstraintProvider {
         return factory.from(Curriculum.class)
                 .join(Lecture.class,
                         filtering((curriculum, lecture) -> lecture.getPeriod() != null),
-                        filtering((curriculum, lecture) -> lecture.getCurriculumList().contains(curriculum)))
+                        filtering((curriculum, lecture) -> lecture.getCurriculumSet().contains(curriculum)))
                 .ifNotExists(Lecture.class,
                         equal((curriculum, lecture) -> lecture.getDay(), Lecture::getDay),
                         equal((curriculum, lecture) -> lecture.getTimeslotIndex(), lecture -> lecture.getTimeslotIndex() + 1),
-                        filtering((curriculum, lectureA, lectureB) -> lectureB.getCurriculumList().contains(curriculum)))
+                        filtering((curriculum, lectureA, lectureB) -> lectureB.getCurriculumSet().contains(curriculum)))
                 .ifNotExists(Lecture.class,
                         equal((curriculum, lecture) -> lecture.getDay(), Lecture::getDay),
                         equal((curriculum, lecture) -> lecture.getTimeslotIndex(), lecture -> lecture.getTimeslotIndex() - 1),
-                        filtering((curriculum, lectureA, lectureB) -> lectureB.getCurriculumList().contains(curriculum)))
+                        filtering((curriculum, lectureA, lectureB) -> lectureB.getCurriculumSet().contains(curriculum)))
                 .penalize("curriculumCompactness", ofSoft(2));
     }
 

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/curriculumcourse/optional/score/CurriculumCourseConstraintProvider.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/curriculumcourse/optional/score/CurriculumCourseConstraintProvider.java
@@ -16,6 +16,13 @@
 
 package org.optaplanner.examples.curriculumcourse.optional.score;
 
+import static org.optaplanner.core.api.score.buildin.hardsoft.HardSoftScore.ONE_HARD;
+import static org.optaplanner.core.api.score.buildin.hardsoft.HardSoftScore.ofHard;
+import static org.optaplanner.core.api.score.buildin.hardsoft.HardSoftScore.ofSoft;
+import static org.optaplanner.core.api.score.stream.ConstraintCollectors.countDistinct;
+import static org.optaplanner.core.api.score.stream.Joiners.equal;
+import static org.optaplanner.core.api.score.stream.Joiners.filtering;
+
 import org.optaplanner.core.api.score.stream.Constraint;
 import org.optaplanner.core.api.score.stream.ConstraintFactory;
 import org.optaplanner.core.api.score.stream.ConstraintProvider;
@@ -23,13 +30,6 @@ import org.optaplanner.examples.curriculumcourse.domain.Curriculum;
 import org.optaplanner.examples.curriculumcourse.domain.Lecture;
 import org.optaplanner.examples.curriculumcourse.domain.UnavailablePeriodPenalty;
 import org.optaplanner.examples.curriculumcourse.domain.solver.CourseConflict;
-
-import static org.optaplanner.core.api.score.buildin.hardsoft.HardSoftScore.ONE_HARD;
-import static org.optaplanner.core.api.score.buildin.hardsoft.HardSoftScore.ofHard;
-import static org.optaplanner.core.api.score.buildin.hardsoft.HardSoftScore.ofSoft;
-import static org.optaplanner.core.api.score.stream.ConstraintCollectors.countDistinct;
-import static org.optaplanner.core.api.score.stream.Joiners.equal;
-import static org.optaplanner.core.api.score.stream.Joiners.filtering;
 
 public class CurriculumCourseConstraintProvider implements ConstraintProvider {
 

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/curriculumcourse/optional/score/CurriculumCourseConstraintProvider.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/curriculumcourse/optional/score/CurriculumCourseConstraintProvider.java
@@ -16,13 +16,6 @@
 
 package org.optaplanner.examples.curriculumcourse.optional.score;
 
-import static org.optaplanner.core.api.score.buildin.hardsoft.HardSoftScore.ONE_HARD;
-import static org.optaplanner.core.api.score.buildin.hardsoft.HardSoftScore.ofHard;
-import static org.optaplanner.core.api.score.buildin.hardsoft.HardSoftScore.ofSoft;
-import static org.optaplanner.core.api.score.stream.ConstraintCollectors.countDistinct;
-import static org.optaplanner.core.api.score.stream.Joiners.equal;
-import static org.optaplanner.core.api.score.stream.Joiners.filtering;
-
 import org.optaplanner.core.api.score.stream.Constraint;
 import org.optaplanner.core.api.score.stream.ConstraintFactory;
 import org.optaplanner.core.api.score.stream.ConstraintProvider;
@@ -30,6 +23,13 @@ import org.optaplanner.examples.curriculumcourse.domain.Curriculum;
 import org.optaplanner.examples.curriculumcourse.domain.Lecture;
 import org.optaplanner.examples.curriculumcourse.domain.UnavailablePeriodPenalty;
 import org.optaplanner.examples.curriculumcourse.domain.solver.CourseConflict;
+
+import static org.optaplanner.core.api.score.buildin.hardsoft.HardSoftScore.ONE_HARD;
+import static org.optaplanner.core.api.score.buildin.hardsoft.HardSoftScore.ofHard;
+import static org.optaplanner.core.api.score.buildin.hardsoft.HardSoftScore.ofSoft;
+import static org.optaplanner.core.api.score.stream.ConstraintCollectors.countDistinct;
+import static org.optaplanner.core.api.score.stream.Joiners.equal;
+import static org.optaplanner.core.api.score.stream.Joiners.filtering;
 
 public class CurriculumCourseConstraintProvider implements ConstraintProvider {
 
@@ -55,7 +55,6 @@ public class CurriculumCourseConstraintProvider implements ConstraintProvider {
         return factory.from(CourseConflict.class)
                 .join(Lecture.class,
                         equal(CourseConflict::getLeftCourse, Lecture::getCourse))
-                .filter(((courseConflict, lecture) -> lecture.getPeriod() != null))
                 .join(Lecture.class,
                         equal((courseConflict, lecture1) -> courseConflict.getRightCourse(), Lecture::getCourse),
                         equal((courseConflict, lecture1) -> lecture1.getPeriod(), Lecture::getPeriod))
@@ -109,7 +108,6 @@ public class CurriculumCourseConstraintProvider implements ConstraintProvider {
     Constraint curriculumCompactness(ConstraintFactory factory) {
         return factory.from(Curriculum.class)
                 .join(Lecture.class,
-                        filtering((curriculum, lecture) -> lecture.getPeriod() != null),
                         filtering((curriculum, lecture) -> lecture.getCurriculumSet().contains(curriculum)))
                 .ifNotExists(Lecture.class,
                         equal((curriculum, lecture) -> lecture.getDay(), Lecture::getDay),

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/curriculumcourse/optional/score/CurriculumCourseConstraintProvider.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/curriculumcourse/optional/score/CurriculumCourseConstraintProvider.java
@@ -16,13 +16,6 @@
 
 package org.optaplanner.examples.curriculumcourse.optional.score;
 
-import static org.optaplanner.core.api.score.buildin.hardsoft.HardSoftScore.ONE_HARD;
-import static org.optaplanner.core.api.score.buildin.hardsoft.HardSoftScore.ofHard;
-import static org.optaplanner.core.api.score.buildin.hardsoft.HardSoftScore.ofSoft;
-import static org.optaplanner.core.api.score.stream.ConstraintCollectors.countDistinct;
-import static org.optaplanner.core.api.score.stream.Joiners.equal;
-import static org.optaplanner.core.api.score.stream.Joiners.filtering;
-
 import org.optaplanner.core.api.score.stream.Constraint;
 import org.optaplanner.core.api.score.stream.ConstraintFactory;
 import org.optaplanner.core.api.score.stream.ConstraintProvider;
@@ -31,7 +24,14 @@ import org.optaplanner.examples.curriculumcourse.domain.Lecture;
 import org.optaplanner.examples.curriculumcourse.domain.UnavailablePeriodPenalty;
 import org.optaplanner.examples.curriculumcourse.domain.solver.CourseConflict;
 
-public class CourseScheduleConstraintProvider implements ConstraintProvider {
+import static org.optaplanner.core.api.score.buildin.hardsoft.HardSoftScore.ONE_HARD;
+import static org.optaplanner.core.api.score.buildin.hardsoft.HardSoftScore.ofHard;
+import static org.optaplanner.core.api.score.buildin.hardsoft.HardSoftScore.ofSoft;
+import static org.optaplanner.core.api.score.stream.ConstraintCollectors.countDistinct;
+import static org.optaplanner.core.api.score.stream.Joiners.equal;
+import static org.optaplanner.core.api.score.stream.Joiners.filtering;
+
+public class CurriculumCourseConstraintProvider implements ConstraintProvider {
 
     @Override
     public Constraint[] defineConstraints(ConstraintFactory factory) {

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/curriculumcourse/persistence/CurriculumCourseGenerator.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/curriculumcourse/persistence/CurriculumCourseGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,13 +16,12 @@
 
 package org.optaplanner.examples.curriculumcourse.persistence;
 
-import static org.optaplanner.examples.common.persistence.AbstractSolutionImporter.getFlooredPossibleSolutionSize;
-
 import java.io.File;
 import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Random;
 import java.util.Set;
@@ -44,6 +43,8 @@ import org.optaplanner.examples.curriculumcourse.domain.Timeslot;
 import org.optaplanner.examples.curriculumcourse.domain.UnavailablePeriodPenalty;
 import org.optaplanner.persistence.common.api.domain.solution.SolutionFileIO;
 import org.optaplanner.persistence.xstream.impl.domain.solution.XStreamSolutionFileIO;
+
+import static org.optaplanner.examples.common.persistence.AbstractSolutionImporter.getFlooredPossibleSolutionSize;
 
 public class CurriculumCourseGenerator extends LoggingMain {
 
@@ -227,7 +228,7 @@ public class CurriculumCourseGenerator extends LoggingMain {
             course.setTeacher(teacher);
             course.setLectureSize(0);
             course.setMinWorkingDaySize(1);
-            course.setCurriculumList(new ArrayList<>());
+            course.setCurriculumSet(new LinkedHashSet<>());
             course.setStudentSize(0);
             courseList.add(course);
         }
@@ -290,7 +291,7 @@ public class CurriculumCourseGenerator extends LoggingMain {
                 if (lectureCount > PERIOD_LIST_SIZE) {
                     break;
                 }
-                course.getCurriculumList().add(curriculum);
+                course.getCurriculumSet().add(curriculum);
                 course.setStudentSize(course.getStudentSize() + studentSize);
             }
 

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/curriculumcourse/persistence/CurriculumCourseGenerator.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/curriculumcourse/persistence/CurriculumCourseGenerator.java
@@ -160,9 +160,7 @@ public class CurriculumCourseGenerator extends LoggingMain {
     private void createTimeslotList(CourseSchedule schedule) {
         List<Timeslot> timeslotList = new ArrayList<>(TIMESLOT_LIST_SIZE);
         for (int i = 0; i < TIMESLOT_LIST_SIZE; i++) {
-            Timeslot timeslot = new Timeslot();
-            timeslot.setId((long) i);
-            timeslot.setTimeslotIndex(i);
+            Timeslot timeslot = new Timeslot(i);
             timeslotList.add(timeslot);
         }
         schedule.setTimeslotList(timeslotList);

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/curriculumcourse/persistence/CurriculumCourseGenerator.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/curriculumcourse/persistence/CurriculumCourseGenerator.java
@@ -16,6 +16,8 @@
 
 package org.optaplanner.examples.curriculumcourse.persistence;
 
+import static org.optaplanner.examples.common.persistence.AbstractSolutionImporter.getFlooredPossibleSolutionSize;
+
 import java.io.File;
 import java.math.BigInteger;
 import java.util.ArrayList;
@@ -43,8 +45,6 @@ import org.optaplanner.examples.curriculumcourse.domain.Timeslot;
 import org.optaplanner.examples.curriculumcourse.domain.UnavailablePeriodPenalty;
 import org.optaplanner.persistence.common.api.domain.solution.SolutionFileIO;
 import org.optaplanner.persistence.xstream.impl.domain.solution.XStreamSolutionFileIO;
-
-import static org.optaplanner.examples.common.persistence.AbstractSolutionImporter.getFlooredPossibleSolutionSize;
 
 public class CurriculumCourseGenerator extends LoggingMain {
 

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/curriculumcourse/persistence/CurriculumCourseImporter.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/curriculumcourse/persistence/CurriculumCourseImporter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 
@@ -127,7 +128,7 @@ public class CurriculumCourseImporter extends AbstractTxtSolutionImporter<Course
                 course.setTeacher(findOrCreateTeacher(teacherMap, lineTokens[1]));
                 course.setLectureSize(Integer.parseInt(lineTokens[2]));
                 course.setMinWorkingDaySize(Integer.parseInt(lineTokens[3]));
-                course.setCurriculumList(new ArrayList<>());
+                course.setCurriculumSet(new LinkedHashSet<>());
                 course.setStudentSize(Integer.parseInt(lineTokens[4]));
                 courseList.add(course);
                 courseMap.put(course.getCode(), course);
@@ -233,7 +234,7 @@ public class CurriculumCourseImporter extends AbstractTxtSolutionImporter<Course
                         throw new IllegalArgumentException("Read line (" + line + ") uses an unexisting course("
                                 + lineTokens[j] + ").");
                     }
-                    course.getCurriculumList().add(curriculum);
+                    course.getCurriculumSet().add(curriculum);
                 }
                 curriculumList.add(curriculum);
             }

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/curriculumcourse/persistence/CurriculumCourseImporter.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/curriculumcourse/persistence/CurriculumCourseImporter.java
@@ -184,9 +184,7 @@ public class CurriculumCourseImporter extends AbstractTxtSolutionImporter<Course
             schedule.setDayList(dayList);
             List<Timeslot> timeslotList = new ArrayList<>(timeslotListSize);
             for (int i = 0; i < timeslotListSize; i++) {
-                Timeslot timeslot = new Timeslot();
-                timeslot.setId((long) i);
-                timeslot.setTimeslotIndex(i);
+                Timeslot timeslot = new Timeslot(i);
                 timeslotList.add(timeslot);
             }
             schedule.setTimeslotList(timeslotList);

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/curriculumcourse/persistence/CurriculumCourseXmlSolutionFileIO.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/curriculumcourse/persistence/CurriculumCourseXmlSolutionFileIO.java
@@ -19,9 +19,9 @@ package org.optaplanner.examples.curriculumcourse.persistence;
 import org.optaplanner.examples.curriculumcourse.domain.CourseSchedule;
 import org.optaplanner.persistence.xstream.impl.domain.solution.XStreamSolutionFileIO;
 
-public class CourseScheduleXmlSolutionFileIO extends XStreamSolutionFileIO<CourseSchedule> {
+public class CurriculumCourseXmlSolutionFileIO extends XStreamSolutionFileIO<CourseSchedule> {
 
-    public CourseScheduleXmlSolutionFileIO() {
+    public CurriculumCourseXmlSolutionFileIO() {
         super(CourseSchedule.class);
     }
 }

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/curriculumcourse/swingui/CurriculumCoursePanel.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/curriculumcourse/swingui/CurriculumCoursePanel.java
@@ -197,7 +197,7 @@ public class CurriculumCoursePanel extends SolutionPanel<CourseSchedule> {
                     createButton(lecture, color, toolTip));
             teachersPanel.addCell(lecture.getTeacher(), lecture.getPeriod(),
                     createButton(lecture, color, toolTip));
-            for (Curriculum curriculum : lecture.getCurriculumList()) {
+            for (Curriculum curriculum : lecture.getCurriculumSet()) {
                 curriculaPanel.addCell(curriculum, lecture.getPeriod(),
                         createButton(lecture, color, toolTip));
             }

--- a/optaplanner-examples/src/main/resources/org/optaplanner/examples/app/benchmark/generalOptaPlannerBenchmarkConfig.xml
+++ b/optaplanner-examples/src/main/resources/org/optaplanner/examples/app/benchmark/generalOptaPlannerBenchmarkConfig.xml
@@ -77,7 +77,7 @@
   <solverBenchmark>
     <name>Course Scheduling Late Acceptance</name>
     <problemBenchmarks>
-      <solutionFileIOClass>org.optaplanner.examples.curriculumcourse.persistence.CourseScheduleXmlSolutionFileIO</solutionFileIOClass>
+      <solutionFileIOClass>org.optaplanner.examples.curriculumcourse.persistence.CurriculumCourseXmlSolutionFileIO</solutionFileIOClass>
       <inputSolutionFile>data/curriculumcourse/unsolved/comp07.xml</inputSolutionFile>
       <inputSolutionFile>data/curriculumcourse/unsolved/comp08.xml</inputSolutionFile>
     </problemBenchmarks>

--- a/optaplanner-examples/src/main/resources/org/optaplanner/examples/app/benchmark/generalOptaPlannerBenchmarkConfigTemplate.xml.ftl
+++ b/optaplanner-examples/src/main/resources/org/optaplanner/examples/app/benchmark/generalOptaPlannerBenchmarkConfigTemplate.xml.ftl
@@ -78,7 +78,7 @@
   <solverBenchmark>
     <name>Course Scheduling Late Acceptance ${randomType}</name>
     <problemBenchmarks>
-      <solutionFileIOClass>org.optaplanner.examples.curriculumcourse.persistence.CourseScheduleXmlSolutionFileIO</solutionFileIOClass>
+      <solutionFileIOClass>org.optaplanner.examples.curriculumcourse.persistence.CurriculumCourseXmlSolutionFileIO</solutionFileIOClass>
       <inputSolutionFile>data/curriculumcourse/unsolved/comp07.xml</inputSolutionFile>
       <inputSolutionFile>data/curriculumcourse/unsolved/comp08.xml</inputSolutionFile>
     </problemBenchmarks>

--- a/optaplanner-examples/src/main/resources/org/optaplanner/examples/curriculumcourse/benchmark/curriculumCourseBenchmarkConfig.xml
+++ b/optaplanner-examples/src/main/resources/org/optaplanner/examples/curriculumcourse/benchmark/curriculumCourseBenchmarkConfig.xml
@@ -5,7 +5,7 @@
 
   <inheritedSolverBenchmark>
     <problemBenchmarks>
-      <solutionFileIOClass>org.optaplanner.examples.curriculumcourse.persistence.CourseScheduleXmlSolutionFileIO</solutionFileIOClass>
+      <solutionFileIOClass>org.optaplanner.examples.curriculumcourse.persistence.CurriculumCourseXmlSolutionFileIO</solutionFileIOClass>
       <inputSolutionFile>data/curriculumcourse/unsolved/comp01.xml</inputSolutionFile>
       <inputSolutionFile>data/curriculumcourse/unsolved/comp02.xml</inputSolutionFile>
       <inputSolutionFile>data/curriculumcourse/unsolved/comp03.xml</inputSolutionFile>

--- a/optaplanner-examples/src/main/resources/org/optaplanner/examples/curriculumcourse/benchmark/curriculumCourseBenchmarkConfigTemplate.xml.ftl
+++ b/optaplanner-examples/src/main/resources/org/optaplanner/examples/curriculumcourse/benchmark/curriculumCourseBenchmarkConfigTemplate.xml.ftl
@@ -5,7 +5,7 @@
 
   <inheritedSolverBenchmark>
     <problemBenchmarks>
-      <solutionFileIOClass>org.optaplanner.examples.curriculumcourse.persistence.CourseScheduleXmlSolutionFileIO</solutionFileIOClass>
+      <solutionFileIOClass>org.optaplanner.examples.curriculumcourse.persistence.CurriculumCourseXmlSolutionFileIO</solutionFileIOClass>
       <inputSolutionFile>data/curriculumcourse/unsolved/comp01.xml</inputSolutionFile>
       <inputSolutionFile>data/curriculumcourse/unsolved/comp02.xml</inputSolutionFile>
       <inputSolutionFile>data/curriculumcourse/unsolved/comp03.xml</inputSolutionFile>

--- a/optaplanner-examples/src/main/resources/org/optaplanner/examples/curriculumcourse/benchmark/curriculumCourseStepLimitBenchmarkConfig.xml
+++ b/optaplanner-examples/src/main/resources/org/optaplanner/examples/curriculumcourse/benchmark/curriculumCourseStepLimitBenchmarkConfig.xml
@@ -5,7 +5,7 @@
 
   <inheritedSolverBenchmark>
     <problemBenchmarks>
-      <solutionFileIOClass>org.optaplanner.examples.curriculumcourse.persistence.CourseScheduleXmlSolutionFileIO</solutionFileIOClass>
+      <solutionFileIOClass>org.optaplanner.examples.curriculumcourse.persistence.CurriculumCourseXmlSolutionFileIO</solutionFileIOClass>
       <inputSolutionFile>data/curriculumcourse/unsolved/comp01_initialized.xml</inputSolutionFile>
     </problemBenchmarks>
 

--- a/optaplanner-examples/src/main/resources/org/optaplanner/examples/curriculumcourse/solver/curriculumCourseConstraints.drl
+++ b/optaplanner-examples/src/main/resources/org/optaplanner/examples/curriculumcourse/solver/curriculumCourseConstraints.drl
@@ -55,7 +55,7 @@ rule "conflictingLecturesSameCourseInSamePeriod"
         Lecture($leftId : id, $leftCourse : course, $period : period, period != null)
         Lecture(course == $leftCourse, period == $period, id > $leftId)
     then
-        scoreHolder.addHardConstraintMatch(kcontext, - (1 + $leftCourse.getCurriculumList().size()));
+        scoreHolder.addHardConstraintMatch(kcontext, - (1 + $leftCourse.getCurriculumSet().size()));
 end
 
 // RoomOccupancy: Two lectures in the same room at the same period.
@@ -120,13 +120,13 @@ rule "curriculumCompactness"
     when
         $curriculum : Curriculum()
 
-        Lecture(curriculumList contains $curriculum,
+        Lecture(curriculumSet contains $curriculum,
             $day : day, $timeslotIndex : timeslotIndex, period != null
         )
-        not Lecture(curriculumList contains $curriculum,
+        not Lecture(curriculumSet contains $curriculum,
             day == $day, timeslotIndex == ($timeslotIndex - 1)
         )
-        not Lecture(curriculumList contains $curriculum,
+        not Lecture(curriculumSet contains $curriculum,
             day == $day, timeslotIndex == ($timeslotIndex + 1)
         )
     then

--- a/optaplanner-examples/src/main/resources/org/optaplanner/examples/curriculumcourse/solver/curriculumCourseSolverConfig.xml
+++ b/optaplanner-examples/src/main/resources/org/optaplanner/examples/curriculumcourse/solver/curriculumCourseSolverConfig.xml
@@ -7,7 +7,7 @@
   <entityClass>org.optaplanner.examples.curriculumcourse.domain.Lecture</entityClass>
 
   <scoreDirectorFactory>
-    <!--<constraintProviderClass>org.optaplanner.examples.curriculumcourse.optional.score.CourseScheduleConstraintProvider</constraintProviderClass>-->
+    <!--<constraintProviderClass>org.optaplanner.examples.curriculumcourse.optional.score.CurriculumCourseConstraintProvider</constraintProviderClass>-->
     <scoreDrl>org/optaplanner/examples/curriculumcourse/solver/curriculumCourseConstraints.drl</scoreDrl>
     <!--<assertionScoreDirectorFactory>-->
       <!--<scoreDrl>org/optaplanner/examples/curriculumcourse/solver/curriculumCourseConstraints.drl</scoreDrl>-->

--- a/optaplanner-examples/src/main/resources/org/optaplanner/examples/curriculumcourse/solver/curriculumCourseSolverConfig.xml
+++ b/optaplanner-examples/src/main/resources/org/optaplanner/examples/curriculumcourse/solver/curriculumCourseSolverConfig.xml
@@ -1,17 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <solver>
-  <!--<environmentMode>FULL_ASSERT</environmentMode>--><!-- To slowly prove there are no bugs in this code -->
+  <environmentMode>FULL_ASSERT</environmentMode>
   <!--<moveThreadCount>AUTO</moveThreadCount>--><!-- To solve faster by saturating multiple CPU cores -->
 
   <solutionClass>org.optaplanner.examples.curriculumcourse.domain.CourseSchedule</solutionClass>
   <entityClass>org.optaplanner.examples.curriculumcourse.domain.Lecture</entityClass>
 
   <scoreDirectorFactory>
-    <!--<constraintProviderClass>org.optaplanner.examples.curriculumcourse.optional.score.CourseScheduleConstraintProvider</constraintProviderClass>-->
-    <scoreDrl>org/optaplanner/examples/curriculumcourse/solver/curriculumCourseConstraints.drl</scoreDrl>
-    <!--<assertionScoreDirectorFactory>-->
-      <!--<scoreDrl>org/optaplanner/examples/curriculumcourse/solver/curriculumCourseConstraints.drl</scoreDrl>-->
-    <!--</assertionScoreDirectorFactory>-->
+    <constraintProviderClass>org.optaplanner.examples.curriculumcourse.optional.score.CourseScheduleConstraintProvider</constraintProviderClass>
+    <assertionScoreDirectorFactory>
+      <scoreDrl>org/optaplanner/examples/curriculumcourse/solver/curriculumCourseConstraints.drl</scoreDrl>
+    </assertionScoreDirectorFactory>
   </scoreDirectorFactory>
 
   <termination>

--- a/optaplanner-examples/src/main/resources/org/optaplanner/examples/curriculumcourse/solver/curriculumCourseSolverConfig.xml
+++ b/optaplanner-examples/src/main/resources/org/optaplanner/examples/curriculumcourse/solver/curriculumCourseSolverConfig.xml
@@ -1,16 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <solver>
-  <environmentMode>FULL_ASSERT</environmentMode>
+  <!--<environmentMode>FULL_ASSERT</environmentMode>--><!-- To slowly prove there are no bugs in this code -->
   <!--<moveThreadCount>AUTO</moveThreadCount>--><!-- To solve faster by saturating multiple CPU cores -->
 
   <solutionClass>org.optaplanner.examples.curriculumcourse.domain.CourseSchedule</solutionClass>
   <entityClass>org.optaplanner.examples.curriculumcourse.domain.Lecture</entityClass>
 
   <scoreDirectorFactory>
-    <constraintProviderClass>org.optaplanner.examples.curriculumcourse.optional.score.CourseScheduleConstraintProvider</constraintProviderClass>
-    <assertionScoreDirectorFactory>
-      <scoreDrl>org/optaplanner/examples/curriculumcourse/solver/curriculumCourseConstraints.drl</scoreDrl>
-    </assertionScoreDirectorFactory>
+    <!--<constraintProviderClass>org.optaplanner.examples.curriculumcourse.optional.score.CourseScheduleConstraintProvider</constraintProviderClass>-->
+    <scoreDrl>org/optaplanner/examples/curriculumcourse/solver/curriculumCourseConstraints.drl</scoreDrl>
+    <!--<assertionScoreDirectorFactory>-->
+      <!--<scoreDrl>org/optaplanner/examples/curriculumcourse/solver/curriculumCourseConstraints.drl</scoreDrl>-->
+    <!--</assertionScoreDirectorFactory>-->
   </scoreDirectorFactory>
 
   <termination>

--- a/optaplanner-examples/src/test/java/org/optaplanner/examples/curriculumcourse/optional/score/CourseScheduleConstraintProviderTest.java
+++ b/optaplanner-examples/src/test/java/org/optaplanner/examples/curriculumcourse/optional/score/CourseScheduleConstraintProviderTest.java
@@ -32,7 +32,6 @@ import org.optaplanner.test.api.score.stream.ConstraintVerifier;
 
 class CourseScheduleConstraintProviderTest {
 
-
     private static final Curriculum CURRICULUM_1 = new Curriculum(1, "Curriculum1");
     private static final Curriculum CURRICULUM_2 = new Curriculum(2, "Curriculum2");
     private static final Teacher TEACHER_1 = new Teacher(1, "Teacher1");

--- a/optaplanner-examples/src/test/java/org/optaplanner/examples/curriculumcourse/optional/score/CourseScheduleConstraintProviderTest.java
+++ b/optaplanner-examples/src/test/java/org/optaplanner/examples/curriculumcourse/optional/score/CourseScheduleConstraintProviderTest.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.examples.curriculumcourse.optional.score;
+
+import org.junit.jupiter.api.Test;
+import org.optaplanner.examples.curriculumcourse.domain.Course;
+import org.optaplanner.examples.curriculumcourse.domain.CourseSchedule;
+import org.optaplanner.examples.curriculumcourse.domain.Curriculum;
+import org.optaplanner.examples.curriculumcourse.domain.Day;
+import org.optaplanner.examples.curriculumcourse.domain.Lecture;
+import org.optaplanner.examples.curriculumcourse.domain.Period;
+import org.optaplanner.examples.curriculumcourse.domain.Room;
+import org.optaplanner.examples.curriculumcourse.domain.Teacher;
+import org.optaplanner.examples.curriculumcourse.domain.Timeslot;
+import org.optaplanner.examples.curriculumcourse.domain.UnavailablePeriodPenalty;
+import org.optaplanner.examples.curriculumcourse.domain.solver.CourseConflict;
+import org.optaplanner.test.api.score.stream.ConstraintVerifier;
+
+class CourseScheduleConstraintProviderTest {
+
+
+    private static final Curriculum CURRICULUM_1 = new Curriculum(1, "Curriculum1");
+    private static final Curriculum CURRICULUM_2 = new Curriculum(2, "Curriculum2");
+    private static final Teacher TEACHER_1 = new Teacher(1, "Teacher1");
+    private static final Teacher TEACHER_2 = new Teacher(2, "Teacher2");
+    private static final Course COURSE_1 = new Course(1, "Course1", TEACHER_1, 10, 20, 3, CURRICULUM_1);
+    private static final Course COURSE_2 = new Course(2, "Course2", TEACHER_2, 10, 10, 2, CURRICULUM_2);
+    private static final Course COURSE_3 = new Course(3, "Course3", TEACHER_1, 10, 5, 1, CURRICULUM_2);
+    private static final Room ROOM_1 = new Room(1, "Room1", 10);
+    private static final Room ROOM_2 = new Room(2, "Room2", 20);
+    private static final Timeslot FIRST_TIMESLOT = new Timeslot(0);
+    private static final Timeslot SECOND_TIMESLOT = new Timeslot(1);
+    private static final Day MONDAY = new Day(0);
+    private static final Day TUESDAY = new Day(1);
+    private static final Period PERIOD_1_MONDAY = new Period(0, MONDAY, FIRST_TIMESLOT);
+    private static final Period PERIOD_2_MONDAY = new Period(1, MONDAY, SECOND_TIMESLOT);
+    private static final Period PERIOD_1_TUESDAY = new Period(2, TUESDAY, FIRST_TIMESLOT);
+
+    private final ConstraintVerifier<CourseScheduleConstraintProvider, CourseSchedule> constraintVerifier =
+            ConstraintVerifier.build(new CourseScheduleConstraintProvider(), CourseSchedule.class, Lecture.class);
+
+    @Test
+    void conflictingLecturesDifferentCourseInSamePeriod() {
+        int conflictCount = 2;
+        CourseConflict courseConflict = new CourseConflict(COURSE_1, COURSE_2, conflictCount);
+
+        // Make sure that unassigned lectures are ignored.
+        Lecture unassignedLecture1 = new Lecture(0, COURSE_1, null, null);
+        Lecture unassignedLecture2 = new Lecture(1, COURSE_1, null, null);
+        // Make sure that different rooms are irrelevant.
+        Lecture assignedLecture1 = new Lecture(2, COURSE_1, PERIOD_1_MONDAY, ROOM_1);
+        Lecture assignedLecture2 = new Lecture(3, COURSE_2, PERIOD_1_MONDAY, ROOM_2);
+        constraintVerifier.verifyThat(CourseScheduleConstraintProvider::conflictingLecturesDifferentCourseInSamePeriod)
+                .given(courseConflict, unassignedLecture1, unassignedLecture2, assignedLecture1, assignedLecture2)
+                .penalizesBy(conflictCount);
+    }
+
+    @Test
+    void conflictingLecturesSameCourseInSamePeriod() {
+        // Make sure that unassigned lectures are ignored.
+        Lecture unassignedLecture1 = new Lecture(0, COURSE_1, null, null);
+        Lecture unassignedLecture2 = new Lecture(1, COURSE_1, null, null);
+        // Make sure that different rooms are irrelevant.
+        Lecture assignedLecture1 = new Lecture(2, COURSE_1, PERIOD_1_MONDAY, ROOM_1);
+        Lecture assignedLecture2 = new Lecture(3, COURSE_1, PERIOD_1_MONDAY, ROOM_2);
+        // Make sure that only pars with the same course and same period are counted.
+        Lecture assignedLecture3 = new Lecture(4, COURSE_2, PERIOD_1_MONDAY, ROOM_1);
+        constraintVerifier.verifyThat(CourseScheduleConstraintProvider::conflictingLecturesSameCourseInSamePeriod)
+                .given(unassignedLecture1, unassignedLecture2, assignedLecture1, assignedLecture2, assignedLecture3)
+                .penalizesBy(2);
+    }
+
+    @Test
+    void roomOccupancy() {
+        // Make sure that unassigned lectures are ignored.
+        Lecture unassignedLecture = new Lecture(0, COURSE_1, null, null);
+        // Make sure only unique pairs are counted.
+        Lecture assignedLecture1 = new Lecture(2, COURSE_1, PERIOD_1_MONDAY, ROOM_1);
+        Lecture assignedLecture2 = new Lecture(3, COURSE_2, PERIOD_1_MONDAY, ROOM_1);
+        Lecture assignedLecture3 = new Lecture(4, COURSE_3, PERIOD_1_MONDAY, ROOM_1);
+        // Make sure that different rooms are irrelevant.
+        Lecture assignedLecture4 = new Lecture(5, COURSE_1, PERIOD_1_MONDAY, ROOM_2);
+        constraintVerifier.verifyThat(CourseScheduleConstraintProvider::roomOccupancy)
+                .given(unassignedLecture, assignedLecture1, assignedLecture2, assignedLecture3, assignedLecture4)
+                .penalizesBy(3);
+    }
+
+    @Test
+    void unavailablePeriodPenalty() {
+        UnavailablePeriodPenalty unavailablePeriodPenalty = new UnavailablePeriodPenalty(0, COURSE_1, PERIOD_1_MONDAY);
+        Lecture matchingLecture = new Lecture(0, COURSE_1, PERIOD_1_MONDAY, ROOM_1);
+        Lecture wrongCourseLecture = new Lecture(1, COURSE_2, PERIOD_1_MONDAY, ROOM_2);
+        Lecture wrongPeriodLecture = new Lecture(2, COURSE_1, PERIOD_2_MONDAY, ROOM_1);
+        constraintVerifier.verifyThat(CourseScheduleConstraintProvider::unavailablePeriodPenalty)
+                .given(unavailablePeriodPenalty, matchingLecture, wrongCourseLecture, wrongPeriodLecture)
+                .penalizesBy(1);
+    }
+
+    @Test
+    void roomCapacity() {
+        Lecture overbookedLecture = new Lecture(0, COURSE_1, PERIOD_1_MONDAY, ROOM_1);
+        Lecture packedLecture = new Lecture(1, COURSE_2, PERIOD_2_MONDAY, ROOM_1);
+        Lecture nearlyEmptyLecture = new Lecture(2, COURSE_3, PERIOD_1_TUESDAY, ROOM_2);
+        constraintVerifier.verifyThat(CourseScheduleConstraintProvider::roomCapacity)
+                .given(overbookedLecture, packedLecture, nearlyEmptyLecture)
+                .penalizesBy(10); // Only penalizes the overbooked lecture.
+    }
+
+    @Test
+    void minimumWorkingDays() {
+        Lecture meetsMinimum = new Lecture(0, COURSE_3, PERIOD_1_MONDAY, ROOM_1);
+        Lecture doesNotMeetMinimumBy1 = new Lecture(1, COURSE_2, PERIOD_1_MONDAY, ROOM_2);
+        Lecture doesNotMeetMinimumBy2 = new Lecture(2, COURSE_1, PERIOD_2_MONDAY, ROOM_1);
+        constraintVerifier.verifyThat(CourseScheduleConstraintProvider::minimumWorkingDays)
+                .given(meetsMinimum, doesNotMeetMinimumBy1, doesNotMeetMinimumBy2)
+                .penalizesBy(3);
+    }
+
+    @Test
+    void curriculumCompactness() {
+        Lecture lectureInCurriculumWithoutOthers1 = new Lecture(0, COURSE_1, PERIOD_1_MONDAY, ROOM_1);
+        Lecture lectureInCurriculumWithoutOthers2 = new Lecture(1, COURSE_2, PERIOD_1_MONDAY, ROOM_1);
+        constraintVerifier.verifyThat(CourseScheduleConstraintProvider::curriculumCompactness)
+                .given(CURRICULUM_1, CURRICULUM_2, lectureInCurriculumWithoutOthers1, lectureInCurriculumWithoutOthers2)
+                .penalizesBy(2);
+    }
+
+    @Test
+    void roomStability() {
+        Lecture lectureOfSameCourse1 = new Lecture(0, COURSE_1, PERIOD_1_MONDAY, ROOM_1);
+        Lecture lectureOfSameCourse2 = new Lecture(0, COURSE_1, PERIOD_1_MONDAY, ROOM_2);
+        Lecture lectureOfSameCourse3 = new Lecture(0, COURSE_1, PERIOD_2_MONDAY, ROOM_1);
+        Lecture lectureOfDifferentCourse = new Lecture(0, COURSE_2, PERIOD_2_MONDAY, ROOM_1);
+        constraintVerifier.verifyThat(CourseScheduleConstraintProvider::roomStability)
+                .given(lectureOfSameCourse1, lectureOfSameCourse2, lectureOfSameCourse3, lectureOfDifferentCourse)
+                .penalizesBy(1); // lectureOfSameCourse2 is penalized
+    }
+
+}

--- a/optaplanner-examples/src/test/java/org/optaplanner/examples/curriculumcourse/optional/score/CourseScheduleConstraintProviderTest.java
+++ b/optaplanner-examples/src/test/java/org/optaplanner/examples/curriculumcourse/optional/score/CourseScheduleConstraintProviderTest.java
@@ -76,7 +76,7 @@ class CourseScheduleConstraintProviderTest {
         // Make sure that different rooms are irrelevant.
         Lecture assignedLecture1 = new Lecture(2, COURSE_1, PERIOD_1_MONDAY, ROOM_1);
         Lecture assignedLecture2 = new Lecture(3, COURSE_1, PERIOD_1_MONDAY, ROOM_2);
-        // Make sure that only pars with the same course and same period are counted.
+        // Make sure that only pairs with the same course and same period are counted.
         Lecture assignedLecture3 = new Lecture(4, COURSE_2, PERIOD_1_MONDAY, ROOM_1);
         constraintVerifier.verifyThat(CourseScheduleConstraintProvider::conflictingLecturesSameCourseInSamePeriod)
                 .given(unassignedLecture1, unassignedLecture2, assignedLecture1, assignedLecture2, assignedLecture3)

--- a/optaplanner-examples/src/test/java/org/optaplanner/examples/curriculumcourse/optional/score/CurriculumCourseConstraintProviderTest.java
+++ b/optaplanner-examples/src/test/java/org/optaplanner/examples/curriculumcourse/optional/score/CurriculumCourseConstraintProviderTest.java
@@ -30,7 +30,7 @@ import org.optaplanner.examples.curriculumcourse.domain.UnavailablePeriodPenalty
 import org.optaplanner.examples.curriculumcourse.domain.solver.CourseConflict;
 import org.optaplanner.test.api.score.stream.ConstraintVerifier;
 
-class CourseScheduleConstraintProviderTest {
+class CurriculumCourseConstraintProviderTest {
 
     private static final Curriculum CURRICULUM_1 = new Curriculum(1, "Curriculum1");
     private static final Curriculum CURRICULUM_2 = new Curriculum(2, "Curriculum2");
@@ -49,8 +49,8 @@ class CourseScheduleConstraintProviderTest {
     private static final Period PERIOD_2_MONDAY = new Period(1, MONDAY, SECOND_TIMESLOT);
     private static final Period PERIOD_1_TUESDAY = new Period(2, TUESDAY, FIRST_TIMESLOT);
 
-    private final ConstraintVerifier<CourseScheduleConstraintProvider, CourseSchedule> constraintVerifier =
-            ConstraintVerifier.build(new CourseScheduleConstraintProvider(), CourseSchedule.class, Lecture.class);
+    private final ConstraintVerifier<CurriculumCourseConstraintProvider, CourseSchedule> constraintVerifier =
+            ConstraintVerifier.build(new CurriculumCourseConstraintProvider(), CourseSchedule.class, Lecture.class);
 
     @Test
     void conflictingLecturesDifferentCourseInSamePeriod() {
@@ -63,7 +63,7 @@ class CourseScheduleConstraintProviderTest {
         // Make sure that different rooms are irrelevant.
         Lecture assignedLecture1 = new Lecture(2, COURSE_1, PERIOD_1_MONDAY, ROOM_1);
         Lecture assignedLecture2 = new Lecture(3, COURSE_2, PERIOD_1_MONDAY, ROOM_2);
-        constraintVerifier.verifyThat(CourseScheduleConstraintProvider::conflictingLecturesDifferentCourseInSamePeriod)
+        constraintVerifier.verifyThat(CurriculumCourseConstraintProvider::conflictingLecturesDifferentCourseInSamePeriod)
                 .given(courseConflict, unassignedLecture1, unassignedLecture2, assignedLecture1, assignedLecture2)
                 .penalizesBy(conflictCount);
     }
@@ -78,7 +78,7 @@ class CourseScheduleConstraintProviderTest {
         Lecture assignedLecture2 = new Lecture(3, COURSE_1, PERIOD_1_MONDAY, ROOM_2);
         // Make sure that only pairs with the same course and same period are counted.
         Lecture assignedLecture3 = new Lecture(4, COURSE_2, PERIOD_1_MONDAY, ROOM_1);
-        constraintVerifier.verifyThat(CourseScheduleConstraintProvider::conflictingLecturesSameCourseInSamePeriod)
+        constraintVerifier.verifyThat(CurriculumCourseConstraintProvider::conflictingLecturesSameCourseInSamePeriod)
                 .given(unassignedLecture1, unassignedLecture2, assignedLecture1, assignedLecture2, assignedLecture3)
                 .penalizesBy(2);
     }
@@ -93,7 +93,7 @@ class CourseScheduleConstraintProviderTest {
         Lecture assignedLecture3 = new Lecture(4, COURSE_3, PERIOD_1_MONDAY, ROOM_1);
         // Make sure that different rooms are irrelevant.
         Lecture assignedLecture4 = new Lecture(5, COURSE_1, PERIOD_1_MONDAY, ROOM_2);
-        constraintVerifier.verifyThat(CourseScheduleConstraintProvider::roomOccupancy)
+        constraintVerifier.verifyThat(CurriculumCourseConstraintProvider::roomOccupancy)
                 .given(unassignedLecture, assignedLecture1, assignedLecture2, assignedLecture3, assignedLecture4)
                 .penalizesBy(3);
     }
@@ -104,7 +104,7 @@ class CourseScheduleConstraintProviderTest {
         Lecture matchingLecture = new Lecture(0, COURSE_1, PERIOD_1_MONDAY, ROOM_1);
         Lecture wrongCourseLecture = new Lecture(1, COURSE_2, PERIOD_1_MONDAY, ROOM_2);
         Lecture wrongPeriodLecture = new Lecture(2, COURSE_1, PERIOD_2_MONDAY, ROOM_1);
-        constraintVerifier.verifyThat(CourseScheduleConstraintProvider::unavailablePeriodPenalty)
+        constraintVerifier.verifyThat(CurriculumCourseConstraintProvider::unavailablePeriodPenalty)
                 .given(unavailablePeriodPenalty, matchingLecture, wrongCourseLecture, wrongPeriodLecture)
                 .penalizesBy(1);
     }
@@ -114,7 +114,7 @@ class CourseScheduleConstraintProviderTest {
         Lecture overbookedLecture = new Lecture(0, COURSE_1, PERIOD_1_MONDAY, ROOM_1);
         Lecture packedLecture = new Lecture(1, COURSE_2, PERIOD_2_MONDAY, ROOM_1);
         Lecture nearlyEmptyLecture = new Lecture(2, COURSE_3, PERIOD_1_TUESDAY, ROOM_2);
-        constraintVerifier.verifyThat(CourseScheduleConstraintProvider::roomCapacity)
+        constraintVerifier.verifyThat(CurriculumCourseConstraintProvider::roomCapacity)
                 .given(overbookedLecture, packedLecture, nearlyEmptyLecture)
                 .penalizesBy(10); // Only penalizes the overbooked lecture.
     }
@@ -124,7 +124,7 @@ class CourseScheduleConstraintProviderTest {
         Lecture meetsMinimum = new Lecture(0, COURSE_3, PERIOD_1_MONDAY, ROOM_1);
         Lecture doesNotMeetMinimumBy1 = new Lecture(1, COURSE_2, PERIOD_1_MONDAY, ROOM_2);
         Lecture doesNotMeetMinimumBy2 = new Lecture(2, COURSE_1, PERIOD_2_MONDAY, ROOM_1);
-        constraintVerifier.verifyThat(CourseScheduleConstraintProvider::minimumWorkingDays)
+        constraintVerifier.verifyThat(CurriculumCourseConstraintProvider::minimumWorkingDays)
                 .given(meetsMinimum, doesNotMeetMinimumBy1, doesNotMeetMinimumBy2)
                 .penalizesBy(3);
     }
@@ -133,7 +133,7 @@ class CourseScheduleConstraintProviderTest {
     void curriculumCompactness() {
         Lecture lectureInCurriculumWithoutOthers1 = new Lecture(0, COURSE_1, PERIOD_1_MONDAY, ROOM_1);
         Lecture lectureInCurriculumWithoutOthers2 = new Lecture(1, COURSE_2, PERIOD_1_MONDAY, ROOM_1);
-        constraintVerifier.verifyThat(CourseScheduleConstraintProvider::curriculumCompactness)
+        constraintVerifier.verifyThat(CurriculumCourseConstraintProvider::curriculumCompactness)
                 .given(CURRICULUM_1, CURRICULUM_2, lectureInCurriculumWithoutOthers1, lectureInCurriculumWithoutOthers2)
                 .penalizesBy(2);
     }
@@ -144,7 +144,7 @@ class CourseScheduleConstraintProviderTest {
         Lecture lectureOfSameCourse2 = new Lecture(0, COURSE_1, PERIOD_1_MONDAY, ROOM_2);
         Lecture lectureOfSameCourse3 = new Lecture(0, COURSE_1, PERIOD_2_MONDAY, ROOM_1);
         Lecture lectureOfDifferentCourse = new Lecture(0, COURSE_2, PERIOD_2_MONDAY, ROOM_1);
-        constraintVerifier.verifyThat(CourseScheduleConstraintProvider::roomStability)
+        constraintVerifier.verifyThat(CurriculumCourseConstraintProvider::roomStability)
                 .given(lectureOfSameCourse1, lectureOfSameCourse2, lectureOfSameCourse3, lectureOfDifferentCourse)
                 .penalizesBy(1); // lectureOfSameCourse2 is penalized
     }

--- a/optaplanner-examples/src/test/java/org/optaplanner/examples/curriculumcourse/optional/score/CurriculumCourseConstraintProviderTest.java
+++ b/optaplanner-examples/src/test/java/org/optaplanner/examples/curriculumcourse/optional/score/CurriculumCourseConstraintProviderTest.java
@@ -30,7 +30,7 @@ import org.optaplanner.examples.curriculumcourse.domain.UnavailablePeriodPenalty
 import org.optaplanner.examples.curriculumcourse.domain.solver.CourseConflict;
 import org.optaplanner.test.api.score.stream.ConstraintVerifier;
 
-class CurriculumCourseConstraintProviderTest {
+public class CurriculumCourseConstraintProviderTest {
 
     private static final Curriculum CURRICULUM_1 = new Curriculum(1, "Curriculum1");
     private static final Curriculum CURRICULUM_2 = new Curriculum(2, "Curriculum2");
@@ -53,7 +53,7 @@ class CurriculumCourseConstraintProviderTest {
             ConstraintVerifier.build(new CurriculumCourseConstraintProvider(), CourseSchedule.class, Lecture.class);
 
     @Test
-    void conflictingLecturesDifferentCourseInSamePeriod() {
+    public void conflictingLecturesDifferentCourseInSamePeriod() {
         int conflictCount = 2;
         CourseConflict courseConflict = new CourseConflict(COURSE_1, COURSE_2, conflictCount);
 
@@ -69,7 +69,7 @@ class CurriculumCourseConstraintProviderTest {
     }
 
     @Test
-    void conflictingLecturesSameCourseInSamePeriod() {
+    public void conflictingLecturesSameCourseInSamePeriod() {
         // Make sure that unassigned lectures are ignored.
         Lecture unassignedLecture1 = new Lecture(0, COURSE_1, null, null);
         Lecture unassignedLecture2 = new Lecture(1, COURSE_1, null, null);
@@ -84,7 +84,7 @@ class CurriculumCourseConstraintProviderTest {
     }
 
     @Test
-    void roomOccupancy() {
+    public void roomOccupancy() {
         // Make sure that unassigned lectures are ignored.
         Lecture unassignedLecture = new Lecture(0, COURSE_1, null, null);
         // Make sure only unique pairs are counted.
@@ -99,7 +99,7 @@ class CurriculumCourseConstraintProviderTest {
     }
 
     @Test
-    void unavailablePeriodPenalty() {
+    public void unavailablePeriodPenalty() {
         UnavailablePeriodPenalty unavailablePeriodPenalty = new UnavailablePeriodPenalty(0, COURSE_1, PERIOD_1_MONDAY);
         Lecture matchingLecture = new Lecture(0, COURSE_1, PERIOD_1_MONDAY, ROOM_1);
         Lecture wrongCourseLecture = new Lecture(1, COURSE_2, PERIOD_1_MONDAY, ROOM_2);
@@ -110,7 +110,7 @@ class CurriculumCourseConstraintProviderTest {
     }
 
     @Test
-    void roomCapacity() {
+    public void roomCapacity() {
         Lecture overbookedLecture = new Lecture(0, COURSE_1, PERIOD_1_MONDAY, ROOM_1);
         Lecture packedLecture = new Lecture(1, COURSE_2, PERIOD_2_MONDAY, ROOM_1);
         Lecture nearlyEmptyLecture = new Lecture(2, COURSE_3, PERIOD_1_TUESDAY, ROOM_2);
@@ -120,7 +120,7 @@ class CurriculumCourseConstraintProviderTest {
     }
 
     @Test
-    void minimumWorkingDays() {
+    public void minimumWorkingDays() {
         Lecture meetsMinimum = new Lecture(0, COURSE_3, PERIOD_1_MONDAY, ROOM_1);
         Lecture doesNotMeetMinimumBy1 = new Lecture(1, COURSE_2, PERIOD_1_MONDAY, ROOM_2);
         Lecture doesNotMeetMinimumBy2 = new Lecture(2, COURSE_1, PERIOD_2_MONDAY, ROOM_1);
@@ -130,7 +130,7 @@ class CurriculumCourseConstraintProviderTest {
     }
 
     @Test
-    void curriculumCompactness() {
+    public void curriculumCompactness() {
         Lecture lectureInCurriculumWithoutOthers1 = new Lecture(0, COURSE_1, PERIOD_1_MONDAY, ROOM_1);
         Lecture lectureInCurriculumWithoutOthers2 = new Lecture(1, COURSE_2, PERIOD_1_MONDAY, ROOM_1);
         constraintVerifier.verifyThat(CurriculumCourseConstraintProvider::curriculumCompactness)
@@ -139,7 +139,7 @@ class CurriculumCourseConstraintProviderTest {
     }
 
     @Test
-    void roomStability() {
+    public void roomStability() {
         Lecture lectureOfSameCourse1 = new Lecture(0, COURSE_1, PERIOD_1_MONDAY, ROOM_1);
         Lecture lectureOfSameCourse2 = new Lecture(0, COURSE_1, PERIOD_1_MONDAY, ROOM_2);
         Lecture lectureOfSameCourse3 = new Lecture(0, COURSE_1, PERIOD_2_MONDAY, ROOM_1);


### PR DESCRIPTION
Most of the changes here are changes to XML data sets, coming from the fact that I changed `curriculumList` to `curriculumSet` for performance reasons. (Doing `contains()` on a `List` is needlessly costly.)