### PR TITLE
Upgrade Quarkus to 1.7.0.Final

### DIFF
--- a/optaplanner-build-parent/pom.xml
+++ b/optaplanner-build-parent/pom.xml
@@ -29,6 +29,7 @@
     <version.com.fasterxml.jackson.core>2.10.4</version.com.fasterxml.jackson.core>
     <version.com.h2database>1.3.173</version.com.h2database>
     <version.com.thoughtworks.xstream>1.4.11.1</version.com.thoughtworks.xstream>
+    <version.io.quarkus>1.7.0.Final</version.io.quarkus>
     <version.jakarta.json.bind>1.0.2</version.jakarta.json.bind>
     <version.jakarta.xml.bind>2.3.3</version.jakarta.xml.bind>
     <version.org.apache.commons.lang3>3.9</version.org.apache.commons.lang3>

--- a/optaplanner-quarkus-integration/pom.xml
+++ b/optaplanner-quarkus-integration/pom.xml
@@ -24,8 +24,6 @@
   <url>https://www.optaplanner.org</url>
 
   <properties>
-    <version.io.quarkus>1.7.0.Final</version.io.quarkus>
-
     <!-- TODO Quarkus is riddled with duplicate classes, see https://github.com/quarkusio/quarkus/issues/9834 -->
     <enforcer.failOnDuplicatedClasses>false</enforcer.failOnDuplicatedClasses>
   </properties>

--- a/optaplanner-quarkus-integration/pom.xml
+++ b/optaplanner-quarkus-integration/pom.xml
@@ -24,7 +24,7 @@
   <url>https://www.optaplanner.org</url>
 
   <properties>
-    <version.io.quarkus>1.6.0.Final</version.io.quarkus>
+    <version.io.quarkus>1.7.0.Final</version.io.quarkus>
 
     <!-- TODO remove if https://issues.redhat.com/browse/PLANNER-2005 is fixed for 8.x -->
     <!-- TODO Extending kie-parent 7 is extremely dangerous and messy because it's not aligned to quarkus -->

--- a/optaplanner-quarkus-integration/pom.xml
+++ b/optaplanner-quarkus-integration/pom.xml
@@ -43,13 +43,6 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
-      <dependency>
-        <groupId>io.quarkus</groupId>
-        <artifactId>quarkus-bom-deployment</artifactId>
-        <version>${version.io.quarkus}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
     </dependencies>
   </dependencyManagement>
   <build>

--- a/optaplanner-quarkus-integration/pom.xml
+++ b/optaplanner-quarkus-integration/pom.xml
@@ -26,41 +26,8 @@
   <properties>
     <version.io.quarkus>1.7.0.Final</version.io.quarkus>
 
-    <!-- TODO remove if https://issues.redhat.com/browse/PLANNER-2005 is fixed for 8.x -->
-    <!-- TODO Extending kie-parent 7 is extremely dangerous and messy because it's not aligned to quarkus -->
-    <version.asm>7.3.1</version.asm>
-    <version.commons-cli>1.4</version.commons-cli>
-    <version.commons-codec>1.13</version.commons-codec>
-    <version.com.google.guava>27.0.1-jre</version.com.google.guava>
-    <version.com.google.inject.guice>4.2.1</version.com.google.inject.guice>
-    <version.org.apache.httpcomponents.httpclient>4.5.12</version.org.apache.httpcomponents.httpclient>
-    <version.org.apache.httpcomponents.httpcore>4.4.13</version.org.apache.httpcomponents.httpcore>
-    <version.org.apache.maven>3.6.3</version.org.apache.maven>
-    <version.org.apache.maven.plugin-tools>3.6.0</version.org.apache.maven.plugin-tools>
-    <version.org.apache.maven.wagon>3.3.3</version.org.apache.maven.wagon>
-    <version.org.codehaus.plexus.plexus-classworlds>2.6.0</version.org.codehaus.plexus.plexus-classworlds>
-    <version.org.codehaus.plexus.plexus-containers>2.1.0</version.org.codehaus.plexus.plexus-containers>
-    <version.org.codehaus.plexus.plexus-interpolation>1.25</version.org.codehaus.plexus.plexus-interpolation>
-    <version.org.codehaus.plexus.plexus-utils>3.2.1</version.org.codehaus.plexus.plexus-utils>
-    <version.org.eclipse.sisu>0.3.4</version.org.eclipse.sisu>
-    <version.org.jsoup>1.11.3</version.org.jsoup>
-    <version.org.junit>5.6.2</version.org.junit>
-    <version.org.sonatype.plexus.plexus-sec-dispatcher>1.4</version.org.sonatype.plexus.plexus-sec-dispatcher>
-    <version.org.wildfly.common>1.5.4.Final-format-001</version.org.wildfly.common>
-    <version.org.ow2.asm>8.0.1</version.org.ow2.asm>
-    <version.org.jboss.jandex>2.1.3.Final</version.org.jboss.jandex>
-
-
-    <version.org.jboss.resteasy>4.5.3.Final</version.org.jboss.resteasy>
-    <version.com.fasterxml.jackson>2.10.3</version.com.fasterxml.jackson>
-    <version.com.fasterxml.jackson.databind>2.10.3</version.com.fasterxml.jackson.databind>
-
     <!-- TODO Quarkus is riddled with duplicate classes, see https://github.com/quarkusio/quarkus/issues/9834 -->
     <enforcer.failOnDuplicatedClasses>false</enforcer.failOnDuplicatedClasses>
