### PR TITLE
Set sonar.java.source to 11

### DIFF
--- a/build/optaplanner-build-parent/pom.xml
+++ b/build/optaplanner-build-parent/pom.xml
@@ -1203,6 +1203,7 @@
         <sonar.organization>kiegroup</sonar.organization>
         <!--suppress UnresolvedMavenProperty -->
         <sonar.login>${env.SONARCLOUD_TOKEN}</sonar.login>
+        <sonar.java.source>${maven.compiler.release}</sonar.java.source>
       </properties>
       <build>
         <plugins>


### PR DESCRIPTION
Currently it's wrongly detected as 8 during Sonar Scanner execution:

[INFO] Configured Java source version (sonar.java.source): 8

According to documentation [1], sonar.java.source affects rule
activation. Using a lower version (8) might cause some Java 11 rules no
being activated.

[1] https://docs.sonarqube.org/latest/analysis/languages/java/
<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>full downstream build</b> please add comment: <b>Jenkins run fdb</b>
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
