### PR TITLE
Move sonar.projectKey from pom.xml to the CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -49,7 +49,7 @@ pipeline {
         stage('Analyze OptaPlanner by SonarCloud') {
             steps {
                 withCredentials([string(credentialsId: 'SONARCLOUD_TOKEN', variable: 'SONARCLOUD_TOKEN')]) {
-                    runMaven("validate", "optaplanner", true, ["sonarcloud-analysis"], "-e -nsu")
+                    runMaven("validate", "optaplanner", true, ["sonarcloud-analysis"], "-e -nsu -Dsonar.projectKey=org.optaplanner:optaplanner")
                 }
             }
         }

--- a/pom.xml
+++ b/pom.xml
@@ -34,8 +34,9 @@
   </licenses>
 
   <properties>
-    <!-- override the default GroupId:ArtifactId to map both master branch and 7.x branches to the same SonarCloud project -->
-    <sonar.projectKey>org.optaplanner:optaplanner</sonar.projectKey>
+    <!-- The property sonar.projectKey is defined in the CI in order not to collide with optawebs. It overrides
+         the default GroupId:ArtifactId to map both master branch and 7.x branches to the same SonarCloud project.
+         As the sonar.moduleKey inherits the value of sonar.projectKey by default, we have to override it too. -->
     <sonar.moduleKey>${project.groupId}:${project.artifactId}</sonar.moduleKey>
   </properties>
 


### PR DESCRIPTION
The `sonar.projectKey` is overridden in the optaplanner-parent, which mistakenly propagates to optawebs. As a result, this project clashes with the optaweb-vehicle-routing on SonarCloud.

<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.
-->

### JIRA

<!-- Add a JIRA ticket link if it exists. -->
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
* https://github.com/kiegroup/drools/pull/3000
* https://github.com/kiegroup/optaplanner/pull/899
* etc.
-->

### Checklist
- [ ] Documentation updated if applicable.
- [ ] Upgrade recipe provided if applicable.

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>full downstream build</b> please add comment: <b>Jenkins run fdb</b>
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
