### PR TITLE
[7.x] Bump Quarkus and Kogito to fix stale optaplanner-core dep

### DIFF
--- a/optaplanner-quarkus-integration/pom.xml
+++ b/optaplanner-quarkus-integration/pom.xml
@@ -23,8 +23,8 @@
   <url>https://www.optaplanner.org</url>
 
   <properties>
-    <version.io.quarkus>1.7.0.Final</version.io.quarkus>
-    <version.org.kie.kogito>0.10.1</version.org.kie.kogito>
+    <version.io.quarkus>1.8.1.Final</version.io.quarkus>
+    <version.org.kie.kogito>0.15.0</version.org.kie.kogito>
 
     <!-- TODO remove if https://issues.redhat.com/browse/PLANNER-2005 is fixed for 8.x -->
     <!-- TODO Extending kie-parent 7 is extremely dangerous and messy because it's not aligned to quarkus -->
@@ -50,10 +50,9 @@
     <version.org.ow2.asm>8.0.1</version.org.ow2.asm>
     <version.org.jboss.jandex>2.1.3.Final</version.org.jboss.jandex>
 
-
-    <version.org.jboss.resteasy>4.5.3.Final</version.org.jboss.resteasy>
-    <version.com.fasterxml.jackson>2.10.3</version.com.fasterxml.jackson>
-    <version.com.fasterxml.jackson.databind>2.10.3</version.com.fasterxml.jackson.databind>
+    <version.org.jboss.resteasy>4.5.7.Final</version.org.jboss.resteasy>
+    <version.com.fasterxml.jackson>2.11.2</version.com.fasterxml.jackson>
+    <version.com.fasterxml.jackson.databind>2.11.2</version.com.fasterxml.jackson.databind>
 
     <!-- TODO Quarkus is riddled with duplicate classes, see https://github.com/quarkusio/quarkus/issues/9834 -->
     <enforcer.failOnDuplicatedClasses>false</enforcer.failOnDuplicatedClasses>


### PR DESCRIPTION
Otherwise `optaplaner-quarkus` gives `optaplanner-core:7.36.1.Final` in the dep tree.