### PR TITLE
Use static import for assertion methods

### DIFF
--- a/optaplanner-core/src/test/java/org/optaplanner/core/config/heuristic/selector/common/nearby/NearbySelectionConfigTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/config/heuristic/selector/common/nearby/NearbySelectionConfigTest.java
@@ -7,7 +7,6 @@ import static org.optaplanner.core.config.heuristic.selector.common.SelectionCac
 import static org.optaplanner.core.config.heuristic.selector.common.SelectionOrder.ORIGINAL;
 import static org.optaplanner.core.config.heuristic.selector.common.SelectionOrder.SORTED;
 
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.optaplanner.core.config.heuristic.selector.entity.EntitySelectorConfig;
@@ -95,7 +94,7 @@ public class NearbySelectionConfigTest {
     public void buildNearbyRandomWithNoRandomSelection() {
         NearbySelectionConfig nearbySelectionConfig = buildNearbySelectionConfig();
 
-        Assertions.assertThat(NearbyRandomFactory.create(nearbySelectionConfig).buildNearbyRandom(false)).isNull();
+        assertThat(NearbyRandomFactory.create(nearbySelectionConfig).buildNearbyRandom(false)).isNull();
     }
 
     @Test

--- a/optaplanner-core/src/test/java/org/optaplanner/core/config/solver/EnvironmentModeTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/config/solver/EnvironmentModeTest.java
@@ -17,6 +17,7 @@
 package org.optaplanner.core.config.solver;
 
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -26,7 +27,6 @@ import java.util.Random;
 import java.util.stream.IntStream;
 
 import org.assertj.core.api.Assertions;
-import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
@@ -195,7 +195,7 @@ public class EnvironmentModeTest {
         ((DefaultSolver<TestdataSolution>) solver1).addPhaseLifecycleListener(listener);
         ((DefaultSolver<TestdataSolution>) solver2).addPhaseLifecycleListener(listener2);
 
-        SoftAssertions.assertSoftly(softly -> IntStream.range(0, NUMBER_OF_TIMES_RUN)
+        assertSoftly(softly -> IntStream.range(0, NUMBER_OF_TIMES_RUN)
                 .forEach(i -> {
                     solver1.solve(inputProblem);
                     solver2.solve(inputProblem);
@@ -213,7 +213,7 @@ public class EnvironmentModeTest {
         ((DefaultSolver<TestdataSolution>) solver1).addPhaseLifecycleListener(listener);
         ((DefaultSolver<TestdataSolution>) solver2).addPhaseLifecycleListener(listener2);
 
-        SoftAssertions.assertSoftly(softly -> IntStream.range(0, NUMBER_OF_TIMES_RUN)
+        assertSoftly(softly -> IntStream.range(0, NUMBER_OF_TIMES_RUN)
                 .forEach(i -> {
                     solver1.solve(inputProblem);
                     solver2.solve(inputProblem);
@@ -230,7 +230,7 @@ public class EnvironmentModeTest {
         Random random = factory1.createRandom();
         Random random2 = factory2.createRandom();
 
-        SoftAssertions.assertSoftly(softly -> IntStream.range(0, NUMBER_OF_RANDOM_NUMBERS_GENERATED)
+        assertSoftly(softly -> IntStream.range(0, NUMBER_OF_RANDOM_NUMBERS_GENERATED)
                 .forEach(i -> softly.assertThat(random.nextInt())
                         .as("Random factories should generate the same results "
                                 + "in a reproducible environment mode.")
@@ -241,7 +241,7 @@ public class EnvironmentModeTest {
         Random random = factory1.createRandom();
         Random random2 = factory2.createRandom();
 
-        SoftAssertions.assertSoftly(softly -> IntStream.range(0, NUMBER_OF_RANDOM_NUMBERS_GENERATED)
+        assertSoftly(softly -> IntStream.range(0, NUMBER_OF_RANDOM_NUMBERS_GENERATED)
                 .forEach(i -> softly.assertThat(random.nextInt())
                         .as("Random factories should not generate exactly the same results "
                                 + "in the non-reproducible environment mode. "

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/exhaustivesearch/BlackBoxExhaustiveSearchPhaseTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/exhaustivesearch/BlackBoxExhaustiveSearchPhaseTest.java
@@ -17,6 +17,7 @@
 package org.optaplanner.core.impl.exhaustivesearch;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -28,7 +29,6 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.optaplanner.core.api.score.buildin.simple.SimpleScore;
@@ -428,7 +428,7 @@ public class BlackBoxExhaustiveSearchPhaseTest {
         SolverFactory<TestdataDifficultyComparingSolution> solverFactory = SolverFactory.create(solverConfig);
 
         if (exhaustiveSearchType == ExhaustiveSearchType.BRUTE_FORCE && nodeExplorationType != null) {
-            Assertions.assertThatIllegalArgumentException()
+            assertThatIllegalArgumentException()
                     .isThrownBy(solverFactory::buildSolver)
                     .withMessage("The phaseConfig (ExhaustiveSearchPhaseConfig) has an "
                             + "nodeExplorationType (" + nodeExplorationType.name()

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/io/jaxb/GenericJaxbIOTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/io/jaxb/GenericJaxbIOTest.java
@@ -19,6 +19,7 @@ package org.optaplanner.core.impl.io.jaxb;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 import java.io.StringReader;
 import java.io.StringWriter;
@@ -28,7 +29,6 @@ import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlValue;
 
-import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.Test;
 import org.optaplanner.core.impl.io.OptaPlannerXmlSerializationException;
 
@@ -49,7 +49,7 @@ class GenericJaxbIOTest {
 
     @Test
     void writeThrowsExceptionOnNullParameters() {
-        SoftAssertions.assertSoftly(softly -> {
+        assertSoftly(softly -> {
             softly.assertThat(assertThatNullPointerException().isThrownBy(() -> xmlIO.write(null, new StringWriter())));
             softly.assertThat(assertThatNullPointerException().isThrownBy(() -> xmlIO.write(new DummyJaxbClass(1, ""), null)));
         });

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/localsearch/decider/forager/finalist/StrategicOscillationByLevelFinalistPodiumTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/localsearch/decider/forager/finalist/StrategicOscillationByLevelFinalistPodiumTest.java
@@ -20,7 +20,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.optaplanner.core.impl.testdata.util.PlannerAssert.extractSingleton;
 
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.optaplanner.core.api.score.buildin.hardmediumsoft.HardMediumSoftScore;
 import org.optaplanner.core.api.score.buildin.hardsoft.HardSoftScore;
@@ -226,7 +225,7 @@ public class StrategicOscillationByLevelFinalistPodiumTest {
         finalistPodium.addMove(moveScope1);
 
         // The better is picked
-        Assertions.assertThat(finalistPodium.getFinalistList()).containsOnly(moveScope1);
+        assertThat(finalistPodium.getFinalistList()).containsOnly(moveScope1);
     }
 
     protected <Solution_> LocalSearchMoveScope<Solution_> buildMoveScope(

--- a/optaplanner-examples/src/test/java/org/optaplanner/examples/common/business/AlphaNumericStringComparatorTest.java
+++ b/optaplanner-examples/src/test/java/org/optaplanner/examples/common/business/AlphaNumericStringComparatorTest.java
@@ -16,9 +16,10 @@
 
 package org.optaplanner.examples.common.business;
 
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
 import java.util.Comparator;
 
-import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.Test;
 
 public class AlphaNumericStringComparatorTest {
@@ -44,14 +45,14 @@ public class AlphaNumericStringComparatorTest {
     }
 
     public <T> void assertCompareEquals(Comparator<T> comparator, T a, T b) {
-        SoftAssertions.assertSoftly(softly -> {
+        assertSoftly(softly -> {
             softly.assertThat(a).usingComparator(comparator).isEqualTo(b);
             softly.assertThat(b).usingComparator(comparator).isEqualTo(a);
         });
     }
 
     public <T> void assertCompareLower(Comparator<T> comparator, T a, T b) {
-        SoftAssertions.assertSoftly(softly -> {
+        assertSoftly(softly -> {
             softly.assertThat(comparator.compare(a, b)).isEqualTo(-1);
             softly.assertThat(comparator.compare(b, a)).isEqualTo(1);
         });

--- a/optaplanner-examples/src/test/java/org/optaplanner/examples/nqueens/app/NQueensAppTest.java
+++ b/optaplanner-examples/src/test/java/org/optaplanner/examples/nqueens/app/NQueensAppTest.java
@@ -16,7 +16,8 @@
 
 package org.optaplanner.examples.nqueens.app;
 
-import org.assertj.core.api.Assertions;
+import static org.assertj.core.api.Assertions.assertThat;
+
 import org.junit.jupiter.api.Test;
 import org.optaplanner.core.api.solver.Solver;
 import org.optaplanner.core.api.solver.SolverFactory;
@@ -29,7 +30,7 @@ public class NQueensAppTest {
         NQueensApp nQueensApp = new NQueensApp();
         SolverFactory<NQueens> solverFactory = nQueensApp.createSolverFactoryByApi();
         Solver<NQueens> solver = solverFactory.buildSolver();
-        Assertions.assertThat(solver).isNotNull();
+        assertThat(solver).isNotNull();
     }
 
 }

--- a/optaplanner-persistence/optaplanner-persistence-jackson/src/test/java/org/optaplanner/persistence/jackson/api/score/AbstractScoreJacksonRoundTripTest.java
+++ b/optaplanner-persistence/optaplanner-persistence-jackson/src/test/java/org/optaplanner/persistence/jackson/api/score/AbstractScoreJacksonRoundTripTest.java
@@ -21,7 +21,6 @@ import static org.assertj.core.api.Assertions.fail;
 
 import java.io.IOException;
 
-import org.assertj.core.api.Assertions;
 import org.optaplanner.core.api.score.Score;
 import org.optaplanner.persistence.jackson.api.AbstractJacksonRoundTripTest;
 
@@ -45,7 +44,7 @@ public abstract class AbstractScoreJacksonRoundTripTest
         } catch (IOException e) {
             throw new IllegalStateException("Marshalling or unmarshalling for input (" + input + ") failed.", e);
         }
-        Assertions.assertThat(output.getScore()).isEqualTo(expectedScore);
+        assertThat(output.getScore()).isEqualTo(expectedScore);
         String regex;
         if (expectedScore != null) {
             regex = "\\{\\s*" // Start of element

--- a/optaplanner-persistence/optaplanner-persistence-jaxb/src/test/java/org/optaplanner/persistence/jaxb/api/score/AbstractScoreJaxbAdapterTest.java
+++ b/optaplanner-persistence/optaplanner-persistence-jaxb/src/test/java/org/optaplanner/persistence/jaxb/api/score/AbstractScoreJaxbAdapterTest.java
@@ -27,7 +27,6 @@ import javax.xml.bind.JAXBException;
 import javax.xml.bind.Marshaller;
 import javax.xml.bind.Unmarshaller;
 
-import org.assertj.core.api.Assertions;
 import org.eclipse.persistence.jaxb.MarshallerProperties;
 import org.eclipse.persistence.jaxb.UnmarshallerProperties;
 import org.optaplanner.core.api.score.Score;
@@ -60,7 +59,7 @@ public abstract class AbstractScoreJaxbAdapterTest {
         } catch (JAXBException e) {
             throw new IllegalStateException("Marshalling or unmarshalling for input (" + input + ") failed.", e);
         }
-        Assertions.assertThat(output.getScore()).isEqualTo(expectedScore);
+        assertThat(output.getScore()).isEqualTo(expectedScore);
         String regex;
         if (expectedScore != null) {
             regex = "<\\?[^\\?]*\\?>" // XML header
@@ -108,7 +107,7 @@ public abstract class AbstractScoreJaxbAdapterTest {
         } catch (JAXBException e) {
             throw new IllegalStateException("Marshalling or unmarshalling for input (" + input + ") failed.", e);
         }
-        Assertions.assertThat(output.getScore()).isEqualTo(expectedScore);
+        assertThat(output.getScore()).isEqualTo(expectedScore);
         String regex;
         if (expectedScore != null) {
             regex = "\\{\\R" // Opening bracket

--- a/optaplanner-persistence/optaplanner-persistence-jpa/src/test/java/org/optaplanner/persistence/jpa/impl/AbstractScoreJpaTest.java
+++ b/optaplanner-persistence/optaplanner-persistence-jpa/src/test/java/org/optaplanner/persistence/jpa/impl/AbstractScoreJpaTest.java
@@ -34,7 +34,6 @@ import javax.transaction.RollbackException;
 import javax.transaction.SystemException;
 import javax.transaction.TransactionManager;
 
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.kie.test.util.db.PersistenceUtil;
@@ -93,7 +92,7 @@ public abstract class AbstractScoreJpaTest {
             EntityManager em = entityManagerFactory.createEntityManager();
             E jpaEntity = em.find(jpaEntityClass, id);
             em.persist(jpaEntity);
-            Assertions.assertThat(jpaEntity.getScore()).isEqualTo(oldScore);
+            assertThat(jpaEntity.getScore()).isEqualTo(oldScore);
             jpaEntity.setScore(newScore);
             jpaEntity = em.merge(jpaEntity);
             transactionManager.commit();
@@ -109,7 +108,7 @@ public abstract class AbstractScoreJpaTest {
             transactionManager.begin();
             EntityManager em = entityManagerFactory.createEntityManager();
             E jpaEntity = em.find(jpaEntityClass, id);
-            Assertions.assertThat(jpaEntity.getScore()).isEqualTo(score);
+            assertThat(jpaEntity.getScore()).isEqualTo(score);
             transactionManager.commit();
         } catch (NotSupportedException | SystemException | RollbackException | HeuristicMixedException
                 | HeuristicRollbackException e) {

--- a/optaplanner-persistence/optaplanner-persistence-xstream/src/test/java/org/optaplanner/persistence/xstream/api/score/AbstractScoreXStreamConverterTest.java
+++ b/optaplanner-persistence/optaplanner-persistence-xstream/src/test/java/org/optaplanner/persistence/xstream/api/score/AbstractScoreXStreamConverterTest.java
@@ -19,7 +19,6 @@ package org.optaplanner.persistence.xstream.api.score;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 
-import org.assertj.core.api.Assertions;
 import org.optaplanner.core.api.score.Score;
 
 import com.thoughtworks.xstream.XStream;
@@ -41,7 +40,7 @@ public abstract class AbstractScoreXStreamConverterTest {
         String xmlString = xStream.toXML(input);
         W output = (W) xStream.fromXML(xmlString);
 
-        Assertions.assertThat(output.getScore()).isEqualTo(expectedScore);
+        assertThat(output.getScore()).isEqualTo(expectedScore);
         String regex;
         if (expectedScore != null) {
             regex = "<([\\w\\-\\.]+)( id=\"\\d+\")?>" // Start of element


### PR DESCRIPTION
Improve readability and consistency by using static imports for `assert*()` methods.

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>full downstream build</b> please add comment: <b>Jenkins run fdb</b>
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
