### PR TITLE
Set default to REFLECTION in Quarkus as a stop-gap for PLANNER-2367

### DIFF
--- a/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/main/java/org/optaplanner/quarkus/deployment/OptaPlannerProcessor.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/main/java/org/optaplanner/quarkus/deployment/OptaPlannerProcessor.java
@@ -276,7 +276,7 @@ class OptaPlannerProcessor {
         optaPlannerBuildTimeConfig.solver.moveThreadCount.ifPresent(solverConfig::setMoveThreadCount);
         optaPlannerBuildTimeConfig.solver.domainAccessType.ifPresent(solverConfig::setDomainAccessType);
         if (solverConfig.getDomainAccessType() == null) {
-            solverConfig.setDomainAccessType(DomainAccessType.GIZMO);
+            solverConfig.setDomainAccessType(DomainAccessType.REFLECTION);
         }
         applyTerminationProperties(solverConfig);
     }

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/test/java/org/optaplanner/quarkus/OptaPlannerProcessorXMLDefaultTest.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/test/java/org/optaplanner/quarkus/OptaPlannerProcessorXMLDefaultTest.java
@@ -54,7 +54,7 @@ public class OptaPlannerProcessorXMLDefaultTest {
     public void solverConfigXml_default() {
         assertNotNull(solverConfig);
         assertEquals(TestdataQuarkusSolution.class, solverConfig.getSolutionClass());
-        assertEquals(DomainAccessType.GIZMO, solverConfig.getDomainAccessType());
+        assertEquals(DomainAccessType.REFLECTION, solverConfig.getDomainAccessType());
         assertEquals(Collections.singletonList(TestdataQuarkusEntity.class), solverConfig.getEntityClassList());
         assertEquals(TestdataQuarkusConstraintProvider.class,
                 solverConfig.getScoreDirectorFactoryConfig().getConstraintProviderClass());

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/test/java/org/optaplanner/quarkus/OptaPlannerProcessorXMLNoneTest.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/test/java/org/optaplanner/quarkus/OptaPlannerProcessorXMLNoneTest.java
@@ -54,7 +54,7 @@ public class OptaPlannerProcessorXMLNoneTest {
     public void solverConfigXml_default() {
         assertNotNull(solverConfig);
         assertEquals(TestdataQuarkusSolution.class, solverConfig.getSolutionClass());
-        assertEquals(DomainAccessType.GIZMO, solverConfig.getDomainAccessType());
+        assertEquals(DomainAccessType.REFLECTION, solverConfig.getDomainAccessType());
         assertEquals(Collections.singletonList(TestdataQuarkusEntity.class), solverConfig.getEntityClassList());
         assertEquals(TestdataQuarkusConstraintProvider.class,
                 solverConfig.getScoreDirectorFactoryConfig().getConstraintProviderClass());

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/test/java/org/optaplanner/quarkus/OptaPlannerProcessorXMLPropertyTest.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/test/java/org/optaplanner/quarkus/OptaPlannerProcessorXMLPropertyTest.java
@@ -54,7 +54,7 @@ public class OptaPlannerProcessorXMLPropertyTest {
     @Test
     public void solverConfigXml_property() {
         assertNotNull(solverConfig);
-        assertEquals(DomainAccessType.GIZMO, solverConfig.getDomainAccessType());
+        assertEquals(DomainAccessType.REFLECTION, solverConfig.getDomainAccessType());
         assertEquals(TestdataQuarkusSolution.class, solverConfig.getSolutionClass());
         assertEquals(Collections.singletonList(TestdataQuarkusEntity.class), solverConfig.getEntityClassList());
         assertEquals(TestdataQuarkusConstraintProvider.class,


### PR DESCRIPTION
<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.
-->

### JIRA

<!-- Add a JIRA ticket link if it exists. -->
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
* https://github.com/kiegroup/drools/pull/3000
* https://github.com/kiegroup/optaplanner/pull/899
* etc.
-->

### Checklist
- [ ] Documentation updated if applicable.
- [ ] Upgrade recipe provided if applicable.

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>full downstream build</b> please add comment: <b>Jenkins run fdb</b>
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
* for a <b>Quarkus LTS check</b> please add comment: <b>Jenkins run LTS</b>
</details>
