### PR TITLE
KOGITO-4635 Use tagLocalAndRemoteRepository to override tag if already exist

### DIFF
--- a/Jenkinsfile.promote
+++ b/Jenkinsfile.promote
@@ -437,7 +437,7 @@ void mergeAndPush(String prLink) {
 
 void tagLatest(String repo) {
     if (getGitTag() != '') {
-        githubscm.tagLocalAndRemoteRepository(repo, getGitTag(), getGitAuthorCredsID(), env.BUILD_TAG, true)
+        githubscm.tagLocalAndRemoteRepository('origin', getGitTag(), getGitAuthorCredsID(), env.BUILD_TAG, true)
     }
 }
 

--- a/Jenkinsfile.promote
+++ b/Jenkinsfile.promote
@@ -70,7 +70,7 @@ pipeline {
                     dir(optaplannerRepository) {
                         checkoutRepo(optaplannerRepository)
                         mergeAndPush(getDeployPrLink(optaplannerRepository))
-                        tagLatest()
+                        tagLatest(optaplannerRepository)
                     }
                 }
             }
@@ -85,7 +85,7 @@ pipeline {
                     dir(vehicleRoutingRepository) {
                         checkoutRepo(vehicleRoutingRepository)
                         mergeAndPush(getDeployPrLink(vehicleRoutingRepository))
-                        tagLatest()
+                        tagLatest(vehicleRoutingRepository)
                     }
                 }
             }
@@ -100,7 +100,7 @@ pipeline {
                     dir(employeeRosteringRepository) {
                         checkoutRepo(employeeRosteringRepository)
                         mergeAndPush(getDeployPrLink(employeeRosteringRepository))
-                        tagLatest()
+                        tagLatest(employeeRosteringRepository)
                     }
                 }
             }
@@ -115,7 +115,7 @@ pipeline {
                     dir(quickstartsRepository) {
                         checkoutRepo(quickstartsRepository)
                         mergeAndPush(getDeployPrLink(quickstartsRepository))
-                        tagLatest()
+                        tagLatest(quickstartsRepository)
                     }
                 }
             }
@@ -435,10 +435,9 @@ void mergeAndPush(String prLink) {
     mergeAndPush(prLink, getBuildBranch())
 }
 
-void tagLatest() {
+void tagLatest(String repo) {
     if (getGitTag() != '') {
-        githubscm.tagRepository(getGitTag(), env.BUILD_TAG)
-        githubscm.pushObject('origin', "--tags ${getGitTag()}", getGitAuthorCredsID())
+        githubscm.tagLocalAndRemoteRepository(repo, getGitTag(), getGitAuthorCredsID(), env.BUILD_TAG, true)
     }
 }
 

--- a/Jenkinsfile.promote
+++ b/Jenkinsfile.promote
@@ -70,7 +70,7 @@ pipeline {
                     dir(optaplannerRepository) {
                         checkoutRepo(optaplannerRepository)
                         mergeAndPush(getDeployPrLink(optaplannerRepository))
-                        tagLatest(optaplannerRepository)
+                        tagLatest()
                     }
                 }
             }
@@ -85,7 +85,7 @@ pipeline {
                     dir(vehicleRoutingRepository) {
                         checkoutRepo(vehicleRoutingRepository)
                         mergeAndPush(getDeployPrLink(vehicleRoutingRepository))
-                        tagLatest(vehicleRoutingRepository)
+                        tagLatest()
                     }
                 }
             }
@@ -100,7 +100,7 @@ pipeline {
                     dir(employeeRosteringRepository) {
                         checkoutRepo(employeeRosteringRepository)
                         mergeAndPush(getDeployPrLink(employeeRosteringRepository))
-                        tagLatest(employeeRosteringRepository)
+                        tagLatest()
                     }
                 }
             }
@@ -115,7 +115,7 @@ pipeline {
                     dir(quickstartsRepository) {
                         checkoutRepo(quickstartsRepository)
                         mergeAndPush(getDeployPrLink(quickstartsRepository))
-                        tagLatest(quickstartsRepository)
+                        tagLatest()
                     }
                 }
             }
@@ -435,7 +435,7 @@ void mergeAndPush(String prLink) {
     mergeAndPush(prLink, getBuildBranch())
 }
 
-void tagLatest(String repo) {
+void tagLatest() {
     if (getGitTag() != '') {
         githubscm.tagLocalAndRemoteRepository('origin', getGitTag(), getGitAuthorCredsID(), env.BUILD_TAG, true)
     }


### PR DESCRIPTION
<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.
-->

### JIRA

Part of:
https://issues.redhat.com/browse/KOGITO-4635

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
* https://github.com/kiegroup/drools/pull/3000
* https://github.com/kiegroup/optaplanner/pull/899
* etc.
-->

### Checklist
- [ ] Documentation updated if applicable.
- [ ] Upgrade recipe provided if applicable.

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>full downstream build</b> please add comment: <b>Jenkins run fdb</b>
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
* for a <b>Quarkus LTS check</b> please add comment: <b>Jenkins run LTS</b>
</details>