-
-    <!-- TODO Remove when we upgrade to jboss-parent 36 -->
-    <version.compiler.plugin>3.8.0-jboss-2</version.compiler.plugin>
-    
   </properties>
 
   <modules>

--- a/optaplanner-quickstarts/quarkus-facility-location/pom.xml
+++ b/optaplanner-quickstarts/quarkus-facility-location/pom.xml
@@ -9,7 +9,7 @@
 
   <properties>
     <version.org.optaplanner>8.0.0-SNAPSHOT</version.org.optaplanner>
-    <version.io.quarkus>1.6.0.Final</version.io.quarkus>
+    <version.io.quarkus>1.7.0.Final</version.io.quarkus>
 
     <compiler-plugin.version>3.8.1</compiler-plugin.version>
     <maven.compiler.parameters>true</maven.compiler.parameters>

--- a/optaplanner-quickstarts/quarkus-school-timetabling/build.gradle
+++ b/optaplanner-quickstarts/quarkus-school-timetabling/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id "io.quarkus" version "1.4.2.Final"
+    id "io.quarkus" version "1.7.0.Final"
     id "java"
 }
 
@@ -14,9 +14,10 @@ repositories {
 }
 
 dependencies {
-    implementation enforcedPlatform("io.quarkus:quarkus-universe-bom:1.4.2.Final")
-    implementation 'io.quarkus:quarkus-optaplanner'
-    implementation 'io.quarkus:quarkus-optaplanner-jackson'
+    implementation platform("io.quarkus:quarkus-universe-bom:1.7.0.Final")
+    implementation "org.optaplanner:optaplanner-quarkus:${optaplannerVersion}"
+    implementation "org.optaplanner:optaplanner-quarkus-jackson:${optaplannerVersion}"
+    implementation "org.optaplanner:optaplanner-test:${optaplannerVersion}"
     implementation 'io.quarkus:quarkus-resteasy'
     implementation 'io.quarkus:quarkus-resteasy-jackson'
     implementation 'io.quarkus:quarkus-hibernate-orm-panache'

--- a/optaplanner-quickstarts/quarkus-school-timetabling/pom.xml
+++ b/optaplanner-quickstarts/quarkus-school-timetabling/pom.xml
@@ -9,6 +9,7 @@
 
   <properties>
     <version.org.optaplanner>8.0.0-SNAPSHOT</version.org.optaplanner>
+    <!-- Always update the version also in the build.gradle. -->
     <version.io.quarkus>1.7.0.Final</version.io.quarkus>
 
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/optaplanner-quickstarts/quarkus-school-timetabling/pom.xml
+++ b/optaplanner-quickstarts/quarkus-school-timetabling/pom.xml
@@ -9,7 +9,7 @@
 
   <properties>
     <version.org.optaplanner>8.0.0-SNAPSHOT</version.org.optaplanner>
-    <version.io.quarkus>1.6.0.Final</version.io.quarkus>
+    <version.io.quarkus>1.7.0.Final</version.io.quarkus>
 
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <compiler-plugin.version>3.8.1</compiler-plugin.version>


### PR DESCRIPTION
Do not merge before io.quarkus:quarkus-bom-deployment:1.7.0.Final is available.

Locally optaplanner-quarkus-integration tests passed with 1.7.0.Final core artifacts (and quarkus-bom-deployment:1.6.0.Final).