### PR TITLE
PLANNER-2227 A non-full build should not generate javadocs and run the enforcer rules twice

### DIFF
--- a/.github/workflows/os_java_ci.yml
+++ b/.github/workflows/os_java_ci.yml
@@ -37,7 +37,7 @@ jobs:
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2
       - name: Build with Maven
-        run: mvn -B clean install
+        run: mvn -B clean install -Dfull
 
   # Early feedback on a compatibility with the newest Java version.
   # TODO: update each time a new major Java version is released.
@@ -59,4 +59,4 @@ jobs:
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2
       - name: Build with Maven
-        run: mvn -B clean install
+        run: mvn -B clean install -Dfull

--- a/build/optaplanner-build-parent/pom.xml
+++ b/build/optaplanner-build-parent/pom.xml
@@ -652,14 +652,6 @@
               </goals>
               <phase>verify</phase>
             </execution>
-            <execution>
-              <!-- report can be found in ${build.directory}/site/revapi-report.html -->
-              <id>report</id>
-              <goals>
-                <goal>report</goal>
-              </goals>
-              <phase>package</phase>
-            </execution>
           </executions>
         </plugin>
 

--- a/build/optaplanner-build-parent/pom.xml
+++ b/build/optaplanner-build-parent/pom.xml
@@ -615,23 +615,14 @@
                 </roots>
               </configurationFile>
             </analysisConfigurationFiles>
-            <!-- By default, revapi will only fail the build if there are potentially breaking or breaking changes. However, in the report
-                 we want even non breaking changes to be present. -->
-            <reportSeverity>nonBreaking</reportSeverity>
             <failSeverity>potentiallyBreaking</failSeverity>
           </configuration>
-          <!-- Running two executions is a workaround to make sure we get a HTML report in case revapi finds
-               some incompatible changes. The "check" goal will simply fail the whole build before it could get
-               to the report. To make sure we always get a HTML report, the "report" goal needs to be executed
-               before the "check" goal.
-               Once https://github.com/revapi/revapi/issues/11 is fixed it should be possible to use single execution. -->
           <executions>
             <execution>
               <id>check</id>
               <goals>
                 <goal>check</goal>
               </goals>
-              <phase>verify</phase>
             </execution>
           </executions>
         </plugin>
@@ -1009,49 +1000,6 @@
             </executions>
           </plugin>
         </plugins>
-      </build>
-    </profile>
-    <profile>
-      <id>generate-revapi-report</id>
-      <!-- There is no need to run tests when generating the report -->
-      <properties>
-        <skipTests>true</skipTests>
-      </properties>
-      <build>
-        <pluginManagement>
-          <plugins>
-            <plugin>
-              <groupId>org.revapi</groupId>
-              <artifactId>revapi-maven-plugin</artifactId>
-              <configuration>
-                <analysisConfigurationFiles>
-                  <configurationFile>
-                    <!-- Only filters should be taken into account, not ignores -->
-                    <roots>
-                      <root>filters</root>
-                    </roots>
-                  </configurationFile>
-                </analysisConfigurationFiles>
-              </configuration>
-              <!-- Run only report generation goal -->
-              <executions>
-                <execution>
-                  <!-- Disable check goal -->
-                  <id>check</id>
-                  <phase>none</phase>
-                </execution>
-                <execution>
-                  <!-- Report can be found in ${build.directory}/site/revapi-report.html -->
-                  <id>report</id>
-                  <goals>
-                    <goal>report</goal>
-                  </goals>
-                  <phase>package</phase>
-                </execution>
-              </executions>
-            </plugin>
-          </plugins>
-        </pluginManagement>
       </build>
     </profile>
     <profile>

--- a/build/optaplanner-build-parent/pom.xml
+++ b/build/optaplanner-build-parent/pom.xml
@@ -938,26 +938,6 @@
         <!--        </executions>-->
       </plugin>
       <plugin>
