### PR TITLE
PLANNER-2254 Fix flaky TimeTableControllerTest

### DIFF
--- a/optaplanner-quickstarts/quarkus-school-timetabling/src/test/java/org/acme/schooltimetabling/rest/TimeTableResourceTest.java
+++ b/optaplanner-quickstarts/quarkus-school-timetabling/src/test/java/org/acme/schooltimetabling/rest/TimeTableResourceTest.java
@@ -40,13 +40,13 @@ public class TimeTableResourceTest {
     @Timeout(600_000)
     public void solveDemoDataUntilFeasible() throws InterruptedException {
         timeTableResource.solve();
-        TimeTable timeTable = timeTableResource.getTimeTable();
-        while (timeTable.getSolverStatus() != SolverStatus.NOT_SOLVING) {
+        TimeTable timeTable;
+        do { // Use do-while to give the solver some time and avoid retrieving an early infeasible solution.
             // Quick polling (not a Test Thread Sleep anti-pattern)
             // Test is still fast on fast machines and doesn't randomly fail on slow machines.
             Thread.sleep(20L);
             timeTable = timeTableResource.getTimeTable();
-        }
+        } while (timeTable.getSolverStatus() != SolverStatus.NOT_SOLVING);
         assertFalse(timeTable.getLessonList().isEmpty());
         for (Lesson lesson : timeTable.getLessonList()) {
             assertNotNull(lesson.getTimeslot());

--- a/optaplanner-quickstarts/spring-boot-school-timetabling/src/test/java/com/example/schooltimetabling/solver/TimeTableControllerTest.java
+++ b/optaplanner-quickstarts/spring-boot-school-timetabling/src/test/java/com/example/schooltimetabling/solver/TimeTableControllerTest.java
@@ -38,18 +38,17 @@ public class TimeTableControllerTest {
     @Autowired
     private TimeTableController timeTableController;
 
-    @Disabled("PLANNER-2254")
     @Test
     @Timeout(600_000)
     public void solveDemoDataUntilFeasible() throws InterruptedException {
         timeTableController.solve();
-        TimeTable timeTable = timeTableController.getTimeTable();
-        while (timeTable.getSolverStatus() != SolverStatus.NOT_SOLVING) {
+        TimeTable timeTable;
+        do { // Use do-while to give the solver some time and avoid retrieving an early infeasible solution.
             // Quick polling (not a Test Thread Sleep anti-pattern)
             // Test is still fast on fast machines and doesn't randomly fail on slow machines.
             Thread.sleep(20L);
             timeTable = timeTableController.getTimeTable();
-        }
+        } while (timeTable.getSolverStatus() != SolverStatus.NOT_SOLVING);
         assertFalse(timeTable.getLessonList().isEmpty());
         for (Lesson lesson : timeTable.getLessonList()) {
             assertNotNull(lesson.getTimeslot());


### PR DESCRIPTION
Backporting the https://github.com/kiegroup/optaplanner-quickstarts/pull/48, as the flaky test was disabled on the 7.x branch.

<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.
-->

### JIRA
https://issues.redhat.com/browse/PLANNER-2254

<!-- Add a JIRA ticket link if it exists. -->
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
* https://github.com/kiegroup/drools/pull/3000
* https://github.com/kiegroup/optaplanner/pull/899
* etc.
-->

### Checklist
- [ ] Documentation updated if applicable.
- [ ] Upgrade recipe provided if applicable.

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>full downstream build</b> please add comment: <b>Jenkins run fdb</b>
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
