### PR TITLE
Reduce raw types usage

### DIFF
--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/constructionheuristic/DefaultConstructionHeuristicPhaseFactory.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/constructionheuristic/DefaultConstructionHeuristicPhaseFactory.java
@@ -51,12 +51,12 @@ public class DefaultConstructionHeuristicPhaseFactory<Solution_>
 
     @Override
     public ConstructionHeuristicPhase<Solution_> buildPhase(int phaseIndex, HeuristicConfigPolicy solverConfigPolicy,
-            BestSolutionRecaller bestSolutionRecaller, Termination solverTermination) {
+            BestSolutionRecaller<Solution_> bestSolutionRecaller, Termination solverTermination) {
 
         HeuristicConfigPolicy phaseConfigPolicy = solverConfigPolicy.createFilteredPhaseConfigPolicy();
-        DefaultConstructionHeuristicPhase phase =
-                new DefaultConstructionHeuristicPhase(phaseIndex, solverConfigPolicy.getLogIndentation(), bestSolutionRecaller,
-                        buildPhaseTermination(phaseConfigPolicy, solverTermination));
+        DefaultConstructionHeuristicPhase<Solution_> phase =
+                new DefaultConstructionHeuristicPhase<>(phaseIndex, solverConfigPolicy.getLogIndentation(),
+                        bestSolutionRecaller, buildPhaseTermination(phaseConfigPolicy, solverTermination));
         phase.setDecider(buildDecider(phaseConfigPolicy, phase.getTermination()));
         ConstructionHeuristicType constructionHeuristicType_ = defaultIfNull(
                 phaseConfig.getConstructionHeuristicType(), ConstructionHeuristicType.ALLOCATE_ENTITY_FROM_QUEUE);
@@ -95,16 +95,16 @@ public class DefaultConstructionHeuristicPhaseFactory<Solution_>
         return phase;
     }
 
