### PR TITLE
Remove comment in sed path matching

### DIFF
--- a/Jenkinsfile.promote
+++ b/Jenkinsfile.promote
@@ -530,7 +530,7 @@ def updateAndResetBranch(String repo, String branchToReset) {
 void removeJbossNexusFromMavenAndGradle() {
     sh "sed -i \':a;N;\$!ba;s/\\n *<repositories>.*<\\/repositories>//g\' */pom.xml"
     sh "sed -i \':a;N;\$!ba;s/\\n *<repositories>.*<\\/repositories>//g\' pom.xml"
-    sh "sed -i \':a;N;\$!ba;s/\\n *\\/\\/ To get snapshots during development[^{}]*maven {[^{}]*mavenContent " +
+    sh "sed -i \':a;N;\$!ba;s/\\n *maven {[^{}]*mavenContent " +
             "{[^{}]*snapshotsOnly[^{}]*}[^{}]*}//g\' */build.gradle"
 
     assert !sh (script:


### PR DESCRIPTION
In 42e8e3374512ef45eb089aaf9caf667d20f8bfd1 I had removed the comment and during implementation of the pipeline forget to remove dependency on the comment in the matching pattern of sed.
Fixed that

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>full downstream build</b> please add comment: <b>Jenkins run fdb</b>
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
