### PR TITLE
Always use the same JDK for Javadoc as for Maven

### DIFF
--- a/optaplanner-build-parent/pom.xml
+++ b/optaplanner-build-parent/pom.xml
@@ -754,6 +754,7 @@
           <artifactId>maven-javadoc-plugin</artifactId>
           <version>3.2.0</version>
           <configuration>
+            <javadocExecutable>${java.home}/bin/javadoc</javadocExecutable> <!-- Always use the same JDK as Maven. -->
             <author>false</author>
             <failOnError>true</failOnError>
             <failOnWarnings>true</failOnWarnings>


### PR DESCRIPTION
For systems where Maven may be running with different `JAVA_HOME` than is the default (such as Fedora), this fixes a whole lot of issues.