### PR TITLE
8.2.x - Fix native image generation for Gizmo

### DIFF
--- a/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/main/java/org/optaplanner/quarkus/deployment/GizmoMemberAccessorEntityEnhancer.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/main/java/org/optaplanner/quarkus/deployment/GizmoMemberAccessorEntityEnhancer.java
@@ -33,6 +33,9 @@ import java.util.Locale;
 import java.util.Optional;
 import java.util.Set;
 
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Named;
+
 import org.jboss.jandex.AnnotationInstance;
 import org.jboss.jandex.ClassInfo;
 import org.jboss.jandex.FieldInfo;
@@ -117,6 +120,9 @@ public class GizmoMemberAccessorEntityEnhancer {
                 .classOutput(classOutput)
                 .build();
 
+        classCreator.addAnnotation(ApplicationScoped.class);
+        classCreator.addAnnotation(Named.class).addValue("value", generatedClassName);
+
         GizmoMemberDescriptor member;
         Class<?> declaringClass = Class.forName(fieldInfo.declaringClass().name().toString(), false,
                 Thread.currentThread().getContextClassLoader());
@@ -197,6 +203,9 @@ public class GizmoMemberAccessorEntityEnhancer {
                 .interfaces(MemberAccessor.class)
                 .classOutput(classOutput)
                 .build();
+
+        classCreator.addAnnotation(ApplicationScoped.class);
+        classCreator.addAnnotation(Named.class).addValue("value", generatedClassName);
 
         GizmoMemberDescriptor member;
         String name = getMemberName(methodInfo);

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/runtime/src/main/java/org/optaplanner/quarkus/nativeimage/Substitute_MemberAccessorFactory.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/runtime/src/main/java/org/optaplanner/quarkus/nativeimage/Substitute_MemberAccessorFactory.java
@@ -28,7 +28,7 @@ import org.optaplanner.core.impl.domain.common.accessor.MemberAccessorFactory;
 import org.optaplanner.core.impl.domain.common.accessor.ReflectionBeanPropertyMemberAccessor;
 import org.optaplanner.core.impl.domain.common.accessor.ReflectionFieldMemberAccessor;
 import org.optaplanner.core.impl.domain.common.accessor.ReflectionMethodMemberAccessor;
-import org.optaplanner.core.impl.domain.common.accessor.gizmo.GizmoMemberAccessorImplementor;
+import org.optaplanner.core.impl.domain.common.accessor.gizmo.GizmoMemberAccessorFactory;
 
 import com.oracle.svm.core.annotate.Substitute;
 import com.oracle.svm.core.annotate.TargetClass;
@@ -41,17 +41,7 @@ public final class Substitute_MemberAccessorFactory {
             Class<? extends Annotation> annotationClass,
             DomainAccessType domainAccessType) {
         if (domainAccessType == DomainAccessType.GIZMO) {
-            try {
-                // Check if Gizmo on the classpath by verifying we can access one of its classes
-                Class.forName("io.quarkus.gizmo.ClassCreator", false,
-                        Thread.currentThread().getContextClassLoader());
-            } catch (ClassNotFoundException e) {
-                throw new IllegalStateException("When using the domainAccessType (" +
-                        domainAccessType +
-                        ") the classpath or modulepath must contain io.quarkus.gizmo:gizmo.\n" +
-                        "Maybe add a dependency to io.quarkus.gizmo:gizmo.");
-            }
-            return GizmoMemberAccessorImplementor.createAccessorFor(member, annotationClass);
+            return GizmoMemberAccessorFactory.buildGizmoMemberAccessor(member, annotationClass);
         }
         if (member instanceof Field) {
             Field field = (Field) member;


### PR DESCRIPTION
Cherry pick of https://github.com/kiegroup/optaplanner/pull/1115

* Fix native image generation for Gizmo

* Use @ApplicationScoped for Gizmo MemberAccessors

<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.
-->

### JIRA

<!-- Add a JIRA ticket link if it exists. -->
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
* https://github.com/kiegroup/drools/pull/3000
* https://github.com/kiegroup/optaplanner/pull/899
* etc.
-->

### Checklist
- [ ] Documentation updated if applicable.
- [ ] Upgrade recipe provided if applicable.

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>full downstream build</b> please add comment: <b>Jenkins run fdb</b>
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
