### PR TITLE
Add location to JAXB validation error

### DIFF
--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/io/jaxb/GenericJaxbIO.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/io/jaxb/GenericJaxbIO.java
@@ -37,7 +37,6 @@ import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBException;
 import javax.xml.bind.Marshaller;
 import javax.xml.bind.Unmarshaller;
-import javax.xml.bind.ValidationEvent;
 import javax.xml.bind.util.ValidationEventCollector;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -173,7 +172,9 @@ public final class GenericJaxbIO<T> implements JaxbIO<T> {
                 String errorMessage =
                         String.format("XML validation failed for a root element class (%s).", rootClass.getName());
                 String validationErrors = Stream.of(validationEventCollector.getEvents())
-                        .map(ValidationEvent::getMessage)
+                        .map(validationEvent -> validationEvent.getMessage()
+                                + "\nNode: "
+                                + validationEvent.getLocator().getNode().getNodeName())
                         .collect(Collectors.joining("\n"));
                 String errorMessageWithValidationEvents = errorMessage + "\n" + validationErrors;
                 throw new OptaPlannerXmlSerializationException(errorMessageWithValidationEvents, jaxbException);

--- a/optaplanner-core/src/test/java/org/optaplanner/core/config/solver/SolverConfigTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/config/solver/SolverConfigTest.java
@@ -127,7 +127,7 @@ class SolverConfigTest {
         assertThatExceptionOfType(OptaPlannerXmlSerializationException.class)
                 .isThrownBy(() -> solverConfigIO.read(stringReader))
                 .withMessageContaining("Invalid content was found")
-                .withMessageContaining("variableName");
+                .withMessageContaining("Node: variableName");
     }
 
     @Test


### PR DESCRIPTION
Slightly improves the validation message as requested in https://kie.zulipchat.com/#narrow/stream/232679-optaplanner/topic/XML.20mistake.20.3D.3E.20no.20line.20number.

However, it's not possible to get the line number, as this information is available only if we use SAX as the underlying parser. In our case, we use DOM, so we get the Node where the validation error occurs.

### JIRA

<!-- Add a JIRA ticket link if it exists. -->
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
* https://github.com/kiegroup/drools/pull/3000
* https://github.com/kiegroup/optaplanner/pull/899
* etc.
-->

### Checklist
- [ ] Documentation updated if applicable.
- [ ] Upgrade recipe provided if applicable.

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>full downstream build</b> please add comment: <b>Jenkins run fdb</b>
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