-        <!-- Entry needed to provide parsed version properties -->
-        <!-- also adds generated sources to -source artifact -->
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <phase>generate-sources</phase>
-            <goals>
-              <goal>add-source</goal>
-              <goal>parse-version</goal>
-            </goals>
-            <configuration>
-              <sources>
-                <source>target/generated-sources/annotations/</source>
-              </sources>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-failsafe-plugin</artifactId>
       </plugin>

--- a/build/optaplanner-build-parent/pom.xml
+++ b/build/optaplanner-build-parent/pom.xml
@@ -617,14 +617,6 @@
             </analysisConfigurationFiles>
             <failSeverity>potentiallyBreaking</failSeverity>
           </configuration>
-          <executions>
-            <execution>
-              <id>check</id>
-              <goals>
-                <goal>check</goal>
-              </goals>
-            </execution>
-          </executions>
         </plugin>
 
         <plugin>
@@ -844,35 +836,6 @@
       <plugin>
         <groupId>net.revelc.code</groupId>
         <artifactId>impsort-maven-plugin</artifactId>
-      </plugin>
-      <plugin> <!-- Make sure the build fails-fast on Javadoc issues. -->
-        <artifactId>maven-javadoc-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>javadoc-javadoc</id>
-            <phase>package</phase>
-            <goals>
-              <goal>javadoc-no-fork</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-dependency-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>analyze-only</id>
-            <goals>
-              <goal>analyze-only</goal>
-            </goals>
-            <configuration>
-              <failOnWarning>true</failOnWarning>
-              <ignoreNonCompile>true</ignoreNonCompile>
-              <verbose>true</verbose>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
       <plugin>
         <artifactId>maven-enforcer-plugin</artifactId>
@@ -1116,6 +1079,60 @@
         <!--suppress UnresolvedMavenProperty -->
         <sonar.pullrequest.base>${env.ghprbTargetBranch}</sonar.pullrequest.base>
       </properties>
+    </profile>
+
+    <profile>
+      <id>fullProfile</id>
+      <activation>
+        <property>
+          <name>full</name>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin> <!-- Make sure the build fails-fast on Javadoc issues. -->
+            <artifactId>maven-javadoc-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>javadoc-javadoc</id>
+                <phase>package</phase>
+                <goals>
+                  <goal>javadoc-no-fork</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.revapi</groupId>
+            <artifactId>revapi-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>check</id>
+                <goals>
+                  <goal>check</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-dependency-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>analyze-only</id>
+                <goals>
+                  <goal>analyze-only</goal>
+                </goals>
+                <configuration>
+                  <failOnWarning>true</failOnWarning>
+                  <ignoreNonCompile>true</ignoreNonCompile>
+                  <verbose>true</verbose>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
     </profile>
   </profiles>
 

--- a/build/optaplanner-build-parent/pom.xml
+++ b/build/optaplanner-build-parent/pom.xml
@@ -1134,6 +1134,21 @@
         </plugins>
       </build>
     </profile>
+    <profile>
+      <id>quickProfile</id>
+      <activation>
+        <property>
+          <name>quick</name>
+        </property>
+      </activation>
+      <properties>
+        <enforcer.skip>true</enforcer.skip>
+        <revapi.skip>true</revapi.skip>
+        <skipTests>true</skipTests>
+        <skipITs>true</skipITs>
+        <formatter.skip>true</formatter.skip>
+      </properties>
+    </profile>
   </profiles>
 
 </project>

--- a/build/optaplanner-build-parent/pom.xml
+++ b/build/optaplanner-build-parent/pom.xml
@@ -74,6 +74,8 @@
     <!-- Latest release to be used by api-compatibility-check to check backwards compatibility of the API. -->
     <revapi.oldKieVersion>7.39.0.Final</revapi.oldKieVersion>
     <revapi.newKieVersion>${project.version}</revapi.newKieVersion>
