### PR TITLE
PLANNER-1868 SolverManager needs an API that allows a user to listen to both best solution and solver terminated events

### DIFF
--- a/optaplanner-core/src/build/revapi-config.json
+++ b/optaplanner-core/src/build/revapi-config.json
@@ -8411,6 +8411,15 @@
           "fieldName": "K",
           "elementKind": "field",
           "justification": "K constant move to the KOptMoveSelectorFactory."
+        },
+        {
+          "code": "java.method.addedToInterface",
+          "new": "method org.optaplanner.core.api.solver.SolverJob<Solution_, ProblemId_> org.optaplanner.core.api.solver.SolverManager<Solution_, ProblemId_>::solveAndListen(ProblemId_, java.util.function.Function<? super ProblemId_, ? extends Solution_>, java.util.function.Consumer<? super Solution_>, java.util.function.Consumer<? super Solution_>, java.util.function.BiConsumer<? super ProblemId_, ? super java.lang.Throwable>)",
+          "package": "org.optaplanner.core.api.solver",
+          "classSimpleName": "SolverManager",
+          "methodName": "solveAndListen",
+          "elementKind": "method",
+          "justification": "SolverManager needs an API that allows a user to listen to both best solution and solver terminated events"
         }
       ]
     }

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/solver/DefaultSolverManager.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/solver/DefaultSolverManager.java
@@ -86,8 +86,9 @@ public final class DefaultSolverManager<Solution_, ProblemId_> implements Solver
     public SolverJob<Solution_, ProblemId_> solveAndListen(ProblemId_ problemId,
             Function<? super ProblemId_, ? extends Solution_> problemFinder,
             Consumer<? super Solution_> bestSolutionConsumer,
+            Consumer<? super Solution_> finalBestSolutionConsumer,
             BiConsumer<? super ProblemId_, ? super Throwable> exceptionHandler) {
-        return solve(problemId, problemFinder, bestSolutionConsumer, null, exceptionHandler);
+        return solve(problemId, problemFinder, bestSolutionConsumer, finalBestSolutionConsumer, exceptionHandler);
     }
 
     protected SolverJob<Solution_, ProblemId_> solve(ProblemId_ problemId,


### PR DESCRIPTION
One of the RH field people is running to this too now, so I intend to backport it after review/merge too.