### PR TITLE
Move deprecated build methods to Factories

### DIFF
--- a/optaplanner-benchmark/src/build/revapi-config.json
+++ b/optaplanner-benchmark/src/build/revapi-config.json
@@ -476,6 +476,15 @@
           "classSimpleName": "SingleStatisticType",
           "elementKind": "enum",
           "justification": "Using JAXB instead of XStream now."
+        },
+        {
+          "code": "java.field.removed",
+          "old": "field org.optaplanner.benchmark.config.PlannerBenchmarkConfig.VALID_NAME_PATTERN",
+          "package": "org.optaplanner.benchmark.config",
+          "classSimpleName": "PlannerBenchmarkConfig",
+          "fieldName": "VALID_NAME_PATTERN",
+          "elementKind": "field",
+          "justification": "Validation of the PlannerBenchmarkConfig moved to the DefaultPlannerBenchmarkFactory class."
         }
       ]
     }

--- a/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/config/ProblemBenchmarksConfig.java
+++ b/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/config/ProblemBenchmarksConfig.java
@@ -17,30 +17,15 @@
 package org.optaplanner.benchmark.config;
 
 import java.io.File;
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlType;
 
-import org.apache.commons.lang3.BooleanUtils;
-import org.optaplanner.benchmark.api.PlannerBenchmarkFactory;
 import org.optaplanner.benchmark.config.statistic.ProblemStatisticType;
 import org.optaplanner.benchmark.config.statistic.SingleStatisticType;
-import org.optaplanner.benchmark.impl.loader.FileProblemProvider;
-import org.optaplanner.benchmark.impl.loader.InstanceProblemProvider;
-import org.optaplanner.benchmark.impl.loader.ProblemProvider;
-import org.optaplanner.benchmark.impl.result.PlannerBenchmarkResult;
-import org.optaplanner.benchmark.impl.result.ProblemBenchmarkResult;
-import org.optaplanner.benchmark.impl.result.SingleBenchmarkResult;
-import org.optaplanner.benchmark.impl.result.SolverBenchmarkResult;
-import org.optaplanner.benchmark.impl.result.SubSingleBenchmarkResult;
-import org.optaplanner.benchmark.impl.statistic.ProblemStatistic;
 import org.optaplanner.core.config.AbstractConfig;
 import org.optaplanner.core.config.util.ConfigUtils;
