### PR TITLE
PLANNER-2025 Provide XSD for SolverConfig

### DIFF
--- a/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/config/PlannerBenchmarkConfig.java
+++ b/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/config/PlannerBenchmarkConfig.java
@@ -51,12 +51,12 @@ import org.optaplanner.benchmark.api.PlannerBenchmarkFactory;
 import org.optaplanner.benchmark.config.blueprint.SolverBenchmarkBluePrintConfig;
 import org.optaplanner.benchmark.config.report.BenchmarkReportConfig;
 import org.optaplanner.benchmark.impl.DefaultPlannerBenchmark;
+import org.optaplanner.benchmark.impl.io.PlannerBenchmarkConfigIO;
 import org.optaplanner.benchmark.impl.report.BenchmarkReport;
 import org.optaplanner.benchmark.impl.result.PlannerBenchmarkResult;
 import org.optaplanner.core.config.solver.SolverConfig;
 import org.optaplanner.core.config.util.ConfigUtils;
-import org.optaplanner.core.impl.io.XmlUnmarshallingException;
-import org.optaplanner.core.impl.io.jaxb.JaxbIO;
+import org.optaplanner.core.impl.io.OptaPlannerXmlSerializationException;
 import org.optaplanner.core.impl.solver.thread.DefaultSolverThreadFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -138,7 +138,7 @@ public class PlannerBenchmarkConfig {
                 throw new IllegalArgumentException(errorMessage);
             }
             return createFromXmlInputStream(in, classLoader);
