### PR TITLE
PLANNER-2242 Add optawebs to the nightly pipeline

### DIFF
--- a/Jenkinsfile.deploy
+++ b/Jenkinsfile.deploy
@@ -81,10 +81,12 @@ pipeline {
             steps {
                 checkoutRepo('optaplanner', getBuildBranch())
                 checkoutRepo('optaplanner-quickstarts', getQuickStartsBranch())
+                checkoutRepo('optaweb-vehicle-routing', getBuildBranch())
+                checkoutRepo('optaweb-employee-rostering', getBuildBranch())
             }
         }
 
-        stage('Prepare for PR'){
+        stage('Prepare for PR') {
             when {
                 expression { return isRelease() }
             }
@@ -93,7 +95,7 @@ pipeline {
             }
         }
 
-        stage('Setup Maven config'){
+        stage('Setup Maven config') {
             steps {
                 script {
                     configFileProvider([configFile(fileId: maven.getSubmarineSettingsXmlId(), targetLocation: 'maven-settings.xml', variable: 'MAVEN_SETTINGS_FILE')]) {
@@ -164,9 +166,37 @@ pipeline {
             }
         }
 
+        stage('Build optaweb-vehicle-routing') {
+            steps {
+                mavenCleanInstall('optaweb-vehicle-routing', params.SKIP_TESTS, [], "-s ${env.GLOBAL_MAVEN_SETTINGS}")
+            }
+            post {
+                always {
+                    saveReports(params.SKIP_TESTS)
+                    // TODO: Enable together with the profile "integration-tests" once dockerhub pull limit is resolved.
+                    // archiveArtifacts(allowEmptyArchive: true, artifacts: "**/cypress/screenshots/**,**/cypress/videos/**", fingerprint: false)
+                }
+            }
+        }
+
+        stage('Build optaweb-employee-rostering') {
+            steps {
+                mavenCleanInstall('optaweb-employee-rostering', params.SKIP_TESTS, [], "-s ${env.GLOBAL_MAVEN_SETTINGS}")
+            }
+            post {
+                always {
+                    saveReports(params.SKIP_TESTS)
+                    // TODO: Enable together with the profile "integration-tests" once dockerhub pull limit is resolved.
+                    // archiveArtifacts(allowEmptyArchive: true, artifacts: "**/cypress/screenshots/**,**/cypress/videos/**", fingerprint: false)
+                }
+            }
+        }
+
         stage('Deploy artifacts') {
             steps {
                 mavenDeploy('optaplanner', '-Dfull')
+                mavenDeploy('optaweb-vehicle-routing', "-s ${env.GLOBAL_MAVEN_SETTINGS}")
+                mavenDeploy('optaweb-employee-rostering', "-s ${env.GLOBAL_MAVEN_SETTINGS}")
             }
         }
 


### PR DESCRIPTION
Already tested with a custom job: https://rhba-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/custom/job/rsynek/job/releasePipeline/job/optaplanner-deploy

<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.
-->

### JIRA
https://issues.redhat.com/browse/PLANNER-2242

<!-- Add a JIRA ticket link if it exists. -->
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
* https://github.com/kiegroup/drools/pull/3000
* https://github.com/kiegroup/optaplanner/pull/899
* etc.
-->

### Checklist
- [ ] Documentation updated if applicable.
- [ ] Upgrade recipe provided if applicable.

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>full downstream build</b> please add comment: <b>Jenkins run fdb</b>
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
