### PR TITLE
PLANNER-2212 Minimize the occurrence of match weight exceptions

### DIFF
--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/buildin/bendable/BendableScoreHolderImpl.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/buildin/bendable/BendableScoreHolderImpl.java
@@ -196,7 +196,7 @@ public final class BendableScoreHolderImpl extends AbstractScoreHolder<BendableS
         throw new UnsupportedOperationException("In the rule (" + kcontext.getRule().getName()
                 + "), the scoreHolder class (" + getClass()
                 + ") does not support a long weightMultiplier (" + weightMultiplier + ").\n"
-                + "If you're using constraint streams, maybe switch from penalizeLong() to penalize()?");
+                + "If you're using constraint streams, maybe switch from penalizeLong() to penalize().");
     }
 
     @Override
@@ -204,7 +204,7 @@ public final class BendableScoreHolderImpl extends AbstractScoreHolder<BendableS
         throw new UnsupportedOperationException("In the rule (" + kcontext.getRule().getName()
                 + "), the scoreHolder class (" + getClass()
                 + ") does not support a BigDecimal weightMultiplier (" + weightMultiplier + ").\n"
-                + "If you're using constraint streams, maybe switch from penalizeBigDecimal() to penalize()?");
+                + "If you're using constraint streams, maybe switch from penalizeBigDecimal() to penalize().");
     }
 
     private void impactScore(RuleContext kcontext, int[] hardWeightsMultiplier, int[] softWeightsMultiplier) {

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/buildin/bendable/BendableScoreHolderImpl.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/buildin/bendable/BendableScoreHolderImpl.java
@@ -16,6 +16,7 @@
 
 package org.optaplanner.core.impl.score.buildin.bendable;
 
+import java.math.BigDecimal;
 import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -188,6 +189,22 @@ public final class BendableScoreHolderImpl extends AbstractScoreHolder<BendableS
                     + ConstraintConfiguration.class.getSimpleName() + " annotated class.");
         }
         matchExecutor.accept(kcontext, weightMultiplier);
+    }
+
+    @Override
+    public void impactScore(RuleContext kcontext, long weightMultiplier) {
+        throw new UnsupportedOperationException("In the rule (" + kcontext.getRule().getName()
+                + "), the scoreHolder class (" + getClass()
+                + ") does not support a long weightMultiplier (" + weightMultiplier + ").\n"
+                + "If you're using constraint streams, maybe switch from penalizeLong() to penalize()?");
+    }
+
+    @Override
+    public void impactScore(RuleContext kcontext, BigDecimal weightMultiplier) {
+        throw new UnsupportedOperationException("In the rule (" + kcontext.getRule().getName()
+                + "), the scoreHolder class (" + getClass()
+                + ") does not support a BigDecimal weightMultiplier (" + weightMultiplier + ").\n"
+                + "If you're using constraint streams, maybe switch from penalizeBigDecimal() to penalize()?");
     }
 
     private void impactScore(RuleContext kcontext, int[] hardWeightsMultiplier, int[] softWeightsMultiplier) {

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/buildin/bendablebigdecimal/BendableBigDecimalScoreHolderImpl.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/buildin/bendablebigdecimal/BendableBigDecimalScoreHolderImpl.java
@@ -183,6 +183,16 @@ public final class BendableBigDecimalScoreHolderImpl extends AbstractScoreHolder
     }
 
     @Override
+    public void impactScore(RuleContext kcontext, int weightMultiplier) {
+        impactScore(kcontext, BigDecimal.valueOf(weightMultiplier));
+    }
+
+    @Override
+    public void impactScore(RuleContext kcontext, long weightMultiplier) {
+        impactScore(kcontext, BigDecimal.valueOf(weightMultiplier));
+    }
+
+    @Override
     public void impactScore(RuleContext kcontext, BigDecimal weightMultiplier) {
         Rule rule = kcontext.getRule();
         BiConsumer<RuleContext, BigDecimal> matchExecutor = matchExecutorByNumberMap.get(rule);

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/buildin/bendablelong/BendableLongScoreHolderImpl.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/buildin/bendablelong/BendableLongScoreHolderImpl.java
@@ -16,6 +16,7 @@
 
 package org.optaplanner.core.impl.score.buildin.bendablelong;
 
+import java.math.BigDecimal;
 import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -194,6 +195,14 @@ public final class BendableLongScoreHolderImpl extends AbstractScoreHolder<Benda
                     + ConstraintConfiguration.class.getSimpleName() + " annotated class.");
         }
         matchExecutor.accept(kcontext, weightMultiplier);
