### PR TITLE
PLANNER-1821 & PLANNER-1873: Add Constraint Provider for Coach Shuttle Gathering

### DIFF
--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/coachshuttlegathering/domain/Bus.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/coachshuttlegathering/domain/Bus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,6 +36,7 @@ public abstract class Bus extends AbstractPersistable implements BusOrStop {
 
     // Shadow variables
     protected BusStop nextStop;
+    private int passengerQuantityTotal = 0;
 
     public String getName() {
         return name;
@@ -77,6 +78,14 @@ public abstract class Bus extends AbstractPersistable implements BusOrStop {
     @Override
     public void setNextStop(BusStop nextStop) {
         this.nextStop = nextStop;
+    }
+
+    public Integer getPassengerQuantityTotal() {
+        return passengerQuantityTotal;
+    }
+
+    public void setPassengerQuantityTotal(final Integer passengerQuantityTotal) {
+        this.passengerQuantityTotal = passengerQuantityTotal == null ? 0 : passengerQuantityTotal;
     }
 
     // ************************************************************************

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/coachshuttlegathering/domain/Coach.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/coachshuttlegathering/domain/Coach.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,11 +16,16 @@
 
 package org.optaplanner.examples.coachshuttlegathering.domain;
 
+import org.optaplanner.core.api.domain.entity.PlanningEntity;
+import org.optaplanner.core.api.domain.variable.CustomShadowVariable;
+import org.optaplanner.core.api.domain.variable.PlanningVariableReference;
 import org.optaplanner.examples.coachshuttlegathering.domain.location.RoadLocation;
+import org.optaplanner.examples.coachshuttlegathering.domain.solver.CoachPassengerCountTotalUpdatingVariableListener;
 
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 
 @XStreamAlias("CsgCoach")
+@PlanningEntity
 public class Coach extends Bus {
 
     protected int stopLimit;
@@ -36,6 +41,13 @@ public class Coach extends Bus {
 
     public void setDestination(BusHub destination) {
         this.destination = destination;
+    }
+
+    @Override
+    @CustomShadowVariable(variableListenerClass = CoachPassengerCountTotalUpdatingVariableListener.class,
+            sources = { @PlanningVariableReference(entityClass = BusStop.class, variableName = "bus") })
+    public Integer getPassengerQuantityTotal() {
+        return super.getPassengerQuantityTotal();
     }
 
     // ************************************************************************

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/coachshuttlegathering/domain/Shuttle.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/coachshuttlegathering/domain/Shuttle.java
@@ -56,7 +56,8 @@ public class Shuttle extends Bus {
 
     @Override
     @CustomShadowVariable(variableListenerClass = ShuttlePassengerCountTotalUpdatingVariableListener.class,
-            sources = { @PlanningVariableReference(entityClass = BusStop.class, variableName = "bus") })
+            sources = { @PlanningVariableReference(entityClass = BusStop.class, variableName = "bus"),
+                    @PlanningVariableReference(entityClass = Shuttle.class, variableName = "destination") })
     public Integer getPassengerQuantityTotal() {
         return super.getPassengerQuantityTotal();
     }

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/coachshuttlegathering/domain/Shuttle.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/coachshuttlegathering/domain/Shuttle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,9 +17,12 @@
 package org.optaplanner.examples.coachshuttlegathering.domain;
 
 import org.optaplanner.core.api.domain.entity.PlanningEntity;
+import org.optaplanner.core.api.domain.variable.CustomShadowVariable;
 import org.optaplanner.core.api.domain.variable.PlanningVariable;
+import org.optaplanner.core.api.domain.variable.PlanningVariableReference;
 import org.optaplanner.examples.coachshuttlegathering.domain.location.RoadLocation;
 import org.optaplanner.examples.coachshuttlegathering.domain.solver.DepotAngleBusStopDifficultyWeightFactory;
+import org.optaplanner.examples.coachshuttlegathering.domain.solver.ShuttlePassengerCountTotalUpdatingVariableListener;
 
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 
@@ -49,6 +52,13 @@ public class Shuttle extends Bus {
 
     public void setDestination(StopOrHub destination) {
         this.destination = destination;
+    }
+
+    @Override
+    @CustomShadowVariable(variableListenerClass = ShuttlePassengerCountTotalUpdatingVariableListener.class,
+            sources = { @PlanningVariableReference(entityClass = BusStop.class, variableName = "bus") })
+    public Integer getPassengerQuantityTotal() {
+        return super.getPassengerQuantityTotal();
     }
 
     // ************************************************************************

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/coachshuttlegathering/domain/solver/BusPassengerCountTotalUpdatingVariableListener.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/coachshuttlegathering/domain/solver/BusPassengerCountTotalUpdatingVariableListener.java
@@ -69,9 +69,6 @@ public abstract class BusPassengerCountTotalUpdatingVariableListener implements 
             return;
         }
         int difference = increase ? busStop.getPassengerQuantity() : -busStop.getPassengerQuantity();
-        if (difference == 0) {
-            return;
-        }
         scoreDirector.beforeVariableChanged(bus, "passengerQuantityTotal");
         bus.setPassengerQuantityTotal(bus.getPassengerQuantityTotal() + difference);
         scoreDirector.afterVariableChanged(bus, "passengerQuantityTotal");

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/coachshuttlegathering/domain/solver/BusPassengerCountTotalUpdatingVariableListener.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/coachshuttlegathering/domain/solver/BusPassengerCountTotalUpdatingVariableListener.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.examples.coachshuttlegathering.domain.solver;
+
+import org.optaplanner.core.api.score.director.ScoreDirector;
+import org.optaplanner.core.impl.domain.variable.listener.VariableListener;
+import org.optaplanner.examples.coachshuttlegathering.domain.Bus;
+import org.optaplanner.examples.coachshuttlegathering.domain.BusStop;
+import org.optaplanner.examples.coachshuttlegathering.domain.CoachShuttleGatheringSolution;
+
+public abstract class BusPassengerCountTotalUpdatingVariableListener implements VariableListener<Object> {
+
+    @Override
+    public void beforeEntityAdded(ScoreDirector scoreDirector, Object busStop) {
+        // Do nothing
+    }
+
+    @Override
+    public void afterEntityAdded(ScoreDirector scoreDirector, Object entity) {
+        if (entity instanceof BusStop) {
+            updateBusPassengerCount(scoreDirector, (BusStop) entity, true);
+        }
+    }
+
+    @Override
+    public void beforeVariableChanged(ScoreDirector scoreDirector, Object entity) {
+        if (entity instanceof BusStop) {
+            updateBusPassengerCount(scoreDirector, (BusStop) entity, false);
+        }
+    }
+
+    @Override
+    public void afterVariableChanged(ScoreDirector scoreDirector, Object entity) {
+        if (entity instanceof BusStop) {
+            updateBusPassengerCount(scoreDirector, (BusStop) entity, true);
+        }
+    }
+
+    @Override
+    public void beforeEntityRemoved(ScoreDirector scoreDirector, Object entity) {
+        // Do nothing
+    }
+
+    @Override
+    public void afterEntityRemoved(ScoreDirector scoreDirector, Object entity) {
+        if (entity instanceof BusStop) {
+            updateBusPassengerCount(scoreDirector, (BusStop) entity, false);
+        }
+    }
+
+    private void updateBusPassengerCount(ScoreDirector<CoachShuttleGatheringSolution> scoreDirector, BusStop busStop,
+            boolean increase) {
+        Bus bus = busStop.getBus();
+        if (!isCorrectBusInstance(bus)) {
+            return;
+        }
+        int difference = increase ? busStop.getPassengerQuantity() : -busStop.getPassengerQuantity();
+        if (difference == 0) {
+            return;
+        }
+        scoreDirector.beforeVariableChanged(bus, "passengerQuantityTotal");
+        bus.setPassengerQuantityTotal(bus.getPassengerQuantityTotal() + difference);
+        scoreDirector.afterVariableChanged(bus, "passengerQuantityTotal");
+    }
+
+    protected abstract boolean isCorrectBusInstance(Bus bus);
+}

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/coachshuttlegathering/domain/solver/CoachPassengerCountTotalUpdatingVariableListener.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/coachshuttlegathering/domain/solver/CoachPassengerCountTotalUpdatingVariableListener.java
@@ -1,84 +1,12 @@
-/*
- * Copyright 2020 Red Hat, Inc. and/or its affiliates.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.optaplanner.examples.coachshuttlegathering.domain.solver;
 
-import org.optaplanner.core.api.score.director.ScoreDirector;
-import org.optaplanner.core.impl.domain.variable.listener.VariableListener;
 import org.optaplanner.examples.coachshuttlegathering.domain.Bus;
-import org.optaplanner.examples.coachshuttlegathering.domain.BusStop;
 import org.optaplanner.examples.coachshuttlegathering.domain.Coach;
-import org.optaplanner.examples.coachshuttlegathering.domain.CoachShuttleGatheringSolution;
 
-public class CoachPassengerCountTotalUpdatingVariableListener implements VariableListener<BusStop> {
-
-    private static void adjustBus(ScoreDirector<CoachShuttleGatheringSolution> scoreDirector, Bus bus, int difference) {
-        if (difference == 0) {
-            return;
-        }
-        scoreDirector.beforeVariableChanged(bus, "passengerQuantityTotal");
-        bus.setPassengerQuantityTotal(bus.getPassengerQuantityTotal() + difference);
-        scoreDirector.afterVariableChanged(bus, "passengerQuantityTotal");
-        if (bus.getPassengerQuantityTotal() < 0) {
-            throw new IllegalStateException("Passenger quantity in " + bus + " got under zero here.");
-        }
-    }
-
-    private static void adjust(ScoreDirector<CoachShuttleGatheringSolution> scoreDirector, BusStop busStop,
-            boolean increase) {
-        Bus bus = busStop.getBus();
-        if (!(bus instanceof Coach)) {
-            return;
-        }
-        adjustBus(scoreDirector, bus, increase ? busStop.getPassengerQuantity() : -busStop.getPassengerQuantity());
-    }
-
-    private static void increase(ScoreDirector<CoachShuttleGatheringSolution> scoreDirector, BusStop busStop) {
-        adjust(scoreDirector, busStop, true);
-    }
-
-    private static void decrease(ScoreDirector<CoachShuttleGatheringSolution> scoreDirector, BusStop busStop) {
-        adjust(scoreDirector, busStop, false);
-    }
+public class CoachPassengerCountTotalUpdatingVariableListener extends BusPassengerCountTotalUpdatingVariableListener {
 
     @Override
-    public void beforeEntityAdded(ScoreDirector scoreDirector, BusStop busStop) {
-    }
-
-    @Override
-    public void afterEntityAdded(ScoreDirector scoreDirector, BusStop busStop) {
-        increase(scoreDirector, busStop);
-    }
-
-    @Override
-    public void beforeVariableChanged(ScoreDirector scoreDirector, BusStop busStop) {
-        decrease(scoreDirector, busStop);
-    }
-
-    @Override
-    public void afterVariableChanged(ScoreDirector scoreDirector, BusStop busStop) {
-        increase(scoreDirector, busStop);
-    }
-
-    @Override
-    public void beforeEntityRemoved(ScoreDirector scoreDirector, BusStop busStop) {
-    }
-
-    @Override
-    public void afterEntityRemoved(ScoreDirector scoreDirector, BusStop busStop) {
-        decrease(scoreDirector, busStop);
+    protected boolean isCorrectBusInstance(Bus bus) {
+        return bus instanceof Coach;
     }
 }

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/coachshuttlegathering/domain/solver/CoachPassengerCountTotalUpdatingVariableListener.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/coachshuttlegathering/domain/solver/CoachPassengerCountTotalUpdatingVariableListener.java
@@ -32,6 +32,9 @@ public class CoachPassengerCountTotalUpdatingVariableListener implements Variabl
         scoreDirector.beforeVariableChanged(bus, "passengerQuantityTotal");
         bus.setPassengerQuantityTotal(bus.getPassengerQuantityTotal() + difference);
         scoreDirector.afterVariableChanged(bus, "passengerQuantityTotal");
+        if (bus.getPassengerQuantityTotal() < 0) {
+            throw new IllegalStateException("Capacity of " + bus + " got under zero here.");
+        }
     }
 
     private static void adjust(ScoreDirector<CoachShuttleGatheringSolution> scoreDirector, BusStop busStop,

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/coachshuttlegathering/domain/solver/CoachPassengerCountTotalUpdatingVariableListener.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/coachshuttlegathering/domain/solver/CoachPassengerCountTotalUpdatingVariableListener.java
@@ -22,10 +22,8 @@ import org.optaplanner.examples.coachshuttlegathering.domain.Bus;
 import org.optaplanner.examples.coachshuttlegathering.domain.BusStop;
 import org.optaplanner.examples.coachshuttlegathering.domain.Coach;
 import org.optaplanner.examples.coachshuttlegathering.domain.CoachShuttleGatheringSolution;
-import org.optaplanner.examples.coachshuttlegathering.domain.Shuttle;
-import org.optaplanner.examples.coachshuttlegathering.domain.StopOrHub;
 
-public class ShuttlePassengerCountTotalUpdatingVariableListener implements VariableListener<BusStop> {
+public class CoachPassengerCountTotalUpdatingVariableListener implements VariableListener<BusStop> {
 
     private static void adjustBus(ScoreDirector<CoachShuttleGatheringSolution> scoreDirector, Bus bus, int difference) {
         scoreDirector.beforeVariableChanged(bus, "passengerQuantityTotal");
@@ -38,19 +36,10 @@ public class ShuttlePassengerCountTotalUpdatingVariableListener implements Varia
     private static void adjust(ScoreDirector<CoachShuttleGatheringSolution> scoreDirector, BusStop busStop,
             boolean increase) {
         Bus bus = busStop.getBus();
-        if (!(bus instanceof Shuttle)) {
+        if (!(bus instanceof Coach)) {
             return;
         }
         adjustBus(scoreDirector, bus, increase ? busStop.getPassengerQuantity() : -busStop.getPassengerQuantity());
-        Shuttle shuttle = (Shuttle) bus;
-        StopOrHub destination = shuttle.getDestination();
-        if (destination instanceof BusStop) {
-            Bus destinationBus = ((BusStop) destination).getBus();
-            if (destinationBus instanceof Coach) {
-                int difference = increase ? busStop.getPassengerQuantity() : -busStop.getPassengerQuantity();
-                adjustBus(scoreDirector, destinationBus, difference);
-            }
-        }
     }
 
     private static void increase(ScoreDirector<CoachShuttleGatheringSolution> scoreDirector, BusStop busStop) {

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/coachshuttlegathering/domain/solver/CoachPassengerCountTotalUpdatingVariableListener.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/coachshuttlegathering/domain/solver/CoachPassengerCountTotalUpdatingVariableListener.java
@@ -16,8 +16,8 @@
 
 package org.optaplanner.examples.coachshuttlegathering.domain.solver;
 
+import org.optaplanner.core.api.score.director.ScoreDirector;
 import org.optaplanner.core.impl.domain.variable.listener.VariableListener;
-import org.optaplanner.core.impl.score.director.ScoreDirector;
 import org.optaplanner.examples.coachshuttlegathering.domain.Bus;
 import org.optaplanner.examples.coachshuttlegathering.domain.BusStop;
 import org.optaplanner.examples.coachshuttlegathering.domain.Coach;

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/coachshuttlegathering/domain/solver/CoachPassengerCountTotalUpdatingVariableListener.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/coachshuttlegathering/domain/solver/CoachPassengerCountTotalUpdatingVariableListener.java
@@ -33,7 +33,7 @@ public class CoachPassengerCountTotalUpdatingVariableListener implements Variabl
         bus.setPassengerQuantityTotal(bus.getPassengerQuantityTotal() + difference);
         scoreDirector.afterVariableChanged(bus, "passengerQuantityTotal");
         if (bus.getPassengerQuantityTotal() < 0) {
-            throw new IllegalStateException("Capacity of " + bus + " got under zero here.");
+            throw new IllegalStateException("Passenger quantity in " + bus + " got under zero here.");
         }
     }
 

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/coachshuttlegathering/domain/solver/CoachPassengerCountTotalUpdatingVariableListener.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/coachshuttlegathering/domain/solver/CoachPassengerCountTotalUpdatingVariableListener.java
@@ -26,10 +26,11 @@ import org.optaplanner.examples.coachshuttlegathering.domain.CoachShuttleGatheri
 public class CoachPassengerCountTotalUpdatingVariableListener implements VariableListener<BusStop> {
 
     private static void adjustBus(ScoreDirector<CoachShuttleGatheringSolution> scoreDirector, Bus bus, int difference) {
+        if (difference == 0) {
+            return;
+        }
         scoreDirector.beforeVariableChanged(bus, "passengerQuantityTotal");
-        System.out.println(bus + " " + bus.getPassengerQuantityTotal());
         bus.setPassengerQuantityTotal(bus.getPassengerQuantityTotal() + difference);
-        System.out.println("To: " + bus.getPassengerQuantityTotal());
         scoreDirector.afterVariableChanged(bus, "passengerQuantityTotal");
     }
 

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/coachshuttlegathering/domain/solver/ShuttlePassengerCountTotalUpdatingVariableListener.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/coachshuttlegathering/domain/solver/ShuttlePassengerCountTotalUpdatingVariableListener.java
@@ -34,7 +34,7 @@ public class ShuttlePassengerCountTotalUpdatingVariableListener implements Varia
         bus.setPassengerQuantityTotal(bus.getPassengerQuantityTotal() + difference);
         scoreDirector.afterVariableChanged(bus, "passengerQuantityTotal");
         if (bus.getPassengerQuantityTotal() < 0) {
-            throw new IllegalStateException("Capacity of " + bus + " got under zero here.");
+            throw new IllegalStateException("Passenger quantity in " + bus + " got under zero here.");
         }
     }
 

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/coachshuttlegathering/domain/solver/ShuttlePassengerCountTotalUpdatingVariableListener.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/coachshuttlegathering/domain/solver/ShuttlePassengerCountTotalUpdatingVariableListener.java
@@ -16,8 +16,8 @@
 
 package org.optaplanner.examples.coachshuttlegathering.domain.solver;
 
+import org.optaplanner.core.api.score.director.ScoreDirector;
 import org.optaplanner.core.impl.domain.variable.listener.VariableListener;
-import org.optaplanner.core.impl.score.director.ScoreDirector;
 import org.optaplanner.examples.coachshuttlegathering.domain.Bus;
 import org.optaplanner.examples.coachshuttlegathering.domain.BusStop;
 import org.optaplanner.examples.coachshuttlegathering.domain.Coach;

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/coachshuttlegathering/domain/solver/ShuttlePassengerCountTotalUpdatingVariableListener.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/coachshuttlegathering/domain/solver/ShuttlePassengerCountTotalUpdatingVariableListener.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.examples.coachshuttlegathering.domain.solver;
+
+import org.optaplanner.core.impl.domain.variable.listener.VariableListener;
+import org.optaplanner.core.impl.score.director.ScoreDirector;
+import org.optaplanner.examples.coachshuttlegathering.domain.Bus;
+import org.optaplanner.examples.coachshuttlegathering.domain.BusStop;
+import org.optaplanner.examples.coachshuttlegathering.domain.CoachShuttleGatheringSolution;
+import org.optaplanner.examples.coachshuttlegathering.domain.Shuttle;
+
+public class ShuttlePassengerCountTotalUpdatingVariableListener implements VariableListener<BusStop> {
+
+    private static void adjustBus(ScoreDirector<CoachShuttleGatheringSolution> scoreDirector, Bus bus, int difference) {
+        scoreDirector.beforeVariableChanged(bus, "passengerQuantityTotal");
+        System.out.println(bus + " " + bus.getPassengerQuantityTotal());
+        bus.setPassengerQuantityTotal(bus.getPassengerQuantityTotal() + difference);
+        System.out.println("To: " + bus.getPassengerQuantityTotal());
+        scoreDirector.afterVariableChanged(bus, "passengerQuantityTotal");
+    }
+
+    private static void adjust(ScoreDirector<CoachShuttleGatheringSolution> scoreDirector, BusStop busStop,
+            boolean increase) {
+        Bus bus = busStop.getBus();
+        if (!(bus instanceof Shuttle)) {
+            return;
+        }
+        adjustBus(scoreDirector, bus, increase ? busStop.getPassengerQuantity() : -busStop.getPassengerQuantity());
+    }
+
+    private static void increase(ScoreDirector<CoachShuttleGatheringSolution> scoreDirector, BusStop busStop) {
+        adjust(scoreDirector, busStop, true);
+    }
+
+    private static void decrease(ScoreDirector<CoachShuttleGatheringSolution> scoreDirector, BusStop busStop) {
+        adjust(scoreDirector, busStop, false);
+    }
+
+    @Override
+    public void beforeEntityAdded(ScoreDirector scoreDirector, BusStop busStop) {
+    }
+
+    @Override
+    public void afterEntityAdded(ScoreDirector scoreDirector, BusStop busStop) {
+        increase(scoreDirector, busStop);
+    }
+
+    @Override
+    public void beforeVariableChanged(ScoreDirector scoreDirector, BusStop busStop) {
+        decrease(scoreDirector, busStop);
+    }
+
+    @Override
+    public void afterVariableChanged(ScoreDirector scoreDirector, BusStop busStop) {
+        increase(scoreDirector, busStop);
+    }
+
+    @Override
+    public void beforeEntityRemoved(ScoreDirector scoreDirector, BusStop busStop) {
+    }
+
+    @Override
+    public void afterEntityRemoved(ScoreDirector scoreDirector, BusStop busStop) {
+        decrease(scoreDirector, busStop);
+    }
+}

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/coachshuttlegathering/domain/solver/ShuttlePassengerCountTotalUpdatingVariableListener.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/coachshuttlegathering/domain/solver/ShuttlePassengerCountTotalUpdatingVariableListener.java
@@ -1,92 +1,12 @@
-/*
- * Copyright 2020 Red Hat, Inc. and/or its affiliates.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.optaplanner.examples.coachshuttlegathering.domain.solver;
 
-import org.optaplanner.core.api.score.director.ScoreDirector;
-import org.optaplanner.core.impl.domain.variable.listener.VariableListener;
 import org.optaplanner.examples.coachshuttlegathering.domain.Bus;
-import org.optaplanner.examples.coachshuttlegathering.domain.BusStop;
-import org.optaplanner.examples.coachshuttlegathering.domain.CoachShuttleGatheringSolution;
 import org.optaplanner.examples.coachshuttlegathering.domain.Shuttle;
 
-public class ShuttlePassengerCountTotalUpdatingVariableListener implements VariableListener<Object> {
-
-    private static void adjustBus(ScoreDirector<CoachShuttleGatheringSolution> scoreDirector, Bus bus, int difference) {
-        if (difference == 0) {
-            return;
-        }
-        scoreDirector.beforeVariableChanged(bus, "passengerQuantityTotal");
-        bus.setPassengerQuantityTotal(bus.getPassengerQuantityTotal() + difference);
-        scoreDirector.afterVariableChanged(bus, "passengerQuantityTotal");
-        if (bus.getPassengerQuantityTotal() < 0) {
-            throw new IllegalStateException("Passenger quantity in " + bus + " got under zero here.");
-        }
-    }
-
-    private static void adjustBusStop(ScoreDirector<CoachShuttleGatheringSolution> scoreDirector, BusStop busStop,
-            boolean increase) {
-        Bus bus = busStop.getBus();
-        if (!(bus instanceof Shuttle)) {
-            return;
-        }
-        adjustBus(scoreDirector, bus, increase ? busStop.getPassengerQuantity() : -busStop.getPassengerQuantity());
-    }
-
-    private static void increase(ScoreDirector<CoachShuttleGatheringSolution> scoreDirector, BusStop busStop) {
-        adjustBusStop(scoreDirector, busStop, true);
-    }
-
-    private static void decrease(ScoreDirector<CoachShuttleGatheringSolution> scoreDirector, BusStop busStop) {
-        adjustBusStop(scoreDirector, busStop, false);
-    }
+public class ShuttlePassengerCountTotalUpdatingVariableListener extends BusPassengerCountTotalUpdatingVariableListener {
 
     @Override
-    public void beforeEntityAdded(ScoreDirector scoreDirector, Object entity) {
-    }
-
-    @Override
-    public void afterEntityAdded(ScoreDirector scoreDirector, Object entity) {
-        if (entity instanceof BusStop) {
-            increase(scoreDirector, (BusStop) entity);
-        }
-    }
-
-    @Override
-    public void beforeVariableChanged(ScoreDirector scoreDirector, Object entity) {
-        if (entity instanceof BusStop) {
-            decrease(scoreDirector, (BusStop) entity);
-        }
-    }
-
-    @Override
-    public void afterVariableChanged(ScoreDirector scoreDirector, Object entity) {
-        if (entity instanceof BusStop) {
-            increase(scoreDirector, (BusStop) entity);
-        }
-    }
-
-    @Override
-    public void beforeEntityRemoved(ScoreDirector scoreDirector, Object entity) {
-    }
-
-    @Override
-    public void afterEntityRemoved(ScoreDirector scoreDirector, Object entity) {
-        if (entity instanceof BusStop) {
-            decrease(scoreDirector, (BusStop) entity);
-        }
+    protected boolean isCorrectBusInstance(Bus bus) {
+        return bus instanceof Shuttle;
     }
 }

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/coachshuttlegathering/domain/solver/ShuttlePassengerCountTotalUpdatingVariableListener.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/coachshuttlegathering/domain/solver/ShuttlePassengerCountTotalUpdatingVariableListener.java
@@ -20,7 +20,6 @@ import org.optaplanner.core.api.score.director.ScoreDirector;
 import org.optaplanner.core.impl.domain.variable.listener.VariableListener;
 import org.optaplanner.examples.coachshuttlegathering.domain.Bus;
 import org.optaplanner.examples.coachshuttlegathering.domain.BusStop;
-import org.optaplanner.examples.coachshuttlegathering.domain.Coach;
 import org.optaplanner.examples.coachshuttlegathering.domain.CoachShuttleGatheringSolution;
 import org.optaplanner.examples.coachshuttlegathering.domain.Shuttle;
 
@@ -45,21 +44,6 @@ public class ShuttlePassengerCountTotalUpdatingVariableListener implements Varia
             return;
         }
         adjustBus(scoreDirector, bus, increase ? busStop.getPassengerQuantity() : -busStop.getPassengerQuantity());
-        Shuttle shuttle = (Shuttle) bus;
-        Bus destinationBus = shuttle.getDestinationBus();
-        if (destinationBus instanceof Coach) {
-            int difference = increase ? busStop.getPassengerQuantity() : -busStop.getPassengerQuantity();
-            adjustBus(scoreDirector, destinationBus, difference);
-        }
-    }
-
-    private static void adjustShuttle(ScoreDirector<CoachShuttleGatheringSolution> scoreDirector, Shuttle shuttle,
-            boolean increase) {
-        Bus destinationBus = shuttle.getDestinationBus();
-        if (destinationBus instanceof Coach) {
-            adjustBus(scoreDirector, destinationBus,
-                    increase ? shuttle.getPassengerQuantityTotal() : -shuttle.getPassengerQuantityTotal());
-        }
     }
 
     private static void increase(ScoreDirector<CoachShuttleGatheringSolution> scoreDirector, BusStop busStop) {
@@ -70,14 +54,6 @@ public class ShuttlePassengerCountTotalUpdatingVariableListener implements Varia
         adjustBusStop(scoreDirector, busStop, false);
     }
 
-    private static void increase(ScoreDirector<CoachShuttleGatheringSolution> scoreDirector, Shuttle shuttle) {
-        adjustShuttle(scoreDirector, shuttle, true);
-    }
-
-    private static void decrease(ScoreDirector<CoachShuttleGatheringSolution> scoreDirector, Shuttle shuttle) {
-        adjustShuttle(scoreDirector, shuttle, false);
-    }
-
     @Override
     public void beforeEntityAdded(ScoreDirector scoreDirector, Object entity) {
     }
@@ -86,8 +62,6 @@ public class ShuttlePassengerCountTotalUpdatingVariableListener implements Varia
     public void afterEntityAdded(ScoreDirector scoreDirector, Object entity) {
         if (entity instanceof BusStop) {
             increase(scoreDirector, (BusStop) entity);
-        } else if (entity instanceof Shuttle) {
-            increase(scoreDirector, (Shuttle) entity);
         }
     }
 
@@ -95,8 +69,6 @@ public class ShuttlePassengerCountTotalUpdatingVariableListener implements Varia
     public void beforeVariableChanged(ScoreDirector scoreDirector, Object entity) {
         if (entity instanceof BusStop) {
             decrease(scoreDirector, (BusStop) entity);
-        } else if (entity instanceof Shuttle) {
-            decrease(scoreDirector, (Shuttle) entity);
         }
     }
 
@@ -104,8 +76,6 @@ public class ShuttlePassengerCountTotalUpdatingVariableListener implements Varia
     public void afterVariableChanged(ScoreDirector scoreDirector, Object entity) {
         if (entity instanceof BusStop) {
             increase(scoreDirector, (BusStop) entity);
-        } else if (entity instanceof Shuttle) {
-            increase(scoreDirector, (Shuttle) entity);
         }
     }
 
@@ -117,8 +87,6 @@ public class ShuttlePassengerCountTotalUpdatingVariableListener implements Varia
     public void afterEntityRemoved(ScoreDirector scoreDirector, Object entity) {
         if (entity instanceof BusStop) {
             decrease(scoreDirector, (BusStop) entity);
-        } else if (entity instanceof Shuttle) {
-            decrease(scoreDirector, (Shuttle) entity);
         }
     }
 }

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/coachshuttlegathering/solver/CoachShuttleGatheringConstraintProvider.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/coachshuttlegathering/solver/CoachShuttleGatheringConstraintProvider.java
@@ -17,7 +17,7 @@ import org.optaplanner.examples.coachshuttlegathering.domain.Shuttle;
 import org.optaplanner.examples.coachshuttlegathering.domain.StopOrHub;
 
 public class CoachShuttleGatheringConstraintProvider implements ConstraintProvider {
-    final static String CONSTRAINT_PACKAGE = "org.optaplanner.examples.coachshuttlegathering.solver";
+    static final String CONSTRAINT_PACKAGE = "org.optaplanner.examples.coachshuttlegathering.solver";
 
     @Override
     public Constraint[] defineConstraints(ConstraintFactory constraintFactory) {
@@ -47,9 +47,9 @@ public class CoachShuttleGatheringConstraintProvider implements ConstraintProvid
 
     Constraint shuttleCapacity(ConstraintFactory constraintFactory) {
         return constraintFactory.from(Shuttle.class)
-                .filter((bus) -> bus.getPassengerQuantityTotal() > bus.getCapacity())
+                .filter(bus -> bus.getPassengerQuantityTotal() > bus.getCapacity())
                 .penalizeLong(CONSTRAINT_PACKAGE, "shuttleCapacity", HardSoftLongScore.ONE_HARD,
-                        (bus) -> (bus.getPassengerQuantityTotal() - bus.getCapacity()) * 1000L);
+                        bus -> (bus.getPassengerQuantityTotal() - bus.getCapacity()) * 1000L);
     }
 
     Constraint coachCapacity(ConstraintFactory constraintFactory) {
@@ -100,14 +100,14 @@ public class CoachShuttleGatheringConstraintProvider implements ConstraintProvid
 
     Constraint transportTime(ConstraintFactory constraintFactory) {
         return constraintFactory.from(BusStop.class)
-                .filter((busStop) -> busStop.getTransportTimeToHub() != null && busStop.getTransportTimeRemainder() < 0)
+                .filter(busStop -> busStop.getTransportTimeToHub() != null && busStop.getTransportTimeRemainder() < 0)
                 .penalizeLong(CONSTRAINT_PACKAGE, "transportTime", HardSoftLongScore.ONE_HARD,
-                        (busStop) -> -busStop.getTransportTimeRemainder());
+                        busStop -> -busStop.getTransportTimeRemainder());
     }
 
     Constraint shuttleDestinationIsCoachOrHub(ConstraintFactory constraintFactory) {
         return constraintFactory.from(Shuttle.class)
-                .filter((shuttle) -> shuttle.getDestination() != null)
+                .filter(shuttle -> shuttle.getDestination() != null)
                 .join(StopOrHub.class, equal(Shuttle::getDestination, Function.identity()))
                 .filter((shuttle, stop) -> !stop.isVisitedByCoach())
                 .penalizeLong(CONSTRAINT_PACKAGE, "shuttleDestinationIsCoachOrHub", HardSoftLongScore.ONE_HARD,

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/coachshuttlegathering/solver/CoachShuttleGatheringConstraintProvider.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/coachshuttlegathering/solver/CoachShuttleGatheringConstraintProvider.java
@@ -1,0 +1,142 @@
+package org.optaplanner.examples.coachshuttlegathering.solver;
+
+import java.util.function.Function;
+
+import org.optaplanner.core.api.score.buildin.hardsoftlong.HardSoftLongScore;
+import org.optaplanner.core.api.score.stream.Constraint;
+import org.optaplanner.core.api.score.stream.ConstraintCollectors;
+import org.optaplanner.core.api.score.stream.ConstraintFactory;
+import org.optaplanner.core.api.score.stream.ConstraintProvider;
+import org.optaplanner.core.api.score.stream.Joiners;
+import org.optaplanner.examples.coachshuttlegathering.domain.Bus;
+import org.optaplanner.examples.coachshuttlegathering.domain.BusStop;
+import org.optaplanner.examples.coachshuttlegathering.domain.Coach;
+import org.optaplanner.examples.coachshuttlegathering.domain.Shuttle;
+import org.optaplanner.examples.coachshuttlegathering.domain.StopOrHub;
+
+public class CoachShuttleGatheringConstraintProvider implements ConstraintProvider {
+    final static String CONSTRAINT_PACKAGE = "org.optaplanner.examples.coachshuttlegathering.solver";
+
+    @Override
+    public Constraint[] defineConstraints(ConstraintFactory constraintFactory) {
+        return new Constraint[] {
+                coachStopLimit(constraintFactory),
+                shuttleCapacity(constraintFactory),
+                coachCapacity(constraintFactory),
+                coachCapacityShuttleButNoShuttle(constraintFactory),
+                coachCapacityCorrection(constraintFactory),
+                transportTime(constraintFactory),
+                shuttleDestinationIsCoachOrHub(constraintFactory),
+                shuttleSetupCost(constraintFactory),
+                distanceFromPrevious(constraintFactory),
+                distanceBusStopToBusDestination(constraintFactory),
+                distanceCoachDirectlyToDestination(constraintFactory)
+        };
+    }
+
+    Constraint coachStopLimit(ConstraintFactory constraintFactory) {
+        return constraintFactory.from(Coach.class)
+                .join(BusStop.class, Joiners.equal(coach -> coach, BusStop::getBus))
+                .groupBy((coach, busStop) -> coach, ConstraintCollectors.countBi())
+                .filter((coach, stopCount) -> stopCount > coach.getStopLimit())
+                .penalizeLong(CONSTRAINT_PACKAGE, "coachStopLimit", HardSoftLongScore.ONE_HARD,
+                        (coach, stopCount) -> (stopCount - coach.getStopLimit()) * 1000000L);
+    }
+
+    Constraint shuttleCapacity(ConstraintFactory constraintFactory) {
+        return constraintFactory.from(Shuttle.class)
+                .filter((bus) -> bus.getPassengerQuantityTotal() > bus.getCapacity())
+                .penalizeLong(CONSTRAINT_PACKAGE, "shuttleCapacity", HardSoftLongScore.ONE_HARD,
+                        (bus) -> (bus.getPassengerQuantityTotal() - bus.getCapacity()) * 1000L);
+    }
+
+    Constraint coachCapacity(ConstraintFactory constraintFactory) {
+        return constraintFactory.from(Coach.class)
+                .join(Shuttle.class)
+                .join(BusStop.class, Joiners.equal((coach, shuttle) -> shuttle.getDestination(), stop -> stop),
+                        Joiners.equal((coach, shuttle) -> coach, BusStop::getBus))
+                .join(BusStop.class, Joiners.equal((coach, shuttle, stop) -> shuttle, BusStop::getBus))
+                .groupBy((coach, shuttle, stop1, stop2) -> coach,
+                        ConstraintCollectors.sum((coach, shuttle, stop1, stop2) -> stop2.getPassengerQuantity()))
+                .filter((coach,
+                        shuttlePassengerQuantityTotal) -> coach.getPassengerQuantityTotal()
+                                + shuttlePassengerQuantityTotal > coach.getCapacity())
+                .penalizeLong(CONSTRAINT_PACKAGE, "coachCapacity", HardSoftLongScore.ONE_HARD,
+                        (coach, shuttlePassengerQuantityTotal) -> (coach.getPassengerQuantityTotal()
+                                + shuttlePassengerQuantityTotal - coach.getCapacity()) * 1000L);
+    }
+
+    // Correct the double counting
+    // Explanation: groupBy is like accumlate, but it doesn't trigger on empty streams.
+    // We need something like
+    // .accumlate(Function<ConstraintStream, UniConstraintStream<T>>, T defaultValue): ConstraintStream+1
+    // To change it from 3 separate constraints (one for the normal case, one in the case of empty stream,
+    // one to remove double counting)
+    Constraint coachCapacityCorrection(ConstraintFactory constraintFactory) {
+        return constraintFactory.from(Coach.class)
+                .join(Shuttle.class)
+                .join(BusStop.class, Joiners.equal((coach, shuttle) -> shuttle.getDestination(), stop -> stop),
+                        Joiners.equal((coach, shuttle) -> coach, BusStop::getBus))
+                .join(BusStop.class, Joiners.equal((coach, shuttle, stop) -> shuttle, BusStop::getBus))
+                .groupBy((coach, shuttle, stop1, stop2) -> coach,
+                        ConstraintCollectors.sum((coach, shuttle, stop1, stop2) -> stop2.getPassengerQuantity()))
+                .filter((coach,
+                        shuttlePassengerQuantityTotal) -> coach.getPassengerQuantityTotal() > coach.getCapacity())
+                .rewardLong(CONSTRAINT_PACKAGE, "coachCapacityCorrection", HardSoftLongScore.ONE_HARD,
+                        (coach, shuttlePassengerQuantityTotal) -> (coach.getPassengerQuantityTotal() - coach.getCapacity())
+                                * 1000L);
+    }
+
+    Constraint coachCapacityShuttleButNoShuttle(ConstraintFactory constraintFactory) {
+        return constraintFactory.from(Coach.class)
+                .filter(coach -> coach.getPassengerQuantityTotal() > coach.getCapacity())
+                .penalizeLong(CONSTRAINT_PACKAGE, "coachCapacityShuttleButNoShuttle", HardSoftLongScore.ONE_HARD,
+                        coach -> (coach.getPassengerQuantityTotal() - coach.getCapacity()) * 1000L);
+    }
+
+    Constraint transportTime(ConstraintFactory constraintFactory) {
+        return constraintFactory.from(BusStop.class)
+                .filter((busStop) -> busStop.getTransportTimeToHub() != null && busStop.getTransportTimeRemainder() < 0)
+                .penalizeLong(CONSTRAINT_PACKAGE, "transportTime", HardSoftLongScore.ONE_HARD,
+                        (busStop) -> -busStop.getTransportTimeRemainder());
+    }
+
+    Constraint shuttleDestinationIsCoachOrHub(ConstraintFactory constraintFactory) {
+        return constraintFactory.from(Shuttle.class)
+                .filter((shuttle) -> shuttle.getDestination() != null)
+                .join(StopOrHub.class, Joiners.equal(Shuttle::getDestination, Function.identity()))
+                .filter((shuttle, stop) -> !stop.isVisitedByCoach())
+                .penalizeLong(CONSTRAINT_PACKAGE, "shuttleDestinationIsCoachOrHub", HardSoftLongScore.ONE_HARD,
+                        (bus, stop) -> 1000000000L);
+    }
+
+    Constraint shuttleSetupCost(ConstraintFactory constraintFactory) {
+        return constraintFactory.from(Bus.class)
+                .filter(bus -> bus.getNextStop() != null)
+                .penalizeLong(CONSTRAINT_PACKAGE, "shuttleSetupCost", HardSoftLongScore.ONE_SOFT, Bus::getSetupCost);
+    }
+
+    Constraint distanceFromPrevious(ConstraintFactory constraintFactory) {
+        return constraintFactory.from(BusStop.class)
+                .filter(bus -> bus.getPreviousBusOrStop() != null)
+                .penalizeLong(CONSTRAINT_PACKAGE, "distanceFromPrevious", HardSoftLongScore.ONE_SOFT,
+                        BusStop::getDistanceFromPreviousCost);
+    }
+
+    Constraint distanceBusStopToBusDestination(ConstraintFactory constraintFactory) {
+        return constraintFactory.from(BusStop.class)
+                .filter(busStop -> busStop.getNextStop() == null)
+                .join(Bus.class, Joiners.equal(BusStop::getBus, Function.identity()))
+                .filter((busStop, bus) -> bus.getDestination() != null && bus.getNextStop() != null)
+                .penalizeLong(CONSTRAINT_PACKAGE, "distanceBusStopToBusDestination", HardSoftLongScore.ONE_SOFT,
+                        (busStop, bus) -> busStop.getDistanceToDestinationCost(bus.getDestination()));
+    }
+
+    Constraint distanceCoachDirectlyToDestination(ConstraintFactory constraintFactory) {
+        return constraintFactory.from(Coach.class)
+                .filter(coach -> coach.getDestination() != null && coach.getNextStop() == null)
+                .penalizeLong(CONSTRAINT_PACKAGE, "distanceCoachDirectlyToDestination", HardSoftLongScore.ONE_SOFT,
+                        Coach::getDistanceToDestinationCost);
+    }
+
+}

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/coachshuttlegathering/solver/CoachShuttleGatheringEasyScoreCalculator.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/coachshuttlegathering/solver/CoachShuttleGatheringEasyScoreCalculator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,8 @@ package org.optaplanner.examples.coachshuttlegathering.solver;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.TreeMap;
+import java.util.stream.Collectors;
 
 import org.optaplanner.core.api.score.buildin.hardsoftlong.HardSoftLongScore;
 import org.optaplanner.core.impl.score.director.easy.EasyScoreCalculator;
@@ -85,6 +87,12 @@ public class CoachShuttleGatheringEasyScoreCalculator implements EasyScoreCalcul
                 softScore -= stop.getDistanceToDestinationCost(bus.getDestination());
             }
         }
+        System.out.println(new TreeMap<>(busToPassengerTotalMap.entrySet().stream()
+                .collect(Collectors.toMap(e -> e.getKey().toString(), Map.Entry::getValue))));
+        int sum = busToPassengerTotalMap.values().stream()
+                .mapToInt(s -> s)
+                .sum();
+        System.out.println(sum);
         for (Bus bus : busList) {
             // Constraint shuttleCapacity and coachCapacity
             Integer passengerTotal = busToPassengerTotalMap.get(bus);

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/coachshuttlegathering/solver/CoachShuttleGatheringEasyScoreCalculator.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/coachshuttlegathering/solver/CoachShuttleGatheringEasyScoreCalculator.java
@@ -19,8 +19,6 @@ package org.optaplanner.examples.coachshuttlegathering.solver;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.TreeMap;
-import java.util.stream.Collectors;
 
 import org.optaplanner.core.api.score.buildin.hardsoftlong.HardSoftLongScore;
 import org.optaplanner.core.impl.score.director.easy.EasyScoreCalculator;
@@ -87,12 +85,6 @@ public class CoachShuttleGatheringEasyScoreCalculator implements EasyScoreCalcul
                 softScore -= stop.getDistanceToDestinationCost(bus.getDestination());
             }
         }
-        System.out.println(new TreeMap<>(busToPassengerTotalMap.entrySet().stream()
-                .collect(Collectors.toMap(e -> e.getKey().toString(), Map.Entry::getValue))));
-        int sum = busToPassengerTotalMap.values().stream()
-                .mapToInt(s -> s)
-                .sum();
-        System.out.println(sum);
         for (Bus bus : busList) {
             // Constraint shuttleCapacity and coachCapacity
             Integer passengerTotal = busToPassengerTotalMap.get(bus);

--- a/optaplanner-examples/src/main/resources/org/optaplanner/examples/coachshuttlegathering/solver/coachShuttleGatheringConstraints.drl
+++ b/optaplanner-examples/src/main/resources/org/optaplanner/examples/coachshuttlegathering/solver/coachShuttleGatheringConstraints.drl
@@ -50,14 +50,10 @@ end
 
 rule "shuttleCapacity"
     when
-        $shuttle : Shuttle($capacity : capacity)
-        accumulate(
-            BusStop(bus == $shuttle, $passengerQuantity : passengerQuantity);
-            $passengerQuantityTotal : sum($passengerQuantity);
-            $passengerQuantityTotal > $capacity
-        )
+        $shuttle : Shuttle(passengerQuantityTotal > capacity)
     then
-        scoreHolder.addHardConstraintMatch(kcontext, ($capacity - $passengerQuantityTotal) * 1000L);
+        System.out.println($shuttle.getCapacity() + " " + $shuttle.getPassengerQuantityTotal());
+        scoreHolder.addHardConstraintMatch(kcontext, ($shuttle.getCapacity() - $shuttle.getPassengerQuantityTotal()) * 1000L);
 end
 
 rule "coachCapacity"
@@ -69,9 +65,8 @@ rule "coachCapacity"
         )
         accumulate(
             $shuttle : Shuttle($destination : destination)
-            and BusStop(this == $destination, bus == $coach)
-            and BusStop(bus == $shuttle, $shuttlePassengerQuantity : passengerQuantity);
-            $shuttlePassengerQuantityTotal : sum($shuttlePassengerQuantity);
+            and exists BusStop(this == $destination, bus == $coach);
+            $shuttlePassengerQuantityTotal : sum($shuttle.getPassengerQuantityTotal());
             $coachPassengerQuantityTotal + $shuttlePassengerQuantityTotal > $capacity
         )
     then

--- a/optaplanner-examples/src/main/resources/org/optaplanner/examples/coachshuttlegathering/solver/coachShuttleGatheringConstraints.drl
+++ b/optaplanner-examples/src/main/resources/org/optaplanner/examples/coachshuttlegathering/solver/coachShuttleGatheringConstraints.drl
@@ -48,29 +48,11 @@ rule "coachStopLimit"
         scoreHolder.addHardConstraintMatch(kcontext, ($stopLimit - $stopTotal) * 1000000L);
 end
 
-rule "shuttleCapacity"
+rule "busCapacity"
     when
-        $shuttle : Shuttle(passengerQuantityTotal > capacity)
+        $bus : Bus(passengerQuantityTotal > capacity)
     then
-        System.out.println($shuttle.getCapacity() + " " + $shuttle.getPassengerQuantityTotal());
-        scoreHolder.addHardConstraintMatch(kcontext, ($shuttle.getCapacity() - $shuttle.getPassengerQuantityTotal()) * 1000L);
-end
-
-rule "coachCapacity"
-    when
-        $coach : Coach($capacity : capacity)
-        accumulate(
-            BusStop(bus == $coach, $coachPassengerQuantity : passengerQuantity);
-            $coachPassengerQuantityTotal : sum($coachPassengerQuantity)
-        )
-        accumulate(
-            $shuttle : Shuttle($destination : destination)
-            and exists BusStop(this == $destination, bus == $coach);
-            $shuttlePassengerQuantityTotal : sum($shuttle.getPassengerQuantityTotal());
-            $coachPassengerQuantityTotal + $shuttlePassengerQuantityTotal > $capacity
-        )
-    then
-        scoreHolder.addHardConstraintMatch(kcontext, ($capacity - $coachPassengerQuantityTotal - $shuttlePassengerQuantityTotal) * 1000L);
+        scoreHolder.addHardConstraintMatch(kcontext, ($bus.getCapacity() - $bus.getPassengerQuantityTotal()) * 1000L);
 end
 
 rule "transportTime"

--- a/optaplanner-examples/src/main/resources/org/optaplanner/examples/coachshuttlegathering/solver/coachShuttleGatheringConstraints.drl
+++ b/optaplanner-examples/src/main/resources/org/optaplanner/examples/coachshuttlegathering/solver/coachShuttleGatheringConstraints.drl
@@ -48,11 +48,25 @@ rule "coachStopLimit"
         scoreHolder.addHardConstraintMatch(kcontext, ($stopLimit - $stopTotal) * 1000000L);
 end
 
-rule "busCapacity"
+rule "shuttleCapacity"
     when
-        $bus : Bus(passengerQuantityTotal > capacity)
+        $bus : Shuttle(passengerQuantityTotal > capacity)
     then
         scoreHolder.addHardConstraintMatch(kcontext, ($bus.getCapacity() - $bus.getPassengerQuantityTotal()) * 1000L);
+end
+
+rule "coachCapacity"
+    when
+        $coach : Coach($capacity : capacity, $coachPassengerQuantityTotal : passengerQuantityTotal)
+        accumulate(
+            $shuttle : Shuttle($destination : destination)
+            and BusStop(this == $destination, bus == $coach)
+            and BusStop(bus == $shuttle, $shuttlePassengerQuantity : passengerQuantity);
+            $shuttlePassengerQuantityTotal : sum($shuttlePassengerQuantity);
+            $coachPassengerQuantityTotal + $shuttlePassengerQuantityTotal > $capacity
+        )
+    then
+        scoreHolder.addHardConstraintMatch(kcontext, ($capacity - $coachPassengerQuantityTotal - $shuttlePassengerQuantityTotal) * 1000L);
 end
 
 rule "transportTime"

--- a/optaplanner-examples/src/main/resources/org/optaplanner/examples/coachshuttlegathering/solver/coachShuttleGatheringSolverConfig.xml
+++ b/optaplanner-examples/src/main/resources/org/optaplanner/examples/coachshuttlegathering/solver/coachShuttleGatheringSolverConfig.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <solver xmlns="https://www.optaplanner.org/xsd/solver" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="https://www.optaplanner.org/xsd/solver https://www.optaplanner.org/xsd/solver/solver.xsd">
-  <!--<environmentMode>FULL_ASSERT</environmentMode>--><!-- To slowly prove there are no bugs in this code -->
+  <<environmentMode>FULL_ASSERT</environmentMode>
   <moveThreadCount>AUTO</moveThreadCount><!-- To solve faster by saturating multiple CPU cores -->
 
   <solutionClass>org.optaplanner.examples.coachshuttlegathering.domain.CoachShuttleGatheringSolution</solutionClass>
@@ -14,9 +14,9 @@
     <!--<easyScoreCalculatorClass>org.optaplanner.examples.coachshuttlegathering.solver.CoachShuttleGatheringEasyScoreCalculator</easyScoreCalculatorClass>-->
     <!--<incrementalScoreCalculatorClass>org.optaplanner.examples.coachshuttlegathering.solver.score.CoachShuttleGatheringIncrementalScoreCalculator</incrementalScoreCalculatorClass>-->
     <scoreDrl>org/optaplanner/examples/coachshuttlegathering/solver/coachShuttleGatheringConstraints.drl</scoreDrl>
-    <!--<assertionScoreDirectorFactory>-->
-      <!--<easyScoreCalculatorClass>org.optaplanner.examples.coachshuttlegathering.solver.CoachShuttleGatheringEasyScoreCalculator</easyScoreCalculatorClass>-->
-    <!--</assertionScoreDirectorFactory>-->
+    <assertionScoreDirectorFactory>
+      <easyScoreCalculatorClass>org.optaplanner.examples.coachshuttlegathering.solver.CoachShuttleGatheringEasyScoreCalculator</easyScoreCalculatorClass>
+    </assertionScoreDirectorFactory>
     <initializingScoreTrend>ONLY_DOWN</initializingScoreTrend>
   </scoreDirectorFactory>
 
@@ -27,10 +27,10 @@
   <constructionHeuristic>
     <queuedEntityPlacer>
       <entitySelector id="placerEntitySelector">
-        <entityClass>org.optaplanner.examples.coachshuttlegathering.domain.BusStop</entityClass>
         <cacheType>PHASE</cacheType>
         <selectionOrder>SORTED</selectionOrder>
         <sorterManner>DECREASING_DIFFICULTY</sorterManner>
+        <entityClass>org.optaplanner.examples.coachshuttlegathering.domain.BusStop</entityClass>
       </entitySelector>
       <changeMoveSelector>
         <entitySelector mimicSelectorRef="placerEntitySelector"/>

--- a/optaplanner-examples/src/main/resources/org/optaplanner/examples/coachshuttlegathering/solver/coachShuttleGatheringSolverConfig.xml
+++ b/optaplanner-examples/src/main/resources/org/optaplanner/examples/coachshuttlegathering/solver/coachShuttleGatheringSolverConfig.xml
@@ -9,6 +9,7 @@
   <entityClass>org.optaplanner.examples.coachshuttlegathering.domain.StopOrHub</entityClass>
   <entityClass>org.optaplanner.examples.coachshuttlegathering.domain.BusStop</entityClass>
   <entityClass>org.optaplanner.examples.coachshuttlegathering.domain.Shuttle</entityClass>
+  <entityClass>org.optaplanner.examples.coachshuttlegathering.domain.Coach</entityClass>
 
   <scoreDirectorFactory>
     <!--<easyScoreCalculatorClass>org.optaplanner.examples.coachshuttlegathering.solver.CoachShuttleGatheringEasyScoreCalculator</easyScoreCalculatorClass>-->

--- a/optaplanner-examples/src/main/resources/org/optaplanner/examples/coachshuttlegathering/solver/coachShuttleGatheringSolverConfig.xml
+++ b/optaplanner-examples/src/main/resources/org/optaplanner/examples/coachshuttlegathering/solver/coachShuttleGatheringSolverConfig.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <solver xmlns="https://www.optaplanner.org/xsd/solver" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="https://www.optaplanner.org/xsd/solver https://www.optaplanner.org/xsd/solver/solver.xsd">
-  <<environmentMode>FULL_ASSERT</environmentMode>
+  <environmentMode>FULL_ASSERT</environmentMode>
   <moveThreadCount>AUTO</moveThreadCount><!-- To solve faster by saturating multiple CPU cores -->
 
   <solutionClass>org.optaplanner.examples.coachshuttlegathering.domain.CoachShuttleGatheringSolution</solutionClass>
@@ -15,10 +15,11 @@
     <!--<easyScoreCalculatorClass>org.optaplanner.examples.coachshuttlegathering.solver.CoachShuttleGatheringEasyScoreCalculator</easyScoreCalculatorClass>-->
     <!--<incrementalScoreCalculatorClass>org.optaplanner.examples.coachshuttlegathering.solver.score.CoachShuttleGatheringIncrementalScoreCalculator</incrementalScoreCalculatorClass>-->
     <scoreDrl>org/optaplanner/examples/coachshuttlegathering/solver/coachShuttleGatheringConstraints.drl</scoreDrl>
-    <assertionScoreDirectorFactory>
+    <!-- <constraintProviderClass>org.optaplanner.examples.coachshuttlegathering.solver.CoachShuttleGatheringConstraintProvider</constraintProviderClass> -->
+    <!-- <assertionScoreDirectorFactory>
       <easyScoreCalculatorClass>org.optaplanner.examples.coachshuttlegathering.solver.CoachShuttleGatheringEasyScoreCalculator</easyScoreCalculatorClass>
-    </assertionScoreDirectorFactory>
-    <initializingScoreTrend>ONLY_DOWN</initializingScoreTrend>
+    </assertionScoreDirectorFactory> -->
+    <!-- <initializingScoreTrend>ONLY_DOWN</initializingScoreTrend> -->
   </scoreDirectorFactory>
 
   <termination>

--- a/optaplanner-examples/src/main/resources/org/optaplanner/examples/coachshuttlegathering/solver/coachShuttleGatheringSolverConfig.xml
+++ b/optaplanner-examples/src/main/resources/org/optaplanner/examples/coachshuttlegathering/solver/coachShuttleGatheringSolverConfig.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <solver xmlns="https://www.optaplanner.org/xsd/solver" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="https://www.optaplanner.org/xsd/solver https://www.optaplanner.org/xsd/solver/solver.xsd">
-  <environmentMode>FULL_ASSERT</environmentMode>
+  <!--<environmentMode>FULL_ASSERT</environmentMode>--><!-- To slowly prove there are no bugs in this code -->
   <moveThreadCount>AUTO</moveThreadCount><!-- To solve faster by saturating multiple CPU cores -->
 
   <solutionClass>org.optaplanner.examples.coachshuttlegathering.domain.CoachShuttleGatheringSolution</solutionClass>
@@ -15,11 +15,11 @@
     <!--<easyScoreCalculatorClass>org.optaplanner.examples.coachshuttlegathering.solver.CoachShuttleGatheringEasyScoreCalculator</easyScoreCalculatorClass>-->
     <!--<incrementalScoreCalculatorClass>org.optaplanner.examples.coachshuttlegathering.solver.score.CoachShuttleGatheringIncrementalScoreCalculator</incrementalScoreCalculatorClass>-->
     <scoreDrl>org/optaplanner/examples/coachshuttlegathering/solver/coachShuttleGatheringConstraints.drl</scoreDrl>
-    <!-- <constraintProviderClass>org.optaplanner.examples.coachshuttlegathering.solver.CoachShuttleGatheringConstraintProvider</constraintProviderClass> -->
-    <!-- <assertionScoreDirectorFactory>
-      <easyScoreCalculatorClass>org.optaplanner.examples.coachshuttlegathering.solver.CoachShuttleGatheringEasyScoreCalculator</easyScoreCalculatorClass>
-    </assertionScoreDirectorFactory> -->
-    <!-- <initializingScoreTrend>ONLY_DOWN</initializingScoreTrend> -->
+    <!--<constraintProviderClass>org.optaplanner.examples.coachshuttlegathering.solver.CoachShuttleGatheringConstraintProvider</constraintProviderClass>-->
+    <!--<assertionScoreDirectorFactory>-->
+      <!--<easyScoreCalculatorClass>org.optaplanner.examples.coachshuttlegathering.solver.CoachShuttleGatheringEasyScoreCalculator</easyScoreCalculatorClass>-->
+    <!--</assertionScoreDirectorFactory>-->
+    <initializingScoreTrend>ONLY_DOWN</initializingScoreTrend>
   </scoreDirectorFactory>
 
   <termination>
@@ -29,10 +29,10 @@
   <constructionHeuristic>
     <queuedEntityPlacer>
       <entitySelector id="placerEntitySelector">
+        <entityClass>org.optaplanner.examples.coachshuttlegathering.domain.BusStop</entityClass>
         <cacheType>PHASE</cacheType>
         <selectionOrder>SORTED</selectionOrder>
         <sorterManner>DECREASING_DIFFICULTY</sorterManner>
-        <entityClass>org.optaplanner.examples.coachshuttlegathering.domain.BusStop</entityClass>
       </entitySelector>
       <changeMoveSelector>
         <entitySelector mimicSelectorRef="placerEntitySelector"/>

--- a/optaplanner-examples/src/test/java/org/optaplanner/examples/coachshuttlegathering/solver/CoachShuttleGatheringConstraintProviderTest.java
+++ b/optaplanner-examples/src/test/java/org/optaplanner/examples/coachshuttlegathering/solver/CoachShuttleGatheringConstraintProviderTest.java
@@ -1,0 +1,372 @@
+package org.optaplanner.examples.coachshuttlegathering.solver;
+
+import java.util.Collections;
+
+import org.junit.jupiter.api.Test;
+import org.optaplanner.examples.coachshuttlegathering.domain.BusHub;
+import org.optaplanner.examples.coachshuttlegathering.domain.BusOrStop;
+import org.optaplanner.examples.coachshuttlegathering.domain.BusStop;
+import org.optaplanner.examples.coachshuttlegathering.domain.Coach;
+import org.optaplanner.examples.coachshuttlegathering.domain.CoachShuttleGatheringSolution;
+import org.optaplanner.examples.coachshuttlegathering.domain.Shuttle;
+import org.optaplanner.examples.coachshuttlegathering.domain.StopOrHub;
+import org.optaplanner.examples.coachshuttlegathering.domain.location.RoadLocation;
+import org.optaplanner.examples.coachshuttlegathering.domain.location.RoadLocationArc;
+import org.optaplanner.test.api.score.stream.ConstraintVerifier;
+
+public class CoachShuttleGatheringConstraintProviderTest {
+    private final ConstraintVerifier<CoachShuttleGatheringConstraintProvider, CoachShuttleGatheringSolution> constraintVerifier =
+            ConstraintVerifier
+                    .build(new CoachShuttleGatheringConstraintProvider(), CoachShuttleGatheringSolution.class,
+                            BusOrStop.class, StopOrHub.class, BusStop.class, Shuttle.class, Coach.class);
+
+    @Test
+    public void coachStopLimit() {
+        Coach coach = new Coach();
+        coach.setStopLimit(2);
+        BusStop stop1 = new BusStop();
+        stop1.setPreviousBusOrStop(coach);
+        stop1.setBus(coach);
+        BusStop stop2 = new BusStop();
+        stop2.setBus(coach);
+        stop2.setPreviousBusOrStop(coach);
+        BusStop stop3 = new BusStop();
+        stop3.setBus(coach);
+        stop3.setPreviousBusOrStop(coach);
+        BusStop stop4 = new BusStop();
+        stop4.setBus(coach);
+        stop4.setPreviousBusOrStop(coach);
+
+        constraintVerifier.verifyThat(CoachShuttleGatheringConstraintProvider::coachStopLimit)
+                .given(coach, stop1)
+                .penalizesBy(0L);
+
+        constraintVerifier.verifyThat(CoachShuttleGatheringConstraintProvider::coachStopLimit)
+                .given(coach, stop1, stop2)
+                .penalizesBy(0L);
+
+        constraintVerifier.verifyThat(CoachShuttleGatheringConstraintProvider::coachStopLimit)
+                .given(coach, stop1, stop2, stop3)
+                .penalizesBy(1L * 1000000);
+
+        constraintVerifier.verifyThat(CoachShuttleGatheringConstraintProvider::coachStopLimit)
+                .given(coach, stop1, stop2, stop3, stop4)
+                .penalizesBy(2L * 1000000);
+    }
+
+    @Test
+    public void shuttleCapacity() {
+        Shuttle shuttle = new Shuttle();
+        BusStop destination = new BusStop();
+        shuttle.setDestination(destination);
+
+        shuttle.setCapacity(2);
+        shuttle.setPassengerQuantityTotal(1);
+
+        constraintVerifier.verifyThat(CoachShuttleGatheringConstraintProvider::shuttleCapacity)
+                .given(shuttle)
+                .penalizesBy(0);
+
+        shuttle.setPassengerQuantityTotal(2);
+        constraintVerifier.verifyThat(CoachShuttleGatheringConstraintProvider::shuttleCapacity)
+                .given(shuttle)
+                .penalizesBy(0);
+
+        shuttle.setPassengerQuantityTotal(3);
+        constraintVerifier.verifyThat(CoachShuttleGatheringConstraintProvider::shuttleCapacity)
+                .given(shuttle)
+                .penalizesBy(1L * 1000);
+
+        shuttle.setPassengerQuantityTotal(4);
+        constraintVerifier.verifyThat(CoachShuttleGatheringConstraintProvider::shuttleCapacity)
+                .given(shuttle)
+                .penalizesBy(2L * 1000);
+    }
+
+    @Test
+    public void coachCapacity() {
+        Coach coach = new Coach();
+        Shuttle shuttle = new Shuttle();
+        BusStop transferStop = new BusStop();
+        shuttle.setDestination(transferStop);
+        transferStop.setPreviousBusOrStop(shuttle);
+        transferStop.setBus(coach);
+        BusStop shuttlePickup1 = new BusStop();
+        shuttlePickup1.setPreviousBusOrStop(transferStop);
+        shuttlePickup1.setPassengerQuantity(1);
+        shuttlePickup1.setBus(shuttle);
+        BusStop shuttlePickup2 = new BusStop();
+        shuttlePickup2.setPreviousBusOrStop(transferStop);
+        shuttlePickup2.setBus(shuttle);
+        shuttlePickup2.setPassengerQuantity(2);
+        BusStop shuttlePickup3 = new BusStop();
+        shuttlePickup3.setPreviousBusOrStop(transferStop);
+        shuttlePickup3.setBus(shuttle);
+        shuttlePickup3.setPassengerQuantity(3);
+
+        coach.setCapacity(2);
+        coach.setPassengerQuantityTotal(0);
+        constraintVerifier.verifyThat(CoachShuttleGatheringConstraintProvider::coachCapacity)
+                .given(coach, shuttle, transferStop)
+                .penalizesBy(0L);
+
+        coach.setPassengerQuantityTotal(1);
+        constraintVerifier.verifyThat(CoachShuttleGatheringConstraintProvider::coachCapacity)
+                .given(coach, shuttle, transferStop, shuttlePickup1)
+                .penalizesBy(0L);
+
+        coach.setPassengerQuantityTotal(1);
+        constraintVerifier.verifyThat(CoachShuttleGatheringConstraintProvider::coachCapacity)
+                .given(coach, shuttle, transferStop, shuttlePickup1, shuttlePickup2)
+                .penalizesBy(2L * 1000);
+
+        coach.setPassengerQuantityTotal(0);
+        constraintVerifier.verifyThat(CoachShuttleGatheringConstraintProvider::coachCapacity)
+                .given(coach, shuttle, transferStop, shuttlePickup1, shuttlePickup2)
+                .penalizesBy(1L * 1000);
+
+        coach.setPassengerQuantityTotal(0);
+        constraintVerifier.verifyThat(CoachShuttleGatheringConstraintProvider::coachCapacity)
+                .given(coach, shuttle, transferStop, shuttlePickup1, shuttlePickup2, shuttlePickup3)
+                .penalizesBy(4L * 1000);
+
+        coach.setPassengerQuantityTotal(3);
+        constraintVerifier.verifyThat(CoachShuttleGatheringConstraintProvider::coachCapacity)
+                .given(coach, shuttle, transferStop, shuttlePickup1)
+                .penalizesBy(2L * 1000);
+    }
+
+    @Test
+    public void coachCapacityCorrection() {
+        Coach coach = new Coach();
+        Shuttle shuttle = new Shuttle();
+        BusStop transferStop = new BusStop();
+        shuttle.setDestination(transferStop);
+        transferStop.setPreviousBusOrStop(shuttle);
+        transferStop.setBus(coach);
+        BusStop shuttlePickup1 = new BusStop();
+        shuttlePickup1.setPreviousBusOrStop(transferStop);
+        shuttlePickup1.setPassengerQuantity(1);
+        shuttlePickup1.setBus(shuttle);
+        BusStop shuttlePickup2 = new BusStop();
+        shuttlePickup2.setPreviousBusOrStop(transferStop);
+        shuttlePickup2.setBus(shuttle);
+        shuttlePickup2.setPassengerQuantity(2);
+        BusStop shuttlePickup3 = new BusStop();
+        shuttlePickup3.setPreviousBusOrStop(transferStop);
+        shuttlePickup3.setBus(shuttle);
+        shuttlePickup3.setPassengerQuantity(3);
+
+        coach.setCapacity(2);
+        coach.setPassengerQuantityTotal(0);
+        constraintVerifier.verifyThat(CoachShuttleGatheringConstraintProvider::coachCapacityCorrection)
+                .given(coach, shuttle, transferStop)
+                .rewardsWith(0L);
+
+        coach.setPassengerQuantityTotal(1);
+        constraintVerifier.verifyThat(CoachShuttleGatheringConstraintProvider::coachCapacityCorrection)
+                .given(coach, shuttle, transferStop, shuttlePickup1)
+                .rewardsWith(0L);
+
+        coach.setPassengerQuantityTotal(1);
+        constraintVerifier.verifyThat(CoachShuttleGatheringConstraintProvider::coachCapacityCorrection)
+                .given(coach, shuttle, transferStop, shuttlePickup1, shuttlePickup2)
+                .rewardsWith(0L);
+
+        coach.setPassengerQuantityTotal(0);
+        constraintVerifier.verifyThat(CoachShuttleGatheringConstraintProvider::coachCapacityCorrection)
+                .given(coach, shuttle, transferStop, shuttlePickup1, shuttlePickup2)
+                .rewardsWith(0L);
+
+        coach.setPassengerQuantityTotal(0);
+        constraintVerifier.verifyThat(CoachShuttleGatheringConstraintProvider::coachCapacityCorrection)
+                .given(coach, shuttle, transferStop, shuttlePickup1, shuttlePickup2, shuttlePickup3)
+                .rewardsWith(0L);
+
+        coach.setPassengerQuantityTotal(3);
+        constraintVerifier.verifyThat(CoachShuttleGatheringConstraintProvider::coachCapacityCorrection)
+                .given(coach, shuttle, transferStop, shuttlePickup1)
+                .rewardsWith(1L * 1000);
+    }
+
+    @Test
+    public void coachCapacityShuttleButNoShuttle() {
+        Coach coach = new Coach();
+        BusHub destination = new BusHub();
+        coach.setDestination(destination);
+
+        coach.setCapacity(2);
+        coach.setPassengerQuantityTotal(1);
+        constraintVerifier.verifyThat(CoachShuttleGatheringConstraintProvider::coachCapacityShuttleButNoShuttle)
+                .given(coach)
+                .penalizesBy(0);
+
+        coach.setPassengerQuantityTotal(2);
+        constraintVerifier.verifyThat(CoachShuttleGatheringConstraintProvider::coachCapacityShuttleButNoShuttle)
+                .given(coach)
+                .penalizesBy(0);
+
+        coach.setPassengerQuantityTotal(3);
+        constraintVerifier.verifyThat(CoachShuttleGatheringConstraintProvider::coachCapacityShuttleButNoShuttle)
+                .given(coach)
+                .penalizesBy(1L * 1000);
+
+        coach.setPassengerQuantityTotal(4);
+        constraintVerifier.verifyThat(CoachShuttleGatheringConstraintProvider::coachCapacityShuttleButNoShuttle)
+                .given(coach)
+                .penalizesBy(2L * 1000);
+    }
+
+    @Test
+    public void transportTime() {
+        Coach bus = new Coach();
+        BusStop busStop = new BusStop();
+        busStop.setPreviousBusOrStop(bus);
+        busStop.setBus(bus);
+        busStop.setPassengerQuantity(0);
+        busStop.setTransportTimeLimit(5);
+        busStop.setTransportTimeToHub(null);
+
+        constraintVerifier.verifyThat(CoachShuttleGatheringConstraintProvider::transportTime)
+                .given(busStop)
+                .penalizesBy(0L);
+
+        busStop.setTransportTimeToHub(10);
+        constraintVerifier.verifyThat(CoachShuttleGatheringConstraintProvider::transportTime)
+                .given(busStop)
+                .penalizesBy(0L);
+
+        busStop.setPassengerQuantity(1);
+        constraintVerifier.verifyThat(CoachShuttleGatheringConstraintProvider::transportTime)
+                .given(busStop)
+                .penalizesBy(5L);
+    }
+
+    @Test
+    public void shuttleDestinationIsCoachOrHub() {
+        Shuttle shuttle = new Shuttle();
+        Coach coach = new Coach();
+        BusStop destination = new BusStop();
+        shuttle.setDestination(destination);
+        destination.setPreviousBusOrStop(shuttle);
+        destination.setBus(shuttle);
+
+        constraintVerifier.verifyThat(CoachShuttleGatheringConstraintProvider::shuttleDestinationIsCoachOrHub)
+                .given(shuttle, destination)
+                .penalizesBy(1000000000L);
+
+        destination.setBus(coach);
+        constraintVerifier.verifyThat(CoachShuttleGatheringConstraintProvider::shuttleDestinationIsCoachOrHub)
+                .given(shuttle, destination)
+                .penalizesBy(0L);
+    }
+
+    @Test
+    public void shuttleSetupCost() {
+        Shuttle shuttle = new Shuttle();
+        Coach coach = new Coach();
+        BusStop destination = new BusStop();
+
+        coach.setNextStop(destination);
+        shuttle.setNextStop(destination);
+
+        shuttle.setSetupCost(2);
+        constraintVerifier.verifyThat(CoachShuttleGatheringConstraintProvider::shuttleSetupCost)
+                .given(shuttle)
+                .penalizesBy(2L);
+
+        shuttle.setSetupCost(3);
+        constraintVerifier.verifyThat(CoachShuttleGatheringConstraintProvider::shuttleSetupCost)
+                .given(shuttle)
+                .penalizesBy(3L);
+
+        shuttle.setNextStop(null);
+        constraintVerifier.verifyThat(CoachShuttleGatheringConstraintProvider::shuttleSetupCost)
+                .given(shuttle)
+                .penalizesBy(0L);
+
+        constraintVerifier.verifyThat(CoachShuttleGatheringConstraintProvider::shuttleSetupCost)
+                .given(coach)
+                .penalizesBy(0L);
+    }
+
+    @Test
+    public void distanceFromPrevious() {
+        Coach bus = new Coach();
+        BusStop busStop = new BusStop();
+
+        RoadLocation busLocation = new RoadLocation(0, 1d, 0d);
+        RoadLocation busStopLocation = new RoadLocation(0, 5d, 0d);
+        RoadLocationArc distance = new RoadLocationArc();
+        distance.setCoachDistance(1);
+        distance.setCoachDuration(1);
+        distance.setShuttleDistance(1);
+        distance.setShuttleDuration(1);
+        busStopLocation.setTravelDistanceMap(Collections.singletonMap(busLocation, distance));
+        busLocation.setTravelDistanceMap(Collections.singletonMap(busStopLocation, distance));
+
+        bus.setDepartureLocation(busLocation);
+        busStop.setLocation(busStopLocation);
+        bus.setMileageCost(1);
+        busStop.setPreviousBusOrStop(bus);
+        busStop.setBus(bus);
+
+        constraintVerifier.verifyThat(CoachShuttleGatheringConstraintProvider::distanceFromPrevious)
+                .given(busStop)
+                .penalizesBy(1L);
+    }
+
+    @Test
+    public void distanceBusStopToBusDestination() {
+        Coach bus = new Coach();
+        BusStop busStop = new BusStop();
+        BusHub busHub = new BusHub();
+
+        RoadLocation busHubLocation = new RoadLocation(0, 1d, 0d);
+        RoadLocation busStopLocation = new RoadLocation(0, 5d, 0d);
+        RoadLocationArc distance = new RoadLocationArc();
+        distance.setCoachDistance(1);
+        distance.setCoachDuration(1);
+        distance.setShuttleDistance(1);
+        distance.setShuttleDuration(1);
+        busStopLocation.setTravelDistanceMap(Collections.singletonMap(busHubLocation, distance));
+        busHubLocation.setTravelDistanceMap(Collections.singletonMap(busStopLocation, distance));
+
+        busHub.setLocation(busHubLocation);
+        bus.setDestination(busHub);
+        bus.setNextStop(busStop);
+        busStop.setLocation(busStopLocation);
+        bus.setMileageCost(1);
+        busStop.setPreviousBusOrStop(bus);
+        busStop.setBus(bus);
+
+        constraintVerifier.verifyThat(CoachShuttleGatheringConstraintProvider::distanceBusStopToBusDestination)
+                .given(busStop, bus)
+                .penalizesBy(1L);
+    }
+
+    @Test
+    public void distanceCoachDirectlyToDestination() {
+        Coach bus = new Coach();
+        BusHub busHub = new BusHub();
+
+        RoadLocation busHubLocation = new RoadLocation(0, 1d, 0d);
+        RoadLocation busLocation = new RoadLocation(0, 5d, 0d);
+        RoadLocationArc distance = new RoadLocationArc();
+        distance.setCoachDistance(1);
+        distance.setCoachDuration(1);
+        distance.setShuttleDistance(1);
+        distance.setShuttleDuration(1);
+        busLocation.setTravelDistanceMap(Collections.singletonMap(busHubLocation, distance));
+        busHubLocation.setTravelDistanceMap(Collections.singletonMap(busLocation, distance));
+
+        bus.setDepartureLocation(busLocation);
+        busHub.setLocation(busHubLocation);
+        bus.setDestination(busHub);
+        bus.setMileageCost(1);
+
+        constraintVerifier.verifyThat(CoachShuttleGatheringConstraintProvider::distanceCoachDirectlyToDestination)
+                .given(bus)
+                .penalizesBy(1L);
+    }
+}


### PR DESCRIPTION
<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.
-->

### JIRA

<!-- Add a JIRA ticket link if it exists. -->
https://issues.redhat.com/browse/PLANNER-1873
https://issues.redhat.com/browse/PLANNER-1821

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
* https://github.com/kiegroup/drools/pull/3000
* https://github.com/kiegroup/optaplanner/pull/899
* etc.
-->

### Checklist
- [ ] Documentation updated if applicable.
- [ ] Upgrade recipe provided if applicable.

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>full downstream build</b> please add comment: <b>Jenkins run fdb</b>
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>

Replaces https://github.com/kiegroup/optaplanner/pull/691 and https://github.com/kiegroup/optaplanner/pull/793

Coach Capacity was a fun one; it would be easy if we had an accumlate that works on empty streams, but since we don't, I need to implement it as three constraints: One when no streams are empty, one that handles when coach is overfilled without shuttle, and one to remove double counting. 