### PR TITLE
PLANNER-2217 Automate release of OptaPlanner documentation and distribution

### DIFF
--- a/Jenkinsfile.promote
+++ b/Jenkinsfile.promote
@@ -92,6 +92,52 @@ pipeline {
             }
         }
 
+        stage('Upload documentation and distribution') {
+            when {
+                expression { return isRelease() }
+            }
+            steps {
+                script {
+                    mavenCleanInstall('optaplanner', true, ['full'])
+                    dir('optaplanner') {
+                        withCredentials(bindings: [sshUserPrivateKey(credentialsId: 'optaplanner-filemgmt',
+                                             keyFileVariable: 'SSH_KEY_JBOSS_FILEMGMT')]) {
+                            // For testing, simulate connection via SSH:
+                            // sh "ssh -i $SSH_KEY_JBOSS_FILEMGMT -oKexAlgorithms=+diffie-hellman-group1-sha1 optaplanner@filemgmt.jboss.org"
+                            sh "./build/release/upload_distribution.sh ${getProjectVersion()} $SSH_KEY_JBOSS_FILEMGMT"
+                        }
+                    }
+                }
+            }
+        }
+
+        stage('Update OptaPlanner website') {
+            when {
+                expression { return isRelease() }
+            }
+            steps {
+                script {
+                    final String websiteRepository = 'optaplanner-website'
+                    dir(websiteRepository) {
+                        String prBranchName = createWebsitePrBranch(websiteRepository)
+
+                        // Update versions in links on the website.
+                        sh "./build/update-versions.sh ${getProjectVersion()} ${getNextMinorSnapshotVersion(getProjectVersion())}"
+
+                        // Update the XSDs. OptaPlanner must be cloned and build with the full profile before.
+                        String optaplannerRoot = "$WORKSPACE/optaplanner"
+                        sh "cp $optaplannerRoot/optaplanner-core/target/classes/solver.xsd xsd/solver/solver-8.xsd"
+                        sh "cp $optaplannerRoot/optaplanner-benchmark/target/classes/benchmark.xsd xsd/benchmark/benchmark-8.xsd"
+
+                        // Add changed files, commit, open and merge PR
+                        sh 'git add xsd/\\*.xsd _config/pom.yml'
+                        String prLink = commitAndCreatePR("Release OptaPlanner ${getProjectVersion()}", prBranchName, 'master')
+                        mergeAndPush(websiteRepository, prLink)
+                    }
+                }
+            }
+        }
+
         stage('Set OptaPlanner next snapshot version'){
             when {
                 expression { return isRelease() }
@@ -101,10 +147,13 @@ pipeline {
                     dir('optaplanner-bot') {
                         prepareForPR('optaplanner')
                         setupMavenConfig()
-                        maven.mvnVersionsSet(getNextSnapshotVersion(getProjectVersion()), true)
-                        updateKogitoVersion(getNextSnapshotVersion(getKogitoVersion()))
+                        String nextSnapshotVersion = getNextMicroSnapshotVersion(getProjectVersion())
+                        maven.mvnVersionsSet(nextSnapshotVersion, true)
+                        updateKogitoVersion(getNextMicroSnapshotVersion(getKogitoVersion()))
 
-                        commitAndCreatePR('optaplanner')
+                        addNotIgnoredPoms()
+                        String prLink = commitAndCreatePR("Update snapshot version to ${nextSnapshotVersion}")
+                        setPipelinePrLink('optaplanner', prLink)
                     }
                     dir('optaplanner') {
                         sh "git checkout ${getBuildBranch()}"
@@ -174,8 +223,12 @@ String getKogitoVersion() {
     return getParamOrDeployProperty('KOGITO_VERSION', 'kogito.version')
 }
 
-String getNextSnapshotVersion(String currentVersion) {
+String getNextMicroSnapshotVersion(String currentVersion) {
     return util.getNextVersion(currentVersion, 'micro')
+}
+
+String getNextMinorSnapshotVersion(String currentVersion) {
+    return util.getNextVersion(currentVersion, 'minor')
 }
 
 String getGitTag() {
@@ -215,18 +268,22 @@ void setPipelinePrLink(String repo, String value){
 }
 
 String getSnapshotBranch(){
-    return "${getNextSnapshotVersion(getProjectVersion()).toLowerCase()}-${env.BOT_BRANCH_HASH}"
+    return "${getNextMicroSnapshotVersion(getProjectVersion()).toLowerCase()}-${env.BOT_BRANCH_HASH}"
 }
 
 //////////////////////////////////////////////////////////////////////////////
 // Git
 //////////////////////////////////////////////////////////////////////////////
 
-void checkoutRepo(String repo) {
+void checkoutRepo(String repo, String branch) {
     deleteDir()
-    checkout(githubscm.resolveRepository(repo, getGitAuthor(), getBuildBranch(), false))
+    checkout(githubscm.resolveRepository(repo, getGitAuthor(), branch, false))
     // need to manually checkout branch since on a detached branch after checkout command
-    sh "git checkout ${getBuildBranch()}"
+    sh "git checkout ${branch}"
+}
+
+void checkoutRepo(String repo) {
+    checkoutRepo(repo, getBuildBranch())
 }
 
 void mergeAndPush(String repo, String prLink) {
@@ -264,15 +321,23 @@ void addNotIgnoredPoms() {
     '''
 }
 
-void commitAndCreatePR(String repo) {
-    def commitMsg = "Update snapshot version to ${getSnapshotBranch()}"
+void commitAndCreatePR(String commitMsg, String localBranch, String targetBranch) {
     def prBody = "Generated by build ${BUILD_TAG}: ${BUILD_URL}"
-    // Not using githubscm.commitChanges() because globbing won't work.
-    // See: https://github.com/kiegroup/kogito-runtimes/pull/570#discussion_r449268738
-    addNotIgnoredPoms()
     sh "git commit -m '${commitMsg}'"
-    githubscm.pushObject('origin', getSnapshotBranch(), getBotAuthorCredsID())
-    setPipelinePrLink(repo, githubscm.createPR(commitMsg, prBody, getBuildBranch(), getBotAuthorCredsID()))
+    githubscm.pushObject('origin', localBranch, getBotAuthorCredsID())
+    return githubscm.createPR(commitMsg, prBody, targetBranch, getBotAuthorCredsID())
+}
+
+void commitAndCreatePR(String commitMsg) {
+    commitAndCreatePR(commitMsg, getSnapshotBranch(), getBuildBranch())
+}
+
+String createWebsitePrBranch(String websiteRepository) {
+    checkoutRepo(websiteRepository, 'master') // there is no other branch
+    githubscm.forkRepo(getBotAuthorCredsID())
+    String prBranchName = "${getProjectVersion().toLowerCase()}-${env.BOT_BRANCH_HASH}"
+    githubscm.createBranch(prBranchName)
+    return prBranchName
 }
 
 void installGithubCLI() {
@@ -315,5 +380,22 @@ void deployArtifacts() {
         maven.runMaven(mvnCmd, true)
     } else {
         maven.runMavenWithSubmarineSettings(mvnCmd, true)
+    }
+}
+
+void mavenCleanInstall(String directory, boolean skipTests = false, List profiles = [], String extraArgs = '') {
+    runMaven('clean install', directory, skipTests, profiles, extraArgs)
+}
+
+void runMaven(String goals, String directory, boolean skipTests = false, List profiles = [], String extraArgs = '') {
+    mvnCmd = goals
+    if(!profiles.isEmpty()){
+        mvnCmd += " -P${profiles.join(',')}"
+    }
+    if(extraArgs != ''){
+        mvnCmd += " ${extraArgs}"
+    }
+    dir(directory) {
+        maven.runMaven(mvnCmd, skipTests, ['-fae'])
     }
 }

--- a/build/release/upload_distribution.sh
+++ b/build/release/upload_distribution.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+
+function display_help() {
+  readonly script_name="./$(basename "$0")"
+
+  echo "This script uploads the documentation, javadocs and distribution.zip to the filemgmt.jboss.org."
+  echo "Make sure the OptaPlanner project has been build with the full profile enabled before calling this script."
+  echo
+  echo "Usage:"
+  echo "  $script_name PROJECT_VERSION SSH_KEY"
+  echo "  $script_name --help"
+}
+
+function create_latest_symlinks() {
+  local _working_directory=$1
+  local _version=$2
+
+  pushd "$_working_directory"
+  cd "$_working_directory"
+  ln -s "$_version" latest
+  if [[ "$_version" == *Final* ]]; then
+    ln -s "$_version" latestFinal
+  fi
+  popd
+}
+
+if [[ $1 == "--help" ]]; then
+  display_help
+  exit 0
+fi
+
+if [[ $# -ne 2 ]]; then
+  echo "Illegal number of arguments."
+  display_help
+  exit 1
+fi
+
+readonly remote_optaplanner_downloads=optaplanner@filemgmt.jboss.org:/downloads_htdocs/optaplanner
+readonly remote_optaplanner_docs=optaplanner@filemgmt.jboss.org:/docs_htdocs/optaplanner
+
+readonly version=$1
+readonly optaplanner_ssh_key=$2
+
+this_script_directory="${BASH_SOURCE%/*}"
+if [[ ! -d "$this_script_directory" ]]; then
+  this_script_directory="$PWD"
+fi
+
+readonly optaplanner_project_root=$this_script_directory/../..
+readonly optaplanner_distribution=$optaplanner_project_root/optaplanner-distribution
+readonly optaplanner_distribution_build_dir="$optaplanner_distribution/target/optaplanner-distribution-$version"
+
+if [[ ! -d "$optaplanner_distribution_build_dir" ]]; then
+  echo "The OptaPlanner distribution does not exist. Please run the build with the full profile enabled."
+  exit 1
+fi
+
+# Create the directory structure .../release/${version}
+readonly temp_release_directory=/tmp/optaplanner-release-$version
+readonly local_optaplanner_downloads=$temp_release_directory/downloads/release
+readonly local_optaplanner_docs=$temp_release_directory/docs/release
+if [ -d "$temp_release_directory" ]; then
+  rm -Rf "$temp_release_directory";
+fi
+mkdir -p "$local_optaplanner_docs/$version/optaplanner-docs"
+mkdir -p "$local_optaplanner_docs/$version/optaplanner-javadoc"
+mkdir -p "$local_optaplanner_downloads/$version"
+
+# Upload the OptaPlanner distribution.zip.
+cp "$optaplanner_distribution/target/optaplanner-distribution-$version.zip" "$local_optaplanner_downloads/$version"
+
+readonly remote_shell="ssh -oKexAlgorithms=+diffie-hellman-group1-sha1 -i $optaplanner_ssh_key"
+create_latest_symlinks "$local_optaplanner_downloads" "$version"
+rsync -a -r -e "$remote_shell" --protocol=28 "$local_optaplanner_downloads/.." "$remote_optaplanner_downloads"
+
+# Upload the documentation and Javadoc.
+cp -r "$optaplanner_distribution_build_dir"/reference_manual/* "$local_optaplanner_docs/$version/optaplanner-docs"
+cp -r "$optaplanner_distribution_build_dir"/javadocs/* "$local_optaplanner_docs/$version/optaplanner-javadoc"
+
+create_latest_symlinks "$local_optaplanner_docs" "$version"
+rsync -a -r -e "$remote_shell" --protocol=28 "$local_optaplanner_docs/.." "$remote_optaplanner_docs"

--- a/optaplanner-distribution/src/main/assembly/assembly-optaplanner.xml
+++ b/optaplanner-distribution/src/main/assembly/assembly-optaplanner.xml
@@ -8,7 +8,7 @@
     <format>zip</format>
   </formats>
 
-  <includeBaseDirectory>true</includeBaseDirectory>
+  <includeBaseDirectory>false</includeBaseDirectory>
 
   <fileSets>
     <fileSet><!-- Note: going outside the module dir is bad, but it is not fetching generated files -->


### PR DESCRIPTION
First step: add a script that will be called from the release pipeline. The script uploads the docs and distribution.
TODO:
- provide documentation for the release process

<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.
-->

### JIRA
https://issues.redhat.com/browse/PLANNER-2217

<!-- Add a JIRA ticket link if it exists. -->
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->

### Referenced pull requests
https://github.com/kiegroup/optaplanner-website/pull/295

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
* https://github.com/kiegroup/drools/pull/3000
* https://github.com/kiegroup/optaplanner/pull/899
* etc.
-->

### Checklist
- [ ] Documentation updated if applicable.
- [x] Upgrade recipe provided if applicable.

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>full downstream build</b> please add comment: <b>Jenkins run fdb</b>
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
