### PR TITLE
Move XSD generation to a later phase

### DIFF
--- a/optaplanner-benchmark/pom.xml
+++ b/optaplanner-benchmark/pom.xml
@@ -174,7 +174,8 @@
         <artifactId>exec-maven-plugin</artifactId>
         <executions>
           <execution>
-            <phase>compile</phase>
+            <!-- Make sure the XSD will be merged after the codebase has been successfully compiled. -->
+            <phase>process-classes</phase>
             <goals>
               <goal>java</goal>
             </goals>

--- a/optaplanner-build-parent/pom.xml
+++ b/optaplanner-build-parent/pom.xml
@@ -873,13 +873,15 @@
           <executions>
             <execution>
               <id>schemagen</id>
+              <!-- Make sure the XSD will be generated after the codebase has been successfully compiled. -->
+              <phase>process-classes</phase>
               <goals>
                 <goal>schemagen</goal>
               </goals>
             </execution>
           </executions>
           <configuration>
-            <clearOutputDir>true</clearOutputDir>
+            <clearOutputDir>false</clearOutputDir>
             <createJavaDocAnnotations>false</createJavaDocAnnotations>
             <generateEpisode>false</generateEpisode>
             <outputDirectory>${project.build.outputDirectory}</outputDirectory>


### PR DESCRIPTION
If there is a compilation failure it should be reported by the compiler plugin and not by the jaxb2 plugin, which was originally configured to run in an earlier phase.

<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.
-->

### JIRA

<!-- Add a JIRA ticket link if it exists. -->
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
* https://github.com/kiegroup/drools/pull/3000
* https://github.com/kiegroup/optaplanner/pull/899
* etc.
-->

### Checklist
- [ ] Documentation updated if applicable.
- [ ] Upgrade recipe provided if applicable.

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>full downstream build</b> please add comment: <b>Jenkins run fdb</b>
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
