### PR TITLE
PLANNER-2144 Upgrade XStream to the latest version

### DIFF
--- a/optaplanner-build-parent/pom.xml
+++ b/optaplanner-build-parent/pom.xml
@@ -28,7 +28,7 @@
     <version.commons-io>2.6</version.commons-io>
     <version.com.fasterxml.jackson.core>2.10.4</version.com.fasterxml.jackson.core>
     <version.com.h2database>1.3.173</version.com.h2database>
-    <version.com.thoughtworks.xstream>1.4.11.1</version.com.thoughtworks.xstream>
+    <version.com.thoughtworks.xstream>1.4.13</version.com.thoughtworks.xstream>
     <version.io.quarkus>1.7.0.Final</version.io.quarkus>
     <version.jakarta.json.bind>1.0.2</version.jakarta.json.bind>
     <version.jakarta.xml.bind>2.3.3</version.jakarta.xml.bind>


### PR DESCRIPTION
In the end, it was easier than expected: XStream fixed the illegal reflective access warnings, and all we have to do is upgrading to the latest version.

<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.
-->

### JIRA

<!-- Add a JIRA ticket link if it exists. -->
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->

https://issues.redhat.com/browse/PLANNER-2144

### Referenced pull requests

backport to 7.x: https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1455

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
* https://github.com/kiegroup/drools/pull/3000
* https://github.com/kiegroup/optaplanner/pull/899
* etc.
-->

### Checklist
- [x] Documentation updated if applicable.
- [x] Upgrade recipe provided if applicable.

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>full downstream build</b> please add comment: <b>Jenkins run fdb</b>
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
