### PR TITLE
[7.x] PLANNER-1362 Deprecate AbstractCustomPhaseCommand

### DIFF
--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/phase/custom/AbstractCustomPhaseCommand.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/phase/custom/AbstractCustomPhaseCommand.java
@@ -22,7 +22,9 @@ import org.optaplanner.core.api.domain.solution.PlanningSolution;
  * Abstract superclass for {@link CustomPhaseCommand}.
  *
  * @param <Solution_> the solution type, the class with the {@link PlanningSolution} annotation
+ * @deprecated Use the {@link CustomPhaseCommand)} interface directly instead.
  */
+@Deprecated
 public abstract class AbstractCustomPhaseCommand<Solution_> implements CustomPhaseCommand<Solution_> {
 
 }


### PR DESCRIPTION
<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.
-->

### JIRA
https://issues.redhat.com/browse/PLANNER-1362

<!-- Add a JIRA ticket link if it exists. -->
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->

### Referenced pull requests
https://github.com/kiegroup/optaplanner/pull/935

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
* https://github.com/kiegroup/drools/pull/3000
* https://github.com/kiegroup/optaplanner/pull/899
* etc.
-->

### Checklist
- [x] Documentation updated if applicable.
- [x] Upgrade recipe provided if applicable.

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>full downstream build</b> please add comment: <b>Jenkins run fdb</b>
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
