### PR TITLE
Improve CI performance by caching local Maven repo

### DIFF
--- a/.github/workflows/jpa_integration_ci.yml
+++ b/.github/workflows/jpa_integration_ci.yml
@@ -47,6 +47,14 @@ jobs:
         with:
           java-version: 11
 
+      # See https://docs.github.com/en/actions/guides/building-and-testing-java-with-maven#caching-dependencies
+      - name: Cache Maven packages
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2
+
       # Builds the JPA module and runs tests in a PostgreSQL container
       - name: Build with Maven
         run: mvn -B clean install -pl :optaplanner-persistence-jpa -am -Ppostgresql ${{ env.MVN_CONNECTION_PROPS }}

--- a/.github/workflows/os_java_ci.yml
+++ b/.github/workflows/os_java_ci.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           java-version: 11
       - name: Run the build
-        run: mvn dependency:go-offline --batch-mode
+        run: mvn dependency:go-offline --batch-mode ${{ env.MVN_CONNECTION_PROPS }}
       - name: Upload the Maven repo cache
         uses: actions/upload-artifact@v2
         with:
@@ -48,7 +48,8 @@ jobs:
         java: [8, 11]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v2
+      - name: Check out Git repository
+        uses: actions/checkout@v2
       - name: Set up JDK
         uses: actions/setup-java@v1
         with:
@@ -68,7 +69,8 @@ jobs:
     name: OpenJDK 15
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - name: Check out Git repository
+        uses: actions/checkout@v2
       - name: Set up JDK
         uses: actions/setup-java@v1
         with:

--- a/.github/workflows/os_java_ci.yml
+++ b/.github/workflows/os_java_ci.yml
@@ -21,7 +21,26 @@ defaults:
     shell: bash
 
 jobs:
+  offline:
+    name: Cache Maven repo
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out Git repository
+        uses: actions/checkout@v2
+      - name: Install Java and Maven
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+      - name: Run the build
+        run: mvn dependency:go-offline --batch-mode
+      - name: Upload the Maven repo cache
+        uses: actions/upload-artifact@v2
+        with:
+          name: maven-repo-cache
+          path: .m2/repository/**/*
+
   os-java:
+    needs: offline
     name: OS x Java
     strategy:
       matrix:
@@ -34,12 +53,18 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: ${{ matrix.java }}
+      - name: Download the Maven cache
+          uses: actions/download-artifact@v2
+          with:
+            name: maven-repo-cache
+            path: .m2/repository
       - name: Build with Maven
         run: mvn -B clean install ${{ env.MVN_CONNECTION_PROPS }}
 
   # Early feedback on a compatibility with the newest Java version.
   # TODO: update each time a new major Java version is released.
   latest-jdk:
+    needs: offline
     name: OpenJDK 15
     runs-on: ubuntu-latest
     steps:
@@ -48,5 +73,10 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 15
+      - name: Download the Maven cache
+          uses: actions/download-artifact@v2
+          with:
+            name: maven-repo-cache
+            path: .m2/repository
       - name: Build with Maven
         run: mvn -B clean install ${{ env.MVN_CONNECTION_PROPS }}

--- a/.github/workflows/os_java_ci.yml
+++ b/.github/workflows/os_java_ci.yml
@@ -21,26 +21,7 @@ defaults:
     shell: bash
 
 jobs:
-  offline:
-    name: Build project and cache Maven repo
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out Git repository
-        uses: actions/checkout@v2
-      - name: Install Java and Maven
-        uses: actions/setup-java@v1
-        with:
-          java-version: 8
-      - name: Run the build
-        run: mvn clean install -DskipTests --batch-mode ${{ env.MVN_CONNECTION_PROPS }}
-      - name: Upload the Maven repo cache
-        uses: actions/upload-artifact@v2
-        with:
-          name: maven-repo-cache
-          path: .m2/repository/**/*
-
   os-java:
-    needs: offline
     name: OS x Java
     strategy:
       matrix:
@@ -54,18 +35,19 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: ${{ matrix.java }}
-      - name: Download the Maven cache
-        uses: actions/download-artifact@v2
+      - name: Cache Maven packages
+        uses: actions/cache@v2
         with:
-          name: maven-repo-cache
-          path: .m2/repository
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2
       - name: Build with Maven
-        run: mvn -B test ${{ env.MVN_CONNECTION_PROPS }}
+        run: mvn -B clean install ${{ env.MVN_CONNECTION_PROPS }}
+      # See https://docs.github.com/en/actions/guides/building-and-testing-java-with-maven#caching-dependencies
 
   # Early feedback on a compatibility with the newest Java version.
   # TODO: update each time a new major Java version is released.
   latest-jdk:
-    needs: offline
     name: OpenJDK 15
     runs-on: ubuntu-latest
     steps:
@@ -75,10 +57,12 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 15
-      - name: Download the Maven cache
-        uses: actions/download-artifact@v2
+      # See https://docs.github.com/en/actions/guides/building-and-testing-java-with-maven#caching-dependencies
+      - name: Cache Maven packages
+        uses: actions/cache@v2
         with:
