### PR TITLE
 Split Quickstarts stage to PR and tag and reset

### DIFF
--- a/Jenkinsfile.promote
+++ b/Jenkinsfile.promote
@@ -10,6 +10,7 @@ String optaplannerRepository = 'optaplanner'
 String vehicleRoutingRepository = 'optaweb-vehicle-routing'
 String employeeRosteringRepository = 'optaweb-employee-rostering'
 String quickstartsRepository = 'optaplanner-quickstarts'
+String stableBranchName = 'stable'
 
 pipeline {
     agent {
@@ -105,7 +106,7 @@ pipeline {
             }
         }
 
-        stage('Merge Quickstarts PR, tag and reset the stable branch') {
+        stage('Merge OptaPlanner Quickstarts PR and tag') {
             when {
                 expression { return isRelease() }
             }
@@ -115,8 +116,21 @@ pipeline {
                         checkoutRepo(quickstartsRepository)
                         mergeAndPush(getDeployPrLink(quickstartsRepository))
                         tagLatest()
+                    }
+                }
+            }
+        }
 
-                        updateAndResetBranch(quickstartsRepository, 'stable')
+        stage('Reset Quickstarts stable branch') {
+            when {
+                expression { return isRelease() }
+            }
+            steps{
+                script {
+                    dir(quickstartsRepository) {
+                        checkoutTag(quickstartsRepository, getGitTag(), stableBranchName)
+                        removeJbossNexusFromMavenAndGradle()
+                        commitAndForcePushProtectedBranch(quickstartsRepository, stableBranchName)
                     }
                 }
             }
@@ -403,6 +417,13 @@ void checkoutRepo(String repo) {
     checkoutRepo(repo, getBuildBranch())
 }
 
+void checkoutTag(String repo, String tagName, String localBranchName) {
+    deleteDir()
+    checkout(githubscm.resolveRepository(repo, getGitAuthor(), getBuildBranch(), false))
+    // need to manually checkout branch since on a detached branch after checkout command
+    sh "git checkout tags/${tagName} -b ${localBranchName}"
+}
+
 void mergeAndPush(String prLink, String targetBranch) {
     if (prLink != '') {
         githubscm.mergePR(prLink, getGitAuthorCredsID())
@@ -433,6 +454,14 @@ String commitAndCreatePR(String commitMsg, Closure precommit, String localBranch
     githubscm.commitChanges(commitMsg, precommit)
     githubscm.pushObject('origin', localBranch, getBotAuthorCredsID())
     return githubscm.createPR(commitMsg, prBody, targetBranch, getBotAuthorCredsID())
+}
+
+void commitAndForcePushProtectedBranch(String repo, String branch){
+    githubscm.commitChanges("[${getBuildBranch()}] Update ${branch} to ${getProjectVersion()}", {
+        githubscm.findAndStageNotIgnoredFiles('pom.xml')
+        githubscm.findAndStageNotIgnoredFiles('build.gradle')
+    })
+    forcePushProtectedBranch(repo, branch)
 }
 
 String commitAndCreatePR(String commitMsg) {
@@ -486,18 +515,6 @@ void runMavenDeploy(MavenCommand mvnCmd) {
         mvnCmd.withDeployRepository(env.MAVEN_DEPLOY_REPOSITORY)
     }
     mvnCmd.skipTests(true).run('clean deploy')
-}
-
-def updateAndResetBranch(String repo, String branchToReset) {
-    githubscm.createBranch(branchToReset)
-
-    removeJbossNexusFromMavenAndGradle()
-
-    githubscm.commitChanges("[${getBuildBranch()}] Update ${branchToReset} to ${getProjectVersion()}", {
-        githubscm.findAndStageNotIgnoredFiles('pom.xml')
-        githubscm.findAndStageNotIgnoredFiles('build.gradle')
-    })
-    forcePushProtectedBranch(repo, branchToReset)
 }
 
 void removeJbossNexusFromMavenAndGradle() {

--- a/Jenkinsfile.promote
+++ b/Jenkinsfile.promote
@@ -420,7 +420,7 @@ void checkoutRepo(String repo) {
 void checkoutTag(String repo, String tagName, String localBranchName) {
     deleteDir()
     checkout(githubscm.resolveRepository(repo, getGitAuthor(), getBuildBranch(), false))
-    // need to manually checkout branch since on a detached branch after checkout command
+    // Need to manually checkout branch since we are in 'detached HEAD' state after the git checkout command.
     sh "git checkout tags/${tagName} -b ${localBranchName}"
 }
 

--- a/Jenkinsfile.promote
+++ b/Jenkinsfile.promote
@@ -561,6 +561,7 @@ def disableForcePushes(String repo, String protectedBranch) {
 }
 
 boolean isBranchProtected(String repo, String protectedBranch, String ghPath = "../gh") {
+    assertGithubCLI(ghPath)
     boolean isProtected = true // Suppose it is protected by default
     withCredentials([string(credentialsId: getGhCredsID(), variable: 'GITHUB_TOKEN')]) {
         // get current branch protection


### PR DESCRIPTION
Move reset task to the separate step to identify the problem faster

The problem is:
If reset falls - it fails the promote job. If promote job fails then snapshots doesn't gets updated. In this case Kogito pipeline could not proceed.

Currently in plan by  @radtriste - separate update of snapshots from the promote part and override tag if it is already exist so we can rerun promote job.

Jenkins build with passed stage for Reset Quickstarts stable branch
https://rhba-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/blue/organizations/jenkins/custom%2Fadupliak%2Fquickstarts-release-pipeline%2Foptaplanner-promote/detail/optaplanner-promote/49/pipeline/189

<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.
-->

### JIRA

<!-- Add a JIRA ticket link if it exists. -->
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
* https://github.com/kiegroup/drools/pull/3000
* https://github.com/kiegroup/optaplanner/pull/899
* etc.
-->

### Checklist
- [ ] Documentation updated if applicable.
- [ ] Upgrade recipe provided if applicable.

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>full downstream build</b> please add comment: <b>Jenkins run fdb</b>
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
* for a <b>Quarkus LTS check</b> please add comment: <b>Jenkins run LTS</b>
</details>
