### PR TITLE
Fail to compile if a member annotation is not in a @PlanningEntity

### DIFF
--- a/optaplanner-core/pom.xml
+++ b/optaplanner-core/pom.xml
@@ -134,6 +134,33 @@
           </ignoredUnusedDeclaredDependencies>
         </configuration>
       </plugin>
+
+      <plugin>
+        <artifactId>maven-resources-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>add-annotation-processor-service</id>
+            <phase>prepare-package</phase>
+            <goals>
+              <goal>copy-resources</goal>
+            </goals>
+            <configuration>
+              <outputDirectory>${basedir}/target/classes/META-INF/services</outputDirectory>
+              <!-- Cannot put this file into resources since it will try to look for
+                   a class that is compiled during the build -->
+              <resources>
+                <resource>
+                  <directory>src/build</directory>
+                  <includes>
+                      <include>javax.annotation.processing.Processor</include>
+                  </includes>
+                </resource>
+              </resources>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
       <plugin>
         <groupId>org.revapi</groupId>
         <artifactId>revapi-maven-plugin</artifactId>

--- a/optaplanner-core/src/build/javax.annotation.processing.Processor
+++ b/optaplanner-core/src/build/javax.annotation.processing.Processor
@@ -1,0 +1,1 @@
+org.optaplanner.core.impl.processor.OptaPlannerAnnotationProcessor

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/processor/OptaPlannerAnnotationProcessor.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/processor/OptaPlannerAnnotationProcessor.java
@@ -1,0 +1,76 @@
+package org.optaplanner.core.impl.processor;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import javax.annotation.processing.AbstractProcessor;
+import javax.annotation.processing.ProcessingEnvironment;
+import javax.annotation.processing.RoundEnvironment;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.TypeElement;
+
+import org.optaplanner.core.api.domain.entity.PlanningEntity;
+import org.optaplanner.core.api.domain.variable.AnchorShadowVariable;
+import org.optaplanner.core.api.domain.variable.CustomShadowVariable;
+import org.optaplanner.core.api.domain.variable.InverseRelationShadowVariable;
+import org.optaplanner.core.api.domain.variable.PlanningVariable;
+
+public class OptaPlannerAnnotationProcessor extends AbstractProcessor {
+
+    @Override
+    public Set<String> getSupportedAnnotationTypes() {
+        return Collections.singleton("org.optaplanner.core.api.*");
+    }
+
+    private static final List<String> planningEntityMemberAnnotationList = Arrays.asList(
+            PlanningVariable.class.getSimpleName(),
+            InverseRelationShadowVariable.class.getSimpleName(),
+            AnchorShadowVariable.class.getSimpleName(),
+            CustomShadowVariable.class.getSimpleName());
+
+    private HashSet<String> planningEntityClassList;
+
+    @Override
+    public synchronized void init(ProcessingEnvironment processingEnv) {
+        super.init(processingEnv);
+        planningEntityClassList = new HashSet<>();
+    }
+
+    @Override
+    public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
+        for (TypeElement annotation : annotations) {
+            if (planningEntityMemberAnnotationList
+                    .stream()
+                    .anyMatch(annotationName -> annotation.getSimpleName().contentEquals(annotationName))) {
+                processPlanningEntityMemberAnnotation(annotation, roundEnv);
+            }
+        }
+
+        return true;
+    }
+
+    private void processPlanningEntityMemberAnnotation(TypeElement annotation, RoundEnvironment roundEnv) {
+        Set<? extends Element> annotatedElements = roundEnv.getElementsAnnotatedWith(annotation);
+        annotatedElements.forEach(element -> {
+            switch (element.getKind()) {
+                case FIELD:
+                case METHOD:
+                    if (element.getEnclosingElement().getAnnotation(PlanningEntity.class) == null) {
+                        throw new IllegalStateException("Member annotation @" + annotation.getSimpleName() +
+                                " was placed in a class without @PlanningEntity ("
+                                + element.getEnclosingElement().getSimpleName()
+                                + "). Maybe add @PlanningEntity to the class (" + element.getEnclosingElement().getSimpleName()
+                                + ")?");
+                    }
+                    break;
+                default:
+                    throw new IllegalStateException("Member annotation @" + annotation.getSimpleName() +
+                            " was placed on a non-member " + element + ".");
+            }
+        });
+    }
+
+}


### PR DESCRIPTION
In maven at least, the annotation processor is automatically used, no changes required on the user end. To test, try commenting out `@PlanningEntity` on some classes in `optaplanner-examples`.
<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.
-->

### JIRA

<!-- Add a JIRA ticket link if it exists. -->
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
* https://github.com/kiegroup/drools/pull/3000
* https://github.com/kiegroup/optaplanner/pull/899
* etc.
-->

### Checklist
- [ ] Documentation updated if applicable.
- [ ] Upgrade recipe provided if applicable.

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>full downstream build</b> please add comment: <b>Jenkins run fdb</b>
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