+    }
+
+    @Override
+    public void impactScore(RuleContext kcontext, BigDecimal weightMultiplier) {
+        throw new UnsupportedOperationException("In the rule (" + kcontext.getRule().getName()
+                + "), the scoreHolder class (" + getClass()
+                + ") does not support a BigDecimal weightMultiplier (" + weightMultiplier + ").\n"
+                + "If you're using constraint streams, maybe switch from penalizeBigDecimal() to penalizeLong()?");
     }
 
     private void impactScore(RuleContext kcontext, long[] hardWeightsMultiplier, long[] softWeightsMultiplier) {

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/buildin/bendablelong/BendableLongScoreHolderImpl.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/buildin/bendablelong/BendableLongScoreHolderImpl.java
@@ -202,7 +202,7 @@ public final class BendableLongScoreHolderImpl extends AbstractScoreHolder<Benda
         throw new UnsupportedOperationException("In the rule (" + kcontext.getRule().getName()
                 + "), the scoreHolder class (" + getClass()
                 + ") does not support a BigDecimal weightMultiplier (" + weightMultiplier + ").\n"
-                + "If you're using constraint streams, maybe switch from penalizeBigDecimal() to penalizeLong()?");
+                + "If you're using constraint streams, maybe switch from penalizeBigDecimal() to penalizeLong().");
     }
 
     private void impactScore(RuleContext kcontext, long[] hardWeightsMultiplier, long[] softWeightsMultiplier) {

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/buildin/bendablelong/BendableLongScoreHolderImpl.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/buildin/bendablelong/BendableLongScoreHolderImpl.java
@@ -180,6 +180,11 @@ public final class BendableLongScoreHolderImpl extends AbstractScoreHolder<Benda
     }
 
     @Override
+    public void impactScore(RuleContext kcontext, int weightMultiplier) {
+        impactScore(kcontext, (long) weightMultiplier);
+    }
+
+    @Override
     public void impactScore(RuleContext kcontext, long weightMultiplier) {
         Rule rule = kcontext.getRule();
         BiConsumer<RuleContext, Long> matchExecutor = matchExecutorByNumberMap.get(rule);

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/buildin/hardmediumsoft/HardMediumSoftScoreHolderImpl.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/buildin/hardmediumsoft/HardMediumSoftScoreHolderImpl.java
@@ -149,7 +149,7 @@ public final class HardMediumSoftScoreHolderImpl extends AbstractScoreHolder<Har
         throw new UnsupportedOperationException("In the rule (" + kcontext.getRule().getName()
                 + "), the scoreHolder class (" + getClass()
                 + ") does not support a long weightMultiplier (" + weightMultiplier + ").\n"
-                + "If you're using constraint streams, maybe switch from penalizeLong() to penalize()?");
+                + "If you're using constraint streams, maybe switch from penalizeLong() to penalize().");
     }
 
     @Override
@@ -157,7 +157,7 @@ public final class HardMediumSoftScoreHolderImpl extends AbstractScoreHolder<Har
         throw new UnsupportedOperationException("In the rule (" + kcontext.getRule().getName()
                 + "), the scoreHolder class (" + getClass()
                 + ") does not support a BigDecimal weightMultiplier (" + weightMultiplier + ").\n"
-                + "If you're using constraint streams, maybe switch from penalizeBigDecimal() to penalize()?");
+                + "If you're using constraint streams, maybe switch from penalizeBigDecimal() to penalize().");
     }
 
     private void impactScore(RuleContext kcontext, int hardWeightMultiplier, int mediumWeightMultiplier,

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/buildin/hardmediumsoft/HardMediumSoftScoreHolderImpl.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/buildin/hardmediumsoft/HardMediumSoftScoreHolderImpl.java
@@ -16,6 +16,7 @@
 
 package org.optaplanner.core.impl.score.buildin.hardmediumsoft;
 
+import java.math.BigDecimal;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.function.BiConsumer;
@@ -141,6 +142,22 @@ public final class HardMediumSoftScoreHolderImpl extends AbstractScoreHolder<Har
                     + ConstraintConfiguration.class.getSimpleName() + " annotated class.");
         }
         matchExecutor.accept(kcontext, weightMultiplier);
