### PR TITLE
[KOGITO-3034][BXMSPROD-1094] Setup Jenkins DSL scripts

### DIFF
--- a/.github/workflows/jenkins-tests-PR.yml
+++ b/.github/workflows/jenkins-tests-PR.yml
@@ -1,0 +1,26 @@
+# This workflow will build a Java project with Maven
+# For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
+
+name: Jenkins Tests
+
+on:
+  pull_request:
+    paths: 
+    - '.jenkins/**'
+
+jobs:
+  dsl-tests:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout 
+      uses: actions/checkout@v2
+
+    - name: Set up JDK 1.11
+      uses: actions/setup-java@v1
+      with:
+        java-version: 11
+      
+    - name: Test DSL
+      # TODO to change back to kiegroup/master
+      run: cd .jenkins/dsl && ./test.sh setup_dsl radtriste

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 # Eclipse, Netbeans and IntelliJ files
 /.*
 !/.github
+!/.jenkins
 !.gitignore
 !.gitattributes
 !/.mvn

--- a/.jenkins/dsl/jobs.groovy
+++ b/.jenkins/dsl/jobs.groovy
@@ -1,0 +1,187 @@
+import org.kie.jenkins.jobdsl.templates.KogitoJobTemplate
+import org.kie.jenkins.jobdsl.KogitoConstants
+import org.kie.jenkins.jobdsl.Utils
+import org.kie.jenkins.jobdsl.KogitoJobType
+
+boolean isMainBranch() {
+    return "${GIT_BRANCH}" == "${GIT_MAIN_BRANCH}"
+}
+
+def getDefaultJobParams(String repoName = 'optaplanner') {
+    return [
+        job: [
+            name: repoName
+        ],
+        git: [
+            author: "${GIT_AUTHOR_NAME}",
+            branch: "${GIT_BRANCH}",
+            repository: repoName,
+            credentials: "${GIT_AUTHOR_CREDENTIALS_ID}",
+            token_credentials: "${GIT_AUTHOR_TOKEN_CREDENTIALS_ID}"
+        ]
+    ]
+}
+
+def getJobParams(String jobName, String jobFolder, String jenkinsfileName, String jobDescription = '') {
+    def jobParams = getDefaultJobParams()
+    jobParams.job.name = jobName
+    jobParams.job.folder = jobFolder
+    jobParams.jenkinsfile = jenkinsfileName
+    if (jobDescription) {
+        jobParams.job.description = jobDescription
+    }
+    return jobParams
+}
+
+def bddRuntimesPrFolder = "${KogitoConstants.KOGITO_DSL_PULLREQUEST_FOLDER}/${KogitoConstants.KOGITO_DSL_RUNTIMES_BDD_FOLDER}"
+def nightlyBranchFolder = "${KogitoConstants.KOGITO_DSL_NIGHTLY_FOLDER}/${JOB_BRANCH_FOLDER}"
+def releaseBranchFolder = "${KogitoConstants.KOGITO_DSL_RELEASE_FOLDER}/${JOB_BRANCH_FOLDER}"
+
+if (isMainBranch()) {
+    folder(KogitoConstants.KOGITO_DSL_PULLREQUEST_FOLDER)
+
+    setupOptaplannerPrJob(KogitoConstants.KOGITO_DSL_PULLREQUEST_FOLDER)
+    setupOptawebEmployeeRosteringPrJob(KogitoConstants.KOGITO_DSL_PULLREQUEST_FOLDER)
+    setupOptawebVehicleRoutingPrJob(KogitoConstants.KOGITO_DSL_PULLREQUEST_FOLDER)
+
+    // For BDD runtimes PR job
+    folder(bddRuntimesPrFolder)
+
+    setupDeployJob(bddRuntimesPrFolder, KogitoJobType.PR)
+}
+
+// Nightly jobs
+folder(KogitoConstants.KOGITO_DSL_NIGHTLY_FOLDER)
+folder(nightlyBranchFolder)
+setupDeployJob(nightlyBranchFolder, KogitoJobType.NIGHTLY)
+setupPromoteJob(nightlyBranchFolder, KogitoJobType.NIGHTLY)
+
+// No release directly on main branch
+if (!isMainBranch()) {
+    folder(KogitoConstants.KOGITO_DSL_RELEASE_FOLDER)
+    folder(releaseBranchFolder)
+    setupDeployJob(releaseBranchFolder, KogitoJobType.RELEASE)
+    setupPromoteJob(releaseBranchFolder, KogitoJobType.RELEASE)
+}
+
+/////////////////////////////////////////////////////////////////
+// Methods
+/////////////////////////////////////////////////////////////////
+
+void setupOptaplannerPrJob(String jobFolder) {
+    def jobParams = getDefaultJobParams()
+    jobParams.job.folder = jobFolder
+    jobParams.pr = [ blackListTargetBranches: ['7.x'] ]
+    KogitoJobTemplate.createPRJob(this, jobParams)
+}
+
+void setupOptawebEmployeeRosteringPrJob(String jobFolder) {
+    def jobParams = getDefaultJobParams('optaweb-employee-rostering')
+    jobParams.job.folder = jobFolder
+    jobParams.pr = [ whiteListTargetBranches: ['master'] ]
+    KogitoJobTemplate.createPRJob(this, jobParams)
+}
+
+void setupOptawebVehicleRoutingPrJob(String jobFolder) {
+    def jobParams = getDefaultJobParams('optaweb-vehicle-routing')
+    jobParams.job.folder = jobFolder
+    jobParams.pr = [ whiteListTargetBranches: ['master'] ]
+    KogitoJobTemplate.createPRJob(this, jobParams)
+}
+
+void setupDeployJob(String jobFolder, KogitoJobType jobType) {
+    def jobParams = getJobParams('optaplanner-deploy', jobFolder, 'Jenkinsfile.deploy', 'Optaplanner Deploy')
+    if (jobType == KogitoJobType.PR) {
+        jobParams.git.branch = '${GIT_BRABUILD_BRANCH_NAMENCH_NAME}'
+        jobParams.git.author = '${GIT_AUTHOR}'
+        jobParams.git.project_url = Utils.createProjectUrl("${GIT_AUTHOR_NAME}", jobParams.git.repository)
+    }
+    KogitoJobTemplate.createPipelineJob(this, jobParams).with {
+        parameters {
+            stringParam('DISPLAY_NAME', '', 'Setup a specific build display name')
+
+            stringParam('BUILD_BRANCH_NAME', "${GIT_BRANCH}", 'Set the Git branch to checkout')
+            if (jobType == KogitoJobType.PR) {
+                // author can be changed as param only for PR behavior, due to source branch/target, else it is considered as an env
+                stringParam('GIT_AUTHOR', "${GIT_AUTHOR_NAME}", 'Set the Git author to checkout')
+            }
+
+            booleanParam('SKIP_TESTS', false, 'Skip tests')
+
+            booleanParam('CREATE_PR', false, 'Should we create a PR with the changes ?')
+            stringParam('PROJECT_VERSION', '', 'Optional if not RELEASE. If RELEASE, cannot be empty.')
+            stringParam('KOGITO_VERSION', '', 'Optional if not RELEASE. If RELEASE, cannot be empty.')
+
+            if (jobType == KogitoJobType.PR) {
+                stringParam('PR_TARGET_BRANCH', '', 'What is the target branch of the PR?')
+            }
+
+            //Build branch name for quickstarts
+            stringParam('QUICKSTARTS_BUILD_BRANCH_NAME', 'development', 'Base branch for quickstarts. Set if you are not on a multibranch pipeline.')
+        }
+
+        environmentVariables {
+            env('RELEASE', jobType == KogitoJobType.RELEASE)
+            env('JENKINS_EMAIL_CREDS_ID', "${JENKINS_EMAIL_CREDS_ID}")
+            env('MAVEN_SETTINGS_CONFIG_FILE_ID', "${MAVEN_SETTINGS_FILE_ID}")
+            
+            if (jobType == KogitoJobType.PR) {
+                env('MAVEN_DEPENDENCIES_REPOSITORY', "${MAVEN_PR_CHECKS_REPOSITORY_URL}")
+                env('MAVEN_DEPLOY_REPOSITORY', "${MAVEN_PR_CHECKS_REPOSITORY_URL}")
+                env('MAVEN_REPO_CREDS_ID', "${MAVEN_PR_CHECKS_REPOSITORY_CREDS_ID}")
+            } else {
+                env('GIT_AUTHOR', "${GIT_AUTHOR_NAME}")
+
+                env('AUTHOR_CREDS_ID', "${GIT_AUTHOR_CREDENTIALS_ID}")
+                env('GITHUB_TOKEN_CREDS_ID', "${GIT_AUTHOR_TOKEN_CREDENTIALS_ID}")
+                env('GIT_AUTHOR_BOT', "${GIT_BOT_AUTHOR_NAME}")
+                env('BOT_CREDENTIALS_ID', "${GIT_BOT_AUTHOR_CREDENTIALS_ID}")
+
+                env('MAVEN_DEPENDENCIES_REPOSITORY', "${MAVEN_ARTIFACTS_REPOSITORY}")
+                env('MAVEN_DEPLOY_REPOSITORY', "${MAVEN_ARTIFACTS_REPOSITORY}")
+                if (jobType == KogitoJobType.RELEASE) {
+                    env('NEXUS_RELEASE_URL', "${MAVEN_NEXUS_RELEASE_URL}")
+                    env('NEXUS_RELEASE_REPOSITORY_ID', "${MAVEN_NEXUS_RELEASE_REPOSITORY}")
+                    env('NEXUS_STAGING_PROFILE_ID', "${MAVEN_NEXUS_STAGING_PROFILE_ID}")
+                    env('NEXUS_BUILD_PROMOTION_PROFILE_ID', "${MAVEN_NEXUS_BUILD_PROMOTION_PROFILE_ID}")
+                }
+                
+            }
+        }
+    }
+}
+
+void setupPromoteJob(String jobFolder, KogitoJobType jobType) {
+    KogitoJobTemplate.createPipelineJob(this, getJobParams('optaplanner-promote', jobFolder, 'Jenkinsfile.promote', 'Optaplanner Promote')).with {
+        parameters {
+            stringParam('DISPLAY_NAME', '', 'Setup a specific build display name')
+
+            stringParam('BUILD_BRANCH_NAME', "${GIT_BRANCH}", 'Set the Git branch to checkout')
+
+            // Deploy job url to retrieve deployment.properties
+            stringParam('DEPLOY_BUILD_URL', '', 'URL to jenkins deploy build to retrieve the `deployment.properties` file. If base parameters are defined, they will override the `deployment.properties` information')
+
+            // Release information which can override `deployment.properties`
+            stringParam('PROJECT_VERSION', '', 'Override `deployment.properties`. Optional if not RELEASE. If RELEASE, cannot be empty.')
+            stringParam('KOGITO_VERSION', '', 'Optional if not RELEASE. If RELEASE, cannot be empty.')
+
+            stringParam('GIT_TAG', '', 'Git tag to set, if different from PROJECT_VERSION')
+        }
+
+        environmentVariables {
+            env('RELEASE', jobType == KogitoJobType.RELEASE)
+            env('JENKINS_EMAIL_CREDS_ID', "${JENKINS_EMAIL_CREDS_ID}")
+
+            env('GIT_AUTHOR', "${GIT_AUTHOR_NAME}")
+
+            env('AUTHOR_CREDS_ID', "${GIT_AUTHOR_CREDENTIALS_ID}")
+            env('GITHUB_TOKEN_CREDS_ID', "${GIT_AUTHOR_TOKEN_CREDENTIALS_ID}")
+            env('GIT_AUTHOR_BOT', "${GIT_BOT_AUTHOR_NAME}")
+            env('BOT_CREDENTIALS_ID', "${GIT_BOT_AUTHOR_CREDENTIALS_ID}")
+
+            env('MAVEN_SETTINGS_CONFIG_FILE_ID', "${MAVEN_SETTINGS_FILE_ID}")
+            env('MAVEN_DEPENDENCIES_REPOSITORY', "${MAVEN_ARTIFACTS_REPOSITORY}")
+            env('MAVEN_DEPLOY_REPOSITORY', "${MAVEN_ARTIFACTS_REPOSITORY}")
+        }
+    }
+}

