### PR TITLE
Upgrade Quarkus to 1.11.4.Final

### DIFF
--- a/build/optaplanner-build-parent/pom.xml
+++ b/build/optaplanner-build-parent/pom.xml
@@ -30,7 +30,7 @@
     <version.com.fasterxml.jackson.core>2.12.1</version.com.fasterxml.jackson.core>
     <version.com.h2database>1.3.173</version.com.h2database>
     <version.com.thoughtworks.xstream>1.4.15</version.com.thoughtworks.xstream>
-    <version.io.quarkus>1.11.0.Final</version.io.quarkus>
+    <version.io.quarkus>1.11.4.Final</version.io.quarkus>
     <version.io.quarkus.gizmo>1.0.6.Final</version.io.quarkus.gizmo>
     <version.org.ow2.asm>9.0</version.org.ow2.asm>
     <version.jakarta.json.bind>1.0.2</version.jakarta.json.bind>


### PR DESCRIPTION
Upgrading the `8.3.x` branch to the same version of Quarkus that Kogito is going to use.

The Quarkus 1.11.4.Final should be available tomorrow.

<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.
-->

### JIRA

<!-- Add a JIRA ticket link if it exists. -->
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->

### Referenced pull requests
https://github.com/kiegroup/optaplanner-quickstarts/pull/64
<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
* https://github.com/kiegroup/drools/pull/3000
* https://github.com/kiegroup/optaplanner/pull/899
* etc.
-->

### Checklist
- [ ] Documentation updated if applicable.
- [ ] Upgrade recipe provided if applicable.

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>full downstream build</b> please add comment: <b>Jenkins run fdb</b>
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