+    }
+
+    @Override
+    public void impactScore(RuleContext kcontext, long weightMultiplier) {
+        throw new UnsupportedOperationException("In the rule (" + kcontext.getRule().getName()
+                + "), the scoreHolder class (" + getClass()
+                + ") does not support a long weightMultiplier (" + weightMultiplier + ").\n"
+                + "If you're using constraint streams, maybe switch from penalizeLong() to penalize()?");
+    }
+
+    @Override
+    public void impactScore(RuleContext kcontext, BigDecimal weightMultiplier) {
+        throw new UnsupportedOperationException("In the rule (" + kcontext.getRule().getName()
+                + "), the scoreHolder class (" + getClass()
+                + ") does not support a BigDecimal weightMultiplier (" + weightMultiplier + ").\n"
+                + "If you're using constraint streams, maybe switch from penalizeBigDecimal() to penalize()?");
     }
 
     private void impactScore(RuleContext kcontext, int hardWeightMultiplier, int mediumWeightMultiplier,

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/buildin/hardmediumsoftbigdecimal/HardMediumSoftBigDecimalScoreHolderImpl.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/buildin/hardmediumsoftbigdecimal/HardMediumSoftBigDecimalScoreHolderImpl.java
@@ -138,6 +138,16 @@ public final class HardMediumSoftBigDecimalScoreHolderImpl extends AbstractScore
     }
 
     @Override
+    public void impactScore(RuleContext kcontext, int weightMultiplier) {
+        impactScore(kcontext, BigDecimal.valueOf(weightMultiplier));
+    }
+
+    @Override
+    public void impactScore(RuleContext kcontext, long weightMultiplier) {
+        impactScore(kcontext, BigDecimal.valueOf(weightMultiplier));
+    }
+
+    @Override
     public void impactScore(RuleContext kcontext, BigDecimal weightMultiplier) {
         Rule rule = kcontext.getRule();
         BiConsumer<RuleContext, BigDecimal> matchExecutor = matchExecutorByNumberMap.get(rule);

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/buildin/hardmediumsoftlong/HardMediumSoftLongScoreHolderImpl.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/buildin/hardmediumsoftlong/HardMediumSoftLongScoreHolderImpl.java
@@ -157,7 +157,7 @@ public final class HardMediumSoftLongScoreHolderImpl extends AbstractScoreHolder
         throw new UnsupportedOperationException("In the rule (" + kcontext.getRule().getName()
                 + "), the scoreHolder class (" + getClass()
                 + ") does not support a BigDecimal weightMultiplier (" + weightMultiplier + ").\n"
-                + "If you're using constraint streams, maybe switch from penalizeBigDecimal() to penalizeLong()?");
+                + "If you're using constraint streams, maybe switch from penalizeBigDecimal() to penalizeLong().");
     }
 
     private void impactScore(RuleContext kcontext, long hardWeightMultiplier, long mediumWeightMultiplier,

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/buildin/hardmediumsoftlong/HardMediumSoftLongScoreHolderImpl.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/buildin/hardmediumsoftlong/HardMediumSoftLongScoreHolderImpl.java
@@ -135,6 +135,11 @@ public final class HardMediumSoftLongScoreHolderImpl extends AbstractScoreHolder
     }
 
     @Override
