### PR TITLE
PLANNER-1433 Handle logical OR in DRL correctly

### DIFF
--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/constraint/DefaultConstraintMatchTotal.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/constraint/DefaultConstraintMatchTotal.java
@@ -16,6 +16,10 @@
 
 package org.optaplanner.core.impl.score.constraint;
 
+import static java.util.Comparator.comparing;
+import static java.util.Objects.hash;
+import static java.util.Objects.requireNonNull;
+
 import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -25,10 +29,6 @@ import java.util.Set;
 import org.optaplanner.core.api.score.Score;
 import org.optaplanner.core.api.score.constraint.ConstraintMatch;
 import org.optaplanner.core.api.score.constraint.ConstraintMatchTotal;
-
-import static java.util.Comparator.comparing;
-import static java.util.Objects.hash;
-import static java.util.Objects.requireNonNull;
 
 public final class DefaultConstraintMatchTotal implements ConstraintMatchTotal,
         Comparable<DefaultConstraintMatchTotal> {

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/constraint/DefaultConstraintMatchTotal.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/constraint/DefaultConstraintMatchTotal.java
@@ -16,18 +16,19 @@
 
 package org.optaplanner.core.impl.score.constraint;
 
-import static java.util.Comparator.comparing;
-import static java.util.Objects.hash;
-import static java.util.Objects.requireNonNull;
-
 import java.util.Comparator;
-import java.util.LinkedHashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import org.optaplanner.core.api.score.Score;
 import org.optaplanner.core.api.score.constraint.ConstraintMatch;
 import org.optaplanner.core.api.score.constraint.ConstraintMatchTotal;
+
+import static java.util.Comparator.comparing;
+import static java.util.Objects.hash;
+import static java.util.Objects.requireNonNull;
 
 public final class DefaultConstraintMatchTotal implements ConstraintMatchTotal,
         Comparable<DefaultConstraintMatchTotal> {
@@ -40,7 +41,7 @@ public final class DefaultConstraintMatchTotal implements ConstraintMatchTotal,
     private final String constraintName;
     private final Score constraintWeight;
 
-    private final Set<ConstraintMatch> constraintMatchSet = new LinkedHashSet<>();
+    private final Map<ConstraintMatch, Integer> constraintMatchRuleFireCountMap = new LinkedHashMap<>();
     private Score score;
 
     public DefaultConstraintMatchTotal(String constraintPackage, String constraintName, Score zeroScore) {
@@ -72,7 +73,7 @@ public final class DefaultConstraintMatchTotal implements ConstraintMatchTotal,
 
     @Override
     public Set<ConstraintMatch> getConstraintMatchSet() {
-        return constraintMatchSet;
+        return constraintMatchRuleFireCountMap.keySet();
     }
 
     @Override
@@ -85,25 +86,36 @@ public final class DefaultConstraintMatchTotal implements ConstraintMatchTotal,
     // ************************************************************************
 
     public ConstraintMatch addConstraintMatch(List<Object> justificationList, Score score) {
-        this.score = this.score.add(score);
-        ConstraintMatch constraintMatch = new ConstraintMatch(constraintPackage, constraintName,
-                justificationList, score);
-        boolean added = constraintMatchSet.add(constraintMatch);
-        if (!added) {
-            throw new IllegalStateException("The constraintMatchTotal (" + this
-                    + ") could not add constraintMatch (" + constraintMatch
-                    + ") to its constraintMatchSet (" + constraintMatchSet + ").");
+        ConstraintMatch constraintMatch = new ConstraintMatch(constraintPackage, constraintName, justificationList,
+                score);
+        int currentFireCount = constraintMatchRuleFireCountMap.compute(constraintMatch,
+                (key, fireCount) -> (fireCount == null) ? 1 : fireCount + 1);
+        if (currentFireCount == 1) {
+            /*
+             * Sometimes the same constraint match may be sent more than once, such as when the DRL uses logical OR on
+             * two facts of the same type which turn out to resolve to the same fact.
+             * This rule will fire twice, sending two distinct constraint match instances with identical contents.
+             * See PLANNER-1433 for details.
+             */
+            this.score = this.score.add(score);
         }
         return constraintMatch;
     }
 
     public void removeConstraintMatch(ConstraintMatch constraintMatch) {
-        score = score.subtract(constraintMatch.getScore());
-        boolean removed = constraintMatchSet.remove(constraintMatch);
-        if (!removed) {
-            throw new IllegalStateException("The constraintMatchTotal (" + this
-                    + ") could not remove constraintMatch (" + constraintMatch
-                    + ") from its constraintMatchSet (" + constraintMatchSet + ").");
+        Integer currentFireCount = constraintMatchRuleFireCountMap.compute(constraintMatch, (key, fireCount) -> {
+            if (fireCount == null || fireCount < 1) {
+                throw new IllegalStateException("The constraintMatchTotal (" + this
+                        + ") could not remove constraintMatch (" + constraintMatch
+                        + ") from its map (" + constraintMatchRuleFireCountMap + ").");
+            } else if (fireCount == 1) { // Unmap as all the constraint matches with the same justifications are gone.
+                return null;
+            } else {
+                return fireCount - 1;
+            }
+        });
+        if (currentFireCount == null) { // Constraint match was just removed.
+            score = score.subtract(constraintMatch.getScore());
         }
     }
 


### PR DESCRIPTION
This may have some small impact on constraint matching performance, but that should not matter as the previous behavior was incorrect.
The performance impact could be eliminated entirely, if we can live with the fact that the duplicate constraint matches will be removed on the first instance, and not on the last. This will allow me to turn the counter `Map` back into the original `Set` and remove the counting logic altogether.