### PR TITLE
Default domain access type is different betwen Quarkus and Spring Boot

### DIFF
--- a/optaplanner-docs/src/main/asciidoc/Integration/config-properties.adoc
+++ b/optaplanner-docs/src/main/asciidoc/Integration/config-properties.adoc
@@ -36,7 +36,14 @@ See <<multithreadedIncrementalSolving,multithreaded incremental solving>>.
 {property_prefix}optaplanner.solver.domain-access-type::
 How OptaPlanner should access the domain model.
 See <<domainAccess,the domain access section>> for more details.
+ifeval::["{property_prefix}" == "quarkus."]
+Defaults to `GIZMO`.
+The other possible value is `REFLECTION`.
+endif::[]
+ifeval::["{property_prefix}" == ""]
 Defaults to `REFLECTION`.
+The other possible value is `GIZMO`.
+endif::[]
 
 {property_prefix}optaplanner.solver.termination.spent-limit::
 How long the solver can run.


### PR DESCRIPTION
<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.
-->

### JIRA

<!-- Add a JIRA ticket link if it exists. -->
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
* https://github.com/kiegroup/drools/pull/3000
* https://github.com/kiegroup/optaplanner/pull/899
* etc.
-->

### Checklist
- [ ] Documentation updated if applicable.
- [ ] Upgrade recipe provided if applicable.

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>full downstream build</b> please add comment: <b>Jenkins run fdb</b>
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