+    public void impactScore(RuleContext kcontext, int weightMultiplier) {
+        impactScore(kcontext, (long) weightMultiplier);
+    }
+
+    @Override
     public void impactScore(RuleContext kcontext, long weightMultiplier) {
         Rule rule = kcontext.getRule();
         BiConsumer<RuleContext, Long> matchExecutor = matchExecutorByNumberMap.get(rule);

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/buildin/hardmediumsoftlong/HardMediumSoftLongScoreHolderImpl.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/buildin/hardmediumsoftlong/HardMediumSoftLongScoreHolderImpl.java
@@ -16,6 +16,7 @@
 
 package org.optaplanner.core.impl.score.buildin.hardmediumsoftlong;
 
+import java.math.BigDecimal;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.function.BiConsumer;
@@ -149,6 +150,14 @@ public final class HardMediumSoftLongScoreHolderImpl extends AbstractScoreHolder
                     + ConstraintConfiguration.class.getSimpleName() + " annotated class.");
         }
         matchExecutor.accept(kcontext, weightMultiplier);
+    }
+
+    @Override
+    public void impactScore(RuleContext kcontext, BigDecimal weightMultiplier) {
+        throw new UnsupportedOperationException("In the rule (" + kcontext.getRule().getName()
+                + "), the scoreHolder class (" + getClass()
+                + ") does not support a BigDecimal weightMultiplier (" + weightMultiplier + ").\n"
+                + "If you're using constraint streams, maybe switch from penalizeBigDecimal() to penalizeLong()?");
     }
 
     private void impactScore(RuleContext kcontext, long hardWeightMultiplier, long mediumWeightMultiplier,

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/buildin/hardsoft/HardSoftScoreHolderImpl.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/buildin/hardsoft/HardSoftScoreHolderImpl.java
@@ -138,7 +138,7 @@ public final class HardSoftScoreHolderImpl extends AbstractScoreHolder<HardSoftS
         throw new UnsupportedOperationException("In the rule (" + kcontext.getRule().getName()
                 + "), the scoreHolder class (" + getClass()
                 + ") does not support a long weightMultiplier (" + weightMultiplier + ").\n"
-                + "If you're using constraint streams, maybe switch from penalizeLong() to penalize()?");
+                + "If you're using constraint streams, maybe switch from penalizeLong() to penalize().");
     }
 
     @Override
@@ -146,7 +146,7 @@ public final class HardSoftScoreHolderImpl extends AbstractScoreHolder<HardSoftS
         throw new UnsupportedOperationException("In the rule (" + kcontext.getRule().getName()
                 + "), the scoreHolder class (" + getClass()
                 + ") does not support a BigDecimal weightMultiplier (" + weightMultiplier + ").\n"
-                + "If you're using constraint streams, maybe switch from penalizeBigDecimal() to penalize()?");
+                + "If you're using constraint streams, maybe switch from penalizeBigDecimal() to penalize().");
     }
 
     private void impactScore(RuleContext kcontext, int hardWeightMultiplier, int softWeightMultiplier) {

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/buildin/hardsoft/HardSoftScoreHolderImpl.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/buildin/hardsoft/HardSoftScoreHolderImpl.java
@@ -16,6 +16,7 @@
 
 package org.optaplanner.core.impl.score.buildin.hardsoft;
 
+import java.math.BigDecimal;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.function.BiConsumer;
@@ -130,6 +131,22 @@ public final class HardSoftScoreHolderImpl extends AbstractScoreHolder<HardSoftS
                     + ConstraintConfiguration.class.getSimpleName() + " annotated class.");
         }
         matchExecutor.accept(kcontext, weightMultiplier);
+    }
+
+    @Override
+    public void impactScore(RuleContext kcontext, long weightMultiplier) {
+        throw new UnsupportedOperationException("In the rule (" + kcontext.getRule().getName()
+                + "), the scoreHolder class (" + getClass()
+                + ") does not support a long weightMultiplier (" + weightMultiplier + ").\n"
+                + "If you're using constraint streams, maybe switch from penalizeLong() to penalize()?");
+    }
+
+    @Override
+    public void impactScore(RuleContext kcontext, BigDecimal weightMultiplier) {
+        throw new UnsupportedOperationException("In the rule (" + kcontext.getRule().getName()
+                + "), the scoreHolder class (" + getClass()
+                + ") does not support a BigDecimal weightMultiplier (" + weightMultiplier + ").\n"
+                + "If you're using constraint streams, maybe switch from penalizeBigDecimal() to penalize()?");
     }
 
     private void impactScore(RuleContext kcontext, int hardWeightMultiplier, int softWeightMultiplier) {

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/buildin/hardsoftbigdecimal/HardSoftBigDecimalScoreHolderImpl.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/buildin/hardsoftbigdecimal/HardSoftBigDecimalScoreHolderImpl.java
@@ -123,6 +123,16 @@ public final class HardSoftBigDecimalScoreHolderImpl extends AbstractScoreHolder
     }
 
     @Override
