### PR TITLE
Increase DefaultPartitionedSearchPhaseTest timeout to prevent flakiness

### DIFF
--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/partitionedsearch/DefaultPartitionedSearchPhaseTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/partitionedsearch/DefaultPartitionedSearchPhaseTest.java
@@ -161,7 +161,7 @@ public class DefaultPartitionedSearchPhaseTest {
         assertThat(solver.isTerminateEarly()).isTrue();
 
         executor.shutdown();
-        assertThat(executor.awaitTermination(100, TimeUnit.MILLISECONDS)).isTrue();
+        assertThat(executor.awaitTermination(1, TimeUnit.SECONDS)).isTrue();
         assertThat(solutionFuture.get()).isNotNull();
     }
 


### PR DESCRIPTION
This measure is to prevent the DefaultPartitionedSearchPhaseTest.terminateEarly() test to stop failing occasionally.