+    <!-- Runs only in the fullProfile. -->
+    <revapi.skip>true</revapi.skip>
     <!--suppress UnresolvedMavenProperty-->
     <project.root.dir>${maven.multiModuleProjectDirectory}</project.root.dir>
 
@@ -617,6 +619,14 @@
             </analysisConfigurationFiles>
             <failSeverity>potentiallyBreaking</failSeverity>
           </configuration>
+          <executions>
+            <execution>
+              <id>check</id>
+              <goals>
+                <goal>check</goal>
+              </goals>
+            </execution>
+          </executions>
         </plugin>
 
         <plugin>
@@ -1088,6 +1098,9 @@
           <name>full</name>
         </property>
       </activation>
+      <properties>
+        <revapi.skip>false</revapi.skip>
+      </properties>
       <build>
         <plugins>
           <plugin> <!-- Make sure the build fails-fast on Javadoc issues. -->
@@ -1098,18 +1111,6 @@
                 <phase>package</phase>
                 <goals>
                   <goal>javadoc-no-fork</goal>
-                </goals>
-              </execution>
-            </executions>
-          </plugin>
-          <plugin>
-            <groupId>org.revapi</groupId>
-            <artifactId>revapi-maven-plugin</artifactId>
-            <executions>
-              <execution>
-                <id>check</id>
-                <goals>
-                  <goal>check</goal>
                 </goals>
               </execution>
             </executions>

--- a/build/optaplanner-build-parent/pom.xml
+++ b/build/optaplanner-build-parent/pom.xml
@@ -465,7 +465,6 @@
               <goals>
                 <goal>enforce</goal>
               </goals>
-              <phase>initialize</phase>
               <configuration>
                 <rules>
                   <requireManagedDeps
@@ -478,7 +477,6 @@
             </execution>
             <execution>
               <id>ban-blacklisted-dependencies</id>
-              <phase>validate</phase>
               <goals>
                 <goal>enforce</goal>
               </goals>

--- a/build/optaplanner-build-parent/pom.xml
+++ b/build/optaplanner-build-parent/pom.xml
@@ -1159,20 +1159,6 @@
                                 Include class files from every module.
                               -->
                               <include name="**/target/classes/**/*.class"/>
-                              <!--
-                                Following classes are excluded as they are present in multiple modules. Usually they
-                                are a product of tests or 3rd party dependencies that got unwrapped in target/classes
-                                folder during the build. These are not a subject of test coverage measurement.
-                              -->
-                              <exclude name="**/target/**/target/classes/**/*.class"/>
-                              <exclude name="**/.errai/**/*.class"/>
-                              <exclude name="**/target/classes/org/jboss/errai/**/*.class"/>
-                              <!--
-                                TODO: there are multiple classes of the same fully qualified name in kie-server modules.
-                                They need to be renamed to enable coverage reporting for them.
-                                -->
-                              <exclude name="**/target/classes/**/org/kie/server/gateway/KieServerGateway.class"/>
-                              <exclude name="**/target/classes/**/org/kie/server/springboot/samples/KieServerApplication.class"/>
                             </fileset>
                           </classfiles>
                           <sourcefiles encoding="UTF-8">

--- a/build/optaplanner-build-parent/pom.xml
+++ b/build/optaplanner-build-parent/pom.xml
@@ -426,24 +426,6 @@
             </dependency>
           </dependencies>
           <executions>
-            <!-- TODO Disabled during kie-parent 7 removal due to false negatives.
-            <execution>
-              <id>enforce-plugin-versions</id>
-              <goals>
-                <goal>enforce</goal>
-              </goals>
-              <configuration>
-                <rules>
-                  <requirePluginVersions>
-                    <message>One or more plugins do not have valid version! The version needs to be
-                      explicitly specified, can not be a -SNAPSHOT version and can not be one of
-                      the special (and buggy) Maven versions (LATEST, RELEASE).
-                    </message>
-                  </requirePluginVersions>
-                </rules>
-              </configuration>
-            </execution>
-            -->
             <execution>
               <id>enforce-no-logback-test-in-main</id>
               <goals>