+    public void impactScore(RuleContext kcontext, int weightMultiplier) {
+        impactScore(kcontext, BigDecimal.valueOf(weightMultiplier));
+    }
+
+    @Override
+    public void impactScore(RuleContext kcontext, long weightMultiplier) {
+        impactScore(kcontext, BigDecimal.valueOf(weightMultiplier));
+    }
+
+    @Override
     public void impactScore(RuleContext kcontext, BigDecimal weightMultiplier) {
         Rule rule = kcontext.getRule();
         BiConsumer<RuleContext, BigDecimal> matchExecutor = matchExecutorByNumberMap.get(rule);

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/buildin/hardsoftlong/HardSoftLongScoreHolderImpl.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/buildin/hardsoftlong/HardSoftLongScoreHolderImpl.java
@@ -16,6 +16,7 @@
 
 package org.optaplanner.core.impl.score.buildin.hardsoftlong;
 
+import java.math.BigDecimal;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.function.BiConsumer;
@@ -136,6 +137,14 @@ public final class HardSoftLongScoreHolderImpl extends AbstractScoreHolder<HardS
                     + ConstraintConfiguration.class.getSimpleName() + " annotated class.");
         }
         matchExecutor.accept(kcontext, weightMultiplier);
+    }
+
+    @Override
+    public void impactScore(RuleContext kcontext, BigDecimal weightMultiplier) {
+        throw new UnsupportedOperationException("In the rule (" + kcontext.getRule().getName()
+                + "), the scoreHolder class (" + getClass()
+                + ") does not support a BigDecimal weightMultiplier (" + weightMultiplier + ").\n"
+                + "If you're using constraint streams, maybe switch from penalizeBigDecimal() to penalizeLong()?");
     }
 
     private void impactScore(RuleContext kcontext, long hardWeightMultiplier, long softWeightMultiplier) {

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/buildin/hardsoftlong/HardSoftLongScoreHolderImpl.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/buildin/hardsoftlong/HardSoftLongScoreHolderImpl.java
@@ -144,7 +144,7 @@ public final class HardSoftLongScoreHolderImpl extends AbstractScoreHolder<HardS
         throw new UnsupportedOperationException("In the rule (" + kcontext.getRule().getName()
                 + "), the scoreHolder class (" + getClass()
                 + ") does not support a BigDecimal weightMultiplier (" + weightMultiplier + ").\n"
-                + "If you're using constraint streams, maybe switch from penalizeBigDecimal() to penalizeLong()?");
+                + "If you're using constraint streams, maybe switch from penalizeBigDecimal() to penalizeLong().");
     }
 
     private void impactScore(RuleContext kcontext, long hardWeightMultiplier, long softWeightMultiplier) {

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/buildin/hardsoftlong/HardSoftLongScoreHolderImpl.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/buildin/hardsoftlong/HardSoftLongScoreHolderImpl.java
@@ -122,6 +122,11 @@ public final class HardSoftLongScoreHolderImpl extends AbstractScoreHolder<HardS
     }
 
     @Override
+    public void impactScore(RuleContext kcontext, int weightMultiplier) {
+        impactScore(kcontext, (long) weightMultiplier);
+    }
+
+    @Override
     public void impactScore(RuleContext kcontext, long weightMultiplier) {
         Rule rule = kcontext.getRule();
         BiConsumer<RuleContext, Long> matchExecutor = matchExecutorByNumberMap.get(rule);

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/buildin/simple/SimpleScoreHolderImpl.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/buildin/simple/SimpleScoreHolderImpl.java
@@ -16,6 +16,7 @@
 
 package org.optaplanner.core.impl.score.buildin.simple;
 
+import java.math.BigDecimal;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.function.BiConsumer;
@@ -102,6 +103,22 @@ public final class SimpleScoreHolderImpl extends AbstractScoreHolder<SimpleScore
                     + ConstraintConfiguration.class.getSimpleName() + " annotated class.");
         }
         matchExecutor.accept(kcontext, weightMultiplier);