-          name: maven-repo-cache
-          path: .m2/repository
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2
       - name: Build with Maven
-        run: mvn -B test ${{ env.MVN_CONNECTION_PROPS }}
+        run: mvn -B clean install ${{ env.MVN_CONNECTION_PROPS }}

--- a/.github/workflows/os_java_ci.yml
+++ b/.github/workflows/os_java_ci.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           java-version: 11
       - name: Run the build
-        run: mvn dependency:go-offline --batch-mode ${{ env.MVN_CONNECTION_PROPS }}
+        run: mvn clean install -DskipTests --batch-mode ${{ env.MVN_CONNECTION_PROPS }}
       - name: Upload the Maven repo cache
         uses: actions/upload-artifact@v2
         with:
@@ -60,7 +60,7 @@ jobs:
           name: maven-repo-cache
           path: .m2/repository
       - name: Build with Maven
-        run: mvn -B clean install ${{ env.MVN_CONNECTION_PROPS }}
+        run: mvn -B test ${{ env.MVN_CONNECTION_PROPS }}
 
   # Early feedback on a compatibility with the newest Java version.
   # TODO: update each time a new major Java version is released.
@@ -81,4 +81,4 @@ jobs:
           name: maven-repo-cache
           path: .m2/repository
       - name: Build with Maven
-        run: mvn -B clean install ${{ env.MVN_CONNECTION_PROPS }}
+        run: mvn -B test ${{ env.MVN_CONNECTION_PROPS }}

--- a/.github/workflows/os_java_ci.yml
+++ b/.github/workflows/os_java_ci.yml
@@ -55,10 +55,10 @@ jobs:
         with:
           java-version: ${{ matrix.java }}
       - name: Download the Maven cache
-          uses: actions/download-artifact@v2
-          with:
-            name: maven-repo-cache
-            path: .m2/repository
+        uses: actions/download-artifact@v2
+        with:
+          name: maven-repo-cache
+          path: .m2/repository
       - name: Build with Maven
         run: mvn -B clean install ${{ env.MVN_CONNECTION_PROPS }}
 
@@ -76,9 +76,9 @@ jobs:
         with:
           java-version: 15
       - name: Download the Maven cache
-          uses: actions/download-artifact@v2
-          with:
-            name: maven-repo-cache
-            path: .m2/repository
+        uses: actions/download-artifact@v2
+        with:
+          name: maven-repo-cache
+          path: .m2/repository
       - name: Build with Maven
         run: mvn -B clean install ${{ env.MVN_CONNECTION_PROPS }}

--- a/.github/workflows/os_java_ci.yml
+++ b/.github/workflows/os_java_ci.yml
@@ -35,6 +35,7 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: ${{ matrix.java }}
+      # See https://docs.github.com/en/actions/guides/building-and-testing-java-with-maven#caching-dependencies
       - name: Cache Maven packages
         uses: actions/cache@v2
         with:
@@ -43,7 +44,6 @@ jobs:
           restore-keys: ${{ runner.os }}-m2
       - name: Build with Maven
         run: mvn -B clean install ${{ env.MVN_CONNECTION_PROPS }}
-      # See https://docs.github.com/en/actions/guides/building-and-testing-java-with-maven#caching-dependencies
 
   # Early feedback on a compatibility with the newest Java version.
   # TODO: update each time a new major Java version is released.

--- a/.github/workflows/os_java_ci.yml
+++ b/.github/workflows/os_java_ci.yml
@@ -22,7 +22,7 @@ defaults:
 
 jobs:
   offline:
-    name: Cache Maven repo
+    name: Build project and cache Maven repo
     runs-on: ubuntu-latest
     steps:
       - name: Check out Git repository
@@ -30,7 +30,7 @@ jobs:
       - name: Install Java and Maven
         uses: actions/setup-java@v1
         with:
-          java-version: 11
+          java-version: 8
       - name: Run the build
         run: mvn clean install -DskipTests --batch-mode ${{ env.MVN_CONNECTION_PROPS }}
       - name: Upload the Maven repo cache

--- a/.github/workflows/quarkus-snapshot.yaml
+++ b/.github/workflows/quarkus-snapshot.yaml
@@ -45,6 +45,14 @@ jobs:
           ref: master
           path: ecosystem-ci
 
+      # See https://docs.github.com/en/actions/guides/building-and-testing-java-with-maven#caching-dependencies
+      - name: Cache Maven packages
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2
+
       - name: Setup and Run Tests
         run: ./ecosystem-ci/setup-and-test
         env:


### PR DESCRIPTION
Implemented Github Actions' Maven caching mechanism. The goals:

- Maven repos are only downloaded incrementally, not the entire world every single time.
- This reduces the likelihood of Maven Central error failing the build.
- And should also speed up CI significantly.

Results once cached:

- Main CI went from 20 min to 15 min, **25 % run time improvement**.
- Persistence CI went from 7.5 min to 3.25 min, **50 % run time improvement**.

There were **no Maven Central-related failures**.
