### PR TITLE
Remove KOptMoveSelector from XML configuration

### DIFF
--- a/optaplanner-core/src/build/revapi-config.json
+++ b/optaplanner-core/src/build/revapi-config.json
@@ -8813,6 +8813,53 @@
           "classSimpleName": "TerminationConfig",
           "elementKind": "class",
           "justification": "Define explicit order of elements in the XML."
+        },
+        {
+          "code": "java.annotation.added",
+          "old": "field org.optaplanner.core.config.constructionheuristic.ConstructionHeuristicPhaseConfig.moveSelectorConfigList",
+          "new": "field org.optaplanner.core.config.constructionheuristic.ConstructionHeuristicPhaseConfig.moveSelectorConfigList",
+          "annotationType": "javax.xml.bind.annotation.XmlElements",
+          "annotation": "@javax.xml.bind.annotation.XmlElements({@javax.xml.bind.annotation.XmlElement(name = \"cartesianProductMoveSelector\", type = org.optaplanner.core.config.heuristic.selector.move.composite.CartesianProductMoveSelectorConfig.class), @javax.xml.bind.annotation.XmlElement(name = \"changeMoveSelector\", type = org.optaplanner.core.config.heuristic.selector.move.generic.ChangeMoveSelectorConfig.class), @javax.xml.bind.annotation.XmlElement(name = \"moveIteratorFactory\", type = org.optaplanner.core.config.heuristic.selector.move.factory.MoveIteratorFactoryConfig.class), @javax.xml.bind.annotation.XmlElement(name = \"moveListFactory\", type = org.optaplanner.core.config.heuristic.selector.move.factory.MoveListFactoryConfig.class), @javax.xml.bind.annotation.XmlElement(name = \"pillarChangeMoveSelector\", type = org.optaplanner.core.config.heuristic.selector.move.generic.PillarChangeMoveSelectorConfig.class), @javax.xml.bind.annotation.XmlElement(name = \"pillarSwapMoveSelector\", type = org.optaplanner.core.config.heuristic.selector.move.generic.PillarSwapMoveSelectorConfig.class), @javax.xml.bind.annotation.XmlElement(name = \"subChainChangeMoveSelector\", type = org.optaplanner.core.config.heuristic.selector.move.generic.chained.SubChainChangeMoveSelectorConfig.class), @javax.xml.bind.annotation.XmlElement(name = \"subChainSwapMoveSelector\", type = org.optaplanner.core.config.heuristic.selector.move.generic.chained.SubChainSwapMoveSelectorConfig.class), @javax.xml.bind.annotation.XmlElement(name = \"swapMoveSelector\", type = org.optaplanner.core.config.heuristic.selector.move.generic.SwapMoveSelectorConfig.class), @javax.xml.bind.annotation.XmlElement(name = \"tailChainSwapMoveSelector\", type = org.optaplanner.core.config.heuristic.selector.move.generic.chained.TailChainSwapMoveSelectorConfig.class), @javax.xml.bind.annotation.XmlElement(name = \"unionMoveSelector\", type = org.optaplanner.core.config.heuristic.selector.move.composite.UnionMoveSelectorConfig.class)})",
+          "package": "org.optaplanner.core.config.constructionheuristic",
+          "classSimpleName": "ConstructionHeuristicPhaseConfig",
+          "fieldName": "moveSelectorConfigList",
+          "elementKind": "field",
+          "justification": "Remove the KOptMoveSelector from XML configuration."
+        },
+        {
+          "code": "java.annotation.added",
+          "old": "field org.optaplanner.core.config.constructionheuristic.placer.QueuedEntityPlacerConfig.moveSelectorConfigList",
+          "new": "field org.optaplanner.core.config.constructionheuristic.placer.QueuedEntityPlacerConfig.moveSelectorConfigList",
+          "annotationType": "javax.xml.bind.annotation.XmlElements",
+          "annotation": "@javax.xml.bind.annotation.XmlElements({@javax.xml.bind.annotation.XmlElement(name = \"cartesianProductMoveSelector\", type = org.optaplanner.core.config.heuristic.selector.move.composite.CartesianProductMoveSelectorConfig.class), @javax.xml.bind.annotation.XmlElement(name = \"changeMoveSelector\", type = org.optaplanner.core.config.heuristic.selector.move.generic.ChangeMoveSelectorConfig.class), @javax.xml.bind.annotation.XmlElement(name = \"moveIteratorFactory\", type = org.optaplanner.core.config.heuristic.selector.move.factory.MoveIteratorFactoryConfig.class), @javax.xml.bind.annotation.XmlElement(name = \"moveListFactory\", type = org.optaplanner.core.config.heuristic.selector.move.factory.MoveListFactoryConfig.class), @javax.xml.bind.annotation.XmlElement(name = \"pillarChangeMoveSelector\", type = org.optaplanner.core.config.heuristic.selector.move.generic.PillarChangeMoveSelectorConfig.class), @javax.xml.bind.annotation.XmlElement(name = \"pillarSwapMoveSelector\", type = org.optaplanner.core.config.heuristic.selector.move.generic.PillarSwapMoveSelectorConfig.class), @javax.xml.bind.annotation.XmlElement(name = \"subChainChangeMoveSelector\", type = org.optaplanner.core.config.heuristic.selector.move.generic.chained.SubChainChangeMoveSelectorConfig.class), @javax.xml.bind.annotation.XmlElement(name = \"subChainSwapMoveSelector\", type = org.optaplanner.core.config.heuristic.selector.move.generic.chained.SubChainSwapMoveSelectorConfig.class), @javax.xml.bind.annotation.XmlElement(name = \"swapMoveSelector\", type = org.optaplanner.core.config.heuristic.selector.move.generic.SwapMoveSelectorConfig.class), @javax.xml.bind.annotation.XmlElement(name = \"tailChainSwapMoveSelector\", type = org.optaplanner.core.config.heuristic.selector.move.generic.chained.TailChainSwapMoveSelectorConfig.class), @javax.xml.bind.annotation.XmlElement(name = \"unionMoveSelector\", type = org.optaplanner.core.config.heuristic.selector.move.composite.UnionMoveSelectorConfig.class)})",
+          "package": "org.optaplanner.core.config.constructionheuristic.placer",
+          "classSimpleName": "QueuedEntityPlacerConfig",
+          "fieldName": "moveSelectorConfigList",
+          "elementKind": "field",
+          "justification": "Remove the KOptMoveSelector from XML configuration."
+        },
+        {
+          "code": "java.annotation.added",
+          "old": "field org.optaplanner.core.config.exhaustivesearch.ExhaustiveSearchPhaseConfig.moveSelectorConfig",
+          "new": "field org.optaplanner.core.config.exhaustivesearch.ExhaustiveSearchPhaseConfig.moveSelectorConfig",
+          "annotationType": "javax.xml.bind.annotation.XmlElements",
+          "annotation": "@javax.xml.bind.annotation.XmlElements({@javax.xml.bind.annotation.XmlElement(name = \"cartesianProductMoveSelector\", type = org.optaplanner.core.config.heuristic.selector.move.composite.CartesianProductMoveSelectorConfig.class), @javax.xml.bind.annotation.XmlElement(name = \"changeMoveSelector\", type = org.optaplanner.core.config.heuristic.selector.move.generic.ChangeMoveSelectorConfig.class), @javax.xml.bind.annotation.XmlElement(name = \"moveIteratorFactory\", type = org.optaplanner.core.config.heuristic.selector.move.factory.MoveIteratorFactoryConfig.class), @javax.xml.bind.annotation.XmlElement(name = \"moveListFactory\", type = org.optaplanner.core.config.heuristic.selector.move.factory.MoveListFactoryConfig.class), @javax.xml.bind.annotation.XmlElement(name = \"pillarChangeMoveSelector\", type = org.optaplanner.core.config.heuristic.selector.move.generic.PillarChangeMoveSelectorConfig.class), @javax.xml.bind.annotation.XmlElement(name = \"pillarSwapMoveSelector\", type = org.optaplanner.core.config.heuristic.selector.move.generic.PillarSwapMoveSelectorConfig.class), @javax.xml.bind.annotation.XmlElement(name = \"subChainChangeMoveSelector\", type = org.optaplanner.core.config.heuristic.selector.move.generic.chained.SubChainChangeMoveSelectorConfig.class), @javax.xml.bind.annotation.XmlElement(name = \"subChainSwapMoveSelector\", type = org.optaplanner.core.config.heuristic.selector.move.generic.chained.SubChainSwapMoveSelectorConfig.class), @javax.xml.bind.annotation.XmlElement(name = \"swapMoveSelector\", type = org.optaplanner.core.config.heuristic.selector.move.generic.SwapMoveSelectorConfig.class), @javax.xml.bind.annotation.XmlElement(name = \"tailChainSwapMoveSelector\", type = org.optaplanner.core.config.heuristic.selector.move.generic.chained.TailChainSwapMoveSelectorConfig.class), @javax.xml.bind.annotation.XmlElement(name = \"unionMoveSelector\", type = org.optaplanner.core.config.heuristic.selector.move.composite.UnionMoveSelectorConfig.class)})",
+          "package": "org.optaplanner.core.config.exhaustivesearch",
+          "classSimpleName": "ExhaustiveSearchPhaseConfig",
+          "fieldName": "moveSelectorConfig",
+          "elementKind": "field",
+          "justification": "Remove the KOptMoveSelector from XML configuration."
+        },
+        {
+          "code": "java.annotation.added",
+          "old": "class org.optaplanner.core.config.heuristic.selector.move.MoveSelectorConfig<C extends org.optaplanner.core.config.heuristic.selector.move.MoveSelectorConfig>",
+          "new": "class org.optaplanner.core.config.heuristic.selector.move.MoveSelectorConfig<C extends org.optaplanner.core.config.heuristic.selector.move.MoveSelectorConfig>",
+          "annotationType": "javax.xml.bind.annotation.XmlSeeAlso",
+          "annotation": "@javax.xml.bind.annotation.XmlSeeAlso({org.optaplanner.core.config.heuristic.selector.move.composite.UnionMoveSelectorConfig.class, org.optaplanner.core.config.heuristic.selector.move.composite.CartesianProductMoveSelectorConfig.class, org.optaplanner.core.config.heuristic.selector.move.generic.ChangeMoveSelectorConfig.class, org.optaplanner.core.config.heuristic.selector.move.generic.SwapMoveSelectorConfig.class, org.optaplanner.core.config.heuristic.selector.move.generic.PillarChangeMoveSelectorConfig.class, org.optaplanner.core.config.heuristic.selector.move.generic.PillarSwapMoveSelectorConfig.class, org.optaplanner.core.config.heuristic.selector.move.generic.chained.TailChainSwapMoveSelectorConfig.class, org.optaplanner.core.config.heuristic.selector.move.generic.chained.SubChainChangeMoveSelectorConfig.class, org.optaplanner.core.config.heuristic.selector.move.generic.chained.SubChainSwapMoveSelectorConfig.class, org.optaplanner.core.config.heuristic.selector.move.factory.MoveListFactoryConfig.class, org.optaplanner.core.config.heuristic.selector.move.factory.MoveIteratorFactoryConfig.class})",
+          "package": "org.optaplanner.core.config.heuristic.selector.move",
+          "classSimpleName": "MoveSelectorConfig",
+          "elementKind": "class",
+          "justification": "Remove the KOptMoveSelector from XML configuration."
         }
       ]
     }

