### PR TITLE
Implemented a JsonSolutionFileIO for benchmark input solution files

### DIFF
--- a/optaplanner-build-parent/pom.xml
+++ b/optaplanner-build-parent/pom.xml
@@ -163,6 +163,11 @@
         <version>${version.com.fasterxml.jackson.core}</version>
       </dependency>
       <dependency>
+        <groupId>com.fasterxml.jackson.core</groupId>
+        <artifactId>jackson-annotations</artifactId>
+        <version>${version.com.fasterxml.jackson.core}</version>
+      </dependency>
+      <dependency>
         <groupId>com.h2database</groupId>
         <artifactId>h2</artifactId>
         <version>${version.com.h2database}</version>

--- a/optaplanner-docs/src/main/asciidoc/BenchmarkingAndTweaking/BenchmarkingAndTweaking-chapter.adoc
+++ b/optaplanner-docs/src/main/asciidoc/BenchmarkingAndTweaking/BenchmarkingAndTweaking-chapter.adoc
@@ -273,7 +273,7 @@ public class NQueensJsonSolutionFileIO extends JacksonSolutionFileIO<NQueens> {
 }
 ----
 
-and use it in the benchmark configuration:
+Then use it in the benchmark configuration like so:
 
 [source,xml,options="nowrap"]
 ----

--- a/optaplanner-docs/src/main/asciidoc/BenchmarkingAndTweaking/BenchmarkingAndTweaking-chapter.adoc
+++ b/optaplanner-docs/src/main/asciidoc/BenchmarkingAndTweaking/BenchmarkingAndTweaking-chapter.adoc
@@ -254,8 +254,10 @@ public class NQueensJsonSolutionFileIO extends JacksonSolutionFileIO<NQueens> {
     }
 }
 ----
+
 If the JSON file requires specific Jackson modules and features to be enabled/disabled.
