### PR TITLE
Fix quickstarts build: fix fail fast that triggered unneeded for a @PlanningId use of school-timetabling's Room class

### DIFF
--- a/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/main/java/org/optaplanner/quarkus/deployment/DotNames.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/main/java/org/optaplanner/quarkus/deployment/DotNames.java
@@ -70,7 +70,6 @@ public final class DotNames {
 
     static final DotName[] PLANNING_ENTITY_FIELD_ANNOTATIONS = {
             PLANNING_PIN,
-            PLANNING_ID,
             PLANNING_VARIABLE,
             ANCHOR_SHADOW_VARIABLE,
             CUSTOM_SHADOW_VARIABLE,

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/main/java/org/optaplanner/quarkus/deployment/OptaPlannerProcessor.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/main/java/org/optaplanner/quarkus/deployment/OptaPlannerProcessor.java
@@ -285,12 +285,11 @@ class OptaPlannerProcessor {
             if (!declaringClass.annotations().containsKey(DotNames.PLANNING_ENTITY)) {
                 throw new IllegalStateException(prefix + "with a @" +
                         annotationInstance.name().withoutPackagePrefix() +
-                        " annotation is in a class (" + declaringClass.name().toString()
+                        " annotation is in a class (" + declaringClass.name()
                         + ") that does not have a @" + PlanningEntity.class.getSimpleName() +
-                        "annotation.\n" +
+                        " annotation.\n" +
                         "Maybe add a @" + PlanningEntity.class.getSimpleName() +
-                        " annotation to (" +
-                        declaringClass.name().toString() + ")?");
+                        " annotation on the class (" + declaringClass.name() + ").");
             }
         }
     }
@@ -472,9 +471,8 @@ class OptaPlannerProcessor {
                                     debuggableClassOutput,
                                     classInfo, fieldInfo, transformers);
                         } catch (ClassNotFoundException e) {
-                            throw new IllegalStateException("Fail to generate member accessor for field (" +
-                                    fieldInfo.name() + ") of class " +
-                                    classInfo.name().toString() + ".", e);
+                            throw new IllegalStateException("Failed to generate member accessor for the field (" +
+                                    fieldInfo.name() + ") of the class (" + classInfo.name() + ").", e);
                         }
                     }
                     break;
@@ -489,9 +487,9 @@ class OptaPlannerProcessor {
                                     debuggableClassOutput,
                                     classInfo, methodInfo, transformers);
                         } catch (ClassNotFoundException e) {
-                            throw new IllegalStateException("Fail to generate member accessor for method (" +
-                                    methodInfo.name() + ") of class " +
-                                    classInfo.name().toString() + ".", e);
+                            throw new IllegalStateException("Failed to generate member accessor for the method (" +
+                                    methodInfo.name() + ") of the class (" +
+                                    classInfo.name() + ").", e);
                         }
                     }
                     break;

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/test/java/org/optaplanner/quarkus/OptaPlannerProcessorInvalidTest.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/test/java/org/optaplanner/quarkus/OptaPlannerProcessorInvalidTest.java
@@ -48,12 +48,11 @@ public class OptaPlannerProcessorInvalidTest {
                             TestdataInvalidQuarkusConstraintProvider.class))
             .assertException(exception -> {
                 assertEquals(IllegalStateException.class, exception.getClass());
-                assertEquals("The field (entityList) with a @InverseRelationShadowVariable annotation is in a" +
-                        " class (org.optaplanner.quarkus.testdata.invalid.inverserelation.domain.TestdataInvalidInverseRelationValue)"
+                assertEquals("The field (entityList) with a @InverseRelationShadowVariable annotation is" +
+                        " in a class (org.optaplanner.quarkus.testdata.invalid.inverserelation.domain.TestdataInvalidInverseRelationValue)"
                         +
-                        " that does not have a @PlanningEntityannotation.\n" +
-                        "Maybe add a @PlanningEntity annotation to " +
-                        "(org.optaplanner.quarkus.testdata.invalid.inverserelation.domain.TestdataInvalidInverseRelationValue)?",
+                        " that does not have a @PlanningEntity annotation.\n" +
+                        "Maybe add a @PlanningEntity annotation on the class (org.optaplanner.quarkus.testdata.invalid.inverserelation.domain.TestdataInvalidInverseRelationValue).",
                         exception.getMessage());
             });
 


### PR DESCRIPTION
Replaces #1127 
<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.
-->

### JIRA

<!-- Add a JIRA ticket link if it exists. -->
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
* https://github.com/kiegroup/drools/pull/3000
* https://github.com/kiegroup/optaplanner/pull/899
* etc.
-->

### Checklist
- [ ] Documentation updated if applicable.
- [ ] Upgrade recipe provided if applicable.

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>full downstream build</b> please add comment: <b>Jenkins run fdb</b>
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
