### PR TITLE
PLANNER-2345: Add auto-configure for ConstraintVerifier in Spring Boot

### DIFF
--- a/optaplanner-spring-integration/optaplanner-spring-boot-autoconfigure/pom.xml
+++ b/optaplanner-spring-integration/optaplanner-spring-boot-autoconfigure/pom.xml
@@ -32,7 +32,15 @@
       <artifactId>optaplanner-core</artifactId>
       <optional>true</optional>
     </dependency>
+
+    <!-- Need this so we can @Autowire ConstraintVerifier -->
     <dependency>
+      <groupId>org.optaplanner</groupId>
+      <artifactId>optaplanner-test</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+
       <groupId>org.optaplanner</groupId>
       <artifactId>optaplanner-persistence-jackson</artifactId>
       <optional>true</optional>

--- a/optaplanner-spring-integration/optaplanner-spring-boot-autoconfigure/pom.xml
+++ b/optaplanner-spring-integration/optaplanner-spring-boot-autoconfigure/pom.xml
@@ -39,8 +39,8 @@
       <artifactId>optaplanner-test</artifactId>
       <optional>true</optional>
     </dependency>
-    <dependency>
 
+    <dependency>
       <groupId>org.optaplanner</groupId>
       <artifactId>optaplanner-persistence-jackson</artifactId>
       <optional>true</optional>

