### PR TITLE
Added Bavet implementation of Bi-groupBy (1 Mapping, 1 Collector)

### DIFF
--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/bavet/bi/BavetAbstractBiConstraintStream.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/bavet/bi/BavetAbstractBiConstraintStream.java
@@ -149,7 +149,13 @@ public abstract class BavetAbstractBiConstraintStream<Solution_, A, B> extends B
     public <GroupKey_, ResultContainer_, Result_> BiConstraintStream<GroupKey_, Result_> groupBy(
             BiFunction<A, B, GroupKey_> groupKeyMapping,
             BiConstraintCollector<A, B, ResultContainer_, Result_> collector) {
-        throw new UnsupportedOperationException();
+        BavetGroupBridgeBiConstraintStream<Solution_, A, B, GroupKey_, ResultContainer_, Result_> bridge =
+                new BavetGroupBridgeBiConstraintStream<>(constraintFactory, this, groupKeyMapping, collector);
+        childStreamList.add(bridge);
+        BavetGroupBiConstraintStream<Solution_, GroupKey_, ResultContainer_, Result_> groupStream =
+                new BavetGroupBiConstraintStream<>(constraintFactory, bridge, collector.finisher());
+        bridge.setGroupStream(groupStream);
+        return groupStream;
     }
 
     @Override

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/bavet/bi/BavetGroupBridgeBiConstraintStream.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/bavet/bi/BavetGroupBridgeBiConstraintStream.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.core.impl.score.stream.bavet.bi;
+
+import java.util.List;
+import java.util.function.BiFunction;
+
+import org.optaplanner.core.api.score.Score;
+import org.optaplanner.core.api.score.stream.bi.BiConstraintCollector;
+import org.optaplanner.core.impl.score.stream.bavet.BavetConstraintFactory;
+import org.optaplanner.core.impl.score.stream.bavet.common.BavetNodeBuildPolicy;
+import org.optaplanner.core.impl.score.stream.bavet.uni.BavetFromUniConstraintStream;
+
+public final class BavetGroupBridgeBiConstraintStream<Solution_, A, B, NewA, ResultContainer_, NewB>
+        extends BavetAbstractBiConstraintStream<Solution_, A, B> {
+
+    private final BavetAbstractBiConstraintStream<Solution_, A, B> parent;
+    private BavetGroupBiConstraintStream<Solution_, NewA, ResultContainer_, NewB> groupStream;
+    private final BiFunction<A, B, NewA> groupKeyMapping;
+    private final BiConstraintCollector<A, B, ResultContainer_, NewB> collector;
+
+    public BavetGroupBridgeBiConstraintStream(BavetConstraintFactory<Solution_> constraintFactory,
+            BavetAbstractBiConstraintStream<Solution_, A, B> parent,
+            BiFunction<A, B, NewA> groupKeyMapping, BiConstraintCollector<A, B, ResultContainer_, NewB> collector) {
+        super(constraintFactory);
+        this.parent = parent;
+        this.groupKeyMapping = groupKeyMapping;
+        this.collector = collector;
+    }
+
+    public void setGroupStream(BavetGroupBiConstraintStream<Solution_, NewA, ResultContainer_, NewB> groupStream) {
+        this.groupStream = groupStream;
+    }
+
+    @Override
+    public List<BavetFromUniConstraintStream<Solution_, Object>> getFromStreamList() {
+        return parent.getFromStreamList();
+    }
+
+    // ************************************************************************
+    // Node creation
+    // ************************************************************************
+
+    @Override
+    protected BavetAbstractBiNode<A, B> createNode(BavetNodeBuildPolicy<Solution_> buildPolicy,
+            Score<?> constraintWeight, int nodeOrder, BavetAbstractBiNode<A, B> parentNode) {
+        BavetGroupBiNode<NewA, ResultContainer_, NewB> groupNode = groupStream.createNodeChain(buildPolicy, constraintWeight,
+                nodeOrder + 1, null);
+        BavetGroupBridgeBiNode<A, B, NewA, ResultContainer_, NewB> node = new BavetGroupBridgeBiNode<>(
+                buildPolicy.getSession(), nodeOrder, parentNode, groupKeyMapping, collector, groupNode);
+        return node;
+    }
+
+    @Override
+    protected void createChildNodeChains(BavetNodeBuildPolicy<Solution_> buildPolicy, Score<?> constraintWeight, int nodeOrder,
+            BavetAbstractBiNode<A, B> node) {
+        if (!childStreamList.isEmpty()) {
+            throw new IllegalStateException("Impossible state: the stream (" + this
+                    + ") has an non-empty childStreamList (" + childStreamList + ") but it's a groupBy bridge.");
+        }
+    }
+}

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/bavet/bi/BavetGroupBridgeBiNode.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/bavet/bi/BavetGroupBridgeBiNode.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.core.impl.score.stream.bavet.bi;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.BiFunction;
+
+import org.optaplanner.core.api.score.stream.bi.BiConstraintCollector;
+import org.optaplanner.core.impl.score.stream.bavet.BavetConstraintSession;
+import org.optaplanner.core.impl.score.stream.bavet.common.BavetTupleState;
+
+public class BavetGroupBridgeBiNode<A, B, NewA, ResultContainer_, NewB> extends BavetAbstractBiNode<A, B> {
+    private final BavetAbstractBiNode<A, B> parentNode;
+    private final BiFunction<A, B, NewA> groupKeyMapping;
+    private final BiConstraintCollector<A, B, ResultContainer_, NewB> collector;
+    private final BavetGroupBiNode<NewA, ResultContainer_, NewB> groupNode;
+
+    private final Map<NewA, BavetGroupBiTuple<NewA, ResultContainer_, NewB>> tupleMap;
+
+    public BavetGroupBridgeBiNode(BavetConstraintSession session, int nodeOrder, BavetAbstractBiNode<A, B> parentNode,
+            BiFunction<A, B, NewA> groupKeyMapping, BiConstraintCollector<A, B, ResultContainer_, NewB> collector,
+            BavetGroupBiNode<NewA, ResultContainer_, NewB> groupNode) {
+        super(session, nodeOrder);
+        this.parentNode = parentNode;
+        this.groupKeyMapping = groupKeyMapping;
+        this.collector = collector;
+        this.groupNode = groupNode;
+        tupleMap = new HashMap<>();
+    }
+
+    @Override
+    public BavetGroupBridgeBiTuple<A, B, NewA, ResultContainer_, NewB> createTuple(BavetAbstractBiTuple<A, B> parentTuple) {
+        return new BavetGroupBridgeBiTuple<>(this, parentTuple);
+    }
+
+    public void refresh(BavetGroupBridgeBiTuple<A, B, NewA, ResultContainer_, NewB> tuple) {
+        if (tuple.getChildTuple() != null) {
+            BavetGroupBiTuple<NewA, ResultContainer_, NewB> childTuple = tuple.getChildTuple();
+            NewA oldGroupKey = childTuple.getGroupKey();
+            int parentCount = childTuple.decreaseParentCount();
+            tuple.getUndoAccumulator().run();
+            childTuple.clearResult();
+            tuple.setChildTuple(null);
+            tuple.setUndoAccumulator(null);
+            if (parentCount == 0) {
+                // Clean up tupleMap
+                tupleMap.remove(oldGroupKey);
+                session.transitionTuple(childTuple, BavetTupleState.DYING);
+            } else {
+                session.transitionTuple(childTuple, BavetTupleState.UPDATING);
+            }
+        }
+        if (tuple.isActive()) {
+            A a = tuple.getFactA();
+            B b = tuple.getFactB();
+            NewA groupKey = groupKeyMapping.apply(a, b);
+            BavetGroupBiTuple<NewA, ResultContainer_, NewB> childTuple = tupleMap.computeIfAbsent(groupKey,
+                    k -> groupNode.createTuple(groupKey, collector.supplier().get()));
+            int parentCount = childTuple.increaseParentCount();
+
+            Runnable undoAccumulator = collector.accumulator().apply(childTuple.getResultContainer(), a, b);
+            tuple.setUndoAccumulator(undoAccumulator);
+            childTuple.clearResult();
+            tuple.setChildTuple(childTuple);
+            if (parentCount == 1) {
+                session.transitionTuple(childTuple, BavetTupleState.CREATING);
+            } else {
+                // It might have just been created by an earlier tuple in the same nodeOrder
+                if (childTuple.getState() != BavetTupleState.CREATING) {
+                    session.transitionTuple(childTuple, BavetTupleState.UPDATING);
+                }
+            }
+        }
+        tuple.refreshed();
+    }
+
+    @Override
+    public String toString() {
+        return "GroupBridge()";
+    }
+
+    // ************************************************************************
+    // Getters/setters
+    // ************************************************************************
+
+}

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/bavet/bi/BavetGroupBridgeBiTuple.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/bavet/bi/BavetGroupBridgeBiTuple.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.core.impl.score.stream.bavet.bi;
+
+public class BavetGroupBridgeBiTuple<A, B, NewA, ResultContainer_, NewB> extends BavetAbstractBiTuple<A, B> {
+
+    private final BavetGroupBridgeBiNode<A, B, NewA, ResultContainer_, NewB> node;
+    private final BavetAbstractBiTuple<A, B> parentTuple;
+
+    private Runnable undoAccumulator;
+    private BavetGroupBiTuple<NewA, ResultContainer_, NewB> childTuple;
+
+    public BavetGroupBridgeBiTuple(BavetGroupBridgeBiNode<A, B, NewA, ResultContainer_, NewB> node,
+            BavetAbstractBiTuple<A, B> parentTuple) {
+        this.node = node;
+        this.parentTuple = parentTuple;
+    }
+
+    @Override
+    public void refresh() {
+        node.refresh(this);
+    }
+
+    @Override
+    public String toString() {
+        return "GroupBridge(" + getFactsString() + ") with " + (childTuple == null ? 0 : 1) + " children";
+    }
+
+    // ************************************************************************
+    // Getters/setters
+    // ************************************************************************
+
+    @Override
+    public BavetGroupBridgeBiNode<A, B, NewA, ResultContainer_, NewB> getNode() {
+        return node;
+    }
+
+    @Override
+    public A getFactA() {
+        return parentTuple.getFactA();
+    }
+
+    @Override
+    public B getFactB() {
+        return parentTuple.getFactB();
+    }
+
+    public Runnable getUndoAccumulator() {
+        return undoAccumulator;
+    }
+
+    public void setUndoAccumulator(Runnable undoAccumulator) {
+        this.undoAccumulator = undoAccumulator;
+    }
+
+    public BavetGroupBiTuple<NewA, ResultContainer_, NewB> getChildTuple() {
+        return childTuple;
+    }
+
+    public void setChildTuple(BavetGroupBiTuple<NewA, ResultContainer_, NewB> childTuple) {
+        this.childTuple = childTuple;
+    }
+}

