### PR TITLE
PLANNER-2363 Re-enable the turtle tests job

### DIFF
--- a/.jenkins/dsl/jobs.groovy
+++ b/.jenkins/dsl/jobs.groovy
@@ -65,8 +65,7 @@ if (!isMainBranch()) {
     setupPromoteJob(releaseBranchFolder, KogitoJobType.RELEASE)
 }
 
-//TODO: Replace with KogitoConstants.KOGITO_DSL_OTHER_FOLDER after https://github.com/kiegroup/kogito-pipelines/pull/134 is merged.
-def otherFolder = 'other'
+def otherFolder = KogitoConstants.KOGITO_DSL_OTHER_FOLDER
 if (isMainBranch()) {
     folder(otherFolder)
     setupOptaPlannerTurtleTestsJob(otherFolder);
@@ -209,7 +208,9 @@ void setupOptaPlannerTurtleTestsJob(String jobFolder) {
     def jobParams = getJobParams('optaplanner-turtle-tests', jobFolder, 'Jenkinsfile.turtle',
             'Run OptaPlanner turtle tests on a weekly basis.')
     KogitoJobTemplate.createPipelineJob(this, jobParams).with {
-        stringParam('BUILD_BRANCH_NAME', "${GIT_BRANCH}", 'Git branch to checkout')
-        stringParam('GIT_AUTHOR', "${GIT_AUTHOR_NAME}", 'Git author or organization.')
+        parameters {
+            stringParam('BUILD_BRANCH_NAME', "${GIT_BRANCH}", 'Git branch to checkout')
+            stringParam('GIT_AUTHOR', "${GIT_AUTHOR_NAME}", 'Git author or organization.')
+        }
     }
 }

--- a/.jenkins/dsl/jobs.groovy
+++ b/.jenkins/dsl/jobs.groovy
@@ -65,6 +65,13 @@ if (!isMainBranch()) {
     setupPromoteJob(releaseBranchFolder, KogitoJobType.RELEASE)
 }
 
+//TODO: Replace with KogitoConstants.KOGITO_DSL_OTHER_FOLDER after https://github.com/kiegroup/kogito-pipelines/pull/134 is merged.
+def otherFolder = 'other'
+if (isMainBranch()) {
+    folder(otherFolder)
+    setupOptaPlannerTurtleTestsJob(otherFolder);
+}
+
 /////////////////////////////////////////////////////////////////
 // Methods
 /////////////////////////////////////////////////////////////////
@@ -195,5 +202,14 @@ void setupPromoteJob(String jobFolder, KogitoJobType jobType) {
             env('PROPERTIES_FILE_NAME', 'deployment.properties')
             env('GITHUB_CLI_VERSION', '0.11.1')
         }
+    }
+}
+
+void setupOptaPlannerTurtleTestsJob(String jobFolder) {
+    def jobParams = getJobParams('optaplanner-turtle-tests', jobFolder, 'Jenkinsfile.turtle',
+            'Run OptaPlanner turtle tests on a weekly basis.')
+    KogitoJobTemplate.createPipelineJob(this, jobParams).with {
+        stringParam('BUILD_BRANCH_NAME', "${GIT_BRANCH}", 'Git branch to checkout')
+        stringParam('GIT_AUTHOR', "${GIT_AUTHOR_NAME}", 'Git author or organization.')
     }
 }

--- a/.jenkins/dsl/jobs.groovy
+++ b/.jenkins/dsl/jobs.groovy
@@ -208,9 +208,13 @@ void setupOptaPlannerTurtleTestsJob(String jobFolder) {
     def jobParams = getJobParams('optaplanner-turtle-tests', jobFolder, 'Jenkinsfile.turtle',
             'Run OptaPlanner turtle tests on a weekly basis.')
     KogitoJobTemplate.createPipelineJob(this, jobParams).with {
+        triggers {
+            cron('H H * * 5') // Run every Friday.
+        }
+        
         parameters {
             stringParam('BUILD_BRANCH_NAME', "${GIT_BRANCH}", 'Git branch to checkout')
-            stringParam('GIT_AUTHOR', "${GIT_AUTHOR_NAME}", 'Git author or organization.')
+            stringParam('GIT_AUTHOR', "${GIT_AUTHOR_NAME}", 'Git author or an organization.')
         }
     }
 }