-You could create your desired object mapper as an dependency to the JacksonSolutionFileIO as the following.
+You could create your desired object mapper as a dependency to the JacksonSolutionFileIO as follows:
+
 [source,java,options="nowrap"]
 ----
 public class NQueensJsonSolutionFileIO extends JacksonSolutionFileIO<NQueens> {

--- a/optaplanner-docs/src/main/asciidoc/BenchmarkingAndTweaking/BenchmarkingAndTweaking-chapter.adoc
+++ b/optaplanner-docs/src/main/asciidoc/BenchmarkingAndTweaking/BenchmarkingAndTweaking-chapter.adoc
@@ -240,6 +240,47 @@ Regardless, XML is still a very verbose format.
 Reading or writing large datasets in this format can cause an `OutOfMemoryError`, `StackOverflowError`
 or large performance degradation.
 
+[[JacksonSolutionFileIO]]
+==== `JacksonSolutionFileIO`: serialize to and from an JSON format
+
+To read and write solutions in JSON format via Jackson, extend the `JacksonSolutionFileIO`:
+
+[source,java,options="nowrap"]
+----
+public class NQueensJsonSolutionFileIO extends JacksonSolutionFileIO<NQueens> {
+    public NQueensJsonSolutionFileIO() {
+        // NQueens is the @PlanningSolution class.
+        super(NQueens.class);
+    }
+}
+----
+If the JSON file requires specific Jackson modules and features to be enabled/disabled.
+You could create your desired object mapper as an dependency to the JacksonSolutionFileIO as the following.
+[source,java,options="nowrap"]
+----
+public class NQueensJsonSolutionFileIO extends JacksonSolutionFileIO<NQueens> {
+    public NQueensJsonSolutionFileIO() {
+        // NQueens is the @PlanningSolution class.
+        super(NQueens.class,
+                new ObjectMapper()
+                        .registerModule(new JavaTimeModule())
+                        .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+        );
+    }
+
+}
+----
+
+and use it in the benchmark configuration:
+
+[source,xml,options="nowrap"]
+----
+    <problemBenchmarks>
+      <solutionFileIOClass>org.optaplanner.examples.nqueens.persistence.NQueensJsonSolutionFileIO</solutionFileIOClass>
+      <inputSolutionFile>data/nqueens/unsolved/32queens.json</inputSolutionFile>
+      ...
+    </problemBenchmarks>
+----
 
 [[customSolutionFileIO]]
 ==== Custom `SolutionFileIO`: serialize to and from a custom format

--- a/optaplanner-persistence/optaplanner-persistence-jackson/pom.xml
+++ b/optaplanner-persistence/optaplanner-persistence-jackson/pom.xml
@@ -33,6 +33,10 @@
     </dependency>
     <dependency>
       <groupId>org.optaplanner</groupId>
+      <artifactId>optaplanner-persistence-common</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.optaplanner</groupId>
       <artifactId>optaplanner-core</artifactId>
       <type>test-jar</type>
       <scope>test</scope>

--- a/optaplanner-persistence/optaplanner-persistence-jackson/pom.xml
+++ b/optaplanner-persistence/optaplanner-persistence-jackson/pom.xml
@@ -59,6 +59,11 @@
     </dependency>
     <!-- Testing -->
     <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
       <scope>test</scope>

--- a/optaplanner-persistence/optaplanner-persistence-jackson/src/main/java/org/optaplanner/persistence/jackson/impl/domain/solution/JacksonSolutionFileIO.java
+++ b/optaplanner-persistence/optaplanner-persistence-jackson/src/main/java/org/optaplanner/persistence/jackson/impl/domain/solution/JacksonSolutionFileIO.java
@@ -1,0 +1,57 @@
+package org.optaplanner.persistence.jackson.impl.domain.solution;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.optaplanner.core.api.domain.solution.PlanningSolution;
+import org.optaplanner.persistence.common.api.domain.solution.SolutionFileIO;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ *
+ * @param <Solution_> the solution type, the class with the {@link PlanningSolution} annotation
+ */
+public class JacksonSolutionFileIO<Solution_> implements SolutionFileIO<Solution_> {
+
+    protected Class<Solution_> clazz;
+    protected ObjectMapper mapper;
+
+    public JacksonSolutionFileIO(Class<Solution_> clazz) {
+        this(clazz, new ObjectMapper());
+    }
+
+    public JacksonSolutionFileIO(Class<Solution_> clazz, ObjectMapper mapper) {
+        this.clazz = clazz;
+        this.mapper = mapper;
+    }
+
+    @Override
+    public String getInputFileExtension() {
+        return "json";
+    }
+
+    @Override
+    public String getOutputFileExtension() {
+        return "json";
+    }
+
+    @Override
+    public Solution_ read(File inputSolutionFile) {
+        try {
+            return (Solution_) mapper.readValue(inputSolutionFile, clazz);
+        } catch (IOException e) {
+            throw new IllegalArgumentException("Failed reading inputSolutionFile (" + inputSolutionFile + ").", e);
+        }
+    }
+
+    @Override
+    public void write(Solution_ solution, File file) {
+        try {
+            mapper.writerWithDefaultPrettyPrinter().writeValue(file, solution);
+        } catch (IOException e) {
+            throw new IllegalArgumentException("Failed write", e);
+        }
+    }
+
+}

--- a/optaplanner-persistence/optaplanner-persistence-jackson/src/main/java/org/optaplanner/persistence/jackson/impl/domain/solution/JacksonSolutionFileIO.java
+++ b/optaplanner-persistence/optaplanner-persistence-jackson/src/main/java/org/optaplanner/persistence/jackson/impl/domain/solution/JacksonSolutionFileIO.java
@@ -14,8 +14,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
  */
 public class JacksonSolutionFileIO<Solution_> implements SolutionFileIO<Solution_> {
 
-    protected Class<Solution_> clazz;
-    protected ObjectMapper mapper;
+    private final Class<Solution_> clazz;
+    private final ObjectMapper mapper;
 
     public JacksonSolutionFileIO(Class<Solution_> clazz) {
         this(clazz, new ObjectMapper());

--- a/optaplanner-persistence/optaplanner-persistence-jackson/src/main/java/org/optaplanner/persistence/jackson/impl/domain/solution/JacksonSolutionFileIO.java
+++ b/optaplanner-persistence/optaplanner-persistence-jackson/src/main/java/org/optaplanner/persistence/jackson/impl/domain/solution/JacksonSolutionFileIO.java
@@ -39,7 +39,7 @@ public class JacksonSolutionFileIO<Solution_> implements SolutionFileIO<Solution
     @Override
     public Solution_ read(File inputSolutionFile) {
         try {
-            return (Solution_) mapper.readValue(inputSolutionFile, clazz);
+            return mapper.readValue(inputSolutionFile, clazz);
         } catch (IOException e) {
             throw new IllegalArgumentException("Failed reading inputSolutionFile (" + inputSolutionFile + ").", e);
         }

--- a/optaplanner-persistence/optaplanner-persistence-jackson/src/test/java/org/optaplanner/persistence/jackson/impl/domain/solution/JacksonSolutionFileIOTest.java
+++ b/optaplanner-persistence/optaplanner-persistence-jackson/src/test/java/org/optaplanner/persistence/jackson/impl/domain/solution/JacksonSolutionFileIOTest.java
@@ -42,7 +42,8 @@ public class JacksonSolutionFileIOTest {
 
     @Test
     public void readAndWrite() {
-        JacksonSolutionFileIO<JacksonTestdataSolution> solutionFileIO = new JacksonSolutionFileIO<>(JacksonTestdataSolution.class);
+        JacksonSolutionFileIO<JacksonTestdataSolution> solutionFileIO =
+                new JacksonSolutionFileIO<>(JacksonTestdataSolution.class);
         File file = new File(solutionTestDir, "testdataSolution.json");
 
         JacksonTestdataSolution original = new JacksonTestdataSolution("s1");

--- a/optaplanner-persistence/optaplanner-persistence-jackson/src/test/java/org/optaplanner/persistence/jackson/impl/domain/solution/JacksonSolutionFileIOTest.java
+++ b/optaplanner-persistence/optaplanner-persistence-jackson/src/test/java/org/optaplanner/persistence/jackson/impl/domain/solution/JacksonSolutionFileIOTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.persistence.jackson.impl.domain.solution;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertAllCodesOfIterator;
+import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertCode;
+
+import java.io.File;
+import java.util.Arrays;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.optaplanner.core.api.score.buildin.simple.SimpleScore;
+import org.optaplanner.persistence.jackson.impl.testdata.domain.JacksonTestdataEntity;
+import org.optaplanner.persistence.jackson.impl.testdata.domain.JacksonTestdataSolution;
+import org.optaplanner.persistence.jackson.impl.testdata.domain.JacksonTestdataValue;
+
+public class JacksonSolutionFileIOTest {
+
+    private static File solutionTestDir;
+
+    @BeforeAll
+    public static void setup() {
+        solutionTestDir = new File("target/solutionTest/");
+        solutionTestDir.mkdirs();
+    }
+
+    @Test
+    public void readAndWrite() {
+        JacksonSolutionFileIO<JacksonTestdataSolution> solutionFileIO = new JacksonSolutionFileIO<>(JacksonTestdataSolution.class);
+        File file = new File(solutionTestDir, "testdataSolution.json");
+
+        JacksonTestdataSolution original = new JacksonTestdataSolution("s1");
+        JacksonTestdataValue originalV1 = new JacksonTestdataValue("v1");
+        original.setValueList(Arrays.asList(originalV1, new JacksonTestdataValue("v2")));
+        original.setEntityList(Arrays.asList(
+                new JacksonTestdataEntity("e1"), new JacksonTestdataEntity("e2", originalV1), new JacksonTestdataEntity("e3")));
+        original.setScore(SimpleScore.of(-321));
+        solutionFileIO.write(original, file);
+        JacksonTestdataSolution copy = solutionFileIO.read(file);
+
+        assertThat(copy).isNotSameAs(original);
+        assertCode("s1", copy);
+        assertAllCodesOfIterator(copy.getValueList().iterator(), "v1", "v2");
+        assertAllCodesOfIterator(copy.getEntityList().iterator(), "e1", "e2", "e3");
+        JacksonTestdataValue copyV1 = copy.getValueList().get(0);
+        JacksonTestdataEntity copyE2 = copy.getEntityList().get(1);
+        assertCode("v1", copyE2.getValue());
+        //        assertThat(copyE2.getValue()).isSameAs(copyV1);
+        assertThat(copy.getScore()).isEqualTo(SimpleScore.of(-321));
+    }
+
+}

--- a/optaplanner-persistence/optaplanner-persistence-jackson/src/test/java/org/optaplanner/persistence/jackson/impl/domain/solution/JacksonSolutionFileIOTest.java
+++ b/optaplanner-persistence/optaplanner-persistence-jackson/src/test/java/org/optaplanner/persistence/jackson/impl/domain/solution/JacksonSolutionFileIOTest.java
@@ -62,7 +62,7 @@ public class JacksonSolutionFileIOTest {
         JacksonTestdataValue copyV1 = copy.getValueList().get(0);
         JacksonTestdataEntity copyE2 = copy.getEntityList().get(1);
         assertCode("v1", copyE2.getValue());
-        //        assertThat(copyE2.getValue()).isSameAs(copyV1);
+        assertThat(copyE2.getValue()).isSameAs(copyV1);
         assertThat(copy.getScore()).isEqualTo(SimpleScore.of(-321));
     }
 

--- a/optaplanner-persistence/optaplanner-persistence-jackson/src/test/java/org/optaplanner/persistence/jackson/impl/testdata/domain/JacksonTestdataValue.java
+++ b/optaplanner-persistence/optaplanner-persistence-jackson/src/test/java/org/optaplanner/persistence/jackson/impl/testdata/domain/JacksonTestdataValue.java
@@ -19,7 +19,7 @@ package org.optaplanner.persistence.jackson.impl.testdata.domain;
 import com.fasterxml.jackson.annotation.JsonIdentityInfo;
 import com.fasterxml.jackson.annotation.ObjectIdGenerators;
 
-@JsonIdentityInfo(generator= ObjectIdGenerators.StringIdGenerator.class)
+@JsonIdentityInfo(generator = ObjectIdGenerators.StringIdGenerator.class)
 public class JacksonTestdataValue extends JacksonTestdataObject {
 
     public JacksonTestdataValue() {

--- a/optaplanner-persistence/optaplanner-persistence-jackson/src/test/java/org/optaplanner/persistence/jackson/impl/testdata/domain/JacksonTestdataValue.java
+++ b/optaplanner-persistence/optaplanner-persistence-jackson/src/test/java/org/optaplanner/persistence/jackson/impl/testdata/domain/JacksonTestdataValue.java
@@ -16,6 +16,10 @@
 
 package org.optaplanner.persistence.jackson.impl.testdata.domain;
 
+import com.fasterxml.jackson.annotation.JsonIdentityInfo;
+import com.fasterxml.jackson.annotation.ObjectIdGenerators;
+
+@JsonIdentityInfo(generator= ObjectIdGenerators.StringIdGenerator.class)
 public class JacksonTestdataValue extends JacksonTestdataObject {
 
     public JacksonTestdataValue() {


### PR DESCRIPTION
Hello,

I was working on using json formatted files as input solution files for benchmarking. I implemented a custom SolutionFileIO implementation and thought that a extendable JsonSolutionFileIO would be a good contribution.

From my understanding there are changes for benchmark configurations in the upcoming 8.0.0. 
Therefore, since `xStreamAnnotatedClass` has been removed, creating a configurable `JacksonAnnotatedClass` would not be desirable.

So, I aimed to make `JsonSolutionFileIO` **heavily** influenced by `XStreamSolutionFileIO`.

The only difference would be that the JsonSolutionFileIO lets the Jackson ObjectMapper to be created by the client in order to provide a high customizable ObjectMapper according to the clients desire.

I could provide the documentation in how to use the JsonSolutionFileIO such as

```java
public class MySolutionFileIO extends JsonSolutionFileIO<TimeTable> {

    public MySolutionFileIO() {
        super(Solution.class,
                new ObjectMapper()
                        .registerModule(new JavaTimeModule())
                        .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
                );
    }
}

```

Also, would the implementation name `JacksonSolutionFileIO` be better name for this SolitionFileIO implementation.

<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.
-->

### JIRA

Could create ticket if required.
<!-- Add a JIRA ticket link if it exists. -->
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->


<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
* https://github.com/kiegroup/drools/pull/3000
* https://github.com/kiegroup/optaplanner/pull/899
* etc.
-->

### Checklist
- [ ] Documentation updated if applicable.
- [ ] Upgrade recipe provided if applicable.

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>full downstream build</b> please add comment: <b>Jenkins run fdb</b>
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
