### PR TITLE
PLANNER-2315 Properly size Bavet child tuple lists

### DIFF
--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/bavet/bi/BavetFilterBiTuple.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/bavet/bi/BavetFilterBiTuple.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,10 +16,16 @@
 
 package org.optaplanner.core.impl.score.stream.bavet.bi;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import org.optaplanner.core.impl.score.stream.bavet.common.BavetAbstractTuple;
+
 public final class BavetFilterBiTuple<A, B> extends BavetAbstractBiTuple<A, B> {
 
     private final BavetFilterBiNode<A, B> node;
     private final BavetAbstractBiTuple<A, B> parentTuple;
+    private final List<BavetAbstractTuple> childTupleList = new ArrayList<>(1);
 
     public BavetFilterBiTuple(BavetFilterBiNode<A, B> node, BavetAbstractBiTuple<A, B> parentTuple) {
         this.node = node;
@@ -38,6 +44,11 @@ public final class BavetFilterBiTuple<A, B> extends BavetAbstractBiTuple<A, B> {
     @Override
     public BavetFilterBiNode<A, B> getNode() {
         return node;
+    }
+
+    @Override
+    public List<BavetAbstractTuple> getChildTupleList() {
+        return childTupleList;
     }
 
     @Override

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/bavet/bi/BavetGroupBiTuple.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/bavet/bi/BavetGroupBiTuple.java
@@ -16,12 +16,12 @@
 
 package org.optaplanner.core.impl.score.stream.bavet.bi;
 
-import org.optaplanner.core.impl.score.stream.bavet.common.BavetAbstractTuple;
-import org.optaplanner.core.impl.score.stream.bavet.common.BavetGroupTuple;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Function;
+
+import org.optaplanner.core.impl.score.stream.bavet.common.BavetAbstractTuple;
+import org.optaplanner.core.impl.score.stream.bavet.common.BavetGroupTuple;
 
 public final class BavetGroupBiTuple<GroupKey_, ResultContainer_, Result_> extends BavetAbstractBiTuple<GroupKey_, Result_>
         implements BavetGroupTuple {

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/bavet/bi/BavetGroupBiTuple.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/bavet/bi/BavetGroupBiTuple.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,8 +16,11 @@
 
 package org.optaplanner.core.impl.score.stream.bavet.bi;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.function.Function;
 
+import org.optaplanner.core.impl.score.stream.bavet.common.BavetAbstractTuple;
 import org.optaplanner.core.impl.score.stream.bavet.common.BavetGroupTuple;
 
 public final class BavetGroupBiTuple<GroupKey_, ResultContainer_, Result_> extends BavetAbstractBiTuple<GroupKey_, Result_>
@@ -29,6 +32,7 @@ public final class BavetGroupBiTuple<GroupKey_, ResultContainer_, Result_> exten
     private int parentCount;
     private ResultContainer_ resultContainer;
     private Result_ result;
+    private final List<BavetAbstractTuple> childTupleList = new ArrayList<>();
 
     public BavetGroupBiTuple(BavetGroupBiNode<GroupKey_, ResultContainer_, Result_> node,
             GroupKey_ groupKey, ResultContainer_ resultContainer) {
@@ -73,6 +77,11 @@ public final class BavetGroupBiTuple<GroupKey_, ResultContainer_, Result_> exten
     @Override
     public BavetGroupBiNode<GroupKey_, ResultContainer_, Result_> getNode() {
         return node;
+    }
+
+    @Override
+    public List<BavetAbstractTuple> getChildTupleList() {
+        return childTupleList;
     }
 
     @Override

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/bavet/bi/BavetGroupBiTuple.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/bavet/bi/BavetGroupBiTuple.java
@@ -16,12 +16,12 @@
 
 package org.optaplanner.core.impl.score.stream.bavet.bi;
 
+import org.optaplanner.core.impl.score.stream.bavet.common.BavetAbstractTuple;
+import org.optaplanner.core.impl.score.stream.bavet.common.BavetGroupTuple;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Function;
-
-import org.optaplanner.core.impl.score.stream.bavet.common.BavetAbstractTuple;
-import org.optaplanner.core.impl.score.stream.bavet.common.BavetGroupTuple;
 
 public final class BavetGroupBiTuple<GroupKey_, ResultContainer_, Result_> extends BavetAbstractBiTuple<GroupKey_, Result_>
         implements BavetGroupTuple {
@@ -32,7 +32,7 @@ public final class BavetGroupBiTuple<GroupKey_, ResultContainer_, Result_> exten
     private int parentCount;
     private ResultContainer_ resultContainer;
     private Result_ result;
-    private final List<BavetAbstractTuple> childTupleList = new ArrayList<>();
+    private final List<BavetAbstractTuple> childTupleList = new ArrayList<>(1);
 
     public BavetGroupBiTuple(BavetGroupBiNode<GroupKey_, ResultContainer_, Result_> node,
             GroupKey_ groupKey, ResultContainer_ resultContainer) {

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/bavet/bi/BavetGroupBridgeBiTuple.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/bavet/bi/BavetGroupBridgeBiTuple.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,11 @@
 
 package org.optaplanner.core.impl.score.stream.bavet.bi;
 
-public class BavetGroupBridgeBiTuple<A, B, NewA, ResultContainer_, NewB> extends BavetAbstractBiTuple<A, B> {
+import java.util.List;
+
+import org.optaplanner.core.impl.score.stream.bavet.common.BavetAbstractTuple;
+
+public final class BavetGroupBridgeBiTuple<A, B, NewA, ResultContainer_, NewB> extends BavetAbstractBiTuple<A, B> {
 
     private final BavetGroupBridgeBiNode<A, B, NewA, ResultContainer_, NewB> node;
     private final BavetAbstractBiTuple<A, B> parentTuple;
@@ -42,6 +46,11 @@ public class BavetGroupBridgeBiTuple<A, B, NewA, ResultContainer_, NewB> extends
     @Override
     public BavetGroupBridgeBiNode<A, B, NewA, ResultContainer_, NewB> getNode() {
         return node;
+    }
+
+    @Override
+    public List<BavetAbstractTuple> getChildTupleList() {
+        throw new IllegalStateException("Impossible state: group bridges only have 1 child tuple.");
     }
 
     @Override

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/bavet/bi/BavetJoinBiTuple.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/bavet/bi/BavetJoinBiTuple.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,10 @@
 
 package org.optaplanner.core.impl.score.stream.bavet.bi;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import org.optaplanner.core.impl.score.stream.bavet.common.BavetAbstractTuple;
 import org.optaplanner.core.impl.score.stream.bavet.common.BavetJoinTuple;
 import org.optaplanner.core.impl.score.stream.bavet.uni.BavetJoinBridgeUniTuple;
 
@@ -25,6 +29,7 @@ public final class BavetJoinBiTuple<A, B> extends BavetAbstractBiTuple<A, B>
     private final BavetJoinBiNode<A, B> node;
     private final BavetJoinBridgeUniTuple<A> aTuple;
     private final BavetJoinBridgeUniTuple<B> bTuple;
+    private final List<BavetAbstractTuple> childTupleList = new ArrayList<>(1);
 
     public BavetJoinBiTuple(BavetJoinBiNode<A, B> node,
             BavetJoinBridgeUniTuple<A> aTuple, BavetJoinBridgeUniTuple<B> bTuple) {
@@ -45,6 +50,11 @@ public final class BavetJoinBiTuple<A, B> extends BavetAbstractBiTuple<A, B>
     @Override
     public BavetJoinBiNode<A, B> getNode() {
         return node;
+    }
+
+    @Override
+    public List<BavetAbstractTuple> getChildTupleList() {
+        return childTupleList;
     }
 
     @Override

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/bavet/bi/BavetJoinBridgeBiTuple.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/bavet/bi/BavetJoinBridgeBiTuple.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,10 @@
 
 package org.optaplanner.core.impl.score.stream.bavet.bi;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import org.optaplanner.core.impl.score.stream.bavet.common.BavetAbstractTuple;
 import org.optaplanner.core.impl.score.stream.bavet.common.BavetJoinBridgeTuple;
 
 public final class BavetJoinBridgeBiTuple<A, B> extends BavetAbstractBiTuple<A, B>
@@ -23,6 +27,7 @@ public final class BavetJoinBridgeBiTuple<A, B> extends BavetAbstractBiTuple<A, 
 
     protected final BavetAbstractBiTuple<A, B> parentTuple;
     private final BavetJoinBridgeBiNode<A, B> node;
+    private final List<BavetAbstractTuple> childTupleList = new ArrayList<>();
 
     private Object[] indexProperties;
 
@@ -44,6 +49,11 @@ public final class BavetJoinBridgeBiTuple<A, B> extends BavetAbstractBiTuple<A, 
     @Override
     public BavetJoinBridgeBiNode<A, B> getNode() {
         return node;
+    }
+
+    @Override
+    public List<BavetAbstractTuple> getChildTupleList() {
+        return childTupleList;
     }
 
     @Override

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/bavet/bi/BavetScoringBiTuple.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/bavet/bi/BavetScoringBiTuple.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,9 +16,12 @@
 
 package org.optaplanner.core.impl.score.stream.bavet.bi;
 
+import java.util.List;
+
 import org.optaplanner.core.api.score.Score;
 import org.optaplanner.core.impl.score.inliner.UndoScoreImpacter;
 import org.optaplanner.core.impl.score.stream.bavet.BavetConstraintSession;
+import org.optaplanner.core.impl.score.stream.bavet.common.BavetAbstractTuple;
 import org.optaplanner.core.impl.score.stream.bavet.common.BavetScoringTuple;
 
 public final class BavetScoringBiTuple<A, B> extends BavetAbstractBiTuple<A, B> implements BavetScoringTuple {
@@ -47,6 +50,11 @@ public final class BavetScoringBiTuple<A, B> extends BavetAbstractBiTuple<A, B> 
     @Override
     public BavetScoringBiNode<A, B> getNode() {
         return node;
+    }
+
+    @Override
+    public List<BavetAbstractTuple> getChildTupleList() {
+        throw new IllegalStateException("Impossible state: scoring can not have child tuples.");
     }
 
     @Override

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/bavet/common/BavetAbstractTuple.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/bavet/common/BavetAbstractTuple.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,13 +16,11 @@
 
 package org.optaplanner.core.impl.score.stream.bavet.common;
 
-import java.util.ArrayList;
 import java.util.List;
 
 public abstract class BavetAbstractTuple implements BavetTuple {
 
     protected BavetTupleState state = BavetTupleState.NEW;
-    protected final List<BavetAbstractTuple> childTupleList = new ArrayList<>(); // TODO initial capacity
 
     public boolean isDirty() {
         return state.isDirty();
@@ -51,8 +49,6 @@ public abstract class BavetAbstractTuple implements BavetTuple {
         this.state = state;
     }
 
-    public final List<BavetAbstractTuple> getChildTupleList() {
-        return childTupleList;
-    }
+    public abstract List<BavetAbstractTuple> getChildTupleList();
 
 }

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/bavet/tri/BavetFilterTriTuple.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/bavet/tri/BavetFilterTriTuple.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,10 +16,16 @@
 
 package org.optaplanner.core.impl.score.stream.bavet.tri;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import org.optaplanner.core.impl.score.stream.bavet.common.BavetAbstractTuple;
+
 public final class BavetFilterTriTuple<A, B, C> extends BavetAbstractTriTuple<A, B, C> {
 
     private final BavetFilterTriNode<A, B, C> node;
     private final BavetAbstractTriTuple<A, B, C> parentTuple;
+    private final List<BavetAbstractTuple> childTupleList = new ArrayList<>(1);
 
     public BavetFilterTriTuple(BavetFilterTriNode<A, B, C> node, BavetAbstractTriTuple<A, B, C> parentTuple) {
         this.node = node;
@@ -38,6 +44,11 @@ public final class BavetFilterTriTuple<A, B, C> extends BavetAbstractTriTuple<A,
     @Override
     public BavetFilterTriNode<A, B, C> getNode() {
         return node;
+    }
+
+    @Override
+    public List<BavetAbstractTuple> getChildTupleList() {
+        return childTupleList;
     }
 
     @Override

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/bavet/tri/BavetJoinTriTuple.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/bavet/tri/BavetJoinTriTuple.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,11 @@
 
 package org.optaplanner.core.impl.score.stream.bavet.tri;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.optaplanner.core.impl.score.stream.bavet.bi.BavetJoinBridgeBiTuple;
+import org.optaplanner.core.impl.score.stream.bavet.common.BavetAbstractTuple;
 import org.optaplanner.core.impl.score.stream.bavet.common.BavetJoinTuple;
 import org.optaplanner.core.impl.score.stream.bavet.uni.BavetJoinBridgeUniTuple;
 
@@ -26,6 +30,7 @@ public final class BavetJoinTriTuple<A, B, C> extends BavetAbstractTriTuple<A, B
     private final BavetJoinTriNode<A, B, C> node;
     private final BavetJoinBridgeBiTuple<A, B> abTuple;
     private final BavetJoinBridgeUniTuple<C> cTuple;
+    private final List<BavetAbstractTuple> childTupleList = new ArrayList<>(1);
 
     public BavetJoinTriTuple(BavetJoinTriNode<A, B, C> node,
             BavetJoinBridgeBiTuple<A, B> abTuple, BavetJoinBridgeUniTuple<C> cTuple) {
@@ -46,6 +51,11 @@ public final class BavetJoinTriTuple<A, B, C> extends BavetAbstractTriTuple<A, B
     @Override
     public BavetJoinTriNode<A, B, C> getNode() {
         return node;
+    }
+
+    @Override
+    public List<BavetAbstractTuple> getChildTupleList() {
+        return childTupleList;
     }
 
     @Override

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/bavet/tri/BavetScoringTriTuple.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/bavet/tri/BavetScoringTriTuple.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,9 +16,12 @@
 
 package org.optaplanner.core.impl.score.stream.bavet.tri;
 
+import java.util.List;
+
 import org.optaplanner.core.api.score.Score;
 import org.optaplanner.core.impl.score.inliner.UndoScoreImpacter;
 import org.optaplanner.core.impl.score.stream.bavet.BavetConstraintSession;
+import org.optaplanner.core.impl.score.stream.bavet.common.BavetAbstractTuple;
 import org.optaplanner.core.impl.score.stream.bavet.common.BavetScoringTuple;
 
 public final class BavetScoringTriTuple<A, B, C> extends BavetAbstractTriTuple<A, B, C> implements BavetScoringTuple {
@@ -47,6 +50,11 @@ public final class BavetScoringTriTuple<A, B, C> extends BavetAbstractTriTuple<A
     @Override
     public BavetScoringTriNode<A, B, C> getNode() {
         return node;
+    }
+
+    @Override
+    public List<BavetAbstractTuple> getChildTupleList() {
+        throw new IllegalStateException("Impossible state: scoring can not have child tuples.");
     }
 
     @Override

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/bavet/uni/BavetFilterUniTuple.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/bavet/uni/BavetFilterUniTuple.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,10 +16,16 @@
 
 package org.optaplanner.core.impl.score.stream.bavet.uni;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import org.optaplanner.core.impl.score.stream.bavet.common.BavetAbstractTuple;
+
 public final class BavetFilterUniTuple<A> extends BavetAbstractUniTuple<A> {
 
     private final BavetFilterUniNode<A> node;
     private final BavetAbstractUniTuple<A> parentTuple;
+    private final List<BavetAbstractTuple> childTupleList = new ArrayList<>(1);
 
     public BavetFilterUniTuple(BavetFilterUniNode<A> node, BavetAbstractUniTuple<A> parentTuple) {
         this.node = node;
@@ -38,6 +44,11 @@ public final class BavetFilterUniTuple<A> extends BavetAbstractUniTuple<A> {
     @Override
     public BavetFilterUniNode<A> getNode() {
         return node;
+    }
+
+    @Override
+    public List<BavetAbstractTuple> getChildTupleList() {
+        return childTupleList;
     }
 
     @Override

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/bavet/uni/BavetFromUniTuple.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/bavet/uni/BavetFromUniTuple.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,12 +16,19 @@
 
 package org.optaplanner.core.impl.score.stream.bavet.uni;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import org.optaplanner.core.impl.score.stream.bavet.common.BavetAbstractTuple;
+
 public final class BavetFromUniTuple<A> extends BavetAbstractUniTuple<A> {
 
     private final BavetFromUniNode<A> node;
     private final A factA;
+    private final List<BavetAbstractTuple> childTupleList;
 
     public BavetFromUniTuple(BavetFromUniNode<A> node, A factA, int childTupleListSize) {
+        this.childTupleList = new ArrayList<>(childTupleListSize);
         this.node = node;
         this.factA = factA;
     }
@@ -38,6 +45,11 @@ public final class BavetFromUniTuple<A> extends BavetAbstractUniTuple<A> {
     @Override
     public BavetFromUniNode<A> getNode() {
         return node;
+    }
+
+    @Override
+    public List<BavetAbstractTuple> getChildTupleList() {
+        return childTupleList;
     }
 
     @Override

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/bavet/uni/BavetGroupBridgeUniTuple.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/bavet/uni/BavetGroupBridgeUniTuple.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,10 @@
 
 package org.optaplanner.core.impl.score.stream.bavet.uni;
 
+import java.util.List;
+
 import org.optaplanner.core.impl.score.stream.bavet.bi.BavetGroupBiTuple;
+import org.optaplanner.core.impl.score.stream.bavet.common.BavetAbstractTuple;
 
 public final class BavetGroupBridgeUniTuple<A, NewA, ResultContainer_, NewB> extends BavetAbstractUniTuple<A> {
 
@@ -44,6 +47,11 @@ public final class BavetGroupBridgeUniTuple<A, NewA, ResultContainer_, NewB> ext
     @Override
     public BavetGroupBridgeUniNode<A, NewA, ResultContainer_, NewB> getNode() {
         return node;
+    }
+
+    @Override
+    public List<BavetAbstractTuple> getChildTupleList() {
+        throw new IllegalStateException("Impossible state: group bridges only have 1 child tuple.");
     }
 
     @Override

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/bavet/uni/BavetJoinBridgeUniTuple.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/bavet/uni/BavetJoinBridgeUniTuple.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,10 @@
 
 package org.optaplanner.core.impl.score.stream.bavet.uni;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import org.optaplanner.core.impl.score.stream.bavet.common.BavetAbstractTuple;
 import org.optaplanner.core.impl.score.stream.bavet.common.BavetJoinBridgeTuple;
 
 public final class BavetJoinBridgeUniTuple<A> extends BavetAbstractUniTuple<A>
@@ -23,6 +27,7 @@ public final class BavetJoinBridgeUniTuple<A> extends BavetAbstractUniTuple<A>
 
     protected final BavetAbstractUniTuple<A> parentTuple;
     private final BavetJoinBridgeUniNode<A> node;
+    private final List<BavetAbstractTuple> childTupleList = new ArrayList<>();
 
     private Object[] indexProperties;
 
@@ -44,6 +49,11 @@ public final class BavetJoinBridgeUniTuple<A> extends BavetAbstractUniTuple<A>
     @Override
     public BavetJoinBridgeUniNode<A> getNode() {
         return node;
+    }
+
+    @Override
+    public List<BavetAbstractTuple> getChildTupleList() {
+        return childTupleList;
     }
 
     @Override

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/bavet/uni/BavetScoringUniTuple.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/bavet/uni/BavetScoringUniTuple.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,9 +16,12 @@
 
 package org.optaplanner.core.impl.score.stream.bavet.uni;
 
+import java.util.List;
+
 import org.optaplanner.core.api.score.Score;
 import org.optaplanner.core.impl.score.inliner.UndoScoreImpacter;
 import org.optaplanner.core.impl.score.stream.bavet.BavetConstraintSession;
+import org.optaplanner.core.impl.score.stream.bavet.common.BavetAbstractTuple;
 import org.optaplanner.core.impl.score.stream.bavet.common.BavetScoringTuple;
 
 public final class BavetScoringUniTuple<A> extends BavetAbstractUniTuple<A> implements BavetScoringTuple {
@@ -47,6 +50,11 @@ public final class BavetScoringUniTuple<A> extends BavetAbstractUniTuple<A> impl
     @Override
     public BavetScoringUniNode<A> getNode() {
         return node;
+    }
+
+    @Override
+    public List<BavetAbstractTuple> getChildTupleList() {
+        throw new IllegalStateException("Impossible state: scoring can not have child tuples.");
     }
 
     @Override


### PR DESCRIPTION
Some tuples will only ever have 1 child.
Some tuples will mostly only have 1 expected child.
Some tuples will never have children.

The sizing of the collections should reflect that, which leads to a performance improvement of ~10 % on average.