--- a/optaplanner-spring-integration/optaplanner-spring-boot-autoconfigure/src/main/java/org/optaplanner/spring/boot/autoconfigure/OptaPlannerAutoConfiguration.java
+++ b/optaplanner-spring-integration/optaplanner-spring-boot-autoconfigure/src/main/java/org/optaplanner/spring/boot/autoconfigure/OptaPlannerAutoConfiguration.java
@@ -145,7 +145,8 @@ public class OptaPlannerAutoConfiguration implements BeanClassLoaderAware {
     @ConditionalOnClass({ ConstraintVerifier.class })
     @ConditionalOnMissingBean({ ConstraintVerifier.class })
     @SuppressWarnings("unchecked")
-    public <ConstraintProvider_ extends ConstraintProvider, SolutionClass_> ConstraintVerifier<ConstraintProvider_, SolutionClass_> constraintVerifier(SolverConfig solverConfig) {
+    public <ConstraintProvider_ extends ConstraintProvider, SolutionClass_>
+            ConstraintVerifier<ConstraintProvider_, SolutionClass_> constraintVerifier(SolverConfig solverConfig) {
         if (solverConfig.getScoreDirectorFactoryConfig().getConstraintProviderClass() == null) {
             // Return a mock ConstraintVerifier so not having ConstraintProvider doesn't crash tests
             // (Cannot create custom condition that checks SolverConfig, since that
@@ -153,12 +154,14 @@ public class OptaPlannerAutoConfiguration implements BeanClassLoaderAware {
             final String noConstraintProviderErrorMsg = "ConstraintVerifier is only supported for ConstraintProviders";
             return new ConstraintVerifier<ConstraintProvider_, SolutionClass_>() {
                 @Override
-                public ConstraintVerifier<ConstraintProvider_, SolutionClass_> withConstraintStreamImplType(ConstraintStreamImplType constraintStreamImplType) {
+                public ConstraintVerifier<ConstraintProvider_, SolutionClass_>
+                        withConstraintStreamImplType(ConstraintStreamImplType constraintStreamImplType) {
                     throw new UnsupportedOperationException(noConstraintProviderErrorMsg);
                 }
 
                 @Override
-                public SingleConstraintVerification<SolutionClass_> verifyThat(BiFunction<ConstraintProvider_, ConstraintFactory, Constraint> constraintFunction) {
+                public SingleConstraintVerification<SolutionClass_>
+                        verifyThat(BiFunction<ConstraintProvider_, ConstraintFactory, Constraint> constraintFunction) {
                     throw new UnsupportedOperationException(noConstraintProviderErrorMsg);
                 }
 
@@ -169,11 +172,15 @@ public class OptaPlannerAutoConfiguration implements BeanClassLoaderAware {
             };
         }
         ConstraintProvider_ constraintProvider = ConfigUtils.newInstance(this, "constraintProvider",
-                                                                         (Class<ConstraintProvider_>) solverConfig.getScoreDirectorFactoryConfig().getConstraintProviderClass());
-        Class<?>[] entityClasses =  solverConfig.getEntityClassList().toArray(new Class<?>[0]);
+                (Class<ConstraintProvider_>) solverConfig.getScoreDirectorFactoryConfig().getConstraintProviderClass());
+        Class<?>[] entityClasses = solverConfig.getEntityClassList().toArray(new Class<?>[0]);
+        ConstraintStreamImplType constraintStreamImplType =
+                solverConfig.getScoreDirectorFactoryConfig().getConstraintStreamImplType();
+
         return (ConstraintVerifier<ConstraintProvider_, SolutionClass_>) ConstraintVerifier.build(constraintProvider,
-                                                                                                  solverConfig.getSolutionClass(),
-                                                                                                  entityClasses);
+                solverConfig.getSolutionClass(),
+                entityClasses).withConstraintStreamImplType(
+                        (constraintStreamImplType != null) ? constraintStreamImplType : ConstraintStreamImplType.DROOLS);
     }
 
     private void applySolverProperties(SolverConfig solverConfig) {

--- a/optaplanner-spring-integration/optaplanner-spring-boot-autoconfigure/src/main/java/org/optaplanner/spring/boot/autoconfigure/OptaPlannerAutoConfiguration.java
+++ b/optaplanner-spring-integration/optaplanner-spring-boot-autoconfigure/src/main/java/org/optaplanner/spring/boot/autoconfigure/OptaPlannerAutoConfiguration.java
@@ -22,6 +22,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.function.BiFunction;
 import java.util.stream.Collectors;
 
 import org.optaplanner.core.api.domain.entity.PlanningEntity;
@@ -30,14 +31,21 @@ import org.optaplanner.core.api.score.Score;
 import org.optaplanner.core.api.score.ScoreManager;
 import org.optaplanner.core.api.score.calculator.EasyScoreCalculator;
 import org.optaplanner.core.api.score.calculator.IncrementalScoreCalculator;
+import org.optaplanner.core.api.score.stream.Constraint;
+import org.optaplanner.core.api.score.stream.ConstraintFactory;
 import org.optaplanner.core.api.score.stream.ConstraintProvider;
+import org.optaplanner.core.api.score.stream.ConstraintStreamImplType;
 import org.optaplanner.core.api.solver.SolverFactory;
 import org.optaplanner.core.api.solver.SolverManager;
 import org.optaplanner.core.config.score.director.ScoreDirectorFactoryConfig;
 import org.optaplanner.core.config.solver.SolverConfig;
 import org.optaplanner.core.config.solver.SolverManagerConfig;
 import org.optaplanner.core.config.solver.termination.TerminationConfig;
+import org.optaplanner.core.config.util.ConfigUtils;
 import org.optaplanner.persistence.jackson.api.OptaPlannerJacksonModule;
+import org.optaplanner.test.api.score.stream.ConstraintVerifier;
+import org.optaplanner.test.api.score.stream.MultiConstraintVerification;
+import org.optaplanner.test.api.score.stream.SingleConstraintVerification;
 import org.springframework.beans.factory.BeanClassLoaderAware;
 import org.springframework.beans.factory.annotation.AnnotatedBeanDefinition;
 import org.springframework.beans.factory.config.BeanDefinition;
@@ -131,6 +139,41 @@ public class OptaPlannerAutoConfiguration implements BeanClassLoaderAware {
 
         applySolverProperties(solverConfig);
         return solverConfig;
+    }
+
+    @Bean
+    @ConditionalOnClass({ ConstraintVerifier.class })
+    @ConditionalOnMissingBean({ ConstraintVerifier.class })
+    @SuppressWarnings("unchecked")
+    public <ConstraintProvider_ extends ConstraintProvider, SolutionClass_> ConstraintVerifier<ConstraintProvider_, SolutionClass_> constraintVerifier(SolverConfig solverConfig) {
+        if (solverConfig.getScoreDirectorFactoryConfig().getConstraintProviderClass() == null) {
+            // Return a mock ConstraintVerifier so not having ConstraintProvider doesn't crash tests
+            // (Cannot create custom condition that checks SolverConfig, since that
+            //  requires OptaPlannerAutoConfiguration to have a no-args constructor)
+            final String noConstraintProviderErrorMsg = "ConstraintVerifier is only supported for ConstraintProviders";
+            return new ConstraintVerifier<ConstraintProvider_, SolutionClass_>() {
+                @Override
+                public ConstraintVerifier<ConstraintProvider_, SolutionClass_> withConstraintStreamImplType(ConstraintStreamImplType constraintStreamImplType) {
+                    throw new UnsupportedOperationException(noConstraintProviderErrorMsg);
+                }
+
+                @Override
+                public SingleConstraintVerification<SolutionClass_> verifyThat(BiFunction<ConstraintProvider_, ConstraintFactory, Constraint> constraintFunction) {
+                    throw new UnsupportedOperationException(noConstraintProviderErrorMsg);
+                }
+
+                @Override
+                public MultiConstraintVerification<SolutionClass_> verifyThat() {
+                    throw new UnsupportedOperationException(noConstraintProviderErrorMsg);
+                }
+            };
+        }
+        ConstraintProvider_ constraintProvider = ConfigUtils.newInstance(this, "constraintProvider",
+                                                                         (Class<ConstraintProvider_>) solverConfig.getScoreDirectorFactoryConfig().getConstraintProviderClass());
+        Class<?>[] entityClasses =  solverConfig.getEntityClassList().toArray(new Class<?>[0]);
+        return (ConstraintVerifier<ConstraintProvider_, SolutionClass_>) ConstraintVerifier.build(constraintProvider,
+                                                                                                  solverConfig.getSolutionClass(),
+                                                                                                  entityClasses);
     }
 
     private void applySolverProperties(SolverConfig solverConfig) {

--- a/optaplanner-spring-integration/optaplanner-spring-boot-autoconfigure/src/test/java/org/optaplanner/spring/boot/autoconfigure/OptaPlannerAutoConfigurationTest.java
+++ b/optaplanner-spring-integration/optaplanner-spring-boot-autoconfigure/src/test/java/org/optaplanner/spring/boot/autoconfigure/OptaPlannerAutoConfigurationTest.java
@@ -32,6 +32,7 @@ import org.junit.jupiter.api.Test;
 import org.optaplanner.core.api.domain.common.DomainAccessType;
 import org.optaplanner.core.api.score.ScoreManager;
 import org.optaplanner.core.api.score.buildin.simple.SimpleScore;
+import org.optaplanner.core.api.score.stream.ConstraintStreamImplType;
 import org.optaplanner.core.api.solver.SolverFactory;
 import org.optaplanner.core.api.solver.SolverJob;
 import org.optaplanner.core.api.solver.SolverManager;
@@ -52,6 +53,7 @@ import org.optaplanner.spring.boot.autoconfigure.normal.constraints.TestdataSpri
 import org.optaplanner.spring.boot.autoconfigure.normal.domain.TestdataSpringEntity;
 import org.optaplanner.spring.boot.autoconfigure.normal.domain.TestdataSpringSolution;
 import org.optaplanner.test.api.score.stream.ConstraintVerifier;
+import org.optaplanner.test.impl.score.stream.DefaultConstraintVerifier;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.FilteredClassLoader;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
@@ -83,10 +85,13 @@ public class OptaPlannerAutoConfigurationTest {
                 .withUserConfiguration(ChainedSpringTestConfiguration.class);
         allDefaultsFilteredClassLoader =
                 new FilteredClassLoader(FilteredClassLoader.PackageFilter.of("org.optaplanner.test"),
-                                        FilteredClassLoader.ClassPathResourceFilter.of(new ClassPathResource(OptaPlannerProperties.DEFAULT_SOLVER_CONFIG_URL)),
-                                        FilteredClassLoader.ClassPathResourceFilter.of(new ClassPathResource(OptaPlannerProperties.DEFAULT_CONSTRAINTS_DRL_URL)));
-        testFilteredClassLoader = new FilteredClassLoader(new ClassPathResource(OptaPlannerProperties.DEFAULT_SOLVER_CONFIG_URL),
-                                        new ClassPathResource(OptaPlannerProperties.DEFAULT_CONSTRAINTS_DRL_URL));
+                        FilteredClassLoader.ClassPathResourceFilter
+                                .of(new ClassPathResource(OptaPlannerProperties.DEFAULT_SOLVER_CONFIG_URL)),
+                        FilteredClassLoader.ClassPathResourceFilter
+                                .of(new ClassPathResource(OptaPlannerProperties.DEFAULT_CONSTRAINTS_DRL_URL)));
+        testFilteredClassLoader =
+                new FilteredClassLoader(new ClassPathResource(OptaPlannerProperties.DEFAULT_SOLVER_CONFIG_URL),
+                        new ClassPathResource(OptaPlannerProperties.DEFAULT_CONSTRAINTS_DRL_URL));
         defaultConstraintsDrlFilteredClassLoader =
                 new FilteredClassLoader(new ClassPathResource(OptaPlannerProperties.DEFAULT_CONSTRAINTS_DRL_URL));
         noGizmoFilteredClassLoader = new FilteredClassLoader(FilteredClassLoader.PackageFilter.of("io.quarkus.gizmo"),
@@ -266,14 +271,47 @@ public class OptaPlannerAutoConfigurationTest {
         contextRunner
                 .withClassLoader(testFilteredClassLoader)
                 .run(context -> {
-                    ConstraintVerifier<TestdataSpringConstraintProvider, TestdataSpringSolution> constraintVerifier = context.getBean(ConstraintVerifier.class);
+                    ConstraintVerifier<TestdataSpringConstraintProvider, TestdataSpringSolution> constraintVerifier =
+                            context.getBean(ConstraintVerifier.class);
+
+                    assertThat(((DefaultConstraintVerifier) constraintVerifier).getConstraintStreamImplType())
+                            .isEqualTo(ConstraintStreamImplType.DROOLS);
                     TestdataSpringSolution problem = new TestdataSpringSolution();
                     problem.setValueList(IntStream.range(1, 3)
-                                                 .mapToObj(i -> "v" + i)
-                                                 .collect(Collectors.toList()));
+                            .mapToObj(i -> "v" + i)
+                            .collect(Collectors.toList()));
                     problem.setEntityList(IntStream.range(1, 3)
-                                                  .mapToObj(i -> new TestdataSpringEntity())
-                                                  .collect(Collectors.toList()));
+                            .mapToObj(i -> new TestdataSpringEntity())
+                            .collect(Collectors.toList()));
+
+                    problem.getEntityList().get(0).setValue("v1");
+                    problem.getEntityList().get(1).setValue("v1");
+                    constraintVerifier.verifyThat().givenSolution(problem).scores(SimpleScore.of(-2));
+
+                    problem.getEntityList().get(1).setValue("v2");
+                    constraintVerifier.verifyThat().givenSolution(problem).scores(SimpleScore.of(0));
+                });
+    }
+
+    @Test
+    public void constraintVerifierBavet() {
+        contextRunner
+                .withClassLoader(testFilteredClassLoader)
+                .withPropertyValues(
+                        "optaplanner.solver-config-xml=org/optaplanner/spring/boot/autoconfigure/bavetSolverConfig.xml")
+                .run(context -> {
+                    ConstraintVerifier<TestdataSpringConstraintProvider, TestdataSpringSolution> constraintVerifier =
+                            context.getBean(ConstraintVerifier.class);
+                    assertThat(((DefaultConstraintVerifier) constraintVerifier).getConstraintStreamImplType())
+                            .isEqualTo(ConstraintStreamImplType.BAVET);
+
+                    TestdataSpringSolution problem = new TestdataSpringSolution();
+                    problem.setValueList(IntStream.range(1, 3)
+                            .mapToObj(i -> "v" + i)
+                            .collect(Collectors.toList()));
+                    problem.setEntityList(IntStream.range(1, 3)
+                            .mapToObj(i -> new TestdataSpringEntity())
+                            .collect(Collectors.toList()));
 
                     problem.getEntityList().get(0).setValue("v1");
                     problem.getEntityList().get(1).setValue("v1");
@@ -291,8 +329,10 @@ public class OptaPlannerAutoConfigurationTest {
                 .withPropertyValues(OptaPlannerProperties.SCORE_DRL_PROPERTY + "=" + constraintsUrl)
                 .withClassLoader(testFilteredClassLoader)
                 .run(context -> {
-                    assertThatCode(() -> { context.getBean(ConstraintVerifier.class).verifyThat(); })
-                        .hasMessage("ConstraintVerifier is only supported for ConstraintProviders");
+                    assertThatCode(() -> {
+                        context.getBean(ConstraintVerifier.class).verifyThat();
+                    })
+                            .hasMessage("ConstraintVerifier is only supported for ConstraintProviders");
                 });
     }
 

--- a/optaplanner-spring-integration/optaplanner-spring-boot-autoconfigure/src/test/java/org/optaplanner/spring/boot/autoconfigure/OptaPlannerAutoConfigurationTest.java
+++ b/optaplanner-spring-integration/optaplanner-spring-boot-autoconfigure/src/test/java/org/optaplanner/spring/boot/autoconfigure/OptaPlannerAutoConfigurationTest.java
@@ -51,6 +51,7 @@ import org.optaplanner.spring.boot.autoconfigure.normal.NormalSpringTestConfigur
 import org.optaplanner.spring.boot.autoconfigure.normal.constraints.TestdataSpringConstraintProvider;
 import org.optaplanner.spring.boot.autoconfigure.normal.domain.TestdataSpringEntity;
 import org.optaplanner.spring.boot.autoconfigure.normal.domain.TestdataSpringSolution;
+import org.optaplanner.test.api.score.stream.ConstraintVerifier;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.FilteredClassLoader;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
@@ -63,6 +64,7 @@ public class OptaPlannerAutoConfigurationTest {
     private final ApplicationContextRunner chainedContextRunner;
     private final ApplicationContextRunner gizmoContextRunner;
     private final FilteredClassLoader allDefaultsFilteredClassLoader;
+    private final FilteredClassLoader testFilteredClassLoader;
     private final FilteredClassLoader noGizmoFilteredClassLoader;
     private final FilteredClassLoader defaultConstraintsDrlFilteredClassLoader;
 
@@ -80,8 +82,11 @@ public class OptaPlannerAutoConfigurationTest {
                 .withConfiguration(AutoConfigurations.of(OptaPlannerAutoConfiguration.class))
                 .withUserConfiguration(ChainedSpringTestConfiguration.class);
         allDefaultsFilteredClassLoader =
-                new FilteredClassLoader(new ClassPathResource(OptaPlannerProperties.DEFAULT_SOLVER_CONFIG_URL),
-                        new ClassPathResource(OptaPlannerProperties.DEFAULT_CONSTRAINTS_DRL_URL));
+                new FilteredClassLoader(FilteredClassLoader.PackageFilter.of("org.optaplanner.test"),
+                                        FilteredClassLoader.ClassPathResourceFilter.of(new ClassPathResource(OptaPlannerProperties.DEFAULT_SOLVER_CONFIG_URL)),
+                                        FilteredClassLoader.ClassPathResourceFilter.of(new ClassPathResource(OptaPlannerProperties.DEFAULT_CONSTRAINTS_DRL_URL)));
+        testFilteredClassLoader = new FilteredClassLoader(new ClassPathResource(OptaPlannerProperties.DEFAULT_SOLVER_CONFIG_URL),
+                                        new ClassPathResource(OptaPlannerProperties.DEFAULT_CONSTRAINTS_DRL_URL));
         defaultConstraintsDrlFilteredClassLoader =
                 new FilteredClassLoader(new ClassPathResource(OptaPlannerProperties.DEFAULT_CONSTRAINTS_DRL_URL));
         noGizmoFilteredClassLoader = new FilteredClassLoader(FilteredClassLoader.PackageFilter.of("io.quarkus.gizmo"),
@@ -253,6 +258,41 @@ public class OptaPlannerAutoConfigurationTest {
                     TestdataSpringSolution solution = solverJob.getFinalBestSolution();
                     assertThat(solution).isNotNull();
                     assertThat(solution.getScore().getScore()).isGreaterThanOrEqualTo(0);
+                });
+    }
+
+    @Test
+    public void constraintVerifier() {
+        contextRunner
+                .withClassLoader(testFilteredClassLoader)
+                .run(context -> {
+                    ConstraintVerifier<TestdataSpringConstraintProvider, TestdataSpringSolution> constraintVerifier = context.getBean(ConstraintVerifier.class);
+                    TestdataSpringSolution problem = new TestdataSpringSolution();
+                    problem.setValueList(IntStream.range(1, 3)
+                                                 .mapToObj(i -> "v" + i)
+                                                 .collect(Collectors.toList()));
+                    problem.setEntityList(IntStream.range(1, 3)
+                                                  .mapToObj(i -> new TestdataSpringEntity())
+                                                  .collect(Collectors.toList()));
+
+                    problem.getEntityList().get(0).setValue("v1");
+                    problem.getEntityList().get(1).setValue("v1");
+                    constraintVerifier.verifyThat().givenSolution(problem).scores(SimpleScore.of(-2));
+
+                    problem.getEntityList().get(1).setValue("v2");
+                    constraintVerifier.verifyThat().givenSolution(problem).scores(SimpleScore.of(0));
+                });
+    }
+
+    @Test
+    public void constraintVerifierOnDrl() {
+        String constraintsUrl = "org/optaplanner/spring/boot/autoconfigure/customConstraints.drl";
+        noConstraintsContextRunner
+                .withPropertyValues(OptaPlannerProperties.SCORE_DRL_PROPERTY + "=" + constraintsUrl)
+                .withClassLoader(testFilteredClassLoader)
+                .run(context -> {
+                    assertThatCode(() -> { context.getBean(ConstraintVerifier.class).verifyThat(); })
+                        .hasMessage("ConstraintVerifier is only supported for ConstraintProviders");
                 });
     }
 

--- a/optaplanner-spring-integration/optaplanner-spring-boot-autoconfigure/src/test/resources/org/optaplanner/spring/boot/autoconfigure/bavetSolverConfig.xml
+++ b/optaplanner-spring-integration/optaplanner-spring-boot-autoconfigure/src/test/resources/org/optaplanner/spring/boot/autoconfigure/bavetSolverConfig.xml
@@ -1,0 +1,9 @@
+<solver>
+  <scoreDirectorFactory>
+    <constraintStreamImplType>BAVET</constraintStreamImplType>
+    <constraintProviderClass>org.optaplanner.spring.boot.autoconfigure.normal.constraints.TestdataSpringConstraintProvider</constraintProviderClass>
+  </scoreDirectorFactory>
+  <termination>
+    <secondsSpentLimit>2</secondsSpentLimit>
+  </termination>
+</solver>


### PR DESCRIPTION
<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.
-->

### JIRA

<!-- Add a JIRA ticket link if it exists. -->
https://issues.redhat.com/browse/PLANNER-2345

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
* https://github.com/kiegroup/drools/pull/3000
* https://github.com/kiegroup/optaplanner/pull/899
* etc.
-->

### Checklist
- [ ] Documentation updated if applicable.
- [ ] Upgrade recipe provided if applicable.

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>full downstream build</b> please add comment: <b>Jenkins run fdb</b>
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
* for a <b>Quarkus LTS check</b> please add comment: <b>Jenkins run LTS</b>
</details>
