### PR TITLE
BXMSPROD-963 pull_request.yml updated

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           parent-dependencies: 'drools@7.x:master'
           child-dependencies: 'jbpm@7.x:master'
-          build-command: 'mvn -e clean install -nsu -Prun-code-coverage,wildfly -Dfull  -Dintegration-tests=true -Dmaven.test.failure.ignore=true -DjvmArgs="-Xms1g -Xmx4g"'
+          build-command: 'mvn -e clean install -nsu -Prun-code-coverage,wildfly -Dfull  -Dintegration-tests=true -Dmaven.test.failure.ignore=true'
           build-command-upstream: "mvn -e clean install -DskipTests -Dgwt.compiler.skip=true -Dgwt.skipCompilation=true -Denforcer.skip=true -Dcheckstyle.skip=true -Dspotbugs.skip=true -Drevapi.skip=true"
           workflow-file-name: "pull_request.yml"
         env:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
     - name: Build Chain ${{ matrix.java-version }}
       id: build-chain   
-      uses: kiegroup/github-action-build-chain@v1.2
+      uses: kiegroup/github-action-build-chain@v1.3
       with:
         parent-dependencies: 'drools@7.x:master'
         child-dependencies: 'jbpm@7.x:master'

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,16 +1,18 @@
-name: Build Chain
+name: Build Chain [pull request]
 
-on: [ workflow_dispatch ]
+on: [pull_request]
 
 jobs:
-  build-chain-openjdk8:
+  build-chain:
+    strategy:
+      matrix:
+        java-version: [8, 11]
     runs-on: ubuntu-latest
-    name: Pull Request openjdk8
+    name: Build Pull Request
     steps:
-    - uses: actions/checkout@v2
-    - name: Build Chain
-      id: build-chain
-      uses: kiegroup/github-action-build-chain@openjdk8
+    - name: Build Chain ${{ matrix.java-version }}
+      id: build-chain   
+      uses: kiegroup/github-action-build-chain@v1.1
       with:
         parent-dependencies: 'drools@7.x:master'
         child-dependencies: 'jbpm@7.x:master'
@@ -18,22 +20,4 @@ jobs:
         build-command-upstream: "mvn -e clean install -DskipTests -Dgwt.compiler.skip=true -Dgwt.skipCompilation=true -Denforcer.skip=true -Dcheckstyle.skip=true -Dspotbugs.skip=true -Drevapi.skip=true"
         workflow-file-name: "pull_request.yml"
       env:
-          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-  build-chain-openjdk11:
-    runs-on: ubuntu-latest
-    name: Pull Request openjdk11
-    steps:
-    - uses: actions/checkout@v2
-    - name: Build Chain
-      id: build-chain
-      uses: kiegroup/github-action-build-chain@openjdk11
-      with:
-        parent-dependencies: 'drools@7.x:master'
-        child-dependencies: 'jbpm@7.x:master'
-        build-command: 'mvn -e clean install -nsu -Prun-code-coverage,wildfly -Dfull  -Dintegration-tests=true -Dmaven.test.failure.ignore=true -DjvmArgs="-Xms1g -Xmx4g"'
-        build-command-upstream: "mvn -e clean install -DskipTests -Dgwt.compiler.skip=true -Dgwt.skipCompilation=true -Denforcer.skip=true -Dcheckstyle.skip=true -Dspotbugs.skip=true -Drevapi.skip=true"
-        workflow-file-name: "pull_request.yml"
-      env:
-          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-        
-
+        GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"                                        

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,4 +1,4 @@
-name: Build Chain [pull request]
+name: Build Chain
 
 on: [pull_request]
 
@@ -7,17 +7,22 @@ jobs:
     strategy:
       matrix:
         java-version: [8, 11]
+      fail-fast: false
     runs-on: ubuntu-latest
-    name: Build Pull Request
+    name: Maven Build
     steps:
-    - name: Build Chain ${{ matrix.java-version }}
-      id: build-chain   
-      uses: kiegroup/github-action-build-chain@v1.3
-      with:
-        parent-dependencies: 'drools@7.x:master'
-        child-dependencies: 'jbpm@7.x:master'
-        build-command: 'mvn -e clean install -nsu -Prun-code-coverage,wildfly -Dfull  -Dintegration-tests=true -Dmaven.test.failure.ignore=true -DjvmArgs="-Xms1g -Xmx4g"'
-        build-command-upstream: "mvn -e clean install -DskipTests -Dgwt.compiler.skip=true -Dgwt.skipCompilation=true -Denforcer.skip=true -Dcheckstyle.skip=true -Dspotbugs.skip=true -Drevapi.skip=true"
-        workflow-file-name: "pull_request.yml"
-      env:
-        GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"                                        
+      - name: Set up JDK
+        uses: actions/setup-java@v1
+        with:
+          java-version: ${{ matrix.java-version }}
+      - name: Build Chain ${{ matrix.java-version }}
+        id: build-chain
+        uses: kiegroup/github-action-build-chain@master
+        with:
+          parent-dependencies: 'drools@7.x:master'
+          child-dependencies: 'jbpm@7.x:master'
+          build-command: 'mvn -e clean install -nsu -Prun-code-coverage,wildfly -Dfull  -Dintegration-tests=true -Dmaven.test.failure.ignore=true -DjvmArgs="-Xms1g -Xmx4g"'
+          build-command-upstream: "mvn -e clean install -DskipTests -Dgwt.compiler.skip=true -Dgwt.skipCompilation=true -Denforcer.skip=true -Dcheckstyle.skip=true -Dspotbugs.skip=true -Drevapi.skip=true"
+          workflow-file-name: "pull_request.yml"
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
     - name: Build Chain ${{ matrix.java-version }}
       id: build-chain   
