### PR TITLE
[8.0.x] PLANNER-2271 ConstraintCollectors.toMap(): Only remove a key when no value remains (#1061)

### DIFF
--- a/optaplanner-core/src/main/java/org/optaplanner/core/api/score/stream/ConstraintCollectors.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/api/score/stream/ConstraintCollectors.java
@@ -1180,6 +1180,10 @@ public final class ConstraintCollectors {
             return counts.keySet();
         }
 
+        public boolean isEmpty() {
+            return counts.isEmpty();
+        }
+
     }
 
     private static final class Tuple<Key, Value> {
@@ -1205,8 +1209,8 @@ public final class ConstraintCollectors {
 
         public void remove(Key key, Value value) {
             ToMapPerKeyCounter<Value> counter = valueCounts.get(key);
-            long remainingCount = counter.remove(value);
-            if (remainingCount < 1) {
+            counter.remove(value);
+            if (counter.isEmpty()) {
                 valueCounts.remove(key);
             }
         }


### PR DESCRIPTION
(cherry picked from commit 200964881ef5adb4a2f84f001757a21a12775528)