### PR TITLE
[8.0.x] Activate fullProfile in all relevant builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -37,7 +37,7 @@ pipeline {
         }
         stage('Build OptaPlanner') {
             steps {
-                mavenCleanInstall("optaplanner", false, ["run-code-coverage", "full"])
+                mavenCleanInstall('optaplanner', false, ['run-code-coverage'], '-Dfull')
             }
         }
         stage('Analyze OptaPlanner by SonarCloud') {

--- a/Jenkinsfile.deploy
+++ b/Jenkinsfile.deploy
@@ -137,9 +137,9 @@ pipeline {
         stage('Build optaplanner') {
             steps {
                 script {
-                    String extraArgs = ''
+                    String extraArgs = '-Dfull'
                     if (params.MAVEN_DEPENDENCIES_REPOSITORY != '') {
-                        extraArgs = "-s ${env.GLOBAL_MAVEN_SETTINGS} -Denforcer.skip"
+                        extraArgs = "$extraArgs -s ${env.GLOBAL_MAVEN_SETTINGS} -Denforcer.skip"
                     }
                     mavenCleanInstall('optaplanner', params.SKIP_TESTS, [], extraArgs)
                 }
@@ -166,7 +166,7 @@ pipeline {
 
         stage('Deploy artifacts') {
             steps {
-                mavenDeploy('optaplanner')
+                mavenDeploy('optaplanner', '-Dfull')
             }
         }
 
@@ -254,9 +254,10 @@ void mavenCleanInstall(String directory, boolean skipTests = false, List profile
     runMaven('clean install', directory, skipTests, profiles, extraArgs)
 }
 
-void mavenDeploy(String directory) {
-    extraArgs = params.MAVEN_DEPLOY_REPOSITORY != '' ? "-DaltDeploymentRepository=runtimes-artifacts::default::${params.MAVEN_DEPLOY_REPOSITORY} -Denforcer.skip=true" : ''
-    runMaven('clean deploy', directory, true, [], extraArgs)
+void mavenDeploy(String directory, extraArgs = '') {
+    String deployRepoArgs = params.MAVEN_DEPLOY_REPOSITORY != '' ? "-DaltDeploymentRepository=runtimes-artifacts::default::${params.MAVEN_DEPLOY_REPOSITORY} -Denforcer.skip=true" : ''
+    String resolvedArgs = "$extraArgs $deployRepoArgs".trim()
+    runMaven('clean deploy', directory, true, [], resolvedArgs)
 }
 
 void runMaven(String goals, String directory, boolean skipTests = false, List profiles = [], String extraArgs = '') {

--- a/Jenkinsfile.promote
+++ b/Jenkinsfile.promote
@@ -98,7 +98,7 @@ pipeline {
             }
             steps {
                 script {
-                    mavenCleanInstall('optaplanner', true, ['full'])
+                    mavenCleanInstall('optaplanner', true, [], '-Dfull')
                     dir('optaplanner') {
                         withCredentials(bindings: [sshUserPrivateKey(credentialsId: 'optaplanner-filemgmt',
                                              keyFileVariable: 'SSH_KEY_JBOSS_FILEMGMT')]) {


### PR DESCRIPTION
The "fullProfile" was not properly activated in all relevant maven builds.

A cherry-pick of #1026 

<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.
-->

### JIRA

<!-- Add a JIRA ticket link if it exists. -->
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
* https://github.com/kiegroup/drools/pull/3000
* https://github.com/kiegroup/optaplanner/pull/899
* etc.
-->

### Checklist
- [x] Documentation updated if applicable.
- [x] Upgrade recipe provided if applicable.

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>full downstream build</b> please add comment: <b>Jenkins run fdb</b>
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
