### PR TITLE
Add a pluginRepository to resolve the optaplanner-ide-config artifact

### DIFF
--- a/build/optaplanner-build-parent/pom.xml
+++ b/build/optaplanner-build-parent/pom.xml
@@ -7,6 +7,7 @@
     <groupId>org.optaplanner</groupId>
     <artifactId>optaplanner-parent</artifactId>
     <version>8.0.0-SNAPSHOT</version>
+    <relativePath>../../pom.xml</relativePath>
   </parent>
 
   <artifactId>optaplanner-build-parent</artifactId>

--- a/build/optaplanner-ide-config/pom.xml
+++ b/build/optaplanner-ide-config/pom.xml
@@ -6,6 +6,7 @@
     <groupId>org.optaplanner</groupId>
     <artifactId>optaplanner-parent</artifactId>
     <version>8.0.0-SNAPSHOT</version>
+    <relativePath>../../pom.xml</relativePath>
   </parent>
   <artifactId>optaplanner-ide-config</artifactId>
   <name>OptaPlanner IDE Configuration</name>

--- a/pom.xml
+++ b/pom.xml
@@ -69,6 +69,23 @@
       </snapshots>
     </repository>
   </repositories>
+  <pluginRepositories>
+    <pluginRepository>
+      <id>jboss-public-repository-group</id>
+      <name>JBoss Public Repository Group</name>
+      <url>https://repository.jboss.org/nexus/content/groups/public/</url>
+      <layout>default</layout>
+      <releases>
+        <!-- Only get SNAPSHOTS from JBoss repository,
+             so it tries to get releases first (and only) from Maven Central. -->
+        <enabled>false</enabled>
+      </releases>
+      <snapshots>
+        <enabled>true</enabled>
+        <updatePolicy>daily</updatePolicy>
+      </snapshots>
+    </pluginRepository>
+  </pluginRepositories>
 
   <scm>
     <connection>scm:git:git@github.com:kiegroup/optaplanner.git</connection>


### PR DESCRIPTION
Plugin dependencies, in this case the maven-formatter-plugin's dependency on optaplanner-ide-config, are resolved using pluginRepository.

<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.
-->

### JIRA

<!-- Add a JIRA ticket link if it exists. -->
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
* https://github.com/kiegroup/drools/pull/3000
* https://github.com/kiegroup/optaplanner/pull/899
* etc.
-->

### Checklist
- [ ] Documentation updated if applicable.
- [ ] Upgrade recipe provided if applicable.

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>full downstream build</b> please add comment: <b>Jenkins run fdb</b>
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
