### PR TITLE
Docs: Replace HardSoftScore.valueOf with HardSoftScore.of

### DIFF
--- a/optaplanner-docs/src/main/asciidoc/QuickStart/PlainJava/CloudBalancingScoreConfiguration/CloudBalancingScoreConfiguration-section.adoc
+++ b/optaplanner-docs/src/main/asciidoc/QuickStart/PlainJava/CloudBalancingScoreConfiguration/CloudBalancingScoreConfiguration-section.adoc
@@ -79,7 +79,7 @@ public class CloudBalancingEasyScoreCalculator
                 softScore -= computer.getCost();
             }
         }
-        return HardSoftScore.valueOf(hardScore, softScore);
+        return HardSoftScore.of(hardScore, softScore);
     }
 
 }


### PR DESCRIPTION
Replace `HardSoftScore.valueOf` with `HardSoftScore.of` at documentation (QuickStart / PlainJava / CloudBalancingScoreConfiguration) because HardSoftScore.valueOf has been removed from OptaPlanner 8.0.0.Final.

Seems as lost changes in #947.

Source code at repo: https://github.com/kiegroup/optaplanner/blob/e5a7d6b5a1e68bdb25a891cd70459486a29ed7c2/optaplanner-examples/src/main/java/org/optaplanner/examples/cloudbalancing/optional/score/CloudBalancingEasyScoreCalculator.java#L70

