### PR TITLE
Add a suggestion about missing Jandex index

### DIFF
--- a/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/main/java/org/optaplanner/quarkus/deployment/OptaPlannerProcessor.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/main/java/org/optaplanner/quarkus/deployment/OptaPlannerProcessor.java
@@ -129,7 +129,11 @@ class OptaPlannerProcessor {
         if (indexView.getAnnotations(DotNames.PLANNING_SOLUTION).isEmpty()
                 && indexView.getAnnotations(DotNames.PLANNING_ENTITY).isEmpty()) {
             log.warn("Skipping OptaPlanner extension because there are no " + PlanningSolution.class.getSimpleName()
-                    + " or " + PlanningEntity.class.getSimpleName() + " annotated classes.");
+                    + " or " + PlanningEntity.class.getSimpleName() + " annotated classes."
+                    + "\nIf your domain classes are located in a dependency of this project, maybe try generating"
+                    + " the Jandex index by using the jandex-maven-plugin in that dependency, or by adding"
+                    + "application.properties entries (quarkus.index-dependency.<name>.group-id"
+                    + " and quarkus.index-dependency.<name>.artifact-id).");
             return;
         }
 


### PR DESCRIPTION
Improve the warning when the `optaplanner-quarkus` extension detects there is no `PlanningSolution` nor `PlanningEntity` in the project.

<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.
-->

### JIRA

<!-- Add a JIRA ticket link if it exists. -->
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
* https://github.com/kiegroup/drools/pull/3000
* https://github.com/kiegroup/optaplanner/pull/899
* etc.
-->

### Checklist
- [ ] Documentation updated if applicable.
- [ ] Upgrade recipe provided if applicable.

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>full downstream build</b> please add comment: <b>Jenkins run fdb</b>
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
* for a <b>Quarkus LTS check</b> please add comment: <b>Jenkins run LTS</b>
</details>
