### PR TITLE
PLANNER-2142 Make OptaPlanner 8 a part of kogito release pipeline

### DIFF
--- a/Jenkinsfile.deploy
+++ b/Jenkinsfile.deploy
@@ -59,6 +59,7 @@ pipeline {
 
                     if (isRelease()) {
                         assert getProjectVersion() != ''
+                        assert getKogitoVersion() != ''
                     }
                 }
             }
@@ -258,7 +259,7 @@ void runMaven(String goals, String directory, boolean skipTests = false, List pr
 }
 
 void updateKogitoVersion(String newVersion) {
-    sh "mvn versions:set-property -Dproperty=version.org.kie.kogito -DnewVersion=$newVersion -DallowSnapshots=true -DgenerateBackupPoms=false"
+    maven.mvnSetVersionProperty('version.org.kie.kogito', newVersion)
 }
 
 // Getters and Setters of params/properties

--- a/Jenkinsfile.deploy
+++ b/Jenkinsfile.deploy
@@ -102,6 +102,9 @@ pipeline {
                     sh "sed -i 's|<repository>|<repository><id>staging</id><name>Staging Repository</name><url>${params.MAVEN_DEPENDENCIES_REPOSITORY}</url><layout>default</layout><snapshots><enabled>true</enabled></snapshots><releases><enabled>true</enabled></releases></repository>\\n        <repository>|g' ${MAVEN_SETTINGS_FILE}"
                     sh "sed -i 's|<pluginRepository>|<pluginRepository><id>staging</id><name>Staging Repository</name><url>${params.MAVEN_DEPENDENCIES_REPOSITORY}</url><layout>default</layout><snapshots><enabled>true</enabled></snapshots><releases><enabled>true</enabled></releases></pluginRepository>\\n        <pluginRepository>|g' ${MAVEN_SETTINGS_FILE}"
                     sh "sed -i 's|external:\\*|central|g' ${MAVEN_SETTINGS_FILE}" // Done to allow Maven to download release artifacts from MAVEN_DEPENDENCIES_REPOSITORY
+
+                    echo 'Resulting maven settings.xml:'
+                    sh "cat ${MAVEN_SETTINGS_FILE}"
                 }
             }
         }

--- a/Jenkinsfile.deploy
+++ b/Jenkinsfile.deploy
@@ -256,7 +256,7 @@ void runMaven(String goals, String directory, boolean skipTests = false, List pr
 }
 
 void updateKogitoVersion(String newVersion) {
-    sh "mvn versions:update-property -Dproperty=version.org.kie.kogito -DnewVersion=[$newVersion] -DallowSnapshots=true -DgenerateBackupPoms=false"
+    sh "mvn versions:set-property -Dproperty=version.org.kie.kogito -DnewVersion=$newVersion -DallowSnapshots=true -DgenerateBackupPoms=false"
 }
 
 // Getters and Setters of params/properties

--- a/Jenkinsfile.deploy
+++ b/Jenkinsfile.deploy
@@ -121,11 +121,11 @@ pipeline {
                         maven.mvnVersionsSet(getProjectVersion())
                         updateKogitoVersion(getKogitoVersion())
                     }
-                    /*
+                    /* TODO:
                         Install optaplanner artifacts to a local maven repository to make them accessible
                         for optaplanner-quickstarts and optaweb apps.
                      */
-                    mavenCleanInstall('optaplanner', true, [], '-U')
+                    //mavenCleanInstall('optaplanner', true, [], '-U')
 
                 }
             }

