### PR TITLE
PLANNER-2297 Fail fast if XML schema does not exist

### DIFF
--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/io/jaxb/GenericJaxbIO.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/io/jaxb/GenericJaxbIO.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.Reader;
 import java.io.Writer;
+import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Deque;
@@ -119,6 +120,11 @@ public final class GenericJaxbIO<T> implements JaxbIO<T> {
 
     private Schema readSchemaResource(String schemaResource) {
         String nonNullSchemaResource = Objects.requireNonNull(schemaResource);
+        URL schemaResourceUrl = GenericJaxbIO.class.getResource(nonNullSchemaResource);
+        if (schemaResourceUrl == null) {
+            throw new IllegalArgumentException("The XML schema (" + nonNullSchemaResource + ") does not exist.\n"
+                    + "Maybe the JAXB maven plugin did not run?");
+        }
         SchemaFactory schemaFactory = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
         try {
             schemaFactory.setProperty(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
@@ -131,7 +137,7 @@ public final class GenericJaxbIO<T> implements JaxbIO<T> {
         }
 
         try {
-            return schemaFactory.newSchema(GenericJaxbIO.class.getResource(nonNullSchemaResource));
+            return schemaFactory.newSchema(schemaResourceUrl);
         } catch (SAXException saxException) {
             String errorMessage =
                     String.format("Failed to read an XML Schema resource (%s) to validate an XML for a root class (%s).",


### PR DESCRIPTION
<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.
-->

### JIRA
https://issues.redhat.com/browse/PLANNER-2297

<!-- Add a JIRA ticket link if it exists. -->
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
* https://github.com/kiegroup/drools/pull/3000
* https://github.com/kiegroup/optaplanner/pull/899
* etc.
-->

### Checklist
- [x] Documentation updated if applicable.
- [x] Upgrade recipe provided if applicable.

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>full downstream build</b> please add comment: <b>Jenkins run fdb</b>
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
