### PR TITLE
Move connection properties to maven.config

### DIFF
--- a/.github/workflows/jpa_integration_ci.yml
+++ b/.github/workflows/jpa_integration_ci.yml
@@ -12,10 +12,6 @@ on:
       - master
       - 7.x
 
-env:
-  # To prevent build failures due to "Connection reset" during artifact download.
-  MVN_CONNECTION_PROPS: -Dmaven.wagon.httpconnectionManager.ttlSeconds=60 -Dmaven.wagon.http.retryHandler.count=5
-
 defaults:
   run:
     shell: bash
@@ -57,4 +53,4 @@ jobs:
 
       # Builds the JPA module and runs tests in a PostgreSQL container
       - name: Build with Maven
-        run: mvn -B clean install -pl :optaplanner-persistence-jpa -am -Ppostgresql ${{ env.MVN_CONNECTION_PROPS }}
+        run: mvn -B clean install -pl :optaplanner-persistence-jpa -am -Ppostgresql

--- a/.github/workflows/os_java_ci.yml
+++ b/.github/workflows/os_java_ci.yml
@@ -12,10 +12,6 @@ on:
       - master
       - 7.x
 
-env:
-  # To prevent build failures due to "Connection reset" during artifact download.
-  MVN_CONNECTION_PROPS: -Dmaven.wagon.httpconnectionManager.ttlSeconds=60 -Dmaven.wagon.http.retryHandler.count=5
-
 defaults:
   run:
     shell: bash
@@ -43,7 +39,7 @@ jobs:
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2
       - name: Build with Maven
-        run: mvn -B clean install ${{ env.MVN_CONNECTION_PROPS }}
+        run: mvn -B clean install
 
   # Early feedback on a compatibility with the newest Java version.
   # TODO: update each time a new major Java version is released.
@@ -65,4 +61,4 @@ jobs:
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2
       - name: Build with Maven
-        run: mvn -B clean install ${{ env.MVN_CONNECTION_PROPS }}
+        run: mvn -B clean install

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 !.gitignore
 !.gitattributes
 !.travis.yml
+!/.mvn
 /nbproject
 /*.ipr
 /*.iws

--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,0 +1,3 @@
+-Dmaven.wagon.httpconnectionManager.ttlSeconds=120
+-Dmaven.wagon.http.retryHandler.requestSentEnabled=true
+-Dmaven.wagon.http.retryHandler.count=10


### PR DESCRIPTION
Puts the maven connection properties into .mvn/maven.config so that any CI can use it. The properties values have been aligned with kogito-runtimes, which uses the same approach.

<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.
-->

### JIRA

<!-- Add a JIRA ticket link if it exists. -->
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
* https://github.com/kiegroup/drools/pull/3000
* https://github.com/kiegroup/optaplanner/pull/899
* etc.
-->

### Checklist
- [ ] Documentation updated if applicable.
- [ ] Upgrade recipe provided if applicable.

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>full downstream build</b> please add comment: <b>Jenkins run fdb</b>
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