-        } catch (XmlUnmarshallingException e) {
+        } catch (OptaPlannerXmlSerializationException e) {
             throw new IllegalArgumentException("Unmarshalling of benchmarkConfigResource (" + benchmarkConfigResource
                     + ") fails.", e);
         } catch (IOException e) {
@@ -218,7 +218,7 @@ public class PlannerBenchmarkConfig {
      * @return never null
      */
     public static PlannerBenchmarkConfig createFromXmlReader(Reader reader, ClassLoader classLoader) {
-        JaxbIO<?> xmlIO = new JaxbIO<>(PlannerBenchmarkConfig.class);
+        PlannerBenchmarkConfigIO xmlIO = new PlannerBenchmarkConfigIO();
         Object benchmarkConfigObject = xmlIO.read(reader);
         if (!(benchmarkConfigObject instanceof PlannerBenchmarkConfig)) {
             throw new IllegalArgumentException("The " + PlannerBenchmarkConfig.class.getSimpleName()

--- a/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/config/SolverBenchmarkConfig.java
+++ b/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/config/SolverBenchmarkConfig.java
@@ -31,7 +31,7 @@ public class SolverBenchmarkConfig<Solution_> extends AbstractConfig<SolverBench
 
     private String name = null;
 
-    @XmlElement(name = "solver")
+    @XmlElement(name = SolverConfig.XML_ELEMENT_NAME, namespace = SolverConfig.XML_NAMESPACE)
     private SolverConfig solverConfig = null;
 
     @XmlElement(name = "problemBenchmarks")

--- a/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/impl/io/PlannerBenchmarkConfigIO.java
+++ b/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/impl/io/PlannerBenchmarkConfigIO.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.benchmark.impl.io;
+
+import java.io.Reader;
+import java.io.Writer;
+
+import org.optaplanner.benchmark.config.PlannerBenchmarkConfig;
+import org.optaplanner.core.config.solver.SolverConfig;
+import org.optaplanner.core.impl.io.jaxb.ElementNamespaceOverride;
+import org.optaplanner.core.impl.io.jaxb.JaxbIO;
+
+public class PlannerBenchmarkConfigIO {
+
+    private final JaxbIO<PlannerBenchmarkConfig> jaxbIO = new JaxbIO<>(PlannerBenchmarkConfig.class);
+
+    public PlannerBenchmarkConfig read(Reader reader) {
+        return jaxbIO.readOverridingNamespace(reader,
+                ElementNamespaceOverride.of(SolverConfig.XML_ELEMENT_NAME, SolverConfig.XML_NAMESPACE));
+    }
+
+    public void write(PlannerBenchmarkConfig plannerBenchmarkConfig, Writer writer) {
+        jaxbIO.writeWithoutNamespaces(plannerBenchmarkConfig, writer);
+    }
+}

--- a/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/impl/result/BenchmarkResultIO.java
+++ b/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/impl/result/BenchmarkResultIO.java
@@ -25,6 +25,7 @@ import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
 import java.io.Reader;
 import java.io.Writer;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -33,24 +34,26 @@ import org.apache.commons.io.filefilter.DirectoryFileFilter;
 import org.optaplanner.benchmark.impl.statistic.ProblemStatistic;
 import org.optaplanner.benchmark.impl.statistic.PureSubSingleStatistic;
 import org.optaplanner.core.config.solver.SolverConfig;
-import org.optaplanner.core.impl.io.XmlUnmarshallingException;
+import org.optaplanner.core.impl.io.OptaPlannerXmlSerializationException;
+import org.optaplanner.core.impl.io.jaxb.ElementNamespaceOverride;
 import org.optaplanner.core.impl.io.jaxb.JaxbIO;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class BenchmarkResultIO {
-
+    // BenchmarkResult contain <solverConfig/> element instead of the default SolverConfig.XML_ELEMENT_NAME
+    private static final String SOLVER_CONFIG_XML_ELEMENT_NAME = "solverConfig";
     private static final String PLANNER_BENCHMARK_RESULT_FILENAME = "plannerBenchmarkResult.xml";
 
     protected final transient Logger logger = LoggerFactory.getLogger(getClass());
 
-    private final JaxbIO<PlannerBenchmarkResult> xmlIO = new JaxbIO(PlannerBenchmarkResult.class);
+    private final JaxbIO<PlannerBenchmarkResult> xmlIO = new JaxbIO<>(PlannerBenchmarkResult.class);
 
     public void writePlannerBenchmarkResult(File benchmarkReportDirectory,
             PlannerBenchmarkResult plannerBenchmarkResult) {
         File plannerBenchmarkResultFile = new File(benchmarkReportDirectory, PLANNER_BENCHMARK_RESULT_FILENAME);
-        try (Writer writer = new OutputStreamWriter(new FileOutputStream(plannerBenchmarkResultFile), "UTF-8")) {
-            xmlIO.write(plannerBenchmarkResult, writer);
+        try (Writer writer = new OutputStreamWriter(new FileOutputStream(plannerBenchmarkResultFile), StandardCharsets.UTF_8)) {
+            write(plannerBenchmarkResult, writer);
         } catch (IOException e) {
             throw new IllegalArgumentException(
                     "Failed writing plannerBenchmarkResultFile (" + plannerBenchmarkResultFile + ").", e);
@@ -85,9 +88,9 @@ public class BenchmarkResultIO {
                     + ") does not exist.");
         }
         PlannerBenchmarkResult plannerBenchmarkResult;
-        try (Reader reader = new InputStreamReader(new FileInputStream(plannerBenchmarkResultFile), "UTF-8")) {
-            plannerBenchmarkResult = xmlIO.read(reader);
-        } catch (XmlUnmarshallingException e) {
+        try (Reader reader = new InputStreamReader(new FileInputStream(plannerBenchmarkResultFile), StandardCharsets.UTF_8)) {
+            plannerBenchmarkResult = read(reader);
+        } catch (OptaPlannerXmlSerializationException e) {
             logger.warn("Failed reading plannerBenchmarkResultFile ({}).", plannerBenchmarkResultFile, e);
             // If the plannerBenchmarkResultFile's format has changed, the app should not crash entirely
             String benchmarkReportDirectoryName = plannerBenchmarkResultFile.getParentFile().getName();
@@ -101,6 +104,15 @@ public class BenchmarkResultIO {
         restoreOmittedBidirectionalFields(plannerBenchmarkResult);
         restoreOtherOmittedFields(plannerBenchmarkResult);
         return plannerBenchmarkResult;
+    }
+
+    protected PlannerBenchmarkResult read(Reader reader) {
+        return xmlIO.readOverridingNamespace(reader,
+                ElementNamespaceOverride.of(SOLVER_CONFIG_XML_ELEMENT_NAME, SolverConfig.XML_NAMESPACE));
+    }
+
+    protected void write(PlannerBenchmarkResult plannerBenchmarkResult, Writer writer) {
+        xmlIO.writeWithoutNamespaces(plannerBenchmarkResult, writer);
     }
 
     private void restoreOmittedBidirectionalFields(PlannerBenchmarkResult plannerBenchmarkResult) {

--- a/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/impl/result/SolverBenchmarkResult.java
+++ b/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/impl/result/SolverBenchmarkResult.java
@@ -49,6 +49,7 @@ public class SolverBenchmarkResult {
 
     private Integer subSingleCount = null;
 
+    @XmlElement(namespace = SolverConfig.XML_NAMESPACE)
     private SolverConfig solverConfig = null;
     @XmlTransient // Restored through BenchmarkResultIO
     private ScoreDefinition scoreDefinition = null;

--- a/optaplanner-benchmark/src/test/java/org/optaplanner/benchmark/config/PlannerBenchmarkConfigTest.java
+++ b/optaplanner-benchmark/src/test/java/org/optaplanner/benchmark/config/PlannerBenchmarkConfigTest.java
@@ -33,8 +33,8 @@ import java.util.TreeSet;
 
 import org.apache.commons.io.IOUtils;
 import org.junit.jupiter.api.Test;
+import org.optaplanner.benchmark.impl.io.PlannerBenchmarkConfigIO;
 import org.optaplanner.core.config.util.ConfigUtils;
-import org.optaplanner.core.impl.io.jaxb.JaxbIO;
 import org.optaplanner.core.impl.testdata.domain.TestdataSolution;
 import org.optaplanner.persistence.xstream.impl.domain.solution.XStreamSolutionFileIO;
 
@@ -169,7 +169,7 @@ public class PlannerBenchmarkConfigTest {
 
     @Test
     public void xmlConfigFileRemainsSameAfterReadWrite() throws IOException {
-        JaxbIO<PlannerBenchmarkConfig> xmlIO = new JaxbIO<>(PlannerBenchmarkConfig.class);
+        PlannerBenchmarkConfigIO xmlIO = new PlannerBenchmarkConfigIO();
         PlannerBenchmarkConfig jaxbBenchmarkConfig;
 
         try (Reader reader =

--- a/optaplanner-benchmark/src/test/java/org/optaplanner/benchmark/impl/result/PlannerBenchmarkResultTest.java
+++ b/optaplanner-benchmark/src/test/java/org/optaplanner/benchmark/impl/result/PlannerBenchmarkResultTest.java
@@ -42,7 +42,6 @@ import org.optaplanner.core.api.score.buildin.simple.SimpleScore;
 import org.optaplanner.core.config.solver.SolverConfig;
 import org.optaplanner.core.config.solver.random.RandomType;
 import org.optaplanner.core.impl.heuristic.selector.common.nearby.NearbyDistanceMeter;
-import org.optaplanner.core.impl.io.jaxb.JaxbIO;
 import org.optaplanner.core.impl.score.director.incremental.AbstractIncrementalScoreCalculator;
 import org.optaplanner.core.impl.testdata.domain.chained.TestdataChainedEntity;
 import org.optaplanner.core.impl.testdata.domain.chained.TestdataChainedSolution;
@@ -50,8 +49,6 @@ import org.optaplanner.core.impl.testdata.domain.chained.TestdataChainedSolution
 public class PlannerBenchmarkResultTest {
 
     private static final String TEST_PLANNER_BENCHMARK_RESULT = "testPlannerBenchmarkResult.xml";
-
-    private final JaxbIO<PlannerBenchmarkResult> xmlIO = new JaxbIO(PlannerBenchmarkResult.class);
 
     @Test
     public void createMergedResult() {
@@ -137,14 +134,15 @@ public class PlannerBenchmarkResultTest {
 
     @Test
     public void xmlReportRemainsSameAfterReadWrite() throws IOException {
+        BenchmarkResultIO benchmarkResultIO = new BenchmarkResultIO();
         PlannerBenchmarkResult plannerBenchmarkResult;
         try (Reader reader = new InputStreamReader(
                 PlannerBenchmarkResultTest.class.getResourceAsStream(TEST_PLANNER_BENCHMARK_RESULT), "UTF-8")) {
-            plannerBenchmarkResult = xmlIO.read(reader);
+            plannerBenchmarkResult = benchmarkResultIO.read(reader);
         }
 
         Writer stringWriter = new StringWriter();
-        xmlIO.write(plannerBenchmarkResult, stringWriter);
+        benchmarkResultIO.write(plannerBenchmarkResult, stringWriter);
         String jaxbString = stringWriter.toString();
 
         String originalXml = IOUtils.toString(

--- a/optaplanner-benchmark/src/test/resources/org/optaplanner/benchmark/config/testBenchmarkConfig.xml
+++ b/optaplanner-benchmark/src/test/resources/org/optaplanner/benchmark/config/testBenchmarkConfig.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<plannerBenchmark>
+<?xml version="1.0" encoding="utf-8"?><plannerBenchmark>
   <benchmarkDirectory>data</benchmarkDirectory>
   <parallelBenchmarkCount>AUTO</parallelBenchmarkCount>
   <warmUpSecondsSpentLimit>0</warmUpSecondsSpentLimit>

--- a/optaplanner-benchmark/src/test/resources/org/optaplanner/benchmark/impl/result/testPlannerBenchmarkResult.xml
+++ b/optaplanner-benchmark/src/test/resources/org/optaplanner/benchmark/impl/result/testPlannerBenchmarkResult.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<plannerBenchmarkResult>
+<?xml version="1.0" encoding="utf-8"?><plannerBenchmarkResult>
   <name>2020-07-13_125809</name>
   <aggregation>false</aggregation>
   <availableProcessors>4</availableProcessors>

--- a/optaplanner-build-parent/pom.xml
+++ b/optaplanner-build-parent/pom.xml
@@ -839,6 +839,11 @@
             </execution>
           </executions>
         </plugin>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>jaxb2-maven-plugin</artifactId>
+          <version>2.5.0</version>
+        </plugin>
       </plugins>
     </pluginManagement>
     <plugins>

--- a/optaplanner-core/pom.xml
+++ b/optaplanner-core/pom.xml
@@ -140,4 +140,41 @@
     </plugins>
   </build>
 
+  <profiles>
+    <profile>
+      <id>generate-xml-schema</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>jaxb2-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>schemagen</id>
+                <goals>
+                  <goal>schemagen</goal>
+                </goals>
+              </execution>
+            </executions>
+            <configuration>
+              <clearOutputDir>true</clearOutputDir>
+              <createJavaDocAnnotations>false</createJavaDocAnnotations>
+              <generateEpisode>false</generateEpisode>
+              <outputDirectory>${project.build.outputDirectory}</outputDirectory>
+              <sources>
+                <source>${project.build.sourceDirectory}/org/optaplanner/core/config/solver</source>
+              </sources>
+              <transformSchemas>
+                <transformSchema>
+                  <!-- Keep in sync with Namespace.SOLVER -->
+                  <uri>https://www.optaplanner.org/xsd/solver</uri>
+                  <toFile>solver.xsd</toFile>
+                </transformSchema>
+              </transformSchemas>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>

--- a/optaplanner-core/src/build/revapi-config.json
+++ b/optaplanner-core/src/build/revapi-config.json
@@ -8265,6 +8265,17 @@
           "methodName": "explainScore",
           "elementKind": "method",
           "justification": "ScoreManager is implemented now."
+        },
+        {
+          "code": "java.annotation.added",
+          "old": "class org.optaplanner.core.config.solver.recaller.BestSolutionRecallerConfig",
+          "new": "class org.optaplanner.core.config.solver.recaller.BestSolutionRecallerConfig",
+          "annotationType": "javax.xml.bind.annotation.XmlTransient",
+          "annotation": "@javax.xml.bind.annotation.XmlTransient",
+          "package": "org.optaplanner.core.config.solver.recaller",
+          "classSimpleName": "BestSolutionRecallerConfig",
+          "elementKind": "class",
+          "justification": "Omit the class in XmlSchema generation."
         }
       ]
     }

--- a/optaplanner-core/src/main/java/org/optaplanner/core/api/score/stream/package-info.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/api/score/stream/package-info.java
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-/**
- * The {@link org.optaplanner.core.api.score.stream.ConstraintStream} API:
- * a way to define constraints for {@link org.optaplanner.core.api.score.Score} calculation.
- */
+@javax.xml.bind.annotation.XmlSchema(namespace = SolverConfig.XML_NAMESPACE)
 package org.optaplanner.core.api.score.stream;
+
+import org.optaplanner.core.config.solver.SolverConfig;

--- a/optaplanner-core/src/main/java/org/optaplanner/core/config/AbstractConfig.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/config/AbstractConfig.java
@@ -38,7 +38,7 @@ import org.optaplanner.core.impl.domain.variable.descriptor.GenuineVariableDescr
  *
  * @param <C> the same class as the implementing subclass
  */
-@XmlAccessorType(XmlAccessType.FIELD)
+@XmlAccessorType(XmlAccessType.FIELD) // Applies to all superclasses.
 public abstract class AbstractConfig<C extends AbstractConfig> {
 
     // ************************************************************************

--- a/optaplanner-core/src/main/java/org/optaplanner/core/config/constructionheuristic/decider/forager/package-info.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/config/constructionheuristic/decider/forager/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,17 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-/**
- * Classes which represent the XML Solver configuration of OptaPlanner.
- * <p>
- * The XML Solver configuration is backwards compatible for all elements,
- * except for elements that require the use of non public API classes.
- */
 @javax.xml.bind.annotation.XmlSchema(
         namespace = SolverConfig.XML_NAMESPACE,
         elementFormDefault = XmlNsForm.QUALIFIED)
-package org.optaplanner.core.config;
+package org.optaplanner.core.config.constructionheuristic.decider.forager;
 
 import javax.xml.bind.annotation.XmlNsForm;
 

--- a/optaplanner-core/src/main/java/org/optaplanner/core/config/constructionheuristic/package-info.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/config/constructionheuristic/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,17 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-/**
- * Classes which represent the XML Solver configuration of OptaPlanner.
- * <p>
- * The XML Solver configuration is backwards compatible for all elements,
- * except for elements that require the use of non public API classes.
- */
 @javax.xml.bind.annotation.XmlSchema(
         namespace = SolverConfig.XML_NAMESPACE,
         elementFormDefault = XmlNsForm.QUALIFIED)
-package org.optaplanner.core.config;
+package org.optaplanner.core.config.constructionheuristic;
 
 import javax.xml.bind.annotation.XmlNsForm;
 

--- a/optaplanner-core/src/main/java/org/optaplanner/core/config/constructionheuristic/placer/package-info.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/config/constructionheuristic/placer/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,17 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-/**
- * Classes which represent the XML Solver configuration of OptaPlanner.
- * <p>
- * The XML Solver configuration is backwards compatible for all elements,
- * except for elements that require the use of non public API classes.
- */
 @javax.xml.bind.annotation.XmlSchema(
         namespace = SolverConfig.XML_NAMESPACE,
         elementFormDefault = XmlNsForm.QUALIFIED)
-package org.optaplanner.core.config;
+package org.optaplanner.core.config.constructionheuristic.placer;
 
 import javax.xml.bind.annotation.XmlNsForm;
 

--- a/optaplanner-core/src/main/java/org/optaplanner/core/config/exhaustivesearch/package-info.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/config/exhaustivesearch/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,17 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-/**
- * Classes which represent the XML Solver configuration of OptaPlanner.
- * <p>
- * The XML Solver configuration is backwards compatible for all elements,
- * except for elements that require the use of non public API classes.
- */
 @javax.xml.bind.annotation.XmlSchema(
         namespace = SolverConfig.XML_NAMESPACE,
         elementFormDefault = XmlNsForm.QUALIFIED)
-package org.optaplanner.core.config;
+package org.optaplanner.core.config.exhaustivesearch;
 
 import javax.xml.bind.annotation.XmlNsForm;
 

--- a/optaplanner-core/src/main/java/org/optaplanner/core/config/heuristic/selector/common/decorator/package-info.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/config/heuristic/selector/common/decorator/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,17 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-/**
- * Classes which represent the XML Solver configuration of OptaPlanner.
- * <p>
- * The XML Solver configuration is backwards compatible for all elements,
- * except for elements that require the use of non public API classes.
- */
 @javax.xml.bind.annotation.XmlSchema(
         namespace = SolverConfig.XML_NAMESPACE,
         elementFormDefault = XmlNsForm.QUALIFIED)
-package org.optaplanner.core.config;
+package org.optaplanner.core.config.heuristic.selector.common.decorator;
 
 import javax.xml.bind.annotation.XmlNsForm;
 

--- a/optaplanner-core/src/main/java/org/optaplanner/core/config/heuristic/selector/common/nearby/package-info.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/config/heuristic/selector/common/nearby/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,17 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-/**
- * Classes which represent the XML Solver configuration of OptaPlanner.
- * <p>
- * The XML Solver configuration is backwards compatible for all elements,
- * except for elements that require the use of non public API classes.
- */
 @javax.xml.bind.annotation.XmlSchema(
         namespace = SolverConfig.XML_NAMESPACE,
         elementFormDefault = XmlNsForm.QUALIFIED)
-package org.optaplanner.core.config;
+package org.optaplanner.core.config.heuristic.selector.common.nearby;
 
 import javax.xml.bind.annotation.XmlNsForm;
 

--- a/optaplanner-core/src/main/java/org/optaplanner/core/config/heuristic/selector/common/package-info.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/config/heuristic/selector/common/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,17 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-/**
- * Classes which represent the XML Solver configuration of OptaPlanner.
- * <p>
- * The XML Solver configuration is backwards compatible for all elements,
- * except for elements that require the use of non public API classes.
- */
 @javax.xml.bind.annotation.XmlSchema(
         namespace = SolverConfig.XML_NAMESPACE,
         elementFormDefault = XmlNsForm.QUALIFIED)
-package org.optaplanner.core.config;
+package org.optaplanner.core.config.heuristic.selector.common;
 
 import javax.xml.bind.annotation.XmlNsForm;
 

--- a/optaplanner-core/src/main/java/org/optaplanner/core/config/heuristic/selector/entity/package-info.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/config/heuristic/selector/entity/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,17 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-/**
- * Classes which represent the XML Solver configuration of OptaPlanner.
- * <p>
- * The XML Solver configuration is backwards compatible for all elements,
- * except for elements that require the use of non public API classes.
- */
 @javax.xml.bind.annotation.XmlSchema(
         namespace = SolverConfig.XML_NAMESPACE,
         elementFormDefault = XmlNsForm.QUALIFIED)
-package org.optaplanner.core.config;
+package org.optaplanner.core.config.heuristic.selector.entity;
 
 import javax.xml.bind.annotation.XmlNsForm;
 

--- a/optaplanner-core/src/main/java/org/optaplanner/core/config/heuristic/selector/entity/pillar/package-info.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/config/heuristic/selector/entity/pillar/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,17 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-/**
- * Classes which represent the XML Solver configuration of OptaPlanner.
- * <p>
- * The XML Solver configuration is backwards compatible for all elements,
- * except for elements that require the use of non public API classes.
- */
 @javax.xml.bind.annotation.XmlSchema(
         namespace = SolverConfig.XML_NAMESPACE,
         elementFormDefault = XmlNsForm.QUALIFIED)
-package org.optaplanner.core.config;
+package org.optaplanner.core.config.heuristic.selector.entity.pillar;
 
 import javax.xml.bind.annotation.XmlNsForm;
 

--- a/optaplanner-core/src/main/java/org/optaplanner/core/config/heuristic/selector/move/composite/package-info.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/config/heuristic/selector/move/composite/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,17 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-/**
- * Classes which represent the XML Solver configuration of OptaPlanner.
- * <p>
- * The XML Solver configuration is backwards compatible for all elements,
- * except for elements that require the use of non public API classes.
- */
 @javax.xml.bind.annotation.XmlSchema(
         namespace = SolverConfig.XML_NAMESPACE,
         elementFormDefault = XmlNsForm.QUALIFIED)
-package org.optaplanner.core.config;
+package org.optaplanner.core.config.heuristic.selector.move.composite;
 
 import javax.xml.bind.annotation.XmlNsForm;
 

--- a/optaplanner-core/src/main/java/org/optaplanner/core/config/heuristic/selector/move/factory/package-info.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/config/heuristic/selector/move/factory/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,17 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-/**
- * Classes which represent the XML Solver configuration of OptaPlanner.
- * <p>
- * The XML Solver configuration is backwards compatible for all elements,
- * except for elements that require the use of non public API classes.
- */
 @javax.xml.bind.annotation.XmlSchema(
         namespace = SolverConfig.XML_NAMESPACE,
         elementFormDefault = XmlNsForm.QUALIFIED)
-package org.optaplanner.core.config;
+package org.optaplanner.core.config.heuristic.selector.move.factory;
 
 import javax.xml.bind.annotation.XmlNsForm;
 

--- a/optaplanner-core/src/main/java/org/optaplanner/core/config/heuristic/selector/move/generic/chained/package-info.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/config/heuristic/selector/move/generic/chained/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,17 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-/**
- * Classes which represent the XML Solver configuration of OptaPlanner.
- * <p>
- * The XML Solver configuration is backwards compatible for all elements,
- * except for elements that require the use of non public API classes.
- */
 @javax.xml.bind.annotation.XmlSchema(
         namespace = SolverConfig.XML_NAMESPACE,
         elementFormDefault = XmlNsForm.QUALIFIED)
-package org.optaplanner.core.config;
+package org.optaplanner.core.config.heuristic.selector.move.generic.chained;
 
 import javax.xml.bind.annotation.XmlNsForm;
 

--- a/optaplanner-core/src/main/java/org/optaplanner/core/config/heuristic/selector/move/generic/package-info.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/config/heuristic/selector/move/generic/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,17 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-/**
- * Classes which represent the XML Solver configuration of OptaPlanner.
- * <p>
- * The XML Solver configuration is backwards compatible for all elements,
- * except for elements that require the use of non public API classes.
- */
 @javax.xml.bind.annotation.XmlSchema(
         namespace = SolverConfig.XML_NAMESPACE,
         elementFormDefault = XmlNsForm.QUALIFIED)
-package org.optaplanner.core.config;
+package org.optaplanner.core.config.heuristic.selector.move.generic;
 
 import javax.xml.bind.annotation.XmlNsForm;
 

--- a/optaplanner-core/src/main/java/org/optaplanner/core/config/heuristic/selector/move/package-info.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/config/heuristic/selector/move/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,17 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-/**
- * Classes which represent the XML Solver configuration of OptaPlanner.
- * <p>
- * The XML Solver configuration is backwards compatible for all elements,
- * except for elements that require the use of non public API classes.
- */
 @javax.xml.bind.annotation.XmlSchema(
         namespace = SolverConfig.XML_NAMESPACE,
         elementFormDefault = XmlNsForm.QUALIFIED)
-package org.optaplanner.core.config;
+package org.optaplanner.core.config.heuristic.selector.move;
 
 import javax.xml.bind.annotation.XmlNsForm;
 

--- a/optaplanner-core/src/main/java/org/optaplanner/core/config/heuristic/selector/package-info.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/config/heuristic/selector/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,17 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-/**
- * Classes which represent the XML Solver configuration of OptaPlanner.
- * <p>
- * The XML Solver configuration is backwards compatible for all elements,
- * except for elements that require the use of non public API classes.
- */
 @javax.xml.bind.annotation.XmlSchema(
         namespace = SolverConfig.XML_NAMESPACE,
         elementFormDefault = XmlNsForm.QUALIFIED)
-package org.optaplanner.core.config;
+package org.optaplanner.core.config.heuristic.selector;
 
 import javax.xml.bind.annotation.XmlNsForm;
 

--- a/optaplanner-core/src/main/java/org/optaplanner/core/config/heuristic/selector/value/chained/package-info.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/config/heuristic/selector/value/chained/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,17 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-/**
- * Classes which represent the XML Solver configuration of OptaPlanner.
- * <p>
- * The XML Solver configuration is backwards compatible for all elements,
- * except for elements that require the use of non public API classes.
- */
 @javax.xml.bind.annotation.XmlSchema(
         namespace = SolverConfig.XML_NAMESPACE,
         elementFormDefault = XmlNsForm.QUALIFIED)
-package org.optaplanner.core.config;
+package org.optaplanner.core.config.heuristic.selector.value.chained;
 
 import javax.xml.bind.annotation.XmlNsForm;
 

--- a/optaplanner-core/src/main/java/org/optaplanner/core/config/heuristic/selector/value/package-info.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/config/heuristic/selector/value/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,17 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-/**
- * Classes which represent the XML Solver configuration of OptaPlanner.
- * <p>
- * The XML Solver configuration is backwards compatible for all elements,
- * except for elements that require the use of non public API classes.
- */
 @javax.xml.bind.annotation.XmlSchema(
         namespace = SolverConfig.XML_NAMESPACE,
         elementFormDefault = XmlNsForm.QUALIFIED)
-package org.optaplanner.core.config;
+package org.optaplanner.core.config.heuristic.selector.value;
 
 import javax.xml.bind.annotation.XmlNsForm;
 

--- a/optaplanner-core/src/main/java/org/optaplanner/core/config/localsearch/decider/acceptor/package-info.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/config/localsearch/decider/acceptor/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,17 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-/**
- * Classes which represent the XML Solver configuration of OptaPlanner.
- * <p>
- * The XML Solver configuration is backwards compatible for all elements,
- * except for elements that require the use of non public API classes.
- */
 @javax.xml.bind.annotation.XmlSchema(
         namespace = SolverConfig.XML_NAMESPACE,
         elementFormDefault = XmlNsForm.QUALIFIED)
-package org.optaplanner.core.config;
+package org.optaplanner.core.config.localsearch.decider.acceptor;
 
 import javax.xml.bind.annotation.XmlNsForm;
 

--- a/optaplanner-core/src/main/java/org/optaplanner/core/config/localsearch/decider/acceptor/stepcountinghillclimbing/package-info.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/config/localsearch/decider/acceptor/stepcountinghillclimbing/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,17 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-/**
- * Classes which represent the XML Solver configuration of OptaPlanner.
- * <p>
- * The XML Solver configuration is backwards compatible for all elements,
- * except for elements that require the use of non public API classes.
- */
 @javax.xml.bind.annotation.XmlSchema(
         namespace = SolverConfig.XML_NAMESPACE,
         elementFormDefault = XmlNsForm.QUALIFIED)
-package org.optaplanner.core.config;
+package org.optaplanner.core.config.localsearch.decider.acceptor.stepcountinghillclimbing;
 
 import javax.xml.bind.annotation.XmlNsForm;
 

--- a/optaplanner-core/src/main/java/org/optaplanner/core/config/localsearch/decider/forager/package-info.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/config/localsearch/decider/forager/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,17 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-/**
- * Classes which represent the XML Solver configuration of OptaPlanner.
- * <p>
- * The XML Solver configuration is backwards compatible for all elements,
- * except for elements that require the use of non public API classes.
- */
 @javax.xml.bind.annotation.XmlSchema(
         namespace = SolverConfig.XML_NAMESPACE,
         elementFormDefault = XmlNsForm.QUALIFIED)
-package org.optaplanner.core.config;
+package org.optaplanner.core.config.localsearch.decider.forager;
 
 import javax.xml.bind.annotation.XmlNsForm;
 

--- a/optaplanner-core/src/main/java/org/optaplanner/core/config/localsearch/package-info.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/config/localsearch/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,17 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-/**
- * Classes which represent the XML Solver configuration of OptaPlanner.
- * <p>
- * The XML Solver configuration is backwards compatible for all elements,
- * except for elements that require the use of non public API classes.
- */
 @javax.xml.bind.annotation.XmlSchema(
         namespace = SolverConfig.XML_NAMESPACE,
         elementFormDefault = XmlNsForm.QUALIFIED)
-package org.optaplanner.core.config;
+package org.optaplanner.core.config.localsearch;
 
 import javax.xml.bind.annotation.XmlNsForm;
 

--- a/optaplanner-core/src/main/java/org/optaplanner/core/config/partitionedsearch/package-info.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/config/partitionedsearch/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,17 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-/**
- * Classes which represent the XML Solver configuration of OptaPlanner.
- * <p>
- * The XML Solver configuration is backwards compatible for all elements,
- * except for elements that require the use of non public API classes.
- */
 @javax.xml.bind.annotation.XmlSchema(
         namespace = SolverConfig.XML_NAMESPACE,
         elementFormDefault = XmlNsForm.QUALIFIED)
-package org.optaplanner.core.config;
+package org.optaplanner.core.config.partitionedsearch;
 
 import javax.xml.bind.annotation.XmlNsForm;
 

--- a/optaplanner-core/src/main/java/org/optaplanner/core/config/phase/custom/package-info.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/config/phase/custom/package-info.java
@@ -14,23 +14,15 @@
  * limitations under the License.
  */
 
-package org.optaplanner.core.impl.io;
+/**
+ * The {@link org.optaplanner.core.api.score.stream.ConstraintStream} API:
+ * a way to define constraints for {@link org.optaplanner.core.api.score.Score} calculation.
+ */
+@javax.xml.bind.annotation.XmlSchema(
+        namespace = SolverConfig.XML_NAMESPACE,
+        elementFormDefault = XmlNsForm.QUALIFIED)
+package org.optaplanner.core.config.phase.custom;
 
-public class XmlUnmarshallingException extends RuntimeException {
+import javax.xml.bind.annotation.XmlNsForm;
 
-    public XmlUnmarshallingException() {
-        super();
-    }
-
-    public XmlUnmarshallingException(String message) {
-        super(message);
-    }
-
-    public XmlUnmarshallingException(String message, Throwable cause) {
-        super(message, cause);
-    }
-
-    public XmlUnmarshallingException(Throwable cause) {
-        super(cause);
-    }
-}
+import org.optaplanner.core.config.solver.SolverConfig;

--- a/optaplanner-core/src/main/java/org/optaplanner/core/config/phase/package-info.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/config/phase/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,17 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-/**
- * Classes which represent the XML Solver configuration of OptaPlanner.
- * <p>
- * The XML Solver configuration is backwards compatible for all elements,
- * except for elements that require the use of non public API classes.
- */
 @javax.xml.bind.annotation.XmlSchema(
         namespace = SolverConfig.XML_NAMESPACE,
         elementFormDefault = XmlNsForm.QUALIFIED)
-package org.optaplanner.core.config;
+package org.optaplanner.core.config.phase;
 
 import javax.xml.bind.annotation.XmlNsForm;
 

--- a/optaplanner-core/src/main/java/org/optaplanner/core/config/score/definition/package-info.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/config/score/definition/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,17 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-/**
- * Classes which represent the XML Solver configuration of OptaPlanner.
- * <p>
- * The XML Solver configuration is backwards compatible for all elements,
- * except for elements that require the use of non public API classes.
- */
 @javax.xml.bind.annotation.XmlSchema(
         namespace = SolverConfig.XML_NAMESPACE,
         elementFormDefault = XmlNsForm.QUALIFIED)
-package org.optaplanner.core.config;
+package org.optaplanner.core.config.score.definition;
 
 import javax.xml.bind.annotation.XmlNsForm;
 

--- a/optaplanner-core/src/main/java/org/optaplanner/core/config/score/director/package-info.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/config/score/director/package-info.java
@@ -23,7 +23,7 @@
 @javax.xml.bind.annotation.XmlSchema(
         namespace = SolverConfig.XML_NAMESPACE,
         elementFormDefault = XmlNsForm.QUALIFIED)
-package org.optaplanner.core.config;
+package org.optaplanner.core.config.score.director;
 
 import javax.xml.bind.annotation.XmlNsForm;
 

--- a/optaplanner-core/src/main/java/org/optaplanner/core/config/score/trend/package-info.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/config/score/trend/package-info.java
@@ -23,7 +23,7 @@
 @javax.xml.bind.annotation.XmlSchema(
         namespace = SolverConfig.XML_NAMESPACE,
         elementFormDefault = XmlNsForm.QUALIFIED)
-package org.optaplanner.core.config;
+package org.optaplanner.core.config.score.trend;
 
 import javax.xml.bind.annotation.XmlNsForm;
 

--- a/optaplanner-core/src/main/java/org/optaplanner/core/config/solver/SolverConfig.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/config/solver/SolverConfig.java
@@ -55,8 +55,8 @@ import org.optaplanner.core.config.solver.termination.TerminationConfig;
 import org.optaplanner.core.config.util.ConfigUtils;
 import org.optaplanner.core.impl.domain.solution.descriptor.SolutionDescriptor;
 import org.optaplanner.core.impl.heuristic.HeuristicConfigPolicy;
-import org.optaplanner.core.impl.io.XmlUnmarshallingException;
-import org.optaplanner.core.impl.io.jaxb.JaxbIO;
+import org.optaplanner.core.impl.io.OptaPlannerXmlSerializationException;
+import org.optaplanner.core.impl.io.jaxb.SolverConfigIO;
 import org.optaplanner.core.impl.phase.Phase;
 import org.optaplanner.core.impl.score.director.InnerScoreDirectorFactory;
 import org.optaplanner.core.impl.solver.DefaultSolver;
@@ -73,8 +73,11 @@ import org.slf4j.LoggerFactory;
  * To read it from XML, use {@link #createFromXmlResource(String)}.
  * To build a {@link SolverFactory} with it, use {@link SolverFactory#create(SolverConfig)}.
  */
-@XmlRootElement(name = "solver")
+@XmlRootElement(name = SolverConfig.XML_ELEMENT_NAME)
 public class SolverConfig extends AbstractConfig<SolverConfig> {
+
+    public static final String XML_ELEMENT_NAME = "solver";
+    public static final String XML_NAMESPACE = "https://www.optaplanner.org/xsd/solver";
 
     /**
      * Reads an XML solver configuration from the classpath.
@@ -110,7 +113,7 @@ public class SolverConfig extends AbstractConfig<SolverConfig> {
                 throw new IllegalArgumentException(errorMessage);
             }
             return createFromXmlInputStream(in, classLoader);
-        } catch (XmlUnmarshallingException e) {
+        } catch (OptaPlannerXmlSerializationException e) {
             throw new IllegalArgumentException("Unmarshalling of solverConfigResource (" + solverConfigResource + ") fails.",
                     e);
         } catch (IOException e) {
@@ -192,8 +195,8 @@ public class SolverConfig extends AbstractConfig<SolverConfig> {
      * @return never null
      */
     public static SolverConfig createFromXmlReader(Reader reader, ClassLoader classLoader) {
-        JaxbIO<?> xmlIO = new JaxbIO<>(SolverConfig.class);
-        Object solverConfigObject = xmlIO.read(reader);
+        SolverConfigIO solverConfigIO = new SolverConfigIO();
+        Object solverConfigObject = solverConfigIO.read(reader);
 
         if (!(solverConfigObject instanceof SolverConfig)) {
             throw new IllegalArgumentException("The " + SolverConfig.class.getSimpleName()

--- a/optaplanner-core/src/main/java/org/optaplanner/core/config/solver/package-info.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/config/solver/package-info.java
@@ -23,8 +23,6 @@
 @javax.xml.bind.annotation.XmlSchema(
         namespace = SolverConfig.XML_NAMESPACE,
         elementFormDefault = XmlNsForm.QUALIFIED)
-package org.optaplanner.core.config;
+package org.optaplanner.core.config.solver;
 
 import javax.xml.bind.annotation.XmlNsForm;
-
-import org.optaplanner.core.config.solver.SolverConfig;

--- a/optaplanner-core/src/main/java/org/optaplanner/core/config/solver/random/package-info.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/config/solver/random/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,17 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-/**
- * Classes which represent the XML Solver configuration of OptaPlanner.
- * <p>
- * The XML Solver configuration is backwards compatible for all elements,
- * except for elements that require the use of non public API classes.
- */
 @javax.xml.bind.annotation.XmlSchema(
         namespace = SolverConfig.XML_NAMESPACE,
         elementFormDefault = XmlNsForm.QUALIFIED)
-package org.optaplanner.core.config;
+package org.optaplanner.core.config.solver.random;
 
 import javax.xml.bind.annotation.XmlNsForm;
 

--- a/optaplanner-core/src/main/java/org/optaplanner/core/config/solver/recaller/BestSolutionRecallerConfig.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/config/solver/recaller/BestSolutionRecallerConfig.java
@@ -16,11 +16,14 @@
 
 package org.optaplanner.core.config.solver.recaller;
 
+import javax.xml.bind.annotation.XmlTransient;
+
 import org.optaplanner.core.config.AbstractConfig;
 import org.optaplanner.core.config.solver.EnvironmentMode;
 import org.optaplanner.core.impl.solver.recaller.BestSolutionRecaller;
 
-// Currently not yet supported as being nested, so no XStreamAlias
+// Currently not yet supported as being nested, so no XML (de)serialization.
+@XmlTransient // To omit the type in XSD generation.
 public class BestSolutionRecallerConfig extends AbstractConfig<BestSolutionRecallerConfig> {
 
     // ************************************************************************

--- a/optaplanner-core/src/main/java/org/optaplanner/core/config/solver/termination/package-info.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/config/solver/termination/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,17 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-/**
- * Classes which represent the XML Solver configuration of OptaPlanner.
- * <p>
- * The XML Solver configuration is backwards compatible for all elements,
- * except for elements that require the use of non public API classes.
- */
 @javax.xml.bind.annotation.XmlSchema(
         namespace = SolverConfig.XML_NAMESPACE,
         elementFormDefault = XmlNsForm.QUALIFIED)
-package org.optaplanner.core.config;
+package org.optaplanner.core.config.solver.termination;
 
 import javax.xml.bind.annotation.XmlNsForm;
 

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/io/OptaPlannerXmlSerializationException.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/io/OptaPlannerXmlSerializationException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,17 +14,23 @@
  * limitations under the License.
  */
 
-/**
- * Classes which represent the XML Solver configuration of OptaPlanner.
- * <p>
- * The XML Solver configuration is backwards compatible for all elements,
- * except for elements that require the use of non public API classes.
- */
-@javax.xml.bind.annotation.XmlSchema(
-        namespace = SolverConfig.XML_NAMESPACE,
-        elementFormDefault = XmlNsForm.QUALIFIED)
-package org.optaplanner.core.config;
+package org.optaplanner.core.impl.io;
 
-import javax.xml.bind.annotation.XmlNsForm;
+public class OptaPlannerXmlSerializationException extends RuntimeException {
 
-import org.optaplanner.core.config.solver.SolverConfig;
+    public OptaPlannerXmlSerializationException() {
+        super();
+    }
+
+    public OptaPlannerXmlSerializationException(String message) {
+        super(message);
+    }
+
+    public OptaPlannerXmlSerializationException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public OptaPlannerXmlSerializationException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/io/jaxb/ElementNamespaceOverride.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/io/jaxb/ElementNamespaceOverride.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.core.impl.io.jaxb;
+
+public class ElementNamespaceOverride {
+
+    public static ElementNamespaceOverride of(String elementLocalName, String namespaceOverride) {
+        return new ElementNamespaceOverride(elementLocalName, namespaceOverride);
+    }
+
+    private final String elementLocalName;
+    private final String namespaceOverride;
+
+    private ElementNamespaceOverride(String elementLocalName, String namespaceOverride) {
+        this.elementLocalName = elementLocalName;
+        this.namespaceOverride = namespaceOverride;
+    }
+
+    public String getElementLocalName() {
+        return elementLocalName;
+    }
+
+    public String getNamespaceOverride() {
+        return namespaceOverride;
+    }
+
+    @Override
+    public String toString() {
+        return "ElementNamespaceOverride{" +
+                "elementLocalName='" + elementLocalName + '\'' +
+                ", namespaceOverride='" + namespaceOverride + '\'' +
+                '}';
+    }
+}

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/io/jaxb/JaxbCustomPropertiesAdapter.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/io/jaxb/JaxbCustomPropertiesAdapter.java
@@ -22,7 +22,10 @@ import java.util.stream.Collectors;
 
 import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlType;
 import javax.xml.bind.annotation.adapters.XmlAdapter;
+
+import org.optaplanner.core.config.solver.SolverConfig;
 
 public class JaxbCustomPropertiesAdapter extends XmlAdapter<JaxbCustomPropertiesAdapter.JaxbAdaptedMap, Map<String, String>> {
 
@@ -46,9 +49,11 @@ public class JaxbCustomPropertiesAdapter extends XmlAdapter<JaxbCustomProperties
         return new JaxbAdaptedMap(entries);
     }
 
+    // Required to generate the XSD type in the same namespace.
+    @XmlType(namespace = SolverConfig.XML_NAMESPACE)
     static class JaxbAdaptedMap {
 
-        @XmlElement(name = "property")
+        @XmlElement(name = "property", namespace = SolverConfig.XML_NAMESPACE)
         private List<JaxbAdaptedMapEntry> entries;
 
         private JaxbAdaptedMap() {
@@ -60,7 +65,9 @@ public class JaxbCustomPropertiesAdapter extends XmlAdapter<JaxbCustomProperties
         }
     }
 
-    private static class JaxbAdaptedMapEntry {
+    // Required to generate the XSD type in the same namespace.
+    @XmlType(namespace = SolverConfig.XML_NAMESPACE)
+    static class JaxbAdaptedMapEntry {
 
         @XmlAttribute
         private String name;

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/io/jaxb/JaxbIO.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/io/jaxb/JaxbIO.java
@@ -102,13 +102,13 @@ public final class JaxbIO<T> {
 
     public T readAndValidate(Reader reader, String schemaResource) {
         Objects.requireNonNull(reader);
-        Objects.requireNonNull(schemaResource);
+        String nonNullSchemaResource = Objects.requireNonNull(schemaResource);
         SchemaFactory schemaFactory = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
         Schema schema;
         try {
-            schema = schemaFactory.newSchema(JaxbIO.class.getResource(schemaResource));
+            schema = schemaFactory.newSchema(JaxbIO.class.getResource(nonNullSchemaResource));
         } catch (SAXException e) {
-            throw new IllegalArgumentException("Unable to read input schema resource (" + schemaResource + ")", e);
+            throw new IllegalArgumentException("Unable to read input schema resource (" + nonNullSchemaResource + ")", e);
         }
 
         Unmarshaller unmarshaller = createUnmarshaller();

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/io/jaxb/JaxbIO.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/io/jaxb/JaxbIO.java
@@ -16,29 +16,56 @@
 
 package org.optaplanner.core.impl.io.jaxb;
 
+import java.io.IOException;
+import java.io.InputStream;
 import java.io.Reader;
 import java.io.Writer;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayDeque;
+import java.util.Arrays;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 
+import javax.xml.XMLConstants;
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBException;
 import javax.xml.bind.Marshaller;
 import javax.xml.bind.Unmarshaller;
+import javax.xml.bind.UnmarshallerHandler;
+import javax.xml.bind.ValidationEvent;
+import javax.xml.bind.util.ValidationEventCollector;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.parsers.SAXParser;
+import javax.xml.parsers.SAXParserFactory;
 import javax.xml.transform.OutputKeys;
+import javax.xml.transform.Source;
 import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerException;
 import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.dom.DOMResult;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
+import javax.xml.transform.stream.StreamSource;
+import javax.xml.validation.Schema;
+import javax.xml.validation.SchemaFactory;
 
-import org.optaplanner.core.impl.io.XmlUnmarshallingException;
+import org.optaplanner.core.impl.io.OptaPlannerXmlSerializationException;
+import org.xml.sax.Attributes;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
+import org.xml.sax.XMLFilter;
+import org.xml.sax.XMLReader;
+import org.xml.sax.helpers.XMLFilterImpl;
 
 public final class JaxbIO<T> {
     private static final int DEFAULT_INDENTATION = 2;
 
-    private final Unmarshaller unmarshaller;
+    private static final String ERR_MSG_WRITE = "Unable to write the %s to XML.";
+    private static final String ERR_MSG_READ = "Unable to read the (%s) from XML.";
+
+    private final JAXBContext jaxbContext;
     private final Marshaller marshaller;
     private final Class<T> rootClass;
     private final int indentation;
@@ -52,25 +79,125 @@ public final class JaxbIO<T> {
         this.rootClass = rootClass;
         this.indentation = indentation;
         try {
-            JAXBContext jaxbContext = JAXBContext.newInstance(rootClass);
-            unmarshaller = jaxbContext.createUnmarshaller();
+            jaxbContext = JAXBContext.newInstance(rootClass);
             marshaller = jaxbContext.createMarshaller();
             marshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, true);
             marshaller.setProperty(Marshaller.JAXB_ENCODING, StandardCharsets.UTF_8.toString());
         } catch (JAXBException jaxbException) {
-            String errMessage = String.format("Unable to create JAXB marshaller or unmarshaller for a root element class %s.",
+            String errMessage = String.format("Unable to create JAXB Marshaller for a root element class (%s).",
                     rootClass.getName());
-            throw new IllegalStateException(errMessage, jaxbException);
+            throw new OptaPlannerXmlSerializationException(errMessage, jaxbException);
         }
     }
 
     public T read(Reader reader) {
         Objects.requireNonNull(reader);
         try {
-            return (T) unmarshaller.unmarshal(reader);
+            @SuppressWarnings("unchecked")
+            final T object = (T) createUnmarshaller().unmarshal(reader);
+            return object;
         } catch (JAXBException jaxbException) {
-            String errMessage = String.format("Unable to read the %s from XML.", rootClass.getName());
-            throw new XmlUnmarshallingException(errMessage, jaxbException);
+            String errMessage = String.format(ERR_MSG_READ, rootClass.getName());
+            throw new OptaPlannerXmlSerializationException(errMessage, jaxbException);
+        }
+    }
+
+    public T readAndValidate(Reader reader, String schemaResource) {
+        Objects.requireNonNull(reader);
+        Objects.requireNonNull(schemaResource);
+        SchemaFactory schemaFactory = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
+        Schema schema;
+        try {
+            schema = schemaFactory.newSchema(JaxbIO.class.getResource(schemaResource));
+        } catch (SAXException e) {
+            throw new IllegalArgumentException("Unable to read input schema resource (" + schemaResource + ")", e);
+        }
+
+        Unmarshaller unmarshaller = createUnmarshaller();
+        unmarshaller.setSchema(schema);
+        ValidationEventStringCollector validationEventHandler = new ValidationEventStringCollector();
+
+        try {
+            unmarshaller.setEventHandler(validationEventHandler);
+        } catch (JAXBException jaxbException) {
+            String errMessage = String.format("Unable to set validation event handler to the unmarshaller for "
+                    + "a root element class (%s).", rootClass.getName());
+            throw new OptaPlannerXmlSerializationException(errMessage, jaxbException);
+        }
+
+        try {
+            @SuppressWarnings("unchecked")
+            final T object = (T) unmarshaller.unmarshal(reader);
+            return object;
+        } catch (JAXBException jaxbException) {
+            String errMessage = String.format(ERR_MSG_READ, rootClass.getName());
+            if (validationEventHandler.hasEvents()) {
+                String errMessageWithValidationEvents = errMessage + "\n" + validationEventHandler.reportAll();
+                throw new OptaPlannerXmlSerializationException(errMessageWithValidationEvents, jaxbException);
+            } else {
+                throw new OptaPlannerXmlSerializationException(errMessage, jaxbException);
+            }
+        }
+    }
+
+    private Unmarshaller createUnmarshaller() {
+        try {
+            return jaxbContext.createUnmarshaller();
+        } catch (JAXBException e) {
+            String errMessage = String.format("Unable to create JAXB unmarshaller for a root element class (%s).",
+                    rootClass.getName());
+            throw new OptaPlannerXmlSerializationException(errMessage, e);
+        }
+    }
+
+    // TODO: provide JavaDoc
+    public T readOverridingNamespace(Reader reader, ElementNamespaceOverride... elementNamespaceOverrides) {
+        Objects.requireNonNull(reader);
+        Objects.requireNonNull(elementNamespaceOverrides);
+
+        final String errMessage = String.format("Unable to read the (%s) from XML with overriding elements' namespaces: %s.",
+                rootClass.getName(), Arrays.toString(elementNamespaceOverrides));
+
+        // Create a SAXParser to use its XMLReader on the XMLFilter
+        SAXParserFactory saxParserFactory = SAXParserFactory.newInstance();
+        SAXParser saxParser;
+        try {
+            // Protect the parser against the XXE attack
+            // https://owasp.org/www-project-top-ten/OWASP_Top_Ten_2017/Top_10-2017_A4-XML_External_Entities_(XXE)
+            saxParserFactory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+            saxParser = saxParserFactory.newSAXParser();
+        } catch (ParserConfigurationException | SAXException e) {
+            throw new OptaPlannerXmlSerializationException(errMessage, e);
+        }
+        XMLReader xmlReader;
+        try {
+            xmlReader = saxParser.getXMLReader();
+        } catch (SAXException e) {
+            throw new OptaPlannerXmlSerializationException(errMessage, e);
+        }
+
+        XMLFilter namespaceOverridingXmlFilter = new NamespaceOverridingXmlFilter(xmlReader, elementNamespaceOverrides);
+        namespaceOverridingXmlFilter.setParent(xmlReader);
+
+        // Use UnmarshallerHandler as a content handler for the XML filter.
+        Unmarshaller unmarshaller = createUnmarshaller();
+        UnmarshallerHandler unmarshallerHandler = unmarshaller.getUnmarshallerHandler();
+        namespaceOverridingXmlFilter.setContentHandler(unmarshallerHandler);
+
+        InputSource xmlInputSource = new InputSource(reader);
+        try {
+            // Parse the XML to feed its content into the UnmarshallerHandler.
+            namespaceOverridingXmlFilter.parse(xmlInputSource);
+        } catch (IOException | SAXException e) {
+            throw new OptaPlannerXmlSerializationException(errMessage, e);
+        }
+
+        try {
+            @SuppressWarnings("unchecked")
+            final T object = (T) unmarshallerHandler.getResult();
+            return object;
+        } catch (JAXBException e) {
+            throw new OptaPlannerXmlSerializationException(errMessage, e);
         }
     }
 
@@ -81,12 +208,32 @@ public final class JaxbIO<T> {
         try {
             marshaller.marshal(root, domResult);
         } catch (JAXBException jaxbException) {
-            String errMessage = String.format("Unable to marshall the %s to XML.", rootClass.getName());
-            throw new IllegalStateException(errMessage, jaxbException);
+            String errMessage = String.format(ERR_MSG_WRITE, rootClass.getName());
+            throw new OptaPlannerXmlSerializationException(errMessage, jaxbException);
         }
 
-        // See https://stackoverflow.com/questions/46708498/jaxb-marshaller-indentation.
+        formatXml(new DOMSource(domResult.getNode()), null, writer);
+    }
 
+    public void writeWithoutNamespaces(T root, Writer writer) {
+        Objects.requireNonNull(root);
+        Objects.requireNonNull(writer);
+        DOMResult domResult = new DOMResult();
+        final String errMessage = String.format(ERR_MSG_WRITE, rootClass.getName());
+        try {
+            marshaller.marshal(root, domResult);
+        } catch (JAXBException jaxbException) {
+            throw new OptaPlannerXmlSerializationException(errMessage, jaxbException);
+        }
+
+        try (InputStream xsltInputStream = getClass().getResourceAsStream("removeNamespaces.xslt")) {
+            formatXml(new DOMSource(domResult.getNode()), new StreamSource(xsltInputStream), writer);
+        } catch (IOException e) {
+            throw new OptaPlannerXmlSerializationException(errMessage, e);
+        }
+    }
+
+    private void formatXml(Source source, Source transformationTemplate, Writer writer) {
         /*
          * The code is not vulnerable to XXE-based attacks as it does not process any external XML nor XSL input.
          * Should the transformerFactory be used for such purposes, it has to be appropriately secured:
@@ -95,15 +242,73 @@ public final class JaxbIO<T> {
         @SuppressWarnings({ "java:S2755", "java:S4435" })
         TransformerFactory transformerFactory = TransformerFactory.newInstance();
         try {
-
-            Transformer transformer = transformerFactory.newTransformer();
+            Transformer transformer = transformationTemplate == null ? transformerFactory.newTransformer()
+                    : transformerFactory.newTransformer(transformationTemplate);
+            // See https://stackoverflow.com/questions/46708498/jaxb-marshaller-indentation.
             transformer.setOutputProperty(OutputKeys.INDENT, "yes");
             transformer.setOutputProperty("{http://xml.apache.org/xslt}indent-amount", String.valueOf(indentation));
-
-            transformer.transform(new DOMSource(domResult.getNode()), new StreamResult(writer));
+            transformer.transform(source, new StreamResult(writer));
         } catch (TransformerException transformerException) {
-            String errMessage = String.format("Unable to format %s XML.", rootClass.getName());
-            throw new IllegalStateException(errMessage, transformerException);
+            String errMessage = String.format(ERR_MSG_WRITE, rootClass.getName());
+            throw new OptaPlannerXmlSerializationException(errMessage, transformerException);
+        }
+    }
+
+    /**
+     * Overrides namespace of every XML element by the namespace.
+     */
+    private static class NamespaceOverridingXmlFilter extends XMLFilterImpl {
+
+        private final Deque<String> activeNamespace = new ArrayDeque<>();
+        private final Map<String, String> elementNamespaceOverridesMap = new HashMap<>();
+
+        public NamespaceOverridingXmlFilter(XMLReader xmlReader, ElementNamespaceOverride... elementNamespaceOverrides) {
+            super(xmlReader);
+            Objects.requireNonNull(elementNamespaceOverrides);
+            for (ElementNamespaceOverride namespaceOverride : elementNamespaceOverrides) {
+                elementNamespaceOverridesMap.put(namespaceOverride.getElementLocalName(),
+                        namespaceOverride.getNamespaceOverride());
+            }
+        }
+
+        @Override
+        public void endElement(String uri, String localName, String qName) throws SAXException {
+            String resultingUri = activeNamespace.isEmpty() ? uri : activeNamespace.peek();
+            if (elementNamespaceOverridesMap.containsKey(qName)) {
+                activeNamespace.pop();
+            }
+            super.endElement(resultingUri, localName, qName);
+        }
+
+        @Override
+        public void startElement(String uri, String localName, String qName, Attributes atts) throws SAXException {
+            String namespaceOverride = elementNamespaceOverridesMap.get(qName);
+            if (namespaceOverride != null) {
+                activeNamespace.push(namespaceOverride);
+            }
+
+            String resultingUri = activeNamespace.isEmpty() ? uri : activeNamespace.peek();
+            super.startElement(resultingUri, localName, qName, atts);
+        }
+
+    }
+
+    private static final class ValidationEventStringCollector extends ValidationEventCollector {
+
+        /**
+         * Reports all validation events in a single string.
+         *
+         * @return string containing all validation events separated by {@link Character#LINE_SEPARATOR}
+         */
+        public String reportAll() {
+            final StringBuilder validationEvents = new StringBuilder();
+
+            for (ValidationEvent event : this.getEvents()) {
+                validationEvents
+                        .append(event.getMessage())
+                        .append(Character.LINE_SEPARATOR);
+            }
+            return validationEvents.toString();
         }
     }
 }

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/io/jaxb/JaxbIO.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/io/jaxb/JaxbIO.java
@@ -93,9 +93,7 @@ public final class JaxbIO<T> {
     public T read(Reader reader) {
         Objects.requireNonNull(reader);
         try {
-            @SuppressWarnings("unchecked")
-            final T object = (T) createUnmarshaller().unmarshal(reader);
-            return object;
+            return (T) createUnmarshaller().unmarshal(reader);
         } catch (JAXBException jaxbException) {
             String errMessage = String.format(ERR_MSG_READ, rootClass.getName());
             throw new OptaPlannerXmlSerializationException(errMessage, jaxbException);
@@ -126,9 +124,7 @@ public final class JaxbIO<T> {
         }
 
         try {
-            @SuppressWarnings("unchecked")
-            final T object = (T) unmarshaller.unmarshal(reader);
-            return object;
+            return (T) unmarshaller.unmarshal(reader);
         } catch (JAXBException jaxbException) {
             String errMessage = String.format(ERR_MSG_READ, rootClass.getName());
             if (validationEventHandler.hasEvents()) {
@@ -193,9 +189,7 @@ public final class JaxbIO<T> {
         }
 
         try {
-            @SuppressWarnings("unchecked")
-            final T object = (T) unmarshallerHandler.getResult();
-            return object;
+            return (T) unmarshallerHandler.getResult();
         } catch (JAXBException e) {
             throw new OptaPlannerXmlSerializationException(errMessage, e);
         }

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/io/jaxb/SolverConfigIO.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/io/jaxb/SolverConfigIO.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *  
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *  
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *  
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.core.impl.io.jaxb;
+
+import java.io.Reader;
+import java.io.Writer;
+
+import org.optaplanner.core.config.solver.SolverConfig;
+
+public class SolverConfigIO {
+
+    private final JaxbIO<SolverConfig> jaxbIO = new JaxbIO<>(SolverConfig.class);
+
+    public SolverConfig read(Reader reader) {
+        return jaxbIO.readOverridingNamespace(reader,
+                ElementNamespaceOverride.of(SolverConfig.XML_ELEMENT_NAME, SolverConfig.XML_NAMESPACE));
+    }
+
+    public void write(SolverConfig solverConfig, Writer writer) {
+        jaxbIO.writeWithoutNamespaces(solverConfig, writer);
+    }
+}

--- a/optaplanner-core/src/main/resources/org/optaplanner/core/impl/io/jaxb/removeNamespaces.xslt
+++ b/optaplanner-core/src/main/resources/org/optaplanner/core/impl/io/jaxb/removeNamespaces.xslt
@@ -1,0 +1,38 @@
+<!--
+  ~ Copyright 2020 Red Hat, Inc. and/or its affiliates.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  <xsl:output indent="yes" method="xml" encoding="utf-8"/>
+
+  <!-- Copy element's local name (ignoring namespace) and apply templates on its content and attributes. -->
+  <xsl:template match="*">
+    <xsl:element name="{local-name()}">
+      <xsl:apply-templates select="@* | node()"/>
+    </xsl:element>
+  </xsl:template>
+
+  <!-- Copy attribute's local name (ignoring namespace) and value. -->
+  <xsl:template match="@*">
+    <xsl:attribute name="{local-name()}">
+      <xsl:value-of select="."/>
+    </xsl:attribute>
+  </xsl:template>
+
+  <!-- Copy everything else. -->
+  <xsl:template match="comment() | text() | processing-instruction()">
+    <xsl:copy/>
+  </xsl:template>
+
+</xsl:stylesheet>

--- a/optaplanner-core/src/main/resources/solver.xsd
+++ b/optaplanner-core/src/main/resources/solver.xsd
@@ -1,0 +1,1622 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:tns="https://www.optaplanner.org/xsd/solver" elementFormDefault="qualified" targetNamespace="https://www.optaplanner.org/xsd/solver" version="1.0">
+    
+  <xs:element name="solver" type="tns:solverConfig"/>
+    
+  <xs:complexType name="solverConfig">
+        
+    <xs:complexContent>
+            
+      <xs:extension base="tns:abstractConfig">
+                
+        <xs:sequence>
+                    
+          <xs:element minOccurs="0" name="environmentMode" type="tns:environmentMode"/>
+                    
+          <xs:element minOccurs="0" name="daemon" type="xs:boolean"/>
+                    
+          <xs:element minOccurs="0" name="randomType" type="tns:randomType"/>
+                    
+          <xs:element minOccurs="0" name="randomSeed" type="xs:long"/>
+                    
+          <xs:element minOccurs="0" name="randomFactoryClass" type="xs:string"/>
+                    
+          <xs:element minOccurs="0" name="moveThreadCount" type="xs:string"/>
+                    
+          <xs:element minOccurs="0" name="moveThreadBufferSize" type="xs:int"/>
+                    
+          <xs:element minOccurs="0" name="threadFactoryClass" type="xs:string"/>
+                    
+          <xs:element minOccurs="0" name="solutionClass" type="xs:string"/>
+                    
+          <xs:element maxOccurs="unbounded" minOccurs="0" name="entityClass" type="xs:string"/>
+                    
+          <xs:element minOccurs="0" name="scoreDirectorFactory" type="tns:scoreDirectorFactoryConfig"/>
+                    
+          <xs:element minOccurs="0" name="termination" type="tns:terminationConfig"/>
+                    
+          <xs:choice maxOccurs="unbounded" minOccurs="0">
+                        
+            <xs:element name="constructionHeuristic" type="tns:constructionHeuristicPhaseConfig"/>
+                        
+            <xs:element name="customPhase" type="tns:customPhaseConfig"/>
+                        
+            <xs:element name="exhaustiveSearch" type="tns:exhaustiveSearchPhaseConfig"/>
+                        
+            <xs:element name="localSearch" type="tns:localSearchPhaseConfig"/>
+                        
+            <xs:element name="noChangePhase" type="tns:noChangePhaseConfig"/>
+                        
+            <xs:element name="partitionedSearch" type="tns:partitionedSearchPhaseConfig"/>
+                      
+          </xs:choice>
+                  
+        </xs:sequence>
+              
+      </xs:extension>
+          
+    </xs:complexContent>
+      
+  </xs:complexType>
+    
+  <xs:complexType abstract="true" name="abstractConfig">
+        
+    <xs:sequence/>
+      
+  </xs:complexType>
+    
+  <xs:complexType name="scoreDirectorFactoryConfig">
+        
+    <xs:complexContent>
+            
+      <xs:extension base="tns:abstractConfig">
+                
+        <xs:sequence>
+                    
+          <xs:element minOccurs="0" name="easyScoreCalculatorClass" type="xs:string"/>
+                    
+          <xs:element minOccurs="0" name="easyScoreCalculatorCustomProperties" type="tns:jaxbAdaptedMap"/>
+                    
+          <xs:element minOccurs="0" name="constraintProviderClass" type="xs:string"/>
+                    
+          <xs:element minOccurs="0" name="constraintProviderCustomProperties" type="tns:jaxbAdaptedMap"/>
+                    
+          <xs:element minOccurs="0" name="constraintStreamImplType" type="tns:constraintStreamImplType"/>
+                    
+          <xs:element minOccurs="0" name="incrementalScoreCalculatorClass" type="xs:string"/>
+                    
+          <xs:element minOccurs="0" name="incrementalScoreCalculatorCustomProperties" type="tns:jaxbAdaptedMap"/>
+                    
+          <xs:element maxOccurs="unbounded" minOccurs="0" name="scoreDrl" type="xs:string"/>
+                    
+          <xs:element maxOccurs="unbounded" minOccurs="0" name="scoreDrlFile" type="xs:string"/>
+                    
+          <xs:element minOccurs="0" name="kieBaseConfigurationProperties" type="tns:jaxbAdaptedMap"/>
+                    
+          <xs:element minOccurs="0" name="initializingScoreTrend" type="xs:string"/>
+                    
+          <xs:element minOccurs="0" name="assertionScoreDirectorFactory" type="tns:scoreDirectorFactoryConfig"/>
+                  
+        </xs:sequence>
+              
+      </xs:extension>
+          
+    </xs:complexContent>
+      
+  </xs:complexType>
+    
+  <xs:complexType name="jaxbAdaptedMap">
+        
+    <xs:sequence>
+            
+      <xs:element maxOccurs="unbounded" minOccurs="0" name="property" type="tns:jaxbAdaptedMapEntry"/>
+          
+    </xs:sequence>
+      
+  </xs:complexType>
+    
+  <xs:complexType name="jaxbAdaptedMapEntry">
+        
+    <xs:sequence/>
+        
+    <xs:attribute name="name" type="xs:string"/>
+        
+    <xs:attribute name="value" type="xs:string"/>
+      
+  </xs:complexType>
+    
+  <xs:complexType name="terminationConfig">
+        
+    <xs:complexContent>
+            
+      <xs:extension base="tns:abstractConfig">
+                
+        <xs:sequence>
+                    
+          <xs:element minOccurs="0" name="terminationClass" type="xs:string"/>
+                    
+          <xs:element minOccurs="0" name="terminationCompositionStyle" type="tns:terminationCompositionStyle"/>
+                    
+          <xs:element minOccurs="0" name="spentLimit" type="xs:string"/>
+                    
+          <xs:element minOccurs="0" name="millisecondsSpentLimit" type="xs:long"/>
+                    
+          <xs:element minOccurs="0" name="secondsSpentLimit" type="xs:long"/>
+                    
+          <xs:element minOccurs="0" name="minutesSpentLimit" type="xs:long"/>
+                    
+          <xs:element minOccurs="0" name="hoursSpentLimit" type="xs:long"/>
+                    
+          <xs:element minOccurs="0" name="daysSpentLimit" type="xs:long"/>
+                    
+          <xs:element minOccurs="0" name="unimprovedSpentLimit" type="xs:string"/>
+                    
+          <xs:element minOccurs="0" name="unimprovedMillisecondsSpentLimit" type="xs:long"/>
+                    
+          <xs:element minOccurs="0" name="unimprovedSecondsSpentLimit" type="xs:long"/>
+                    
+          <xs:element minOccurs="0" name="unimprovedMinutesSpentLimit" type="xs:long"/>
+                    
+          <xs:element minOccurs="0" name="unimprovedHoursSpentLimit" type="xs:long"/>
+                    
+          <xs:element minOccurs="0" name="unimprovedDaysSpentLimit" type="xs:long"/>
+                    
+          <xs:element minOccurs="0" name="unimprovedScoreDifferenceThreshold" type="xs:string"/>
+                    
+          <xs:element minOccurs="0" name="bestScoreLimit" type="xs:string"/>
+                    
+          <xs:element minOccurs="0" name="bestScoreFeasible" type="xs:boolean"/>
+                    
+          <xs:element minOccurs="0" name="stepCountLimit" type="xs:int"/>
+                    
+          <xs:element minOccurs="0" name="unimprovedStepCountLimit" type="xs:int"/>
+                    
+          <xs:element minOccurs="0" name="scoreCalculationCountLimit" type="xs:long"/>
+                    
+          <xs:element maxOccurs="unbounded" minOccurs="0" name="termination" type="tns:terminationConfig"/>
+                  
+        </xs:sequence>
+              
+      </xs:extension>
+          
+    </xs:complexContent>
+      
+  </xs:complexType>
+    
+  <xs:complexType name="constructionHeuristicPhaseConfig">
+        
+    <xs:complexContent>
+            
+      <xs:extension base="tns:phaseConfig">
+                
+        <xs:sequence>
+                    
+          <xs:element minOccurs="0" name="constructionHeuristicType" type="tns:constructionHeuristicType"/>
+                    
+          <xs:element minOccurs="0" name="entitySorterManner" type="tns:entitySorterManner"/>
+                    
+          <xs:element minOccurs="0" name="valueSorterManner" type="tns:valueSorterManner"/>
+                    
+          <xs:choice minOccurs="0">
+                        
+            <xs:element name="queuedEntityPlacer" type="tns:queuedEntityPlacerConfig"/>
+                        
+            <xs:element name="queuedValuePlacer" type="tns:queuedValuePlacerConfig"/>
+                        
+            <xs:element name="pooledEntityPlacer" type="tns:pooledEntityPlacerConfig"/>
+                      
+          </xs:choice>
+                    
+          <xs:choice maxOccurs="unbounded" minOccurs="0">
+                        
+            <xs:element name="cartesianProductMoveSelector" type="tns:cartesianProductMoveSelectorConfig"/>
+                        
+            <xs:element name="changeMoveSelector" type="tns:changeMoveSelectorConfig"/>
+                        
+            <xs:element name="kOptMoveSelector" type="tns:kOptMoveSelectorConfig"/>
+                        
+            <xs:element name="moveIteratorFactory" type="tns:moveIteratorFactoryConfig"/>
+                        
+            <xs:element name="moveListFactory" type="tns:moveListFactoryConfig"/>
+                        
+            <xs:element name="pillarChangeMoveSelector" type="tns:pillarChangeMoveSelectorConfig"/>
+                        
+            <xs:element name="pillarSwapMoveSelector" type="tns:pillarSwapMoveSelectorConfig"/>
+                        
+            <xs:element name="subChainChangeMoveSelector" type="tns:subChainChangeMoveSelectorConfig"/>
+                        
+            <xs:element name="subChainSwapMoveSelector" type="tns:subChainSwapMoveSelectorConfig"/>
+                        
+            <xs:element name="swapMoveSelector" type="tns:swapMoveSelectorConfig"/>
+                        
+            <xs:element name="tailChainSwapMoveSelector" type="tns:tailChainSwapMoveSelectorConfig"/>
+                        
+            <xs:element name="unionMoveSelector" type="tns:unionMoveSelectorConfig"/>
+                      
+          </xs:choice>
+                    
+          <xs:element minOccurs="0" name="forager" type="tns:constructionHeuristicForagerConfig"/>
+                  
+        </xs:sequence>
+              
+      </xs:extension>
+          
+    </xs:complexContent>
+      
+  </xs:complexType>
+    
+  <xs:complexType abstract="true" name="phaseConfig">
+        
+    <xs:complexContent>
+            
+      <xs:extension base="tns:abstractConfig">
+                
+        <xs:sequence>
+                    
+          <xs:element minOccurs="0" name="termination" type="tns:terminationConfig"/>
+                  
+        </xs:sequence>
+              
+      </xs:extension>
+          
+    </xs:complexContent>
+      
+  </xs:complexType>
+    
+  <xs:complexType name="queuedEntityPlacerConfig">
+        
+    <xs:complexContent>
+            
+      <xs:extension base="tns:entityPlacerConfig">
+                
+        <xs:sequence>
+                    
+          <xs:element minOccurs="0" name="entitySelector" type="tns:entitySelectorConfig"/>
+                    
+          <xs:choice maxOccurs="unbounded" minOccurs="0">
+                        
+            <xs:element name="cartesianProductMoveSelector" type="tns:cartesianProductMoveSelectorConfig"/>
+                        
+            <xs:element name="changeMoveSelector" type="tns:changeMoveSelectorConfig"/>
+                        
+            <xs:element name="kOptMoveSelector" type="tns:kOptMoveSelectorConfig"/>
+                        
+            <xs:element name="moveIteratorFactory" type="tns:moveIteratorFactoryConfig"/>
+                        
+            <xs:element name="moveListFactory" type="tns:moveListFactoryConfig"/>
+                        
+            <xs:element name="pillarChangeMoveSelector" type="tns:pillarChangeMoveSelectorConfig"/>
+                        
+            <xs:element name="pillarSwapMoveSelector" type="tns:pillarSwapMoveSelectorConfig"/>
+                        
+            <xs:element name="subChainChangeMoveSelector" type="tns:subChainChangeMoveSelectorConfig"/>
+                        
+            <xs:element name="subChainSwapMoveSelector" type="tns:subChainSwapMoveSelectorConfig"/>
+                        
+            <xs:element name="swapMoveSelector" type="tns:swapMoveSelectorConfig"/>
+                        
+            <xs:element name="tailChainSwapMoveSelector" type="tns:tailChainSwapMoveSelectorConfig"/>
+                        
+            <xs:element name="unionMoveSelector" type="tns:unionMoveSelectorConfig"/>
+                      
+          </xs:choice>
+                  
+        </xs:sequence>
+              
+      </xs:extension>
+          
+    </xs:complexContent>
+      
+  </xs:complexType>
+    
+  <xs:complexType abstract="true" name="entityPlacerConfig">
+        
+    <xs:complexContent>
+            
+      <xs:extension base="tns:abstractConfig">
+                
+        <xs:sequence/>
+              
+      </xs:extension>
+          
+    </xs:complexContent>
+      
+  </xs:complexType>
+    
+  <xs:complexType name="entitySelectorConfig">
+        
+    <xs:complexContent>
+            
+      <xs:extension base="tns:selectorConfig">
+                
+        <xs:sequence>
+                    
+          <xs:element minOccurs="0" name="entityClass" type="xs:string"/>
+                    
+          <xs:element minOccurs="0" name="cacheType" type="tns:selectionCacheType"/>
+                    
+          <xs:element minOccurs="0" name="selectionOrder" type="tns:selectionOrder"/>
+                    
+          <xs:element minOccurs="0" name="nearbySelection" type="tns:nearbySelectionConfig"/>
+                    
+          <xs:element minOccurs="0" name="filterClass" type="xs:string"/>
+                    
+          <xs:element minOccurs="0" name="sorterManner" type="tns:entitySorterManner"/>
+                    
+          <xs:element minOccurs="0" name="sorterComparatorClass" type="xs:string"/>
+                    
+          <xs:element minOccurs="0" name="sorterWeightFactoryClass" type="xs:string"/>
+                    
+          <xs:element minOccurs="0" name="sorterOrder" type="tns:selectionSorterOrder"/>
+                    
+          <xs:element minOccurs="0" name="sorterClass" type="xs:string"/>
+                    
+          <xs:element minOccurs="0" name="probabilityWeightFactoryClass" type="xs:string"/>
+                    
+          <xs:element minOccurs="0" name="selectedCountLimit" type="xs:long"/>
+                  
+        </xs:sequence>
+                
+        <xs:attribute name="id" type="xs:string"/>
+                
+        <xs:attribute name="mimicSelectorRef" type="xs:string"/>
+              
+      </xs:extension>
+          
+    </xs:complexContent>
+      
+  </xs:complexType>
+    
+  <xs:complexType abstract="true" name="selectorConfig">
+        
+    <xs:complexContent>
+            
+      <xs:extension base="tns:abstractConfig">
+                
+        <xs:sequence/>
+              
+      </xs:extension>
+          
+    </xs:complexContent>
+      
+  </xs:complexType>
+    
+  <xs:complexType name="nearbySelectionConfig">
+        
+    <xs:complexContent>
+            
+      <xs:extension base="tns:selectorConfig">
+                
+        <xs:sequence>
+                    
+          <xs:element minOccurs="0" name="originEntitySelector" type="tns:entitySelectorConfig"/>
+                    
+          <xs:element minOccurs="0" name="nearbyDistanceMeterClass" type="xs:string"/>
+                    
+          <xs:element minOccurs="0" name="nearbySelectionDistributionType" type="tns:nearbySelectionDistributionType"/>
+                    
+          <xs:element minOccurs="0" name="blockDistributionSizeMinimum" type="xs:int"/>
+                    
+          <xs:element minOccurs="0" name="blockDistributionSizeMaximum" type="xs:int"/>
+                    
+          <xs:element minOccurs="0" name="blockDistributionSizeRatio" type="xs:double"/>
+                    
+          <xs:element minOccurs="0" name="blockDistributionUniformDistributionProbability" type="xs:double"/>
+                    
+          <xs:element minOccurs="0" name="linearDistributionSizeMaximum" type="xs:int"/>
+                    
+          <xs:element minOccurs="0" name="parabolicDistributionSizeMaximum" type="xs:int"/>
+                    
+          <xs:element minOccurs="0" name="betaDistributionAlpha" type="xs:double"/>
+                    
+          <xs:element minOccurs="0" name="betaDistributionBeta" type="xs:double"/>
+                  
+        </xs:sequence>
+              
+      </xs:extension>
+          
+    </xs:complexContent>
+      
+  </xs:complexType>
+    
+  <xs:complexType name="cartesianProductMoveSelectorConfig">
+        
+    <xs:complexContent>
+            
+      <xs:extension base="tns:moveSelectorConfig">
+                
+        <xs:sequence>
+                    
+          <xs:choice maxOccurs="unbounded" minOccurs="0">
+                        
+            <xs:element name="cartesianProductMoveSelector" type="tns:cartesianProductMoveSelectorConfig"/>
+                        
+            <xs:element name="changeMoveSelector" type="tns:changeMoveSelectorConfig"/>
+                        
+            <xs:element name="kOptMoveSelector" type="tns:kOptMoveSelectorConfig"/>
+                        
+            <xs:element name="moveIteratorFactory" type="tns:moveIteratorFactoryConfig"/>
+                        
+            <xs:element name="moveListFactory" type="tns:moveListFactoryConfig"/>
+                        
+            <xs:element name="pillarChangeMoveSelector" type="tns:pillarChangeMoveSelectorConfig"/>
+                        
+            <xs:element name="pillarSwapMoveSelector" type="tns:pillarSwapMoveSelectorConfig"/>
+                        
+            <xs:element name="subChainChangeMoveSelector" type="tns:subChainChangeMoveSelectorConfig"/>
+                        
+            <xs:element name="subChainSwapMoveSelector" type="tns:subChainSwapMoveSelectorConfig"/>
+                        
+            <xs:element name="swapMoveSelector" type="tns:swapMoveSelectorConfig"/>
+                        
+            <xs:element name="tailChainSwapMoveSelector" type="tns:tailChainSwapMoveSelectorConfig"/>
+                        
+            <xs:element name="unionMoveSelector" type="tns:unionMoveSelectorConfig"/>
+                      
+          </xs:choice>
+                    
+          <xs:element minOccurs="0" name="ignoreEmptyChildIterators" type="xs:boolean"/>
+                  
+        </xs:sequence>
+              
+      </xs:extension>
+          
+    </xs:complexContent>
+      
+  </xs:complexType>
+    
+  <xs:complexType abstract="true" name="moveSelectorConfig">
+        
+    <xs:complexContent>
+            
+      <xs:extension base="tns:selectorConfig">
+                
+        <xs:sequence>
+                    
+          <xs:element minOccurs="0" name="cacheType" type="tns:selectionCacheType"/>
+                    
+          <xs:element minOccurs="0" name="selectionOrder" type="tns:selectionOrder"/>
+                    
+          <xs:element minOccurs="0" name="filterClass" type="xs:string"/>
+                    
+          <xs:element minOccurs="0" name="sorterComparatorClass" type="xs:string"/>
+                    
+          <xs:element minOccurs="0" name="sorterWeightFactoryClass" type="xs:string"/>
+                    
+          <xs:element minOccurs="0" name="sorterOrder" type="tns:selectionSorterOrder"/>
+                    
+          <xs:element minOccurs="0" name="sorterClass" type="xs:string"/>
+                    
+          <xs:element minOccurs="0" name="probabilityWeightFactoryClass" type="xs:string"/>
+                    
+          <xs:element minOccurs="0" name="selectedCountLimit" type="xs:long"/>
+                    
+          <xs:element minOccurs="0" name="fixedProbabilityWeight" type="xs:double"/>
+                  
+        </xs:sequence>
+              
+      </xs:extension>
+          
+    </xs:complexContent>
+      
+  </xs:complexType>
+    
+  <xs:complexType name="changeMoveSelectorConfig">
+        
+    <xs:complexContent>
+            
+      <xs:extension base="tns:moveSelectorConfig">
+                
+        <xs:sequence>
+                    
+          <xs:element minOccurs="0" name="entitySelector" type="tns:entitySelectorConfig"/>
+                    
+          <xs:element minOccurs="0" name="valueSelector" type="tns:valueSelectorConfig"/>
+                  
+        </xs:sequence>
+              
+      </xs:extension>
+          
+    </xs:complexContent>
+      
+  </xs:complexType>
+    
+  <xs:complexType name="valueSelectorConfig">
+        
+    <xs:complexContent>
+            
+      <xs:extension base="tns:selectorConfig">
+                
+        <xs:sequence>
+                    
+          <xs:element minOccurs="0" name="downcastEntityClass" type="xs:string"/>
+                    
+          <xs:element minOccurs="0" name="cacheType" type="tns:selectionCacheType"/>
+                    
+          <xs:element minOccurs="0" name="selectionOrder" type="tns:selectionOrder"/>
+                    
+          <xs:element minOccurs="0" name="nearbySelection" type="tns:nearbySelectionConfig"/>
+                    
+          <xs:element minOccurs="0" name="filterClass" type="xs:string"/>
+                    
+          <xs:element minOccurs="0" name="sorterManner" type="tns:valueSorterManner"/>
+                    
+          <xs:element minOccurs="0" name="sorterComparatorClass" type="xs:string"/>
+                    
+          <xs:element minOccurs="0" name="sorterWeightFactoryClass" type="xs:string"/>
+                    
+          <xs:element minOccurs="0" name="sorterOrder" type="tns:selectionSorterOrder"/>
+                    
+          <xs:element minOccurs="0" name="sorterClass" type="xs:string"/>
+                    
+          <xs:element minOccurs="0" name="probabilityWeightFactoryClass" type="xs:string"/>
+                    
+          <xs:element minOccurs="0" name="selectedCountLimit" type="xs:long"/>
+                  
+        </xs:sequence>
+                
+        <xs:attribute name="id" type="xs:string"/>
+                
+        <xs:attribute name="mimicSelectorRef" type="xs:string"/>
+                
+        <xs:attribute name="variableName" type="xs:string"/>
+              
+      </xs:extension>
+          
+    </xs:complexContent>
+      
+  </xs:complexType>
+    
+  <xs:complexType name="unionMoveSelectorConfig">
+        
+    <xs:complexContent>
+            
+      <xs:extension base="tns:moveSelectorConfig">
+                
+        <xs:sequence>
+                    
+          <xs:choice maxOccurs="unbounded" minOccurs="0">
+                        
+            <xs:element name="cartesianProductMoveSelector" type="tns:cartesianProductMoveSelectorConfig"/>
+                        
+            <xs:element name="changeMoveSelector" type="tns:changeMoveSelectorConfig"/>
+                        
+            <xs:element name="kOptMoveSelector" type="tns:kOptMoveSelectorConfig"/>
+                        
+            <xs:element name="moveIteratorFactory" type="tns:moveIteratorFactoryConfig"/>
+                        
+            <xs:element name="moveListFactory" type="tns:moveListFactoryConfig"/>
+                        
+            <xs:element name="pillarChangeMoveSelector" type="tns:pillarChangeMoveSelectorConfig"/>
+                        
+            <xs:element name="pillarSwapMoveSelector" type="tns:pillarSwapMoveSelectorConfig"/>
+                        
+            <xs:element name="subChainChangeMoveSelector" type="tns:subChainChangeMoveSelectorConfig"/>
+                        
+            <xs:element name="subChainSwapMoveSelector" type="tns:subChainSwapMoveSelectorConfig"/>
+                        
+            <xs:element name="swapMoveSelector" type="tns:swapMoveSelectorConfig"/>
+                        
+            <xs:element name="tailChainSwapMoveSelector" type="tns:tailChainSwapMoveSelectorConfig"/>
+                        
+            <xs:element name="unionMoveSelector" type="tns:unionMoveSelectorConfig"/>
+                      
+          </xs:choice>
+                    
+          <xs:element minOccurs="0" name="selectorProbabilityWeightFactoryClass" type="xs:string"/>
+                  
+        </xs:sequence>
+              
+      </xs:extension>
+          
+    </xs:complexContent>
+      
+  </xs:complexType>
+    
+  <xs:complexType name="kOptMoveSelectorConfig">
+        
+    <xs:complexContent>
+            
+      <xs:extension base="tns:moveSelectorConfig">
+                
+        <xs:sequence>
+                    
+          <xs:element minOccurs="0" name="entitySelector" type="tns:entitySelectorConfig"/>
+                    
+          <xs:element minOccurs="0" name="valueSelector" type="tns:valueSelectorConfig"/>
+                  
+        </xs:sequence>
+              
+      </xs:extension>
+          
+    </xs:complexContent>
+      
+  </xs:complexType>
+    
+  <xs:complexType name="moveIteratorFactoryConfig">
+        
+    <xs:complexContent>
+            
+      <xs:extension base="tns:moveSelectorConfig">
+                
+        <xs:sequence>
+                    
+          <xs:element minOccurs="0" name="moveIteratorFactoryClass" type="xs:string"/>
+                    
+          <xs:element minOccurs="0" name="moveIteratorFactoryCustomProperties" type="tns:jaxbAdaptedMap"/>
+                  
+        </xs:sequence>
+              
+      </xs:extension>
+          
+    </xs:complexContent>
+      
+  </xs:complexType>
+    
+  <xs:complexType name="moveListFactoryConfig">
+        
+    <xs:complexContent>
+            
+      <xs:extension base="tns:moveSelectorConfig">
+                
+        <xs:sequence>
+                    
+          <xs:element minOccurs="0" name="moveListFactoryClass" type="xs:string"/>
+                    
+          <xs:element minOccurs="0" name="moveListFactoryCustomProperties" type="tns:jaxbAdaptedMap"/>
+                  
+        </xs:sequence>
+              
+      </xs:extension>
+          
+    </xs:complexContent>
+      
+  </xs:complexType>
+    
+  <xs:complexType name="pillarChangeMoveSelectorConfig">
+        
+    <xs:complexContent>
+            
+      <xs:extension base="tns:abstractPillarMoveSelectorConfig">
+                
+        <xs:sequence>
+                    
+          <xs:element minOccurs="0" name="valueSelector" type="tns:valueSelectorConfig"/>
+                  
+        </xs:sequence>
+              
+      </xs:extension>
+          
+    </xs:complexContent>
+      
+  </xs:complexType>
+    
+  <xs:complexType abstract="true" name="abstractPillarMoveSelectorConfig">
+        
+    <xs:complexContent>
+            
+      <xs:extension base="tns:moveSelectorConfig">
+                
+        <xs:sequence>
+                    
+          <xs:element minOccurs="0" name="subPillarType" type="tns:subPillarType"/>
+                    
+          <xs:element minOccurs="0" name="subPillarSequenceComparatorClass" type="xs:string"/>
+                    
+          <xs:element minOccurs="0" name="pillarSelector" type="tns:pillarSelectorConfig"/>
+                  
+        </xs:sequence>
+              
+      </xs:extension>
+          
+    </xs:complexContent>
+      
+  </xs:complexType>
+    
+  <xs:complexType name="pillarSelectorConfig">
+        
+    <xs:complexContent>
+            
+      <xs:extension base="tns:selectorConfig">
+                
+        <xs:sequence>
+                    
+          <xs:element minOccurs="0" name="entitySelector" type="tns:entitySelectorConfig"/>
+                    
+          <xs:element minOccurs="0" name="minimumSubPillarSize" type="xs:int"/>
+                    
+          <xs:element minOccurs="0" name="maximumSubPillarSize" type="xs:int"/>
+                  
+        </xs:sequence>
+              
+      </xs:extension>
+          
+    </xs:complexContent>
+      
+  </xs:complexType>
+    
+  <xs:complexType name="pillarSwapMoveSelectorConfig">
+        
+    <xs:complexContent>
+            
+      <xs:extension base="tns:abstractPillarMoveSelectorConfig">
+                
+        <xs:sequence>
+                    
+          <xs:element minOccurs="0" name="secondaryPillarSelector" type="tns:pillarSelectorConfig"/>
+                    
+          <xs:element minOccurs="0" name="variableNameIncludes">
+                        
+            <xs:complexType>
+                            
+              <xs:sequence>
+                                
+                <xs:element maxOccurs="unbounded" minOccurs="0" name="variableNameInclude" type="xs:string"/>
+                              
+              </xs:sequence>
+                          
+            </xs:complexType>
+                      
+          </xs:element>
+                  
+        </xs:sequence>
+              
+      </xs:extension>
+          
+    </xs:complexContent>
+      
+  </xs:complexType>
+    
+  <xs:complexType name="subChainChangeMoveSelectorConfig">
+        
+    <xs:complexContent>
+            
+      <xs:extension base="tns:moveSelectorConfig">
+                
+        <xs:sequence>
+                    
+          <xs:element minOccurs="0" name="entityClass" type="xs:string"/>
+                    
+          <xs:element minOccurs="0" name="subChainSelector" type="tns:subChainSelectorConfig"/>
+                    
+          <xs:element minOccurs="0" name="valueSelector" type="tns:valueSelectorConfig"/>
+                    
+          <xs:element minOccurs="0" name="selectReversingMoveToo" type="xs:boolean"/>
+                  
+        </xs:sequence>
+              
+      </xs:extension>
+          
+    </xs:complexContent>
+      
+  </xs:complexType>
+    
+  <xs:complexType name="subChainSelectorConfig">
+        
+    <xs:complexContent>
+            
+      <xs:extension base="tns:selectorConfig">
+                
+        <xs:sequence>
+                    
+          <xs:element minOccurs="0" name="valueSelector" type="tns:valueSelectorConfig"/>
+                    
+          <xs:element minOccurs="0" name="minimumSubChainSize" type="xs:int"/>
+                    
+          <xs:element minOccurs="0" name="maximumSubChainSize" type="xs:int"/>
+                  
+        </xs:sequence>
+              
+      </xs:extension>
+          
+    </xs:complexContent>
+      
+  </xs:complexType>
+    
+  <xs:complexType name="subChainSwapMoveSelectorConfig">
+        
+    <xs:complexContent>
+            
+      <xs:extension base="tns:moveSelectorConfig">
+                
+        <xs:sequence>
+                    
+          <xs:element minOccurs="0" name="entityClass" type="xs:string"/>
+                    
+          <xs:element minOccurs="0" name="subChainSelector" type="tns:subChainSelectorConfig"/>
+                    
+          <xs:element minOccurs="0" name="secondarySubChainSelector" type="tns:subChainSelectorConfig"/>
+                    
+          <xs:element minOccurs="0" name="selectReversingMoveToo" type="xs:boolean"/>
+                  
+        </xs:sequence>
+              
+      </xs:extension>
+          
+    </xs:complexContent>
+      
+  </xs:complexType>
+    
+  <xs:complexType name="swapMoveSelectorConfig">
+        
+    <xs:complexContent>
+            
+      <xs:extension base="tns:moveSelectorConfig">
+                
+        <xs:sequence>
+                    
+          <xs:element minOccurs="0" name="entitySelector" type="tns:entitySelectorConfig"/>
+                    
+          <xs:element minOccurs="0" name="secondaryEntitySelector" type="tns:entitySelectorConfig"/>
+                    
+          <xs:element minOccurs="0" name="variableNameIncludes">
+                        
+            <xs:complexType>
+                            
+              <xs:sequence>
+                                
+                <xs:element maxOccurs="unbounded" minOccurs="0" name="variableNameInclude" type="xs:string"/>
+                              
+              </xs:sequence>
+                          
+            </xs:complexType>
+                      
+          </xs:element>
+                  
+        </xs:sequence>
+              
+      </xs:extension>
+          
+    </xs:complexContent>
+      
+  </xs:complexType>
+    
+  <xs:complexType name="tailChainSwapMoveSelectorConfig">
+        
+    <xs:complexContent>
+            
+      <xs:extension base="tns:moveSelectorConfig">
+                
+        <xs:sequence>
+                    
+          <xs:element minOccurs="0" name="entitySelector" type="tns:entitySelectorConfig"/>
+                    
+          <xs:element minOccurs="0" name="valueSelector" type="tns:valueSelectorConfig"/>
+                  
+        </xs:sequence>
+              
+      </xs:extension>
+          
+    </xs:complexContent>
+      
+  </xs:complexType>
+    
+  <xs:complexType name="queuedValuePlacerConfig">
+        
+    <xs:complexContent>
+            
+      <xs:extension base="tns:entityPlacerConfig">
+                
+        <xs:sequence>
+                    
+          <xs:element minOccurs="0" name="entityClass" type="xs:string"/>
+                    
+          <xs:element minOccurs="0" name="valueSelector" type="tns:valueSelectorConfig"/>
+                    
+          <xs:choice minOccurs="0">
+                        
+            <xs:element name="cartesianProductMoveSelector" type="tns:cartesianProductMoveSelectorConfig"/>
+                        
+            <xs:element name="changeMoveSelector" type="tns:changeMoveSelectorConfig"/>
+                        
+            <xs:element name="kOptMoveSelector" type="tns:kOptMoveSelectorConfig"/>
+                        
+            <xs:element name="moveIteratorFactory" type="tns:moveIteratorFactoryConfig"/>
+                        
+            <xs:element name="moveListFactory" type="tns:moveListFactoryConfig"/>
+                        
+            <xs:element name="pillarChangeMoveSelector" type="tns:pillarChangeMoveSelectorConfig"/>
+                        
+            <xs:element name="pillarSwapMoveSelector" type="tns:pillarSwapMoveSelectorConfig"/>
+                        
+            <xs:element name="subChainChangeMoveSelector" type="tns:subChainChangeMoveSelectorConfig"/>
+                        
+            <xs:element name="subChainSwapMoveSelector" type="tns:subChainSwapMoveSelectorConfig"/>
+                        
+            <xs:element name="swapMoveSelector" type="tns:swapMoveSelectorConfig"/>
+                        
+            <xs:element name="tailChainSwapMoveSelector" type="tns:tailChainSwapMoveSelectorConfig"/>
+                        
+            <xs:element name="unionMoveSelector" type="tns:unionMoveSelectorConfig"/>
+                      
+          </xs:choice>
+                  
+        </xs:sequence>
+              
+      </xs:extension>
+          
+    </xs:complexContent>
+      
+  </xs:complexType>
+    
+  <xs:complexType name="pooledEntityPlacerConfig">
+        
+    <xs:complexContent>
+            
+      <xs:extension base="tns:entityPlacerConfig">
+                
+        <xs:sequence>
+                    
+          <xs:choice minOccurs="0">
+                        
+            <xs:element name="cartesianProductMoveSelector" type="tns:cartesianProductMoveSelectorConfig"/>
+                        
+            <xs:element name="changeMoveSelector" type="tns:changeMoveSelectorConfig"/>
+                        
+            <xs:element name="kOptMoveSelector" type="tns:kOptMoveSelectorConfig"/>
+                        
+            <xs:element name="moveIteratorFactory" type="tns:moveIteratorFactoryConfig"/>
+                        
+            <xs:element name="moveListFactory" type="tns:moveListFactoryConfig"/>
+                        
+            <xs:element name="pillarChangeMoveSelector" type="tns:pillarChangeMoveSelectorConfig"/>
+                        
+            <xs:element name="pillarSwapMoveSelector" type="tns:pillarSwapMoveSelectorConfig"/>
+                        
+            <xs:element name="subChainChangeMoveSelector" type="tns:subChainChangeMoveSelectorConfig"/>
+                        
+            <xs:element name="subChainSwapMoveSelector" type="tns:subChainSwapMoveSelectorConfig"/>
+                        
+            <xs:element name="swapMoveSelector" type="tns:swapMoveSelectorConfig"/>
+                        
+            <xs:element name="tailChainSwapMoveSelector" type="tns:tailChainSwapMoveSelectorConfig"/>
+                        
+            <xs:element name="unionMoveSelector" type="tns:unionMoveSelectorConfig"/>
+                      
+          </xs:choice>
+                  
+        </xs:sequence>
+              
+      </xs:extension>
+          
+    </xs:complexContent>
+      
+  </xs:complexType>
+    
+  <xs:complexType name="constructionHeuristicForagerConfig">
+        
+    <xs:complexContent>
+            
+      <xs:extension base="tns:abstractConfig">
+                
+        <xs:sequence>
+                    
+          <xs:element minOccurs="0" name="pickEarlyType" type="tns:constructionHeuristicPickEarlyType"/>
+                  
+        </xs:sequence>
+              
+      </xs:extension>
+          
+    </xs:complexContent>
+      
+  </xs:complexType>
+    
+  <xs:complexType name="customPhaseConfig">
+        
+    <xs:complexContent>
+            
+      <xs:extension base="tns:phaseConfig">
+                
+        <xs:sequence>
+                    
+          <xs:element maxOccurs="unbounded" minOccurs="0" name="customPhaseCommandClass" type="xs:string"/>
+                    
+          <xs:element minOccurs="0" name="customProperties" type="tns:jaxbAdaptedMap"/>
+                  
+        </xs:sequence>
+              
+      </xs:extension>
+          
+    </xs:complexContent>
+      
+  </xs:complexType>
+    
+  <xs:complexType name="exhaustiveSearchPhaseConfig">
+        
+    <xs:complexContent>
+            
+      <xs:extension base="tns:phaseConfig">
+                
+        <xs:sequence>
+                    
+          <xs:element minOccurs="0" name="exhaustiveSearchType" type="tns:exhaustiveSearchType"/>
+                    
+          <xs:element minOccurs="0" name="nodeExplorationType" type="tns:nodeExplorationType"/>
+                    
+          <xs:element minOccurs="0" name="entitySorterManner" type="tns:entitySorterManner"/>
+                    
+          <xs:element minOccurs="0" name="valueSorterManner" type="tns:valueSorterManner"/>
+                    
+          <xs:element minOccurs="0" name="entitySelector" type="tns:entitySelectorConfig"/>
+                    
+          <xs:choice minOccurs="0">
+                        
+            <xs:element name="cartesianProductMoveSelector" type="tns:cartesianProductMoveSelectorConfig"/>
+                        
+            <xs:element name="changeMoveSelector" type="tns:changeMoveSelectorConfig"/>
+                        
+            <xs:element name="kOptMoveSelector" type="tns:kOptMoveSelectorConfig"/>
+                        
+            <xs:element name="moveIteratorFactory" type="tns:moveIteratorFactoryConfig"/>
+                        
+            <xs:element name="moveListFactory" type="tns:moveListFactoryConfig"/>
+                        
+            <xs:element name="pillarChangeMoveSelector" type="tns:pillarChangeMoveSelectorConfig"/>
+                        
+            <xs:element name="pillarSwapMoveSelector" type="tns:pillarSwapMoveSelectorConfig"/>
+                        
+            <xs:element name="subChainChangeMoveSelector" type="tns:subChainChangeMoveSelectorConfig"/>
+                        
+            <xs:element name="subChainSwapMoveSelector" type="tns:subChainSwapMoveSelectorConfig"/>
+                        
+            <xs:element name="swapMoveSelector" type="tns:swapMoveSelectorConfig"/>
+                        
+            <xs:element name="tailChainSwapMoveSelector" type="tns:tailChainSwapMoveSelectorConfig"/>
+                        
+            <xs:element name="unionMoveSelector" type="tns:unionMoveSelectorConfig"/>
+                      
+          </xs:choice>
+                  
+        </xs:sequence>
+              
+      </xs:extension>
+          
+    </xs:complexContent>
+      
+  </xs:complexType>
+    
+  <xs:complexType name="localSearchPhaseConfig">
+        
+    <xs:complexContent>
+            
+      <xs:extension base="tns:phaseConfig">
+                
+        <xs:sequence>
+                    
+          <xs:element minOccurs="0" name="localSearchType" type="tns:localSearchType"/>
+                    
+          <xs:choice minOccurs="0">
+                        
+            <xs:element name="cartesianProductMoveSelector" type="tns:cartesianProductMoveSelectorConfig"/>
+                        
+            <xs:element name="changeMoveSelector" type="tns:changeMoveSelectorConfig"/>
+                        
+            <xs:element name="kOptMoveSelector" type="tns:kOptMoveSelectorConfig"/>
+                        
+            <xs:element name="moveIteratorFactory" type="tns:moveIteratorFactoryConfig"/>
+                        
+            <xs:element name="moveListFactory" type="tns:moveListFactoryConfig"/>
+                        
+            <xs:element name="pillarChangeMoveSelector" type="tns:pillarChangeMoveSelectorConfig"/>
+                        
+            <xs:element name="pillarSwapMoveSelector" type="tns:pillarSwapMoveSelectorConfig"/>
+                        
+            <xs:element name="subChainChangeMoveSelector" type="tns:subChainChangeMoveSelectorConfig"/>
+                        
+            <xs:element name="subChainSwapMoveSelector" type="tns:subChainSwapMoveSelectorConfig"/>
+                        
+            <xs:element name="swapMoveSelector" type="tns:swapMoveSelectorConfig"/>
+                        
+            <xs:element name="tailChainSwapMoveSelector" type="tns:tailChainSwapMoveSelectorConfig"/>
+                        
+            <xs:element name="unionMoveSelector" type="tns:unionMoveSelectorConfig"/>
+                      
+          </xs:choice>
+                    
+          <xs:element minOccurs="0" name="acceptor" type="tns:localSearchAcceptorConfig"/>
+                    
+          <xs:element minOccurs="0" name="forager" type="tns:localSearchForagerConfig"/>
+                  
+        </xs:sequence>
+              
+      </xs:extension>
+          
+    </xs:complexContent>
+      
+  </xs:complexType>
+    
+  <xs:complexType name="localSearchAcceptorConfig">
+        
+    <xs:complexContent>
+            
+      <xs:extension base="tns:abstractConfig">
+                
+        <xs:sequence>
+                    
+          <xs:element maxOccurs="unbounded" minOccurs="0" name="acceptorType" type="tns:acceptorType"/>
+                    
+          <xs:element minOccurs="0" name="entityTabuSize" type="xs:int"/>
+                    
+          <xs:element minOccurs="0" name="entityTabuRatio" type="xs:double"/>
+                    
+          <xs:element minOccurs="0" name="fadingEntityTabuSize" type="xs:int"/>
+                    
+          <xs:element minOccurs="0" name="fadingEntityTabuRatio" type="xs:double"/>
+                    
+          <xs:element minOccurs="0" name="valueTabuSize" type="xs:int"/>
+                    
+          <xs:element minOccurs="0" name="valueTabuRatio" type="xs:double"/>
+                    
+          <xs:element minOccurs="0" name="fadingValueTabuSize" type="xs:int"/>
+                    
+          <xs:element minOccurs="0" name="fadingValueTabuRatio" type="xs:double"/>
+                    
+          <xs:element minOccurs="0" name="moveTabuSize" type="xs:int"/>
+                    
+          <xs:element minOccurs="0" name="fadingMoveTabuSize" type="xs:int"/>
+                    
+          <xs:element minOccurs="0" name="undoMoveTabuSize" type="xs:int"/>
+                    
+          <xs:element minOccurs="0" name="fadingUndoMoveTabuSize" type="xs:int"/>
+                    
+          <xs:element minOccurs="0" name="simulatedAnnealingStartingTemperature" type="xs:string"/>
+                    
+          <xs:element minOccurs="0" name="lateAcceptanceSize" type="xs:int"/>
+                    
+          <xs:element minOccurs="0" name="greatDelugeWaterLevelIncrementScore" type="xs:string"/>
+                    
+          <xs:element minOccurs="0" name="greatDelugeWaterLevelIncrementRatio" type="xs:double"/>
+                    
+          <xs:element minOccurs="0" name="stepCountingHillClimbingSize" type="xs:int"/>
+                    
+          <xs:element minOccurs="0" name="stepCountingHillClimbingType" type="tns:stepCountingHillClimbingType"/>
+                  
+        </xs:sequence>
+              
+      </xs:extension>
+          
+    </xs:complexContent>
+      
+  </xs:complexType>
+    
+  <xs:complexType name="localSearchForagerConfig">
+        
+    <xs:complexContent>
+            
+      <xs:extension base="tns:abstractConfig">
+                
+        <xs:sequence>
+                    
+          <xs:element minOccurs="0" name="pickEarlyType" type="tns:localSearchPickEarlyType"/>
+                    
+          <xs:element minOccurs="0" name="acceptedCountLimit" type="xs:int"/>
+                    
+          <xs:element minOccurs="0" name="finalistPodiumType" type="tns:finalistPodiumType"/>
+                    
+          <xs:element minOccurs="0" name="breakTieRandomly" type="xs:boolean"/>
+                  
+        </xs:sequence>
+              
+      </xs:extension>
+          
+    </xs:complexContent>
+      
+  </xs:complexType>
+    
+  <xs:complexType name="noChangePhaseConfig">
+        
+    <xs:complexContent>
+            
+      <xs:extension base="tns:phaseConfig">
+                
+        <xs:sequence/>
+              
+      </xs:extension>
+          
+    </xs:complexContent>
+      
+  </xs:complexType>
+    
+  <xs:complexType name="partitionedSearchPhaseConfig">
+        
+    <xs:complexContent>
+            
+      <xs:extension base="tns:phaseConfig">
+                
+        <xs:sequence>
+                    
+          <xs:element minOccurs="0" name="solutionPartitionerClass" type="xs:string"/>
+                    
+          <xs:element minOccurs="0" name="solutionPartitionerCustomProperties" type="tns:jaxbAdaptedMap"/>
+                    
+          <xs:element minOccurs="0" name="runnablePartThreadLimit" type="xs:string"/>
+                    
+          <xs:choice maxOccurs="unbounded" minOccurs="0">
+                        
+            <xs:element name="constructionHeuristic" type="tns:constructionHeuristicPhaseConfig"/>
+                        
+            <xs:element name="customPhase" type="tns:customPhaseConfig"/>
+                        
+            <xs:element name="exhaustiveSearch" type="tns:exhaustiveSearchPhaseConfig"/>
+                        
+            <xs:element name="localSearch" type="tns:localSearchPhaseConfig"/>
+                        
+            <xs:element name="noChangePhase" type="tns:noChangePhaseConfig"/>
+                        
+            <xs:element name="partitionedSearch" type="tns:partitionedSearchPhaseConfig"/>
+                      
+          </xs:choice>
+                  
+        </xs:sequence>
+              
+      </xs:extension>
+          
+    </xs:complexContent>
+      
+  </xs:complexType>
+    
+  <xs:complexType name="solverManagerConfig">
+        
+    <xs:complexContent>
+            
+      <xs:extension base="tns:abstractConfig">
+                
+        <xs:sequence>
+                    
+          <xs:element minOccurs="0" name="parallelSolverCount" type="xs:string"/>
+                    
+          <xs:element minOccurs="0" name="threadFactoryClass" type="xs:string"/>
+                  
+        </xs:sequence>
+              
+      </xs:extension>
+          
+    </xs:complexContent>
+      
+  </xs:complexType>
+    
+  <xs:simpleType name="environmentMode">
+        
+    <xs:restriction base="xs:string">
+            
+      <xs:enumeration value="FULL_ASSERT"/>
+            
+      <xs:enumeration value="NON_INTRUSIVE_FULL_ASSERT"/>
+            
+      <xs:enumeration value="FAST_ASSERT"/>
+            
+      <xs:enumeration value="REPRODUCIBLE"/>
+            
+      <xs:enumeration value="NON_REPRODUCIBLE"/>
+          
+    </xs:restriction>
+      
+  </xs:simpleType>
+    
+  <xs:simpleType name="randomType">
+        
+    <xs:restriction base="xs:string">
+            
+      <xs:enumeration value="JDK"/>
+            
+      <xs:enumeration value="MERSENNE_TWISTER"/>
+            
+      <xs:enumeration value="WELL512A"/>
+            
+      <xs:enumeration value="WELL1024A"/>
+            
+      <xs:enumeration value="WELL19937A"/>
+            
+      <xs:enumeration value="WELL19937C"/>
+            
+      <xs:enumeration value="WELL44497A"/>
+            
+      <xs:enumeration value="WELL44497B"/>
+          
+    </xs:restriction>
+      
+  </xs:simpleType>
+    
+  <xs:simpleType name="constraintStreamImplType">
+        
+    <xs:restriction base="xs:string">
+            
+      <xs:enumeration value="BAVET"/>
+            
+      <xs:enumeration value="DROOLS"/>
+          
+    </xs:restriction>
+      
+  </xs:simpleType>
+    
+  <xs:simpleType name="terminationCompositionStyle">
+        
+    <xs:restriction base="xs:string">
+            
+      <xs:enumeration value="AND"/>
+            
+      <xs:enumeration value="OR"/>
+          
+    </xs:restriction>
+      
+  </xs:simpleType>
+    
+  <xs:simpleType name="constructionHeuristicType">
+        
+    <xs:restriction base="xs:string">
+            
+      <xs:enumeration value="FIRST_FIT"/>
+            
+      <xs:enumeration value="FIRST_FIT_DECREASING"/>
+            
+      <xs:enumeration value="WEAKEST_FIT"/>
+            
+      <xs:enumeration value="WEAKEST_FIT_DECREASING"/>
+            
+      <xs:enumeration value="STRONGEST_FIT"/>
+            
+      <xs:enumeration value="STRONGEST_FIT_DECREASING"/>
+            
+      <xs:enumeration value="ALLOCATE_ENTITY_FROM_QUEUE"/>
+            
+      <xs:enumeration value="ALLOCATE_TO_VALUE_FROM_QUEUE"/>
+            
+      <xs:enumeration value="CHEAPEST_INSERTION"/>
+            
+      <xs:enumeration value="ALLOCATE_FROM_POOL"/>
+          
+    </xs:restriction>
+      
+  </xs:simpleType>
+    
+  <xs:simpleType name="entitySorterManner">
+        
+    <xs:restriction base="xs:string">
+            
+      <xs:enumeration value="NONE"/>
+            
+      <xs:enumeration value="DECREASING_DIFFICULTY"/>
+            
+      <xs:enumeration value="DECREASING_DIFFICULTY_IF_AVAILABLE"/>
+          
+    </xs:restriction>
+      
+  </xs:simpleType>
+    
+  <xs:simpleType name="valueSorterManner">
+        
+    <xs:restriction base="xs:string">
+            
+      <xs:enumeration value="NONE"/>
+            
+      <xs:enumeration value="INCREASING_STRENGTH"/>
+            
+      <xs:enumeration value="INCREASING_STRENGTH_IF_AVAILABLE"/>
+            
+      <xs:enumeration value="DECREASING_STRENGTH"/>
+            
+      <xs:enumeration value="DECREASING_STRENGTH_IF_AVAILABLE"/>
+          
+    </xs:restriction>
+      
+  </xs:simpleType>
+    
+  <xs:simpleType name="selectionCacheType">
+        
+    <xs:restriction base="xs:string">
+            
+      <xs:enumeration value="JUST_IN_TIME"/>
+            
+      <xs:enumeration value="STEP"/>
+            
+      <xs:enumeration value="PHASE"/>
+            
+      <xs:enumeration value="SOLVER"/>
+          
+    </xs:restriction>
+      
+  </xs:simpleType>
+    
+  <xs:simpleType name="selectionOrder">
+        
+    <xs:restriction base="xs:string">
+            
+      <xs:enumeration value="INHERIT"/>
+            
+      <xs:enumeration value="ORIGINAL"/>
+            
+      <xs:enumeration value="SORTED"/>
+            
+      <xs:enumeration value="RANDOM"/>
+            
+      <xs:enumeration value="SHUFFLED"/>
+            
+      <xs:enumeration value="PROBABILISTIC"/>
+          
+    </xs:restriction>
+      
+  </xs:simpleType>
+    
+  <xs:simpleType name="nearbySelectionDistributionType">
+        
+    <xs:restriction base="xs:string">
+            
+      <xs:enumeration value="BLOCK_DISTRIBUTION"/>
+            
+      <xs:enumeration value="LINEAR_DISTRIBUTION"/>
+            
+      <xs:enumeration value="PARABOLIC_DISTRIBUTION"/>
+            
+      <xs:enumeration value="BETA_DISTRIBUTION"/>
+          
+    </xs:restriction>
+      
+  </xs:simpleType>
+    
+  <xs:simpleType name="selectionSorterOrder">
+        
+    <xs:restriction base="xs:string">
+            
+      <xs:enumeration value="ASCENDING"/>
+            
+      <xs:enumeration value="DESCENDING"/>
+          
+    </xs:restriction>
+      
+  </xs:simpleType>
+    
+  <xs:simpleType name="subPillarType">
+        
+    <xs:restriction base="xs:string">
+            
+      <xs:enumeration value="NONE"/>
+            
+      <xs:enumeration value="SEQUENCE"/>
+            
+      <xs:enumeration value="ALL"/>
+          
+    </xs:restriction>
+      
+  </xs:simpleType>
+    
+  <xs:simpleType name="constructionHeuristicPickEarlyType">
+        
+    <xs:restriction base="xs:string">
+            
+      <xs:enumeration value="NEVER"/>
+            
+      <xs:enumeration value="FIRST_NON_DETERIORATING_SCORE"/>
+            
+      <xs:enumeration value="FIRST_FEASIBLE_SCORE"/>
+            
+      <xs:enumeration value="FIRST_FEASIBLE_SCORE_OR_NON_DETERIORATING_HARD"/>
+          
+    </xs:restriction>
+      
+  </xs:simpleType>
+    
+  <xs:simpleType name="exhaustiveSearchType">
+        
+    <xs:restriction base="xs:string">
+            
+      <xs:enumeration value="BRUTE_FORCE"/>
+            
+      <xs:enumeration value="BRANCH_AND_BOUND"/>
+          
+    </xs:restriction>
+      
+  </xs:simpleType>
+    
+  <xs:simpleType name="nodeExplorationType">
+        
+    <xs:restriction base="xs:string">
+            
+      <xs:enumeration value="ORIGINAL_ORDER"/>
+            
+      <xs:enumeration value="DEPTH_FIRST"/>
+            
+      <xs:enumeration value="BREADTH_FIRST"/>
+            
+      <xs:enumeration value="SCORE_FIRST"/>
+            
+      <xs:enumeration value="OPTIMISTIC_BOUND_FIRST"/>
+          
+    </xs:restriction>
+      
+  </xs:simpleType>
+    
+  <xs:simpleType name="localSearchType">
+        
+    <xs:restriction base="xs:string">
+            
+      <xs:enumeration value="HILL_CLIMBING"/>
+            
+      <xs:enumeration value="TABU_SEARCH"/>
+            
+      <xs:enumeration value="SIMULATED_ANNEALING"/>
+            
+      <xs:enumeration value="LATE_ACCEPTANCE"/>
+            
+      <xs:enumeration value="GREAT_DELUGE"/>
+            
+      <xs:enumeration value="VARIABLE_NEIGHBORHOOD_DESCENT"/>
+          
+    </xs:restriction>
+      
+  </xs:simpleType>
+    
+  <xs:simpleType name="acceptorType">
+        
+    <xs:restriction base="xs:string">
+            
+      <xs:enumeration value="HILL_CLIMBING"/>
+            
+      <xs:enumeration value="ENTITY_TABU"/>
+            
+      <xs:enumeration value="VALUE_TABU"/>
+            
+      <xs:enumeration value="MOVE_TABU"/>
+            
+      <xs:enumeration value="UNDO_MOVE_TABU"/>
+            
+      <xs:enumeration value="SIMULATED_ANNEALING"/>
+            
+      <xs:enumeration value="LATE_ACCEPTANCE"/>
+            
+      <xs:enumeration value="GREAT_DELUGE"/>
+            
+      <xs:enumeration value="STEP_COUNTING_HILL_CLIMBING"/>
+          
+    </xs:restriction>
+      
+  </xs:simpleType>
+    
+  <xs:simpleType name="stepCountingHillClimbingType">
+        
+    <xs:restriction base="xs:string">
+            
+      <xs:enumeration value="SELECTED_MOVE"/>
+            
+      <xs:enumeration value="ACCEPTED_MOVE"/>
+            
+      <xs:enumeration value="STEP"/>
+            
+      <xs:enumeration value="EQUAL_OR_IMPROVING_STEP"/>
+            
+      <xs:enumeration value="IMPROVING_STEP"/>
+          
+    </xs:restriction>
+      
+  </xs:simpleType>
+    
+  <xs:simpleType name="localSearchPickEarlyType">
+        
+    <xs:restriction base="xs:string">
+            
+      <xs:enumeration value="NEVER"/>
+            
+      <xs:enumeration value="FIRST_BEST_SCORE_IMPROVING"/>
+            
+      <xs:enumeration value="FIRST_LAST_STEP_SCORE_IMPROVING"/>
+          
+    </xs:restriction>
+      
+  </xs:simpleType>
+    
+  <xs:simpleType name="finalistPodiumType">
+        
+    <xs:restriction base="xs:string">
+            
+      <xs:enumeration value="HIGHEST_SCORE"/>
+            
+      <xs:enumeration value="STRATEGIC_OSCILLATION"/>
+            
+      <xs:enumeration value="STRATEGIC_OSCILLATION_BY_LEVEL"/>
+            
+      <xs:enumeration value="STRATEGIC_OSCILLATION_BY_LEVEL_ON_BEST_SCORE"/>
+          
+    </xs:restriction>
+      
+  </xs:simpleType>
+  
+</xs:schema>

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/io/jaxb/JaxbCustomPropertiesAdapterTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/io/jaxb/JaxbCustomPropertiesAdapterTest.java
@@ -32,7 +32,7 @@ import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 
 import org.junit.jupiter.api.Test;
 
-public class JaxbCustomPropertiesAdapterTest {
+class JaxbCustomPropertiesAdapterTest {
 
     private final Unmarshaller unmarshaller;
 
@@ -42,22 +42,23 @@ public class JaxbCustomPropertiesAdapterTest {
     }
 
     @Test
-    public void readCustomProperties() throws JAXBException {
+    void readCustomProperties() throws JAXBException {
         String xmlFragment = "<testBean>"
                 + "  <customProperties>"
-                + "    <property name=\"firstKey\" value=\"firstValue\"/>"
-                + "    <property name=\"secondKey\" value=\"secondValue\"/>"
+                + "    <property xmlns=\"https://www.optaplanner.org/xsd/solver\" name=\"firstKey\" value=\"firstValue\"/>"
+                + "    <property xmlns=\"https://www.optaplanner.org/xsd/solver\" name=\"secondKey\" value=\"secondValue\"/>"
                 + "  </customProperties>"
                 + "</testBean>";
         Reader stringReader = new StringReader(xmlFragment);
         TestBean testBean = (TestBean) unmarshaller.unmarshal(stringReader);
-        assertThat(testBean.customProperties).hasSize(2);
-        assertThat(testBean.customProperties.get("firstKey")).isEqualTo("firstValue");
-        assertThat(testBean.customProperties.get("secondKey")).isEqualTo("secondValue");
+        assertThat(testBean.customProperties)
+                .hasSize(2)
+                .containsEntry("firstKey", "firstValue")
+                .containsEntry("secondKey", "secondValue");
     }
 
     @Test
-    public void nullValues() {
+    void nullValues() {
         JaxbCustomPropertiesAdapter jaxbCustomPropertiesAdapter = new JaxbCustomPropertiesAdapter();
         assertThat(jaxbCustomPropertiesAdapter.marshal(null)).isNull();
         assertThat(jaxbCustomPropertiesAdapter.unmarshal(null)).isNull();

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/io/jaxb/JaxbIOTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/io/jaxb/JaxbIOTest.java
@@ -26,18 +26,19 @@ import java.util.Objects;
 
 import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlValue;
 
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.Test;
-import org.optaplanner.core.impl.io.XmlUnmarshallingException;
+import org.optaplanner.core.impl.io.OptaPlannerXmlSerializationException;
 
-public class JaxbIOTest {
+class JaxbIOTest {
 
     private final JaxbIO<DummyJaxbClass> xmlIO = new JaxbIO<>(DummyJaxbClass.class);
 
     @Test
-    public void readWriteSimpleObject() {
-        DummyJaxbClass original = new DummyJaxbClass(1);
+    void readWriteSimpleObject() {
+        DummyJaxbClass original = new DummyJaxbClass(1, "");
 
         StringWriter stringWriter = new StringWriter();
         xmlIO.write(original, stringWriter);
@@ -47,26 +48,44 @@ public class JaxbIOTest {
     }
 
     @Test
-    public void writeThrowsExceptionOnNullParameters() {
+    void writeThrowsExceptionOnNullParameters() {
         SoftAssertions.assertSoftly(softly -> {
             softly.assertThat(assertThatNullPointerException().isThrownBy(() -> xmlIO.write(null, new StringWriter())));
-            softly.assertThat(assertThatNullPointerException().isThrownBy(() -> xmlIO.write(new DummyJaxbClass(1), null)));
+            softly.assertThat(assertThatNullPointerException().isThrownBy(() -> xmlIO.write(new DummyJaxbClass(1, ""), null)));
         });
     }
 
     @Test
-    public void readThrowsExceptionOnNullParameter() {
+    void readThrowsExceptionOnNullParameter() {
         assertThatNullPointerException().isThrownBy(() -> new JaxbIO<>(DummyJaxbClass.class).read(null));
     }
 
     @Test
-    public void readThrowsExceptionOnInvalidXml() {
+    void readThrowsExceptionOnInvalidXml() {
         String invalidXml = "<unknownRootElement/>";
-        assertThatExceptionOfType(XmlUnmarshallingException.class).isThrownBy(() -> xmlIO.read(new StringReader(invalidXml)));
+        StringReader stringReader = new StringReader(invalidXml);
+        assertThatExceptionOfType(OptaPlannerXmlSerializationException.class).isThrownBy(() -> xmlIO.read(stringReader));
+    }
+
+    @Test
+    void readOverridingNamespaceIsProtectedFromXXE() {
+        String maliciousXml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+                + "<!DOCTYPE dummyJaxbClass [  \n"
+                + "  <!ELEMENT dummyJaxbClass ANY >\n"
+                + "  <!ENTITY xxe SYSTEM \"file:///etc/passwd\" >]"
+                + ">"
+                + "<dummyJaxbClass>&xxe;</dummyJaxbClass>";
+        DummyJaxbClass dummyJaxbClass = xmlIO.readOverridingNamespace(new StringReader(maliciousXml));
+        assertThat(dummyJaxbClass.value).isEmpty();
     }
 
     @XmlRootElement
     private static class DummyJaxbClass {
+
+        // This field is used only for evaluating the XXE attack protection.
+        @XmlValue
+        private String value;
+
         @XmlAttribute
         private int id;
 
@@ -74,8 +93,9 @@ public class JaxbIOTest {
             // Required by JAXB
         }
 
-        private DummyJaxbClass(int id) {
+        private DummyJaxbClass(int id, String value) {
             this.id = id;
+            this.value = value;
         }
 
         @Override

--- a/optaplanner-core/src/test/resources/org/optaplanner/core/config/solver/testSolverConfigWithNamespace.xml
+++ b/optaplanner-core/src/test/resources/org/optaplanner/core/config/solver/testSolverConfigWithNamespace.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<solver xmlns="https://www.optaplanner.org/xsd/solver">
+  <environmentMode>FULL_ASSERT</environmentMode>
+  <moveThreadCount>AUTO</moveThreadCount>
+  <solutionClass>org.optaplanner.core.impl.testdata.domain.TestdataSolution</solutionClass>
+  <entityClass>org.optaplanner.core.impl.testdata.domain.TestdataEntity</entityClass>
+  <scoreDirectorFactory>
+    <constraintProviderClass>org.optaplanner.core.config.solver.SolverConfigTest$DummyConstraintProvider</constraintProviderClass>
+    <initializingScoreTrend>ONLY_DOWN</initializingScoreTrend>
+  </scoreDirectorFactory>
+  <constructionHeuristic>
+    <constructionHeuristicType>FIRST_FIT_DECREASING</constructionHeuristicType>
+  </constructionHeuristic>
+  <localSearch>
+    <localSearchType>TABU_SEARCH</localSearchType>
+  </localSearch>
+</solver>

--- a/optaplanner-core/src/test/resources/org/optaplanner/core/config/solver/testSolverConfigWithoutNamespace.xml
+++ b/optaplanner-core/src/test/resources/org/optaplanner/core/config/solver/testSolverConfigWithoutNamespace.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<solver>
+<?xml version="1.0" encoding="utf-8"?><solver>
   <environmentMode>FULL_ASSERT</environmentMode>
   <moveThreadCount>AUTO</moveThreadCount>
   <solutionClass>org.optaplanner.core.impl.testdata.domain.TestdataSolution</solutionClass>


### PR DESCRIPTION
The first draft of having XSD for the SolverConfig.

Limitations:
- XSD defines an exact order of elements (xs:sequence), which introduces a backward incompatibility on a validation.
- presence of JAXB annotations required for generating XSD forces the root element `<solver/>` to declare a namespace
- this is also truth for any presence of the `SolverConfig` in other elements - `PlannerBenchmarkConfig` and `PlannerBenchmarkResult`

Workaround for the limitations:
- don't validate; XSD is optional
- read and write `solverConfig` in a "compatible mode", without namespaces.

TODO:
- [ ] documentation
- [ ] more test coverage
