### PR TITLE
Deploy Pipeline executes MavenCleanInstall in all cases

### DIFF
--- a/Jenkinsfile.deploy
+++ b/Jenkinsfile.deploy
@@ -135,9 +135,11 @@ pipeline {
         stage('Build optaplanner') {
             steps {
                 script {
+                    String extraArgs = ''
                     if (params.MAVEN_DEPENDENCIES_REPOSITORY != '') {
-                        mavenCleanInstall('optaplanner', params.SKIP_TESTS, [], "-s ${env.GLOBAL_MAVEN_SETTINGS} -Denforcer.skip")
+                        extraArgs = "-s ${env.GLOBAL_MAVEN_SETTINGS} -Denforcer.skip"
                     }
+                    mavenCleanInstall('optaplanner', params.SKIP_TESTS, [], extraArgs)
                 }
             }
             post {


### PR DESCRIPTION
Small bug correction as cleanInstall was ignored if no `MAVEN_DEPENDENCIES_REPOSITORY` is set