+    }
+
+    @Override
+    public void impactScore(RuleContext kcontext, long weightMultiplier) {
+        throw new UnsupportedOperationException("In the rule (" + kcontext.getRule().getName()
+                + "), the scoreHolder class (" + getClass()
+                + ") does not support a long weightMultiplier (" + weightMultiplier + ").\n"
+                + "If you're using constraint streams, maybe switch from penalizeLong() to penalize()?");
+    }
+
+    @Override
+    public void impactScore(RuleContext kcontext, BigDecimal weightMultiplier) {
+        throw new UnsupportedOperationException("In the rule (" + kcontext.getRule().getName()
+                + "), the scoreHolder class (" + getClass()
+                + ") does not support a BigDecimal weightMultiplier (" + weightMultiplier + ").\n"
+                + "If you're using constraint streams, maybe switch from penalizeBigDecimal() to penalize()?");
     }
 
     // ************************************************************************

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/buildin/simple/SimpleScoreHolderImpl.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/buildin/simple/SimpleScoreHolderImpl.java
@@ -110,7 +110,7 @@ public final class SimpleScoreHolderImpl extends AbstractScoreHolder<SimpleScore
         throw new UnsupportedOperationException("In the rule (" + kcontext.getRule().getName()
                 + "), the scoreHolder class (" + getClass()
                 + ") does not support a long weightMultiplier (" + weightMultiplier + ").\n"
-                + "If you're using constraint streams, maybe switch from penalizeLong() to penalize()?");
+                + "If you're using constraint streams, maybe switch from penalizeLong() to penalize().");
     }
 
     @Override
@@ -118,7 +118,7 @@ public final class SimpleScoreHolderImpl extends AbstractScoreHolder<SimpleScore
         throw new UnsupportedOperationException("In the rule (" + kcontext.getRule().getName()
                 + "), the scoreHolder class (" + getClass()
                 + ") does not support a BigDecimal weightMultiplier (" + weightMultiplier + ").\n"
-                + "If you're using constraint streams, maybe switch from penalizeBigDecimal() to penalize()?");
+                + "If you're using constraint streams, maybe switch from penalizeBigDecimal() to penalize().");
     }
 
     // ************************************************************************

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/buildin/simplebigdecimal/SimpleBigDecimalScoreHolderImpl.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/buildin/simplebigdecimal/SimpleBigDecimalScoreHolderImpl.java
@@ -95,6 +95,16 @@ public final class SimpleBigDecimalScoreHolderImpl extends AbstractScoreHolder<S
     }
 
     @Override
+    public void impactScore(RuleContext kcontext, int weightMultiplier) {
+        impactScore(kcontext, BigDecimal.valueOf(weightMultiplier));
+    }
+
+    @Override
+    public void impactScore(RuleContext kcontext, long weightMultiplier) {
+        impactScore(kcontext, BigDecimal.valueOf(weightMultiplier));
+    }
+
+    @Override
     public void impactScore(RuleContext kcontext, BigDecimal weightMultiplier) {
         Rule rule = kcontext.getRule();
         BiConsumer<RuleContext, BigDecimal> matchExecutor = matchExecutorByNumberMap.get(rule);

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/buildin/simplelong/SimpleLongScoreHolderImpl.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/buildin/simplelong/SimpleLongScoreHolderImpl.java
@@ -116,7 +116,7 @@ public final class SimpleLongScoreHolderImpl extends AbstractScoreHolder<SimpleL
         throw new UnsupportedOperationException("In the rule (" + kcontext.getRule().getName()
                 + "), the scoreHolder class (" + getClass()
                 + ") does not support a BigDecimal weightMultiplier (" + weightMultiplier + ").\n"
-                + "If you're using constraint streams, maybe switch from penalizeBigDecimal() to penalizeLong()?");
+                + "If you're using constraint streams, maybe switch from penalizeBigDecimal() to penalizeLong().");
     }
 
     // ************************************************************************

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/buildin/simplelong/SimpleLongScoreHolderImpl.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/buildin/simplelong/SimpleLongScoreHolderImpl.java
@@ -16,6 +16,7 @@
 
 package org.optaplanner.core.impl.score.buildin.simplelong;
 
