### PR TITLE
Add integration-tests profile

### DIFF
--- a/Jenkinsfile.deploy
+++ b/Jenkinsfile.deploy
@@ -38,6 +38,7 @@ pipeline {
         string(name: 'MAVEN_DEPENDENCIES_REPOSITORY', defaultValue: '', description: 'Maven repository where to find dependencies if those are not in the default JBoss repository.')
         string(name: 'MAVEN_REPO_CREDS_ID', defaultValue: '', description: 'Credentials for Maven repository to deploy the artifacts.')
         booleanParam(name: 'SKIP_TESTS', defaultValue: false, description: 'Skip tests')
+        booleanParam(name: 'SKIP_INTEGRATION_TESTS', defaultValue: false, description: 'Skip big integration tests')
         string(name: 'MAVEN_SETTINGS_CONFIG_FILE_ID', defaultValue: 'kogito_release_settings', description: 'Maven settings configfile to use in pipeline for Maven commands')
 
         // Deploy information
@@ -172,14 +173,14 @@ pipeline {
         stage("Build Vehicle Routing") {
             steps {
                 script {
-                    getOptawebVehicleRoutingMavenCommand().skipTests(params.SKIP_TESTS).run('clean install')
+                    getOptawebVehicleRoutingMavenCommand().skipTests(params.SKIP_TESTS)
+                            .withProfiles(getIntegrationTestProfiles()).run('clean install')
                 }
             }
             post {
                 always {
                     saveReports(params.SKIP_TESTS)
-                    // TODO: Enable together with the profile "integration-tests" once dockerhub pull limit is resolved.
-                    // archiveArtifacts(allowEmptyArchive: true, artifacts: "**/cypress/screenshots/**,**/cypress/videos/**", fingerprint: false)
+                    saveArtifacts(params.SKIP_INTEGRATION_TESTS)
                 }
             }
         }
@@ -187,14 +188,14 @@ pipeline {
         stage("Build Employee Rostering") {
             steps {
                 script {
-                    getOptawebEmployeeRosteringMavenCommand().skipTests(params.SKIP_TESTS).run('clean install')
+                    getOptawebEmployeeRosteringMavenCommand().skipTests(params.SKIP_TESTS)
+                            .withProfiles(getIntegrationTestProfiles()).run('clean install')
                 }
             }
             post {
                 always {
                     saveReports(params.SKIP_TESTS)
-                    // TODO: Enable together with the profile "integration-tests" once dockerhub pull limit is resolved.
-                    // archiveArtifacts(allowEmptyArchive: true, artifacts: "**/cypress/screenshots/**,**/cypress/videos/**", fingerprint: false)
+                    saveArtifacts(params.SKIP_INTEGRATION_TESTS)
                 }
             }
         }
@@ -251,6 +252,20 @@ pipeline {
             cleanWs()
         }
     }
+}
+
+void saveArtifacts(boolean skipIntegrationTests=false) {
+    if (!skipIntegrationTests) {
+        archiveArtifacts(allowEmptyArchive: true, artifacts: "**/cypress/screenshots/**,**/cypress/videos/**", fingerprint: false)
+    }
+}
+
+List getIntegrationTestProfiles(){
+    integrationTestProfiles = []
+    if (!params.SKIP_INTEGRATION_TESTS) {
+        integrationTestProfiles.add('integration-tests')
+    }
+    return integrationTestProfiles
 }
 
 void updateQuickstartsVersions(){

--- a/Jenkinsfile.deploy
+++ b/Jenkinsfile.deploy
@@ -261,11 +261,7 @@ void saveArtifacts(boolean skipIntegrationTests=false) {
 }
 
 List getIntegrationTestProfiles(){
-    integrationTestProfiles = []
-    if (!params.SKIP_INTEGRATION_TESTS) {
-        integrationTestProfiles.add('integration-tests')
-    }
-    return integrationTestProfiles
+    return params.SKIP_INTEGRATION_TESTS ? [] : ['integration-tests']
 }
 
 void updateQuickstartsVersions(){

--- a/Jenkinsfile.deploy
+++ b/Jenkinsfile.deploy
@@ -173,8 +173,24 @@ pipeline {
         stage("Build Vehicle Routing") {
             steps {
                 script {
-                    getOptawebVehicleRoutingMavenCommand().skipTests(params.SKIP_TESTS)
-                            .withProfiles(getIntegrationTestProfiles()).run('clean install')
+                    getOptawebVehicleRoutingMavenCommand().skipTests(params.SKIP_TESTS).run('clean install')
+                }
+            }
+            post {
+                always {
+                    saveReports(params.SKIP_TESTS)
+                }
+            }
+        }
+
+        stage("Run integration tests Vehicle Routing") {
+            when {
+                expression { return !isRelease() }
+            }
+            steps {
+                script {
+                    getOptawebVehicleRoutingMavenCommand().skipTests(true)
+                            .withProfiles(getIntegrationTestProfiles()).run('verify')
                 }
             }
             post {
@@ -188,8 +204,24 @@ pipeline {
         stage("Build Employee Rostering") {
             steps {
                 script {
-                    getOptawebEmployeeRosteringMavenCommand().skipTests(params.SKIP_TESTS)
-                            .withProfiles(getIntegrationTestProfiles()).run('clean install')
+                    getOptawebEmployeeRosteringMavenCommand().skipTests(params.SKIP_TESTS).run('clean install')
+                }
+            }
+            post {
+                always {
+                    saveReports(params.SKIP_TESTS)
+                }
+            }
+        }
+
+        stage("Run integration tests Employee Rostering") {
+            when {
+                expression { return !isRelease() }
+            }
+            steps {
+                script {
+                    getOptawebEmployeeRosteringMavenCommand().skipTests(true)
+                            .withProfiles(getIntegrationTestProfiles()).run('verify')
                 }
             }
             post {

--- a/Jenkinsfile.deploy
+++ b/Jenkinsfile.deploy
@@ -195,7 +195,6 @@ pipeline {
             }
             post {
                 always {
-                    saveReports(params.SKIP_TESTS)
                     saveArtifacts(params.SKIP_INTEGRATION_TESTS)
                 }
             }
@@ -226,7 +225,6 @@ pipeline {
             }
             post {
                 always {
-                    saveReports(params.SKIP_TESTS)
                     saveArtifacts(params.SKIP_INTEGRATION_TESTS)
                 }
             }

--- a/Jenkinsfile.deploy
+++ b/Jenkinsfile.deploy
@@ -173,28 +173,12 @@ pipeline {
         stage("Build Vehicle Routing") {
             steps {
                 script {
-                    getOptawebVehicleRoutingMavenCommand().skipTests(params.SKIP_TESTS).run('clean install')
+                    buildOptaweb(getOptawebVehicleRoutingMavenCommand())
                 }
             }
             post {
                 always {
                     saveReports(params.SKIP_TESTS)
-                }
-            }
-        }
-
-        stage("Run integration tests Vehicle Routing") {
-            when {
-                expression { return !isRelease() }
-            }
-            steps {
-                script {
-                    getOptawebVehicleRoutingMavenCommand().skipTests(true)
-                            .withProfiles(getIntegrationTestProfiles()).run('verify')
-                }
-            }
-            post {
-                always {
                     saveArtifacts(params.SKIP_INTEGRATION_TESTS)
                 }
             }
@@ -203,28 +187,12 @@ pipeline {
         stage("Build Employee Rostering") {
             steps {
                 script {
-                    getOptawebEmployeeRosteringMavenCommand().skipTests(params.SKIP_TESTS).run('clean install')
+                    buildOptaweb(getOptawebEmployeeRosteringMavenCommand())
                 }
             }
             post {
                 always {
                     saveReports(params.SKIP_TESTS)
-                }
-            }
-        }
-
-        stage("Run integration tests Employee Rostering") {
-            when {
-                expression { return !isRelease() }
-            }
-            steps {
-                script {
-                    getOptawebEmployeeRosteringMavenCommand().skipTests(true)
-                            .withProfiles(getIntegrationTestProfiles()).run('verify')
-                }
-            }
-            post {
-                always {
                     saveArtifacts(params.SKIP_INTEGRATION_TESTS)
                 }
             }
@@ -282,6 +250,14 @@ pipeline {
             cleanWs()
         }
     }
+}
+
+void buildOptaweb(MavenCommand optawebCommand){
+    MavenCommand buildCommand = optawebCommand
+    if (!isRelease()) {
+        buildCommand = buildCommand.withProfiles(getIntegrationTestProfiles())
+    }
+    buildCommand.skipTests(params.SKIP_TESTS).run('clean install')
 }
 
 void saveArtifacts(boolean skipIntegrationTests=false) {

--- a/Jenkinsfile.deploy
+++ b/Jenkinsfile.deploy
@@ -255,9 +255,7 @@ pipeline {
 }
 
 void saveArtifacts(boolean skipIntegrationTests=false) {
-    if (!skipIntegrationTests) {
-        archiveArtifacts(allowEmptyArchive: true, artifacts: "**/cypress/screenshots/**,**/cypress/videos/**", fingerprint: false)
-    }
+        archiveArtifacts(allowEmptyArchive: skipIntegrationTests, artifacts: "**/cypress/screenshots/**,**/cypress/videos/**", fingerprint: false)
 }
 
 List getIntegrationTestProfiles(){


### PR DESCRIPTION
Runs cypress tests on ERP and VRP if SKIP_INTEGRATION_TESTS id is false

### JIRA

https://issues.redhat.com/browse/PLANNER-2329

### Referenced pull requests
https://github.com/kiegroup/optaweb-vehicle-routing/pull/426
https://github.com/kiegroup/optaweb-employee-rostering/pull/565

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>full downstream build</b> please add comment: <b>Jenkins run fdb</b>
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
