### PR TITLE
PLANNER-2345: Allow @Inject ConstraintVerifier in tests in Quarkus

### DIFF
--- a/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/pom.xml
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/pom.xml
@@ -71,6 +71,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.optaplanner</groupId>
+      <artifactId>optaplanner-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/main/java/org/optaplanner/quarkus/deployment/DotNames.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/main/java/org/optaplanner/quarkus/deployment/DotNames.java
@@ -71,6 +71,9 @@ public final class DotNames {
     static final DotName CUSTOM_SHADOW_VARIABLE = DotName.createSimple(CustomShadowVariable.class.getName());
     static final DotName INVERSE_RELATION_SHADOW_VARIABLE = DotName.createSimple(InverseRelationShadowVariable.class.getName());
 
+    // Need to use String since optaplanner-test is not on the compile classpath
+    static final DotName CONSTRAINT_VERIFIER = DotName.createSimple("org.optaplanner.test.api.score.stream.ConstraintVerifier");
+
     static final DotName[] PLANNING_ENTITY_FIELD_ANNOTATIONS = {
             PLANNING_PIN,
             PLANNING_VARIABLE,

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/main/java/org/optaplanner/quarkus/deployment/OptaPlannerProcessor.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/main/java/org/optaplanner/quarkus/deployment/OptaPlannerProcessor.java
@@ -32,7 +32,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Singleton;
 
 import org.apache.commons.lang3.ObjectUtils;
@@ -217,7 +216,7 @@ class OptaPlannerProcessor {
                     ObjectUtils.defaultIfNull(solverConfig.getScoreDirectorFactoryConfig().getConstraintStreamImplType(),
                             ConstraintStreamImplType.DROOLS);
             syntheticBeanBuildItemBuildProducer.produce(SyntheticBeanBuildItem.configure(DotNames.CONSTRAINT_VERIFIER)
-                    .scope(ApplicationScoped.class)
+                    .scope(Singleton.class)
                     .creator(methodCreator -> {
                         ResultHandle constraintProviderResultHandle =
                                 methodCreator.newInstance(MethodDescriptor.ofConstructor(constraintProviderClass));

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/test/java/org/optaplanner/quarkus/verifier/OptaPlannerConstraintVerifierBavetStreamImplTest.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/test/java/org/optaplanner/quarkus/verifier/OptaPlannerConstraintVerifierBavetStreamImplTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.quarkus.verifier;
+
+import java.util.Arrays;
+
+import javax.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.optaplanner.core.api.score.buildin.simple.SimpleScore;
+import org.optaplanner.core.api.score.stream.ConstraintStreamImplType;
+import org.optaplanner.quarkus.testdata.normal.constraints.TestdataQuarkusConstraintProvider;
+import org.optaplanner.quarkus.testdata.normal.domain.TestdataQuarkusEntity;
+import org.optaplanner.quarkus.testdata.normal.domain.TestdataQuarkusSolution;
+import org.optaplanner.test.api.score.stream.ConstraintVerifier;
+import org.optaplanner.test.impl.score.stream.DefaultConstraintVerifier;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class OptaPlannerConstraintVerifierBavetStreamImplTest {
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(TestdataQuarkusEntity.class,
+                            TestdataQuarkusSolution.class, TestdataQuarkusConstraintProvider.class)
+                    .addAsResource("org/optaplanner/quarkus/bavetSolverConfig.xml", "solverConfig.xml"));
+
+    @Inject
+    ConstraintVerifier<TestdataQuarkusConstraintProvider, TestdataQuarkusSolution> constraintVerifier;
+
+    @Test
+    public void constraintVerifierDroolsStreamImpl() {
+        Assertions.assertEquals(ConstraintStreamImplType.BAVET,
+                ((DefaultConstraintVerifier<?, ?, ?>) constraintVerifier)
+                        .getConstraintStreamImplType());
+        TestdataQuarkusSolution solution = new TestdataQuarkusSolution();
+        TestdataQuarkusEntity entityA = new TestdataQuarkusEntity();
+        TestdataQuarkusEntity entityB = new TestdataQuarkusEntity();
+        entityA.setValue("A");
+        entityB.setValue("A");
+
+        solution.setEntityList(Arrays.asList(
+                entityA, entityB));
+        solution.setValueList(Arrays.asList("A", "B"));
+        constraintVerifier.verifyThat().givenSolution(solution).scores(SimpleScore.of(-2));
+
+        entityB.setValue("B");
+        constraintVerifier.verifyThat().givenSolution(solution).scores(SimpleScore.ZERO);
+    }
+}

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/test/java/org/optaplanner/quarkus/verifier/OptaPlannerConstraintVerifierDroolsStreamImplTest.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/test/java/org/optaplanner/quarkus/verifier/OptaPlannerConstraintVerifierDroolsStreamImplTest.java
@@ -22,17 +22,20 @@ import javax.inject.Inject;
 
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.optaplanner.core.api.score.buildin.simple.SimpleScore;
+import org.optaplanner.core.api.score.stream.ConstraintStreamImplType;
 import org.optaplanner.quarkus.testdata.normal.constraints.TestdataQuarkusConstraintProvider;
 import org.optaplanner.quarkus.testdata.normal.domain.TestdataQuarkusEntity;
 import org.optaplanner.quarkus.testdata.normal.domain.TestdataQuarkusSolution;
 import org.optaplanner.test.api.score.stream.ConstraintVerifier;
+import org.optaplanner.test.impl.score.stream.DefaultConstraintVerifier;
 
 import io.quarkus.test.QuarkusUnitTest;
 
-public class OptaPlannerConstraintVerifierTest {
+public class OptaPlannerConstraintVerifierDroolsStreamImplTest {
     @RegisterExtension
     static final QuarkusUnitTest config = new QuarkusUnitTest()
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
@@ -43,7 +46,10 @@ public class OptaPlannerConstraintVerifierTest {
     ConstraintVerifier<TestdataQuarkusConstraintProvider, TestdataQuarkusSolution> constraintVerifier;
 
     @Test
-    public void constraintVerifier() {
+    public void constraintVerifierDroolsStreamImpl() {
+        Assertions.assertEquals(ConstraintStreamImplType.DROOLS,
+                ((DefaultConstraintVerifier<?, ?, ?>) constraintVerifier)
+                        .getConstraintStreamImplType());
         TestdataQuarkusSolution solution = new TestdataQuarkusSolution();
         TestdataQuarkusEntity entityA = new TestdataQuarkusEntity();
         TestdataQuarkusEntity entityB = new TestdataQuarkusEntity();

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/test/java/org/optaplanner/quarkus/verifier/OptaPlannerConstraintVerifierTest.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/test/java/org/optaplanner/quarkus/verifier/OptaPlannerConstraintVerifierTest.java
@@ -57,6 +57,5 @@ public class OptaPlannerConstraintVerifierTest {
 
         entityB.setValue("B");
         constraintVerifier.verifyThat().givenSolution(solution).scores(SimpleScore.ZERO);
-
     }
 }

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/test/java/org/optaplanner/quarkus/verifier/OptaPlannerConstraintVerifierTest.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/test/java/org/optaplanner/quarkus/verifier/OptaPlannerConstraintVerifierTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.quarkus.verifier;
+
+import java.util.Arrays;
+
+import javax.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.optaplanner.core.api.score.buildin.simple.SimpleScore;
+import org.optaplanner.quarkus.testdata.normal.constraints.TestdataQuarkusConstraintProvider;
+import org.optaplanner.quarkus.testdata.normal.domain.TestdataQuarkusEntity;
+import org.optaplanner.quarkus.testdata.normal.domain.TestdataQuarkusSolution;
+import org.optaplanner.test.api.score.stream.ConstraintVerifier;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class OptaPlannerConstraintVerifierTest {
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(TestdataQuarkusEntity.class,
+                            TestdataQuarkusSolution.class, TestdataQuarkusConstraintProvider.class));
+
+    @Inject
+    ConstraintVerifier<TestdataQuarkusConstraintProvider, TestdataQuarkusSolution> constraintVerifier;
+
+    @Test
+    public void constraintVerifier() {
+        TestdataQuarkusSolution solution = new TestdataQuarkusSolution();
+        TestdataQuarkusEntity entityA = new TestdataQuarkusEntity();
+        TestdataQuarkusEntity entityB = new TestdataQuarkusEntity();
+        entityA.setValue("A");
+        entityB.setValue("A");
+
+        solution.setEntityList(Arrays.asList(
+                entityA, entityB));
+        solution.setValueList(Arrays.asList("A", "B"));
+        constraintVerifier.verifyThat().givenSolution(solution).scores(SimpleScore.of(-2));
+
+        entityB.setValue("B");
+        constraintVerifier.verifyThat().givenSolution(solution).scores(SimpleScore.ZERO);
+
+    }
+}

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/test/resources/org/optaplanner/quarkus/bavetSolverConfig.xml
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/test/resources/org/optaplanner/quarkus/bavetSolverConfig.xml
@@ -1,0 +1,25 @@
+<!--
+  ~ Copyright 2020 Red Hat, Inc. and/or its affiliates.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<solver>
+  <scoreDirectorFactory>
+    <constraintStreamImplType>BAVET</constraintStreamImplType>
+    <constraintProviderClass>org.optaplanner.quarkus.testdata.normal.constraints.TestdataQuarkusConstraintProvider</constraintProviderClass>
+  </scoreDirectorFactory>
+  <termination>
+    <secondsSpentLimit>2</secondsSpentLimit>
+  </termination>
+</solver>

--- a/optaplanner-test/src/main/java/org/optaplanner/test/impl/score/stream/DefaultConstraintVerifier.java
+++ b/optaplanner-test/src/main/java/org/optaplanner/test/impl/score/stream/DefaultConstraintVerifier.java
@@ -45,6 +45,10 @@ public final class DefaultConstraintVerifier<ConstraintProvider_ extends Constra
         return solutionDescriptor;
     }
 
+    public ConstraintStreamImplType getConstraintStreamImplType() {
+        return constraintStreamImplType;
+    }
+
     @Override
     public ConstraintVerifier<ConstraintProvider_, Solution_> withConstraintStreamImplType(
             ConstraintStreamImplType constraintStreamImplType) {


### PR DESCRIPTION
No new dependencies added to optaplanner-quarkus; it detects if ConstraintVerifier is on the classpath, and if so, create a Gizmo supplier of the ConstraintVerifier.
<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.
-->

### JIRA

<!-- Add a JIRA ticket link if it exists. -->
https://issues.redhat.com/browse/PLANNER-2345
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
* https://github.com/kiegroup/drools/pull/3000
* https://github.com/kiegroup/optaplanner/pull/899
* etc.
-->

### Checklist
- [ ] Documentation updated if applicable.
- [ ] Upgrade recipe provided if applicable.

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>full downstream build</b> please add comment: <b>Jenkins run fdb</b>
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