-import org.optaplanner.core.impl.domain.solution.descriptor.SolutionDescriptor;
-import org.optaplanner.core.impl.solver.DefaultSolverFactory;
 import org.optaplanner.persistence.common.api.domain.solution.SolutionFileIO;
 
 @XmlType(propOrder = {
@@ -118,139 +103,6 @@ public class ProblemBenchmarksConfig extends AbstractConfig<ProblemBenchmarksCon
 
     public void setSingleStatisticTypeList(List<SingleStatisticType> singleStatisticTypeList) {
         this.singleStatisticTypeList = singleStatisticTypeList;
-    }
-
-    // ************************************************************************
-    // Builder methods
-    // ************************************************************************
-
-    public <Solution_> void buildProblemBenchmarkList(SolverBenchmarkResult solverBenchmarkResult,
-            Solution_[] extraProblems) {
-        PlannerBenchmarkResult plannerBenchmarkResult = solverBenchmarkResult.getPlannerBenchmarkResult();
-        List<ProblemBenchmarkResult> unifiedProblemBenchmarkResultList = plannerBenchmarkResult
-                .getUnifiedProblemBenchmarkResultList();
-        for (ProblemProvider<Solution_> problemProvider : buildProblemProviderList(
-                solverBenchmarkResult, extraProblems)) {
-            // 2 SolverBenchmarks containing equal ProblemBenchmarks should contain the same instance
-            ProblemBenchmarkResult<Solution_> newProblemBenchmarkResult = buildProblemBenchmark(
-                    plannerBenchmarkResult, problemProvider);
-            ProblemBenchmarkResult<Solution_> problemBenchmarkResult;
-            int index = unifiedProblemBenchmarkResultList.indexOf(newProblemBenchmarkResult);
-            if (index < 0) {
-                problemBenchmarkResult = newProblemBenchmarkResult;
-                unifiedProblemBenchmarkResultList.add(problemBenchmarkResult);
-            } else {
-                problemBenchmarkResult = unifiedProblemBenchmarkResultList.get(index);
-            }
-            buildSingleBenchmark(solverBenchmarkResult, problemBenchmarkResult);
-        }
-    }
-
-    private <Solution_> List<ProblemProvider<Solution_>> buildProblemProviderList(
-            SolverBenchmarkResult solverBenchmarkResult, Solution_[] extraProblems) {
-        if (ConfigUtils.isEmptyCollection(inputSolutionFileList) && extraProblems.length == 0) {
-            throw new IllegalArgumentException(
-                    "The solverBenchmarkResult (" + solverBenchmarkResult.getName() + ") has no problems.\n"
-                            + "Maybe configure at least 1 <inputSolutionFile> directly or indirectly by inheriting it.\n"
-                            + "Or maybe pass at least one problem to " + PlannerBenchmarkFactory.class.getSimpleName()
-                            + ".buildPlannerBenchmark().");
-        }
-        List<ProblemProvider<Solution_>> problemProviderList = new ArrayList<>(
-                extraProblems.length + (inputSolutionFileList == null ? 0 : inputSolutionFileList.size()));
-        DefaultSolverFactory<Solution_> defaultSolverFactory =
-                new DefaultSolverFactory<>(solverBenchmarkResult.getSolverConfig());
-        SolutionDescriptor<Solution_> solutionDescriptor = defaultSolverFactory.buildSolutionDescriptor();
-        int extraProblemIndex = 0;
-        for (Solution_ extraProblem : extraProblems) {
-            if (extraProblem == null) {
-                throw new IllegalStateException("The benchmark problem (" + extraProblem + ") is null.");
-            }
-            String problemName = "Problem_" + extraProblemIndex;
-            problemProviderList.add(new InstanceProblemProvider<>(problemName, solutionDescriptor, extraProblem));
-            extraProblemIndex++;
-        }
-        if (ConfigUtils.isEmptyCollection(inputSolutionFileList)) {
-            if (solutionFileIOClass != null) {
-                throw new IllegalArgumentException("Cannot use solutionFileIOClass (" + solutionFileIOClass
-                        + ") with an empty inputSolutionFileList (" + inputSolutionFileList + ").");
-            }
-        } else {
-            SolutionFileIO<Solution_> solutionFileIO = buildSolutionFileIO();
-            for (File inputSolutionFile : inputSolutionFileList) {
-                if (!inputSolutionFile.exists()) {
-                    throw new IllegalArgumentException("The inputSolutionFile (" + inputSolutionFile
-                            + ") does not exist.");
-                }
-                problemProviderList.add(new FileProblemProvider<>(solutionFileIO, inputSolutionFile));
-            }
-        }
-        return problemProviderList;
-    }
-
-    private <Solution_> SolutionFileIO<Solution_> buildSolutionFileIO() {
-        if (solutionFileIOClass == null) {
-            throw new IllegalArgumentException("The solutionFileIOClass (" + solutionFileIOClass + ") cannot be null.");
-        }
-        return (SolutionFileIO<Solution_>) ConfigUtils.newInstance(this, "solutionFileIOClass", solutionFileIOClass);
-    }
-
-    private <Solution_> ProblemBenchmarkResult<Solution_> buildProblemBenchmark(
-            PlannerBenchmarkResult plannerBenchmarkResult, ProblemProvider<Solution_> problemProvider) {
-        ProblemBenchmarkResult<Solution_> problemBenchmarkResult = new ProblemBenchmarkResult<>(plannerBenchmarkResult);
-        problemBenchmarkResult.setName(problemProvider.getProblemName());
-        problemBenchmarkResult.setProblemProvider(problemProvider);
-        problemBenchmarkResult.setWriteOutputSolutionEnabled(
-                writeOutputSolutionEnabled == null ? false : writeOutputSolutionEnabled);
-        List<ProblemStatistic> problemStatisticList;
-        if (BooleanUtils.isFalse(problemStatisticEnabled)) {
-            if (!ConfigUtils.isEmptyCollection(problemStatisticTypeList)) {
-                throw new IllegalArgumentException("The problemStatisticEnabled (" + problemStatisticEnabled
-                        + ") and problemStatisticTypeList (" + problemStatisticTypeList + ") can be used together.");
-            }
-            problemStatisticList = Collections.emptyList();
-        } else {
-            List<ProblemStatisticType> problemStatisticTypeList_ = (problemStatisticTypeList == null)
-                    ? Collections.singletonList(ProblemStatisticType.BEST_SCORE)
-                    : problemStatisticTypeList;
-            problemStatisticList = new ArrayList<>(problemStatisticTypeList_.size());
-            for (ProblemStatisticType problemStatisticType : problemStatisticTypeList_) {
-                problemStatisticList.add(problemStatisticType.buildProblemStatistic(problemBenchmarkResult));
-            }
-        }
-        problemBenchmarkResult.setProblemStatisticList(problemStatisticList);
-        problemBenchmarkResult.setSingleBenchmarkResultList(new ArrayList<>());
-        return problemBenchmarkResult;
-    }
-
-    private void buildSingleBenchmark(SolverBenchmarkResult solverBenchmarkResult,
-            ProblemBenchmarkResult problemBenchmarkResult) {
-        SingleBenchmarkResult singleBenchmarkResult = new SingleBenchmarkResult(solverBenchmarkResult, problemBenchmarkResult);
-        buildSubSingleBenchmarks(singleBenchmarkResult, solverBenchmarkResult.getSubSingleCount());
-        for (SubSingleBenchmarkResult subSingleBenchmarkResult : singleBenchmarkResult.getSubSingleBenchmarkResultList()) {
-            subSingleBenchmarkResult.setPureSubSingleStatisticList(new ArrayList<>(
-                    singleStatisticTypeList == null ? 0 : singleStatisticTypeList.size()));
-        }
-        if (singleStatisticTypeList != null) {
-            for (SingleStatisticType singleStatisticType : singleStatisticTypeList) {
-                for (SubSingleBenchmarkResult subSingleBenchmarkResult : singleBenchmarkResult
-                        .getSubSingleBenchmarkResultList()) {
-                    subSingleBenchmarkResult.getPureSubSingleStatisticList().add(
-                            singleStatisticType.buildPureSubSingleStatistic(subSingleBenchmarkResult));
-                }
-            }
-        }
-        singleBenchmarkResult.initSubSingleStatisticMaps();
-        solverBenchmarkResult.getSingleBenchmarkResultList().add(singleBenchmarkResult);
-        problemBenchmarkResult.getSingleBenchmarkResultList().add(singleBenchmarkResult);
-    }
-
-    private void buildSubSingleBenchmarks(SingleBenchmarkResult parent, int subSingleCount) {
-        List<SubSingleBenchmarkResult> subSingleBenchmarkResultList = new ArrayList<>(subSingleCount);
-        for (int i = 0; i < subSingleCount; i++) {
-            SubSingleBenchmarkResult subSingleBenchmarkResult = new SubSingleBenchmarkResult(parent, i);
-            subSingleBenchmarkResultList.add(subSingleBenchmarkResult);
-        }
-        parent.setSubSingleBenchmarkResultList(subSingleBenchmarkResultList);
     }
 
     @Override

--- a/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/config/SolverBenchmarkConfig.java
+++ b/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/config/SolverBenchmarkConfig.java
@@ -16,18 +16,12 @@
 
 package org.optaplanner.benchmark.config;
 
-import java.util.ArrayList;
-
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlType;
 
-import org.optaplanner.benchmark.impl.result.PlannerBenchmarkResult;
-import org.optaplanner.benchmark.impl.result.SolverBenchmarkResult;
 import org.optaplanner.core.config.AbstractConfig;
 import org.optaplanner.core.config.solver.SolverConfig;
 import org.optaplanner.core.config.util.ConfigUtils;
-import org.optaplanner.core.impl.domain.solution.descriptor.SolutionDescriptor;
-import org.optaplanner.core.impl.solver.DefaultSolverFactory;
 
 @XmlType(propOrder = {
         "name",
@@ -81,56 +75,6 @@ public class SolverBenchmarkConfig extends AbstractConfig<SolverBenchmarkConfig>
 
     public void setSubSingleCount(Integer subSingleCount) {
         this.subSingleCount = subSingleCount;
-    }
-
-    // ************************************************************************
-    // Builder methods
-    // ************************************************************************
-
-    public <Solution_> void buildSolverBenchmark(ClassLoader classLoader, PlannerBenchmarkResult plannerBenchmark,
-            Solution_[] extraProblems) {
-        validate();
-        SolverBenchmarkResult solverBenchmarkResult = new SolverBenchmarkResult(plannerBenchmark);
-        solverBenchmarkResult.setName(name);
-        solverBenchmarkResult.setSubSingleCount(ConfigUtils.inheritOverwritableProperty(subSingleCount, 1));
-        if (solverConfig.getClassLoader() == null) {
-            solverConfig.setClassLoader(classLoader);
-        }
-        solverBenchmarkResult.setSolverConfig(solverConfig);
-        DefaultSolverFactory<Solution_> defaultSolverFactory = new DefaultSolverFactory<>(solverConfig);
-        SolutionDescriptor<Solution_> solutionDescriptor = defaultSolverFactory.buildSolutionDescriptor();
-        for (Solution_ extraProblem : extraProblems) {
-            if (!solutionDescriptor.getSolutionClass().isInstance(extraProblem)) {
-                throw new IllegalArgumentException("The solverBenchmark name (" + name
-                        + ") for solution class (" + solutionDescriptor.getSolutionClass()
-                        + ") cannot solve a problem (" + extraProblem
-                        + ") of class (" + (extraProblem == null ? null : extraProblem.getClass()) + ").");
-            }
-        }
-        solverBenchmarkResult.setScoreDefinition(
-                solutionDescriptor.getScoreDefinition());
-        solverBenchmarkResult.setSingleBenchmarkResultList(new ArrayList<>());
-        ProblemBenchmarksConfig problemBenchmarksConfig_ = problemBenchmarksConfig == null ? new ProblemBenchmarksConfig()
-                : problemBenchmarksConfig;
-        plannerBenchmark.getSolverBenchmarkResultList().add(solverBenchmarkResult);
-        problemBenchmarksConfig_.buildProblemBenchmarkList(solverBenchmarkResult, extraProblems);
-    }
-
-    protected void validate() {
-        if (!PlannerBenchmarkConfig.VALID_NAME_PATTERN.matcher(name).matches()) {
-            throw new IllegalStateException("The solverBenchmark name (" + name
-                    + ") is invalid because it does not follow the nameRegex ("
-                    + PlannerBenchmarkConfig.VALID_NAME_PATTERN.pattern() + ")" +
-                    " which might cause an illegal filename.");
-        }
-        if (!name.trim().equals(name)) {
-            throw new IllegalStateException("The solverBenchmark name (" + name
-                    + ") is invalid because it starts or ends with whitespace.");
-        }
-        if (subSingleCount != null && subSingleCount < 1) {
-            throw new IllegalStateException("The solverBenchmark name (" + name
-                    + ") is invalid because the subSingleCount (" + subSingleCount + ") must be greater than 1.");
-        }
     }
 
     @Override

--- a/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/config/report/BenchmarkReportConfig.java
+++ b/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/config/report/BenchmarkReportConfig.java
@@ -16,7 +16,6 @@
 
 package org.optaplanner.benchmark.config.report;
 
-import java.time.ZoneId;
 import java.util.Comparator;
 import java.util.Locale;
 
@@ -25,11 +24,6 @@ import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 
 import org.optaplanner.benchmark.config.ranking.SolverRankingType;
 import org.optaplanner.benchmark.impl.ranking.SolverRankingWeightFactory;
-import org.optaplanner.benchmark.impl.ranking.TotalRankSolverRankingWeightFactory;
-import org.optaplanner.benchmark.impl.ranking.TotalScoreSolverRankingComparator;
-import org.optaplanner.benchmark.impl.ranking.WorstScoreSolverRankingComparator;
-import org.optaplanner.benchmark.impl.report.BenchmarkReport;
-import org.optaplanner.benchmark.impl.result.PlannerBenchmarkResult;
 import org.optaplanner.benchmark.impl.result.SolverBenchmarkResult;
 import org.optaplanner.core.config.AbstractConfig;
 import org.optaplanner.core.config.util.ConfigUtils;
@@ -90,72 +84,8 @@ public class BenchmarkReportConfig extends AbstractConfig<BenchmarkReportConfig>
         this.solverRankingWeightFactoryClass = solverRankingWeightFactoryClass;
     }
 
-    // ************************************************************************
-    // Builder methods
-    // ************************************************************************
-
-    public BenchmarkReport buildBenchmarkReport(PlannerBenchmarkResult plannerBenchmark) {
-        BenchmarkReport benchmarkReport = new BenchmarkReport(plannerBenchmark);
-        benchmarkReport.setLocale(determineLocale());
-        benchmarkReport.setTimezoneId(ZoneId.systemDefault());
-        supplySolverRanking(benchmarkReport);
-        return benchmarkReport;
-    }
-
     public Locale determineLocale() {
-        return locale == null ? Locale.getDefault() : locale;
-    }
-
-    protected void supplySolverRanking(BenchmarkReport benchmarkReport) {
-        if (solverRankingType != null && solverRankingComparatorClass != null) {
-            throw new IllegalStateException("The PlannerBenchmark cannot have"
-                    + " a solverRankingType (" + solverRankingType
-                    + ") and a solverRankingComparatorClass (" + solverRankingComparatorClass.getName()
-                    + ") at the same time.");
-        } else if (solverRankingType != null && solverRankingWeightFactoryClass != null) {
-            throw new IllegalStateException("The PlannerBenchmark cannot have"
-                    + " a solverRankingType (" + solverRankingType
-                    + ") and a solverRankingWeightFactoryClass (" + solverRankingWeightFactoryClass.getName()
-                    + ") at the same time.");
-        } else if (solverRankingComparatorClass != null && solverRankingWeightFactoryClass != null) {
-            throw new IllegalStateException("The PlannerBenchmark cannot have"
-                    + " a solverRankingComparatorClass (" + solverRankingComparatorClass.getName()
-                    + ") and a solverRankingWeightFactoryClass (" + solverRankingWeightFactoryClass.getName()
-                    + ") at the same time.");
-        }
-        Comparator<SolverBenchmarkResult> solverRankingComparator = null;
-        SolverRankingWeightFactory solverRankingWeightFactory = null;
-        if (solverRankingType != null) {
-            switch (solverRankingType) {
-                case TOTAL_SCORE:
-                    solverRankingComparator = new TotalScoreSolverRankingComparator();
-                    break;
-                case WORST_SCORE:
-                    solverRankingComparator = new WorstScoreSolverRankingComparator();
-                    break;
-                case TOTAL_RANKING:
-                    solverRankingWeightFactory = new TotalRankSolverRankingWeightFactory();
-                    break;
-                default:
-                    throw new IllegalStateException("The solverRankingType ("
-                            + solverRankingType + ") is not implemented.");
-            }
-        }
-        if (solverRankingComparatorClass != null) {
-            solverRankingComparator = ConfigUtils.newInstance(this,
-                    "solverRankingComparatorClass", solverRankingComparatorClass);
-        }
-        if (solverRankingWeightFactoryClass != null) {
-            solverRankingWeightFactory = ConfigUtils.newInstance(this,
-                    "solverRankingWeightFactoryClass", solverRankingWeightFactoryClass);
-        }
-        if (solverRankingComparator != null) {
-            benchmarkReport.setSolverRankingComparator(solverRankingComparator);
-        } else if (solverRankingWeightFactory != null) {
-            benchmarkReport.setSolverRankingWeightFactory(solverRankingWeightFactory);
-        } else {
-            benchmarkReport.setSolverRankingComparator(new TotalScoreSolverRankingComparator());
-        }
+        return getLocale() == null ? Locale.getDefault() : getLocale();
     }
 
     @Override

--- a/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/impl/DefaultPlannerBenchmarkFactory.java
+++ b/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/impl/DefaultPlannerBenchmarkFactory.java
@@ -16,14 +16,39 @@
 
 package org.optaplanner.benchmark.impl;
 
+import static org.apache.commons.lang3.ObjectUtils.defaultIfNull;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
+import java.util.regex.Pattern;
+
 import org.optaplanner.benchmark.api.PlannerBenchmark;
 import org.optaplanner.benchmark.api.PlannerBenchmarkFactory;
 import org.optaplanner.benchmark.config.PlannerBenchmarkConfig;
+import org.optaplanner.benchmark.config.SolverBenchmarkConfig;
+import org.optaplanner.benchmark.config.blueprint.SolverBenchmarkBluePrintConfig;
+import org.optaplanner.benchmark.config.report.BenchmarkReportConfig;
+import org.optaplanner.benchmark.impl.report.BenchmarkReport;
+import org.optaplanner.benchmark.impl.report.BenchmarkReportFactory;
+import org.optaplanner.benchmark.impl.result.PlannerBenchmarkResult;
+import org.optaplanner.core.config.util.ConfigUtils;
+import org.optaplanner.core.impl.solver.thread.DefaultSolverThreadFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * @see PlannerBenchmarkFactory
  */
 public class DefaultPlannerBenchmarkFactory extends PlannerBenchmarkFactory {
+
+    public static final Pattern VALID_NAME_PATTERN = Pattern.compile("(?U)^[\\w\\d _\\-\\.\\(\\)]+$");
+    private static final Logger logger = LoggerFactory.getLogger(DefaultPlannerBenchmarkFactory.class);
 
     protected final PlannerBenchmarkConfig plannerBenchmarkConfig;
 
@@ -38,15 +63,212 @@ public class DefaultPlannerBenchmarkFactory extends PlannerBenchmarkFactory {
     // Worker methods
     // ************************************************************************
 
+    /**
+     * @return never null
+     */
     @Override
     public PlannerBenchmark buildPlannerBenchmark() {
-        return plannerBenchmarkConfig.buildPlannerBenchmark();
+        return buildPlannerBenchmark(new Object[0]);
     }
 
     @Override
     @SafeVarargs
     public final <Solution_> PlannerBenchmark buildPlannerBenchmark(Solution_... problems) {
-        return plannerBenchmarkConfig.buildPlannerBenchmark(problems);
+        validate();
+        generateSolverBenchmarkConfigNames();
+        List<SolverBenchmarkConfig> effectiveSolverBenchmarkConfigList = buildEffectiveSolverBenchmarkConfigList();
+
+        PlannerBenchmarkResult plannerBenchmarkResult = new PlannerBenchmarkResult();
+        plannerBenchmarkResult.setName(plannerBenchmarkConfig.getName());
+        plannerBenchmarkResult.setAggregation(false);
+        int parallelBenchmarkCount = resolveParallelBenchmarkCount();
+        plannerBenchmarkResult.setParallelBenchmarkCount(parallelBenchmarkCount);
+        plannerBenchmarkResult.setWarmUpTimeMillisSpentLimit(defaultIfNull(calculateWarmUpTimeMillisSpentLimit(), 30L));
+        plannerBenchmarkResult.setUnifiedProblemBenchmarkResultList(new ArrayList<>());
+        plannerBenchmarkResult.setSolverBenchmarkResultList(new ArrayList<>(effectiveSolverBenchmarkConfigList.size()));
+        for (SolverBenchmarkConfig solverBenchmarkConfig : effectiveSolverBenchmarkConfigList) {
+            SolverBenchmarkFactory solverBenchmarkFactory = new SolverBenchmarkFactory(solverBenchmarkConfig);
+            solverBenchmarkFactory.buildSolverBenchmark(plannerBenchmarkConfig.getClassLoader(), plannerBenchmarkResult,
+                    problems);
+        }
+
+        BenchmarkReportConfig benchmarkReportConfig_ =
+                plannerBenchmarkConfig.getBenchmarkReportConfig() == null ? new BenchmarkReportConfig()
+                        : plannerBenchmarkConfig.getBenchmarkReportConfig();
+        BenchmarkReport benchmarkReport =
+                new BenchmarkReportFactory(benchmarkReportConfig_).buildBenchmarkReport(plannerBenchmarkResult);
+        return new DefaultPlannerBenchmark(plannerBenchmarkResult, plannerBenchmarkConfig.getBenchmarkDirectory(),
+                buildExecutorService(parallelBenchmarkCount), buildExecutorService(parallelBenchmarkCount), benchmarkReport);
     }
 
+    private ExecutorService buildExecutorService(int parallelBenchmarkCount) {
+        ThreadFactory threadFactory;
+        if (plannerBenchmarkConfig.getThreadFactoryClass() != null) {
+            threadFactory = ConfigUtils.newInstance(plannerBenchmarkConfig, "threadFactoryClass",
+                    plannerBenchmarkConfig.getThreadFactoryClass());
+        } else {
+            threadFactory = new DefaultSolverThreadFactory("BenchmarkThread");
+        }
+        return Executors.newFixedThreadPool(parallelBenchmarkCount, threadFactory);
+    }
+
+    protected void validate() {
+        if (plannerBenchmarkConfig.getName() != null) {
+            if (!VALID_NAME_PATTERN.matcher(plannerBenchmarkConfig.getName()).matches()) {
+                throw new IllegalStateException("The plannerBenchmark name (" + plannerBenchmarkConfig.getName()
+                        + ") is invalid because it does not follow the nameRegex ("
+                        + VALID_NAME_PATTERN.pattern() + ")" +
+                        " which might cause an illegal filename.");
+            }
+            if (!plannerBenchmarkConfig.getName().trim().equals(plannerBenchmarkConfig.getName())) {
+                throw new IllegalStateException("The plannerBenchmark name (" + plannerBenchmarkConfig.getName()
+                        + ") is invalid because it starts or ends with whitespace.");
+            }
+        }
+        if (ConfigUtils.isEmptyCollection(plannerBenchmarkConfig.getSolverBenchmarkBluePrintConfigList())
+                && ConfigUtils.isEmptyCollection(plannerBenchmarkConfig.getSolverBenchmarkConfigList())) {
+            throw new IllegalArgumentException(
+                    "Configure at least 1 <solverBenchmark> (or 1 <solverBenchmarkBluePrint>)"
+                            + " in the <plannerBenchmark> configuration.");
+        }
+    }
+
+    protected void generateSolverBenchmarkConfigNames() {
+        if (plannerBenchmarkConfig.getSolverBenchmarkConfigList() != null) {
+            Set<String> nameSet = new HashSet<>(plannerBenchmarkConfig.getSolverBenchmarkConfigList().size());
+            Set<SolverBenchmarkConfig> noNameBenchmarkConfigSet =
+                    new LinkedHashSet<>(plannerBenchmarkConfig.getSolverBenchmarkConfigList().size());
+            for (SolverBenchmarkConfig solverBenchmarkConfig : plannerBenchmarkConfig.getSolverBenchmarkConfigList()) {
+                if (solverBenchmarkConfig.getName() != null) {
+                    boolean unique = nameSet.add(solverBenchmarkConfig.getName());
+                    if (!unique) {
+                        throw new IllegalStateException("The benchmark name (" + solverBenchmarkConfig.getName()
+                                + ") is used in more than 1 benchmark.");
+                    }
+                } else {
+                    noNameBenchmarkConfigSet.add(solverBenchmarkConfig);
+                }
+            }
+            int generatedNameIndex = 0;
+            for (SolverBenchmarkConfig solverBenchmarkConfig : noNameBenchmarkConfigSet) {
+                String generatedName = "Config_" + generatedNameIndex;
+                while (nameSet.contains(generatedName)) {
+                    generatedNameIndex++;
+                    generatedName = "Config_" + generatedNameIndex;
+                }
+                solverBenchmarkConfig.setName(generatedName);
+                generatedNameIndex++;
+            }
+        }
+    }
+
+    protected List<SolverBenchmarkConfig> buildEffectiveSolverBenchmarkConfigList() {
+        List<SolverBenchmarkConfig> effectiveSolverBenchmarkConfigList = new ArrayList<>(0);
+        if (plannerBenchmarkConfig.getSolverBenchmarkConfigList() != null) {
+            effectiveSolverBenchmarkConfigList.addAll(plannerBenchmarkConfig.getSolverBenchmarkConfigList());
+        }
+        if (plannerBenchmarkConfig.getSolverBenchmarkBluePrintConfigList() != null) {
+            for (SolverBenchmarkBluePrintConfig solverBenchmarkBluePrintConfig : plannerBenchmarkConfig
+                    .getSolverBenchmarkBluePrintConfigList()) {
+                effectiveSolverBenchmarkConfigList.addAll(solverBenchmarkBluePrintConfig.buildSolverBenchmarkConfigList());
+            }
+        }
+        if (plannerBenchmarkConfig.getInheritedSolverBenchmarkConfig() != null) {
+            for (SolverBenchmarkConfig solverBenchmarkConfig : effectiveSolverBenchmarkConfigList) {
+                // Side effect: changes the unmarshalled solverBenchmarkConfig
+                solverBenchmarkConfig.inherit(plannerBenchmarkConfig.getInheritedSolverBenchmarkConfig());
+            }
+        }
+        return effectiveSolverBenchmarkConfigList;
+    }
+
+    protected int resolveParallelBenchmarkCount() {
+        int availableProcessorCount = Runtime.getRuntime().availableProcessors();
+        int resolvedParallelBenchmarkCount;
+        if (plannerBenchmarkConfig.getParallelBenchmarkCount() == null) {
+            resolvedParallelBenchmarkCount = 1;
+        } else if (plannerBenchmarkConfig.getParallelBenchmarkCount()
+                .equals(PlannerBenchmarkConfig.PARALLEL_BENCHMARK_COUNT_AUTO)) {
+            resolvedParallelBenchmarkCount = resolveParallelBenchmarkCountAutomatically(availableProcessorCount);
+        } else {
+            resolvedParallelBenchmarkCount = ConfigUtils.resolvePoolSize("parallelBenchmarkCount",
+                    plannerBenchmarkConfig.getParallelBenchmarkCount(), PlannerBenchmarkConfig.PARALLEL_BENCHMARK_COUNT_AUTO);
+        }
+        if (resolvedParallelBenchmarkCount < 1) {
+            throw new IllegalArgumentException(
+                    "The parallelBenchmarkCount (" + plannerBenchmarkConfig.getParallelBenchmarkCount()
+                            + ") resulted in a resolvedParallelBenchmarkCount (" + resolvedParallelBenchmarkCount
+                            + ") that is lower than 1.");
+        }
+        if (resolvedParallelBenchmarkCount > availableProcessorCount) {
+            logger.warn("Because the resolvedParallelBenchmarkCount ({}) is higher "
+                    + "than the availableProcessorCount ({}), it is reduced to "
+                    + "availableProcessorCount.", resolvedParallelBenchmarkCount, availableProcessorCount);
+            resolvedParallelBenchmarkCount = availableProcessorCount;
+        }
+        return resolvedParallelBenchmarkCount;
+    }
+
+    protected int resolveParallelBenchmarkCountAutomatically(int availableProcessorCount) {
+        // Tweaked based on experience
+        if (availableProcessorCount <= 2) {
+            return 1;
+        } else if (availableProcessorCount <= 4) {
+            return 2;
+        } else {
+            return (availableProcessorCount / 2) + 1;
+        }
+    }
+
+    protected Long calculateWarmUpTimeMillisSpentLimit() {
+        if (plannerBenchmarkConfig.getWarmUpMillisecondsSpentLimit() == null
+                && plannerBenchmarkConfig.getWarmUpSecondsSpentLimit() == null
+                && plannerBenchmarkConfig.getWarmUpMinutesSpentLimit() == null
+                && plannerBenchmarkConfig.getWarmUpHoursSpentLimit() == null
+                && plannerBenchmarkConfig.getWarmUpDaysSpentLimit() == null) {
+            return null;
+        }
+        long warmUpTimeMillisSpentLimit = 0L;
+        if (plannerBenchmarkConfig.getWarmUpMillisecondsSpentLimit() != null) {
+            if (plannerBenchmarkConfig.getWarmUpMillisecondsSpentLimit() < 0L) {
+                throw new IllegalArgumentException(
+                        "The warmUpMillisecondsSpentLimit (" + plannerBenchmarkConfig.getWarmUpMillisecondsSpentLimit()
+                                + ") cannot be negative.");
+            }
+            warmUpTimeMillisSpentLimit += plannerBenchmarkConfig.getWarmUpMillisecondsSpentLimit();
+        }
+        if (plannerBenchmarkConfig.getWarmUpSecondsSpentLimit() != null) {
+            if (plannerBenchmarkConfig.getWarmUpSecondsSpentLimit() < 0L) {
+                throw new IllegalArgumentException(
+                        "The warmUpSecondsSpentLimit (" + plannerBenchmarkConfig.getWarmUpSecondsSpentLimit()
+                                + ") cannot be negative.");
+            }
+            warmUpTimeMillisSpentLimit += plannerBenchmarkConfig.getWarmUpSecondsSpentLimit() * 1_000L;
+        }
+        if (plannerBenchmarkConfig.getWarmUpMinutesSpentLimit() != null) {
+            if (plannerBenchmarkConfig.getWarmUpMinutesSpentLimit() < 0L) {
+                throw new IllegalArgumentException(
+                        "The warmUpMinutesSpentLimit (" + plannerBenchmarkConfig.getWarmUpMinutesSpentLimit()
+                                + ") cannot be negative.");
+            }
+            warmUpTimeMillisSpentLimit += plannerBenchmarkConfig.getWarmUpMinutesSpentLimit() * 60_000L;
+        }
+        if (plannerBenchmarkConfig.getWarmUpHoursSpentLimit() != null) {
+            if (plannerBenchmarkConfig.getWarmUpHoursSpentLimit() < 0L) {
+                throw new IllegalArgumentException(
+                        "The warmUpHoursSpentLimit (" + plannerBenchmarkConfig.getWarmUpHoursSpentLimit()
+                                + ") cannot be negative.");
+            }
+            warmUpTimeMillisSpentLimit += plannerBenchmarkConfig.getWarmUpHoursSpentLimit() * 3_600_000L;
+        }
+        if (plannerBenchmarkConfig.getWarmUpDaysSpentLimit() != null) {
+            if (plannerBenchmarkConfig.getWarmUpDaysSpentLimit() < 0L) {
+                throw new IllegalArgumentException(
+                        "The warmUpDaysSpentLimit (" + plannerBenchmarkConfig.getWarmUpDaysSpentLimit()
+                                + ") cannot be negative.");
+            }
+            warmUpTimeMillisSpentLimit += plannerBenchmarkConfig.getWarmUpDaysSpentLimit() * 86_400_000L;
+        }
+        return warmUpTimeMillisSpentLimit;
+    }
 }

--- a/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/impl/ProblemBenchmarksFactory.java
+++ b/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/impl/ProblemBenchmarksFactory.java
@@ -1,0 +1,182 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.benchmark.impl;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.apache.commons.lang3.BooleanUtils;
+import org.optaplanner.benchmark.api.PlannerBenchmarkFactory;
+import org.optaplanner.benchmark.config.ProblemBenchmarksConfig;
+import org.optaplanner.benchmark.config.statistic.ProblemStatisticType;
+import org.optaplanner.benchmark.config.statistic.SingleStatisticType;
+import org.optaplanner.benchmark.impl.loader.FileProblemProvider;
+import org.optaplanner.benchmark.impl.loader.InstanceProblemProvider;
+import org.optaplanner.benchmark.impl.loader.ProblemProvider;
+import org.optaplanner.benchmark.impl.result.PlannerBenchmarkResult;
+import org.optaplanner.benchmark.impl.result.ProblemBenchmarkResult;
+import org.optaplanner.benchmark.impl.result.SingleBenchmarkResult;
+import org.optaplanner.benchmark.impl.result.SolverBenchmarkResult;
+import org.optaplanner.benchmark.impl.result.SubSingleBenchmarkResult;
+import org.optaplanner.benchmark.impl.statistic.ProblemStatistic;
+import org.optaplanner.core.config.util.ConfigUtils;
+import org.optaplanner.core.impl.domain.solution.descriptor.SolutionDescriptor;
+import org.optaplanner.core.impl.solver.DefaultSolverFactory;
+import org.optaplanner.persistence.common.api.domain.solution.SolutionFileIO;
+
+public class ProblemBenchmarksFactory {
+    private final ProblemBenchmarksConfig config;
+
+    public ProblemBenchmarksFactory(ProblemBenchmarksConfig config) {
+        this.config = config;
+    }
+
+    public <Solution_> void buildProblemBenchmarkList(SolverBenchmarkResult solverBenchmarkResult,
+            Solution_[] extraProblems) {
+        PlannerBenchmarkResult plannerBenchmarkResult = solverBenchmarkResult.getPlannerBenchmarkResult();
+        List<ProblemBenchmarkResult> unifiedProblemBenchmarkResultList = plannerBenchmarkResult
+                .getUnifiedProblemBenchmarkResultList();
+        for (ProblemProvider<Solution_> problemProvider : buildProblemProviderList(
+                solverBenchmarkResult, extraProblems)) {
+            // 2 SolverBenchmarks containing equal ProblemBenchmarks should contain the same instance
+            ProblemBenchmarkResult<Solution_> newProblemBenchmarkResult = buildProblemBenchmark(
+                    plannerBenchmarkResult, problemProvider);
+            ProblemBenchmarkResult<Solution_> problemBenchmarkResult;
+            int index = unifiedProblemBenchmarkResultList.indexOf(newProblemBenchmarkResult);
+            if (index < 0) {
+                problemBenchmarkResult = newProblemBenchmarkResult;
+                unifiedProblemBenchmarkResultList.add(problemBenchmarkResult);
+            } else {
+                problemBenchmarkResult = unifiedProblemBenchmarkResultList.get(index);
+            }
+            buildSingleBenchmark(solverBenchmarkResult, problemBenchmarkResult);
+        }
+    }
+
+    private <Solution_> List<ProblemProvider<Solution_>> buildProblemProviderList(
+            SolverBenchmarkResult solverBenchmarkResult, Solution_[] extraProblems) {
+        if (ConfigUtils.isEmptyCollection(config.getInputSolutionFileList()) && extraProblems.length == 0) {
+            throw new IllegalArgumentException(
+                    "The solverBenchmarkResult (" + solverBenchmarkResult.getName() + ") has no problems.\n"
+                            + "Maybe configure at least 1 <inputSolutionFile> directly or indirectly by inheriting it.\n"
+                            + "Or maybe pass at least one problem to " + PlannerBenchmarkFactory.class.getSimpleName()
+                            + ".buildPlannerBenchmark().");
+        }
+        List<ProblemProvider<Solution_>> problemProviderList = new ArrayList<>(
+                extraProblems.length
+                        + (config.getInputSolutionFileList() == null ? 0 : config.getInputSolutionFileList().size()));
+        DefaultSolverFactory<Solution_> defaultSolverFactory =
+                new DefaultSolverFactory<>(solverBenchmarkResult.getSolverConfig());
+        SolutionDescriptor<Solution_> solutionDescriptor = defaultSolverFactory.buildSolutionDescriptor();
+        int extraProblemIndex = 0;
+        for (Solution_ extraProblem : extraProblems) {
+            if (extraProblem == null) {
+                throw new IllegalStateException("The benchmark problem (" + extraProblem + ") is null.");
+            }
+            String problemName = "Problem_" + extraProblemIndex;
+            problemProviderList.add(new InstanceProblemProvider<>(problemName, solutionDescriptor, extraProblem));
+            extraProblemIndex++;
+        }
+        if (ConfigUtils.isEmptyCollection(config.getInputSolutionFileList())) {
+            if (config.getSolutionFileIOClass() != null) {
+                throw new IllegalArgumentException("Cannot use solutionFileIOClass (" + config.getSolutionFileIOClass()
+                        + ") with an empty inputSolutionFileList (" + config.getInputSolutionFileList() + ").");
+            }
+        } else {
+            SolutionFileIO<Solution_> solutionFileIO = buildSolutionFileIO();
+            for (File inputSolutionFile : config.getInputSolutionFileList()) {
+                if (!inputSolutionFile.exists()) {
+                    throw new IllegalArgumentException("The inputSolutionFile (" + inputSolutionFile
+                            + ") does not exist.");
+                }
+                problemProviderList.add(new FileProblemProvider<>(solutionFileIO, inputSolutionFile));
+            }
+        }
+        return problemProviderList;
+    }
+
+    private <Solution_> SolutionFileIO<Solution_> buildSolutionFileIO() {
+        if (config.getSolutionFileIOClass() == null) {
+            throw new IllegalArgumentException(
+                    "The solutionFileIOClass (" + config.getSolutionFileIOClass() + ") cannot be null.");
+        }
+        return (SolutionFileIO<Solution_>) ConfigUtils.newInstance(config, "solutionFileIOClass",
+                config.getSolutionFileIOClass());
+    }
+
+    private <Solution_> ProblemBenchmarkResult<Solution_> buildProblemBenchmark(
+            PlannerBenchmarkResult plannerBenchmarkResult, ProblemProvider<Solution_> problemProvider) {
+        ProblemBenchmarkResult<Solution_> problemBenchmarkResult = new ProblemBenchmarkResult<>(plannerBenchmarkResult);
+        problemBenchmarkResult.setName(problemProvider.getProblemName());
+        problemBenchmarkResult.setProblemProvider(problemProvider);
+        problemBenchmarkResult.setWriteOutputSolutionEnabled(
+                config.getWriteOutputSolutionEnabled() == null ? false : config.getWriteOutputSolutionEnabled());
+        List<ProblemStatistic> problemStatisticList;
+        if (BooleanUtils.isFalse(config.getProblemStatisticEnabled())) {
+            if (!ConfigUtils.isEmptyCollection(config.getProblemStatisticTypeList())) {
+                throw new IllegalArgumentException("The problemStatisticEnabled (" + config.getProblemStatisticEnabled()
+                        + ") and problemStatisticTypeList (" + config.getProblemStatisticTypeList()
+                        + ") can be used together.");
+            }
+            problemStatisticList = Collections.emptyList();
+        } else {
+            List<ProblemStatisticType> problemStatisticTypeList_ = (config.getProblemStatisticTypeList() == null)
+                    ? Collections.singletonList(ProblemStatisticType.BEST_SCORE)
+                    : config.getProblemStatisticTypeList();
+            problemStatisticList = new ArrayList<>(problemStatisticTypeList_.size());
+            for (ProblemStatisticType problemStatisticType : problemStatisticTypeList_) {
+                problemStatisticList.add(problemStatisticType.buildProblemStatistic(problemBenchmarkResult));
+            }
+        }
+        problemBenchmarkResult.setProblemStatisticList(problemStatisticList);
+        problemBenchmarkResult.setSingleBenchmarkResultList(new ArrayList<>());
+        return problemBenchmarkResult;
+    }
+
+    private void buildSingleBenchmark(SolverBenchmarkResult solverBenchmarkResult,
+            ProblemBenchmarkResult problemBenchmarkResult) {
+        SingleBenchmarkResult singleBenchmarkResult = new SingleBenchmarkResult(solverBenchmarkResult, problemBenchmarkResult);
+        buildSubSingleBenchmarks(singleBenchmarkResult, solverBenchmarkResult.getSubSingleCount());
+        for (SubSingleBenchmarkResult subSingleBenchmarkResult : singleBenchmarkResult.getSubSingleBenchmarkResultList()) {
+            subSingleBenchmarkResult.setPureSubSingleStatisticList(new ArrayList<>(
+                    config.getSingleStatisticTypeList() == null ? 0 : config.getSingleStatisticTypeList().size()));
+        }
+        if (config.getSingleStatisticTypeList() != null) {
+            for (SingleStatisticType singleStatisticType : config.getSingleStatisticTypeList()) {
+                for (SubSingleBenchmarkResult subSingleBenchmarkResult : singleBenchmarkResult
+                        .getSubSingleBenchmarkResultList()) {
+                    subSingleBenchmarkResult.getPureSubSingleStatisticList().add(
+                            singleStatisticType.buildPureSubSingleStatistic(subSingleBenchmarkResult));
+                }
+            }
+        }
+        singleBenchmarkResult.initSubSingleStatisticMaps();
+        solverBenchmarkResult.getSingleBenchmarkResultList().add(singleBenchmarkResult);
+        problemBenchmarkResult.getSingleBenchmarkResultList().add(singleBenchmarkResult);
+    }
+
+    private void buildSubSingleBenchmarks(SingleBenchmarkResult parent, int subSingleCount) {
+        List<SubSingleBenchmarkResult> subSingleBenchmarkResultList = new ArrayList<>(subSingleCount);
+        for (int i = 0; i < subSingleCount; i++) {
+            SubSingleBenchmarkResult subSingleBenchmarkResult = new SubSingleBenchmarkResult(parent, i);
+            subSingleBenchmarkResultList.add(subSingleBenchmarkResult);
+        }
+        parent.setSubSingleBenchmarkResultList(subSingleBenchmarkResultList);
+    }
+}

--- a/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/impl/SolverBenchmarkFactory.java
+++ b/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/impl/SolverBenchmarkFactory.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.benchmark.impl;
+
+import java.util.ArrayList;
+
+import org.optaplanner.benchmark.config.ProblemBenchmarksConfig;
+import org.optaplanner.benchmark.config.SolverBenchmarkConfig;
+import org.optaplanner.benchmark.impl.result.PlannerBenchmarkResult;
+import org.optaplanner.benchmark.impl.result.SolverBenchmarkResult;
+import org.optaplanner.core.config.util.ConfigUtils;
+import org.optaplanner.core.impl.domain.solution.descriptor.SolutionDescriptor;
+import org.optaplanner.core.impl.solver.DefaultSolverFactory;
+
+public class SolverBenchmarkFactory {
+    private final SolverBenchmarkConfig config;
+
+    public SolverBenchmarkFactory(SolverBenchmarkConfig config) {
+        this.config = config;
+    }
+
+    public <Solution_> void buildSolverBenchmark(ClassLoader classLoader, PlannerBenchmarkResult plannerBenchmark,
+            Solution_[] extraProblems) {
+        validate();
+        SolverBenchmarkResult solverBenchmarkResult = new SolverBenchmarkResult(plannerBenchmark);
+        solverBenchmarkResult.setName(config.getName());
+        solverBenchmarkResult.setSubSingleCount(ConfigUtils.inheritOverwritableProperty(config.getSubSingleCount(), 1));
+        if (config.getSolverConfig().getClassLoader() == null) {
+            config.getSolverConfig().setClassLoader(classLoader);
+        }
+        solverBenchmarkResult.setSolverConfig(config.getSolverConfig());
+        DefaultSolverFactory<Solution_> defaultSolverFactory = new DefaultSolverFactory<>(config.getSolverConfig());
+        SolutionDescriptor<Solution_> solutionDescriptor = defaultSolverFactory.buildSolutionDescriptor();
+        for (Solution_ extraProblem : extraProblems) {
+            if (!solutionDescriptor.getSolutionClass().isInstance(extraProblem)) {
+                throw new IllegalArgumentException("The solverBenchmark name (" + config.getName()
+                        + ") for solution class (" + solutionDescriptor.getSolutionClass()
+                        + ") cannot solve a problem (" + extraProblem
+                        + ") of class (" + (extraProblem == null ? null : extraProblem.getClass()) + ").");
+            }
+        }
+        solverBenchmarkResult.setScoreDefinition(solutionDescriptor.getScoreDefinition());
+        solverBenchmarkResult.setSingleBenchmarkResultList(new ArrayList<>());
+        ProblemBenchmarksConfig problemBenchmarksConfig_ =
+                config.getProblemBenchmarksConfig() == null ? new ProblemBenchmarksConfig()
+                        : config.getProblemBenchmarksConfig();
+        plannerBenchmark.getSolverBenchmarkResultList().add(solverBenchmarkResult);
+        ProblemBenchmarksFactory problemBenchmarksFactory = new ProblemBenchmarksFactory(problemBenchmarksConfig_);
+        problemBenchmarksFactory.buildProblemBenchmarkList(solverBenchmarkResult, extraProblems);
+    }
+
+    protected void validate() {
+        if (!DefaultPlannerBenchmarkFactory.VALID_NAME_PATTERN.matcher(config.getName()).matches()) {
+            throw new IllegalStateException("The solverBenchmark name (" + config.getName()
+                    + ") is invalid because it does not follow the nameRegex ("
+                    + DefaultPlannerBenchmarkFactory.VALID_NAME_PATTERN.pattern() + ")" +
+                    " which might cause an illegal filename.");
+        }
+        if (!config.getName().trim().equals(config.getName())) {
+            throw new IllegalStateException("The solverBenchmark name (" + config.getName()
+                    + ") is invalid because it starts or ends with whitespace.");
+        }
+        if (config.getSubSingleCount() != null && config.getSubSingleCount() < 1) {
+            throw new IllegalStateException("The solverBenchmark name (" + config.getName()
+                    + ") is invalid because the subSingleCount (" + config.getSubSingleCount() + ") must be greater than 1.");
+        }
+    }
+}

--- a/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/impl/aggregator/BenchmarkAggregator.java
+++ b/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/impl/aggregator/BenchmarkAggregator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,6 +24,7 @@ import java.util.Map.Entry;
 
 import org.optaplanner.benchmark.config.report.BenchmarkReportConfig;
 import org.optaplanner.benchmark.impl.report.BenchmarkReport;
+import org.optaplanner.benchmark.impl.report.BenchmarkReportFactory;
 import org.optaplanner.benchmark.impl.result.PlannerBenchmarkResult;
 import org.optaplanner.benchmark.impl.result.SingleBenchmarkResult;
 import org.optaplanner.benchmark.impl.result.SolverBenchmarkResult;
@@ -102,7 +103,8 @@ public class BenchmarkAggregator {
         plannerBenchmarkResult.setStartingTimestamp(startingTimestamp);
         plannerBenchmarkResult.initBenchmarkReportDirectory(benchmarkDirectory);
 
-        BenchmarkReport benchmarkReport = benchmarkReportConfig.buildBenchmarkReport(plannerBenchmarkResult);
+        BenchmarkReportFactory benchmarkReportFactory = new BenchmarkReportFactory(benchmarkReportConfig);
+        BenchmarkReport benchmarkReport = benchmarkReportFactory.buildBenchmarkReport(plannerBenchmarkResult);
         plannerBenchmarkResult.accumulateResults(benchmarkReport);
         benchmarkReport.writeReport();
 

--- a/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/impl/aggregator/swingui/BenchmarkAggregatorFrame.java
+++ b/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/impl/aggregator/swingui/BenchmarkAggregatorFrame.java
@@ -68,6 +68,7 @@ import org.optaplanner.benchmark.config.PlannerBenchmarkConfig;
 import org.optaplanner.benchmark.config.report.BenchmarkReportConfig;
 import org.optaplanner.benchmark.impl.aggregator.BenchmarkAggregator;
 import org.optaplanner.benchmark.impl.aggregator.swingui.MixedCheckBox.MixedCheckBoxStatus;
+import org.optaplanner.benchmark.impl.report.BenchmarkReportFactory;
 import org.optaplanner.benchmark.impl.result.BenchmarkResultIO;
 import org.optaplanner.benchmark.impl.result.PlannerBenchmarkResult;
 import org.optaplanner.benchmark.impl.result.ProblemBenchmarkResult;
@@ -260,9 +261,9 @@ public class BenchmarkAggregatorFrame extends JFrame {
     private void initPlannerBenchmarkResultList() {
         plannerBenchmarkResultList = benchmarkResultIO.readPlannerBenchmarkResultList(
                 benchmarkAggregator.getBenchmarkDirectory());
+        BenchmarkReportFactory reportFactory = new BenchmarkReportFactory(benchmarkAggregator.getBenchmarkReportConfig());
         for (PlannerBenchmarkResult plannerBenchmarkResult : plannerBenchmarkResultList) {
-            plannerBenchmarkResult.accumulateResults(
-                    benchmarkAggregator.getBenchmarkReportConfig().buildBenchmarkReport(plannerBenchmarkResult));
+            plannerBenchmarkResult.accumulateResults(reportFactory.buildBenchmarkReport(plannerBenchmarkResult));
         }
     }
 

--- a/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/impl/loader/ProblemProvider.java
+++ b/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/impl/loader/ProblemProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,13 +18,12 @@ package org.optaplanner.benchmark.impl.loader;
 
 import javax.xml.bind.annotation.XmlSeeAlso;
 
-import org.optaplanner.benchmark.config.ProblemBenchmarksConfig;
 import org.optaplanner.benchmark.impl.result.SubSingleBenchmarkResult;
 import org.optaplanner.core.api.domain.solution.PlanningSolution;
 
 /**
  * Subclasses need to implement {@link Object#equals(Object) equals()} and {@link Object#hashCode() hashCode()}
- * which are used by {@link ProblemBenchmarksConfig#buildProblemBenchmarkList}.
+ * which are used by {@link org.optaplanner.benchmark.impl.ProblemBenchmarksFactory#buildProblemBenchmarkList}.
  *
  * @param <Solution_> the solution type, the class with the {@link PlanningSolution} annotation
  */

--- a/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/impl/report/BenchmarkReportFactory.java
+++ b/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/impl/report/BenchmarkReportFactory.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.benchmark.impl.report;
+
+import java.time.ZoneId;
+import java.util.Comparator;
+
+import org.optaplanner.benchmark.config.report.BenchmarkReportConfig;
+import org.optaplanner.benchmark.impl.ranking.SolverRankingWeightFactory;
+import org.optaplanner.benchmark.impl.ranking.TotalRankSolverRankingWeightFactory;
+import org.optaplanner.benchmark.impl.ranking.TotalScoreSolverRankingComparator;
+import org.optaplanner.benchmark.impl.ranking.WorstScoreSolverRankingComparator;
+import org.optaplanner.benchmark.impl.result.PlannerBenchmarkResult;
+import org.optaplanner.benchmark.impl.result.SolverBenchmarkResult;
+import org.optaplanner.core.config.util.ConfigUtils;
+
+public class BenchmarkReportFactory {
+
+    private final BenchmarkReportConfig config;
+
+    public BenchmarkReportFactory(BenchmarkReportConfig config) {
+        this.config = config;
+    }
+
+    public BenchmarkReport buildBenchmarkReport(PlannerBenchmarkResult plannerBenchmark) {
+        BenchmarkReport benchmarkReport = new BenchmarkReport(plannerBenchmark);
+        benchmarkReport.setLocale(config.determineLocale());
+        benchmarkReport.setTimezoneId(ZoneId.systemDefault());
+        supplySolverRanking(benchmarkReport);
+        return benchmarkReport;
+    }
+
+    protected void supplySolverRanking(BenchmarkReport benchmarkReport) {
+        if (config.getSolverRankingType() != null && config.getSolverRankingComparatorClass() != null) {
+            throw new IllegalStateException("The PlannerBenchmark cannot have"
+                    + " a solverRankingType (" + config.getSolverRankingType()
+                    + ") and a solverRankingComparatorClass (" + config.getSolverRankingComparatorClass().getName()
+                    + ") at the same time.");
+        } else if (config.getSolverRankingType() != null && config.getSolverRankingWeightFactoryClass() != null) {
+            throw new IllegalStateException("The PlannerBenchmark cannot have"
+                    + " a solverRankingType (" + config.getSolverRankingType()
+                    + ") and a solverRankingWeightFactoryClass ("
+                    + config.getSolverRankingWeightFactoryClass().getName() + ") at the same time.");
+        } else if (config.getSolverRankingComparatorClass() != null && config.getSolverRankingWeightFactoryClass() != null) {
+            throw new IllegalStateException("The PlannerBenchmark cannot have"
+                    + " a solverRankingComparatorClass (" + config.getSolverRankingComparatorClass().getName()
+                    + ") and a solverRankingWeightFactoryClass (" + config.getSolverRankingWeightFactoryClass().getName()
+                    + ") at the same time.");
+        }
+        Comparator<SolverBenchmarkResult> solverRankingComparator = null;
+        SolverRankingWeightFactory solverRankingWeightFactory = null;
+        if (config.getSolverRankingType() != null) {
+            switch (config.getSolverRankingType()) {
+                case TOTAL_SCORE:
+                    solverRankingComparator = new TotalScoreSolverRankingComparator();
+                    break;
+                case WORST_SCORE:
+                    solverRankingComparator = new WorstScoreSolverRankingComparator();
+                    break;
+                case TOTAL_RANKING:
+                    solverRankingWeightFactory = new TotalRankSolverRankingWeightFactory();
+                    break;
+                default:
+                    throw new IllegalStateException("The solverRankingType ("
+                            + config.getSolverRankingType() + ") is not implemented.");
+            }
+        }
+        if (config.getSolverRankingComparatorClass() != null) {
+            solverRankingComparator = ConfigUtils.newInstance(config,
+                    "solverRankingComparatorClass", config.getSolverRankingComparatorClass());
+        }
+        if (config.getSolverRankingWeightFactoryClass() != null) {
+            solverRankingWeightFactory = ConfigUtils.newInstance(config,
+                    "solverRankingWeightFactoryClass", config.getSolverRankingWeightFactoryClass());
+        }
+        if (solverRankingComparator != null) {
+            benchmarkReport.setSolverRankingComparator(solverRankingComparator);
+        } else if (solverRankingWeightFactory != null) {
+            benchmarkReport.setSolverRankingWeightFactory(solverRankingWeightFactory);
+        } else {
+            benchmarkReport.setSolverRankingComparator(new TotalScoreSolverRankingComparator());
+        }
+    }
+}

--- a/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/impl/result/ProblemBenchmarkResult.java
+++ b/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/impl/result/ProblemBenchmarkResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,7 +35,6 @@ import javax.xml.bind.annotation.XmlElements;
 import javax.xml.bind.annotation.XmlIDREF;
 import javax.xml.bind.annotation.XmlTransient;
 
-import org.optaplanner.benchmark.config.ProblemBenchmarksConfig;
 import org.optaplanner.benchmark.config.statistic.ProblemStatisticType;
 import org.optaplanner.benchmark.config.statistic.SingleStatisticType;
 import org.optaplanner.benchmark.impl.loader.FileProblemProvider;
@@ -476,7 +475,7 @@ public class ProblemBenchmarkResult<Solution_> {
     }
 
     /**
-     * Used by {@link ProblemBenchmarksConfig#buildProblemBenchmarkList}.
+     * Used by {@link org.optaplanner.benchmark.impl.ProblemBenchmarksFactory#buildProblemBenchmarkList}.
      *
      * @param o sometimes null
      * @return true if equal

--- a/optaplanner-benchmark/src/test/java/org/optaplanner/benchmark/config/PlannerBenchmarkConfigTest.java
+++ b/optaplanner-benchmark/src/test/java/org/optaplanner/benchmark/config/PlannerBenchmarkConfigTest.java
@@ -18,8 +18,6 @@ package org.optaplanner.benchmark.config;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
-import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
-import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
 
 import java.io.IOException;
 import java.io.InputStreamReader;
@@ -28,10 +26,6 @@ import java.io.StringReader;
 import java.io.StringWriter;
 import java.io.Writer;
 import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import java.util.TreeSet;
 
 import org.apache.commons.io.IOUtils;
 import org.junit.jupiter.api.Test;
@@ -46,123 +40,6 @@ class PlannerBenchmarkConfigTest {
 
     private static final String TEST_PLANNER_BENCHMARK_CONFIG_WITH_NAMESPACE = "testBenchmarkConfigWithNamespace.xml";
     private static final String TEST_PLANNER_BENCHMARK_CONFIG_WITHOUT_NAMESPACE = "testBenchmarkConfigWithoutNamespace.xml";
-
-    @Test
-    void validNameWithUnderscoreAndSpace() {
-        PlannerBenchmarkConfig config = new PlannerBenchmarkConfig();
-        config.setName("Valid_name with space_and_underscore");
-        config.setSolverBenchmarkConfigList(Collections.singletonList(new SolverBenchmarkConfig()));
-        config.validate();
-    }
-
-    @Test
-    void validNameWithJapanese() {
-        PlannerBenchmarkConfig config = new PlannerBenchmarkConfig();
-        config.setName("Valid name (有効名 in Japanese)");
-        config.setSolverBenchmarkConfigList(Collections.singletonList(new SolverBenchmarkConfig()));
-        config.validate();
-    }
-
-    @Test
-    void invalidNameWithSlash() {
-        PlannerBenchmarkConfig config = new PlannerBenchmarkConfig();
-        config.setName("slash/name");
-        config.setSolverBenchmarkConfigList(Collections.singletonList(new SolverBenchmarkConfig()));
-        assertThatIllegalStateException().isThrownBy(config::validate);
-    }
-
-    @Test
-    void invalidNameWithSuffixWhitespace() {
-        PlannerBenchmarkConfig config = new PlannerBenchmarkConfig();
-        config.setName("Suffixed with space ");
-        config.setSolverBenchmarkConfigList(Collections.singletonList(new SolverBenchmarkConfig()));
-        assertThatIllegalStateException().isThrownBy(config::validate);
-    }
-
-    @Test
-    void invalidNameWithPrefixWhitespace() {
-        PlannerBenchmarkConfig config = new PlannerBenchmarkConfig();
-        config.setName(" prefixed with space");
-        config.setSolverBenchmarkConfigList(Collections.singletonList(new SolverBenchmarkConfig()));
-        assertThatIllegalStateException().isThrownBy(config::validate);
-    }
-
-    @Test
-    void noSolverConfigs() {
-        PlannerBenchmarkConfig config = new PlannerBenchmarkConfig();
-        config.setSolverBenchmarkConfigList(null);
-        config.setSolverBenchmarkBluePrintConfigList(null);
-        assertThatIllegalArgumentException().isThrownBy(config::validate);
-    }
-
-    @Test
-    void nonUniqueSolverConfigName() {
-        PlannerBenchmarkConfig config = new PlannerBenchmarkConfig();
-        final String sbcName = "x";
-        SolverBenchmarkConfig sbc1 = new SolverBenchmarkConfig();
-        sbc1.setName(sbcName);
-        SolverBenchmarkConfig sbc2 = new SolverBenchmarkConfig();
-        sbc2.setName(sbcName);
-        config.setSolverBenchmarkConfigList(Arrays.asList(sbc1, sbc2));
-        assertThatIllegalStateException().isThrownBy(config::generateSolverBenchmarkConfigNames);
-    }
-
-    @Test
-    void uniqueNamesGenerated() {
-        PlannerBenchmarkConfig config = new PlannerBenchmarkConfig();
-        SolverBenchmarkConfig sbc1 = new SolverBenchmarkConfig();
-        SolverBenchmarkConfig sbc2 = new SolverBenchmarkConfig();
-        SolverBenchmarkConfig sbc3 = new SolverBenchmarkConfig();
-        sbc3.setName("Config_1");
-        List<SolverBenchmarkConfig> configs = Arrays.asList(sbc1, sbc2, sbc3);
-        config.setSolverBenchmarkConfigList(configs);
-        config.generateSolverBenchmarkConfigNames();
-        assertThat(sbc3.getName()).isEqualTo("Config_1");
-        TreeSet<String> names = new TreeSet<>();
-        for (SolverBenchmarkConfig sc : configs) {
-            names.add(sc.getName());
-        }
-        for (int i = 0; i < configs.size(); i++) {
-            assertThat(names).contains("Config_" + i);
-        }
-    }
-
-    @Test
-    void resolveParallelBenchmarkCountAutomatically() {
-        PlannerBenchmarkConfig config = new PlannerBenchmarkConfig();
-        assertThat(config.resolveParallelBenchmarkCountAutomatically(-1)).isEqualTo(1);
-        assertThat(config.resolveParallelBenchmarkCountAutomatically(0)).isEqualTo(1);
-        assertThat(config.resolveParallelBenchmarkCountAutomatically(1)).isEqualTo(1);
-        assertThat(config.resolveParallelBenchmarkCountAutomatically(2)).isEqualTo(1);
-        assertThat(config.resolveParallelBenchmarkCountAutomatically(3)).isEqualTo(2);
-        assertThat(config.resolveParallelBenchmarkCountAutomatically(4)).isEqualTo(2);
-        assertThat(config.resolveParallelBenchmarkCountAutomatically(5)).isEqualTo(3);
-        assertThat(config.resolveParallelBenchmarkCountAutomatically(6)).isEqualTo(4);
-        assertThat(config.resolveParallelBenchmarkCountAutomatically(17)).isEqualTo(9);
-    }
-
-    @Test
-    void parallelBenchmarkDisabledByDefault() {
-        PlannerBenchmarkConfig config = new PlannerBenchmarkConfig();
-        assertThat(config.resolveParallelBenchmarkCount()).isEqualTo(1);
-    }
-
-    @Test
-    void resolvedParallelBenchmarkCountNegative() {
-        PlannerBenchmarkConfig config = new PlannerBenchmarkConfig();
-        config.setParallelBenchmarkCount("-1");
-        assertThatIllegalArgumentException().isThrownBy(config::resolveParallelBenchmarkCount);
-    }
-
-    @Test
-    void calculateWarmUpTimeMillisSpentLimit() {
-        PlannerBenchmarkConfig config = new PlannerBenchmarkConfig();
-        config.setWarmUpHoursSpentLimit(1L);
-        config.setWarmUpMinutesSpentLimit(2L);
-        config.setWarmUpSecondsSpentLimit(5L);
-        config.setWarmUpMillisecondsSpentLimit(753L);
-        assertThat(config.calculateWarmUpTimeMillisSpentLimit()).isEqualTo(3_725_753L);
-    }
 
     @ParameterizedTest
     @ValueSource(strings = { TEST_PLANNER_BENCHMARK_CONFIG_WITHOUT_NAMESPACE, TEST_PLANNER_BENCHMARK_CONFIG_WITH_NAMESPACE })

--- a/optaplanner-benchmark/src/test/java/org/optaplanner/benchmark/config/report/BenchmarkReportConfigTest.java
+++ b/optaplanner-benchmark/src/test/java/org/optaplanner/benchmark/config/report/BenchmarkReportConfigTest.java
@@ -1,8 +1,22 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.optaplanner.benchmark.config.report;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
-import static org.mockito.Mockito.mock;
 
 import java.util.Locale;
 
@@ -10,7 +24,6 @@ import org.junit.jupiter.api.Test;
 import org.optaplanner.benchmark.config.ranking.SolverRankingType;
 import org.optaplanner.benchmark.impl.ranking.TotalRankSolverRankingWeightFactory;
 import org.optaplanner.benchmark.impl.ranking.TotalScoreSolverRankingComparator;
-import org.optaplanner.benchmark.impl.result.PlannerBenchmarkResult;
 
 public class BenchmarkReportConfigTest {
 
@@ -30,41 +43,5 @@ public class BenchmarkReportConfigTest {
                 .isEqualTo(inheritedReportConfig.getSolverRankingComparatorClass());
         assertThat(reportConfig.getSolverRankingWeightFactoryClass())
                 .isEqualTo(inheritedReportConfig.getSolverRankingWeightFactoryClass());
-    }
-
-    @Test
-    public void buildWithSolverRankingTypeAndSolverRankingComparatorClass() {
-        BenchmarkReportConfig config = new BenchmarkReportConfig();
-        config.setSolverRankingType(SolverRankingType.TOTAL_RANKING);
-        config.setSolverRankingComparatorClass(TotalScoreSolverRankingComparator.class);
-
-        PlannerBenchmarkResult result = mock(PlannerBenchmarkResult.class);
-
-        assertThatExceptionOfType(IllegalStateException.class).isThrownBy(() -> config.buildBenchmarkReport(result))
-                .withMessageContaining("solverRankingType").withMessageContaining("solverRankingComparatorClass");
-    }
-
-    @Test
-    public void buildWithSolverRankingTypeAndSolverRankingWeightFactoryClass() {
-        BenchmarkReportConfig config = new BenchmarkReportConfig();
-        config.setSolverRankingType(SolverRankingType.TOTAL_RANKING);
-        config.setSolverRankingWeightFactoryClass(TotalRankSolverRankingWeightFactory.class);
-
-        PlannerBenchmarkResult result = mock(PlannerBenchmarkResult.class);
-
-        assertThatExceptionOfType(IllegalStateException.class).isThrownBy(() -> config.buildBenchmarkReport(result))
-                .withMessageContaining("solverRankingType").withMessageContaining("solverRankingWeightFactoryClass");
-    }
-
-    @Test
-    public void buildWithSolverRankingComparatorClassAndSolverRankingWeightFactoryClass() {
-        BenchmarkReportConfig config = new BenchmarkReportConfig();
-        config.setSolverRankingComparatorClass(TotalScoreSolverRankingComparator.class);
-        config.setSolverRankingWeightFactoryClass(TotalRankSolverRankingWeightFactory.class);
-
-        PlannerBenchmarkResult result = mock(PlannerBenchmarkResult.class);
-
-        assertThatExceptionOfType(IllegalStateException.class).isThrownBy(() -> config.buildBenchmarkReport(result))
-                .withMessageContaining("solverRankingComparatorClass").withMessageContaining("solverRankingWeightFactoryClass");
     }
 }

--- a/optaplanner-benchmark/src/test/java/org/optaplanner/benchmark/impl/DefaultPlannerBenchmarkFactoryTest.java
+++ b/optaplanner-benchmark/src/test/java/org/optaplanner/benchmark/impl/DefaultPlannerBenchmarkFactoryTest.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.benchmark.impl;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.TreeSet;
+
+import org.junit.jupiter.api.Test;
+import org.optaplanner.benchmark.config.PlannerBenchmarkConfig;
+import org.optaplanner.benchmark.config.SolverBenchmarkConfig;
+
+class DefaultPlannerBenchmarkFactoryTest {
+
+    @Test
+    void validNameWithUnderscoreAndSpace() {
+        PlannerBenchmarkConfig config = new PlannerBenchmarkConfig();
+        config.setName("Valid_name with space_and_underscore");
+        config.setSolverBenchmarkConfigList(Collections.singletonList(new SolverBenchmarkConfig()));
+        new DefaultPlannerBenchmarkFactory(config).validate();
+    }
+
+    @Test
+    void validNameWithJapanese() {
+        PlannerBenchmarkConfig config = new PlannerBenchmarkConfig();
+        config.setName("Valid name (有効名 in Japanese)");
+        config.setSolverBenchmarkConfigList(Collections.singletonList(new SolverBenchmarkConfig()));
+        DefaultPlannerBenchmarkFactory benchmarkFactory = new DefaultPlannerBenchmarkFactory(config);
+        benchmarkFactory.validate();
+    }
+
+    @Test
+    void invalidNameWithSlash() {
+        PlannerBenchmarkConfig config = new PlannerBenchmarkConfig();
+        config.setName("slash/name");
+        config.setSolverBenchmarkConfigList(Collections.singletonList(new SolverBenchmarkConfig()));
+        DefaultPlannerBenchmarkFactory benchmarkFactory = new DefaultPlannerBenchmarkFactory(config);
+        assertThatIllegalStateException().isThrownBy(benchmarkFactory::validate);
+    }
+
+    @Test
+    void invalidNameWithSuffixWhitespace() {
+        PlannerBenchmarkConfig config = new PlannerBenchmarkConfig();
+        config.setName("Suffixed with space ");
+        config.setSolverBenchmarkConfigList(Collections.singletonList(new SolverBenchmarkConfig()));
+        DefaultPlannerBenchmarkFactory benchmarkFactory = new DefaultPlannerBenchmarkFactory(config);
+        assertThatIllegalStateException().isThrownBy(benchmarkFactory::validate);
+    }
+
+    @Test
+    void invalidNameWithPrefixWhitespace() {
+        PlannerBenchmarkConfig config = new PlannerBenchmarkConfig();
+        config.setName(" prefixed with space");
+        config.setSolverBenchmarkConfigList(Collections.singletonList(new SolverBenchmarkConfig()));
+        DefaultPlannerBenchmarkFactory benchmarkFactory = new DefaultPlannerBenchmarkFactory(config);
+        assertThatIllegalStateException().isThrownBy(benchmarkFactory::validate);
+    }
+
+    @Test
+    void noSolverConfigs() {
+        PlannerBenchmarkConfig config = new PlannerBenchmarkConfig();
+        config.setSolverBenchmarkConfigList(null);
+        config.setSolverBenchmarkBluePrintConfigList(null);
+        DefaultPlannerBenchmarkFactory benchmarkFactory = new DefaultPlannerBenchmarkFactory(config);
+        assertThatIllegalArgumentException().isThrownBy(benchmarkFactory::validate);
+    }
+
+    @Test
+    void nonUniqueSolverConfigName() {
+        PlannerBenchmarkConfig config = new PlannerBenchmarkConfig();
+        final String sbcName = "x";
+        SolverBenchmarkConfig sbc1 = new SolverBenchmarkConfig();
+        sbc1.setName(sbcName);
+        SolverBenchmarkConfig sbc2 = new SolverBenchmarkConfig();
+        sbc2.setName(sbcName);
+        config.setSolverBenchmarkConfigList(Arrays.asList(sbc1, sbc2));
+        DefaultPlannerBenchmarkFactory benchmarkFactory = new DefaultPlannerBenchmarkFactory(config);
+        assertThatIllegalStateException().isThrownBy(benchmarkFactory::generateSolverBenchmarkConfigNames);
+    }
+
+    @Test
+    void uniqueNamesGenerated() {
+        PlannerBenchmarkConfig config = new PlannerBenchmarkConfig();
+        SolverBenchmarkConfig sbc1 = new SolverBenchmarkConfig();
+        SolverBenchmarkConfig sbc2 = new SolverBenchmarkConfig();
+        SolverBenchmarkConfig sbc3 = new SolverBenchmarkConfig();
+        sbc3.setName("Config_1");
+        List<SolverBenchmarkConfig> configs = Arrays.asList(sbc1, sbc2, sbc3);
+        config.setSolverBenchmarkConfigList(configs);
+        DefaultPlannerBenchmarkFactory benchmarkFactory = new DefaultPlannerBenchmarkFactory(config);
+        benchmarkFactory.generateSolverBenchmarkConfigNames();
+        assertThat(sbc3.getName()).isEqualTo("Config_1");
+        TreeSet<String> names = new TreeSet<>();
+        for (SolverBenchmarkConfig sc : configs) {
+            names.add(sc.getName());
+        }
+        for (int i = 0; i < configs.size(); i++) {
+            assertThat(names).contains("Config_" + i);
+        }
+    }
+
+    @Test
+    void resolveParallelBenchmarkCountAutomatically() {
+        DefaultPlannerBenchmarkFactory benchmarkFactory = new DefaultPlannerBenchmarkFactory(new PlannerBenchmarkConfig());
+        assertThat(benchmarkFactory.resolveParallelBenchmarkCountAutomatically(-1)).isEqualTo(1);
+        assertThat(benchmarkFactory.resolveParallelBenchmarkCountAutomatically(0)).isEqualTo(1);
+        assertThat(benchmarkFactory.resolveParallelBenchmarkCountAutomatically(1)).isEqualTo(1);
+        assertThat(benchmarkFactory.resolveParallelBenchmarkCountAutomatically(2)).isEqualTo(1);
+        assertThat(benchmarkFactory.resolveParallelBenchmarkCountAutomatically(3)).isEqualTo(2);
+        assertThat(benchmarkFactory.resolveParallelBenchmarkCountAutomatically(4)).isEqualTo(2);
+        assertThat(benchmarkFactory.resolveParallelBenchmarkCountAutomatically(5)).isEqualTo(3);
+        assertThat(benchmarkFactory.resolveParallelBenchmarkCountAutomatically(6)).isEqualTo(4);
+        assertThat(benchmarkFactory.resolveParallelBenchmarkCountAutomatically(17)).isEqualTo(9);
+    }
+
+    @Test
+    void parallelBenchmarkDisabledByDefault() {
+        DefaultPlannerBenchmarkFactory benchmarkFactory = new DefaultPlannerBenchmarkFactory(new PlannerBenchmarkConfig());
+        assertThat(benchmarkFactory.resolveParallelBenchmarkCount()).isEqualTo(1);
+    }
+
+    @Test
+    void resolvedParallelBenchmarkCountNegative() {
+        PlannerBenchmarkConfig config = new PlannerBenchmarkConfig();
+        config.setParallelBenchmarkCount("-1");
+        DefaultPlannerBenchmarkFactory benchmarkFactory = new DefaultPlannerBenchmarkFactory(config);
+        assertThatIllegalArgumentException().isThrownBy(benchmarkFactory::resolveParallelBenchmarkCount);
+    }
+
+    @Test
+    void calculateWarmUpTimeMillisSpentLimit() {
+        PlannerBenchmarkConfig config = new PlannerBenchmarkConfig();
+        config.setWarmUpHoursSpentLimit(1L);
+        config.setWarmUpMinutesSpentLimit(2L);
+        config.setWarmUpSecondsSpentLimit(5L);
+        config.setWarmUpMillisecondsSpentLimit(753L);
+        DefaultPlannerBenchmarkFactory benchmarkFactory = new DefaultPlannerBenchmarkFactory(config);
+        assertThat(benchmarkFactory.calculateWarmUpTimeMillisSpentLimit()).isEqualTo(3_725_753L);
+    }
+}

--- a/optaplanner-benchmark/src/test/java/org/optaplanner/benchmark/impl/SolverBenchmarkFactoryTest.java
+++ b/optaplanner-benchmark/src/test/java/org/optaplanner/benchmark/impl/SolverBenchmarkFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,20 +14,21 @@
  * limitations under the License.
  */
 
-package org.optaplanner.benchmark.config;
+package org.optaplanner.benchmark.impl;
 
 import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
 
 import org.junit.jupiter.api.Test;
+import org.optaplanner.benchmark.config.SolverBenchmarkConfig;
 
-public class SolverBenchmarkConfigTest {
+public class SolverBenchmarkFactoryTest {
 
     @Test
     public void validNameWithUnderscoreAndSpace() {
         SolverBenchmarkConfig config = new SolverBenchmarkConfig();
         config.setName("Valid_name with space_and_underscore");
         config.setSubSingleCount(1);
-        config.validate();
+        validateConfig(config);
     }
 
     @Test
@@ -35,7 +36,7 @@ public class SolverBenchmarkConfigTest {
         SolverBenchmarkConfig config = new SolverBenchmarkConfig();
         config.setName("Valid name (有効名 in Japanese)");
         config.setSubSingleCount(1);
-        config.validate();
+        validateConfig(config);
     }
 
     @Test
@@ -43,7 +44,7 @@ public class SolverBenchmarkConfigTest {
         SolverBenchmarkConfig config = new SolverBenchmarkConfig();
         config.setName("slash/name");
         config.setSubSingleCount(1);
-        assertThatIllegalStateException().isThrownBy(config::validate);
+        assertThatIllegalStateException().isThrownBy(() -> validateConfig(config));
     }
 
     @Test
@@ -51,7 +52,7 @@ public class SolverBenchmarkConfigTest {
         SolverBenchmarkConfig config = new SolverBenchmarkConfig();
         config.setName("Suffixed with space ");
         config.setSubSingleCount(1);
-        assertThatIllegalStateException().isThrownBy(config::validate);
+        assertThatIllegalStateException().isThrownBy(() -> validateConfig(config));
     }
 
     @Test
@@ -59,7 +60,7 @@ public class SolverBenchmarkConfigTest {
         SolverBenchmarkConfig config = new SolverBenchmarkConfig();
         config.setName(" prefixed with space");
         config.setSubSingleCount(1);
-        assertThatIllegalStateException().isThrownBy(config::validate);
+        assertThatIllegalStateException().isThrownBy(() -> validateConfig(config));
     }
 
     @Test
@@ -67,7 +68,7 @@ public class SolverBenchmarkConfigTest {
         SolverBenchmarkConfig config = new SolverBenchmarkConfig();
         config.setName("name");
         config.setSubSingleCount(2);
-        config.validate();
+        validateConfig(config);
     }
 
     @Test
@@ -75,7 +76,7 @@ public class SolverBenchmarkConfigTest {
         SolverBenchmarkConfig config = new SolverBenchmarkConfig();
         config.setName("name");
         config.setSubSingleCount(null);
-        config.validate();
+        validateConfig(config);
     }
 
     @Test
@@ -83,7 +84,11 @@ public class SolverBenchmarkConfigTest {
         SolverBenchmarkConfig config = new SolverBenchmarkConfig();
         config.setName("name");
         config.setSubSingleCount(0);
-        assertThatIllegalStateException().isThrownBy(config::validate);
+        assertThatIllegalStateException().isThrownBy(() -> validateConfig(config));
     }
 
+    private void validateConfig(SolverBenchmarkConfig config) {
+        SolverBenchmarkFactory solverBenchmarkFactory = new SolverBenchmarkFactory(config);
+        solverBenchmarkFactory.validate();
+    }
 }

--- a/optaplanner-benchmark/src/test/java/org/optaplanner/benchmark/impl/report/BenchmarkReportFactoryTest.java
+++ b/optaplanner-benchmark/src/test/java/org/optaplanner/benchmark/impl/report/BenchmarkReportFactoryTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.benchmark.impl.report;
+
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.Mockito.mock;
+
+import org.junit.jupiter.api.Test;
+import org.optaplanner.benchmark.config.ranking.SolverRankingType;
+import org.optaplanner.benchmark.config.report.BenchmarkReportConfig;
+import org.optaplanner.benchmark.impl.ranking.TotalRankSolverRankingWeightFactory;
+import org.optaplanner.benchmark.impl.ranking.TotalScoreSolverRankingComparator;
+import org.optaplanner.benchmark.impl.result.PlannerBenchmarkResult;
+
+class BenchmarkReportFactoryTest {
+
+    @Test
+    void buildWithSolverRankingTypeAndSolverRankingComparatorClass() {
+        BenchmarkReportConfig config = new BenchmarkReportConfig();
+        config.setSolverRankingType(SolverRankingType.TOTAL_RANKING);
+        config.setSolverRankingComparatorClass(TotalScoreSolverRankingComparator.class);
+
+        PlannerBenchmarkResult result = mock(PlannerBenchmarkResult.class);
+        BenchmarkReportFactory reportFactory = new BenchmarkReportFactory(config);
+        assertThatExceptionOfType(IllegalStateException.class).isThrownBy(() -> reportFactory.buildBenchmarkReport(result))
+                .withMessageContaining("solverRankingType").withMessageContaining("solverRankingComparatorClass");
+    }
+
+    @Test
+    void buildWithSolverRankingTypeAndSolverRankingWeightFactoryClass() {
+        BenchmarkReportConfig config = new BenchmarkReportConfig();
+        config.setSolverRankingType(SolverRankingType.TOTAL_RANKING);
+        config.setSolverRankingWeightFactoryClass(TotalRankSolverRankingWeightFactory.class);
+
+        PlannerBenchmarkResult result = mock(PlannerBenchmarkResult.class);
+        BenchmarkReportFactory reportFactory = new BenchmarkReportFactory(config);
+        assertThatExceptionOfType(IllegalStateException.class).isThrownBy(() -> reportFactory.buildBenchmarkReport(result))
+                .withMessageContaining("solverRankingType").withMessageContaining("solverRankingWeightFactoryClass");
+    }
+
+    @Test
+    void buildWithSolverRankingComparatorClassAndSolverRankingWeightFactoryClass() {
+        BenchmarkReportConfig config = new BenchmarkReportConfig();
+        config.setSolverRankingComparatorClass(TotalScoreSolverRankingComparator.class);
+        config.setSolverRankingWeightFactoryClass(TotalRankSolverRankingWeightFactory.class);
+
+        PlannerBenchmarkResult result = mock(PlannerBenchmarkResult.class);
+        BenchmarkReportFactory reportFactory = new BenchmarkReportFactory(config);
+        assertThatExceptionOfType(IllegalStateException.class).isThrownBy(() -> reportFactory.buildBenchmarkReport(result))
+                .withMessageContaining("solverRankingComparatorClass").withMessageContaining("solverRankingWeightFactoryClass");
+    }
+}

--- a/optaplanner-benchmark/src/test/java/org/optaplanner/benchmark/impl/result/PlannerBenchmarkResultTest.java
+++ b/optaplanner-benchmark/src/test/java/org/optaplanner/benchmark/impl/result/PlannerBenchmarkResultTest.java
@@ -38,6 +38,7 @@ import org.optaplanner.benchmark.config.report.BenchmarkReportConfig;
 import org.optaplanner.benchmark.impl.aggregator.BenchmarkAggregator;
 import org.optaplanner.benchmark.impl.loader.FileProblemProvider;
 import org.optaplanner.benchmark.impl.report.BenchmarkReport;
+import org.optaplanner.benchmark.impl.report.BenchmarkReportFactory;
 import org.optaplanner.core.api.score.buildin.simple.SimpleScore;
 import org.optaplanner.core.api.score.calculator.IncrementalScoreCalculator;
 import org.optaplanner.core.config.solver.SolverConfig;
@@ -164,8 +165,9 @@ public class PlannerBenchmarkResultTest {
         PlannerBenchmarkResult plannerBenchmarkResult =
                 benchmarkResultIO.readPlannerBenchmarkResult(plannerBenchmarkResultFile);
 
-        BenchmarkReport benchmarkReport =
-                benchmarkAggregator.getBenchmarkReportConfig().buildBenchmarkReport(plannerBenchmarkResult);
+        BenchmarkReportConfig benchmarkReportConfig = benchmarkAggregator.getBenchmarkReportConfig();
+        BenchmarkReport benchmarkReport = new BenchmarkReportFactory(benchmarkReportConfig)
+                .buildBenchmarkReport(plannerBenchmarkResult);
         plannerBenchmarkResult.accumulateResults(benchmarkReport);
 
         PlannerBenchmarkResult aggregatedPlannerBenchmarkResult = benchmarkReport.getPlannerBenchmarkResult();


### PR DESCRIPTION
As we moved `build()` methods from the `SolverConfig` and its underlying classes to Factories in the past, this PR does the same thing for similar methods in the `PlannerBenchmarkConfig`.

TODO: open a PR to update the upgrade recipe.

<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.
-->

### JIRA

<!-- Add a JIRA ticket link if it exists. -->
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
* https://github.com/kiegroup/drools/pull/3000
* https://github.com/kiegroup/optaplanner/pull/899
* etc.
-->

### Checklist
- [ ] Documentation updated if applicable.
- [ ] Upgrade recipe provided if applicable.

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>full downstream build</b> please add comment: <b>Jenkins run fdb</b>
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
