### PR TITLE
Fail early in Quarkus build if shadow variable not on planning entity

### DIFF
--- a/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/main/java/org/optaplanner/quarkus/deployment/DotNames.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/main/java/org/optaplanner/quarkus/deployment/DotNames.java
@@ -68,6 +68,15 @@ public final class DotNames {
     static final DotName CUSTOM_SHADOW_VARIABLE = DotName.createSimple(CustomShadowVariable.class.getName());
     static final DotName INVERSE_RELATION_SHADOW_VARIABLE = DotName.createSimple(InverseRelationShadowVariable.class.getName());
 
+    static final DotName[] PLANNING_ENTITY_FIELD_ANNOTATIONS = {
+            PLANNING_PIN,
+            PLANNING_ID,
+            PLANNING_VARIABLE,
+            ANCHOR_SHADOW_VARIABLE,
+            CUSTOM_SHADOW_VARIABLE,
+            INVERSE_RELATION_SHADOW_VARIABLE,
+    };
+
     static final DotName[] GIZMO_MEMBER_ACCESSOR_ANNOTATIONS = {
             PLANNING_ENTITY_COLLECTION_PROPERTY,
             PLANNING_ENTITY_PROPERTY,

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/main/java/org/optaplanner/quarkus/deployment/OptaPlannerProcessor.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/main/java/org/optaplanner/quarkus/deployment/OptaPlannerProcessor.java
@@ -27,6 +27,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -146,6 +147,7 @@ class OptaPlannerProcessor {
         }
 
         applySolverProperties(recorderContext, indexView, solverConfig);
+        assertNoMemberAnnotationWithoutClassAnnotation(indexView);
 
         if (solverConfig.getSolutionClass() != null) {
             Type jandexType = Type.create(DotName.createSimple(solverConfig.getSolutionClass().getName()), Type.Kind.CLASS);
@@ -249,6 +251,47 @@ class OptaPlannerProcessor {
         return targetList.stream()
                 .map(target -> (Class<?>) convertClassInfoToClass(target.asClass()))
                 .collect(Collectors.toList());
+    }
+
+    private void assertNoMemberAnnotationWithoutClassAnnotation(IndexView indexView) {
+        Collection<AnnotationInstance> optaplannerFieldAnnotations = new HashSet<>();
+
+        for (DotName annotationName : DotNames.PLANNING_ENTITY_FIELD_ANNOTATIONS) {
+            optaplannerFieldAnnotations.addAll(indexView.getAnnotations(annotationName));
+        }
+
+        for (AnnotationInstance annotationInstance : optaplannerFieldAnnotations) {
+            AnnotationTarget annotationTarget = annotationInstance.target();
+            ClassInfo declaringClass;
+            String prefix;
+            switch (annotationTarget.kind()) {
+                case FIELD:
+                    prefix = "The field (" + annotationTarget.asField().name() + ") ";
+                    declaringClass = annotationTarget.asField().declaringClass();
+                    break;
+                case METHOD:
+                    prefix = "The method (" + annotationTarget.asMethod().name() + ") ";
+                    declaringClass = annotationTarget.asMethod().declaringClass();
+                    break;
+                default:
+                    throw new IllegalStateException(
+                            "Member annotation @" + annotationInstance.name().withoutPackagePrefix() + " is on ("
+                                    + annotationTarget +
+                                    "), which is an invalid target type (" + annotationTarget.kind() +
+                                    ") for @" + annotationInstance.name().withoutPackagePrefix() + ".");
+            }
+
+            if (!declaringClass.annotations().containsKey(DotNames.PLANNING_ENTITY)) {
+                throw new IllegalStateException(prefix + "with a @" +
+                        annotationInstance.name().withoutPackagePrefix() +
+                        " annotation is in a class (" + declaringClass.name().toString()
+                        + ") that does not have a @" + PlanningEntity.class.getSimpleName() +
+                        "annotation.\n" +
+                        "Maybe add a @" + PlanningEntity.class.getSimpleName() +
+                        " annotation to (" +
+                        declaringClass.name().toString() + ")?");
+            }
+        }
     }
 
     protected void applyScoreDirectorFactoryProperties(IndexView indexView, SolverConfig solverConfig) {

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/test/java/org/optaplanner/quarkus/OptaPlannerProcessorInvalidTest.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/test/java/org/optaplanner/quarkus/OptaPlannerProcessorInvalidTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.quarkus;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import javax.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.optaplanner.core.api.score.ScoreManager;
+import org.optaplanner.core.api.score.buildin.simple.SimpleScore;
+import org.optaplanner.core.api.solver.SolverFactory;
+import org.optaplanner.core.api.solver.SolverManager;
+import org.optaplanner.quarkus.testdata.invalid.inverserelation.constraints.TestdataInvalidQuarkusConstraintProvider;
+import org.optaplanner.quarkus.testdata.invalid.inverserelation.domain.TestdataInvalidInverseRelationEntity;
+import org.optaplanner.quarkus.testdata.invalid.inverserelation.domain.TestdataInvalidInverseRelationSolution;
+import org.optaplanner.quarkus.testdata.invalid.inverserelation.domain.TestdataInvalidInverseRelationValue;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class OptaPlannerProcessorInvalidTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .overrideConfigKey("quarkus.optaplanner.solver.termination.best-score-limit", "0")
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(TestdataInvalidInverseRelationSolution.class,
+                            TestdataInvalidInverseRelationEntity.class,
+                            TestdataInvalidInverseRelationValue.class,
+                            TestdataInvalidQuarkusConstraintProvider.class))
+            .assertException(exception -> {
+                assertEquals(IllegalStateException.class, exception.getClass());
+                assertEquals("The field (entityList) with a @InverseRelationShadowVariable annotation is in a" +
+                        " class (org.optaplanner.quarkus.testdata.invalid.inverserelation.domain.TestdataInvalidInverseRelationValue)"
+                        +
+                        " that does not have a @PlanningEntityannotation.\n" +
+                        "Maybe add a @PlanningEntity annotation to " +
+                        "(org.optaplanner.quarkus.testdata.invalid.inverserelation.domain.TestdataInvalidInverseRelationValue)?",
+                        exception.getMessage());
+            });
+
+    @Inject
+    SolverFactory<TestdataInvalidInverseRelationSolution> solverFactory;
+    @Inject
+    SolverManager<TestdataInvalidInverseRelationSolution, Long> solverManager;
+    @Inject
+    ScoreManager<TestdataInvalidInverseRelationSolution, SimpleScore> scoreManager;
+
+    @Test
+    public void solve() {
+        fail("Build should fail");
+    }
+
+}

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/test/java/org/optaplanner/quarkus/testdata/invalid/inverserelation/constraints/TestdataInvalidQuarkusConstraintProvider.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/test/java/org/optaplanner/quarkus/testdata/invalid/inverserelation/constraints/TestdataInvalidQuarkusConstraintProvider.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.quarkus.testdata.invalid.inverserelation.constraints;
+
+import org.optaplanner.core.api.score.buildin.simple.SimpleScore;
+import org.optaplanner.core.api.score.stream.Constraint;
+import org.optaplanner.core.api.score.stream.ConstraintFactory;
+import org.optaplanner.core.api.score.stream.ConstraintProvider;
+import org.optaplanner.quarkus.testdata.invalid.inverserelation.domain.TestdataInvalidInverseRelationValue;
+
+public class TestdataInvalidQuarkusConstraintProvider implements ConstraintProvider {
+
+    @Override
+    public Constraint[] defineConstraints(ConstraintFactory factory) {
+        return new Constraint[] {
+                factory.from(TestdataInvalidInverseRelationValue.class)
+                        .filter(room -> room.getEntityList().size() > 1)
+                        .penalize("Don't assign 2 entities the same room.", SimpleScore.ONE)
+        };
+    }
+
+}

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/test/java/org/optaplanner/quarkus/testdata/invalid/inverserelation/domain/TestdataInvalidInverseRelationEntity.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/test/java/org/optaplanner/quarkus/testdata/invalid/inverserelation/domain/TestdataInvalidInverseRelationEntity.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.quarkus.testdata.invalid.inverserelation.domain;
+
+import org.optaplanner.core.api.domain.entity.PlanningEntity;
+import org.optaplanner.core.api.domain.variable.PlanningVariable;
+
+@PlanningEntity
+public class TestdataInvalidInverseRelationEntity {
+
+    private TestdataInvalidInverseRelationValue value;
+
+    @PlanningVariable(valueRangeProviderRefs = "valueRange")
+    public TestdataInvalidInverseRelationValue getValue() {
+        return value;
+    }
+
+    public void setValue(TestdataInvalidInverseRelationValue value) {
+        this.value = value;
+    }
+
+}

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/test/java/org/optaplanner/quarkus/testdata/invalid/inverserelation/domain/TestdataInvalidInverseRelationSolution.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/test/java/org/optaplanner/quarkus/testdata/invalid/inverserelation/domain/TestdataInvalidInverseRelationSolution.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.quarkus.testdata.invalid.inverserelation.domain;
+
+import java.util.List;
+
+import org.optaplanner.core.api.domain.solution.PlanningEntityCollectionProperty;
+import org.optaplanner.core.api.domain.solution.PlanningScore;
+import org.optaplanner.core.api.domain.solution.PlanningSolution;
+import org.optaplanner.core.api.domain.solution.ProblemFactCollectionProperty;
+import org.optaplanner.core.api.domain.valuerange.ValueRangeProvider;
+import org.optaplanner.core.api.score.buildin.simple.SimpleScore;
+
+@PlanningSolution
+public class TestdataInvalidInverseRelationSolution {
+
+    private List<TestdataInvalidInverseRelationValue> valueList;
+    private List<TestdataInvalidInverseRelationEntity> entityList;
+
+    private SimpleScore score;
+
+    @ValueRangeProvider(id = "valueRange")
+    @ProblemFactCollectionProperty
+    public List<TestdataInvalidInverseRelationValue> getValueList() {
+        return valueList;
+    }
+
+    public void setValueList(List<TestdataInvalidInverseRelationValue> valueList) {
+        this.valueList = valueList;
+    }
+
+    @PlanningEntityCollectionProperty
+    public List<TestdataInvalidInverseRelationEntity> getEntityList() {
+        return entityList;
+    }
+
+    public void setEntityList(List<TestdataInvalidInverseRelationEntity> entityList) {
+        this.entityList = entityList;
+    }
+
+    @PlanningScore
+    public SimpleScore getScore() {
+        return score;
+    }
+
+    public void setScore(SimpleScore score) {
+        this.score = score;
+    }
+
+}

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/test/java/org/optaplanner/quarkus/testdata/invalid/inverserelation/domain/TestdataInvalidInverseRelationValue.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/test/java/org/optaplanner/quarkus/testdata/invalid/inverserelation/domain/TestdataInvalidInverseRelationValue.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.quarkus.testdata.invalid.inverserelation.domain;
+
+import java.util.List;
+
+import org.optaplanner.core.api.domain.variable.InverseRelationShadowVariable;
+
+public class TestdataInvalidInverseRelationValue {
+    @InverseRelationShadowVariable(
+            sourceVariableName = "value")
+    private List<TestdataInvalidInverseRelationEntity> entityList;
+
+    public List<TestdataInvalidInverseRelationEntity> getEntityList() {
+        return entityList;
+    }
+}


### PR DESCRIPTION
<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.
-->

### JIRA

<!-- Add a JIRA ticket link if it exists. -->
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
* https://github.com/kiegroup/drools/pull/3000
* https://github.com/kiegroup/optaplanner/pull/899
* etc.
-->

### Checklist
- [ ] Documentation updated if applicable.
- [ ] Upgrade recipe provided if applicable.

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>full downstream build</b> please add comment: <b>Jenkins run fdb</b>
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