+import java.math.BigDecimal;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.function.BiConsumer;
@@ -108,6 +109,14 @@ public final class SimpleLongScoreHolderImpl extends AbstractScoreHolder<SimpleL
                     + ConstraintConfiguration.class.getSimpleName() + " annotated class.");
         }
         matchExecutor.accept(kcontext, weightMultiplier);
+    }
+
+    @Override
+    public void impactScore(RuleContext kcontext, BigDecimal weightMultiplier) {
+        throw new UnsupportedOperationException("In the rule (" + kcontext.getRule().getName()
+                + "), the scoreHolder class (" + getClass()
+                + ") does not support a BigDecimal weightMultiplier (" + weightMultiplier + ").\n"
+                + "If you're using constraint streams, maybe switch from penalizeBigDecimal() to penalizeLong()?");
     }
 
     // ************************************************************************

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/buildin/simplelong/SimpleLongScoreHolderImpl.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/buildin/simplelong/SimpleLongScoreHolderImpl.java
@@ -94,6 +94,11 @@ public final class SimpleLongScoreHolderImpl extends AbstractScoreHolder<SimpleL
     }
 
     @Override
+    public void impactScore(RuleContext kcontext, int weightMultiplier) {
+        impactScore(kcontext, (long) weightMultiplier);
+    }
+
+    @Override
     public void impactScore(RuleContext kcontext, long weightMultiplier) {
         Rule rule = kcontext.getRule();
         BiConsumer<RuleContext, Long> matchExecutor = matchExecutorByNumberMap.get(rule);

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/holder/AbstractScoreHolder.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/holder/AbstractScoreHolder.java
@@ -174,7 +174,7 @@ public abstract class AbstractScoreHolder<Score_ extends Score<Score_>> implemen
     public void impactScore(RuleContext kcontext, long weightMultiplier) {
         throw new UnsupportedOperationException("In the rule (" + kcontext.getRule().getName()
                 + "), the scoreHolder class (" + getClass()
-                + ") does not support an int weightMultiplier (" + weightMultiplier + ").");
+                + ") does not support a long weightMultiplier (" + weightMultiplier + ").");
     }
 
     /**
@@ -186,7 +186,7 @@ public abstract class AbstractScoreHolder<Score_ extends Score<Score_>> implemen
     public void impactScore(RuleContext kcontext, BigDecimal weightMultiplier) {
         throw new UnsupportedOperationException("In the rule (" + kcontext.getRule().getName()
                 + "), the scoreHolder class (" + getClass()
-                + ") does not support an int weightMultiplier (" + weightMultiplier + ").");
+                + ") does not support a BigDecimal weightMultiplier (" + weightMultiplier + ").");
     }
 
     public abstract Score_ extractScore(int initScore);

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/holder/AbstractScoreHolder.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/holder/AbstractScoreHolder.java
@@ -159,11 +159,7 @@ public abstract class AbstractScoreHolder<Score_ extends Score<Score_>> implemen
      * @param kcontext never null
      * @param weightMultiplier any
      */
-    public void impactScore(RuleContext kcontext, int weightMultiplier) {
-        throw new UnsupportedOperationException("In the rule (" + kcontext.getRule().getName()
-                + "), the scoreHolder class (" + getClass()
-                + ") does not support an int weightMultiplier (" + weightMultiplier + ").");
-    }
+    public abstract void impactScore(RuleContext kcontext, int weightMultiplier);
 
     /**
      * For internal use only, use penalize() or reward() instead.
@@ -171,11 +167,7 @@ public abstract class AbstractScoreHolder<Score_ extends Score<Score_>> implemen
      * @param kcontext never null
      * @param weightMultiplier any
      */
