### PR TITLE
PLANNER-2135 Remove support for JavaScript expressions from configs

### DIFF
--- a/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/config/PlannerBenchmarkConfig.java
+++ b/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/config/PlannerBenchmarkConfig.java
@@ -584,8 +584,7 @@ public class PlannerBenchmarkConfig {
      * <p>
      * If there aren't enough processors available, it will be decreased.
      *
-     * @return null, a number, {@value #PARALLEL_BENCHMARK_COUNT_AUTO} or a JavaScript calculation using
-     *         {@value org.optaplanner.core.config.util.ConfigUtils#AVAILABLE_PROCESSOR_COUNT}.
+     * @return null, a number or {@value #PARALLEL_BENCHMARK_COUNT_AUTO}.
      */
     public String getParallelBenchmarkCount() {
         return parallelBenchmarkCount;
@@ -806,8 +805,8 @@ public class PlannerBenchmarkConfig {
         } else if (parallelBenchmarkCount.equals(PARALLEL_BENCHMARK_COUNT_AUTO)) {
             resolvedParallelBenchmarkCount = resolveParallelBenchmarkCountAutomatically(availableProcessorCount);
         } else {
-            resolvedParallelBenchmarkCount = ConfigUtils.resolveThreadPoolSizeScript(
-                    "parallelBenchmarkCount", parallelBenchmarkCount, PARALLEL_BENCHMARK_COUNT_AUTO);
+            resolvedParallelBenchmarkCount = ConfigUtils.resolvePoolSize("parallelBenchmarkCount",
+                    parallelBenchmarkCount, PARALLEL_BENCHMARK_COUNT_AUTO);
         }
         if (resolvedParallelBenchmarkCount < 1) {
             throw new IllegalArgumentException("The parallelBenchmarkCount (" + parallelBenchmarkCount

--- a/optaplanner-benchmark/src/test/java/org/optaplanner/benchmark/config/PlannerBenchmarkConfigTest.java
+++ b/optaplanner-benchmark/src/test/java/org/optaplanner/benchmark/config/PlannerBenchmarkConfigTest.java
@@ -34,7 +34,6 @@ import java.util.TreeSet;
 import org.apache.commons.io.IOUtils;
 import org.junit.jupiter.api.Test;
 import org.optaplanner.benchmark.impl.io.PlannerBenchmarkConfigIO;
-import org.optaplanner.core.config.util.ConfigUtils;
 import org.optaplanner.core.impl.io.jaxb.GenericJaxbIO;
 import org.optaplanner.core.impl.testdata.domain.TestdataSolution;
 import org.optaplanner.persistence.xstream.impl.domain.solution.XStreamSolutionFileIO;
@@ -137,14 +136,6 @@ class PlannerBenchmarkConfigTest {
         assertThat(config.resolveParallelBenchmarkCountAutomatically(5)).isEqualTo(3);
         assertThat(config.resolveParallelBenchmarkCountAutomatically(6)).isEqualTo(4);
         assertThat(config.resolveParallelBenchmarkCountAutomatically(17)).isEqualTo(9);
-    }
-
-    @Test
-    void resolveParallelBenchmarkCountFromFormula() {
-        PlannerBenchmarkConfig config = new PlannerBenchmarkConfig();
-        config.setParallelBenchmarkCount(ConfigUtils.AVAILABLE_PROCESSOR_COUNT + "+1");
-        // resolved benchmark count cannot be higher than available processors
-        assertThat(config.resolveParallelBenchmarkCount()).isEqualTo(Runtime.getRuntime().availableProcessors());
     }
 
     @Test

--- a/optaplanner-core/src/build/revapi-config.json
+++ b/optaplanner-core/src/build/revapi-config.json
@@ -8871,6 +8871,15 @@
           "classSimpleName": "SolverConfig",
           "elementKind": "class",
           "justification": "Declare XML type name."
+        },
+        {
+          "code": "java.field.removedWithConstant",
+          "old": "field org.optaplanner.core.config.util.ConfigUtils.AVAILABLE_PROCESSOR_COUNT",
+          "package": "org.optaplanner.core.config.util",
+          "classSimpleName": "ConfigUtils",
+          "fieldName": "AVAILABLE_PROCESSOR_COUNT",
+          "elementKind": "field",
+          "justification": "Constant no longer used."
         }
       ]
     }

--- a/optaplanner-core/src/main/java/org/optaplanner/core/config/partitionedsearch/PartitionedSearchPhaseConfig.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/config/partitionedsearch/PartitionedSearchPhaseConfig.java
@@ -107,9 +107,7 @@ public class PartitionedSearchPhaseConfig extends PhaseConfig<PartitionedSearchP
      * Use {@value #ACTIVE_THREAD_COUNT_UNLIMITED} to give it all CPU cores.
      * This is useful if you're handling the CPU consumption on an OS level.
      *
-     * @return null, a number, {@value #ACTIVE_THREAD_COUNT_AUTO}, {@value #ACTIVE_THREAD_COUNT_UNLIMITED}
-     *         or a JavaScript calculation using
-     *         {@value org.optaplanner.core.config.util.ConfigUtils#AVAILABLE_PROCESSOR_COUNT}.
+     * @return null, a number, {@value #ACTIVE_THREAD_COUNT_AUTO} or {@value #ACTIVE_THREAD_COUNT_UNLIMITED}.
      */
     public String getRunnablePartThreadLimit() {
         return runnablePartThreadLimit;

--- a/optaplanner-core/src/main/java/org/optaplanner/core/config/solver/SolverManagerConfig.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/config/solver/SolverManagerConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -89,8 +89,8 @@ public class SolverManagerConfig extends AbstractConfig<SolverManagerConfig> {
         if (parallelSolverCount == null || parallelSolverCount.equals(PARALLEL_SOLVER_COUNT_AUTO)) {
             resolvedParallelSolverCount = resolveParallelSolverCountAutomatically(availableProcessorCount);
         } else {
-            resolvedParallelSolverCount = ConfigUtils.resolveThreadPoolSizeScript(
-                    "parallelSolverCount", parallelSolverCount, PARALLEL_SOLVER_COUNT_AUTO);
+            resolvedParallelSolverCount = ConfigUtils.resolvePoolSize("parallelSolverCount",
+                    parallelSolverCount, PARALLEL_SOLVER_COUNT_AUTO);
         }
         if (resolvedParallelSolverCount < 1) {
             throw new IllegalArgumentException("The parallelSolverCount (" + parallelSolverCount

--- a/optaplanner-core/src/main/java/org/optaplanner/core/config/util/ConfigUtils.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/config/util/ConfigUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,10 +38,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-
-import javax.script.ScriptEngine;
-import javax.script.ScriptEngineManager;
-import javax.script.ScriptException;
 
 import org.optaplanner.core.api.domain.lookup.PlanningId;
 import org.optaplanner.core.config.AbstractConfig;
@@ -261,35 +257,13 @@ public class ConfigUtils {
         return (dividend / divisor) + correction;
     }
 
-    /**
-     * Name of the variable that represents {@link Runtime#availableProcessors()}.
-     */
-    public static final String AVAILABLE_PROCESSOR_COUNT = "availableProcessorCount";
-
-    public static int resolveThreadPoolSizeScript(String propertyName, String script, String... magicValues) {
-        final String scriptLanguage = "JavaScript";
-        ScriptEngine scriptEngine = new ScriptEngineManager().getEngineByName(scriptLanguage);
-        if (scriptEngine == null) {
-            throw new IllegalStateException("The " + propertyName + " (" + script
-                    + ") could not resolve because the JVM doesn't support scriptLanguage (" + scriptLanguage + ").\n"
-                    + "Maybe try running in a normal JVM.");
-        }
-        scriptEngine.put(AVAILABLE_PROCESSOR_COUNT, Runtime.getRuntime().availableProcessors());
-        Object scriptResult;
+    public static int resolvePoolSize(String propertyName, String value, String... magicValues) {
         try {
-            scriptResult = scriptEngine.eval(script);
-        } catch (ScriptException e) {
-            throw new IllegalArgumentException("The " + propertyName + " (" + script
-                    + ") is not in magicValues (" + Arrays.toString(magicValues)
-                    + ") and cannot be parsed in " + scriptLanguage
-                    + " with the variables ([" + AVAILABLE_PROCESSOR_COUNT + "]).", e);
+            return Integer.parseInt(value);
+        } catch (NumberFormatException ex) {
+            throw new IllegalStateException("The " + propertyName + " (" + value + ") resolved to neither of ("
+                    + Arrays.toString(magicValues) + ") nor a number.");
         }
-        if (!(scriptResult instanceof Number)) {
-            throw new IllegalArgumentException("The " + propertyName + " (" + script
-                    + ") is resolved to scriptResult (" + scriptResult + ") in " + scriptLanguage
-                    + " but is not a " + Number.class.getSimpleName() + ".");
-        }
-        return ((Number) scriptResult).intValue();
     }
 
     // ************************************************************************

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/partitionedsearch/DefaultPartitionedSearchPhaseFactory.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/partitionedsearch/DefaultPartitionedSearchPhaseFactory.java
@@ -106,7 +106,7 @@ public class DefaultPartitionedSearchPhaseFactory<Solution_>
         } else if (runnablePartThreadLimit.equals(ACTIVE_THREAD_COUNT_UNLIMITED)) {
             resolvedActiveThreadCount = null;
         } else {
-            resolvedActiveThreadCount = ConfigUtils.resolveThreadPoolSizeScript("runnablePartThreadLimit",
+            resolvedActiveThreadCount = ConfigUtils.resolvePoolSize("runnablePartThreadLimit",
                     runnablePartThreadLimit, ACTIVE_THREAD_COUNT_AUTO, ACTIVE_THREAD_COUNT_UNLIMITED);
             if (resolvedActiveThreadCount < 1) {
                 throw new IllegalArgumentException("The runnablePartThreadLimit (" + runnablePartThreadLimit

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/solver/DefaultSolverFactory.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/solver/DefaultSolverFactory.java
@@ -191,7 +191,7 @@ public final class DefaultSolverFactory<Solution_> implements SolverFactory<Solu
                     return null;
                 }
             } else {
-                resolvedMoveThreadCount = ConfigUtils.resolveThreadPoolSizeScript("moveThreadCount", moveThreadCount,
+                resolvedMoveThreadCount = ConfigUtils.resolvePoolSize("moveThreadCount", moveThreadCount,
                         SolverConfig.MOVE_THREAD_COUNT_NONE, SolverConfig.MOVE_THREAD_COUNT_AUTO);
             }
             if (resolvedMoveThreadCount < 1) {

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/partitionedsearch/DefaultPartitionedSearchPhaseFactoryTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/partitionedsearch/DefaultPartitionedSearchPhaseFactoryTest.java
@@ -49,12 +49,6 @@ class DefaultPartitionedSearchPhaseFactoryTest {
                 .resolveActiveThreadCount(PartitionedSearchPhaseConfig.ACTIVE_THREAD_COUNT_UNLIMITED)).isNull();
     }
 
-    @Test //TODO: The expression resolution could use much more testing
-    void resolveActiveThreadCountExpression() {
-        assertThat(createDefaultPartitionedSearchPhaseFactory()
-                .resolveActiveThreadCount("2*3-1")).isEqualTo(5);
-    }
-
     private Integer mockResolveActiveThreadCount(String runnablePartThreadLimit, int cpuCount) {
         DefaultPartitionedSearchPhaseFactory<TestdataSolution> partitionedSearchPhaseFactory =
                 spy(createDefaultPartitionedSearchPhaseFactory());

--- a/optaplanner-docs/src/main/asciidoc/BenchmarkingAndTweaking/BenchmarkingAndTweaking-chapter.adoc
+++ b/optaplanner-docs/src/main/asciidoc/BenchmarkingAndTweaking/BenchmarkingAndTweaking-chapter.adoc
@@ -941,12 +941,6 @@ The following ``parallelBenchmarkCount``s are supported:
 ----
 <parallelBenchmarkCount>2</parallelBenchmarkCount>
 ----
-* JavaScript formula: Formula for the number of benchmarks to run in parallel. It can use the variable ``availableProcessorCount``. For example:
-+
-[source,xml,options="nowrap"]
-----
-<parallelBenchmarkCount>(availableProcessorCount / 2) + 1</parallelBenchmarkCount>
-----
 
 [NOTE]
 ====

--- a/optaplanner-docs/src/main/asciidoc/OptimizationAlgorithms/OptimizationAlgorithms-chapter.adoc
+++ b/optaplanner-docs/src/main/asciidoc/OptimizationAlgorithms/OptimizationAlgorithms-chapter.adoc
@@ -953,12 +953,6 @@ On machines or containers with little or no CPUs, this falls back to the single 
 +
 This can be `1` to enforce running the multithreaded code with only 1 move thread
 (which is less efficient than `NONE`).
-* JavaScript formula: Formula for the number of move threads to run in parallel. It can use the variable ``availableProcessorCount``. For example:
-+
-[source,xml,options="nowrap"]
-----
-<moveThreadCount>(availableProcessorCount / 2) + 1</moveThreadCount>
-----
 
 It is counter-effective to set a `moveThreadCount`
 that is higher than the number of available CPU cores,

--- a/optaplanner-docs/src/main/asciidoc/PartitionedSearch/PartitionedSearch-chapter.adoc
+++ b/optaplanner-docs/src/main/asciidoc/PartitionedSearch/PartitionedSearch-chapter.adoc
@@ -253,13 +253,6 @@ It does not hog all CPU cores on a multi-core machine.
 ----
 <runnablePartThreadLimit>2</runnablePartThreadLimit>
 ----
-* JavaScript formula: Formula for the number of CPU cores to occupy.
-It can use the variable `availableProcessorCount`. For example:
-+
-[source,xml,options="nowrap"]
-----
-<runnablePartThreadLimit>availableProcessorCount - 2</runnablePartThreadLimit>
-----
 
 [WARNING]
 ====


### PR DESCRIPTION
Verified to work correctly on OpenJDK 15.
This will not be backported to 7.x - we'll have to use a different approach there.