--- a/build/optaplanner-build-parent/pom.xml
+++ b/build/optaplanner-build-parent/pom.xml
@@ -585,54 +585,6 @@
                           <ignoreClass>*</ignoreClass>
                         </ignoreClasses>
                       </dependency>
-                      <dependency>
-                        <groupId>org.elasticsearch</groupId>
-                        <artifactId>elasticsearch</artifactId>
-                        <ignoreClasses>
-                          <!-- Elasticsearch team claims they fixed performance issues in the class and re-bundled it.
-                               See https://discuss.elastic.co/t/an-unshaded-joda-time-classes-in-elasticsearch-2-1-1-jar/38943
-                               Nothing we can do here. -->
-                          <ignoreClass>org.joda.time.base.BaseDateTime</ignoreClass>
-                        </ignoreClasses>
-                      </dependency>
-                      <!-- ignore jboss-logging included in kie server router as it is required by undertow and uberjar usage-->
-                      <dependency>
-                        <groupId>org.kie.server</groupId>
-                        <artifactId>kie-server-router-proxy</artifactId>
-                        <type>jar</type>
-                        <ignoreClasses>
-                          <ignoreClass>org.jboss.logging.*</ignoreClass>
-                          <ignoreClass>io.undertow.*</ignoreClass>
-                          <ignoreClass>org.json.*</ignoreClass>
-                          <ignoreClass>org.jboss.threads.*</ignoreClass>
-                          <ignoreClass>org.xnio.*</ignoreClass>
-                          <ignoreClass>org.wildfly.*</ignoreClass>
-                          <ignoreClass>org.apache.commons.*</ignoreClass>
-                        </ignoreClasses>
-                      </dependency>
-                      <dependency>
-                        <groupId>org.wildfly.security</groupId>
-                        <artifactId>wildfly-elytron</artifactId>
-                        <type>jar</type>
-                        <ignoreClasses>
-                          <ignoreClass>*</ignoreClass>
-                        </ignoreClasses>
-                      </dependency>
-                      <dependency>
-                        <!-- The openshift-client duplicates these classes from the kubernetes-client.
-                             It is an upstream io.fabric8 issue that needs to be fixed there:
-                             https://github.com/fabric8io/kubernetes-client/issues/828 -->
-                        <groupId>io.fabric8</groupId>
-                        <artifactId>openshift-client</artifactId>
-                        <type>jar</type>
-                        <ignoreClasses>
-                          <ignoreClass>io.fabric8.kubernetes.client.ConfigFluent</ignoreClass>
-                          <ignoreClass>io.fabric8.kubernetes.client.ConfigBuilder
-                          </ignoreClass>
-                          <ignoreClass>io.fabric8.kubernetes.client.ConfigFluentImpl
-                          </ignoreClass>
-                        </ignoreClasses>
-                      </dependency>
                     </dependencies>
                     <findAllDuplicates>true</findAllDuplicates>
                   </banDuplicateClasses>

--- a/build/optaplanner-build-parent/pom.xml
+++ b/build/optaplanner-build-parent/pom.xml
@@ -876,30 +876,6 @@
       </plugin>
       <plugin>
         <artifactId>maven-enforcer-plugin</artifactId>