--- a/Jenkinsfile.turtle
+++ b/Jenkinsfile.turtle
@@ -18,11 +18,9 @@ pipeline {
     options {
         timeout(time: 3, unit: 'DAYS') // Turtle tests take ~2 days to complete.
     }
-    parameters {
-        // Git information
-        string(name: 'BUILD_BRANCH_NAME', defaultValue: 'master', description: 'Git branch to build.')
-        string(name: 'GIT_AUTHOR', defaultValue: 'kiegroup', description: 'Git author repository.')
-    }
+    // parameters {
+    // For parameters, check the .jenkins/dsl/jobs.groovy file.
+    // }
     environment {
         MAVEN_OPTS = '-Xms1024m -Xmx4g'
         OPTAPLANNER_CI_EMAIL = credentials('OPTAPLANNER_CI_EMAIL') // Contains the email address of the team's Zulip channel.

--- a/Jenkinsfile.turtle
+++ b/Jenkinsfile.turtle
@@ -1,0 +1,82 @@
+@Library('jenkins-pipeline-shared-libraries')_
+
+import org.kie.jenkins.MavenCommand
+
+optaplannerRepo = 'optaplanner'
+
+pipeline {
+    agent {
+        label 'kie-rhel7 && kie-mem16g'
+    }
+    triggers {
+        cron('H H * * 5') // Run every Friday.
+    }
+    tools {
+        maven 'kie-maven-3.6.2'
+        jdk 'kie-jdk11'
+    }
+    options {
+        timeout(time: 3, unit: 'DAYS') // Turtle tests take ~2 days to complete.
+    }
+    parameters {
+        // Git information
+        string(name: 'BUILD_BRANCH_NAME', defaultValue: 'master', description: 'Git branch to build.')
+        string(name: 'GIT_AUTHOR', defaultValue: 'kiegroup', description: 'Git author repository.')
+    }
+    environment {
+        MAVEN_OPTS = '-Xms1024m -Xmx4g'
+        OPTAPLANNER_CI_EMAIL = credentials('OPTAPLANNER_CI_EMAIL') // Contains the email address of the team's Zulip channel.
+    }
+    stages {
+        stage('Initialize') {
+            steps {
+                script {
+                    checkoutRepo(optaplannerRepo)
+                }
+            }
+        }
+        stage('Build OptaPlanner with turtle tests') {
+            steps {
+                script {
+                    new MavenCommand(this)
+                            // Use the same settings.xml as for the nightly builds, including a maven mirror.
+                            .withSettingsXmlId('kogito_release_settings')
+                            .inDirectory(optaplannerRepo)
+                            .withOptions(['-U', '-e', '-fae'])
+                            .withProperty('full')
+                            .withProperty('runTurtleTests', true)
+                            .run('clean install')
+                }
+            }
+        }
+    }
+    post {
+        always {
+            junit '**/target/surefire-reports/**/*.xml, **/target/failsafe-reports/**/*.xml'
+            sendEmail()
+            cleanWs()
+        }
+    }
+}
+
+void checkoutRepo(String repo, String dirName=repo) {
+    dir(dirName) {
+        checkout(githubscm.resolveRepository(repo, getGitAuthor(), getBuildBranch(), false))
+    }
+}
+
+String getBuildBranch() {
+    return params.BUILD_BRANCH_NAME
+}
+
+String getGitAuthor() {
+    return params.GIT_AUTHOR
+}
+
+void sendEmail() {
+    echo 'Sending a summary email.'
+    String body = """OptaPlanner turtle tests build #${BUILD_NUMBER} was: ${currentBuild.currentResult}.
+        \nPlease have a look here: ${env.BUILD_URL}."""
+    echo body
+    emailext(body: body, subject: 'OptaPlanner turtle tests', to: env.OPTAPLANNER_CI_EMAIL)
+}

--- a/Jenkinsfile.turtle
+++ b/Jenkinsfile.turtle
@@ -8,9 +8,6 @@ pipeline {
     agent {
         label 'kie-rhel7 && kie-mem16g'
     }
-    triggers {
-        cron('H H * * 5') // Run every Friday.
-    }
     tools {
         maven 'kie-maven-3.6.2'
         jdk 'kie-jdk11'


### PR DESCRIPTION
<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.
-->

### JIRA
https://issues.redhat.com/browse/PLANNER-2363
<!-- Add a JIRA ticket link if it exists. -->
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
* https://github.com/kiegroup/drools/pull/3000
* https://github.com/kiegroup/optaplanner/pull/899
* etc.
-->

### Checklist
- [ ] Documentation updated if applicable.
- [ ] Upgrade recipe provided if applicable.

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>full downstream build</b> please add comment: <b>Jenkins run fdb</b>
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
* for a <b>Quarkus LTS check</b> please add comment: <b>Jenkins run LTS</b>
</details>