--- a/optaplanner-core/src/main/java/org/optaplanner/core/config/constructionheuristic/ConstructionHeuristicPhaseConfig.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/config/constructionheuristic/ConstructionHeuristicPhaseConfig.java
@@ -37,7 +37,6 @@ import org.optaplanner.core.config.heuristic.selector.move.generic.ChangeMoveSel
 import org.optaplanner.core.config.heuristic.selector.move.generic.PillarChangeMoveSelectorConfig;
 import org.optaplanner.core.config.heuristic.selector.move.generic.PillarSwapMoveSelectorConfig;
 import org.optaplanner.core.config.heuristic.selector.move.generic.SwapMoveSelectorConfig;
-import org.optaplanner.core.config.heuristic.selector.move.generic.chained.KOptMoveSelectorConfig;
 import org.optaplanner.core.config.heuristic.selector.move.generic.chained.SubChainChangeMoveSelectorConfig;
 import org.optaplanner.core.config.heuristic.selector.move.generic.chained.SubChainSwapMoveSelectorConfig;
 import org.optaplanner.core.config.heuristic.selector.move.generic.chained.TailChainSwapMoveSelectorConfig;
@@ -76,7 +75,6 @@ public class ConstructionHeuristicPhaseConfig extends PhaseConfig<ConstructionHe
             @XmlElement(name = CartesianProductMoveSelectorConfig.XML_ELEMENT_NAME,
                     type = CartesianProductMoveSelectorConfig.class),
             @XmlElement(name = ChangeMoveSelectorConfig.XML_ELEMENT_NAME, type = ChangeMoveSelectorConfig.class),