-        <!--        <executions>-->
-        <!--          <execution>-->
-        <!--            <id>ban-duplicated-classes</id>-->
-        <!--            <goals>-->
-        <!--              <goal>enforce</goal>-->
-        <!--            </goals>-->
-        <!--            <configuration>-->
-        <!--              <rules>-->
-        <!--                <banDuplicateClasses>-->
-        <!--                  <dependencies combine.children="append">-->
-        <!--                    &lt;!&ndash; sundr-codegen is required to compile test classes. &ndash;&gt;-->
-        <!--                    <dependency>-->
-        <!--                      <groupId>io.sundr</groupId>-->
-        <!--                      <artifactId>sundr-codegen</artifactId>-->
-        <!--                      <ignoreClasses>-->
-        <!--                        <ignoreClass>*</ignoreClass>-->
-        <!--                      </ignoreClasses>-->
-        <!--                    </dependency>-->
-        <!--                  </dependencies>-->
-        <!--                </banDuplicateClasses>-->
-        <!--              </rules>-->
-        <!--            </configuration>-->
-        <!--          </execution>-->
-        <!--        </executions>-->
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/build/optaplanner-build-parent/pom.xml
+++ b/build/optaplanner-build-parent/pom.xml
@@ -492,10 +492,6 @@
                       <!-- In case of transitive dependency, exclude it and use 'org.javassist:javassist' instead -->
                       <exclude>javassist:javassist</exclude>
                       <exclude>org.apache.cxf:cxf-bundle-jaxrs</exclude>
-                      <exclude>org.jboss.weld.se:weld-se
-                      </exclude><!-- Use weld-se-core instead -->
-                      <exclude>org.jboss.weld.servlet:weld-servlet
-                      </exclude><!-- Use weld-servlet-core instead -->
                       <exclude>org.mockito:mockito-all</exclude><!-- Use mockito-core instead -->
                     </excludes>
                   </bannedDependencies>

--- a/build/optaplanner-build-parent/pom.xml
+++ b/build/optaplanner-build-parent/pom.xml
@@ -410,11 +410,6 @@
               <version>6.2.1</version>
             </dependency>
             <dependency>
-              <groupId>de.is24.maven.enforcer.rules</groupId>
-              <artifactId>illegal-transitive-dependency-check</artifactId>
-              <version>1.7.4</version>
-            </dependency>
-            <dependency>
               <groupId>com.redhat.victims</groupId>
               <artifactId>enforce-victims-rule</artifactId>
               <version>1.3.4</version>
@@ -467,31 +462,6 @@
                     <checkProfiles>true</checkProfiles>
                     <failOnViolation>true</failOnViolation>
                   </requireManagedDeps>
-                </rules>
-              </configuration>
-            </execution>
-            <execution>
-              <id>enforce-direct-dependencies</id>
-              <goals>
-                <goal>enforce</goal>
-              </goals>
-              <phase>none</phase>
-              <configuration>
-                <rules>
-                  <illegalTransitiveDependencyCheck
-                      implementation="de.is24.maven.enforcer.rules.IllegalTransitiveDependencyCheck">
-                    <reportOnly>false</reportOnly>
-                    <regexIgnoredClasses combine.children="append">
-                      <!-- The maven-shade-plugin needs these classes to be compile-scope in guvnor-ala-openshift-client to be picked up, and
-                           then referenced in guvnor-ala-openshift-provider. When we don't need to shade anymore, we can remove these lines. -->
-                      <regexIgnoredClass>io\.fabric8\.kubernetes.*</regexIgnoredClass>
-                      <regexIgnoredClass>io\.fabric8\.openshift.*</regexIgnoredClass>
-                      <regexIgnoredClass>com\.sun\.net\.httpserver\..+</regexIgnoredClass>
-                      <regexIgnoredClass>javax\..+</regexIgnoredClass>
-                      <regexIgnoredClass>org\.w3c\.dom\..+</regexIgnoredClass>
-                      <regexIgnoredClass>org\.xml\.sax\..+</regexIgnoredClass>
-                    </regexIgnoredClasses>
-                  </illegalTransitiveDependencyCheck>
                 </rules>
               </configuration>
             </execution>

--- a/build/optaplanner-build-parent/pom.xml
+++ b/build/optaplanner-build-parent/pom.xml
@@ -350,7 +350,7 @@
         <version>${version.org.springframework.boot}</version>
       </dependency>
 
