### PR TITLE
PLANNER-2250 Disable flaky tests

### DIFF
--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/partitionedsearch/DefaultPartitionedSearchPhaseTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/partitionedsearch/DefaultPartitionedSearchPhaseTest.java
@@ -31,6 +31,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.optaplanner.core.api.solver.Solver;
@@ -165,6 +166,7 @@ public class DefaultPartitionedSearchPhaseTest {
         assertThat(solutionFuture.get()).isNotNull();
     }
 
+    @Disabled("PLANNER-2249")
     @Test
     @Timeout(5)
     public void shutdownMainThreadAbruptly() throws InterruptedException {

--- a/optaplanner-examples/src/test/java/org/optaplanner/examples/cloudbalancing/app/CloudBalancingDaemonTest.java
+++ b/optaplanner-examples/src/test/java/org/optaplanner/examples/cloudbalancing/app/CloudBalancingDaemonTest.java
@@ -24,6 +24,7 @@ import java.util.Queue;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.optaplanner.core.api.solver.Solver;
@@ -50,6 +51,7 @@ public class CloudBalancingDaemonTest extends LoggingTest {
     private volatile Throwable solverThreadException = null;
     private volatile CloudBalance currentBestSolution = null;
 
+    @Disabled("PLANNER-2249")
     @Test
     @Timeout(600)
     public void daemon() throws InterruptedException {


### PR DESCRIPTION
Tests identified as flaky:

DefaultPartitionedSearchPhaseTest.shutdownMainThreadAbruptly
CloudBalancingDaemonTest.daemon

These tests have failed sporadically in the past and need to be reviewed.