### PR TITLE
[7.44.x] RHPAM-3256 Fix for productized assembly with spring-boot quickstart

### DIFF
--- a/optaplanner-distribution/pom.xml
+++ b/optaplanner-distribution/pom.xml
@@ -180,15 +180,6 @@
       <artifactId>optaplanner-examples</artifactId>
       <classifier>sources</classifier>
     </dependency>
-    <dependency>
-      <groupId>com.example</groupId>
-      <artifactId>optaplanner-spring-boot-school-timetabling-quickstart</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>com.example</groupId>
-      <artifactId>optaplanner-spring-boot-school-timetabling-quickstart</artifactId>
-      <classifier>sources</classifier>
-    </dependency>
 
     <!-- Documentation -->
     <dependency>

--- a/optaplanner-distribution/src/main/assembly/assembly-optaplanner.xml
+++ b/optaplanner-distribution/src/main/assembly/assembly-optaplanner.xml
@@ -63,13 +63,26 @@
         <exclude>.git/**</exclude>
       </excludes>
     </fileSet>
+    <fileSet><!-- Note: going outside the module dir is bad, but it is not fetching generated files -->
+      <directory>../optaplanner-quickstarts/spring-boot-school-timetabling</directory>
+      <outputDirectory>quickstarts/spring-boot-school-timetabling</outputDirectory>
+      <excludes>
+        <exclude>target/**</exclude>
+        <exclude>local/**</exclude>
+        <exclude>.*/**</exclude>
+        <exclude>nbproject/**</exclude>
+        <exclude>*.ipr</exclude>
+        <exclude>*.iws</exclude>
+        <exclude>*.iml</exclude>
+        <exclude>.git/**</exclude>
+      </excludes>
+    </fileSet>
   </fileSets>
 
   <dependencySets>
     <dependencySet>
       <includes>
         <include>org.optaplanner:*:jar</include>
-        <include>com.example:optaplanner-spring-boot-school-timetabling-quickstart:jar</include>
       </includes>
       <excludes>
         <exclude>org.optaplanner:optaplanner-examples</exclude>
@@ -84,7 +97,6 @@
     <dependencySet>
       <includes>
         <include>org.optaplanner:*:jar:sources</include>
-        <include>com.example:optaplanner-spring-boot-school-timetabling-quickstart:jar:sources</include>
       </includes>
       <excludes>
         <exclude>org.optaplanner:optaplanner-examples:jar:sources</exclude>

--- a/optaplanner-quickstarts/quarkus-school-timetabling/pom.xml
+++ b/optaplanner-quickstarts/quarkus-school-timetabling/pom.xml
@@ -25,6 +25,8 @@
     <deploy-plugin.version>2.8.2</deploy-plugin.version>
     <surefire-plugin.version>2.22.2</surefire-plugin.version>
     <docker-plugin.version>0.28.0</docker-plugin.version>
+    <!-- TODO Workaround for "mvn quarkus:dev" for https://github.com/quarkusio/quarkus/issues/12715 -->
+    <noDeps>true</noDeps>
   </properties>
 
   <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,6 @@
     <!-- TODO https://issues.redhat.com/browse/PLANNER-2042 -->
     <spotbugs.failOnViolation>false</spotbugs.failOnViolation>
     <version.org.mockito>3.1.0</version.org.mockito>
-    <version.com.example.optaplanner-school-timetabling-quickstart>0.1.0-SNAPSHOT</version.com.example.optaplanner-school-timetabling-quickstart>
   </properties>
 
   <repositories>
@@ -110,17 +109,6 @@
         <version>${version.org.mozilla.rhino}</version>
         <scope>compile</scope>
         <optional>true</optional>
-      </dependency>
-      <dependency>
-        <groupId>com.example</groupId>
-        <artifactId>optaplanner-spring-boot-school-timetabling-quickstart</artifactId>
-        <version>${version.com.example.optaplanner-school-timetabling-quickstart}</version>
-      </dependency>
-      <dependency>
-        <groupId>com.example</groupId>
-        <artifactId>optaplanner-spring-boot-school-timetabling-quickstart</artifactId>
-        <version>${version.com.example.optaplanner-school-timetabling-quickstart}</version>
-        <classifier>sources</classifier>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
A cherry-pick of https://github.com/kiegroup/optaplanner/commit/c143e1f82ac02f639595439d9055a970bdb2bdb6

<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.
-->

### JIRA
https://issues.redhat.com/browse/RHPAM-3256
<!-- Add a JIRA ticket link if it exists. -->
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
* https://github.com/kiegroup/drools/pull/3000
* https://github.com/kiegroup/optaplanner/pull/899
* etc.
-->

### Checklist
- [x] Documentation updated if applicable.
- [x] Upgrade recipe provided if applicable.

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>full downstream build</b> please add comment: <b>Jenkins run fdb</b>
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