-    public void impactScore(RuleContext kcontext, long weightMultiplier) {
-        throw new UnsupportedOperationException("In the rule (" + kcontext.getRule().getName()
-                + "), the scoreHolder class (" + getClass()
-                + ") does not support a long weightMultiplier (" + weightMultiplier + ").");
-    }
+    public abstract void impactScore(RuleContext kcontext, long weightMultiplier);
 
     /**
      * For internal use only, use penalize() or reward() instead.
@@ -183,11 +175,7 @@ public abstract class AbstractScoreHolder<Score_ extends Score<Score_>> implemen
      * @param kcontext never null
      * @param weightMultiplier any
      */
-    public void impactScore(RuleContext kcontext, BigDecimal weightMultiplier) {
-        throw new UnsupportedOperationException("In the rule (" + kcontext.getRule().getName()
-                + "), the scoreHolder class (" + getClass()
-                + ") does not support a BigDecimal weightMultiplier (" + weightMultiplier + ").");
-    }
+    public abstract void impactScore(RuleContext kcontext, BigDecimal weightMultiplier);
 
     public abstract Score_ extractScore(int initScore);
 

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/common/rules/AbstractRuleAssembler.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/common/rules/AbstractRuleAssembler.java
@@ -105,7 +105,11 @@ abstract class AbstractRuleAssembler<Predicate_> implements RuleAssembler,
             BigDecimal impact) {
         RuleContext kcontext = (RuleContext) drools;
         constraint.assertCorrectImpact(impact);
-        scoreHolder.impactScore(kcontext, impact);
+        try {
+            scoreHolder.impactScore(kcontext, impact);
+        } catch (UnsupportedOperationException exception) {
+
+        }
     }
 
     int getExpectedGroupByCount() {

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/common/rules/AbstractRuleAssembler.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/common/rules/AbstractRuleAssembler.java
@@ -105,11 +105,7 @@ abstract class AbstractRuleAssembler<Predicate_> implements RuleAssembler,
             BigDecimal impact) {
         RuleContext kcontext = (RuleContext) drools;
         constraint.assertCorrectImpact(impact);
-        try {
-            scoreHolder.impactScore(kcontext, impact);
-        } catch (UnsupportedOperationException exception) {
-
-        }
+        scoreHolder.impactScore(kcontext, impact);
     }
 
     int getExpectedGroupByCount() {

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/score/buildin/AbstractScoreHolderTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/score/buildin/AbstractScoreHolderTest.java
@@ -21,6 +21,7 @@ import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.math.BigDecimal;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
@@ -132,6 +133,21 @@ public abstract class AbstractScoreHolderTest<Score_ extends Score<Score_>> {
 
             @Override
             public void configureConstraintWeight(org.kie.api.definition.rule.Rule rule, SimpleScore constraintWeight) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public void impactScore(RuleContext kcontext, int weightMultiplier) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public void impactScore(RuleContext kcontext, long weightMultiplier) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public void impactScore(RuleContext kcontext, BigDecimal weightMultiplier) {
                 throw new UnsupportedOperationException();
             }
         };


### PR DESCRIPTION
I know that we spoke about this before, and I'm doing something else than what we agreed on. I believe I have a good reason for why this is the best option, as it is also the only option.

Consider the following:

- The exception about wrong match weight type comes from `AbstractScoreHolder` - I can not be speaking about `penalizeBigDecimal()` there, as the user may see this in DRL as well.
- One level up, in `impactScore()` in Constraint Streams, I do not know which numeric types `AbstractScoreHolder` will or will not accept, and so I can not add that check there.

Therefore, I only have three options:

1. Modify `AbstractScoreHolder` to return the type of match weight it requires. I'd argue this is needless complexity.
1. In CS, catch the exception from `AbstractScoreHolder` and throw a new one, with a better exception message. I'd argue this is ugly.
1. Make sure the user never sees this exception, assuming they're not doing anything crazy like multiplying `SimpleScore` with a `BigDecimal`.

I am doing the latter. Here's why this is not a problem:

- Multiplying `LongScore` with `int` is safe. 
- Multiplying `BigDecimalScore` with `long` or `int` is safe.
- Multiplying `IntScore` with `long` or `BigDecimal` continues to throw an exception.
- Multiplying `LongScore` with `BigDecimal` continues to throw an exception.

Therefore, this is perfectly safe and a better situation than before.