--- a/.jenkins/dsl/jobs.groovy
+++ b/.jenkins/dsl/jobs.groovy
@@ -182,6 +182,9 @@ void setupPromoteJob(String jobFolder, KogitoJobType jobType) {
             env('MAVEN_SETTINGS_CONFIG_FILE_ID', "${MAVEN_SETTINGS_FILE_ID}")
             env('MAVEN_DEPENDENCIES_REPOSITORY', "${MAVEN_ARTIFACTS_REPOSITORY}")
             env('MAVEN_DEPLOY_REPOSITORY', "${MAVEN_ARTIFACTS_REPOSITORY}")
+
+            env('PROPERTIES_FILE_NAME', 'deployment.properties')
+            env('GITHUB_CLI_VERSION', '0.11.1')
         }
     }
 }

--- a/.jenkins/dsl/jobs.groovy
+++ b/.jenkins/dsl/jobs.groovy
@@ -121,6 +121,8 @@ void setupDeployJob(String jobFolder, KogitoJobType jobType) {
         }
 
         environmentVariables {
+            env('PROPERTIES_FILE_NAME', 'deployment.properties')
+
             env('RELEASE', jobType == KogitoJobType.RELEASE)
             env('JENKINS_EMAIL_CREDS_ID', "${JENKINS_EMAIL_CREDS_ID}")
             env('MAVEN_SETTINGS_CONFIG_FILE_ID', "${MAVEN_SETTINGS_FILE_ID}")

--- a/.jenkins/dsl/test.sh
+++ b/.jenkins/dsl/test.sh
@@ -1,0 +1,20 @@
+#!/bin/bash -e
+
+TEMP_DIR=`mktemp -d`
+
+branch=$1
+author=$2
+
+if [ -z $branch ]; then
+  branch='master'
+fi
+
+if [ -z $author ]; then
+  author='kiegroup'
+fi
+
+echo "----- Cloning pipelines repo from ${author} on branch ${branch}"
+git clone --single-branch --branch ${branch} https://github.com/${author}/kogito-pipelines.git $TEMP_DIR
+
+echo '----- Launching seed tests'
+${TEMP_DIR}/dsl/seed/scripts/seed_test.sh ${TEMP_DIR}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,7 +13,6 @@ pipeline {
         jdk 'kie-jdk11'
     }
     options {
-        buildDiscarder logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '10', numToKeepStr: '')
         timeout(time: 120, unit: 'MINUTES')
     }
     environment {

--- a/Jenkinsfile.deploy
+++ b/Jenkinsfile.deploy
@@ -24,20 +24,20 @@ pipeline {
     options {
         timeout(time: 120, unit: 'MINUTES')
     }
-    
+
     // parameters {
-    // For parameters, check into ./dsl/jobs.groovy file
+    // For parameters, check into .jenkins/dsl/jobs.groovy file
     // }
 
     environment {
-        // Some generated env is also defined into ./dsl/jobs.groovy file
+        // Some generated env is also defined into .jenkins/dsl/jobs.groovy file
 
         MAVEN_OPTS = '-Xms1024m -Xmx4g'
 
         BOT_BRANCH_HASH = "${util.generateHash(10)}"
 
         // Maven configuration
-        MAVEN_DEPLOY_LOCAL_DIR="${WORKSPACE}/maven_deploy_dir"
+        MAVEN_DEPLOY_LOCAL_DIR = "${WORKSPACE}/maven_deploy_dir"
     }
 
     stages {
@@ -46,13 +46,19 @@ pipeline {
                 script {
                     cleanWs()
 
-                    if (params.DISPLAY_NAME != '') {
+                    if (params.DISPLAY_NAME) {
                         currentBuild.displayName = params.DISPLAY_NAME
                     }
 
                     if (isRelease() || isCreatePr()) {
-                        assert getProjectVersion() != ''
-                        assert getKogitoVersion() != ''
+                        // Verify version is set
+                        assert getProjectVersion()
+                        assert getKogitoVersion()
+
+                        if(isRelease()) {
+                            // Verify if on right release branch
+                            assert getBuildBranch() == util.getReleaseBranchFromVersion(getProjectVersion())
+                        }
                     }
 
                 }
@@ -60,7 +66,7 @@ pipeline {
             post {
                 success {
                     script {
-                        setDeployPropertyIfNeeded('git.branch', getGitBranch())
+                        setDeployPropertyIfNeeded('git.branch', getBuildBranch())
                         setDeployPropertyIfNeeded('git.branchQuickstarts', getQuickStartsBranch())
                         setDeployPropertyIfNeeded('git.author', getGitAuthor())
                         setDeployPropertyIfNeeded('project.version', getProjectVersion())
@@ -136,7 +142,7 @@ pipeline {
             }
         }
 
-        stage("Build Vehicle Routing") {
+        stage('Build Vehicle Routing') {
             steps {
                 script {
                     getOptawebVehicleRoutingMavenCommand().skipTests(params.SKIP_TESTS).run('clean install')
@@ -151,7 +157,7 @@ pipeline {
             }
         }
 
-        stage("Build Employee Rostering") {
+        stage('Build Employee Rostering') {
             steps {
                 script {
                     getOptawebEmployeeRosteringMavenCommand().skipTests(params.SKIP_TESTS).run('clean install')
@@ -181,9 +187,9 @@ pipeline {
                 expression { return isRelease() || isCreatePr()  }
             }
             steps {
-                commitAndCreatePR(optaplannerRepository, getGitBranch())
-                commitAndCreatePRIgnoringNpmRegistry(vehicleRoutingRepository, getGitBranch())
-                commitAndCreatePRIgnoringNpmRegistry(employeeRosteringRepository, getGitBranch())
+                commitAndCreatePR(optaplannerRepository, getBuildBranch())
+                commitAndCreatePRIgnoringNpmRegistry(vehicleRoutingRepository, getBuildBranch())
+                commitAndCreatePRIgnoringNpmRegistry(employeeRosteringRepository, getBuildBranch())
                 commitAndCreatePR(quickstartsRepository, getQuickStartsBranch())
             }
             post {
@@ -192,17 +198,17 @@ pipeline {
                         setDeployPropertyIfNeeded("${optaplannerRepository}.pr.source.uri", "https://github.com/${getBotAuthor()}/${optaplannerRepository}")
                         setDeployPropertyIfNeeded("${optaplannerRepository}.pr.source.ref", getBotBranch())
                         setDeployPropertyIfNeeded("${optaplannerRepository}.pr.target.uri", "https://github.com/${getGitAuthor()}/${optaplannerRepository}")
-                        setDeployPropertyIfNeeded("${optaplannerRepository}.pr.target.ref", getGitBranch())
+                        setDeployPropertyIfNeeded("${optaplannerRepository}.pr.target.ref", getBuildBranch())
 
                         setDeployPropertyIfNeeded("${vehicleRoutingRepository}.pr.source.uri", "https://github.com/${getBotAuthor()}/${vehicleRoutingRepository}")
                         setDeployPropertyIfNeeded("${vehicleRoutingRepository}.pr.source.ref", getBotBranch())
                         setDeployPropertyIfNeeded("${vehicleRoutingRepository}.pr.target.uri", "https://github.com/${getGitAuthor()}/${vehicleRoutingRepository}")
-                        setDeployPropertyIfNeeded("${vehicleRoutingRepository}.pr.target.ref", getGitBranch())
+                        setDeployPropertyIfNeeded("${vehicleRoutingRepository}.pr.target.ref", getBuildBranch())
 
                         setDeployPropertyIfNeeded("${employeeRosteringRepository}.pr.source.uri", "https://github.com/${getBotAuthor()}/${employeeRosteringRepository}")
                         setDeployPropertyIfNeeded("${employeeRosteringRepository}.pr.source.ref", getBotBranch())
                         setDeployPropertyIfNeeded("${employeeRosteringRepository}.pr.target.uri", "https://github.com/${getGitAuthor()}/${employeeRosteringRepository}")
-                        setDeployPropertyIfNeeded("${employeeRosteringRepository}.pr.target.ref", getGitBranch())
+                        setDeployPropertyIfNeeded("${employeeRosteringRepository}.pr.target.ref", getBuildBranch())
                     }
                 }
             }
@@ -211,7 +217,7 @@ pipeline {
     post {
         always {
             script {
-                def propertiesStr = deployProperties.collect{ entry ->  "${entry.key}=${entry.value}" }.join("\n")
+                def propertiesStr = deployProperties.collect { entry ->  "${entry.key}=${entry.value}" }.join('\n')
                 writeFile(text: propertiesStr, file: 'deployment.properties')
                 archiveArtifacts(artifacts: 'deployment.properties')
             }
@@ -243,13 +249,13 @@ void updateQuickstartsVersions(){
    }
 }
 
-void gradleVersionsUpdate(String repo, String newVersion){
+void gradleVersionsUpdate(String repo, String newVersion) {
     dir(repo) {
         sh "sed -i -E 's/def optaplannerVersion = \"[^\"\\s]+\"/def optaplannerVersion = \"${newVersion}\"/' */build.gradle"
     }
 }
 
-void saveReports(boolean allowEmpty=false){
+void saveReports(boolean allowEmpty=false) {
     junit testResults: '**/target/surefire-reports/**/*.xml, **/target/failsafe-reports/**/*.xml', allowEmptyResults: allowEmpty
 }
 
@@ -257,9 +263,9 @@ void checkoutRepo(String repo, String dirName=repo) {
     dir(dirName) {
         deleteDir()
         if (params.PR_TARGET_BRANCH) {
-            githubscm.checkoutIfExists(repo, getGitAuthor(), getGitBranch(), 'kiegroup', getFallbackBranch(repo), true)
+            githubscm.checkoutIfExists(repo, getGitAuthor(), getBuildBranch(), 'kiegroup', getFallbackBranch(repo), true)
         } else {
-            checkout(githubscm.resolveRepository(repo, getGitAuthor(), getGitBranch(), false))
+            checkout(githubscm.resolveRepository(repo, getGitAuthor(), getBuildBranch(), false))
         }
     }
 }
@@ -293,7 +299,7 @@ void commitAndCreatePR(String repo, String buildBranch) {
         def prBody = "Generated by build ${BUILD_TAG}: ${BUILD_URL}.\nPlease do not merge, it will be merged automatically after testing."
 
         githubscm.commitChanges(commitMsg, {
-            githubscm.findAndStageNotIgnoredFiles('pom.xml') 
+            githubscm.findAndStageNotIgnoredFiles('pom.xml')
             githubscm.findAndStageNotIgnoredFiles('build.gradle')
         })
         githubscm.pushObject('origin', getBotBranch(), getBotAuthorCredsID())
@@ -309,7 +315,7 @@ void commitAndCreatePRIgnoringNpmRegistry(String repo, String buildBranch) {
     commitAndCreatePR(repo, buildBranch)
 }
 
-MavenCommand getMavenDefaultCommand(){
+MavenCommand getMavenDefaultCommand() {
     MavenCommand mvnCmd = new MavenCommand(this, ['-fae']).withSettingsXmlId(env.MAVEN_SETTINGS_CONFIG_FILE_ID)
     if (env.MAVEN_DEPENDENCIES_REPOSITORY) {
         mvnCmd.withDependencyRepositoryInSettings('deps-repo', env.MAVEN_DEPENDENCIES_REPOSITORY)
@@ -317,19 +323,19 @@ MavenCommand getMavenDefaultCommand(){
     return mvnCmd
 }
 
-MavenCommand getOptaplannerMavenCommand(){
+MavenCommand getOptaplannerMavenCommand() {
     return getMavenDefaultCommand().inDirectory(optaplannerRepository).withProperty('full')
 }
 
-MavenCommand getOptaplannerQuickstartsMavenCommand(){
+MavenCommand getOptaplannerQuickstartsMavenCommand() {
     return getMavenDefaultCommand().inDirectory(quickstartsRepository)
 }
 
-MavenCommand getOptawebVehicleRoutingMavenCommand(){
+MavenCommand getOptawebVehicleRoutingMavenCommand() {
     return getMavenDefaultCommand().inDirectory(vehicleRoutingRepository)
 }
 
-MavenCommand getOptawebEmployeeRosteringMavenCommand(){
+MavenCommand getOptawebEmployeeRosteringMavenCommand() {
     return getMavenDefaultCommand().inDirectory(employeeRosteringRepository)
 }
 
@@ -343,12 +349,12 @@ void mavenCleanInstallOptaPlannerParents() {
         .run('clean install')
 }
 
-void deployMavenArtifacts(MavenCommand mvnCmd, String localDeployId){
+void deployMavenArtifacts(MavenCommand mvnCmd, String localDeployId) {
     if (env.MAVEN_DEPLOY_REPOSITORY && env.MAVEN_REPO_CREDS_ID) {
         // Deploy to specific repository with credentials
         runMavenDeployLocally(mvnCmd, localDeployId)
         maven.uploadLocalArtifacts(env.MAVEN_REPO_CREDS_ID, getLocalDeploymentFolder(localDeployId), getMavenRepoZipUrl())
-    } else if(!isRelease() || env.MAVEN_DEPLOY_REPOSITORY){
+    } else if (!isRelease() || env.MAVEN_DEPLOY_REPOSITORY) {
         // Normal deploy
         runMavenDeploy(mvnCmd)
     } else {
@@ -359,9 +365,9 @@ void deployMavenArtifacts(MavenCommand mvnCmd, String localDeployId){
 }
 
 void runMavenDeploy(MavenCommand mvnCmd) {
-    mvnCmd= mvnCmd.clone()
-    
-    if(env.MAVEN_DEPLOY_REPOSITORY) {
+    mvnCmd = mvnCmd.clone()
+
+    if (env.MAVEN_DEPLOY_REPOSITORY) {
         mvnCmd.withDeployRepository(env.MAVEN_DEPLOY_REPOSITORY)
     }
 
@@ -369,7 +375,7 @@ void runMavenDeploy(MavenCommand mvnCmd) {
 }
 
 String getMavenRepoZipUrl() {
-     return "${params.MAVEN_DEPLOY_REPOSITORY.replaceAll('/content/', '/service/local/').replaceFirst('/*$', '')}/content-compressed"
+    return "${params.MAVEN_DEPLOY_REPOSITORY.replaceAll('/content/', '/service/local/').replaceFirst('/*$', '')}/content-compressed"
 }
 
 void runMavenDeployLocally(MavenCommand mvnCmd, String localDeployId) {
@@ -410,7 +416,7 @@ String getGitAuthor() {
     return "${GIT_AUTHOR}"
 }
 
-String getGitBranch() {
+String getBuildBranch() {
     return params.BUILD_BRANCH_NAME
 }
 
@@ -418,24 +424,24 @@ String getKogitoVersion() {
     return params.KOGITO_VERSION
 }
 
-String getProjectVersion(){
+String getProjectVersion() {
     return params.PROJECT_VERSION
 }
 
-String getBotBranch(){
+String getBotBranch() {
     return "${getProjectVersion()}-${env.BOT_BRANCH_HASH}"
 }
 
-String getBotAuthor(){
+String getBotAuthor() {
     return env.GIT_AUTHOR_BOT
 }
 
-String getBotAuthorCredsID(){
+String getBotAuthorCredsID() {
     return env.BOT_CREDENTIALS_ID
 }
 
 void setDeployPropertyIfNeeded(String key, def value) {
-    if (value != null && value != ''){
+    if (value != null && value != '') {
         deployProperties[key] = value
     }
 }

--- a/Jenkinsfile.deploy
+++ b/Jenkinsfile.deploy
@@ -218,8 +218,8 @@ pipeline {
         always {
             script {
                 def propertiesStr = deployProperties.collect { entry ->  "${entry.key}=${entry.value}" }.join('\n')
-                writeFile(text: propertiesStr, file: 'deployment.properties')
-                archiveArtifacts(artifacts: 'deployment.properties')
+                writeFile(text: propertiesStr, file: env.PROPERTIES_FILE_NAME)
+                archiveArtifacts(artifacts: env.PROPERTIES_FILE_NAME)
             }
             cleanWs()
         }

--- a/Jenkinsfile.deploy
+++ b/Jenkinsfile.deploy
@@ -22,51 +22,16 @@ pipeline {
     }
 
     options {
-        buildDiscarder logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '10')
         timeout(time: 120, unit: 'MINUTES')
     }
-
-    parameters {
-
-        string(name: 'DISPLAY_NAME', defaultValue: '', description: 'Setup a specific build display name')
-
-        // Git information
-        string(name: 'BUILD_BRANCH_NAME', defaultValue: 'master', description: 'Which branch to build? Set if you are not on a multibranch pipeline.')
-        string(name: 'GIT_AUTHOR', defaultValue: 'kiegroup', description: 'Which Git author repository ?')
-
-        // Build&test information
-        string(name: 'MAVEN_DEPENDENCIES_REPOSITORY', defaultValue: '', description: 'Maven repository where to find dependencies if those are not in the default JBoss repository.')
-        string(name: 'MAVEN_REPO_CREDS_ID', defaultValue: '', description: 'Credentials for Maven repository to deploy the artifacts.')
-        booleanParam(name: 'SKIP_TESTS', defaultValue: false, description: 'Skip tests')
-        string(name: 'MAVEN_SETTINGS_CONFIG_FILE_ID', defaultValue: 'kogito_release_settings', description: 'Maven settings configfile to use in pipeline for Maven commands')
-
-        // Deploy information
-        string(name: 'MAVEN_DEPLOY_REPOSITORY', defaultValue: '', description: 'Specify a Maven repository to deploy the artifacts.')
-
-        // Release information
-        booleanParam(name: 'RELEASE', defaultValue: false, description: 'Is this build for a release?')
-        booleanParam(name: 'CREATE_PR', defaultValue: false, description: 'Should we create a PR with the changes ?')
-        string(name: 'PROJECT_VERSION', defaultValue: '', description: 'Optional if not RELEASE. If RELEASE, cannot be empty.')
-        string(name: 'KOGITO_VERSION', defaultValue: '', description: 'Optional if not RELEASE. If RELEASE, cannot be empty.')
-        
-        // Nexus staging default parameters
-        string(name: 'NEXUS_RELEASE_URL', defaultValue: 'https://repository.jboss.org/nexus', description: 'Nexus URL for release staging')
-        string(name: 'NEXUS_RELEASE_REPOSITORY_ID', defaultValue: 'jboss-releases-repository', description: 'Nexus Release repository ID for staging')
-        string(name: 'NEXUS_STAGING_PROFILE_ID', defaultValue: '2161b7b8da0080', description: 'Nexus staging profile ID for release process ')
-        string(name: 'NEXUS_BUILD_PROMOTION_PROFILE_ID', defaultValue: 'ea49ccd6f174', description: 'Nexus Build Promotion profile ID for release process')
-
-        // Bot author information. Set as params for easy testing.
-        string(name: 'GIT_AUTHOR_BOT', defaultValue: 'bsig-gh-bot', description: 'From which author should the PR be created ?')
-        string(name: 'BOT_CREDENTIALS_ID', defaultValue: 'bsig-gh-bot', description: 'Credentials for PR creation')
-
-        // PR parameter to be filled out for PR checks
-        string(name: 'PR_TARGET_BRANCH', defaultValue: '', description: 'What is the target branch of the PR?')
-
-        //Build branch name for quickstarts
-        string(name: 'QUICKSTARTS_BUILD_BRANCH_NAME', defaultValue: 'development', description: 'Base branch for quickstarts. Set if you are not on a multibranch pipeline.')
-    }
+    
+    // parameters {
+    // For parameters, check into ./dsl/jobs.groovy file
+    // }
 
     environment {
+        // Some generated env is also defined into ./dsl/jobs.groovy file
+
         MAVEN_OPTS = '-Xms1024m -Xmx4g'
 
         BOT_BRANCH_HASH = "${util.generateHash(10)}"
@@ -95,7 +60,7 @@ pipeline {
             post {
                 success {
                     script {
-                        setDeployPropertyIfNeeded('git.branch', getBuildBranch())
+                        setDeployPropertyIfNeeded('git.branch', getGitBranch())
                         setDeployPropertyIfNeeded('git.branchQuickstarts', getQuickStartsBranch())
                         setDeployPropertyIfNeeded('git.author', getGitAuthor())
                         setDeployPropertyIfNeeded('project.version', getProjectVersion())
@@ -216,9 +181,9 @@ pipeline {
                 expression { return isRelease() || isCreatePr()  }
             }
             steps {
-                commitAndCreatePR(optaplannerRepository, getBuildBranch())
-                commitAndCreatePRIgnoringNpmRegistry(vehicleRoutingRepository, getBuildBranch())
-                commitAndCreatePRIgnoringNpmRegistry(employeeRosteringRepository, getBuildBranch())
+                commitAndCreatePR(optaplannerRepository, getGitBranch())
+                commitAndCreatePRIgnoringNpmRegistry(vehicleRoutingRepository, getGitBranch())
+                commitAndCreatePRIgnoringNpmRegistry(employeeRosteringRepository, getGitBranch())
                 commitAndCreatePR(quickstartsRepository, getQuickStartsBranch())
             }
             post {
@@ -227,17 +192,17 @@ pipeline {
                         setDeployPropertyIfNeeded("${optaplannerRepository}.pr.source.uri", "https://github.com/${getBotAuthor()}/${optaplannerRepository}")
                         setDeployPropertyIfNeeded("${optaplannerRepository}.pr.source.ref", getBotBranch())
                         setDeployPropertyIfNeeded("${optaplannerRepository}.pr.target.uri", "https://github.com/${getGitAuthor()}/${optaplannerRepository}")
-                        setDeployPropertyIfNeeded("${optaplannerRepository}.pr.target.ref", getBuildBranch())
+                        setDeployPropertyIfNeeded("${optaplannerRepository}.pr.target.ref", getGitBranch())
 
                         setDeployPropertyIfNeeded("${vehicleRoutingRepository}.pr.source.uri", "https://github.com/${getBotAuthor()}/${vehicleRoutingRepository}")
                         setDeployPropertyIfNeeded("${vehicleRoutingRepository}.pr.source.ref", getBotBranch())
                         setDeployPropertyIfNeeded("${vehicleRoutingRepository}.pr.target.uri", "https://github.com/${getGitAuthor()}/${vehicleRoutingRepository}")
-                        setDeployPropertyIfNeeded("${vehicleRoutingRepository}.pr.target.ref", getBuildBranch())
+                        setDeployPropertyIfNeeded("${vehicleRoutingRepository}.pr.target.ref", getGitBranch())
 
                         setDeployPropertyIfNeeded("${employeeRosteringRepository}.pr.source.uri", "https://github.com/${getBotAuthor()}/${employeeRosteringRepository}")
                         setDeployPropertyIfNeeded("${employeeRosteringRepository}.pr.source.ref", getBotBranch())
                         setDeployPropertyIfNeeded("${employeeRosteringRepository}.pr.target.uri", "https://github.com/${getGitAuthor()}/${employeeRosteringRepository}")
-                        setDeployPropertyIfNeeded("${employeeRosteringRepository}.pr.target.ref", getBuildBranch())
+                        setDeployPropertyIfNeeded("${employeeRosteringRepository}.pr.target.ref", getGitBranch())
                     }
                 }
             }
@@ -292,9 +257,9 @@ void checkoutRepo(String repo, String dirName=repo) {
     dir(dirName) {
         deleteDir()
         if (params.PR_TARGET_BRANCH) {
-            githubscm.checkoutIfExists(repo, getGitAuthor(), getBuildBranch(), 'kiegroup', getFallbackBranch(repo), true)
+            githubscm.checkoutIfExists(repo, getGitAuthor(), getGitBranch(), 'kiegroup', getFallbackBranch(repo), true)
         } else {
-            checkout(githubscm.resolveRepository(repo, getGitAuthor(), getBuildBranch(), false))
+            checkout(githubscm.resolveRepository(repo, getGitAuthor(), getGitBranch(), false))
         }
     }
 }
@@ -345,9 +310,9 @@ void commitAndCreatePRIgnoringNpmRegistry(String repo, String buildBranch) {
 }
 
 MavenCommand getMavenDefaultCommand(){
-    MavenCommand mvnCmd = new MavenCommand(this, ['-fae']).withSettingsXmlId(params.MAVEN_SETTINGS_CONFIG_FILE_ID)
-    if (params.MAVEN_DEPENDENCIES_REPOSITORY) {
-        mvnCmd.withDependencyRepositoryInSettings('deps-repo', params.MAVEN_DEPENDENCIES_REPOSITORY)
+    MavenCommand mvnCmd = new MavenCommand(this, ['-fae']).withSettingsXmlId(env.MAVEN_SETTINGS_CONFIG_FILE_ID)
+    if (env.MAVEN_DEPENDENCIES_REPOSITORY) {
+        mvnCmd.withDependencyRepositoryInSettings('deps-repo', env.MAVEN_DEPENDENCIES_REPOSITORY)
     }
     return mvnCmd
 }
@@ -379,11 +344,11 @@ void mavenCleanInstallOptaPlannerParents() {
 }
 
 void deployMavenArtifacts(MavenCommand mvnCmd, String localDeployId){
-    if (params.MAVEN_DEPLOY_REPOSITORY && params.MAVEN_REPO_CREDS_ID) {
+    if (env.MAVEN_DEPLOY_REPOSITORY && env.MAVEN_REPO_CREDS_ID) {
         // Deploy to specific repository with credentials
         runMavenDeployLocally(mvnCmd, localDeployId)
-        maven.uploadLocalArtifacts(params.MAVEN_REPO_CREDS_ID, getLocalDeploymentFolder(localDeployId), getMavenRepoZipUrl())
-    } else if(!isRelease() || params.MAVEN_DEPLOY_REPOSITORY){
+        maven.uploadLocalArtifacts(env.MAVEN_REPO_CREDS_ID, getLocalDeploymentFolder(localDeployId), getMavenRepoZipUrl())
+    } else if(!isRelease() || env.MAVEN_DEPLOY_REPOSITORY){
         // Normal deploy
         runMavenDeploy(mvnCmd)
     } else {
@@ -396,8 +361,8 @@ void deployMavenArtifacts(MavenCommand mvnCmd, String localDeployId){
 void runMavenDeploy(MavenCommand mvnCmd) {
     mvnCmd= mvnCmd.clone()
     
-    if(params.MAVEN_DEPLOY_REPOSITORY) {
-        mvnCmd.withDeployRepository(params.MAVEN_DEPLOY_REPOSITORY)
+    if(env.MAVEN_DEPLOY_REPOSITORY) {
+        mvnCmd.withDeployRepository(env.MAVEN_DEPLOY_REPOSITORY)
     }
 
     mvnCmd.skipTests(true).run('clean deploy')
@@ -416,14 +381,14 @@ void runMavenDeployLocally(MavenCommand mvnCmd, String localDeployId) {
 
 void runMavenStage(MavenCommand mvnCmd, String localDeployId) {
     MavenStagingHelper stagingHelper = getStagingHelper(mvnCmd)
-    deployProperties.putAll(stagingHelper.stageLocalArtifacts(params.NEXUS_STAGING_PROFILE_ID, getLocalDeploymentFolder(localDeployId)))
-    stagingHelper.promoteStagingRepository(params.NEXUS_BUILD_PROMOTION_PROFILE_ID)
+    deployProperties.putAll(stagingHelper.stageLocalArtifacts(env.NEXUS_STAGING_PROFILE_ID, getLocalDeploymentFolder(localDeployId)))
+    stagingHelper.promoteStagingRepository(env.NEXUS_BUILD_PROMOTION_PROFILE_ID)
 }
 
 MavenStagingHelper getStagingHelper(MavenCommand mvnCmd) {
     return new MavenStagingHelper(this, mvnCmd)
-                .withNexusReleaseUrl(params.NEXUS_RELEASE_URL)
-                .withNexusReleaseRepositoryId(params.NEXUS_RELEASE_REPOSITORY_ID)
+                .withNexusReleaseUrl(env.NEXUS_RELEASE_URL)
+                .withNexusReleaseRepositoryId(env.NEXUS_RELEASE_REPOSITORY_ID)
 }
 
 String getLocalDeploymentFolder(String localDeployId) {
@@ -433,7 +398,7 @@ String getLocalDeploymentFolder(String localDeployId) {
 // Getters and Setters of params/properties
 
 boolean isRelease() {
-    return params.RELEASE
+    return env.RELEASE.toBoolean()
 }
 
 boolean isCreatePr() {
@@ -441,10 +406,11 @@ boolean isCreatePr() {
 }
 
 String getGitAuthor() {
-    return params.GIT_AUTHOR
+    // GIT_AUTHOR can be env or param
+    return "${GIT_AUTHOR}"
 }
 
-String getBuildBranch() {
+String getGitBranch() {
     return params.BUILD_BRANCH_NAME
 }
 
@@ -461,11 +427,11 @@ String getBotBranch(){
 }
 
 String getBotAuthor(){
-    return params.GIT_AUTHOR_BOT
+    return env.GIT_AUTHOR_BOT
 }
 
 String getBotAuthorCredsID(){
-    return params.BOT_CREDENTIALS_ID
+    return env.BOT_CREDENTIALS_ID
 }
 
 void setDeployPropertyIfNeeded(String key, def value) {

--- a/Jenkinsfile.promote
+++ b/Jenkinsfile.promote
@@ -300,8 +300,8 @@ void readDeployProperties(){
         if(!deployUrl.endsWith('/')){
             deployUrl += '/'
         }
-        sh "wget ${deployUrl}artifact/${PROPERTIES_FILE_NAME} -O ${PROPERTIES_FILE_NAME}"
-        deployProperties = readProperties file: PROPERTIES_FILE_NAME
+        sh "wget ${deployUrl}artifact/${env.PROPERTIES_FILE_NAME} -O ${env.PROPERTIES_FILE_NAME}"
+        deployProperties = readProperties file: env.PROPERTIES_FILE_NAME
         // echo all properties
         echo deployProperties.collect{ entry -> "${entry.key}=${entry.value}" }.join('\n')
     }
@@ -544,7 +544,7 @@ def disableForcePushes(String repo, String protectedBranch) {
 boolean isBranchProtected(String repo, String protectedBranch, String ghPath = "../gh") {
     boolean isProtected = true // Suppose it is protected by default
     withCredentials([string(credentialsId: getGhCredsID(), variable: 'GITHUB_TOKEN')]) {
-        //get current branch protection and remove allow force push
+        // get current branch protection
         int status = sh (script: "${ghPath} api 'repos/${getGitAuthor()}/${repo}/branches/${protectedBranch}/protection'", returnStatus: true)
         isProtected = status == 0
     }

--- a/Jenkinsfile.promote
+++ b/Jenkinsfile.promote
@@ -22,43 +22,16 @@ pipeline {
     }
 
     options {
-        buildDiscarder logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '10')
         timeout(time: 120, unit: 'MINUTES')
     }
 
-    parameters {
-        string(name: 'DISPLAY_NAME', defaultValue: '', description: 'Setup a specific build display name')
-
-        // Deploy job url to retrieve deployment.properties
-        string(name: 'DEPLOY_BUILD_URL', defaultValue: '', description: 'URL to jenkins deploy build to retrieve the `deployment.properties` file. If base parameters are defined, they will override the `deployment.properties` information')
-
-        // Git information which can override `deployment.properties`
-        string(name: 'BUILD_BRANCH_NAME', defaultValue: '', description: 'Override `deployment.properties`. Which branch to build? Set if you are not on a multibranch pipeline.')
-        string(name: 'GIT_AUTHOR', defaultValue: '', description: 'Override `deployment.properties`. Which Git author repository ?')
-
-        // Build&Deploy information for next snapshots
-        string(name: 'MAVEN_SETTINGS_CONFIG_FILE_ID', defaultValue: 'kogito_release_settings', description: 'Maven settings configfile to use in pipeline for Maven commands')
-        string(name: 'MAVEN_DEPENDENCIES_REPOSITORY', defaultValue: '', description: 'Maven repository where to find dependencies if those are not in the default Jboss repository.')
-        string(name: 'MAVEN_DEPLOY_REPOSITORY', defaultValue: '', description: 'Specify a Maven repository to deploy the artifacts.')
-
-        // Release information which can override `deployment.properties`
-        booleanParam(name: 'RELEASE', defaultValue: false, description: 'Override `deployment.properties`. Is this build for a release?')
-
-        string(name: 'PROJECT_VERSION', defaultValue: '', description: 'Override `deployment.properties`. Optional if not RELEASE. If RELEASE, cannot be empty.')
-        string(name: 'KOGITO_VERSION', defaultValue: '', description: 'Optional if not RELEASE. If RELEASE, cannot be empty.')
-
-        string(name: 'STAGING_REPO_URL', defaultValue: '', description: 'Override `deployment.properties`.')
-        string(name: 'GIT_TAG', defaultValue: '', description: 'Git tag to set, if different from PROJECT_VERSION')
-
-        // Bot author information. Set as params for easy testing.
-        string(name: 'BOT_CREDENTIALS_ID', defaultValue: 'bsig-gh-bot', description: 'Credentials for PR creation')
-
-        // Main author creds
-        string(name: 'AUTHOR_CREDS_ID', defaultValue: 'kie-ci', description: 'Credentials for PR merge')
-        string(name: 'GITHUB_TOKEN_CREDS_ID', defaultValue: 'kie-ci2-token', description: 'GH token to be used with GH CLI')
-    }
+    // parameters {
+    // For parameters, check into ./dsl/jobs.groovy file
+    // }
 
     environment {
+        // Some generated env is also defined into ./dsl/jobs.groovy file
+        
         PROPERTIES_FILE_NAME = 'deployment.properties'
         BOT_BRANCH_HASH = "${util.generateHash(10)}"
         GITHUB_CLI_VERSION = '0.11.1'
@@ -184,35 +157,35 @@ pipeline {
             }
         }
 
-        stage('Update OptaPlanner website') {
-            when {
-                expression { return isRelease() }
-            }
-            steps {
-                script {
-                    final String websiteRepository = 'optaplanner-website'
-                    String prLink = null
-                    dir("$websiteRepository-bot") {
-                        String prBranchName = createWebsitePrBranch(websiteRepository)
+        // stage('Update OptaPlanner website') {
+        //     when {
+        //         expression { return isRelease() }
+        //     }
+        //     steps {
+        //         script {
+        //             final String websiteRepository = 'optaplanner-website'
+        //             String prLink = null
+        //             dir("$websiteRepository-bot") {
+        //                 String prBranchName = createWebsitePrBranch(websiteRepository)
 
-                        // Update versions in links on the website.
-                        sh "./build/update-versions.sh ${getProjectVersion()} ${getNextMinorSnapshotVersion(getProjectVersion())}"
+        //                 // Update versions in links on the website.
+        //                 sh "./build/update-versions.sh ${getProjectVersion()} ${getNextMinorSnapshotVersion(getProjectVersion())}"
 
-                        // Update the XSDs. OptaPlanner must be cloned and build with the full profile before.
-                        String optaplannerRoot = "$WORKSPACE/optaplanner"
-                        sh "cp $optaplannerRoot/optaplanner-core/target/classes/solver.xsd xsd/solver/solver-8.xsd"
-                        sh "cp $optaplannerRoot/optaplanner-benchmark/target/classes/benchmark.xsd xsd/benchmark/benchmark-8.xsd"
+        //                 // Update the XSDs. OptaPlanner must be cloned and build with the full profile before.
+        //                 String optaplannerRoot = "$WORKSPACE/optaplanner"
+        //                 sh "cp $optaplannerRoot/optaplanner-core/target/classes/solver.xsd xsd/solver/solver-8.xsd"
+        //                 sh "cp $optaplannerRoot/optaplanner-benchmark/target/classes/benchmark.xsd xsd/benchmark/benchmark-8.xsd"
 
-                        // Add changed files, commit, open and merge PR
-                        prLink = commitAndCreatePR("Release OptaPlanner ${getProjectVersion()}", { sh 'git add xsd/\\*.xsd _config/pom.yml' }, prBranchName, 'master')
-                    }
-                    dir(websiteRepository) {
-                        checkoutRepo(websiteRepository, 'master')
-                        mergeAndPush(prLink, 'master')
-                    }
-                }
-            }
-        }
+        //                 // Add changed files, commit, open and merge PR
+        //                 prLink = commitAndCreatePR("Release OptaPlanner ${getProjectVersion()}", { sh 'git add xsd/\\*.xsd _config/pom.yml' }, prBranchName, 'master')
+        //             }
+        //             dir(websiteRepository) {
+        //                 checkoutRepo(websiteRepository, 'master')
+        //                 mergeAndPush(prLink, 'master')
+        //             }
+        //         }
+        //     }
+        // }
 
         stage('Set OptaPlanner next snapshot version') {
             when {
@@ -228,11 +201,11 @@ pipeline {
                         maven.mvnVersionsSet(getMavenCommand(), nextSnapshotVersion, true)
                         maven.mvnSetVersionProperty(getMavenCommand(), 'version.org.kie.kogito', getNextMicroSnapshotVersion(getKogitoVersion()))
 
-                        String prLink = commitAndCreatePR("[${getBuildBranch()}] Update snapshot version to ${nextMicroSnapshotVersion}")
+                        String prLink = commitAndCreatePR("[${getGitBranch()}] Update snapshot version to ${nextMicroSnapshotVersion}")
                         setPipelinePrLink(optaplannerRepository, prLink)
                     }
                     dir(optaplannerRepository) {
-                        sh "git checkout ${getBuildBranch()}"
+                        sh "git checkout ${getGitBranch()}"
                         mergeAndPush(getPipelinePrLink(optaplannerRepository))
                         runMavenDeploy(getMavenCommand())
                     }
@@ -251,11 +224,11 @@ pipeline {
                         prepareForPR(vehicleRoutingRepository)
                         maven.mvnVersionsUpdateParentAndChildModules(nextMicroSnapshotVersion, true)
 
-                        String prLink = commitAndCreatePR("[${getBuildBranch()}] Update snapshot version to ${nextMicroSnapshotVersion}")
+                        String prLink = commitAndCreatePR("[${getGitBranch()}] Update snapshot version to ${nextMicroSnapshotVersion}")
                         setPipelinePrLink(vehicleRoutingRepository, prLink)
                     }
                     dir(vehicleRoutingRepository) {
-                        sh "git checkout ${getBuildBranch()}"
+                        sh "git checkout ${getGitBranch()}"
                         mergeAndPush(getPipelinePrLink(vehicleRoutingRepository))
                         runMavenDeploy(getMavenCommand())
                     }
@@ -274,11 +247,11 @@ pipeline {
                         prepareForPR(employeeRosteringRepository)
                         maven.mvnVersionsUpdateParentAndChildModules(nextMicroSnapshotVersion, true)
 
-                        String prLink = commitAndCreatePR("[${getBuildBranch()}] Update snapshot version to ${nextMicroSnapshotVersion}")
+                        String prLink = commitAndCreatePR("[${getGitBranch()}] Update snapshot version to ${nextMicroSnapshotVersion}")
                         setPipelinePrLink(employeeRosteringRepository, prLink)
                     }
                     dir(employeeRosteringRepository) {
-                        sh "git checkout ${getBuildBranch()}"
+                        sh "git checkout ${getGitBranch()}"
                         mergeAndPush(getPipelinePrLink(employeeRosteringRepository))
                         runMavenDeploy(getMavenCommand())
                     }
@@ -298,11 +271,11 @@ pipeline {
                         prepareForPR(quickstartsRepository)
                         updateQuickstartsVersions(nextMicroSnapshotVersion)
 
-                        String prLink = commitAndCreatePR(("[${getBuildBranch()}] Update snapshot version to ${nextMicroSnapshotVersion}"));
+                        String prLink = commitAndCreatePR(("[${getGitBranch()}] Update snapshot version to ${nextMicroSnapshotVersion}"));
                         setPipelinePrLink(quickstartsRepository, prLink)
                     }
                     dir(quickstartsRepository) {
-                        sh "git checkout ${getBuildBranch()}"
+                        sh "git checkout ${getGitBranch()}"
                         mergeAndPush(getPipelinePrLink(quickstartsRepository))
                     }
                 }
@@ -356,7 +329,7 @@ String getParamOrDeployProperty(String paramKey, String deployPropertyKey){
 //////////////////////////////////////////////////////////////////////////////
 
 boolean isRelease() {
-    return params.RELEASE || (getDeployProperty('release') == 'true')
+    return env.RELEASE.toBoolean()
 }
 
 String getProjectVersion() {
@@ -379,24 +352,20 @@ String getGitTag() {
     return params.GIT_TAG != '' ? params.GIT_TAG : getProjectVersion()
 }
 
-String getBuildBranch() {
-    return getParamOrDeployProperty('BUILD_BRANCH_NAME', 'git.branch')
+String getGitBranch() {
+    return params.BUILD_BRANCH_NAME
 }
 
 String getGitAuthor() {
-    return getParamOrDeployProperty('GIT_AUTHOR', 'git.author')
+    return env.GIT_AUTHOR
 }
 
 String getGitAuthorCredsID(){
-    return params.AUTHOR_CREDS_ID
+    return env.AUTHOR_CREDS_ID
 }
 
 String getBotAuthorCredsID(){
-    return params.BOT_CREDENTIALS_ID
-}
-
-String getStagingRepoUrl(){
-    return getParamOrDeployProperty('STAGING_REPO_URL', 'staging-repo.url')
+    return env.BOT_CREDENTIALS_ID
 }
 
 String getDeployPrLink(String repo){
@@ -427,7 +396,7 @@ void checkoutRepo(String repo, String branch) {
 }
 
 void checkoutRepo(String repo) {
-    checkoutRepo(repo, getBuildBranch())
+    checkoutRepo(repo, getGitBranch())
 }
 
 void mergeAndPush(String prLink, String targetBranch) {
@@ -438,7 +407,7 @@ void mergeAndPush(String prLink, String targetBranch) {
 }
 
 void mergeAndPush(String prLink) {
-    mergeAndPush(prLink, getBuildBranch())
+    mergeAndPush(prLink, getGitBranch())
 }
 
 void tagLatest() {
@@ -466,7 +435,7 @@ String commitAndCreatePR(String commitMsg) {
     return commitAndCreatePR(commitMsg, {
         githubscm.findAndStageNotIgnoredFiles('pom.xml')
         githubscm.findAndStageNotIgnoredFiles('build.gradle')
-    }, getSnapshotBranch(), getBuildBranch())
+    }, getSnapshotBranch(), getGitBranch())
 }
 
 String createWebsitePrBranch(String websiteRepository) {
@@ -487,30 +456,31 @@ void installGithubCLI() {
 }
 
 void uploadDistribution(String directory) {
-    dir(directory) {
-        echo "uploadDistribution for ${directory}"
-        withCredentials(bindings: [sshUserPrivateKey(credentialsId: 'optaplanner-filemgmt',
-                keyFileVariable: 'SSH_KEY_JBOSS_FILEMGMT')]) {
-            // For testing, simulate connection via SSH:
-            // sh "ssh -i $SSH_KEY_JBOSS_FILEMGMT -oKexAlgorithms=+diffie-hellman-group1-sha1 optaplanner@filemgmt.jboss.org"
-            sh "./build/release/upload_distribution.sh ${getProjectVersion()} $SSH_KEY_JBOSS_FILEMGMT"
-        }
-    }
+    echo "uploadDistribution for ${directory}"
+    // TODO set back
+    // dir(directory) {
+    //     withCredentials(bindings: [sshUserPrivateKey(credentialsId: 'optaplanner-filemgmt',
+    //             keyFileVariable: 'SSH_KEY_JBOSS_FILEMGMT')]) {
+    //         // For testing, simulate connection via SSH:
+    //         // sh "ssh -i $SSH_KEY_JBOSS_FILEMGMT -oKexAlgorithms=+diffie-hellman-group1-sha1 optaplanner@filemgmt.jboss.org"
+    //         sh "./build/release/upload_distribution.sh ${getProjectVersion()} $SSH_KEY_JBOSS_FILEMGMT"
+    //     }
+    // }
 }
 
 MavenCommand getMavenCommand() {
     mvnCmd = new MavenCommand(this, ['-fae'])
-                    .withSettingsXmlId(params.MAVEN_SETTINGS_CONFIG_FILE_ID)
-    if (params.MAVEN_DEPENDENCIES_REPOSITORY) {
-        mvnCmd.withDependencyRepositoryInSettings('deps-repo', params.MAVEN_DEPENDENCIES_REPOSITORY)
+                    .withSettingsXmlId(env.MAVEN_SETTINGS_CONFIG_FILE_ID)
+    if (env.MAVEN_DEPENDENCIES_REPOSITORY) {
+        mvnCmd.withDependencyRepositoryInSettings('deps-repo', env.MAVEN_DEPENDENCIES_REPOSITORY)
     }
     return mvnCmd
 }
 
 void runMavenDeploy(MavenCommand mvnCmd) {
     mvnCmd = mvnCmd.clone()
-    if(params.MAVEN_DEPLOY_REPOSITORY){
-        mvnCmd.withDeployRepository(params.MAVEN_DEPLOY_REPOSITORY)
+    if(env.MAVEN_DEPLOY_REPOSITORY){
+        mvnCmd.withDeployRepository(env.MAVEN_DEPLOY_REPOSITORY)
     }
     mvnCmd.skipTests(true).run('clean deploy')
 }
@@ -520,7 +490,7 @@ def updateAndResetBranch(String repo, String branchToReset) {
 
     removeJbossNexusFromMavenAndGradle()
 
-    githubscm.commitChanges("[${getBuildBranch()}] Update ${branchToReset} to ${getProjectVersion()}", {
+    githubscm.commitChanges("[${getGitBranch()}] Update ${branchToReset} to ${getProjectVersion()}", {
         githubscm.findAndStageNotIgnoredFiles('pom.xml')
         githubscm.findAndStageNotIgnoredFiles('build.gradle')
     })

--- a/Jenkinsfile.promote
+++ b/Jenkinsfile.promote
@@ -26,15 +26,13 @@ pipeline {
     }
 
     // parameters {
-    // For parameters, check into ./dsl/jobs.groovy file
+    // For parameters, check into .jenkins/dsl/jobs.groovy file
     // }
 
     environment {
-        // Some generated env is also defined into ./dsl/jobs.groovy file
-        
-        PROPERTIES_FILE_NAME = 'deployment.properties'
+        // Some generated env is also defined into .jenkins/dsl/jobs.groovy file
+
         BOT_BRANCH_HASH = "${util.generateHash(10)}"
-        GITHUB_CLI_VERSION = '0.11.1'
     }
 
     stages {
@@ -43,15 +41,18 @@ pipeline {
                 script {
                     cleanWs()
 
-                    if (params.DISPLAY_NAME != '') {
+                    if (params.DISPLAY_NAME) {
                         currentBuild.displayName = params.DISPLAY_NAME
                     }
 
                     readDeployProperties()
 
                     if (isRelease()) {
-                        assert getProjectVersion() != ''
-                        assert getKogitoVersion() != ''
+                        // Verify version is set and if on right release branch
+                        assert getProjectVersion()
+                        assert getKogitoVersion()
+
+                        assert getBuildBranch() == util.getReleaseBranchFromVersion(getProjectVersion())
                     }
 
                     installGithubCLI()
@@ -115,7 +116,7 @@ pipeline {
                         mergeAndPush(getDeployPrLink(quickstartsRepository))
                         tagLatest()
 
-                        updateAndResetBranch(quickstartsRepository,'stable')
+                        updateAndResetBranch(quickstartsRepository, 'stable')
                     }
                 }
             }
@@ -157,35 +158,35 @@ pipeline {
             }
         }
 
-        // stage('Update OptaPlanner website') {
-        //     when {
-        //         expression { return isRelease() }
-        //     }
-        //     steps {
-        //         script {
-        //             final String websiteRepository = 'optaplanner-website'
-        //             String prLink = null
-        //             dir("$websiteRepository-bot") {
-        //                 String prBranchName = createWebsitePrBranch(websiteRepository)
+        stage('Update OptaPlanner website') {
+            when {
+                expression { return isRelease() }
+            }
+            steps {
+                script {
+                    final String websiteRepository = 'optaplanner-website'
+                    String prLink = null
+                    dir("$websiteRepository-bot") {
+                        String prBranchName = createWebsitePrBranch(websiteRepository)
 
-        //                 // Update versions in links on the website.
-        //                 sh "./build/update-versions.sh ${getProjectVersion()} ${getNextMinorSnapshotVersion(getProjectVersion())}"
+                        // Update versions in links on the website.
+                        sh "./build/update-versions.sh ${getProjectVersion()} ${getNextMinorSnapshotVersion(getProjectVersion())}"
 
-        //                 // Update the XSDs. OptaPlanner must be cloned and build with the full profile before.
-        //                 String optaplannerRoot = "$WORKSPACE/optaplanner"
-        //                 sh "cp $optaplannerRoot/optaplanner-core/target/classes/solver.xsd xsd/solver/solver-8.xsd"
-        //                 sh "cp $optaplannerRoot/optaplanner-benchmark/target/classes/benchmark.xsd xsd/benchmark/benchmark-8.xsd"
+                        // Update the XSDs. OptaPlanner must be cloned and build with the full profile before.
+                        String optaplannerRoot = "$WORKSPACE/optaplanner"
+                        sh "cp $optaplannerRoot/optaplanner-core/target/classes/solver.xsd xsd/solver/solver-8.xsd"
+                        sh "cp $optaplannerRoot/optaplanner-benchmark/target/classes/benchmark.xsd xsd/benchmark/benchmark-8.xsd"
 
-        //                 // Add changed files, commit, open and merge PR
-        //                 prLink = commitAndCreatePR("Release OptaPlanner ${getProjectVersion()}", { sh 'git add xsd/\\*.xsd _config/pom.yml' }, prBranchName, 'master')
-        //             }
-        //             dir(websiteRepository) {
-        //                 checkoutRepo(websiteRepository, 'master')
-        //                 mergeAndPush(prLink, 'master')
-        //             }
-        //         }
-        //     }
-        // }
+                        // Add changed files, commit, open and merge PR
+                        prLink = commitAndCreatePR("Release OptaPlanner ${getProjectVersion()}", { sh 'git add xsd/\\*.xsd _config/pom.yml' }, prBranchName, 'master')
+                    }
+                    dir(websiteRepository) {
+                        checkoutRepo(websiteRepository, 'master')
+                        mergeAndPush(prLink, 'master')
+                    }
+                }
+            }
+        }
 
         stage('Set OptaPlanner next snapshot version') {
             when {
@@ -201,11 +202,11 @@ pipeline {
                         maven.mvnVersionsSet(getMavenCommand(), nextSnapshotVersion, true)
                         maven.mvnSetVersionProperty(getMavenCommand(), 'version.org.kie.kogito', getNextMicroSnapshotVersion(getKogitoVersion()))
 
-                        String prLink = commitAndCreatePR("[${getGitBranch()}] Update snapshot version to ${nextMicroSnapshotVersion}")
+                        String prLink = commitAndCreatePR("[${getBuildBranch()}] Update snapshot version to ${nextMicroSnapshotVersion}")
                         setPipelinePrLink(optaplannerRepository, prLink)
                     }
                     dir(optaplannerRepository) {
-                        sh "git checkout ${getGitBranch()}"
+                        sh "git checkout ${getBuildBranch()}"
                         mergeAndPush(getPipelinePrLink(optaplannerRepository))
                         runMavenDeploy(getMavenCommand())
                     }
@@ -224,11 +225,11 @@ pipeline {
                         prepareForPR(vehicleRoutingRepository)
                         maven.mvnVersionsUpdateParentAndChildModules(nextMicroSnapshotVersion, true)
 
-                        String prLink = commitAndCreatePR("[${getGitBranch()}] Update snapshot version to ${nextMicroSnapshotVersion}")
+                        String prLink = commitAndCreatePR("[${getBuildBranch()}] Update snapshot version to ${nextMicroSnapshotVersion}")
                         setPipelinePrLink(vehicleRoutingRepository, prLink)
                     }
                     dir(vehicleRoutingRepository) {
-                        sh "git checkout ${getGitBranch()}"
+                        sh "git checkout ${getBuildBranch()}"
                         mergeAndPush(getPipelinePrLink(vehicleRoutingRepository))
                         runMavenDeploy(getMavenCommand())
                     }
@@ -247,11 +248,11 @@ pipeline {
                         prepareForPR(employeeRosteringRepository)
                         maven.mvnVersionsUpdateParentAndChildModules(nextMicroSnapshotVersion, true)
 
-                        String prLink = commitAndCreatePR("[${getGitBranch()}] Update snapshot version to ${nextMicroSnapshotVersion}")
+                        String prLink = commitAndCreatePR("[${getBuildBranch()}] Update snapshot version to ${nextMicroSnapshotVersion}")
                         setPipelinePrLink(employeeRosteringRepository, prLink)
                     }
                     dir(employeeRosteringRepository) {
-                        sh "git checkout ${getGitBranch()}"
+                        sh "git checkout ${getBuildBranch()}"
                         mergeAndPush(getPipelinePrLink(employeeRosteringRepository))
                         runMavenDeploy(getMavenCommand())
                     }
@@ -271,11 +272,11 @@ pipeline {
                         prepareForPR(quickstartsRepository)
                         updateQuickstartsVersions(nextMicroSnapshotVersion)
 
-                        String prLink = commitAndCreatePR(("[${getGitBranch()}] Update snapshot version to ${nextMicroSnapshotVersion}"));
+                        String prLink = commitAndCreatePR(("[${getBuildBranch()}] Update snapshot version to ${nextMicroSnapshotVersion}"));
                         setPipelinePrLink(quickstartsRepository, prLink)
                     }
                     dir(quickstartsRepository) {
-                        sh "git checkout ${getGitBranch()}"
+                        sh "git checkout ${getBuildBranch()}"
                         mergeAndPush(getPipelinePrLink(quickstartsRepository))
                     }
                 }
@@ -352,7 +353,7 @@ String getGitTag() {
     return params.GIT_TAG != '' ? params.GIT_TAG : getProjectVersion()
 }
 
-String getGitBranch() {
+String getBuildBranch() {
     return params.BUILD_BRANCH_NAME
 }
 
@@ -396,7 +397,7 @@ void checkoutRepo(String repo, String branch) {
 }
 
 void checkoutRepo(String repo) {
-    checkoutRepo(repo, getGitBranch())
+    checkoutRepo(repo, getBuildBranch())
 }
 
 void mergeAndPush(String prLink, String targetBranch) {
@@ -407,7 +408,7 @@ void mergeAndPush(String prLink, String targetBranch) {
 }
 
 void mergeAndPush(String prLink) {
-    mergeAndPush(prLink, getGitBranch())
+    mergeAndPush(prLink, getBuildBranch())
 }
 
 void tagLatest() {
@@ -435,7 +436,7 @@ String commitAndCreatePR(String commitMsg) {
     return commitAndCreatePR(commitMsg, {
         githubscm.findAndStageNotIgnoredFiles('pom.xml')
         githubscm.findAndStageNotIgnoredFiles('build.gradle')
-    }, getSnapshotBranch(), getGitBranch())
+    }, getSnapshotBranch(), getBuildBranch())
 }
 
 String createWebsitePrBranch(String websiteRepository) {
@@ -490,7 +491,7 @@ def updateAndResetBranch(String repo, String branchToReset) {
 
     removeJbossNexusFromMavenAndGradle()
 
-    githubscm.commitChanges("[${getGitBranch()}] Update ${branchToReset} to ${getProjectVersion()}", {
+    githubscm.commitChanges("[${getBuildBranch()}] Update ${branchToReset} to ${getProjectVersion()}", {
         githubscm.findAndStageNotIgnoredFiles('pom.xml')
         githubscm.findAndStageNotIgnoredFiles('build.gradle')
     })
@@ -509,7 +510,7 @@ void removeJbossNexusFromMavenAndGradle() {
 }
 
 String getGhCredsID() {
-    return params.GITHUB_TOKEN_CREDS_ID;
+    return env.GITHUB_TOKEN_CREDS_ID
 }
 
 //maps git branch protection response json into update request body to rewrite branch protection
@@ -529,11 +530,25 @@ String getProtectionMapScript() {
 }
 
 def enableForcePushes(String repo, String protectedBranch) {
-    setAllowForcePushes(repo, protectedBranch, "true");
+    if (isBranchProtected(repo, protectedBranch)) {
+        setAllowForcePushes(repo, protectedBranch, "true")
+    }
 }
 
 def disableForcePushes(String repo, String protectedBranch) {
-    setAllowForcePushes(repo, protectedBranch, "false");
+    if (isBranchProtected(repo, protectedBranch)) {
+        setAllowForcePushes(repo, protectedBranch, "false")
+    }
+}
+
+boolean isBranchProtected(String repo, String protectedBranch, String ghPath = "../gh") {
+    boolean isProtected = true // Suppose it is protected by default
+    withCredentials([string(credentialsId: getGhCredsID(), variable: 'GITHUB_TOKEN')]) {
+        //get current branch protection and remove allow force push
+        int status = sh (script: "${ghPath} api 'repos/${getGitAuthor()}/${repo}/branches/${protectedBranch}/protection'", returnStatus: true)
+        isProtected = status == 0
+    }
+    return isProtected
 }
 
 def setAllowForcePushes(String repo, String protectedBranch, String enabled, String ghPath = "../gh") {
@@ -542,17 +557,17 @@ def setAllowForcePushes(String repo, String protectedBranch, String enabled, Str
     withCredentials([string(credentialsId: getGhCredsID(), variable: 'GITHUB_TOKEN')]) {
         //get current branch protection and remove allow force push
         sh "${ghPath} api 'repos/${getGitAuthor()}/${repo}/branches/${protectedBranch}/protection' | " +
-           "jq 'del(.allow_force_pushes)' > protectionBefore.json";
+           "jq 'del(.allow_force_pushes)' > protectionBefore.json"
 
         //create new json based on current protection mapped as parameters
         sh "jq \"${getProtectionMapScript()}\" protectionBefore.json | " +
-           "jq \". + {\"allow_force_pushes\":${enabled}}\" > protectionParameters.json";
+           "jq \". + {\"allow_force_pushes\":${enabled}}\" > protectionParameters.json"
 
         //update protection on git
         def allowForcePushEnabled = sh(script:
                 "${ghPath} api -XPUT 'repos/${getGitAuthor()}/${repo}/branches/${protectedBranch}/protection' " +
                         "--input protectionParameters.json |" +
-                        " jq '.allow_force_pushes.enabled'", returnStdout: true).trim();
+                        " jq '.allow_force_pushes.enabled'", returnStdout: true).trim()
         assert allowForcePushEnabled == enabled
 
         //check that protection didn't changed except for allow_force_pushes

--- a/Jenkinsfile.promote
+++ b/Jenkinsfile.promote
@@ -458,15 +458,14 @@ void installGithubCLI() {
 
 void uploadDistribution(String directory) {
     echo "uploadDistribution for ${directory}"
-    // TODO set back
-    // dir(directory) {
-    //     withCredentials(bindings: [sshUserPrivateKey(credentialsId: 'optaplanner-filemgmt',
-    //             keyFileVariable: 'SSH_KEY_JBOSS_FILEMGMT')]) {
-    //         // For testing, simulate connection via SSH:
-    //         // sh "ssh -i $SSH_KEY_JBOSS_FILEMGMT -oKexAlgorithms=+diffie-hellman-group1-sha1 optaplanner@filemgmt.jboss.org"
-    //         sh "./build/release/upload_distribution.sh ${getProjectVersion()} $SSH_KEY_JBOSS_FILEMGMT"
-    //     }
-    // }
+    dir(directory) {
+        withCredentials(bindings: [sshUserPrivateKey(credentialsId: 'optaplanner-filemgmt',
+                keyFileVariable: 'SSH_KEY_JBOSS_FILEMGMT')]) {
+            // For testing, simulate connection via SSH:
+            // sh "ssh -i $SSH_KEY_JBOSS_FILEMGMT -oKexAlgorithms=+diffie-hellman-group1-sha1 optaplanner@filemgmt.jboss.org"
+            sh "./build/release/upload_distribution.sh ${getProjectVersion()} $SSH_KEY_JBOSS_FILEMGMT"
+        }
+    }
 }
 
 MavenCommand getMavenCommand() {


### PR DESCRIPTION
https://issues.redhat.com/browse/KOGITO-3034
https://issues.redhat.com/browse/BXMSPROD-1094

Related PRs:
- https://github.com/kiegroup/kogito-pipelines/pull/92
- https://github.com/kiegroup/kogito-runtimes/pull/940
- https://github.com/kiegroup/kogito-apps/pull/581
- https://github.com/kiegroup/optaplanner/pull/1085
- https://github.com/kiegroup/kogito-examples/pull/500
- https://github.com/kiegroup/kogito-images/pull/307
- https://github.com/kiegroup/kogito-cloud-operator/pull/710

**Setup DSL scripts for the different Kogito jobs.**

- Allow easy setup of jobs for own purpose (with different configuration for example)
- Moved parameters as environment
  - That allows exact same configuration information for all the jobs, without having to 
  - For testing, taking the getting the seed job and generating for its own GH author is easy
- Separate folders for nightly and release
  - And still keep branching parts
  - Means deploy/promote jobs are copied in each of them
  - Gives a better history of running jobs without losing release part for example
  - Created also a `pullrequest/kogito-runtimes.bdd` folder for deploy jobs used in that specific PR check

More information on https://github.com/kiegroup/kogito-pipelines/pull/92