--- a/Jenkinsfile.deploy
+++ b/Jenkinsfile.deploy
@@ -94,14 +94,14 @@ pipeline {
             }
             steps {
                 echo 'Setup Maven release config'
-                configFileProvider([configFile(fileId: '771ff52a-a8b4-40e6-9b22-d54c7314aa1e', targetLocation: 'maven-settings.xml', variable: 'MAVEN_SETTINGS_FILE')]){
+                configFileProvider([configFile(fileId: '9239af2e-46e3-4ba3-8dd6-1a814fc8a56d', targetLocation: 'maven-settings.xml', variable: 'MAVEN_SETTINGS_FILE')]){
                     sh "echo '-B -s ${MAVEN_SETTINGS_FILE}' | tee optaplanner/.mvn/maven.config"
                     // TODO: figure out why the assert does not work
                     // assert params.MAVEN_DEPENDENCIES_REPOSITORY != '' // OptaPlanner depends on Kogito Runtimes
                     echo "MAVEN_DEPENDENCIES_REPOSITORY passed: ${params.MAVEN_DEPENDENCIES_REPOSITORY}"
-                    sh "sed -i 's|<repository>|<repository><id>staging</id><name>Staging Repository</name><url>${params.MAVEN_DEPENDENCIES_REPOSITORY}</url><layout>default</layout><snapshots><enabled>true</enabled></snapshots><releases><enabled>true</enabled></releases></repository>\\n        <repository>|g' ${MAVEN_SETTINGS_FILE}"
-                    sh "sed -i 's|<pluginRepository>|<pluginRepository><id>staging</id><name>Staging Repository</name><url>${params.MAVEN_DEPENDENCIES_REPOSITORY}</url><layout>default</layout><snapshots><enabled>true</enabled></snapshots><releases><enabled>true</enabled></releases></pluginRepository>\\n        <pluginRepository>|g' ${MAVEN_SETTINGS_FILE}"
-                    sh "sed -i 's|external:\\*|central|g' ${MAVEN_SETTINGS_FILE}" // Done to allow Maven to download release artifacts from MAVEN_DEPENDENCIES_REPOSITORY
+                    sh "sed -i 's|<repositories>|<repositories><repository><id>staging</id><name>Staging Repository</name><url>${params.MAVEN_DEPENDENCIES_REPOSITORY}</url><layout>default</layout><snapshots><enabled>true</enabled></snapshots><releases><enabled>true</enabled></releases></repository>|g' ${MAVEN_SETTINGS_FILE}"
+                    sh "sed -i 's|<pluginRepositories>|<pluginRepositories><pluginRepository><id>staging</id><name>Staging Repository</name><url>${params.MAVEN_DEPENDENCIES_REPOSITORY}</url><layout>default</layout><snapshots><enabled>true</enabled></snapshots><releases><enabled>true</enabled></releases></pluginRepository>|g' ${MAVEN_SETTINGS_FILE}"
+                    sh "sed -i 's|external:\\*|external:*,!staging|g' ${MAVEN_SETTINGS_FILE}" // Done to allow Maven to download release artificats from MAVEN_DEPENDENCIES_REPOSITORY
 
                     echo 'Resulting maven settings.xml:'
                     sh "cat ${MAVEN_SETTINGS_FILE}"

--- a/Jenkinsfile.deploy
+++ b/Jenkinsfile.deploy
@@ -99,8 +99,8 @@ pipeline {
                 script {
                     echo 'Setup Maven release config'
                     configFileProvider([configFile(fileId: maven.getSubmarineSettingsXmlId(), targetLocation: 'maven-settings.xml', variable: 'MAVEN_SETTINGS_FILE')]) {
+                        sh "echo '\n-Denforcer.skip=true' | tee -a optaplanner/.mvn/maven.config"
                         sh "echo '\n-B -s ${MAVEN_SETTINGS_FILE}' | tee -a optaplanner/.mvn/maven.config"
-
                         if (params.MAVEN_DEPENDENCIES_REPOSITORY != '') {
                             sh "sed -i 's|<repositories>|<repositories><repository><id>staging</id><name>Staging Repository</name><url>${params.MAVEN_DEPENDENCIES_REPOSITORY}</url><layout>default</layout><snapshots><enabled>true</enabled></snapshots><releases><enabled>true</enabled></releases></repository>|g' ${MAVEN_SETTINGS_FILE}"
                             sh "sed -i 's|<pluginRepositories>|<pluginRepositories><pluginRepository><id>staging</id><name>Staging Repository</name><url>${params.MAVEN_DEPENDENCIES_REPOSITORY}</url><layout>default</layout><snapshots><enabled>true</enabled></snapshots><releases><enabled>true</enabled></releases></pluginRepository>|g' ${MAVEN_SETTINGS_FILE}"

--- a/Jenkinsfile.deploy
+++ b/Jenkinsfile.deploy
@@ -35,13 +35,14 @@ pipeline {
         booleanParam(name: 'RELEASE', defaultValue: false, description: 'Is this build for a release?')
         string(name: 'PROJECT_VERSION', defaultValue: '', description: 'Optional if not RELEASE. If RELEASE, cannot be empty.')
         string(name: 'KOGITO_VERSION', defaultValue: '', description: 'Optional if not RELEASE. If RELEASE, cannot be empty.')
+
+        // Bot author information. Set as params for easy testing.
+        string(name: 'GIT_AUTHOR_BOT', defaultValue: 'bsig-gh-bot', description: 'From which author should the PR be created ?')
+        string(name: 'BOT_CREDENTIALS_ID', defaultValue: 'bsig-gh-bot', description: 'Credentials for PR creation')
     }
 
     environment {
         MAVEN_OPTS = '-Xms1024m -Xmx4g'
-
-        BOT_CREDENTIALS_ID = 'bsig-gh-bot'
-        GIT_AUTHOR_BOT = 'bsig-gh-bot'
 
         BOT_BRANCH_HASH = "${util.generateHash(10)}"
     }
@@ -193,7 +194,7 @@ void checkoutRepo(String repo, String dirName=repo) {
 
 void prepareForPR(String repo) {
     dir(repo) {
-        githubscm.forkRepo(env.BOT_CREDENTIALS_ID)
+        githubscm.forkRepo(getBotAuthorCredsID())
         githubscm.createBranch(getBotBranch())
     }
 }
@@ -206,8 +207,8 @@ void commitAndCreatePR(String repo) {
     dir(repo) {
         addNotIgnoredPoms()
         sh "git commit -m '${commitMsg}'"
-        githubscm.pushObject('origin', getBotBranch(), env.BOT_CREDENTIALS_ID)
-        deployProperties["${repo}.pr.link"] = githubscm.createPR(commitMsg, prBody, getBuildBranch(), env.BOT_CREDENTIALS_ID)
+        githubscm.pushObject('origin', getBotBranch(), getBotAuthorCredsID())
+        deployProperties["${repo}.pr.link"] = githubscm.createPR(commitMsg, prBody, getBuildBranch(), getBotAuthorCredsID())
     }
 }
 
@@ -286,7 +287,11 @@ String getBotBranch(){
 }
 
 String getBotAuthor(){
-    return env.GIT_AUTHOR_BOT
+    return params.GIT_AUTHOR_BOT
+}
+
+String getBotAuthorCredsID(){
+    return params.BOT_CREDENTIALS_ID
 }
 
 void setDeployPropertyIfNeeded(String key, def value) {

--- a/Jenkinsfile.deploy
+++ b/Jenkinsfile.deploy
@@ -95,7 +95,7 @@ pipeline {
             steps {
                 echo 'Setup Maven release config'
                 configFileProvider([configFile(fileId: '771ff52a-a8b4-40e6-9b22-d54c7314aa1e', targetLocation: 'maven-settings.xml', variable: 'MAVEN_SETTINGS_FILE')]){
-                    sh "echo '-B -s ${MAVEN_SETTINGS_FILE}' | tee {optaplanner}/.mvn/maven.config"
+                    sh "echo '-B -s ${MAVEN_SETTINGS_FILE}' | tee optaplanner/.mvn/maven.config"
                     // TODO: figure out why the assert does not work
                     // assert params.MAVEN_DEPENDENCIES_REPOSITORY != '' // OptaPlanner depends on Kogito Runtimes
                     echo "MAVEN_DEPENDENCIES_REPOSITORY passed: ${params.MAVEN_DEPENDENCIES_REPOSITORY}"

--- a/Jenkinsfile.deploy
+++ b/Jenkinsfile.deploy
@@ -99,7 +99,7 @@ pipeline {
                 script {
                     echo 'Setup Maven release config'
                     configFileProvider([configFile(fileId: maven.getSubmarineSettingsXmlId(), targetLocation: 'maven-settings.xml', variable: 'MAVEN_SETTINGS_FILE')]) {
-                        sh "echo '-B -s ${MAVEN_SETTINGS_FILE}' | tee optaplanner/.mvn/maven.config"
+                        sh "echo '\n-B -s ${MAVEN_SETTINGS_FILE}' | tee -a optaplanner/.mvn/maven.config"
 
                         if (params.MAVEN_DEPENDENCIES_REPOSITORY != '') {
                             sh "sed -i 's|<repositories>|<repositories><repository><id>staging</id><name>Staging Repository</name><url>${params.MAVEN_DEPENDENCIES_REPOSITORY}</url><layout>default</layout><snapshots><enabled>true</enabled></snapshots><releases><enabled>true</enabled></releases></repository>|g' ${MAVEN_SETTINGS_FILE}"
@@ -236,7 +236,7 @@ void mavenCleanInstall(String directory, boolean skipTests = false, List profile
 }
 
 void mavenDeploy(String directory) {
-    extraArgs = params.MAVEN_DEPLOY_REPOSITORY != '' ? "-DaltDeploymentRepository=runtimes-artifacts::default::${params.MAVEN_DEPLOY_REPOSITORY}" : ''
+    extraArgs = params.MAVEN_DEPLOY_REPOSITORY != '' ? "-DaltDeploymentRepository=runtimes-artifacts::default::${params.MAVEN_DEPLOY_REPOSITORY} -Denforcer.skip=true" : ''
     runMaven('clean deploy', directory, true, [], extraArgs)
 }
 

--- a/Jenkinsfile.deploy
+++ b/Jenkinsfile.deploy
@@ -96,7 +96,9 @@ pipeline {
                 echo 'Setup Maven release config'
                 configFileProvider([configFile(fileId: '771ff52a-a8b4-40e6-9b22-d54c7314aa1e', targetLocation: 'maven-settings.xml', variable: 'MAVEN_SETTINGS_FILE')]){
                     sh "echo '-B -s ${MAVEN_SETTINGS_FILE}' | tee {optaplanner}/.mvn/maven.config"
-                    assert params.MAVEN_DEPENDENCIES_REPOSITORY != '' // OptaPlanner depends on Kogito Runtimes
+                    // TODO: figure out why the assert does not work
+                    // assert params.MAVEN_DEPENDENCIES_REPOSITORY != '' // OptaPlanner depends on Kogito Runtimes
+                    echo "MAVEN_DEPENDENCIES_REPOSITORY passed: ${params.MAVEN_DEPENDENCIES_REPOSITORY}"
                     sh "sed -i 's|<repository>|<repository><id>staging</id><name>Staging Repository</name><url>${params.MAVEN_DEPENDENCIES_REPOSITORY}</url><layout>default</layout><snapshots><enabled>true</enabled></snapshots><releases><enabled>true</enabled></releases></repository>\\n        <repository>|g' ${MAVEN_SETTINGS_FILE}"
                     sh "sed -i 's|<pluginRepository>|<pluginRepository><id>staging</id><name>Staging Repository</name><url>${params.MAVEN_DEPENDENCIES_REPOSITORY}</url><layout>default</layout><snapshots><enabled>true</enabled></snapshots><releases><enabled>true</enabled></releases></pluginRepository>\\n        <pluginRepository>|g' ${MAVEN_SETTINGS_FILE}"
                     sh "sed -i 's|external:\\*|central|g' ${MAVEN_SETTINGS_FILE}" // Done to allow Maven to download release artifacts from MAVEN_DEPENDENCIES_REPOSITORY

--- a/Jenkinsfile.deploy
+++ b/Jenkinsfile.deploy
@@ -245,12 +245,7 @@ void runMaven(String goals, String directory, boolean skipTests = false, List pr
         mvnCmd += " ${extraArgs}"
     }
     dir(directory) {
-        if(isRelease()){
-            // In case of release, we already have the settings.xml
-            maven.runMaven(mvnCmd, skipTests, ['-fae'])
-        } else {
-            maven.runMavenWithSubmarineSettings(mvnCmd, skipTests)
-        }
+        maven.runMaven(mvnCmd, skipTests, ['-fae'])
     }
 }
 

--- a/Jenkinsfile.deploy
+++ b/Jenkinsfile.deploy
@@ -17,20 +17,33 @@ pipeline {
     }
 
     parameters {
+
         string(name: 'DISPLAY_NAME', defaultValue: '', description: 'Setup a specific build display name')
 
         // Git information
         string(name: 'BUILD_BRANCH_NAME', defaultValue: 'master', description: 'Which branch to build? Set if you are not on a multibranch pipeline.')
         string(name: 'GIT_AUTHOR', defaultValue: 'kiegroup', description: 'Which Git author repository ?')
 
+        // Build&test information
+        string(name: 'MAVEN_DEPENDENCIES_REPOSITORY', defaultValue: '', description: 'Maven repository where to find dependencies if those are not in the default JBoss repository.')
         booleanParam(name: 'SKIP_TESTS', defaultValue: false, description: 'Skip tests')
 
         // Deploy information
         string(name: 'MAVEN_DEPLOY_REPOSITORY', defaultValue: '', description: 'Specify a Maven repository to deploy the artifacts.')
+
+        // Release information
+        booleanParam(name: 'RELEASE', defaultValue: false, description: 'Is this build for a release?')
+        string(name: 'PROJECT_VERSION', defaultValue: '', description: 'Optional if not RELEASE. If RELEASE, cannot be empty.')
+        string(name: 'KOGITO_VERSION', defaultValue: '', description: 'Optional if not RELEASE. If RELEASE, cannot be empty.')
     }
 
     environment {
         MAVEN_OPTS = '-Xms1024m -Xmx4g'
+
+        BOT_CREDENTIALS_ID = 'bsig-gh-bot'
+        GIT_AUTHOR_BOT = 'bsig-gh-bot'
+
+        BOT_BRANCH_HASH = "${util.generateHash(10)}"
     }
 
     stages {
@@ -42,6 +55,10 @@ pipeline {
                     if (params.DISPLAY_NAME != '') {
                         currentBuild.displayName = params.DISPLAY_NAME
                     }
+
+                    if (isRelease()) {
+                        assert getProjectVersion() != ''
+                    }
                 }
             }
             post {
@@ -49,15 +66,65 @@ pipeline {
                     script {
                         setDeployPropertyIfNeeded('git.branch', getBuildBranch())
                         setDeployPropertyIfNeeded('git.author', getGitAuthor())
+                        setDeployPropertyIfNeeded('project.version', getProjectVersion())
+                        setDeployPropertyIfNeeded('release', isRelease())
                     }
                 }
             }
         }
+
         stage('Clone repositories') {
             steps {
                 checkoutRepo('optaplanner')
             }
         }
+
+        stage('Prepare for PR'){
+            when {
+                expression { return isRelease() }
+            }
+            steps {
+                prepareForPR('optaplanner')
+            }
+        }
+
+        stage('Setup Maven release config'){
+            when {
+                expression { return isRelease() }
+            }
+            steps {
+                echo 'Setup Maven release config'
+                configFileProvider([configFile(fileId: '771ff52a-a8b4-40e6-9b22-d54c7314aa1e', targetLocation: 'maven-settings.xml', variable: 'MAVEN_SETTINGS_FILE')]){
+                    sh "echo '-B -s ${MAVEN_SETTINGS_FILE}' | tee {optaplanner}/.mvn/maven.config"
+                    assert params.MAVEN_DEPENDENCIES_REPOSITORY != '' // OptaPlanner depends on Kogito Runtimes
+                    sh "sed -i 's|<repository>|<repository><id>staging</id><name>Staging Repository</name><url>${params.MAVEN_DEPENDENCIES_REPOSITORY}</url><layout>default</layout><snapshots><enabled>true</enabled></snapshots><releases><enabled>true</enabled></releases></repository>\\n        <repository>|g' ${MAVEN_SETTINGS_FILE}"
+                    sh "sed -i 's|<pluginRepository>|<pluginRepository><id>staging</id><name>Staging Repository</name><url>${params.MAVEN_DEPENDENCIES_REPOSITORY}</url><layout>default</layout><snapshots><enabled>true</enabled></snapshots><releases><enabled>true</enabled></releases></pluginRepository>\\n        <pluginRepository>|g' ${MAVEN_SETTINGS_FILE}"
+                }
+            }
+        }
+
+        stage('Update project version'){
+            when {
+                expression { return getProjectVersion() != '' }
+            }
+            steps {
+                script {
+                    // To make sure that the project will resolve during version upgrade.
+                    mavenCleanInstall('optaplanner', true, [], '-U')
+                    dir('optaplanner') {
+                        maven.mvnVersionsSet(getProjectVersion())
+                        updateKogitoVersion(getKogitoVersion())
+                    }
+                    /*
+                        Install optaplanner artifacts to a local maven repository to make them accessible
+                        for optaplanner-quickstarts and optaweb apps.
+                     */
+                    mavenCleanInstall('optaplanner', true, [], '-U')
+
+                }
+            }
+        }
+
         stage('Build optaplanner') {
             steps {
                 mavenCleanInstall('optaplanner', params.SKIP_TESTS)
@@ -68,11 +135,32 @@ pipeline {
                 }
             }
         }
+
         stage('Deploy artifacts') {
             steps {
                 mavenDeploy('optaplanner')
             }
         }
+
+        stage('Create PR'){
+            when {
+                expression { return isRelease() }
+            }
+            steps {
+                commitAndCreatePR('optaplanner')
+            }
+            post {
+                success {
+                    script {
+                        setDeployPropertyIfNeeded('optaplanner.pr.source.uri', "https://github.com/${getBotAuthor()}/optaplanner")
+                        setDeployPropertyIfNeeded('optaplanner.pr.source.ref', getBotBranch())
+                        setDeployPropertyIfNeeded('optaplanner.pr.target.uri', "https://github.com/${getGitAuthor()}/optaplanner")
+                        setDeployPropertyIfNeeded('optaplanner.pr.target.ref', getBuildBranch())
+                    }
+                }
+            }
+        }
+
     }
     post {
         always {
@@ -97,18 +185,41 @@ void checkoutRepo(String repo, String dirName=repo) {
     }
 }
 
-String getGitAuthor(){
-    return params.GIT_AUTHOR
-}
-
-String getBuildBranch(){
-    return params.BUILD_BRANCH_NAME
-}
-
-void setDeployPropertyIfNeeded(String key, def value){
-    if (value != null && value != ''){
-        deployProperties[key] = value
+void prepareForPR(String repo) {
+    dir(repo) {
+        githubscm.forkRepo(env.BOT_CREDENTIALS_ID)
+        githubscm.createBranch(getBotBranch())
     }
+}
+
+void commitAndCreatePR(String repo) {
+    def commitMsg = "Update project version to ${getProjectVersion()} for release"
+    def prBody = "Generated by build ${BUILD_TAG}: ${BUILD_URL}.\nPlease do not merge, it will be merged automatically after testing."
+    // Not using githubscm.commitChanges() because globbing won't work.
+    // See: https://github.com/kiegroup/kogito-runtimes/pull/570#discussion_r449268738
+    dir(repo) {
+        addNotIgnoredPoms()
+        sh "git commit -m '${commitMsg}'"
+        githubscm.pushObject('origin', getBotBranch(), env.BOT_CREDENTIALS_ID)
+        deployProperties["${repo}.pr.link"] = githubscm.createPR(commitMsg, prBody, getBuildBranch(), env.BOT_CREDENTIALS_ID)
+    }
+}
+
+// TODO: move to a shared library
+void addNotIgnoredPoms() {
+    // based on https://stackoverflow.com/a/59888964/8811872
+    sh '''
+    find . -type f -name 'pom.xml' > found_poms.txt
+    poms_to_add=""
+    while IFS= read -r pom; do
+        if ! git check-ignore -q "\$pom"; then
+            poms_to_add="\$poms_to_add \$pom"
+        fi
+    done < found_poms.txt
+    rm found_poms.txt
+    git add \$poms_to_add
+    git status
+    '''
 }
 
 void mavenCleanInstall(String directory, boolean skipTests = false, List profiles = [], String extraArgs = '') {
@@ -130,5 +241,45 @@ void runMaven(String goals, String directory, boolean skipTests = false, List pr
     }
     dir(directory) {
         maven.runMavenWithSubmarineSettings(mvnCmd, skipTests)
+    }
+}
+
+void updateKogitoVersion(String newVersion) {
+    sh "mvn versions:update-property -Dproperty=version.org.kie.kogito -DnewVersion=[$newVersion] -DallowSnapshots=true -DgenerateBackupPoms=false"
+}
+
+// Getters and Setters of params/properties
+
+boolean isRelease() {
+    return params.RELEASE
+}
+
+String getGitAuthor() {
+    return params.GIT_AUTHOR
+}
+
+String getBuildBranch() {
+    return params.BUILD_BRANCH_NAME
+}
+
+String getKogitoVersion() {
+    return params.KOGITO_VERSION
+}
+
+String getProjectVersion(){
+    return params.PROJECT_VERSION
+}
+
+String getBotBranch(){
+    return "${getProjectVersion()}-${env.BOT_BRANCH_HASH}"
+}
+
+String getBotAuthor(){
+    return env.GIT_AUTHOR_BOT
+}
+
+void setDeployPropertyIfNeeded(String key, def value) {
+    if (value != null && value != ''){
+        deployProperties[key] = value
     }
 }

--- a/Jenkinsfile.deploy
+++ b/Jenkinsfile.deploy
@@ -91,17 +91,13 @@ pipeline {
             }
         }
 
-        stage('Setup Maven release config'){
-            when {
-                expression { return isRelease() }
-            }
+        stage('Setup Maven config'){
             steps {
                 script {
-                    echo 'Setup Maven release config'
                     configFileProvider([configFile(fileId: maven.getSubmarineSettingsXmlId(), targetLocation: 'maven-settings.xml', variable: 'MAVEN_SETTINGS_FILE')]) {
-                        sh "echo '\n-Denforcer.skip=true' | tee -a optaplanner/.mvn/maven.config"
                         sh "echo '\n-B -s ${MAVEN_SETTINGS_FILE}' | tee -a optaplanner/.mvn/maven.config"
                         if (params.MAVEN_DEPENDENCIES_REPOSITORY != '') {
+                            sh "echo '\n-Denforcer.skip=true' | tee -a optaplanner/.mvn/maven.config"
                             sh "sed -i 's|<repositories>|<repositories><repository><id>staging</id><name>Staging Repository</name><url>${params.MAVEN_DEPENDENCIES_REPOSITORY}</url><layout>default</layout><snapshots><enabled>true</enabled></snapshots><releases><enabled>true</enabled></releases></repository>|g' ${MAVEN_SETTINGS_FILE}"
                             sh "sed -i 's|<pluginRepositories>|<pluginRepositories><pluginRepository><id>staging</id><name>Staging Repository</name><url>${params.MAVEN_DEPENDENCIES_REPOSITORY}</url><layout>default</layout><snapshots><enabled>true</enabled></snapshots><releases><enabled>true</enabled></releases></pluginRepository>|g' ${MAVEN_SETTINGS_FILE}"
                             sh "sed -i 's|external:\\*|external:*,!staging|g' ${MAVEN_SETTINGS_FILE}"

--- a/Jenkinsfile.deploy
+++ b/Jenkinsfile.deploy
@@ -94,14 +94,14 @@ pipeline {
             }
             steps {
                 echo 'Setup Maven release config'
-                configFileProvider([configFile(fileId: '9239af2e-46e3-4ba3-8dd6-1a814fc8a56d', targetLocation: 'maven-settings.xml', variable: 'MAVEN_SETTINGS_FILE')]){
+                configFileProvider([configFile(fileId: maven.getSubmarineSettingsXmlId(), targetLocation: 'maven-settings.xml', variable: 'MAVEN_SETTINGS_FILE')]){
                     sh "echo '-B -s ${MAVEN_SETTINGS_FILE}' | tee optaplanner/.mvn/maven.config"
                     // TODO: figure out why the assert does not work
                     // assert params.MAVEN_DEPENDENCIES_REPOSITORY != '' // OptaPlanner depends on Kogito Runtimes
                     echo "MAVEN_DEPENDENCIES_REPOSITORY passed: ${params.MAVEN_DEPENDENCIES_REPOSITORY}"
                     sh "sed -i 's|<repositories>|<repositories><repository><id>staging</id><name>Staging Repository</name><url>${params.MAVEN_DEPENDENCIES_REPOSITORY}</url><layout>default</layout><snapshots><enabled>true</enabled></snapshots><releases><enabled>true</enabled></releases></repository>|g' ${MAVEN_SETTINGS_FILE}"
                     sh "sed -i 's|<pluginRepositories>|<pluginRepositories><pluginRepository><id>staging</id><name>Staging Repository</name><url>${params.MAVEN_DEPENDENCIES_REPOSITORY}</url><layout>default</layout><snapshots><enabled>true</enabled></snapshots><releases><enabled>true</enabled></releases></pluginRepository>|g' ${MAVEN_SETTINGS_FILE}"
-                    sh "sed -i 's|external:\\*|external:*,!staging|g' ${MAVEN_SETTINGS_FILE}" // Done to allow Maven to download release artificats from MAVEN_DEPENDENCIES_REPOSITORY
+                    sh "sed -i 's|external:\\*|external:*,!staging|g' ${MAVEN_SETTINGS_FILE}" // Done to allow Maven to download release artifacts from MAVEN_DEPENDENCIES_REPOSITORY
 
                     echo 'Resulting maven settings.xml:'
                     sh "cat ${MAVEN_SETTINGS_FILE}"
@@ -246,7 +246,12 @@ void runMaven(String goals, String directory, boolean skipTests = false, List pr
         mvnCmd += " ${extraArgs}"
     }
     dir(directory) {
-        maven.runMavenWithSubmarineSettings(mvnCmd, skipTests)
+        if(isRelease()){
+            // In case of release, we already have the settings.xml
+            maven.runMaven(mvnCmd, skipTests, ['-fae'])
+        } else {
+            maven.runMavenWithSubmarineSettings(mvnCmd, skipTests)
+        }
     }
 }
 

--- a/Jenkinsfile.deploy
+++ b/Jenkinsfile.deploy
@@ -99,6 +99,7 @@ pipeline {
                     assert params.MAVEN_DEPENDENCIES_REPOSITORY != '' // OptaPlanner depends on Kogito Runtimes
                     sh "sed -i 's|<repository>|<repository><id>staging</id><name>Staging Repository</name><url>${params.MAVEN_DEPENDENCIES_REPOSITORY}</url><layout>default</layout><snapshots><enabled>true</enabled></snapshots><releases><enabled>true</enabled></releases></repository>\\n        <repository>|g' ${MAVEN_SETTINGS_FILE}"
                     sh "sed -i 's|<pluginRepository>|<pluginRepository><id>staging</id><name>Staging Repository</name><url>${params.MAVEN_DEPENDENCIES_REPOSITORY}</url><layout>default</layout><snapshots><enabled>true</enabled></snapshots><releases><enabled>true</enabled></releases></pluginRepository>\\n        <pluginRepository>|g' ${MAVEN_SETTINGS_FILE}"
+                    sh "sed -i 's|external:\\*|central|g' ${MAVEN_SETTINGS_FILE}" // Done to allow Maven to download release artifacts from MAVEN_DEPENDENCIES_REPOSITORY
                 }
             }
         }

--- a/Jenkinsfile.deploy
+++ b/Jenkinsfile.deploy
@@ -137,7 +137,7 @@ pipeline {
             }
             post {
                 always {
-                    saveReports()
+                    saveReports(params.SKIP_TESTS)
                 }
             }
         }

--- a/Jenkinsfile.deploy
+++ b/Jenkinsfile.deploy
@@ -69,6 +69,7 @@ pipeline {
                         setDeployPropertyIfNeeded('git.author', getGitAuthor())
                         setDeployPropertyIfNeeded('project.version', getProjectVersion())
                         setDeployPropertyIfNeeded('release', isRelease())
+                        setDeployPropertyIfNeeded('kogito.version', getKogitoVersion())
                     }
                 }
             }
@@ -97,15 +98,12 @@ pipeline {
                 echo 'Setup Maven release config'
                 configFileProvider([configFile(fileId: maven.getSubmarineSettingsXmlId(), targetLocation: 'maven-settings.xml', variable: 'MAVEN_SETTINGS_FILE')]){
                     sh "echo '-B -s ${MAVEN_SETTINGS_FILE}' | tee optaplanner/.mvn/maven.config"
-                    // TODO: figure out why the assert does not work
-                    // assert params.MAVEN_DEPENDENCIES_REPOSITORY != '' // OptaPlanner depends on Kogito Runtimes
-                    echo "MAVEN_DEPENDENCIES_REPOSITORY passed: ${params.MAVEN_DEPENDENCIES_REPOSITORY}"
-                    sh "sed -i 's|<repositories>|<repositories><repository><id>staging</id><name>Staging Repository</name><url>${params.MAVEN_DEPENDENCIES_REPOSITORY}</url><layout>default</layout><snapshots><enabled>true</enabled></snapshots><releases><enabled>true</enabled></releases></repository>|g' ${MAVEN_SETTINGS_FILE}"
-                    sh "sed -i 's|<pluginRepositories>|<pluginRepositories><pluginRepository><id>staging</id><name>Staging Repository</name><url>${params.MAVEN_DEPENDENCIES_REPOSITORY}</url><layout>default</layout><snapshots><enabled>true</enabled></snapshots><releases><enabled>true</enabled></releases></pluginRepository>|g' ${MAVEN_SETTINGS_FILE}"
-                    sh "sed -i 's|external:\\*|external:*,!staging|g' ${MAVEN_SETTINGS_FILE}" // Done to allow Maven to download release artifacts from MAVEN_DEPENDENCIES_REPOSITORY
 
-                    echo 'Resulting maven settings.xml:'
-                    sh "cat ${MAVEN_SETTINGS_FILE}"
+                    if (params.MAVEN_DEPENDENCIES_REPOSITORY != '') {
+                        sh "sed -i 's|<repositories>|<repositories><repository><id>staging</id><name>Staging Repository</name><url>${params.MAVEN_DEPENDENCIES_REPOSITORY}</url><layout>default</layout><snapshots><enabled>true</enabled></snapshots><releases><enabled>true</enabled></releases></repository>|g' ${MAVEN_SETTINGS_FILE}"
+                        sh "sed -i 's|<pluginRepositories>|<pluginRepositories><pluginRepository><id>staging</id><name>Staging Repository</name><url>${params.MAVEN_DEPENDENCIES_REPOSITORY}</url><layout>default</layout><snapshots><enabled>true</enabled></snapshots><releases><enabled>true</enabled></releases></pluginRepository>|g' ${MAVEN_SETTINGS_FILE}"
+                        sh "sed -i 's|external:\\*|external:*,!staging|g' ${MAVEN_SETTINGS_FILE}" // Done to allow Maven to download release artifacts from MAVEN_DEPENDENCIES_REPOSITORY
+                    }
                 }
             }
         }

--- a/Jenkinsfile.deploy
+++ b/Jenkinsfile.deploy
@@ -95,14 +95,17 @@ pipeline {
                 expression { return isRelease() }
             }
             steps {
-                echo 'Setup Maven release config'
-                configFileProvider([configFile(fileId: maven.getSubmarineSettingsXmlId(), targetLocation: 'maven-settings.xml', variable: 'MAVEN_SETTINGS_FILE')]){
-                    sh "echo '-B -s ${MAVEN_SETTINGS_FILE}' | tee optaplanner/.mvn/maven.config"
+                script {
+                    echo 'Setup Maven release config'
+                    configFileProvider([configFile(fileId: maven.getSubmarineSettingsXmlId(), targetLocation: 'maven-settings.xml', variable: 'MAVEN_SETTINGS_FILE')]) {
+                        sh "echo '-B -s ${MAVEN_SETTINGS_FILE}' | tee optaplanner/.mvn/maven.config"
 
-                    if (params.MAVEN_DEPENDENCIES_REPOSITORY != '') {
-                        sh "sed -i 's|<repositories>|<repositories><repository><id>staging</id><name>Staging Repository</name><url>${params.MAVEN_DEPENDENCIES_REPOSITORY}</url><layout>default</layout><snapshots><enabled>true</enabled></snapshots><releases><enabled>true</enabled></releases></repository>|g' ${MAVEN_SETTINGS_FILE}"
-                        sh "sed -i 's|<pluginRepositories>|<pluginRepositories><pluginRepository><id>staging</id><name>Staging Repository</name><url>${params.MAVEN_DEPENDENCIES_REPOSITORY}</url><layout>default</layout><snapshots><enabled>true</enabled></snapshots><releases><enabled>true</enabled></releases></pluginRepository>|g' ${MAVEN_SETTINGS_FILE}"
-                        sh "sed -i 's|external:\\*|external:*,!staging|g' ${MAVEN_SETTINGS_FILE}" // Done to allow Maven to download release artifacts from MAVEN_DEPENDENCIES_REPOSITORY
+                        if (params.MAVEN_DEPENDENCIES_REPOSITORY != '') {
+                            sh "sed -i 's|<repositories>|<repositories><repository><id>staging</id><name>Staging Repository</name><url>${params.MAVEN_DEPENDENCIES_REPOSITORY}</url><layout>default</layout><snapshots><enabled>true</enabled></snapshots><releases><enabled>true</enabled></releases></repository>|g' ${MAVEN_SETTINGS_FILE}"
+                            sh "sed -i 's|<pluginRepositories>|<pluginRepositories><pluginRepository><id>staging</id><name>Staging Repository</name><url>${params.MAVEN_DEPENDENCIES_REPOSITORY}</url><layout>default</layout><snapshots><enabled>true</enabled></snapshots><releases><enabled>true</enabled></releases></pluginRepository>|g' ${MAVEN_SETTINGS_FILE}"
+                            sh "sed -i 's|external:\\*|external:*,!staging|g' ${MAVEN_SETTINGS_FILE}"
+                            // Done to allow Maven to download release artifacts from MAVEN_DEPENDENCIES_REPOSITORY
+                        }
                     }
                 }
             }

--- a/Jenkinsfile.promote
+++ b/Jenkinsfile.promote
@@ -280,7 +280,7 @@ void installGithubCLI() {
 }
 
 void updateKogitoVersion(String newVersion) {
-    sh "mvn versions:update-property -Dproperty=version.org.kie.kogito -DnewVersion=[$newVersion] -DallowSnapshots=true -DgenerateBackupPoms=false"
+    sh "mvn versions:set-property -Dproperty=version.org.kie.kogito -DnewVersion=$newVersion -DallowSnapshots=true -DgenerateBackupPoms=false"
 }
 
 // TODO: move to shared libraries

--- a/Jenkinsfile.promote
+++ b/Jenkinsfile.promote
@@ -96,16 +96,8 @@ pipeline {
                     dir('optaplanner-bot') {
                         prepareForPR('optaplanner')
 
-                        // To make sure that the project will resolve during version upgrade.
-                        sh 'mvn -B -U clean install -DskipTests'
                         maven.mvnVersionsSet(getNextSnapshotVersion(getProjectVersion()), true)
                         updateKogitoVersion(getNextSnapshotVersion(getKogitoVersion()))
-
-                        /*
-                            Install optaplanner artifacts to a local maven repository to make them accessible
-                            for optaplanner-quickstarts and optaweb apps.
-                        */
-                        sh 'mvn -B clean install -DskipTests'
 
                         commitAndCreatePR('optaplanner')
                     }

--- a/Jenkinsfile.promote
+++ b/Jenkinsfile.promote
@@ -168,9 +168,7 @@ String getKogitoVersion() {
 }
 
 String getNextSnapshotVersion(String currentVersion) {
-    Integer [] versionParts = majorMinorMicroOf(currentVersion)
-    String majorMinorMicroVersion = "${versionParts[0]}.${versionParts[1]}.${versionParts[2]}"
-    return util.getNextVersion(majorMinorMicroVersion, 'micro')
+    return util.getNextVersion(currentVersion, 'micro')
 }
 
 String getGitTag() {
@@ -281,11 +279,4 @@ void installGithubCLI() {
 
 void updateKogitoVersion(String newVersion) {
     sh "mvn versions:set-property -Dproperty=version.org.kie.kogito -DnewVersion=$newVersion -DallowSnapshots=true -DgenerateBackupPoms=false"
-}
-
-// TODO: move to shared libraries
-Integer[] majorMinorMicroOf(String version) {
-    String[] versionParts = version.split("\\.")
-    return versionParts.length == 4 ? util.parseVersion("${versionParts[0]}.${versionParts[1]}.${versionParts[2]}")
-            : util.parseVersion(version)
 }

--- a/Jenkinsfile.promote
+++ b/Jenkinsfile.promote
@@ -36,18 +36,18 @@ pipeline {
 
         string(name: 'STAGING_REPO_URL', defaultValue: '', description: 'Override `deployment.properties`.')
         string(name: 'GIT_TAG', defaultValue: '', description: 'Git tag to set, if different from PROJECT_VERSION')
-        booleanParam(name: 'UPDATE_STABLE_BRANCH', defaultValue: false, description: 'Set to true if you want to update the `stable` branch to new created Git tag.')
+
+        // Bot author information. Set as params for easy testing.
+        string(name: 'BOT_CREDENTIALS_ID', defaultValue: 'bsig-gh-bot', description: 'Credentials for PR creation')
+
+        // Main author creds
+        string(name: 'AUTHOR_CREDS_ID', defaultValue: 'kie-ci', description: 'Credentials for PR merge')
+        string(name: 'GITHUB_TOKEN_CREDS_ID', defaultValue: 'kie-ci2-token', description: 'GH token to be used with GH CLI')
     }
 
     environment {
         PROPERTIES_FILE_NAME = 'deployment.properties'
-        
-        AUTHOR_CREDS_ID = 'kie-ci'
-        GITHUB_TOKEN_CREDS_ID = 'kie-ci2-token'
-        BOT_CREDENTIALS_ID = 'bsig-gh-bot'
-
         BOT_BRANCH_HASH = "${util.generateHash(10)}"
-        
         GITHUB_CLI_VERSION = '0.11.1'
     }
 
@@ -71,25 +71,7 @@ pipeline {
                 }
             }
         }
-
-        // TODO: remove when the manual step has moved to the top-level release pipeline
-        stage('Is staging repository promoted?') {
-            when {
-                expression { return isRelease() && getStagingRepoUrl() != '' }
-            }
-            steps {
-                script {
-                    withCredentials([string(credentialsId: 'KOGITO_CI_EMAIL_TO', variable: 'ZULIP_EMAIL')]) {
-                        emailext body: "${getProjectVersion()} artifacts are ready for promotion.\n" +
-                                 "The staging repository can be found at: ${getStagingRepoUrl()}\n" +
-                                 "Please promote the repository and then confirm the promotion here: ${env.BUILD_URL}input",
-                                 subject: "[${getBuildBranch()}] Release Pipeline",
-                                 to: ZULIP_EMAIL
-                    }
-                    input message: 'Has the staging repository been promoted?', ok: 'Yes'
-                }
-            }
-        }
+        //TODO: check branches!!!
         stage('Merge OptaPlanner deploy PR and tag') {
             when {
                 expression { return isRelease() }
@@ -209,6 +191,14 @@ String getGitAuthor() {
     return getParamOrDeployProperty('GIT_AUTHOR', 'git.author')
 }
 
+String getGitAuthorCredsID(){
+    return params.AUTHOR_CREDS_ID
+}
+
+String getBotAuthorCredsID(){
+    return params.BOT_CREDENTIALS_ID
+}
+
 String getStagingRepoUrl(){
     return getParamOrDeployProperty('STAGING_REPO_URL', 'staging-repo.url')
 }
@@ -242,21 +232,21 @@ void checkoutRepo(String repo) {
 
 void mergeAndPush(String repo, String prLink) {
     if (prLink != '') {
-        githubscm.mergePR(prLink, env.AUTHOR_CREDS_ID)
-        githubscm.pushObject('origin', getBuildBranch(), env.AUTHOR_CREDS_ID)
+        githubscm.mergePR(prLink, getGitAuthorCredsID())
+        githubscm.pushObject('origin', getBuildBranch(), getGitAuthorCredsID())
     }
 }
 
 void tagLatest() {
     if (getGitTag() != '') {
         githubscm.tagRepository(getGitTag(), env.BUILD_TAG)
-        githubscm.pushObject('origin', "--tags ${getGitTag()}", env.AUTHOR_CREDS_ID)
+        githubscm.pushObject('origin', "--tags ${getGitTag()}", getGitAuthorCredsID())
     }
 }
 
 void prepareForPR(String repo) {
     checkoutRepo(repo)
-    githubscm.forkRepo(env.BOT_CREDENTIALS_ID)
+    githubscm.forkRepo(getBotAuthorCredsID())
     githubscm.createBranch(getSnapshotBranch())
 }
 
@@ -282,8 +272,8 @@ void commitAndCreatePR(String repo) {
     // See: https://github.com/kiegroup/kogito-runtimes/pull/570#discussion_r449268738
     addNotIgnoredPoms()
     sh "git commit -m '${commitMsg}'"
-    githubscm.pushObject('origin', getSnapshotBranch(), env.BOT_CREDENTIALS_ID)
-    setPipelinePrLink(repo, githubscm.createPR(commitMsg, prBody, getBuildBranch(), env.BOT_CREDENTIALS_ID))
+    githubscm.pushObject('origin', getSnapshotBranch(), getBotAuthorCredsID())
+    setPipelinePrLink(repo, githubscm.createPR(commitMsg, prBody, getBuildBranch(), getBotAuthorCredsID()))
 }
 
 void installGithubCLI() {

--- a/Jenkinsfile.promote
+++ b/Jenkinsfile.promote
@@ -1,0 +1,300 @@
+import org.jenkinsci.plugins.workflow.libs.Library
+@Library('jenkins-pipeline-shared-libraries')_
+
+deployProperties = [:]
+pipelineProperties = [:]
+
+pipeline {
+    agent {
+        label 'kie-rhel7'
+    }
+
+    tools {
+        maven 'kie-maven-3.6.2'
+        jdk 'kie-jdk11'
+    }
+    
+    options {
+        buildDiscarder logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '10')
+    }
+
+    parameters {
+        string(name: 'DISPLAY_NAME', defaultValue: '', description: 'Setup a specific build display name')
+        
+        // Deploy job url to retrieve deployment.properties
+        string(name: 'DEPLOY_BUILD_URL', defaultValue: '', description: 'URL to jenkins deploy build to retrieve the `deployment.properties` file. If base parameters are defined, they will override the `deployment.properties` information')
+        
+        // Git information which can override `deployment.properties`
+        string(name: 'BUILD_BRANCH_NAME', defaultValue: '', description: 'Override `deployment.properties`. Which branch to build? Set if you are not on a multibranch pipeline.')
+        string(name: 'GIT_AUTHOR', defaultValue: '', description: 'Override `deployment.properties`. Which Git author repository ?')
+        
+        // Release information which can override `deployment.properties`
+        booleanParam(name: 'RELEASE', defaultValue: false, description: 'Override `deployment.properties`. Is this build for a release?')
+
+        string(name: 'PROJECT_VERSION', defaultValue: '', description: 'Override `deployment.properties`. Optional if not RELEASE. If RELEASE, cannot be empty.')
+        string(name: 'KOGITO_VERSION', defaultValue: '', description: 'Optional if not RELEASE. If RELEASE, cannot be empty.')
+
+        string(name: 'STAGING_REPO_URL', defaultValue: '', description: 'Override `deployment.properties`.')
+        string(name: 'GIT_TAG', defaultValue: '', description: 'Git tag to set, if different from PROJECT_VERSION')
+        booleanParam(name: 'UPDATE_STABLE_BRANCH', defaultValue: false, description: 'Set to true if you want to update the `stable` branch to new created Git tag.')
+    }
+
+    environment {
+        PROPERTIES_FILE_NAME = 'deployment.properties'
+        
+        AUTHOR_CREDS_ID = 'kie-ci'
+        GITHUB_TOKEN_CREDS_ID = 'kie-ci2-token'
+        BOT_CREDENTIALS_ID = 'bsig-gh-bot'
+
+        BOT_BRANCH_HASH = "${util.generateHash(10)}"
+        
+        GITHUB_CLI_VERSION = '0.11.1'
+    }
+
+    stages {
+        stage('Initialization') {
+            steps {
+                script {
+                    cleanWs()
+                    
+                    if (params.DISPLAY_NAME != '') {
+                        currentBuild.displayName = params.DISPLAY_NAME
+                    }
+
+                    readDeployProperties()
+
+                    if (isRelease()) {
+                        assert getProjectVersion() != ''
+                    }
+
+                    installGithubCLI()
+                }
+            }
+        }
+
+        // TODO: remove when the manual step has moved to the top-level release pipeline
+        stage('Is staging repository promoted?') {
+            when {
+                expression { return isRelease() && getStagingRepoUrl() != '' }
+            }
+            steps {
+                script {
+                    withCredentials([string(credentialsId: 'KOGITO_CI_EMAIL_TO', variable: 'ZULIP_EMAIL')]) {
+                        emailext body: "${getProjectVersion()} artifacts are ready for promotion.\n" +
+                                 "The staging repository can be found at: ${getStagingRepoUrl()}\n" +
+                                 "Please promote the repository and then confirm the promotion here: ${env.BUILD_URL}input",
+                                 subject: "[${getBuildBranch()}] Release Pipeline",
+                                 to: ZULIP_EMAIL
+                    }
+                    input message: 'Has the staging repository been promoted?', ok: 'Yes'
+                }
+            }
+        }
+        stage('Merge OptaPlanner deploy PR and tag') {
+            when {
+                expression { return isRelease() }
+            }
+            steps{
+                script {
+                    dir('optaplanner') {
+                        checkoutRepo('optaplanner')
+                        mergeAndPush('optaplanner', getDeployPrLink('optaplanner'))
+                        tagLatest()
+                    }
+                }
+            }
+        }
+
+        stage('Set OptaPlanner next snapshot version'){
+            when {
+                expression { return isRelease() }
+            }
+            steps {
+                script {
+                    dir('optaplanner-bot') {
+                        prepareForPR('optaplanner')
+
+                        // To make sure that the project will resolve during version upgrade.
+                        sh 'mvn -B -U clean install -DskipTests'
+                        maven.mvnVersionsSet(getNextSnapshotVersion(getProjectVersion()), true)
+                        updateKogitoVersion(getNextSnapshotVersion(getKogitoVersion()))
+
+                        /*
+                            Install optaplanner artifacts to a local maven repository to make them accessible
+                            for optaplanner-quickstarts and optaweb apps.
+                        */
+                        sh 'mvn -B clean install -DskipTests'
+
+                        commitAndCreatePR('optaplanner')
+                    }
+                    dir('optaplanner') {
+                        sh "git checkout ${getBuildBranch()}"
+                        mergeAndPush('optaplanner', getPipelinePrLink('optaplanner'))
+                    }
+                }
+            }
+        }
+    }
+    post {
+        always {
+            cleanWs()
+        }
+    }
+}
+
+//////////////////////////////////////////////////////////////////////////////
+// Deployment properties
+//////////////////////////////////////////////////////////////////////////////
+
+void readDeployProperties(){
+    String deployUrl = params.DEPLOY_BUILD_URL
+    if (deployUrl != ''){
+        if(!deployUrl.endsWith('/')){
+            deployUrl += '/'
+        }
+        sh "wget ${deployUrl}artifact/${PROPERTIES_FILE_NAME} -O ${PROPERTIES_FILE_NAME}"
+        deployProperties = readProperties file: PROPERTIES_FILE_NAME
+        // echo all properties
+        echo deployProperties.collect{ entry -> "${entry.key}=${entry.value}" }.join('\n')
+    }
+}
+
+boolean hasDeployProperty(String key){
+    return deployProperties[key] != null
+}
+
+String getDeployProperty(String key){
+    if(hasDeployProperty(key)){
+        return deployProperties[key]
+    }
+    return ''
+}
+
+String getParamOrDeployProperty(String paramKey, String deployPropertyKey){
+    if (params[paramKey] != ''){
+        return params[paramKey]
+    }
+    return getDeployProperty(deployPropertyKey)
+}
+
+//////////////////////////////////////////////////////////////////////////////
+// Getter / Setter
+//////////////////////////////////////////////////////////////////////////////
+
+boolean isRelease() {
+    return params.RELEASE || (getDeployProperty('release') == 'true')
+}
+
+String getProjectVersion() {
+    return getParamOrDeployProperty('PROJECT_VERSION', 'project.version')
+}
+
+String getKogitoVersion() {
+    return getParamOrDeployProperty('KOGITO_VERSION', 'kogito.version')
+}
+
+String getNextSnapshotVersion(String currentVersion) {
+    return util.getNextVersion(currentVersion, 'micro')
+}
+
+String getGitTag() {
+    return params.GIT_TAG != '' ? params.GIT_TAG : getProjectVersion()
+}
+
+String getBuildBranch() {
+    return getParamOrDeployProperty('BUILD_BRANCH_NAME', 'git.branch')
+}
+
+String getGitAuthor() {
+    return getParamOrDeployProperty('GIT_AUTHOR', 'git.author')
+}
+
+String getStagingRepoUrl(){
+    return getParamOrDeployProperty('STAGING_REPO_URL', 'staging-repo.url')
+}
+
+String getDeployPrLink(String repo){
+    return getDeployProperty("${repo}.pr.link")
+}
+
+String getPipelinePrLink(String repo){
+    return pipelineProperties["${repo}.pr.link"]
+}
+
+void setPipelinePrLink(String repo, String value){
+    pipelineProperties["${repo}.pr.link"] = value
+}
+
+String getSnapshotBranch(){
+    return "${getNextSnapshotVersion(getProjectVersion()).toLowerCase()}-${env.BOT_BRANCH_HASH}"
+}
+
+//////////////////////////////////////////////////////////////////////////////
+// Git
+//////////////////////////////////////////////////////////////////////////////
+
+void checkoutRepo(String repo) {
+    deleteDir()
+    checkout(githubscm.resolveRepository(repo, getGitAuthor(), getBuildBranch(), false))
+    // need to manually checkout branch since on a detached branch after checkout command
+    sh "git checkout ${getBuildBranch()}"
+}
+
+void mergeAndPush(String repo, String prLink) {
+    if (prLink != '') {
+        githubscm.mergePR(prLink, env.AUTHOR_CREDS_ID)
+        githubscm.pushObject('origin', getBuildBranch(), env.AUTHOR_CREDS_ID)
+    }
+}
+
+void tagLatest() {
+    if (getGitTag() != '') {
+        githubscm.tagRepository(getGitTag(), env.BUILD_TAG)
+        githubscm.pushObject('origin', "--tags ${getGitTag()}", env.AUTHOR_CREDS_ID)
+    }
+}
+
+void prepareForPR(String repo) {
+    checkoutRepo(repo)
+    githubscm.forkRepo(env.BOT_CREDENTIALS_ID)
+    githubscm.createBranch(getSnapshotBranch())
+}
+
+void addNotIgnoredPoms() {
+    // based on https://stackoverflow.com/a/59888964/8811872
+    sh '''
+    find . -type f -name 'pom.xml' > found_poms.txt
+    poms_to_add=""
+    while IFS= read -r pom; do
+        if ! git check-ignore -q "\$pom"; then
+            poms_to_add="\$poms_to_add \$pom"
+        fi
+    done < found_poms.txt
+    rm found_poms.txt
+    git add \$poms_to_add
+    '''
+}
+
+void commitAndCreatePR(String repo) {
+    def commitMsg = "Update snapshot version to ${getSnapshotBranch()}"
+    def prBody = "Generated by build ${BUILD_TAG}: ${BUILD_URL}"
+    // Not using githubscm.commitChanges() because globbing won't work.
+    // See: https://github.com/kiegroup/kogito-runtimes/pull/570#discussion_r449268738
+    addNotIgnoredPoms()
+    sh "git commit -m '${commitMsg}'"
+    githubscm.pushObject('origin', getSnapshotBranch(), env.BOT_CREDENTIALS_ID)
+    setPipelinePrLink(repo, githubscm.createPR(commitMsg, prBody, getBuildBranch(), env.BOT_CREDENTIALS_ID))
+}
+
+void installGithubCLI() {
+    sh """
+    wget https://github.com/cli/cli/releases/download/v${env.GITHUB_CLI_VERSION}/gh_${env.GITHUB_CLI_VERSION}_linux_amd64.tar.gz
+    tar xzf gh_${env.GITHUB_CLI_VERSION}_linux_amd64.tar.gz
+    mv gh_${env.GITHUB_CLI_VERSION}_linux_amd64/bin/gh .
+    rm -r gh_${env.GITHUB_CLI_VERSION}_linux_amd64*
+    """
+}
+
+void updateKogitoVersion(String newVersion) {
+    sh "mvn versions:update-property -Dproperty=version.org.kie.kogito -DnewVersion=[$newVersion] -DallowSnapshots=true -DgenerateBackupPoms=false"
+}

--- a/Jenkinsfile.promote
+++ b/Jenkinsfile.promote
@@ -176,7 +176,9 @@ String getKogitoVersion() {
 }
 
 String getNextSnapshotVersion(String currentVersion) {
-    return util.getNextVersion(currentVersion, 'micro')
+    Integer [] versionParts = majorMinorMicroOf(currentVersion)
+    String majorMinorMicroVersion = "${versionParts[0]}.${versionParts[1]}.${versionParts[2]}"
+    return util.getNextVersion(majorMinorMicroVersion, 'micro')
 }
 
 String getGitTag() {
@@ -287,4 +289,11 @@ void installGithubCLI() {
 
 void updateKogitoVersion(String newVersion) {
     sh "mvn versions:update-property -Dproperty=version.org.kie.kogito -DnewVersion=[$newVersion] -DallowSnapshots=true -DgenerateBackupPoms=false"
+}
+
+// TODO: move to shared libraries
+Integer[] majorMinorMicroOf(String version) {
+    String[] versionParts = version.split("\\.")
+    return versionParts.length == 4 ? util.parseVersion("${versionParts[0]}.${versionParts[1]}.${versionParts[2]}")
+            : util.parseVersion(version)
 }

--- a/Jenkinsfile.promote
+++ b/Jenkinsfile.promote
@@ -65,6 +65,7 @@ pipeline {
 
                     if (isRelease()) {
                         assert getProjectVersion() != ''
+                        assert getKogitoVersion() != ''
                     }
 
                     installGithubCLI()
@@ -278,5 +279,5 @@ void installGithubCLI() {
 }
 
 void updateKogitoVersion(String newVersion) {
-    sh "mvn versions:set-property -Dproperty=version.org.kie.kogito -DnewVersion=$newVersion -DallowSnapshots=true -DgenerateBackupPoms=false"
+    maven.mvnSetVersionProperty('version.org.kie.kogito', newVersion)
 }

--- a/Jenkinsfile.promote
+++ b/Jenkinsfile.promote
@@ -27,6 +27,10 @@ pipeline {
         // Git information which can override `deployment.properties`
         string(name: 'BUILD_BRANCH_NAME', defaultValue: '', description: 'Override `deployment.properties`. Which branch to build? Set if you are not on a multibranch pipeline.')
         string(name: 'GIT_AUTHOR', defaultValue: '', description: 'Override `deployment.properties`. Which Git author repository ?')
+
+        // Build&Deploy information for next snapshots
+        string(name: 'MAVEN_DEPENDENCIES_REPOSITORY', defaultValue: '', description: 'Maven repository where to find dependencies if those are not in the default Jboss repository.')
+        string(name: 'MAVEN_DEPLOY_REPOSITORY', defaultValue: '', description: 'Specify a Maven repository to deploy the artifacts.')
         
         // Release information which can override `deployment.properties`
         booleanParam(name: 'RELEASE', defaultValue: false, description: 'Override `deployment.properties`. Is this build for a release?')
@@ -96,7 +100,7 @@ pipeline {
                 script {
                     dir('optaplanner-bot') {
                         prepareForPR('optaplanner')
-
+                        setupMavenConfig()
                         maven.mvnVersionsSet(getNextSnapshotVersion(getProjectVersion()), true)
                         updateKogitoVersion(getNextSnapshotVersion(getKogitoVersion()))
 
@@ -105,6 +109,8 @@ pipeline {
                     dir('optaplanner') {
                         sh "git checkout ${getBuildBranch()}"
                         mergeAndPush('optaplanner', getPipelinePrLink('optaplanner'))
+                        setupMavenConfig()
+                        deployArtifacts()
                     }
                 }
             }
@@ -280,4 +286,34 @@ void installGithubCLI() {
 
 void updateKogitoVersion(String newVersion) {
     maven.mvnSetVersionProperty('version.org.kie.kogito', newVersion)
+}
+
+void setupMavenConfig() {
+    if (isSpecificMavenConfig()) {
+        echo 'Setup Maven release config'
+        configFileProvider([configFile(fileId: maven.getSubmarineSettingsXmlId(), targetLocation: 'maven-settings.xml', variable: 'MAVEN_SETTINGS_FILE')]){
+            sh "echo '\n-Denforcer.skip=true' | tee -a .mvn/maven.config"
+            sh "echo '\n-B -s ${MAVEN_SETTINGS_FILE}' | tee -a .mvn/maven.config"
+            sh "sed -i 's|<repositories>|<repositories><repository><id>staging</id><name>Staging Repository</name><url>${params.MAVEN_DEPENDENCIES_REPOSITORY}</url><layout>default</layout><snapshots><enabled>true</enabled></snapshots><releases><enabled>true</enabled></releases></repository>|g' ${MAVEN_SETTINGS_FILE}"
+            sh "sed -i 's|<pluginRepositories>|<pluginRepositories><pluginRepository><id>staging</id><name>Staging Repository</name><url>${params.MAVEN_DEPENDENCIES_REPOSITORY}</url><layout>default</layout><snapshots><enabled>true</enabled></snapshots><releases><enabled>true</enabled></releases></pluginRepository>|g' ${MAVEN_SETTINGS_FILE}"
+            sh "sed -i 's|external:\\*|external:*,!staging|g' ${MAVEN_SETTINGS_FILE}" // Done to allow Maven to download release artifacts from MAVEN_DEPENDENCIES_REPOSITORY
+        }
+    }
+}
+
+boolean isSpecificMavenConfig() {
+    return params.MAVEN_DEPENDENCIES_REPOSITORY != ''
+}
+
+void deployArtifacts() {
+    def mvnCmd = 'clean deploy'
+    if (params.MAVEN_DEPLOY_REPOSITORY) {
+        mvnCmd += " -DaltDeploymentRepository=runtimes-artifacts::default::${params.MAVEN_DEPLOY_REPOSITORY} -Denforcer.skip=true"
+    }
+
+    if (isSpecificMavenConfig()) {
+        maven.runMaven(mvnCmd, true)
+    } else {
+        maven.runMavenWithSubmarineSettings(mvnCmd, true)
+    }
 }

--- a/Jenkinsfile.promote
+++ b/Jenkinsfile.promote
@@ -71,7 +71,7 @@ pipeline {
                 }
             }
         }
-        //TODO: check branches!!!
+
         stage('Merge OptaPlanner deploy PR and tag') {
             when {
                 expression { return isRelease() }

--- a/optaplanner-build-parent/pom.xml
+++ b/optaplanner-build-parent/pom.xml
@@ -56,6 +56,7 @@
     <!-- The first version that supports analysis of classes compiled by Java 11. -->
     <version.dependency.plugin>3.1.2</version.dependency.plugin>
     <version.surefire.plugin>2.22.2</version.surefire.plugin>
+    <version.versions.plugin>2.8.1</version.versions.plugin>
     <!-- This property needs to be defined in all modules that use the packaging 'jar'.
          It is used by different plugins to make sure the module/bundle names are consistent. -->
     <java.module.name/>
@@ -899,6 +900,11 @@
               </transformSchema>
             </transformSchemas>
           </configuration>
+        </plugin>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>versions-maven-plugin</artifactId>
+          <version>${version.versions.plugin}</version>
         </plugin>
       </plugins>
     </pluginManagement>

--- a/optaplanner-build-parent/pom.xml
+++ b/optaplanner-build-parent/pom.xml
@@ -940,33 +940,7 @@
           </execution>
         </executions>
       </plugin>
-      <plugin>
-        <artifactId>maven-enforcer-plugin</artifactId>
-        <!--        <executions>-->
-        <!--          <execution>-->
-        <!--            <id>ban-duplicated-classes</id>-->
-        <!--            <goals>-->
-        <!--              <goal>enforce</goal>-->
-        <!--            </goals>-->
-        <!--            <configuration>-->
-        <!--              <rules>-->
-        <!--                <banDuplicateClasses>-->
-        <!--                  <dependencies combine.children="append">-->
-        <!--                    &lt;!&ndash; sundr-codegen is required to compile test classes. &ndash;&gt;-->
-        <!--                    <dependency>-->
-        <!--                      <groupId>io.sundr</groupId>-->
-        <!--                      <artifactId>sundr-codegen</artifactId>-->
-        <!--                      <ignoreClasses>-->
-        <!--                        <ignoreClass>*</ignoreClass>-->
-        <!--                      </ignoreClasses>-->
-        <!--                    </dependency>-->
-        <!--                  </dependencies>-->
-        <!--                </banDuplicateClasses>-->
-        <!--              </rules>-->
-        <!--            </configuration>-->
-        <!--          </execution>-->
-        <!--        </executions>-->
-      </plugin>
+
       <plugin>
         <!-- Entry needed to provide parsed version properties -->
         <!-- also adds generated sources to -source artifact -->

--- a/optaplanner-build-parent/pom.xml
+++ b/optaplanner-build-parent/pom.xml
@@ -940,7 +940,33 @@
           </execution>
         </executions>
       </plugin>
-
+      <plugin>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <!--        <executions>-->
+        <!--          <execution>-->
+        <!--            <id>ban-duplicated-classes</id>-->
+        <!--            <goals>-->
+        <!--              <goal>enforce</goal>-->
+        <!--            </goals>-->
+        <!--            <configuration>-->
+        <!--              <rules>-->
+        <!--                <banDuplicateClasses>-->
+        <!--                  <dependencies combine.children="append">-->
+        <!--                    &lt;!&ndash; sundr-codegen is required to compile test classes. &ndash;&gt;-->
+        <!--                    <dependency>-->
+        <!--                      <groupId>io.sundr</groupId>-->
+        <!--                      <artifactId>sundr-codegen</artifactId>-->
+        <!--                      <ignoreClasses>-->
+        <!--                        <ignoreClass>*</ignoreClass>-->
+        <!--                      </ignoreClasses>-->
+        <!--                    </dependency>-->
+        <!--                  </dependencies>-->
+        <!--                </banDuplicateClasses>-->
+        <!--              </rules>-->
+        <!--            </configuration>-->
+        <!--          </execution>-->
+        <!--        </executions>-->
+      </plugin>
       <plugin>
         <!-- Entry needed to provide parsed version properties -->
         <!-- also adds generated sources to -source artifact -->

--- a/pom.xml
+++ b/pom.xml
@@ -34,8 +34,6 @@
   </licenses>
 
   <properties>
-    <!-- TODO: remove before merging -->
-    <enforcer.skip>true</enforcer.skip>
     <!-- override the default GroupId:ArtifactId to map both master branch and 7.x branches to the same SonarCloud project -->
     <sonar.projectKey>org.optaplanner:optaplanner</sonar.projectKey>
     <sonar.moduleKey>${project.groupId}:${project.artifactId}</sonar.moduleKey>

--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,8 @@
   </licenses>
 
   <properties>
+    <!-- TODO: remove before merging -->
+    <enforcer.skip>true</enforcer.skip>
     <!-- override the default GroupId:ArtifactId to map both master branch and 7.x branches to the same SonarCloud project -->
     <sonar.projectKey>org.optaplanner:optaplanner</sonar.projectKey>
     <sonar.moduleKey>${project.groupId}:${project.artifactId}</sonar.moduleKey>


### PR DESCRIPTION
<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.
-->

### JIRA

<!-- Add a JIRA ticket link if it exists. -->
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->

https://issues.redhat.com/browse/PLANNER-2142

### Referenced pull requests
https://github.com/kiegroup/kogito-pipelines/pull/69
https://github.com/kiegroup/kogito-examples/pull/402

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
* https://github.com/kiegroup/drools/pull/3000
* https://github.com/kiegroup/optaplanner/pull/899
* etc.
-->

### Checklist
- [x] Documentation updated if applicable.
- [x] Upgrade recipe provided if applicable.

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>full downstream build</b> please add comment: <b>Jenkins run fdb</b>
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