--- a/optaplanner-core/src/test/java/org/optaplanner/core/api/score/stream/bi/BiConstraintStreamTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/api/score/stream/bi/BiConstraintStreamTest.java
@@ -750,7 +750,7 @@ public class BiConstraintStreamTest extends AbstractConstraintStreamTest {
 
     @TestTemplate
     public void groupBy_1Mapping1Collector_count() {
-        assumeDrools();
+
         TestdataLavishSolution solution = TestdataLavishSolution.generateSolution(2, 5, 3, 7);
 
         InnerScoreDirector<TestdataLavishSolution, SimpleScore> scoreDirector = buildScoreDirector((factory) -> {


### PR DESCRIPTION
### Checklist
- [ ] Documentation updated if applicable (?).

<details>
<summary>
This PR adds a Bavet implementation of the groupBy that has been available for Uni-Streams for the Bi-Streams. The implementation is almost the same as the existing one for Uni, with the necessary adjustments made to make it compatible with Bi streams. The test that exists for the Drools implementation passes, and testing the new implementation in use in a project was successful as well.

The existing test mentioned above is `optaplanner-core/src/test/java/org/optaplanner/core/api/score/stream/bi/BiConstraintStreamTest.java->groupBy_1Mapping1Collector_count()`
</summary>

<b>Jenkins retest this</b>
</details>
