### PR TITLE
Upgrade Quarkus to 1.10.0.Final

### DIFF
--- a/build/optaplanner-build-parent/pom.xml
+++ b/build/optaplanner-build-parent/pom.xml
@@ -30,7 +30,7 @@
     <version.com.fasterxml.jackson.core>2.10.4</version.com.fasterxml.jackson.core>
     <version.com.h2database>1.3.173</version.com.h2database>
     <version.com.thoughtworks.xstream>1.4.14</version.com.thoughtworks.xstream>
-    <version.io.quarkus>1.9.0.Final</version.io.quarkus>
+    <version.io.quarkus>1.10.0.Final</version.io.quarkus>
     <version.jakarta.json.bind>1.0.2</version.jakarta.json.bind>
     <version.jakarta.xml.bind>2.3.3</version.jakarta.xml.bind>
     <version.org.apache.commons.lang3>3.9</version.org.apache.commons.lang3>


### PR DESCRIPTION
Quarkus 1.10.0.Final has just become publicly available. A PR to optaplanner-quickstarts and cherry-picking to 8.0.x branches will follow.

<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.
-->

### JIRA

<!-- Add a JIRA ticket link if it exists. -->
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->

### Referenced pull requests
https://github.com/kiegroup/optaplanner/pull/1038
https://github.com/kiegroup/optaplanner-quickstarts/pull/24

https://github.com/kiegroup/optaplanner/pull/1039
https://github.com/kiegroup/optaplanner-quickstarts/pull/25

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
* https://github.com/kiegroup/drools/pull/3000
* https://github.com/kiegroup/optaplanner/pull/899
* etc.
-->

### Checklist
- [ ] Documentation updated if applicable.
- [ ] Upgrade recipe provided if applicable.

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>full downstream build</b> please add comment: <b>Jenkins run fdb</b>
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
