### PR TITLE
[7.X] PLANNER-2085: Include ide-configuration in distribution

### DIFF
--- a/optaplanner-distribution/src/main/assembly/assembly-optaplanner.xml
+++ b/optaplanner-distribution/src/main/assembly/assembly-optaplanner.xml
@@ -64,6 +64,18 @@
       </excludes>
     </fileSet>
     <fileSet><!-- Note: going outside the module dir is bad, but it is not fetching generated files -->
+      <directory>../ide-configuration</directory>
+      <outputDirectory>examples/ide-configuration</outputDirectory>
+      <excludes>
+        <exclude>.*/**</exclude>
+        <exclude>nbproject/**</exclude>
+        <exclude>*.ipr</exclude>
+        <exclude>*.iws</exclude>
+        <exclude>*.iml</exclude>
+        <exclude>.git/**</exclude>
+      </excludes>
+    </fileSet>
+    <fileSet><!-- Note: going outside the module dir is bad, but it is not fetching generated files -->
       <directory>../optaplanner-quickstarts/spring-boot-school-timetabling</directory>
       <outputDirectory>quickstarts/spring-boot-school-timetabling</outputDirectory>
       <excludes>


### PR DESCRIPTION
The pom file for optaplanner-examples references
`../ide-configuration` to configure the automatic
code formatter. This folder was not included in the
distribution, which causes `mvn clean install` to fail
if a user try building from the `examples/sources`
folder. To remedy this, the folder was included so
builds will past.

<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.
-->

### JIRA

<!-- Add a JIRA ticket link if it exists. -->
https://issues.redhat.com/browse/PLANNER-2085

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
* https://github.com/kiegroup/drools/pull/3000
* https://github.com/kiegroup/optaplanner/pull/899
* etc.
-->

### Checklist
- [ ] Documentation updated if applicable.
- [ ] Upgrade recipe provided if applicable.

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>full downstream build</b> please add comment: <b>Jenkins run fdb</b>
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
