### PR TITLE
PLANNER-2187 Use java 11 minimum for OptaPlanner 8

### DIFF
--- a/.github/workflows/jpa_integration_ci.yml
+++ b/.github/workflows/jpa_integration_ci.yml
@@ -6,11 +6,9 @@ on:
   push:
     branches:
       - master
-      - 7.x
   pull_request:
     branches:
       - master
-      - 7.x
 
 defaults:
   run:

--- a/.github/workflows/os_java_ci.yml
+++ b/.github/workflows/os_java_ci.yml
@@ -6,11 +6,9 @@ on:
   push:
     branches:
       - master
-      - 7.x
   pull_request:
     branches:
       - master
-      - 7.x
 
 defaults:
   run:
@@ -22,7 +20,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        java: [8, 11]
+        java: [11]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Check out Git repository

--- a/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/impl/DefaultPlannerBenchmark.java
+++ b/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/impl/DefaultPlannerBenchmark.java
@@ -140,14 +140,7 @@ public class DefaultPlannerBenchmark implements PlannerBenchmark {
         long timeLeftTotal = plannerBenchmarkResult.getWarmUpTimeMillisSpentLimit();
         int parallelBenchmarkCount = plannerBenchmarkResult.getParallelBenchmarkCount();
         int solverBenchmarkResultCount = plannerBenchmarkResult.getSolverBenchmarkResultList().size();
-        /*
-         * cyclesCount needs to be long, as opposed to its natural int,
-         * otherwise JDK 11 compiler uses Math.floorDiv(long, int), which is only available on JDK 9+.
-         * When such compiled code is then used on Java 8, there is a NoSuchMethodError.
-         * All is fine When the code is compiled on JDK 8, the compiler will use the good old Math.floorDiv(long, long).
-         * TODO Remove when JDK 8 is no longer supported.
-         */
-        long cyclesCount = ConfigUtils.ceilDivide(solverBenchmarkResultCount, parallelBenchmarkCount);
+        int cyclesCount = ConfigUtils.ceilDivide(solverBenchmarkResultCount, parallelBenchmarkCount);
         long timeLeftPerCycle = Math.floorDiv(timeLeftTotal, cyclesCount);
         Map<ProblemBenchmarkResult, List<ProblemStatistic>> originalProblemStatisticMap = new HashMap<>(
                 plannerBenchmarkResult.getUnifiedProblemBenchmarkResultList().size());

--- a/optaplanner-build-parent/pom.xml
+++ b/optaplanner-build-parent/pom.xml
@@ -52,6 +52,9 @@
     <!-- ************************************************************************ -->
 
     <maven.min.version>3.6.2</maven.min.version>
+    <maven.compiler.release>11</maven.compiler.release>
+    <!-- The first version that supports analysis of classes compiled by Java 11. -->
+    <version.dependency.plugin>3.1.2</version.dependency.plugin>
     <version.surefire.plugin>2.22.2</version.surefire.plugin>
     <!-- This property needs to be defined in all modules that use the packaging 'jar'.
          It is used by different plugins to make sure the module/bundle names are consistent. -->


### PR DESCRIPTION
<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.
-->

### JIRA

<!-- Add a JIRA ticket link if it exists. -->
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->
https://issues.redhat.com/browse/PLANNER-2187

### Referenced pull requests
https://github.com/kiegroup/optaplanner-quickstarts/pull/6
https://github.com/kiegroup/optaplanner-website/pull/285

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
* https://github.com/kiegroup/drools/pull/3000
* https://github.com/kiegroup/optaplanner/pull/899
* etc.
-->

### Checklist
- [x] Documentation updated if applicable.
- [x] Upgrade recipe provided if applicable.

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>full downstream build</b> please add comment: <b>Jenkins run fdb</b>
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
