### PR TITLE
KOGITO-4501 Clean node in pipelines

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -62,7 +62,6 @@ pipeline {
         always {
             sh '$WORKSPACE/trace.sh'
             junit '**/target/surefire-reports/**/*.xml, **/target/failsafe-reports/**/*.xml'
-            cleanWs()
         }
         failure {
             script {
@@ -77,6 +76,12 @@ pipeline {
         fixed {
             script {
                 mailer.sendEmail_fixedPR()
+            }
+        }
+        cleanup {
+            script {
+                // Clean also docker in case of usage of testcontainers lib
+                util.cleanNode('docker')
             }
         }
     }

--- a/Jenkinsfile.deploy
+++ b/Jenkinsfile.deploy
@@ -221,7 +221,12 @@ pipeline {
                 writeFile(text: propertiesStr, file: env.PROPERTIES_FILE_NAME)
                 archiveArtifacts(artifacts: env.PROPERTIES_FILE_NAME)
             }
-            cleanWs()
+        }
+        cleanup {
+            script {
+                // Clean also docker in case of usage of testcontainers lib
+                util.cleanNode('docker')
+            }
         }
     }
 }

--- a/Jenkinsfile.promote
+++ b/Jenkinsfile.promote
@@ -284,8 +284,11 @@ pipeline {
         }
     }
     post {
-        always {
-            cleanWs()
+        cleanup {
+            script {
+                // Clean also docker in case of usage of testcontainers lib
+                util.cleanNode('docker')
+            }
         }
     }
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/KOGITO-4501

Use shared library to clean the node used by Jenkins.
This will also allow to improve the shared lib later on without having to modify all pipelines.

Related PRs:
- https://github.com/kiegroup/kogito-runtimes/pull/1090
- https://github.com/kiegroup/optaplanner/pull/1172
- https://github.com/kiegroup/kogito-apps/pull/665
- https://github.com/kiegroup/kogito-examples/pull/584