### PR TITLE
Wrap gh api admin calls and mapping in try catch

### DIFF
--- a/Jenkinsfile.promote
+++ b/Jenkinsfile.promote
@@ -460,7 +460,13 @@ void commitAndForcePushProtectedBranch(String repo, String branch){
         githubscm.findAndStageNotIgnoredFiles('pom.xml')
         githubscm.findAndStageNotIgnoredFiles('build.gradle')
     })
-    forcePushProtectedBranch(repo, branch)
+    try {
+        forcePushProtectedBranch(repo, branch)
+    }
+    catch (exception){
+        println "[ERROR] Force push branch: ${branch} from repo : ${repo} failed with exception: ${exception}"
+        currentBuild.result = 'UNSTABLE'
+    }
 }
 
 String commitAndCreatePR(String commitMsg) {
@@ -568,7 +574,6 @@ boolean isBranchProtected(String repo, String protectedBranch, String ghPath = "
 
 def setAllowForcePushes(String repo, String protectedBranch, String enabled, String ghPath = "../gh") {
     assertGithubCLI(ghPath)
-    try {
         //Use separate admin token credentials
         withCredentials([string(credentialsId: getGhCredsID(), variable: 'GITHUB_TOKEN')]) {
             //get current branch protection and remove allow force push
@@ -605,11 +610,6 @@ def setAllowForcePushes(String repo, String protectedBranch, String enabled, Str
             //cleanup workspace
             sh "rm -f protectionParameters.json protectionBefore.json protectionAfter.json"
         }
-    }
-    catch (exception){
-        println "[ERROR] Failed to update Allow force pushes for ${repo}: ${exception}"
-        currentBuild.result = 'UNSTABLE'
-    }
 }
 
 def forcePushProtectedBranch(String repo, String protectedBranch) {

--- a/Jenkinsfile.promote
+++ b/Jenkinsfile.promote
@@ -537,11 +537,7 @@ String getProtectionMapScript() {
             "else . + {\"restrictions_used\":{\"users\":[.restrictions.users[].login], \"team\":[.restrictions.users[].slug]}} end |" +
             " {" +
                 "\"required_status_checks\": .required_status_checks," +
-                "\"required_pull_request_reviews\": " +
-                    "{" +
-                        "\"dismiss_stale_reviews\":(.required_pull_request_reviews.dismiss_stale_reviews//false), " +
-                        "\"require_code_owner_reviews\":(.required_pull_request_reviews.require_code_owner_reviews//false)" +
-                    "}, " +
+                "\"required_pull_request_reviews\": .required_pull_request_reviews," +
                 "\"enforce_admins\":(.enforce_admins.enabled)," +
                 " \"restrictions\":.restrictions_used" +
             "}";
@@ -572,41 +568,47 @@ boolean isBranchProtected(String repo, String protectedBranch, String ghPath = "
 
 def setAllowForcePushes(String repo, String protectedBranch, String enabled, String ghPath = "../gh") {
     assertGithubCLI(ghPath)
-    //Use separate admin token credentials
-    withCredentials([string(credentialsId: getGhCredsID(), variable: 'GITHUB_TOKEN')]) {
-        //get current branch protection and remove allow force push
-        sh "${ghPath} api 'repos/${getGitAuthor()}/${repo}/branches/${protectedBranch}/protection' | " +
-           "jq 'del(.allow_force_pushes)' > protectionBefore.json"
+    try {
+        //Use separate admin token credentials
+        withCredentials([string(credentialsId: getGhCredsID(), variable: 'GITHUB_TOKEN')]) {
+            //get current branch protection and remove allow force push
+            sh "${ghPath} api 'repos/${getGitAuthor()}/${repo}/branches/${protectedBranch}/protection' | " +
+                    "jq 'del(.allow_force_pushes)' > protectionBefore.json"
 
-        //create new json based on current protection mapped as parameters
-        sh "jq \"${getProtectionMapScript()}\" protectionBefore.json | " +
-           "jq \". + {\"allow_force_pushes\":${enabled}}\" > protectionParameters.json"
+            //create new json based on current protection mapped as parameters
+            sh "jq \"${getProtectionMapScript()}\" protectionBefore.json | " +
+                    "jq \". + {\"allow_force_pushes\":${enabled}}\" > protectionParameters.json"
 
-        //update protection on git
-        def allowForcePushEnabled = sh(script:
-                "${ghPath} api -XPUT 'repos/${getGitAuthor()}/${repo}/branches/${protectedBranch}/protection' " +
-                        "--input protectionParameters.json |" +
-                        " jq '.allow_force_pushes.enabled'", returnStdout: true).trim()
-        assert allowForcePushEnabled == enabled
+            //update protection on git
+            def allowForcePushEnabled = sh(script:
+                    "${ghPath} api -XPUT 'repos/${getGitAuthor()}/${repo}/branches/${protectedBranch}/protection' " +
+                            "--input protectionParameters.json |" +
+                            " jq '.allow_force_pushes.enabled'", returnStdout: true).trim()
+            assert allowForcePushEnabled == enabled
 
-        //check that protection didn't changed except for allow_force_pushes
-        sh "${ghPath} api 'repos/${getGitAuthor()}/${repo}/branches/${protectedBranch}/protection' | " +
-                "jq 'del(.allow_force_pushes)' > protectionAfter.json";
-        def differences = sh (script: "diff protectionBefore.json protectionAfter.json | cat", returnStdout: true)
-        if (differences) {
-            error "Protection settings lost"+
-                    "\nBefore: "+
-                    "\n${readFile 'protectionBefore.json'} " +
-                    "\nAfter: "+
-                    "\n${readFile 'protectionAfter.json'} " +
-                    "\nDifferences: " +
-                    "\n${differences} " +
-                    "\nProtection parameters: " +
-                    "\n${readFile 'protectionParameters.json'} " +
-                    "Please rollback to Before state and update getProtectionMapScript"
+            //check that protection didn't changed except for allow_force_pushes
+            sh "${ghPath} api 'repos/${getGitAuthor()}/${repo}/branches/${protectedBranch}/protection' | " +
+                    "jq 'del(.allow_force_pushes)' > protectionAfter.json";
+            def differences = sh(script: "diff protectionBefore.json protectionAfter.json | cat", returnStdout: true)
+            if (differences) {
+                error "Protection settings lost" +
+                        "\nBefore: " +
+                        "\n${readFile 'protectionBefore.json'} " +
+                        "\nAfter: " +
+                        "\n${readFile 'protectionAfter.json'} " +
+                        "\nDifferences: " +
+                        "\n${differences} " +
+                        "\nProtection parameters: " +
+                        "\n${readFile 'protectionParameters.json'} " +
+                        "Please rollback to Before state and update getProtectionMapScript"
+            }
+            //cleanup workspace
+            sh "rm -f protectionParameters.json protectionBefore.json protectionAfter.json"
         }
-        //cleanup workspace
-        sh "rm -f protectionParameters.json protectionBefore.json protectionAfter.json"
+    }
+    catch (exception){
+        println "[ERROR] Failed to update Allow force pushes for ${repo}: ${exception}"
+        currentBuild.result = 'UNSTABLE'
     }
 }
 

--- a/Jenkinsfile.promote
+++ b/Jenkinsfile.promote
@@ -574,42 +574,42 @@ boolean isBranchProtected(String repo, String protectedBranch, String ghPath = "
 
 def setAllowForcePushes(String repo, String protectedBranch, String enabled, String ghPath = "../gh") {
     assertGithubCLI(ghPath)
-        //Use separate admin token credentials
-        withCredentials([string(credentialsId: getGhCredsID(), variable: 'GITHUB_TOKEN')]) {
-            //get current branch protection and remove allow force push
-            sh "${ghPath} api 'repos/${getGitAuthor()}/${repo}/branches/${protectedBranch}/protection' | " +
-                    "jq 'del(.allow_force_pushes)' > protectionBefore.json"
+    //Use separate admin token credentials
+    withCredentials([string(credentialsId: getGhCredsID(), variable: 'GITHUB_TOKEN')]) {
+        //get current branch protection and remove allow force push
+        sh "${ghPath} api 'repos/${getGitAuthor()}/${repo}/branches/${protectedBranch}/protection' | " +
+                "jq 'del(.allow_force_pushes)' > protectionBefore.json"
 
-            //create new json based on current protection mapped as parameters
-            sh "jq \"${getProtectionMapScript()}\" protectionBefore.json | " +
-                    "jq \". + {\"allow_force_pushes\":${enabled}}\" > protectionParameters.json"
+        //create new json based on current protection mapped as parameters
+        sh "jq \"${getProtectionMapScript()}\" protectionBefore.json | " +
+                "jq \". + {\"allow_force_pushes\":${enabled}}\" > protectionParameters.json"
 
-            //update protection on git
-            def allowForcePushEnabled = sh(script:
-                    "${ghPath} api -XPUT 'repos/${getGitAuthor()}/${repo}/branches/${protectedBranch}/protection' " +
-                            "--input protectionParameters.json |" +
-                            " jq '.allow_force_pushes.enabled'", returnStdout: true).trim()
-            assert allowForcePushEnabled == enabled
+        //update protection on git
+        def allowForcePushEnabled = sh(script:
+                "${ghPath} api -XPUT 'repos/${getGitAuthor()}/${repo}/branches/${protectedBranch}/protection' " +
+                        "--input protectionParameters.json |" +
+                        " jq '.allow_force_pushes.enabled'", returnStdout: true).trim()
+        assert allowForcePushEnabled == enabled
 
-            //check that protection didn't changed except for allow_force_pushes
-            sh "${ghPath} api 'repos/${getGitAuthor()}/${repo}/branches/${protectedBranch}/protection' | " +
-                    "jq 'del(.allow_force_pushes)' > protectionAfter.json";
-            def differences = sh(script: "diff protectionBefore.json protectionAfter.json | cat", returnStdout: true)
-            if (differences) {
-                error "Protection settings lost" +
-                        "\nBefore: " +
-                        "\n${readFile 'protectionBefore.json'} " +
-                        "\nAfter: " +
-                        "\n${readFile 'protectionAfter.json'} " +
-                        "\nDifferences: " +
-                        "\n${differences} " +
-                        "\nProtection parameters: " +
-                        "\n${readFile 'protectionParameters.json'} " +
-                        "Please rollback to Before state and update getProtectionMapScript"
-            }
-            //cleanup workspace
-            sh "rm -f protectionParameters.json protectionBefore.json protectionAfter.json"
+        //check that protection didn't changed except for allow_force_pushes
+        sh "${ghPath} api 'repos/${getGitAuthor()}/${repo}/branches/${protectedBranch}/protection' | " +
+                "jq 'del(.allow_force_pushes)' > protectionAfter.json";
+        def differences = sh(script: "diff protectionBefore.json protectionAfter.json | cat", returnStdout: true)
+        if (differences) {
+            error "Protection settings lost" +
+                    "\nBefore: " +
+                    "\n${readFile 'protectionBefore.json'} " +
+                    "\nAfter: " +
+                    "\n${readFile 'protectionAfter.json'} " +
+                    "\nDifferences: " +
+                    "\n${differences} " +
+                    "\nProtection parameters: " +
+                    "\n${readFile 'protectionParameters.json'} " +
+                    "Please rollback to Before state and update getProtectionMapScript"
         }
+        //cleanup workspace
+        sh "rm -f protectionParameters.json protectionBefore.json protectionAfter.json"
+    }
 }
 
 def forcePushProtectedBranch(String repo, String protectedBranch) {


### PR DESCRIPTION
In case if permissions will be changed on github.com side or if github CLI will change this job should proceed with other steps to continue release and mark the build as unstable.

In that case the step should be applied manually

Mapped .required_pull_request_reviews 

<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.
-->

### JIRA
https://issues.redhat.com/browse/KOGITO-4705

<!-- Add a JIRA ticket link if it exists. -->
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
* https://github.com/kiegroup/drools/pull/3000
* https://github.com/kiegroup/optaplanner/pull/899
* etc.
-->

### Checklist
- [ ] Documentation updated if applicable.
- [ ] Upgrade recipe provided if applicable.

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>full downstream build</b> please add comment: <b>Jenkins run fdb</b>
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
* for a <b>Quarkus LTS check</b> please add comment: <b>Jenkins run LTS</b>
</details>
