### PR TITLE
KOGITO-4770 Corrected native PR check

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -166,8 +166,9 @@ MavenCommand getMavenCommand(String directory, boolean addQuarkusVersion=true, b
     }
     if(canNative && isNative()) {
         mvnCmd.withProfiles(['native'])
-        // Added due to https://github.com/quarkusio/quarkus/issues/13341
-        mvnCmd.withProperty('quarkus.profile', 'native')
+            .withProperty('quarkus.native.container-build', true)
+            .withProperty('quarkus.native.container-runtime', 'docker')
+            .withProperty('quarkus.profile', 'native') // Added due to https://github.com/quarkusio/quarkus/issues/13341
     }
     return mvnCmd
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/KOGITO-4770

So we don't need to have the latest GraalVM on node for native building. It uses the quarkus provided docker image.

Related PRs:
- https://github.com/kiegroup/kogito-runtimes/pull/1173
- https://github.com/kiegroup/optaplanner/pull/1232
- https://github.com/kiegroup/kogito-apps/pull/727
- https://github.com/kiegroup/kogito-examples/pull/626