### PR TITLE
[8.0.0.beta1] Add dependencies repository before mvn install

### DIFF
--- a/Jenkinsfile.deploy
+++ b/Jenkinsfile.deploy
@@ -95,10 +95,15 @@ pipeline {
             steps {
                 script {
                     configFileProvider([configFile(fileId: maven.getSubmarineSettingsXmlId(), targetLocation: 'maven-settings.xml', variable: 'MAVEN_SETTINGS_FILE')]) {
+                        // expose the temp file via a global environment variable for other stages
+                        env.GLOBAL_MAVEN_SETTINGS = "${MAVEN_SETTINGS_FILE}"
                         sh "echo '\n-B -s ${MAVEN_SETTINGS_FILE}' | tee -a optaplanner/.mvn/maven.config"
                         if (params.MAVEN_DEPENDENCIES_REPOSITORY != '') {
                             sh "echo '\n-Denforcer.skip=true' | tee -a optaplanner/.mvn/maven.config"
-                            addRepositoryToSettings(params.MAVEN_DEPENDENCIES_REPOSITORY, env.MAVEN_SETTINGS_FILE)
+                            sh "sed -i 's|<repositories>|<repositories><repository><id>staging</id><name>Staging Repository</name><url>${params.MAVEN_DEPENDENCIES_REPOSITORY}</url><layout>default</layout><snapshots><enabled>true</enabled></snapshots><releases><enabled>true</enabled></releases></repository>|g' ${MAVEN_SETTINGS_FILE}"
+                            sh "sed -i 's|<pluginRepositories>|<pluginRepositories><pluginRepository><id>staging</id><name>Staging Repository</name><url>${params.MAVEN_DEPENDENCIES_REPOSITORY}</url><layout>default</layout><snapshots><enabled>true</enabled></snapshots><releases><enabled>true</enabled></releases></pluginRepository>|g' ${MAVEN_SETTINGS_FILE}"
+                            // Done to allow Maven to download release artifacts from the repository
+                            sh "sed -i 's|external:\\*|external:*,!staging|g' ${MAVEN_SETTINGS_FILE}"
                         }
                     }
                 }
@@ -130,14 +135,10 @@ pipeline {
         stage('Build optaplanner') {
             steps {
                 script {
-                    configFileProvider([configFile(fileId: maven.getSubmarineSettingsXmlId(), targetLocation: 'maven-settings.xml', variable: 'MAVEN_SETTINGS_FILE')]) {
-                        if (params.MAVEN_DEPENDENCIES_REPOSITORY != '') {
-                            addRepositoryToSettings(params.MAVEN_DEPENDENCIES_REPOSITORY, env.MAVEN_SETTINGS_FILE)
-                            mavenCleanInstall('optaplanner', params.SKIP_TESTS, [], "-s ${MAVEN_SETTINGS_FILE} -Denforcer.skip")
-                        }
+                    if (params.MAVEN_DEPENDENCIES_REPOSITORY != '') {
+                        mavenCleanInstall('optaplanner', params.SKIP_TESTS, [], "-s ${env.GLOBAL_MAVEN_SETTINGS} -Denforcer.skip")
                     }
                 }
-
             }
             post {
                 always {
@@ -182,13 +183,6 @@ pipeline {
             cleanWs()
         }
     }
-}
-
-void addRepositoryToSettings(String repository, String settingsFile) {
-    sh "sed -i 's|<repositories>|<repositories><repository><id>staging</id><name>Staging Repository</name><url>${repository}</url><layout>default</layout><snapshots><enabled>true</enabled></snapshots><releases><enabled>true</enabled></releases></repository>|g' ${settingsFile}"
-    sh "sed -i 's|<pluginRepositories>|<pluginRepositories><pluginRepository><id>staging</id><name>Staging Repository</name><url>${repository}</url><layout>default</layout><snapshots><enabled>true</enabled></snapshots><releases><enabled>true</enabled></releases></pluginRepository>|g' ${settingsFile}"
-    // Done to allow Maven to download release artifacts from the repository
-    sh "sed -i 's|external:\\*|external:*,!staging|g' ${settingsFile}"
 }
 
 void saveReports(boolean allowEmpty=false){

--- a/Jenkinsfile.deploy
+++ b/Jenkinsfile.deploy
@@ -98,10 +98,7 @@ pipeline {
                         sh "echo '\n-B -s ${MAVEN_SETTINGS_FILE}' | tee -a optaplanner/.mvn/maven.config"
                         if (params.MAVEN_DEPENDENCIES_REPOSITORY != '') {
                             sh "echo '\n-Denforcer.skip=true' | tee -a optaplanner/.mvn/maven.config"
-                            sh "sed -i 's|<repositories>|<repositories><repository><id>staging</id><name>Staging Repository</name><url>${params.MAVEN_DEPENDENCIES_REPOSITORY}</url><layout>default</layout><snapshots><enabled>true</enabled></snapshots><releases><enabled>true</enabled></releases></repository>|g' ${MAVEN_SETTINGS_FILE}"
-                            sh "sed -i 's|<pluginRepositories>|<pluginRepositories><pluginRepository><id>staging</id><name>Staging Repository</name><url>${params.MAVEN_DEPENDENCIES_REPOSITORY}</url><layout>default</layout><snapshots><enabled>true</enabled></snapshots><releases><enabled>true</enabled></releases></pluginRepository>|g' ${MAVEN_SETTINGS_FILE}"
-                            sh "sed -i 's|external:\\*|external:*,!staging|g' ${MAVEN_SETTINGS_FILE}"
-                            // Done to allow Maven to download release artifacts from MAVEN_DEPENDENCIES_REPOSITORY
+                            addRepositoryToSettings(params.MAVEN_DEPENDENCIES_REPOSITORY, env.MAVEN_SETTINGS_FILE)
                         }
                     }
                 }
@@ -132,7 +129,15 @@ pipeline {
 
         stage('Build optaplanner') {
             steps {
-                mavenCleanInstall('optaplanner', params.SKIP_TESTS)
+                script {
+                    configFileProvider([configFile(fileId: maven.getSubmarineSettingsXmlId(), targetLocation: 'maven-settings.xml', variable: 'MAVEN_SETTINGS_FILE')]) {
+                        if (params.MAVEN_DEPENDENCIES_REPOSITORY != '') {
+                            addRepositoryToSettings(params.MAVEN_DEPENDENCIES_REPOSITORY, env.MAVEN_SETTINGS_FILE)
+                            mavenCleanInstall('optaplanner', params.SKIP_TESTS, [], "-s ${MAVEN_SETTINGS_FILE} -Denforcer.skip")
+                        }
+                    }
+                }
+
             }
             post {
                 always {
@@ -177,6 +182,13 @@ pipeline {
             cleanWs()
         }
     }
+}
+
+void addRepositoryToSettings(String repository, String settingsFile) {
+    sh "sed -i 's|<repositories>|<repositories><repository><id>staging</id><name>Staging Repository</name><url>${repository}</url><layout>default</layout><snapshots><enabled>true</enabled></snapshots><releases><enabled>true</enabled></releases></repository>|g' ${settingsFile}"
+    sh "sed -i 's|<pluginRepositories>|<pluginRepositories><pluginRepository><id>staging</id><name>Staging Repository</name><url>${repository}</url><layout>default</layout><snapshots><enabled>true</enabled></snapshots><releases><enabled>true</enabled></releases></pluginRepository>|g' ${settingsFile}"
+    // Done to allow Maven to download release artifacts from the repository
+    sh "sed -i 's|external:\\*|external:*,!staging|g' ${settingsFile}"
 }
 
 void saveReports(boolean allowEmpty=false){


### PR DESCRIPTION
Backports the https://github.com/kiegroup/optaplanner/pull/992.

<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.
-->

### JIRA

<!-- Add a JIRA ticket link if it exists. -->
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
* https://github.com/kiegroup/drools/pull/3000
* https://github.com/kiegroup/optaplanner/pull/899
* etc.
-->

### Checklist
- [x] Documentation updated if applicable.
- [x] Upgrade recipe provided if applicable.

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>full downstream build</b> please add comment: <b>Jenkins run fdb</b>
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
