### PR TITLE
Planner 2130 nightly

### DIFF
--- a/Jenkinsfile.deploy
+++ b/Jenkinsfile.deploy
@@ -22,7 +22,6 @@ pipeline {
 
         // Git information
         string(name: 'BUILD_BRANCH_NAME', defaultValue: 'master', description: 'Which branch to build? Set if you are not on a multibranch pipeline.')
-        string(name: 'BUILD_BRANCH_QUICKSTARTS', defaultValue: 'development', description: 'Which branch for quickstarts to build? Set if you are not on a multibranch pipeline.')
         string(name: 'GIT_AUTHOR', defaultValue: 'kiegroup', description: 'Which Git author repository ?')
 
         // Build&test information
@@ -317,6 +316,6 @@ void setDeployPropertyIfNeeded(String key, def value) {
     }
 }
 
-String[] getQuickStartsBranch(){
-    return params.BUILD_BRANCH_QUICKSTARTS
+String getQuickStartsBranch(String quickStartsBranch = 'development'){
+    return quickStartsBranch
 }

--- a/Jenkinsfile.deploy
+++ b/Jenkinsfile.deploy
@@ -22,6 +22,7 @@ pipeline {
 
         // Git information
         string(name: 'BUILD_BRANCH_NAME', defaultValue: 'master', description: 'Which branch to build? Set if you are not on a multibranch pipeline.')
+        string(name: 'BUILD_BRANCH_QUICKSTARTS', defaultValue: 'development', description: 'Which branch for quickstarts to build? Set if you are not on a multibranch pipeline.')
         string(name: 'GIT_AUTHOR', defaultValue: 'kiegroup', description: 'Which Git author repository ?')
 
         // Build&test information
@@ -67,6 +68,7 @@ pipeline {
                 success {
                     script {
                         setDeployPropertyIfNeeded('git.branch', getBuildBranch())
+                        setDeployPropertyIfNeeded('git.branchQuickstarts', getQuickStartsBranch())
                         setDeployPropertyIfNeeded('git.author', getGitAuthor())
                         setDeployPropertyIfNeeded('project.version', getProjectVersion())
                         setDeployPropertyIfNeeded('release', isRelease())
@@ -78,7 +80,8 @@ pipeline {
 
         stage('Clone repositories') {
             steps {
-                checkoutRepo('optaplanner')
+                checkoutRepo('optaplanner', getBuildBranch())
+                checkoutRepo('optaplanner-quickstarts', getQuickStartsBranch())
             }
         }
 
@@ -149,6 +152,23 @@ pipeline {
             }
         }
 
+        stage('Build optaplanner-quickstarts') {
+            steps {
+                script {
+                    String extraArgs = ''
+                    if (params.MAVEN_DEPENDENCIES_REPOSITORY != '') {
+                        extraArgs = "-s ${env.GLOBAL_MAVEN_SETTINGS} -Denforcer.skip"
+                    }
+                    mavenCleanInstall('optaplanner-quickstarts', params.SKIP_TESTS, [], extraArgs)
+                }
+            }
+            post {
+                always {
+                    saveReports(params.SKIP_TESTS)
+                }
+            }
+        }
+
         stage('Deploy artifacts') {
             steps {
                 mavenDeploy('optaplanner')
@@ -191,10 +211,10 @@ void saveReports(boolean allowEmpty=false){
     junit testResults: '**/target/surefire-reports/**/*.xml, **/target/failsafe-reports/**/*.xml', allowEmptyResults: allowEmpty
 }
 
-void checkoutRepo(String repo, String dirName=repo) {
+void checkoutRepo(String repo, String branch, String dirName=repo) {
     dir(dirName) {
         deleteDir()
-        checkout(githubscm.resolveRepository(repo, getGitAuthor(), getBuildBranch(), false))
+        checkout(githubscm.resolveRepository(repo, getGitAuthor(), branch, false))
     }
 }
 
@@ -299,4 +319,8 @@ void setDeployPropertyIfNeeded(String key, def value) {
     if (value != null && value != ''){
         deployProperties[key] = value
     }
+}
+
+String[] getQuickStartsBranch(){
+    return params.BUILD_BRANCH_QUICKSTARTS
 }

--- a/Jenkinsfile.deploy
+++ b/Jenkinsfile.deploy
@@ -155,11 +155,7 @@ pipeline {
         stage('Build optaplanner-quickstarts') {
             steps {
                 script {
-                    String extraArgs = ''
-                    if (params.MAVEN_DEPENDENCIES_REPOSITORY != '') {
-                        extraArgs = "-s ${env.GLOBAL_MAVEN_SETTINGS} -Denforcer.skip"
-                    }
-                    mavenCleanInstall('optaplanner-quickstarts', params.SKIP_TESTS, [], extraArgs)
+                    mavenCleanInstall('optaplanner-quickstarts', params.SKIP_TESTS, [])
                 }
             }
             post {


### PR DESCRIPTION
 Add nightly configuration for quickstarts

- added build stage and repo for quickstarts

Tested here

https://rhba-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/custom/job/adupliak/job/optaplanner-quickstarts-deploy/
 - The quickstarts version is SNAPSHOT 1.0
 - See "Test results" for surefire outcome
 - Dont use  MAVEN_DEPENDENCIES_REPOSITORY 


<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.
-->

### JIRA

<!-- Add a JIRA ticket link if it exists. -->
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
* https://github.com/kiegroup/drools/pull/3000
* https://github.com/kiegroup/optaplanner/pull/899
* etc.
-->

### Checklist
- [ ] Documentation updated if applicable.
- [ ] Upgrade recipe provided if applicable.

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>full downstream build</b> please add comment: <b>Jenkins run fdb</b>
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