-      <!-- TODO Dependencies that must use a jakarta.* groupId instead in 8 -->
+      <!-- TODO Dependencies that must use a jakarta.* groupId instead in 8 https://issues.redhat.com/browse/PLANNER-2262 -->
       <dependency>
         <groupId>javax.persistence</groupId>
         <artifactId>javax.persistence-api</artifactId>
@@ -373,7 +373,7 @@
         <version>1.1.1.Final</version>
       </dependency>
 
-      <!-- TODO Dependencies that should maybe be removed/replaced in 8 -->
+      <!-- TODO Dependencies that should maybe be removed/replaced in 8 https://issues.redhat.com/browse/PLANNER-2262 -->
       <dependency>
         <groupId>org.eclipse.persistence</groupId>
         <artifactId>org.eclipse.persistence.moxy</artifactId>

--- a/build/optaplanner-build-parent/pom.xml
+++ b/build/optaplanner-build-parent/pom.xml
@@ -426,6 +426,7 @@
             </dependency>
           </dependencies>
           <executions>
+            <!-- TODO Disabled during kie-parent 7 removal due to false negatives.
             <execution>
               <id>enforce-plugin-versions</id>
               <goals>
@@ -433,13 +434,23 @@
               </goals>
               <configuration>
                 <rules>
-                  <!-- TODO Disabled during kie-parent 7 removal due to false negatives -->
-                  <!--                  <requirePluginVersions>-->
-                  <!--                    <message>One or more plugins do not have valid version! The version needs to be-->
-                  <!--                      explicitly specified, can not be a -SNAPSHOT version and can not be one of-->
-                  <!--                      the special (and buggy) Maven versions (LATEST, RELEASE).-->
-                  <!--                    </message>-->
-                  <!--                  </requirePluginVersions>-->
+                  <requirePluginVersions>
+                    <message>One or more plugins do not have valid version! The version needs to be
+                      explicitly specified, can not be a -SNAPSHOT version and can not be one of
+                      the special (and buggy) Maven versions (LATEST, RELEASE).
+                    </message>
+                  </requirePluginVersions>
+                </rules>
+              </configuration>
+            </execution>
+            -->
+            <execution>
+              <id>enforce-no-logback-test-in-main</id>
+              <goals>
+                <goal>enforce</goal>
+              </goals>
+              <configuration>
+                <rules>
                   <requireFilesDontExist>
                     <files>
                       <file>${project.basedir}/src/main/resources/logback-test.xml</file>
@@ -931,7 +942,7 @@
             <id>javadoc-javadoc</id>
             <phase>package</phase>
             <goals>
-              <goal>javadoc</goal>
+              <goal>javadoc-no-fork</goal>
             </goals>
           </execution>
         </executions>

--- a/build/optaplanner-build-parent/pom.xml
+++ b/build/optaplanner-build-parent/pom.xml
@@ -501,8 +501,7 @@
             </execution>
             <execution>
               <id>ban-duplicated-classes</id>
-              <!-- Using phase=none as we don't want this execution as part of the default build. The phase
-                   is specified in the "full" profile and thus the execution will only be activated when using that profile. -->
+              <!-- Currently disabled as it fails the build. See https://issues.redhat.com/browse/PLANNER-2261. -->
               <phase>none</phase>
               <goals>
                 <goal>enforce</goal>

--- a/build/optaplanner-build-parent/pom.xml
+++ b/build/optaplanner-build-parent/pom.xml
@@ -74,8 +74,6 @@
     <!-- Latest release to be used by api-compatibility-check to check backwards compatibility of the API. -->
     <revapi.oldKieVersion>7.39.0.Final</revapi.oldKieVersion>
     <revapi.newKieVersion>${project.version}</revapi.newKieVersion>
-    <!-- Runs only in the fullProfile. -->
-    <revapi.skip>true</revapi.skip>
     <!--suppress UnresolvedMavenProperty-->
     <project.root.dir>${maven.multiModuleProjectDirectory}</project.root.dir>
 