-      uses: kiegroup/github-action-build-chain@v1.1
+      uses: kiegroup/github-action-build-chain@v1.2
       with:
         parent-dependencies: 'drools@7.x:master'
         child-dependencies: 'jbpm@7.x:master'

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -21,9 +21,9 @@ jobs:
         with:
           parent-dependencies: 'drools@7.x:master'
           child-dependencies: 'jbpm@7.x:master'
-          build-command: 'mvn -e clean install -nsu -Prun-code-coverage,wildfly -Dfull  -Dintegration-tests=true -Dmaven.test.failure.ignore=true'
+          build-command: 'mvn -e install -nsu -Prun-code-coverage,wildfly -Dfull  -Dintegration-tests=true -Dmaven.test.failure.ignore=true'
           build-command-upstream: |
-            mvn -e clean install -DskipTests -Dgwt.compiler.skip=true -Dgwt.skipCompilation=true -Denforcer.skip=true -Dcheckstyle.skip=true -Dspotbugs.skip=true -Drevapi.skip=true
+            mvn -e install -DskipTests -Dgwt.compiler.skip=true -Dgwt.skipCompilation=true -Denforcer.skip=true -Dcheckstyle.skip=true -Dspotbugs.skip=true -Drevapi.skip=true
             rm -rf ./*
           workflow-file-name: "pull_request.yml"
         env:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -17,7 +17,7 @@ jobs:
           java-version: ${{ matrix.java-version }}
       - name: Build Chain ${{ matrix.java-version }}
         id: build-chain
-        uses: kiegroup/github-action-build-chain@master
+        uses: kiegroup/github-action-build-chain@v1.4
         with:
           parent-dependencies: 'drools@7.x:master'
           child-dependencies: 'jbpm@7.x:master'

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -22,7 +22,9 @@ jobs:
           parent-dependencies: 'drools@7.x:master'
           child-dependencies: 'jbpm@7.x:master'
           build-command: 'mvn -e clean install -nsu -Prun-code-coverage,wildfly -Dfull  -Dintegration-tests=true -Dmaven.test.failure.ignore=true'
-          build-command-upstream: "mvn -e clean install -DskipTests -Dgwt.compiler.skip=true -Dgwt.skipCompilation=true -Denforcer.skip=true -Dcheckstyle.skip=true -Dspotbugs.skip=true -Drevapi.skip=true"
+          build-command-upstream: |
+            mvn -e clean install -DskipTests -Dgwt.compiler.skip=true -Dgwt.skipCompilation=true -Denforcer.skip=true -Dcheckstyle.skip=true -Dspotbugs.skip=true -Drevapi.skip=true
+            rm -rf ./*
           workflow-file-name: "pull_request.yml"
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
https://issues.redhat.com/browse/BXMSPROD-963

[strategy.fail-fast](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idstrategyfail-fast) to **false** since java 11 is working
depends on:
- https://github.com/kiegroup/lienzo-core/pull/124
- https://github.com/kiegroup/lienzo-tests/pull/105
- https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1447
- https://github.com/kiegroup/kie-soup/pull/154
- https://github.com/kiegroup/appformer/pull/1037
- https://github.com/kiegroup/droolsjbpm-knowledge/pull/459
- https://github.com/kiegroup/drools/pull/3063
- https://github.com/kiegroup/optaplanner/pull/901
- https://github.com/kiegroup/jbpm/pull/1739
- https://github.com/kiegroup/kie-jpmml-integration/pull/39
- https://github.com/kiegroup/droolsjbpm-integration/pull/2210
- https://github.com/kiegroup/openshift-drools-hacep/pull/97
- https://github.com/kiegroup/droolsjbpm-tools/pull/116
- https://github.com/kiegroup/kie-uberfire-extensions/pull/103
- https://github.com/kiegroup/kie-wb-playground/pull/94
- https://github.com/kiegroup/kie-wb-common/pull/3401
- https://github.com/kiegroup/drools-wb/pull/1414
- https://github.com/kiegroup/optaplanner-wb/pull/378
- https://github.com/kiegroup/jbpm-designer/pull/888
- https://github.com/kiegroup/jbpm-work-items/pull/142
- https://github.com/kiegroup/jbpm-wb/pull/1457
- https://github.com/kiegroup/kie-docs/pull/2787
- https://github.com/kiegroup/optaweb-employee-rostering/pull/492
- https://github.com/kiegroup/optaweb-vehicle-routing/pull/353
- https://github.com/kiegroup/kie-wb-distributions/pull/1053

**Thank you for submitting this pull request**

**JIRA**: _(please edit the JIRA link if it exists)_ 

[link](https://www.example.com)

**referenced Pull Requests**: _(please edit the URLs of referenced pullrequests if they exist)_

paste the link(s) from GitHub here

**How to retest or run**:

* a pull request please add comment: regex **[.\*[j|J]enkins,?.\*(retest|test) this.\*]**

* a full downstream build please add comment: regex **[.*\[j|J]enkins,?.\*(execute|run|trigger|start|do) fdb.\*]**

* a compile downstream build please  add comment: regex **[.\*[j|J]enkins,?.\*(execute|run|trigger|start|do) cdb.\*]**

* a full production downstream please add comment: regex **[.\*[j|J]enkins,?.\*(execute|run|trigger|start|do) product fdb.\*]**

* an upstream build please add comment: regex **[.\*[j|J]enkins,?.\*(execute|run|trigger|start|do) upstream.\*]**

i.e for running a full downstream build =  **Jenkins do fdb**