-            @XmlElement(name = KOptMoveSelectorConfig.XML_ELEMENT_NAME, type = KOptMoveSelectorConfig.class),
             @XmlElement(name = MoveIteratorFactoryConfig.XML_ELEMENT_NAME, type = MoveIteratorFactoryConfig.class),
             @XmlElement(name = MoveListFactoryConfig.XML_ELEMENT_NAME, type = MoveListFactoryConfig.class),
             @XmlElement(name = PillarChangeMoveSelectorConfig.XML_ELEMENT_NAME,

--- a/optaplanner-core/src/main/java/org/optaplanner/core/config/constructionheuristic/placer/PooledEntityPlacerConfig.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/config/constructionheuristic/placer/PooledEntityPlacerConfig.java
@@ -29,7 +29,6 @@ import org.optaplanner.core.config.heuristic.selector.move.generic.ChangeMoveSel
 import org.optaplanner.core.config.heuristic.selector.move.generic.PillarChangeMoveSelectorConfig;
 import org.optaplanner.core.config.heuristic.selector.move.generic.PillarSwapMoveSelectorConfig;
 import org.optaplanner.core.config.heuristic.selector.move.generic.SwapMoveSelectorConfig;
-import org.optaplanner.core.config.heuristic.selector.move.generic.chained.KOptMoveSelectorConfig;
 import org.optaplanner.core.config.heuristic.selector.move.generic.chained.SubChainChangeMoveSelectorConfig;
 import org.optaplanner.core.config.heuristic.selector.move.generic.chained.SubChainSwapMoveSelectorConfig;
 import org.optaplanner.core.config.heuristic.selector.move.generic.chained.TailChainSwapMoveSelectorConfig;
@@ -44,7 +43,6 @@ public class PooledEntityPlacerConfig extends EntityPlacerConfig<PooledEntityPla
             @XmlElement(name = CartesianProductMoveSelectorConfig.XML_ELEMENT_NAME,
                     type = CartesianProductMoveSelectorConfig.class),
             @XmlElement(name = ChangeMoveSelectorConfig.XML_ELEMENT_NAME, type = ChangeMoveSelectorConfig.class),
-            @XmlElement(name = KOptMoveSelectorConfig.XML_ELEMENT_NAME, type = KOptMoveSelectorConfig.class),
             @XmlElement(name = MoveIteratorFactoryConfig.XML_ELEMENT_NAME, type = MoveIteratorFactoryConfig.class),
             @XmlElement(name = MoveListFactoryConfig.XML_ELEMENT_NAME, type = MoveListFactoryConfig.class),
             @XmlElement(name = PillarChangeMoveSelectorConfig.XML_ELEMENT_NAME,

--- a/optaplanner-core/src/main/java/org/optaplanner/core/config/constructionheuristic/placer/QueuedEntityPlacerConfig.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/config/constructionheuristic/placer/QueuedEntityPlacerConfig.java
@@ -32,7 +32,6 @@ import org.optaplanner.core.config.heuristic.selector.move.generic.ChangeMoveSel
 import org.optaplanner.core.config.heuristic.selector.move.generic.PillarChangeMoveSelectorConfig;
 import org.optaplanner.core.config.heuristic.selector.move.generic.PillarSwapMoveSelectorConfig;
 import org.optaplanner.core.config.heuristic.selector.move.generic.SwapMoveSelectorConfig;
-import org.optaplanner.core.config.heuristic.selector.move.generic.chained.KOptMoveSelectorConfig;
 import org.optaplanner.core.config.heuristic.selector.move.generic.chained.SubChainChangeMoveSelectorConfig;
 import org.optaplanner.core.config.heuristic.selector.move.generic.chained.SubChainSwapMoveSelectorConfig;
 import org.optaplanner.core.config.heuristic.selector.move.generic.chained.TailChainSwapMoveSelectorConfig;
@@ -51,7 +50,6 @@ public class QueuedEntityPlacerConfig extends EntityPlacerConfig<QueuedEntityPla
             @XmlElement(name = CartesianProductMoveSelectorConfig.XML_ELEMENT_NAME,
                     type = CartesianProductMoveSelectorConfig.class),
             @XmlElement(name = ChangeMoveSelectorConfig.XML_ELEMENT_NAME, type = ChangeMoveSelectorConfig.class),
-            @XmlElement(name = KOptMoveSelectorConfig.XML_ELEMENT_NAME, type = KOptMoveSelectorConfig.class),
             @XmlElement(name = MoveIteratorFactoryConfig.XML_ELEMENT_NAME, type = MoveIteratorFactoryConfig.class),
             @XmlElement(name = MoveListFactoryConfig.XML_ELEMENT_NAME, type = MoveListFactoryConfig.class),
             @XmlElement(name = PillarChangeMoveSelectorConfig.XML_ELEMENT_NAME,

--- a/optaplanner-core/src/main/java/org/optaplanner/core/config/constructionheuristic/placer/QueuedValuePlacerConfig.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/config/constructionheuristic/placer/QueuedValuePlacerConfig.java
@@ -29,7 +29,6 @@ import org.optaplanner.core.config.heuristic.selector.move.generic.ChangeMoveSel
 import org.optaplanner.core.config.heuristic.selector.move.generic.PillarChangeMoveSelectorConfig;
 import org.optaplanner.core.config.heuristic.selector.move.generic.PillarSwapMoveSelectorConfig;
 import org.optaplanner.core.config.heuristic.selector.move.generic.SwapMoveSelectorConfig;
-import org.optaplanner.core.config.heuristic.selector.move.generic.chained.KOptMoveSelectorConfig;
 import org.optaplanner.core.config.heuristic.selector.move.generic.chained.SubChainChangeMoveSelectorConfig;
 import org.optaplanner.core.config.heuristic.selector.move.generic.chained.SubChainSwapMoveSelectorConfig;
 import org.optaplanner.core.config.heuristic.selector.move.generic.chained.TailChainSwapMoveSelectorConfig;
@@ -52,7 +51,6 @@ public class QueuedValuePlacerConfig extends EntityPlacerConfig<QueuedValuePlace
             @XmlElement(name = CartesianProductMoveSelectorConfig.XML_ELEMENT_NAME,
                     type = CartesianProductMoveSelectorConfig.class),
             @XmlElement(name = ChangeMoveSelectorConfig.XML_ELEMENT_NAME, type = ChangeMoveSelectorConfig.class),
-            @XmlElement(name = KOptMoveSelectorConfig.XML_ELEMENT_NAME, type = KOptMoveSelectorConfig.class),
             @XmlElement(name = MoveIteratorFactoryConfig.XML_ELEMENT_NAME, type = MoveIteratorFactoryConfig.class),
             @XmlElement(name = MoveListFactoryConfig.XML_ELEMENT_NAME, type = MoveListFactoryConfig.class),
             @XmlElement(name = PillarChangeMoveSelectorConfig.XML_ELEMENT_NAME,

--- a/optaplanner-core/src/main/java/org/optaplanner/core/config/exhaustivesearch/ExhaustiveSearchPhaseConfig.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/config/exhaustivesearch/ExhaustiveSearchPhaseConfig.java
@@ -31,7 +31,6 @@ import org.optaplanner.core.config.heuristic.selector.move.generic.ChangeMoveSel
 import org.optaplanner.core.config.heuristic.selector.move.generic.PillarChangeMoveSelectorConfig;
 import org.optaplanner.core.config.heuristic.selector.move.generic.PillarSwapMoveSelectorConfig;
 import org.optaplanner.core.config.heuristic.selector.move.generic.SwapMoveSelectorConfig;
-import org.optaplanner.core.config.heuristic.selector.move.generic.chained.KOptMoveSelectorConfig;
 import org.optaplanner.core.config.heuristic.selector.move.generic.chained.SubChainChangeMoveSelectorConfig;
 import org.optaplanner.core.config.heuristic.selector.move.generic.chained.SubChainSwapMoveSelectorConfig;
 import org.optaplanner.core.config.heuristic.selector.move.generic.chained.TailChainSwapMoveSelectorConfig;
@@ -66,7 +65,6 @@ public class ExhaustiveSearchPhaseConfig extends PhaseConfig<ExhaustiveSearchPha
             @XmlElement(name = CartesianProductMoveSelectorConfig.XML_ELEMENT_NAME,
                     type = CartesianProductMoveSelectorConfig.class),
             @XmlElement(name = ChangeMoveSelectorConfig.XML_ELEMENT_NAME, type = ChangeMoveSelectorConfig.class),
-            @XmlElement(name = KOptMoveSelectorConfig.XML_ELEMENT_NAME, type = KOptMoveSelectorConfig.class),
             @XmlElement(name = MoveIteratorFactoryConfig.XML_ELEMENT_NAME, type = MoveIteratorFactoryConfig.class),
             @XmlElement(name = MoveListFactoryConfig.XML_ELEMENT_NAME, type = MoveListFactoryConfig.class),
             @XmlElement(name = PillarChangeMoveSelectorConfig.XML_ELEMENT_NAME,

--- a/optaplanner-core/src/main/java/org/optaplanner/core/config/heuristic/selector/move/MoveSelectorConfig.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/config/heuristic/selector/move/MoveSelectorConfig.java
@@ -34,7 +34,6 @@ import org.optaplanner.core.config.heuristic.selector.move.generic.ChangeMoveSel
 import org.optaplanner.core.config.heuristic.selector.move.generic.PillarChangeMoveSelectorConfig;
 import org.optaplanner.core.config.heuristic.selector.move.generic.PillarSwapMoveSelectorConfig;
 import org.optaplanner.core.config.heuristic.selector.move.generic.SwapMoveSelectorConfig;
-import org.optaplanner.core.config.heuristic.selector.move.generic.chained.KOptMoveSelectorConfig;
 import org.optaplanner.core.config.heuristic.selector.move.generic.chained.SubChainChangeMoveSelectorConfig;
 import org.optaplanner.core.config.heuristic.selector.move.generic.chained.SubChainSwapMoveSelectorConfig;
 import org.optaplanner.core.config.heuristic.selector.move.generic.chained.TailChainSwapMoveSelectorConfig;
@@ -49,11 +48,9 @@ import org.optaplanner.core.impl.heuristic.selector.common.decorator.SelectionSo
  */
 
 @XmlSeeAlso({
-        UnionMoveSelectorConfig.class, CartesianProductMoveSelectorConfig.class,
-        ChangeMoveSelectorConfig.class, SwapMoveSelectorConfig.class,
-        PillarChangeMoveSelectorConfig.class, PillarSwapMoveSelectorConfig.class,
-        TailChainSwapMoveSelectorConfig.class, KOptMoveSelectorConfig.class,
-        SubChainChangeMoveSelectorConfig.class, SubChainSwapMoveSelectorConfig.class,
+        UnionMoveSelectorConfig.class, CartesianProductMoveSelectorConfig.class, ChangeMoveSelectorConfig.class,
+        SwapMoveSelectorConfig.class, PillarChangeMoveSelectorConfig.class, PillarSwapMoveSelectorConfig.class,
+        TailChainSwapMoveSelectorConfig.class, SubChainChangeMoveSelectorConfig.class, SubChainSwapMoveSelectorConfig.class,
         MoveListFactoryConfig.class, MoveIteratorFactoryConfig.class })
 @XmlType(propOrder = {
         "cacheType",

--- a/optaplanner-core/src/main/java/org/optaplanner/core/config/heuristic/selector/move/composite/CartesianProductMoveSelectorConfig.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/config/heuristic/selector/move/composite/CartesianProductMoveSelectorConfig.java
@@ -29,7 +29,6 @@ import org.optaplanner.core.config.heuristic.selector.move.generic.ChangeMoveSel
 import org.optaplanner.core.config.heuristic.selector.move.generic.PillarChangeMoveSelectorConfig;
 import org.optaplanner.core.config.heuristic.selector.move.generic.PillarSwapMoveSelectorConfig;
 import org.optaplanner.core.config.heuristic.selector.move.generic.SwapMoveSelectorConfig;
-import org.optaplanner.core.config.heuristic.selector.move.generic.chained.KOptMoveSelectorConfig;
 import org.optaplanner.core.config.heuristic.selector.move.generic.chained.SubChainChangeMoveSelectorConfig;
 import org.optaplanner.core.config.heuristic.selector.move.generic.chained.SubChainSwapMoveSelectorConfig;
 import org.optaplanner.core.config.heuristic.selector.move.generic.chained.TailChainSwapMoveSelectorConfig;
@@ -47,7 +46,6 @@ public class CartesianProductMoveSelectorConfig extends MoveSelectorConfig<Carte
             @XmlElement(name = CartesianProductMoveSelectorConfig.XML_ELEMENT_NAME,
                     type = CartesianProductMoveSelectorConfig.class),
             @XmlElement(name = ChangeMoveSelectorConfig.XML_ELEMENT_NAME, type = ChangeMoveSelectorConfig.class),
-            @XmlElement(name = KOptMoveSelectorConfig.XML_ELEMENT_NAME, type = KOptMoveSelectorConfig.class),
             @XmlElement(name = MoveIteratorFactoryConfig.XML_ELEMENT_NAME, type = MoveIteratorFactoryConfig.class),
             @XmlElement(name = MoveListFactoryConfig.XML_ELEMENT_NAME, type = MoveListFactoryConfig.class),
             @XmlElement(name = PillarChangeMoveSelectorConfig.XML_ELEMENT_NAME,

--- a/optaplanner-core/src/main/java/org/optaplanner/core/config/heuristic/selector/move/composite/UnionMoveSelectorConfig.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/config/heuristic/selector/move/composite/UnionMoveSelectorConfig.java
@@ -29,7 +29,6 @@ import org.optaplanner.core.config.heuristic.selector.move.generic.ChangeMoveSel
 import org.optaplanner.core.config.heuristic.selector.move.generic.PillarChangeMoveSelectorConfig;
 import org.optaplanner.core.config.heuristic.selector.move.generic.PillarSwapMoveSelectorConfig;
 import org.optaplanner.core.config.heuristic.selector.move.generic.SwapMoveSelectorConfig;
-import org.optaplanner.core.config.heuristic.selector.move.generic.chained.KOptMoveSelectorConfig;
 import org.optaplanner.core.config.heuristic.selector.move.generic.chained.SubChainChangeMoveSelectorConfig;
 import org.optaplanner.core.config.heuristic.selector.move.generic.chained.SubChainSwapMoveSelectorConfig;
 import org.optaplanner.core.config.heuristic.selector.move.generic.chained.TailChainSwapMoveSelectorConfig;
@@ -48,7 +47,6 @@ public class UnionMoveSelectorConfig extends MoveSelectorConfig<UnionMoveSelecto
             @XmlElement(name = CartesianProductMoveSelectorConfig.XML_ELEMENT_NAME,
                     type = CartesianProductMoveSelectorConfig.class),
             @XmlElement(name = ChangeMoveSelectorConfig.XML_ELEMENT_NAME, type = ChangeMoveSelectorConfig.class),
-            @XmlElement(name = KOptMoveSelectorConfig.XML_ELEMENT_NAME, type = KOptMoveSelectorConfig.class),
             @XmlElement(name = MoveIteratorFactoryConfig.XML_ELEMENT_NAME, type = MoveIteratorFactoryConfig.class),
             @XmlElement(name = MoveListFactoryConfig.XML_ELEMENT_NAME, type = MoveListFactoryConfig.class),
             @XmlElement(name = PillarChangeMoveSelectorConfig.XML_ELEMENT_NAME,

--- a/optaplanner-core/src/main/java/org/optaplanner/core/config/heuristic/selector/move/generic/chained/KOptMoveSelectorConfig.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/config/heuristic/selector/move/generic/chained/KOptMoveSelectorConfig.java
@@ -25,8 +25,10 @@ import org.optaplanner.core.config.heuristic.selector.value.ValueSelectorConfig;
 import org.optaplanner.core.config.util.ConfigUtils;
 
 /**
- * THIS IS VERY EXPERIMENTAL. It's NOT DOCUMENTED because we'll only document it when it actually works in more than 1 use case.
- * It's riddled with TODOs.
+ * THIS CLASS IS EXPERIMENTAL AND UNSUPPORTED.
+ * Backward compatibility is not guaranteed.
+ * It's NOT DOCUMENTED because we'll only document it when it actually works in more than 1 use case.
+ *
  * Do not use.
  *
  * @see TailChainSwapMoveSelectorConfig

--- a/optaplanner-core/src/main/java/org/optaplanner/core/config/localsearch/LocalSearchPhaseConfig.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/config/localsearch/LocalSearchPhaseConfig.java
@@ -29,7 +29,6 @@ import org.optaplanner.core.config.heuristic.selector.move.generic.ChangeMoveSel
 import org.optaplanner.core.config.heuristic.selector.move.generic.PillarChangeMoveSelectorConfig;
 import org.optaplanner.core.config.heuristic.selector.move.generic.PillarSwapMoveSelectorConfig;
 import org.optaplanner.core.config.heuristic.selector.move.generic.SwapMoveSelectorConfig;
-import org.optaplanner.core.config.heuristic.selector.move.generic.chained.KOptMoveSelectorConfig;
 import org.optaplanner.core.config.heuristic.selector.move.generic.chained.SubChainChangeMoveSelectorConfig;
 import org.optaplanner.core.config.heuristic.selector.move.generic.chained.SubChainSwapMoveSelectorConfig;
 import org.optaplanner.core.config.heuristic.selector.move.generic.chained.TailChainSwapMoveSelectorConfig;
@@ -57,7 +56,6 @@ public class LocalSearchPhaseConfig extends PhaseConfig<LocalSearchPhaseConfig> 
             @XmlElement(name = CartesianProductMoveSelectorConfig.XML_ELEMENT_NAME,
                     type = CartesianProductMoveSelectorConfig.class),
             @XmlElement(name = ChangeMoveSelectorConfig.XML_ELEMENT_NAME, type = ChangeMoveSelectorConfig.class),
-            @XmlElement(name = KOptMoveSelectorConfig.XML_ELEMENT_NAME, type = KOptMoveSelectorConfig.class),
             @XmlElement(name = MoveIteratorFactoryConfig.XML_ELEMENT_NAME, type = MoveIteratorFactoryConfig.class),
             @XmlElement(name = MoveListFactoryConfig.XML_ELEMENT_NAME, type = MoveListFactoryConfig.class),
             @XmlElement(name = PillarChangeMoveSelectorConfig.XML_ELEMENT_NAME,


### PR DESCRIPTION
**How to retest or run**:

* a pull request please add comment: regex **[.\*[j|J]enkins,?.\*(retest|test) this.\*]**

* a full downstream build please add comment: regex **[.*\[j|J]enkins,?.\*(execute|run|trigger|start|do) fdb.\*]**

* a compile downstream build please  add comment: regex **[.\*[j|J]enkins,?.\*(execute|run|trigger|start|do) cdb.\*]**

* a full production downstream please add comment: regex **[.\*[j|J]enkins,?.\*(execute|run|trigger|start|do) product fdb.\*]**

* an upstream build please add comment: regex **[.\*[j|J]enkins,?.\*(execute|run|trigger|start|do) upstream.\*]**

i.e for running a full downstream build =  **Jenkins do fdb**