@@ -1092,15 +1090,28 @@
     </profile>
 
     <profile>
+      <id>quickProfile</id>
+      <activation>
+        <property>
+          <name>quickly</name>
+        </property>
+      </activation>
+      <properties>
+        <enforcer.skip>true</enforcer.skip>
+        <revapi.skip>true</revapi.skip>
+        <skipTests>true</skipTests>
+        <skipITs>true</skipITs>
+        <formatter.skip>true</formatter.skip>
+      </properties>
+    </profile>
+
+    <profile>
       <id>fullProfile</id>
       <activation>
         <property>
           <name>full</name>
         </property>
       </activation>
-      <properties>
-        <revapi.skip>false</revapi.skip>
-      </properties>
       <build>
         <plugins>
           <plugin> <!-- Make sure the build fails-fast on Javadoc issues. -->
@@ -1134,21 +1145,6 @@
           </plugin>
         </plugins>
       </build>
-    </profile>
-    <profile>
-      <id>quickProfile</id>
-      <activation>
-        <property>
-          <name>quick</name>
-        </property>
-      </activation>
-      <properties>
-        <enforcer.skip>true</enforcer.skip>
-        <revapi.skip>true</revapi.skip>
-        <skipTests>true</skipTests>
-        <skipITs>true</skipITs>
-        <formatter.skip>true</formatter.skip>
-      </properties>
     </profile>
   </profiles>
 


### PR DESCRIPTION

Plugin execution | Defined in | Decision | Comment
-- | -- | -- | --
org.apache.maven.plugins:maven-javadoc-plugin:3.2.0:javadoc {execution: javadoc-javadoc} | optaplanner-build-parent | full profile | On 7.x it's full profile only too
org.revapi:revapi-maven-plugin:0.9.5:report {execution: report} | optaplanner-build-parent | remove | The report does not matter, only the "check" goal
org.revapi:revapi-maven-plugin:0.9.5:check {execution: check} | optaplanner-build-parent | full profile |  
net.revelc.code.formatter:formatter-maven-plugin:2.11.0:format {execution: default} | optaplanner-build-parent | keep |  
org.apache.maven.plugins:maven-enforcer-plugin:3.0.0-M2:enforce (all executions) | jboss-parent | keep |  
org.codehaus.mojo:jaxb2-maven-plugin:2.5.0:schemagen {execution: schemagen} | optaplanner-build-parent | keep | Tests depend on XSD being generated
org.apache.maven.plugins:maven-dependency-plugin:3.1.2:analyze-only {execution: analyze-only} | optaplanner-build-parent | full profile |  
org.codehaus.mojo:build-helper-maven-plugin:3.0.0:parse-version {execution: default} | optaplanner-build-parent | remove | Unused
org.codehaus.mojo:build-helper-maven-plugin:3.0.0:add-source {execution: default} | optaplanner-build-parent | remove | GWT-specific
org.apache.maven.plugins:maven-enforcer-plugin:3.0.0-M2:enforce {execution: enforce-direct-dependencies} | optaplanner-build-parent | remove | Unused; duplicates dependency:analyze
org.apache.maven.plugins:maven-enforcer-plugin:3.0.0-M2:enforce {execution: enforce-plugin-versions} | optaplanner-build-parent | remove | Complains about missing versions that are, in fact, defined in jboss-parent



<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.
-->

### JIRA
https://issues.redhat.com/browse/PLANNER-2227

<!-- Add a JIRA ticket link if it exists. -->
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
* https://github.com/kiegroup/drools/pull/3000
* https://github.com/kiegroup/optaplanner/pull/899
* etc.
-->

### Checklist
- [x] Documentation updated if applicable.
- [x] Upgrade recipe provided if applicable.

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>full downstream build</b> please add comment: <b>Jenkins run fdb</b>
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
