### PR TITLE
PLANNER-2270 Make CS-D GroupBy2Map0Collect return bi rule

### DIFF
--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/common/ConstraintGraph.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/common/ConstraintGraph.java
@@ -70,6 +70,7 @@ import org.optaplanner.core.impl.score.stream.drools.common.nodes.QuadConstraint
 import org.optaplanner.core.impl.score.stream.drools.common.nodes.TriConstraintGraphNode;
 import org.optaplanner.core.impl.score.stream.drools.common.nodes.UniConstraintGraphChildNode;
 import org.optaplanner.core.impl.score.stream.drools.common.nodes.UniConstraintGraphNode;
+import org.optaplanner.core.impl.score.stream.drools.common.rules.RuleAssembler;
 import org.optaplanner.core.impl.score.stream.drools.common.rules.RuleAssembly;
 
 public final class ConstraintGraph {
@@ -428,8 +429,8 @@ public final class ConstraintGraph {
             DroolsConstraint constraint) {
         ConstraintTree constraintTree = getTree(constraint.getConsequence());
         ConstraintSubTree nestedNodes = constraintTree.getNestedNodes();
-        return nestedNodes.getRuleAssembler()
-                .assemble(scoreHolderGlobal, constraint);
+        RuleAssembler assembler = nestedNodes.getRuleAssembler();
+        return assembler.assemble(scoreHolderGlobal, constraint);
     }
 
 }

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/common/ConstraintSubTree.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/common/ConstraintSubTree.java
@@ -90,12 +90,22 @@ final class ConstraintSubTree {
     }
 
     public RuleAssembler getRuleAssembler(int totalExpectedGroupByCount) {
-        RuleAssembler builder = isJoin ? leftSubTree.getRuleAssembler(totalExpectedGroupByCount)
-                .join(rightSubTree.getRuleAssembler(totalExpectedGroupByCount), nodeList.get(0))
-                : RuleAssembler.from(variableFactory, nodeList.get(0), totalExpectedGroupByCount);
+        RuleAssembler assembler = getRuleAssemblerForFirstNode(totalExpectedGroupByCount);
         for (int i = 1; i < nodeList.size(); i++) {
-            builder = builder.andThen(nodeList.get(i));
+            ConstraintGraphNode nextNode = nodeList.get(i);
+            assembler = assembler.andThen(nextNode);
         }
-        return builder;
+        return assembler;
+    }
+
+    private RuleAssembler getRuleAssemblerForFirstNode(int totalExpectedGroupByCount) {
+        ConstraintGraphNode firstNode = nodeList.get(0);
+        if (isJoin) {
+            RuleAssembler left = leftSubTree.getRuleAssembler(totalExpectedGroupByCount);
+            RuleAssembler right = rightSubTree.getRuleAssembler(totalExpectedGroupByCount);
+            return left.join(right, firstNode);
+        } else {
+            return RuleAssembler.from(variableFactory, firstNode, totalExpectedGroupByCount);
+        }
     }
 }

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/common/rules/UniGroupBy2Map0CollectMutator.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/common/rules/UniGroupBy2Map0CollectMutator.java
@@ -35,12 +35,12 @@ final class UniGroupBy2Map0CollectMutator<A, NewA, NewB> extends AbstractUniGrou
 
     @Override
     public AbstractRuleAssembler apply(AbstractRuleAssembler ruleAssembler) {
-        BiConsumer<PatternDef, Variable<NewA>> binder = (pattern, tuple) -> pattern.bind(tuple, a -> {
+        BiConsumer<PatternDef, Variable<BiTuple<NewA, NewB>>> binder = (pattern, tuple) -> pattern.bind(tuple, a -> {
             final NewA newA = groupKeyMappingA.apply((A) a);
             final NewB newB = groupKeyMappingB.apply((A) a);
             return new BiTuple<>(newA, newB);
         });
         return universalGroup(ruleAssembler, binder,
-                (var, pattern, accumulate) -> regroup(ruleAssembler, var, pattern, accumulate));
+                (variable, pattern, accumulate) -> regroupBi(ruleAssembler, variable, pattern, accumulate));
     }
 }

--- a/optaplanner-core/src/test/java/org/optaplanner/core/api/score/stream/AdvancedGroupByConstraintStreamTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/api/score/stream/AdvancedGroupByConstraintStreamTest.java
@@ -16,6 +16,7 @@
 
 package org.optaplanner.core.api.score.stream;
 
+import static org.assertj.core.api.Assertions.*;
 import static org.optaplanner.core.api.score.stream.ConstraintCollectors.count;
 import static org.optaplanner.core.api.score.stream.ConstraintCollectors.countBi;
 import static org.optaplanner.core.api.score.stream.ConstraintCollectors.countQuad;
@@ -557,12 +558,10 @@ public class AdvancedGroupByConstraintStreamTest extends AbstractConstraintStrea
     @TestTemplate
     public void groupByThenJoinThenGroupBy() { // PLANNER-2270
         assumeDrools();
-        Assertions.assertThatCode(() -> buildScoreDirector((factory) -> {
+        assertThatCode(() -> buildScoreDirector((factory) -> {
             return factory.from(TestdataLavishEntity.class)
                     .groupBy(TestdataLavishEntity::getEntityGroup, TestdataLavishEntity::getValue)
-                    .join(TestdataLavishEntity.class,
-                            equal((group, value) -> group, e -> e.getEntityGroup()),
-                            greaterThanOrEqual((group, value) -> 1, e -> 1))
+                    .join(TestdataLavishEntity.class)
                     .groupBy((group, value, entity) -> group,
                             (group, value, entity) -> entity,
                             sum((group, count, entity) -> 1))

--- a/optaplanner-core/src/test/java/org/optaplanner/core/api/score/stream/AdvancedGroupByConstraintStreamTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/api/score/stream/AdvancedGroupByConstraintStreamTest.java
@@ -26,7 +26,6 @@ import static org.optaplanner.core.api.score.stream.ConstraintCollectors.toMap;
 import static org.optaplanner.core.api.score.stream.ConstraintCollectors.toSet;
 import static org.optaplanner.core.api.score.stream.Joiners.equal;
 import static org.optaplanner.core.api.score.stream.Joiners.filtering;
-import static org.optaplanner.core.api.score.stream.Joiners.greaterThanOrEqual;
 import static org.optaplanner.core.impl.testdata.util.PlannerTestUtils.asMap;
 import static org.optaplanner.core.impl.testdata.util.PlannerTestUtils.asSet;
 
@@ -36,7 +35,6 @@ import java.util.function.Function;
 import java.util.stream.Stream;
 
 import org.apache.commons.lang3.tuple.ImmutablePair;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.TestTemplate;
 import org.optaplanner.core.api.score.buildin.simple.SimpleScore;
 import org.optaplanner.core.impl.score.director.InnerScoreDirector;


### PR DESCRIPTION
Fixes a typo resulting from an unfortunate lack of type safety in this part of the code.