### PR TITLE
Add optaplanner-examples jar to the classpath of exec:java

### DIFF
--- a/optaplanner-examples/pom.xml
+++ b/optaplanner-examples/pom.xml
@@ -60,6 +60,12 @@
           <!-- It is impossible to write a configuration that is compatible with both exec:java and exec:exec -->
           <configuration>
             <mainClass>org.optaplanner.examples.app.OptaPlannerExamplesApp</mainClass>
+            <!-- For some reason, Drools cannot find domain classes unless they are specified as a Jar in the classpath -->
+            <!-- (By default, exec:java add target/classes, not target/jarfile) -->
+            <!-- REMOVE ME when https://issues.redhat.com/browse/KOGITO-3954 is fixed -->
+            <additionalClasspathElements>
+                <additionalClasspathElement>${project.build.directory}${file.separator}${project.build.finalName}.jar</additionalClasspathElement>
+            </additionalClasspathElements>
             <arguments>
               <argument>-Xms256m</argument>
               <!-- Most examples run (potentially slower) with max heap of 128 MB (so -Xmx128m), but 1 example's dataset requires 1.5 GB -->


### PR DESCRIPTION
Got the following error when trying to run exec:java:
```
[Message [id=1, level=ERROR, path=src/main/java/org/optaplanner/examples/tsp/solver/PAD/LambdaExtractorADBC3A59CE62AEB61CBB82A8956AE4DE.java, line=4, column=43
   text=package org.optaplanner.examples.tsp.domain does not exist], Message [id=2, level=ERROR, path=src/main/java/org/optaplanner/examples/tsp/solver/PAD/LambdaExtractorADBC3A59CE62AEB61CBB82A8956AE4DE.java, line=5, column=52
   text=package org.optaplanner.examples.tsp.domain.location does not exist], Message [id=3, level=ERROR, path=src/main/java/org/optaplanner/examples/tsp/solver/PAD/LambdaExtractorADBC3A59CE62AEB61CBB82A8956AE4DE.java, line=7, column=43
   text=package org.optaplanner.examples.tsp.domain does not exist], Message [id=4, level=ERROR, path=src/main/java/org/optaplanner/examples/tsp/solver/PAD/LambdaExtractorADBC3A59CE62AEB61CBB82A8956AE4DE.java, line=8, column=43
   text=package org.optaplanner.examples.tsp.domain does not exist], Message [id=5, level=ERROR, path=src/main/java/org/optaplanner/examples/tsp/solver/PAD/LambdaExtractorADBC3A59CE62AEB61CBB82A8956AE4DE.java, line=13, column=144
   text=package org.optaplanner.examples.tsp.domain does not exist], Message [id=6, level=ERROR, path=src/main/java/org/optaplanner/examples/tsp/solver/PAD/LambdaExtractorADBC3A59CE62AEB61CBB82A8956AE4DE.java, line=13, column=187
   text=package org.optaplanner.examples.tsp.domain does not exist], Message [id=7, level=ERROR, path=src/main/java/org/optaplanner/examples/tsp/solver/PAD/LambdaExtractorADBC3A59CE62AEB61CBB82A8956AE4DE.java, line=20, column=100
   text=package org.optaplanner.examples.tsp.domain does not exist], Message [id=8, level=ERROR, path=src/main/java/org/optaplanner/examples/tsp/solver/PAD/LambdaExtractorADBC3A59CE62AEB61CBB82A8956AE4DE.java, line=20, column=47
   text=package org.optaplanner.examples.tsp.domain does not exist], Message [id=9, level=ERROR, path=src/main/java/org/optaplanner/examples/tsp/solver/PAD/LambdaExtractorADBC3A59CE62AEB61CBB82A8956AE4DE.java, line=0, column=0
   text=Java source of src/main/java/org/optaplanner/examples/tsp/solver/PAD/LambdaExtractorADBC3A59CE62AEB61CBB82A8956AE4DE.java in error:
package org.optaplanner.examples.tsp.solver.PAD;

import static org.optaplanner.examples.tsp.solver.Rules412DCB55EE85F50E462B28D279CBEBB0.*;
import org.optaplanner.examples.tsp.domain.Domicile;
import org.optaplanner.examples.tsp.domain.location.Location;
import org.optaplanner.core.api.score.buildin.simplelong.SimpleLongScoreHolder;
import org.optaplanner.examples.tsp.domain.TspSolution;
import org.optaplanner.examples.tsp.domain.Visit;
import org.optaplanner.examples.tsp.solver.*;
import org.drools.modelcompiler.dsl.pattern.D;

@org.drools.compiler.kie.builder.MaterializedLambda()
public enum LambdaExtractorADBC3A59CE62AEB61CBB82A8956AE4DE implements org.drools.model.functions.Function1<org.optaplanner.examples.tsp.domain.Visit, org.optaplanner.examples.tsp.domain.Standstill> {

    INSTANCE;

    public static final String EXPRESSION_HASH = "3FDFB2CFCF1860358DEE2401494D547D";

    @Override()
    public org.optaplanner.examples.tsp.domain.Standstill apply(org.optaplanner.examples.tsp.domain.Visit _this) {
        return _this.getPreviousStandstill();
    }
}
]
```
Apparently, Drools is unable to find the domain classes we defined.
exec:java, by default, add target/classes to the class path. It appears
that does not work with Drools. Adding target/outputfile.jar seems to
fix the issue.

<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.
-->

### JIRA

<!-- Add a JIRA ticket link if it exists. -->
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
* https://github.com/kiegroup/drools/pull/3000
* https://github.com/kiegroup/optaplanner/pull/899
* etc.
-->

### Checklist
- [ ] Documentation updated if applicable.
- [ ] Upgrade recipe provided if applicable.

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>full downstream build</b> please add comment: <b>Jenkins run fdb</b>
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