-    private ConstructionHeuristicDecider buildDecider(HeuristicConfigPolicy configPolicy, Termination termination) {
+    private ConstructionHeuristicDecider<Solution_> buildDecider(HeuristicConfigPolicy configPolicy, Termination termination) {
         ConstructionHeuristicForagerConfig foragerConfig_ = phaseConfig.getForagerConfig() == null
                 ? new ConstructionHeuristicForagerConfig()
                 : phaseConfig.getForagerConfig();
         ConstructionHeuristicForager forager = foragerConfig_.buildForager(configPolicy);
         EnvironmentMode environmentMode = configPolicy.getEnvironmentMode();
-        ConstructionHeuristicDecider decider;
+        ConstructionHeuristicDecider<Solution_> decider;
         Integer moveThreadCount = configPolicy.getMoveThreadCount();
         if (moveThreadCount == null) {
-            decider = new ConstructionHeuristicDecider(configPolicy.getLogIndentation(), termination, forager);
+            decider = new ConstructionHeuristicDecider<>(configPolicy.getLogIndentation(), termination, forager);
         } else {
             Integer moveThreadBufferSize = configPolicy.getMoveThreadBufferSize();
             if (moveThreadBufferSize == null) {
@@ -115,9 +115,9 @@ public class DefaultConstructionHeuristicPhaseFactory<Solution_>
             }
             ThreadFactory threadFactory = configPolicy.buildThreadFactory(ChildThreadType.MOVE_THREAD);
             int selectedMoveBufferSize = moveThreadCount * moveThreadBufferSize;
-            MultiThreadedConstructionHeuristicDecider multiThreadedDecider = new MultiThreadedConstructionHeuristicDecider(
-                    configPolicy.getLogIndentation(), termination, forager,
-                    threadFactory, moveThreadCount, selectedMoveBufferSize);
+            MultiThreadedConstructionHeuristicDecider<Solution_> multiThreadedDecider =
+                    new MultiThreadedConstructionHeuristicDecider<>(configPolicy.getLogIndentation(), termination, forager,
+                            threadFactory, moveThreadCount, selectedMoveBufferSize);
             if (environmentMode.isNonIntrusiveFullAsserted()) {
                 multiThreadedDecider.setAssertStepScoreFromScratch(true);
             }

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/exhaustivesearch/DefaultExhaustiveSearchPhaseFactory.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/exhaustivesearch/DefaultExhaustiveSearchPhaseFactory.java
@@ -66,9 +66,9 @@ public class DefaultExhaustiveSearchPhaseFactory<Solution_>
                         : exhaustiveSearchType_.getDefaultEntitySorterManner());
         phaseConfigPolicy.setValueSorterManner(phaseConfig.getValueSorterManner() != null ? phaseConfig.getValueSorterManner()
                 : exhaustiveSearchType_.getDefaultValueSorterManner());
-        DefaultExhaustiveSearchPhase phase = new DefaultExhaustiveSearchPhase(
-                phaseIndex, solverConfigPolicy.getLogIndentation(), bestSolutionRecaller,
-                buildPhaseTermination(phaseConfigPolicy, solverTermination));
+        DefaultExhaustiveSearchPhase<Solution_> phase =
+                new DefaultExhaustiveSearchPhase<>(phaseIndex, solverConfigPolicy.getLogIndentation(), bestSolutionRecaller,
+                        buildPhaseTermination(phaseConfigPolicy, solverTermination));
         boolean scoreBounderEnabled = exhaustiveSearchType_.isScoreBounderEnabled();
         NodeExplorationType nodeExplorationType_;
         if (exhaustiveSearchType_ == ExhaustiveSearchType.BRUTE_FORCE) {
@@ -106,7 +106,7 @@ public class DefaultExhaustiveSearchPhaseFactory<Solution_>
         EntitySelectorConfig entitySelectorConfig_;
         if (phaseConfig.getEntitySelectorConfig() == null) {
             entitySelectorConfig_ = new EntitySelectorConfig();
-            EntityDescriptor entityDescriptor = deduceEntityDescriptor(configPolicy.getSolutionDescriptor());
+            EntityDescriptor<Solution_> entityDescriptor = deduceEntityDescriptor(configPolicy.getSolutionDescriptor());
             entitySelectorConfig_.setEntityClass(entityDescriptor.getEntityClass());
             if (EntitySelectorConfig.hasSorter(configPolicy.getEntitySorterManner(), entityDescriptor)) {
                 entitySelectorConfig_.setCacheType(SelectionCacheType.PHASE);
@@ -126,8 +126,8 @@ public class DefaultExhaustiveSearchPhaseFactory<Solution_>
         return entitySelectorConfig_;
     }
 
-    protected EntityDescriptor deduceEntityDescriptor(SolutionDescriptor solutionDescriptor) {
-        Collection<EntityDescriptor> entityDescriptors = solutionDescriptor.getGenuineEntityDescriptors();
+    protected EntityDescriptor<Solution_> deduceEntityDescriptor(SolutionDescriptor<Solution_> solutionDescriptor) {
+        Collection<EntityDescriptor<Solution_>> entityDescriptors = solutionDescriptor.getGenuineEntityDescriptors();
         if (entityDescriptors.size() != 1) {
             throw new IllegalArgumentException("The phaseConfig (" + phaseConfig
                     + ") has no entitySelector configured"
@@ -137,9 +137,8 @@ public class DefaultExhaustiveSearchPhaseFactory<Solution_>
         return entityDescriptors.iterator().next();
     }
 
-    private ExhaustiveSearchDecider buildDecider(HeuristicConfigPolicy configPolicy,
-            EntitySelector sourceEntitySelector,
-            BestSolutionRecaller bestSolutionRecaller, Termination termination,
+    private ExhaustiveSearchDecider<Solution_> buildDecider(HeuristicConfigPolicy configPolicy,
+            EntitySelector sourceEntitySelector, BestSolutionRecaller<Solution_> bestSolutionRecaller, Termination termination,
             boolean scoreBounderEnabled) {
         ManualEntityMimicRecorder manualEntityMimicRecorder = new ManualEntityMimicRecorder(sourceEntitySelector);
         String mimicSelectorId = sourceEntitySelector.getEntityDescriptor().getEntityClass().getName(); // TODO mimicSelectorId must be a field
@@ -151,7 +150,7 @@ public class DefaultExhaustiveSearchPhaseFactory<Solution_>
         ScoreBounder scoreBounder = scoreBounderEnabled
                 ? new TrendBasedScoreBounder(configPolicy.getScoreDirectorFactory())
                 : null;
-        ExhaustiveSearchDecider decider = new ExhaustiveSearchDecider(configPolicy.getLogIndentation(),
+        ExhaustiveSearchDecider<Solution_> decider = new ExhaustiveSearchDecider<>(configPolicy.getLogIndentation(),
                 bestSolutionRecaller, termination,
                 manualEntityMimicRecorder, moveSelector, scoreBounderEnabled, scoreBounder);
         EnvironmentMode environmentMode = configPolicy.getEnvironmentMode();
@@ -168,13 +167,14 @@ public class DefaultExhaustiveSearchPhaseFactory<Solution_>
             EntitySelector entitySelector, String mimicSelectorId) {
         MoveSelectorConfig moveSelectorConfig_;
         if (phaseConfig.getMoveSelectorConfig() == null) {
-            EntityDescriptor entityDescriptor = entitySelector.getEntityDescriptor();
+            EntityDescriptor<Solution_> entityDescriptor = entitySelector.getEntityDescriptor();
             // Keep in sync with DefaultExhaustiveSearchPhase.fillLayerList()
             // which includes all genuineVariableDescriptors
-            Collection<GenuineVariableDescriptor> variableDescriptors = entityDescriptor.getGenuineVariableDescriptors();
+            Collection<GenuineVariableDescriptor<Solution_>> variableDescriptors =
+                    entityDescriptor.getGenuineVariableDescriptors();
             List<MoveSelectorConfig> subMoveSelectorConfigList = new ArrayList<>(
                     variableDescriptors.size());
-            for (GenuineVariableDescriptor variableDescriptor : variableDescriptors) {
+            for (GenuineVariableDescriptor<Solution_> variableDescriptor : variableDescriptors) {
                 ChangeMoveSelectorConfig changeMoveSelectorConfig = new ChangeMoveSelectorConfig();
                 changeMoveSelectorConfig.setEntitySelectorConfig(
                         EntitySelectorConfig.newMimicSelectorConfig(mimicSelectorId));

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/localsearch/DefaultLocalSearchPhaseFactory.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/localsearch/DefaultLocalSearchPhaseFactory.java
@@ -53,12 +53,11 @@ public class DefaultLocalSearchPhaseFactory<Solution_> extends AbstractPhaseFact
 
     @Override
     public LocalSearchPhase<Solution_> buildPhase(int phaseIndex, HeuristicConfigPolicy solverConfigPolicy,
-            BestSolutionRecaller bestSolutionRecaller,
-            Termination solverTermination) {
+            BestSolutionRecaller<Solution_> bestSolutionRecaller, Termination solverTermination) {
         HeuristicConfigPolicy phaseConfigPolicy = solverConfigPolicy.createPhaseConfigPolicy();
-        DefaultLocalSearchPhase phase = new DefaultLocalSearchPhase(
-                phaseIndex, solverConfigPolicy.getLogIndentation(), bestSolutionRecaller,
-                buildPhaseTermination(phaseConfigPolicy, solverTermination));
+        DefaultLocalSearchPhase<Solution_> phase =
+                new DefaultLocalSearchPhase<>(phaseIndex, solverConfigPolicy.getLogIndentation(), bestSolutionRecaller,
+                        buildPhaseTermination(phaseConfigPolicy, solverTermination));
         phase.setDecider(buildDecider(phaseConfigPolicy,
                 phase.getTermination()));
         EnvironmentMode environmentMode = phaseConfigPolicy.getEnvironmentMode();
@@ -72,7 +71,7 @@ public class DefaultLocalSearchPhaseFactory<Solution_> extends AbstractPhaseFact
         return phase;
     }
 
-    private LocalSearchDecider buildDecider(HeuristicConfigPolicy configPolicy, Termination termination) {
+    private LocalSearchDecider<Solution_> buildDecider(HeuristicConfigPolicy configPolicy, Termination termination) {
         MoveSelector moveSelector = buildMoveSelector(configPolicy);
         Acceptor acceptor = buildAcceptor(configPolicy);
         LocalSearchForager forager = buildForager(configPolicy);
@@ -85,10 +84,9 @@ public class DefaultLocalSearchPhaseFactory<Solution_> extends AbstractPhaseFact
         }
         Integer moveThreadCount = configPolicy.getMoveThreadCount();
         EnvironmentMode environmentMode = configPolicy.getEnvironmentMode();
-        LocalSearchDecider decider;
+        LocalSearchDecider<Solution_> decider;
         if (moveThreadCount == null) {
-            decider = new LocalSearchDecider(configPolicy.getLogIndentation(),
-                    termination, moveSelector, acceptor, forager);
+            decider = new LocalSearchDecider<>(configPolicy.getLogIndentation(), termination, moveSelector, acceptor, forager);
         } else {
             Integer moveThreadBufferSize = configPolicy.getMoveThreadBufferSize();
             if (moveThreadBufferSize == null) {
@@ -99,7 +97,7 @@ public class DefaultLocalSearchPhaseFactory<Solution_> extends AbstractPhaseFact
             }
             ThreadFactory threadFactory = configPolicy.buildThreadFactory(ChildThreadType.MOVE_THREAD);
             int selectedMoveBufferSize = moveThreadCount * moveThreadBufferSize;
-            MultiThreadedLocalSearchDecider multiThreadedDecider = new MultiThreadedLocalSearchDecider(
+            MultiThreadedLocalSearchDecider<Solution_> multiThreadedDecider = new MultiThreadedLocalSearchDecider<>(
                     configPolicy.getLogIndentation(), termination, moveSelector, acceptor, forager,
                     threadFactory, moveThreadCount, selectedMoveBufferSize);
             if (environmentMode.isNonIntrusiveFullAsserted()) {

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/phase/NoChangePhaseFactory.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/phase/NoChangePhaseFactory.java
@@ -29,10 +29,9 @@ public class NoChangePhaseFactory<Solution_> extends AbstractPhaseFactory<Soluti
 
     @Override
     public NoChangePhase<Solution_> buildPhase(int phaseIndex, HeuristicConfigPolicy solverConfigPolicy,
-            BestSolutionRecaller bestSolutionRecaller, Termination solverTermination) {
+            BestSolutionRecaller<Solution_> bestSolutionRecaller, Termination solverTermination) {
         HeuristicConfigPolicy phaseConfigPolicy = solverConfigPolicy.createPhaseConfigPolicy();
-        return new NoChangePhase(
-                phaseIndex, solverConfigPolicy.getLogIndentation(), bestSolutionRecaller,
+        return new NoChangePhase<>(phaseIndex, solverConfigPolicy.getLogIndentation(), bestSolutionRecaller,
                 buildPhaseTermination(phaseConfigPolicy, solverTermination));
     }
 }

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/phase/custom/DefaultCustomPhaseFactory.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/phase/custom/DefaultCustomPhaseFactory.java
@@ -35,11 +35,10 @@ public class DefaultCustomPhaseFactory<Solution_> extends AbstractPhaseFactory<S
 
     @Override
     public CustomPhase<Solution_> buildPhase(int phaseIndex, HeuristicConfigPolicy solverConfigPolicy,
-            BestSolutionRecaller bestSolutionRecaller, Termination solverTermination) {
+            BestSolutionRecaller<Solution_> bestSolutionRecaller, Termination solverTermination) {
         HeuristicConfigPolicy phaseConfigPolicy = solverConfigPolicy.createPhaseConfigPolicy();
-        DefaultCustomPhase phase = new DefaultCustomPhase(
-                phaseIndex, solverConfigPolicy.getLogIndentation(), bestSolutionRecaller,
-                buildPhaseTermination(phaseConfigPolicy, solverTermination));
+        DefaultCustomPhase phase = new DefaultCustomPhase(phaseIndex, solverConfigPolicy.getLogIndentation(),
+                bestSolutionRecaller, buildPhaseTermination(phaseConfigPolicy, solverTermination));
         if (ConfigUtils.isEmptyCollection(phaseConfig.getCustomPhaseCommandClassList())
                 && ConfigUtils.isEmptyCollection(phaseConfig.getCustomPhaseCommandList())) {
             throw new IllegalArgumentException(
@@ -49,11 +48,7 @@ public class DefaultCustomPhaseFactory<Solution_> extends AbstractPhaseFactory<S
         List<CustomPhaseCommand<?>> customPhaseCommandList_ = new ArrayList<>(getCustomPhaseCommandListSize());
         if (phaseConfig.getCustomPhaseCommandClassList() != null) {
             for (Class<? extends CustomPhaseCommand> customPhaseCommandClass : phaseConfig.getCustomPhaseCommandClassList()) {
-                CustomPhaseCommand customPhaseCommand = ConfigUtils.newInstance(phaseConfig,
-                        "customPhaseCommandClass", customPhaseCommandClass);
-                ConfigUtils.applyCustomProperties(customPhaseCommand, "customPhaseCommandClass",
-                        phaseConfig.getCustomProperties(), "customProperties");
-                customPhaseCommandList_.add(customPhaseCommand);
+                customPhaseCommandList_.add(createCustomPhaseCommand(customPhaseCommandClass));
             }
         }
         if (phaseConfig.getCustomPhaseCommandList() != null) {
@@ -65,6 +60,14 @@ public class DefaultCustomPhaseFactory<Solution_> extends AbstractPhaseFactory<S
             phase.setAssertStepScoreFromScratch(true);
         }
         return phase;
+    }
+
+    private CustomPhaseCommand<?> createCustomPhaseCommand(Class<? extends CustomPhaseCommand> customPhaseCommandClass) {
+        CustomPhaseCommand<?> customPhaseCommand =
+                ConfigUtils.newInstance(phaseConfig, "customPhaseCommandClass", customPhaseCommandClass);
+        ConfigUtils.applyCustomProperties(customPhaseCommand, "customPhaseCommandClass", phaseConfig.getCustomProperties(),
+                "customProperties");
+        return customPhaseCommand;
     }
 
     private int getCustomPhaseCommandListSize() {

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/solver/DefaultSolverFactory.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/solver/DefaultSolverFactory.java
@@ -107,9 +107,10 @@ public final class DefaultSolverFactory<Solution_> implements SolverFactory<Solu
         ScoreDirectorFactoryConfig scoreDirectorFactoryConfig_ = solverConfig.getScoreDirectorFactoryConfig() == null
                 ? new ScoreDirectorFactoryConfig()
                 : solverConfig.getScoreDirectorFactoryConfig();
-        ScoreDirectorFactoryFactory scoreDirectorFactoryFactory = new ScoreDirectorFactoryFactory(scoreDirectorFactoryConfig_);
-        return scoreDirectorFactoryFactory.buildScoreDirectorFactory(
-                solverConfig.getClassLoader(), environmentMode, solutionDescriptor);
+        ScoreDirectorFactoryFactory<Solution_> scoreDirectorFactoryFactory =
+                new ScoreDirectorFactoryFactory<>(scoreDirectorFactoryConfig_);
+        return scoreDirectorFactoryFactory.buildScoreDirectorFactory(solverConfig.getClassLoader(), environmentMode,
+                solutionDescriptor);
     }
 
     /**
@@ -153,7 +154,7 @@ public final class DefaultSolverFactory<Solution_> implements SolverFactory<Solu
     }
 
     protected List<Phase<Solution_>> buildPhaseList(HeuristicConfigPolicy configPolicy,
-            BestSolutionRecaller bestSolutionRecaller, Termination termination) {
+            BestSolutionRecaller<Solution_> bestSolutionRecaller, Termination termination) {
         List<PhaseConfig> phaseConfigList_ = solverConfig.getPhaseConfigList();
         if (ConfigUtils.isEmptyCollection(phaseConfigList_)) {
             phaseConfigList_ = Arrays.asList(

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/partitionedsearch/DefaultPartitionedSearchPhaseFactoryTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/partitionedsearch/DefaultPartitionedSearchPhaseFactoryTest.java
@@ -46,13 +46,13 @@ class DefaultPartitionedSearchPhaseFactoryTest {
     @Test
     void resolveActiveThreadCountUnlimited() {
         assertThat(createDefaultPartitionedSearchPhaseFactory()
-                .resolvedActiveThreadCount(PartitionedSearchPhaseConfig.ACTIVE_THREAD_COUNT_UNLIMITED)).isNull();
+                .resolveActiveThreadCount(PartitionedSearchPhaseConfig.ACTIVE_THREAD_COUNT_UNLIMITED)).isNull();
     }
 
     @Test //TODO: The expression resolution could use much more testing
     void resolveActiveThreadCountExpression() {
         assertThat(createDefaultPartitionedSearchPhaseFactory()
-                .resolvedActiveThreadCount("2*3-1")).isEqualTo(5);
+                .resolveActiveThreadCount("2*3-1")).isEqualTo(5);
     }
 
     private Integer mockResolveActiveThreadCount(String runnablePartThreadLimit, int cpuCount) {
@@ -60,7 +60,7 @@ class DefaultPartitionedSearchPhaseFactoryTest {
                 spy(createDefaultPartitionedSearchPhaseFactory());
 
         when(partitionedSearchPhaseFactory.getAvailableProcessors()).thenReturn(cpuCount);
-        return partitionedSearchPhaseFactory.resolvedActiveThreadCount(runnablePartThreadLimit);
+        return partitionedSearchPhaseFactory.resolveActiveThreadCount(runnablePartThreadLimit);
     }
 
     private DefaultPartitionedSearchPhaseFactory<TestdataSolution> createDefaultPartitionedSearchPhaseFactory() {

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/score/director/ScoreDirectorFactoryFactoryTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/score/director/ScoreDirectorFactoryFactoryTest.java
@@ -116,7 +116,7 @@ class ScoreDirectorFactoryFactoryTest {
         kieBaseConfigurationProperties.put(secondPropertyName, secondPropertyValue);
 
         config.setKieBaseConfigurationProperties(kieBaseConfigurationProperties);
-        ScoreDirectorFactoryFactory scoreDirectorFactoryFactory = new ScoreDirectorFactoryFactory(config);
+        ScoreDirectorFactoryFactory<TestdataSolution> scoreDirectorFactoryFactory = new ScoreDirectorFactoryFactory<>(config);
         KieBaseConfiguration kieBaseConfiguration =
                 scoreDirectorFactoryFactory.buildKieBaseConfiguration(KieServices.Factory.get());
 
@@ -152,9 +152,8 @@ class ScoreDirectorFactoryFactoryTest {
 
     private ScoreDirectorFactory<TestdataSolution> buildTestdataScoreDirectoryFactory(ScoreDirectorFactoryConfig config,
             EnvironmentMode environmentMode) {
-        return new ScoreDirectorFactoryFactory(config)
-                .buildScoreDirectorFactory(getClass().getClassLoader(), environmentMode,
-                        TestdataSolution.buildSolutionDescriptor());
+        return new ScoreDirectorFactoryFactory<TestdataSolution>(config).buildScoreDirectorFactory(getClass().getClassLoader(),
+                environmentMode, TestdataSolution.buildSolutionDescriptor());
     }
 
     private ScoreDirectorFactory<TestdataSolution> buildTestdataScoreDirectoryFactory(ScoreDirectorFactoryConfig config) {


### PR DESCRIPTION
Also:
- renames `resolvedActiveThreadCount` to `resolveActiveThreadCount`
- fixes error message by passing correct instance to `ConfigUtils.newInstance`.