### PR TITLE
DO NOT MERGE: Experimental GIZMO_MEMBER DomainAccessType

### DIFF
--- a/build/optaplanner-build-parent/pom.xml
+++ b/build/optaplanner-build-parent/pom.xml
@@ -913,6 +913,11 @@
               <failOnWarning>true</failOnWarning>
               <ignoreNonCompile>true</ignoreNonCompile>
               <verbose>true</verbose>
+              <ignoredDependencies>
+                <!-- Gizmo can be used w/o using any classes from it since it an optional dependency on optaplanner-core -->
+                <!-- TODO: Remove me when testing w/ GIZMO is done -->
+                <ignoredDependency>io.quarkus.gizmo:gizmo</ignoredDependency>
+              </ignoredDependencies>
             </configuration>
           </execution>
         </executions>

--- a/optaplanner-core/src/main/java/org/optaplanner/core/api/domain/common/DomainAccessType.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/api/domain/common/DomainAccessType.java
@@ -42,5 +42,6 @@ public enum DomainAccessType {
      * and you must add Gizmo in your classpath or modulepath
      * and use planning annotations on public members only.
      */
-    GIZMO
+    GIZMO,
+    GIZMO_MEMBER;
 }

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/common/accessor/MemberAccessorFactory.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/common/accessor/MemberAccessorFactory.java
@@ -40,6 +40,9 @@ public class MemberAccessorFactory {
             case GIZMO:
                 return GizmoMemberAccessorFactory.buildGizmoMemberAccessor(member, annotationClass);
 
+            case GIZMO_MEMBER:
+                return GizmoMemberAccessorFactory.buildDeferGizmoMemberAccessor(member, annotationClass);
+
             case REFLECTION:
                 return buildReflectiveMemberAccessor(member, memberAccessorType, annotationClass);
 

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/common/accessor/gizmo/GizmoMemberAccessorFactory.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/common/accessor/gizmo/GizmoMemberAccessorFactory.java
@@ -67,6 +67,24 @@ public class GizmoMemberAccessorFactory {
         });
     }
 
+    public static MemberAccessor buildDeferGizmoMemberAccessor(Member member, Class<? extends Annotation> annotationClass) {
+        String gizmoMemberAccessorClassName = getGeneratedClassName(member);
+        return memberAccessorMap.computeIfAbsent(gizmoMemberAccessorClassName, key -> {
+            try {
+                // Check if Gizmo on the classpath by verifying we can access one of its classes
+                Class.forName("io.quarkus.gizmo.ClassCreator", false,
+                        Thread.currentThread().getContextClassLoader());
+            } catch (ClassNotFoundException e) {
+                throw new IllegalStateException("When using the domainAccessType (" +
+                        DomainAccessType.GIZMO +
+                        ") the classpath or modulepath must contain io.quarkus.gizmo:gizmo.\n" +
+                        "Maybe add a dependency to io.quarkus.gizmo:gizmo.");
+            }
+            MemberAccessor accessor = GizmoMemberAccessorImplementor.createDeferAccessorFor(member, annotationClass);
+            return accessor;
+        });
+    }
+
     private GizmoMemberAccessorFactory() {
     }
 }

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/solution/cloner/gizmo/GizmoSolutionClonerFactory.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/solution/cloner/gizmo/GizmoSolutionClonerFactory.java
@@ -48,6 +48,27 @@ public final class GizmoSolutionClonerFactory {
         }
     }
 
+    public static <T> SolutionCloner<T> buildDefer(SolutionDescriptor<T> solutionDescriptor) {
+        String gizmoMemberAccessorClassName = getGeneratedClassName(solutionDescriptor);
+        if (solutionClonerMap.containsKey(gizmoMemberAccessorClassName)) {
+            return (SolutionCloner<T>) solutionClonerMap.get(gizmoMemberAccessorClassName);
+        } else {
+            try {
+                // Check if Gizmo on the classpath by verifying we can access one of its classes
+                Class.forName("io.quarkus.gizmo.ClassCreator", false,
+                        Thread.currentThread().getContextClassLoader());
+            } catch (ClassNotFoundException e) {
+                throw new IllegalStateException("When using the domainAccessType (" +
+                        DomainAccessType.GIZMO +
+                        ") the classpath or modulepath must contain io.quarkus.gizmo:gizmo.\n" +
+                        "Maybe add a dependency to io.quarkus.gizmo:gizmo.");
+            }
+            SolutionCloner<T> cloner = GizmoSolutionClonerImplementor.createDeferClonerFor(solutionDescriptor);
+            solutionClonerMap.put(gizmoMemberAccessorClassName, cloner);
+            return cloner;
+        }
+    }
+
     // ************************************************************************
     // Private constructor
     // ************************************************************************

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/solution/cloner/gizmo/GizmoSolutionClonerImplementor.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/solution/cloner/gizmo/GizmoSolutionClonerImplementor.java
@@ -268,13 +268,8 @@ public class GizmoSolutionClonerImplementor {
                         Method getter = ReflectionHelper.getGetterMethod(currentClass, field.getName());
                         Method setter = ReflectionHelper.getSetterMethod(currentClass, field.getName());
                         if (getter != null && setter != null) {
-                            MethodDescriptor getterDescriptor = MethodDescriptor.ofMethod(field.getDeclaringClass().getName(),
-                                    getter.getName(),
-                                    field.getType());
-                            MethodDescriptor setterDescriptor = MethodDescriptor.ofMethod(field.getDeclaringClass().getName(),
-                                    setter.getName(),
-                                    setter.getReturnType(),
-                                    field.getType());
+                            MethodDescriptor getterDescriptor = MethodDescriptor.ofMethod(getter);
+                            MethodDescriptor setterDescriptor = MethodDescriptor.ofMethod(setter);
                             member = new GizmoMemberDescriptor(name, getterDescriptor, memberDescriptor, declaringClass,
                                     setterDescriptor);
                         } else {

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/solution/descriptor/SolutionDescriptor.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/solution/descriptor/SolutionDescriptor.java
@@ -166,6 +166,8 @@ public class SolutionDescriptor<Solution_> {
     // Non-static members
     // ************************************************************************
 
+    protected final transient Logger logger = LoggerFactory.getLogger(getClass());
+
     private final Class<Solution_> solutionClass;
 
     private DomainAccessType domainAccessType;
@@ -735,6 +737,9 @@ public class SolutionDescriptor<Solution_> {
             switch (descriptorPolicy.getDomainAccessType()) {
                 case GIZMO:
                     solutionCloner = GizmoSolutionClonerFactory.build(this);
+                    break;
+                case GIZMO_MEMBER:
+                    solutionCloner = GizmoSolutionClonerFactory.buildDefer(this);
                     break;
                 case REFLECTION:
                     solutionCloner = new FieldAccessingSolutionCloner<>(this);

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/domain/solution/cloner/GizmoSolutionClonerTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/domain/solution/cloner/GizmoSolutionClonerTest.java
@@ -110,7 +110,7 @@ public class GizmoSolutionClonerTest extends AbstractSolutionClonerTest {
     }
 
     // HACK: use public getters/setters of fields so test domain can remain private
-    // TODO: should this another DomainAccessType? DomainAcessType.GIZMO_RELAXED_ACCESS?
+    // TODO: should this another DomainAccessType? DomainAccessType.GIZMO_RELAXED_ACCESS?
     private GizmoSolutionOrEntityDescriptor generateGizmoSolutionOrEntityDescriptor(SolutionDescriptor solutionDescriptor,
             Class<?> entityClass) {
         Map<Field, GizmoMemberDescriptor> solutionFieldToMemberDescriptor = new HashMap<>();
@@ -130,13 +130,8 @@ public class GizmoSolutionClonerTest extends AbstractSolutionClonerTest {
                         Method getter = ReflectionHelper.getGetterMethod(currentClass, field.getName());
                         Method setter = ReflectionHelper.getSetterMethod(currentClass, field.getName());
                         if (getter != null && setter != null) {
-                            MethodDescriptor getterDescriptor = MethodDescriptor.ofMethod(field.getDeclaringClass().getName(),
-                                    getter.getName(),
-                                    field.getType());
-                            MethodDescriptor setterDescriptor = MethodDescriptor.ofMethod(field.getDeclaringClass().getName(),
-                                    setter.getName(),
-                                    setter.getReturnType(),
-                                    field.getType());
+                            MethodDescriptor getterDescriptor = MethodDescriptor.ofMethod(getter);
+                            MethodDescriptor setterDescriptor = MethodDescriptor.ofMethod(setter);
                             member = new GizmoMemberDescriptor(name, getterDescriptor, memberDescriptor, declaringClass,
                                     setterDescriptor);
                         } else {

--- a/optaplanner-examples/pom.xml
+++ b/optaplanner-examples/pom.xml
@@ -104,6 +104,10 @@
       <groupId>org.kie</groupId>
       <artifactId>kie-api</artifactId>
     </dependency>
+    <dependency>
+      <groupId>io.quarkus.gizmo</groupId>
+      <artifactId>gizmo</artifactId>
+    </dependency>
     <!-- External dependencies -->
     <dependency>
       <groupId>commons-io</groupId>

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/curriculumcourse/domain/CourseSchedule.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/curriculumcourse/domain/CourseSchedule.java
@@ -158,7 +158,7 @@ public class CourseSchedule extends AbstractPersistable {
     // ************************************************************************
 
     @ProblemFactCollectionProperty
-    private List<CourseConflict> calculateCourseConflictList() {
+    public List<CourseConflict> calculateCourseConflictList() {
         List<CourseConflict> courseConflictList = new ArrayList<>();
         for (Course leftCourse : courseList) {
             for (Course rightCourse : courseList) {

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/machinereassignment/domain/MachineReassignment.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/machinereassignment/domain/MachineReassignment.java
@@ -157,7 +157,7 @@ public class MachineReassignment extends AbstractPersistable {
     // ************************************************************************
 
     @ProblemFactCollectionProperty
-    private List<MrServiceDependency> getServiceDependencyList() {
+    public List<MrServiceDependency> getServiceDependencyList() {
         List<MrServiceDependency> serviceDependencyList = new ArrayList<>(serviceList.size() * 5);
         for (MrService service : serviceList) {
             for (MrService toService : service.getToDependencyServiceList()) {

--- a/optaplanner-examples/src/main/resources/org/optaplanner/examples/batchscheduling/solver/batchSchedulingSolverConfig.xml
+++ b/optaplanner-examples/src/main/resources/org/optaplanner/examples/batchscheduling/solver/batchSchedulingSolverConfig.xml
@@ -5,6 +5,7 @@
 	<solutionClass>org.optaplanner.examples.batchscheduling.domain.BatchSchedule</solutionClass>
 	<entityClass>org.optaplanner.examples.batchscheduling.domain.Allocation</entityClass>
 	<entityClass>org.optaplanner.examples.batchscheduling.domain.AllocationPath</entityClass>
+	<domainAccessType>GIZMO_MEMBER</domainAccessType>
 	<scoreDirectorFactory>
 		<!-- <easyScoreCalculatorClass>org.optaplanner.examples.batchscheduling.solver.score.BatchSchedulingEasyScoreCalculator</easyScoreCalculatorClass> -->
 		<incrementalScoreCalculatorClass>org.optaplanner.examples.batchscheduling.solver.score.BatchSchedulingIncrementalScoreCalculator</incrementalScoreCalculatorClass>

--- a/optaplanner-examples/src/main/resources/org/optaplanner/examples/cheaptime/solver/cheapTimeSolverConfig.xml
+++ b/optaplanner-examples/src/main/resources/org/optaplanner/examples/cheaptime/solver/cheapTimeSolverConfig.xml
@@ -7,7 +7,7 @@
   <!-- Domain model configuration -->
   <solutionClass>org.optaplanner.examples.cheaptime.domain.CheapTimeSolution</solutionClass>
   <entityClass>org.optaplanner.examples.cheaptime.domain.TaskAssignment</entityClass>
-
+  <domainAccessType>GIZMO_MEMBER</domainAccessType>
   <!-- Score configuration -->
   <scoreDirectorFactory>
     <!--<easyScoreCalculatorClass>org.optaplanner.examples.cheaptime.optional.score.CheapTimeEasyScoreCalculator</easyScoreCalculatorClass>-->

--- a/optaplanner-examples/src/main/resources/org/optaplanner/examples/cloudbalancing/solver/cloudBalancingSolverConfig.xml
+++ b/optaplanner-examples/src/main/resources/org/optaplanner/examples/cloudbalancing/solver/cloudBalancingSolverConfig.xml
@@ -7,6 +7,7 @@
   <!-- Domain model configuration -->
   <solutionClass>org.optaplanner.examples.cloudbalancing.domain.CloudBalance</solutionClass>
   <entityClass>org.optaplanner.examples.cloudbalancing.domain.CloudProcess</entityClass>
+  <domainAccessType>GIZMO_MEMBER</domainAccessType>
 
   <!-- Score configuration -->
   <scoreDirectorFactory>

--- a/optaplanner-examples/src/main/resources/org/optaplanner/examples/coachshuttlegathering/solver/coachShuttleGatheringSolverConfig.xml
+++ b/optaplanner-examples/src/main/resources/org/optaplanner/examples/coachshuttlegathering/solver/coachShuttleGatheringSolverConfig.xml
@@ -10,7 +10,7 @@
   <entityClass>org.optaplanner.examples.coachshuttlegathering.domain.BusStop</entityClass>
   <entityClass>org.optaplanner.examples.coachshuttlegathering.domain.Shuttle</entityClass>
   <entityClass>org.optaplanner.examples.coachshuttlegathering.domain.Coach</entityClass>
-
+  <domainAccessType>GIZMO_MEMBER</domainAccessType>
   <scoreDirectorFactory>
     <!--<easyScoreCalculatorClass>org.optaplanner.examples.coachshuttlegathering.optional.score.CoachShuttleGatheringEasyScoreCalculator</easyScoreCalculatorClass>-->
     <!--<incrementalScoreCalculatorClass>org.optaplanner.examples.coachshuttlegathering.optional.score.CoachShuttleGatheringIncrementalScoreCalculator</incrementalScoreCalculatorClass>-->

--- a/optaplanner-examples/src/main/resources/org/optaplanner/examples/conferencescheduling/solver/conferenceSchedulingSolverConfig.xml
+++ b/optaplanner-examples/src/main/resources/org/optaplanner/examples/conferencescheduling/solver/conferenceSchedulingSolverConfig.xml
@@ -6,7 +6,7 @@
 
   <solutionClass>org.optaplanner.examples.conferencescheduling.domain.ConferenceSolution</solutionClass>
   <entityClass>org.optaplanner.examples.conferencescheduling.domain.Talk</entityClass>
-
+  <domainAccessType>GIZMO_MEMBER</domainAccessType>
   <scoreDirectorFactory>
     <!--<constraintProviderClass>org.optaplanner.examples.conferencescheduling.optional.score.ConferenceSchedulingConstraintProvider</constraintProviderClass>-->
     <scoreDrl>org/optaplanner/examples/conferencescheduling/solver/conferenceSchedulingConstraints.drl</scoreDrl>

--- a/optaplanner-examples/src/main/resources/org/optaplanner/examples/curriculumcourse/solver/curriculumCourseSolverConfig.xml
+++ b/optaplanner-examples/src/main/resources/org/optaplanner/examples/curriculumcourse/solver/curriculumCourseSolverConfig.xml
@@ -6,7 +6,7 @@
 
   <solutionClass>org.optaplanner.examples.curriculumcourse.domain.CourseSchedule</solutionClass>
   <entityClass>org.optaplanner.examples.curriculumcourse.domain.Lecture</entityClass>
-
+  <domainAccessType>GIZMO_MEMBER</domainAccessType>
   <scoreDirectorFactory>
     <!--<constraintProviderClass>org.optaplanner.examples.curriculumcourse.optional.score.CurriculumCourseConstraintProvider</constraintProviderClass>-->
     <scoreDrl>org/optaplanner/examples/curriculumcourse/solver/curriculumCourseConstraints.drl</scoreDrl>

--- a/optaplanner-examples/src/main/resources/org/optaplanner/examples/examination/solver/examinationSolverConfig.xml
+++ b/optaplanner-examples/src/main/resources/org/optaplanner/examples/examination/solver/examinationSolverConfig.xml
@@ -8,7 +8,7 @@
   <entityClass>org.optaplanner.examples.examination.domain.Exam</entityClass>
   <entityClass>org.optaplanner.examples.examination.domain.LeadingExam</entityClass>
   <entityClass>org.optaplanner.examples.examination.domain.FollowingExam</entityClass>
-
+  <domainAccessType>GIZMO_MEMBER</domainAccessType>
   <scoreDirectorFactory>
     <scoreDrl>org/optaplanner/examples/examination/solver/examinationConstraints.drl</scoreDrl>
     <initializingScoreTrend>ONLY_DOWN</initializingScoreTrend>

--- a/optaplanner-examples/src/main/resources/org/optaplanner/examples/flightcrewscheduling/solver/flightCrewSchedulingSolverConfig.xml
+++ b/optaplanner-examples/src/main/resources/org/optaplanner/examples/flightcrewscheduling/solver/flightCrewSchedulingSolverConfig.xml
@@ -7,7 +7,7 @@
   <solutionClass>org.optaplanner.examples.flightcrewscheduling.domain.FlightCrewSolution</solutionClass>
   <entityClass>org.optaplanner.examples.flightcrewscheduling.domain.FlightAssignment</entityClass>
   <entityClass>org.optaplanner.examples.flightcrewscheduling.domain.Employee</entityClass>
-
+  <domainAccessType>GIZMO_MEMBER</domainAccessType>
   <scoreDirectorFactory>
     <!--<constraintProviderClass>org.optaplanner.examples.flightcrewscheduling.optional.score.FlightCrewSchedulingConstraintProvider</constraintProviderClass>-->
     <scoreDrl>org/optaplanner/examples/flightcrewscheduling/solver/flightCrewSchedulingConstraints.drl</scoreDrl>

--- a/optaplanner-examples/src/main/resources/org/optaplanner/examples/investment/solver/investmentSolverConfig.xml
+++ b/optaplanner-examples/src/main/resources/org/optaplanner/examples/investment/solver/investmentSolverConfig.xml
@@ -7,7 +7,7 @@
   <!-- Domain model configuration -->
   <solutionClass>org.optaplanner.examples.investment.domain.InvestmentSolution</solutionClass>
   <entityClass>org.optaplanner.examples.investment.domain.AssetClassAllocation</entityClass>
-
+  <domainAccessType>GIZMO_MEMBER</domainAccessType>
   <!-- Score configuration -->
   <scoreDirectorFactory>
     <!--<easyScoreCalculatorClass>org.optaplanner.examples.investment.optional.score.InvestmentEasyScoreCalculator</easyScoreCalculatorClass>-->

--- a/optaplanner-examples/src/main/resources/org/optaplanner/examples/machinereassignment/solver/machineReassignmentSolverConfig.xml
+++ b/optaplanner-examples/src/main/resources/org/optaplanner/examples/machinereassignment/solver/machineReassignmentSolverConfig.xml
@@ -6,7 +6,7 @@
 
   <solutionClass>org.optaplanner.examples.machinereassignment.domain.MachineReassignment</solutionClass>
   <entityClass>org.optaplanner.examples.machinereassignment.domain.MrProcessAssignment</entityClass>
-
+  <domainAccessType>GIZMO_MEMBER</domainAccessType>
   <scoreDirectorFactory>
     <incrementalScoreCalculatorClass>org.optaplanner.examples.machinereassignment.score.MachineReassignmentIncrementalScoreCalculator</incrementalScoreCalculatorClass>
     <!--<constraintProviderClass>org.optaplanner.examples.machinereassignment.optional.score.MachineReassignmentConstraintProvider</constraintProviderClass>-->

--- a/optaplanner-examples/src/main/resources/org/optaplanner/examples/meetingscheduling/solver/meetingSchedulingSolverConfig.xml
+++ b/optaplanner-examples/src/main/resources/org/optaplanner/examples/meetingscheduling/solver/meetingSchedulingSolverConfig.xml
@@ -6,7 +6,7 @@
 
   <solutionClass>org.optaplanner.examples.meetingscheduling.domain.MeetingSchedule</solutionClass>
   <entityClass>org.optaplanner.examples.meetingscheduling.domain.MeetingAssignment</entityClass>
-
+  <domainAccessType>GIZMO_MEMBER</domainAccessType>
   <scoreDirectorFactory>
     <!--<constraintProviderClass>org.optaplanner.examples.meetingscheduling.optional.score.MeetingSchedulingConstraintProvider</constraintProviderClass>-->
     <scoreDrl>org/optaplanner/examples/meetingscheduling/solver/meetingSchedulingConstraints.drl</scoreDrl>

--- a/optaplanner-examples/src/main/resources/org/optaplanner/examples/nqueens/solver/nqueensSolverConfig.xml
+++ b/optaplanner-examples/src/main/resources/org/optaplanner/examples/nqueens/solver/nqueensSolverConfig.xml
@@ -6,7 +6,7 @@
 
   <solutionClass>org.optaplanner.examples.nqueens.domain.NQueens</solutionClass>
   <entityClass>org.optaplanner.examples.nqueens.domain.Queen</entityClass>
-
+  <domainAccessType>GIZMO_MEMBER</domainAccessType>
   <scoreDirectorFactory>
     <!--<easyScoreCalculatorClass>org.optaplanner.examples.nqueens.optional.score.NQueensEasyScoreCalculator</easyScoreCalculatorClass>-->
     <!--<easyScoreCalculatorClass>org.optaplanner.examples.nqueens.optional.score.NQueensMapBasedEasyScoreCalculator</easyScoreCalculatorClass>-->

--- a/optaplanner-examples/src/main/resources/org/optaplanner/examples/nurserostering/solver/nurseRosteringSolverConfig.xml
+++ b/optaplanner-examples/src/main/resources/org/optaplanner/examples/nurserostering/solver/nurseRosteringSolverConfig.xml
@@ -6,7 +6,7 @@
 
   <solutionClass>org.optaplanner.examples.nurserostering.domain.NurseRoster</solutionClass>
   <entityClass>org.optaplanner.examples.nurserostering.domain.ShiftAssignment</entityClass>
-
+  <domainAccessType>GIZMO_MEMBER</domainAccessType>
   <scoreDirectorFactory>
     <scoreDrl>org/optaplanner/examples/nurserostering/solver/nurseRosteringConstraints.drl</scoreDrl>
   </scoreDirectorFactory>

--- a/optaplanner-examples/src/main/resources/org/optaplanner/examples/pas/solver/patientAdmissionScheduleSolverConfig.xml
+++ b/optaplanner-examples/src/main/resources/org/optaplanner/examples/pas/solver/patientAdmissionScheduleSolverConfig.xml
@@ -6,7 +6,7 @@
 
   <solutionClass>org.optaplanner.examples.pas.domain.PatientAdmissionSchedule</solutionClass>
   <entityClass>org.optaplanner.examples.pas.domain.BedDesignation</entityClass>
-
+  <domainAccessType>GIZMO_MEMBER</domainAccessType>
   <scoreDirectorFactory>
     <!--<constraintProviderClass>org.optaplanner.examples.pas.optional.score.PatientAdmissionScheduleConstraintProvider</constraintProviderClass>-->
     <scoreDrl>org/optaplanner/examples/pas/solver/patientAdmissionScheduleConstraints.drl</scoreDrl>

--- a/optaplanner-examples/src/main/resources/org/optaplanner/examples/projectjobscheduling/solver/projectJobSchedulingSolverConfig.xml
+++ b/optaplanner-examples/src/main/resources/org/optaplanner/examples/projectjobscheduling/solver/projectJobSchedulingSolverConfig.xml
@@ -6,7 +6,7 @@
 
   <solutionClass>org.optaplanner.examples.projectjobscheduling.domain.Schedule</solutionClass>
   <entityClass>org.optaplanner.examples.projectjobscheduling.domain.Allocation</entityClass>
-
+  <domainAccessType>GIZMO_MEMBER</domainAccessType>
   <scoreDirectorFactory>
     <incrementalScoreCalculatorClass>org.optaplanner.examples.projectjobscheduling.score.ProjectJobSchedulingIncrementalScoreCalculator</incrementalScoreCalculatorClass>
     <!--<scoreDrl>org/optaplanner/examples/projectjobscheduling/solver/projectJobSchedulingConstraints.drl</scoreDrl>-->

--- a/optaplanner-examples/src/main/resources/org/optaplanner/examples/rocktour/solver/rockTourSolverConfig.xml
+++ b/optaplanner-examples/src/main/resources/org/optaplanner/examples/rocktour/solver/rockTourSolverConfig.xml
@@ -7,7 +7,7 @@
   <solutionClass>org.optaplanner.examples.rocktour.domain.RockTourSolution</solutionClass>
   <entityClass>org.optaplanner.examples.rocktour.domain.RockShow</entityClass>
   <entityClass>org.optaplanner.examples.rocktour.domain.RockStandstill</entityClass>
-
+  <domainAccessType>GIZMO_MEMBER</domainAccessType>
   <scoreDirectorFactory>
     <!--<constraintProviderClass>org.optaplanner.examples.rocktour.optional.score.RockTourConstraintProvider</constraintProviderClass>-->
     <scoreDrl>org/optaplanner/examples/rocktour/solver/rockTourConstraints.drl</scoreDrl>

--- a/optaplanner-examples/src/main/resources/org/optaplanner/examples/taskassigning/solver/taskAssigningSolverConfig.xml
+++ b/optaplanner-examples/src/main/resources/org/optaplanner/examples/taskassigning/solver/taskAssigningSolverConfig.xml
@@ -7,7 +7,7 @@
   <solutionClass>org.optaplanner.examples.taskassigning.domain.TaskAssigningSolution</solutionClass>
   <entityClass>org.optaplanner.examples.taskassigning.domain.TaskOrEmployee</entityClass>
   <entityClass>org.optaplanner.examples.taskassigning.domain.Task</entityClass>
-
+  <domainAccessType>GIZMO_MEMBER</domainAccessType>
   <scoreDirectorFactory>
     <!--<constraintProviderClass>org.optaplanner.examples.taskassigning.optional.score.TaskAssigningConstraintProvider</constraintProviderClass>-->
     <scoreDrl>org/optaplanner/examples/taskassigning/solver/taskAssigningConstraints.drl</scoreDrl>

--- a/optaplanner-examples/src/main/resources/org/optaplanner/examples/tennis/solver/tennisSolverConfig.xml
+++ b/optaplanner-examples/src/main/resources/org/optaplanner/examples/tennis/solver/tennisSolverConfig.xml
@@ -7,7 +7,7 @@
   <!-- Domain model configuration -->
   <solutionClass>org.optaplanner.examples.tennis.domain.TennisSolution</solutionClass>
   <entityClass>org.optaplanner.examples.tennis.domain.TeamAssignment</entityClass>
-
+  <domainAccessType>GIZMO_MEMBER</domainAccessType>
   <!-- Score configuration -->
   <scoreDirectorFactory>
     <!--<constraintProviderClass>org.optaplanner.examples.tennis.optional.score.TennisConstraintProvider</constraintProviderClass>-->

--- a/optaplanner-examples/src/main/resources/org/optaplanner/examples/travelingtournament/solver/travelingTournamentSolverConfig.xml
+++ b/optaplanner-examples/src/main/resources/org/optaplanner/examples/travelingtournament/solver/travelingTournamentSolverConfig.xml
@@ -6,7 +6,7 @@
 
   <solutionClass>org.optaplanner.examples.travelingtournament.domain.TravelingTournament</solutionClass>
   <entityClass>org.optaplanner.examples.travelingtournament.domain.Match</entityClass>
-
+  <domainAccessType>GIZMO_MEMBER</domainAccessType>
   <scoreDirectorFactory>
     <!--<constraintProviderClass>org.optaplanner.examples.travelingtournament.optional.score.TravelingTournamentConstraintProvider</constraintProviderClass>-->
     <scoreDrl>org/optaplanner/examples/travelingtournament/solver/travelingTournamentConstraints.drl</scoreDrl>

--- a/optaplanner-examples/src/main/resources/org/optaplanner/examples/tsp/solver/tspSolverConfig.xml
+++ b/optaplanner-examples/src/main/resources/org/optaplanner/examples/tsp/solver/tspSolverConfig.xml
@@ -6,7 +6,7 @@
 
   <solutionClass>org.optaplanner.examples.tsp.domain.TspSolution</solutionClass>
   <entityClass>org.optaplanner.examples.tsp.domain.Visit</entityClass>
-
+  <domainAccessType>GIZMO_MEMBER</domainAccessType>
   <scoreDirectorFactory>
     <!--<easyScoreCalculatorClass>org.optaplanner.examples.tsp.optional.score.TspEasyScoreCalculator</easyScoreCalculatorClass>-->
     <!--<constraintProviderClass>org.optaplanner.examples.tsp.optional.score.TspConstraintProvider</constraintProviderClass>-->

--- a/optaplanner-examples/src/main/resources/org/optaplanner/examples/vehiclerouting/solver/vehicleRoutingSolverConfig.xml
+++ b/optaplanner-examples/src/main/resources/org/optaplanner/examples/vehiclerouting/solver/vehicleRoutingSolverConfig.xml
@@ -8,7 +8,7 @@
   <entityClass>org.optaplanner.examples.vehiclerouting.domain.Standstill</entityClass>
   <entityClass>org.optaplanner.examples.vehiclerouting.domain.Customer</entityClass>
   <entityClass>org.optaplanner.examples.vehiclerouting.domain.timewindowed.TimeWindowedCustomer</entityClass>
-
+  <domainAccessType>GIZMO_MEMBER</domainAccessType>
   <scoreDirectorFactory>
     <!--<easyScoreCalculatorClass>org.optaplanner.examples.vehiclerouting.optional.score.VehicleRoutingEasyScoreCalculator</easyScoreCalculatorClass>-->
     <!--<constraintProviderClass>org.optaplanner.examples.vehiclerouting.optional.score.VehicleRoutingConstraintProvider</constraintProviderClass>-->

--- a/optaplanner-examples/src/main/resources/org/optaplanner/examples/vehiclerouting/solver/vehicleRoutingSolverConfig.xml
+++ b/optaplanner-examples/src/main/resources/org/optaplanner/examples/vehiclerouting/solver/vehicleRoutingSolverConfig.xml
@@ -8,7 +8,6 @@
   <entityClass>org.optaplanner.examples.vehiclerouting.domain.Standstill</entityClass>
   <entityClass>org.optaplanner.examples.vehiclerouting.domain.Customer</entityClass>
   <entityClass>org.optaplanner.examples.vehiclerouting.domain.timewindowed.TimeWindowedCustomer</entityClass>
-  <domainAccessType>GIZMO_MEMBER</domainAccessType>
   <scoreDirectorFactory>
     <!--<easyScoreCalculatorClass>org.optaplanner.examples.vehiclerouting.optional.score.VehicleRoutingEasyScoreCalculator</easyScoreCalculatorClass>-->
     <!--<constraintProviderClass>org.optaplanner.examples.vehiclerouting.optional.score.VehicleRoutingConstraintProvider</constraintProviderClass>-->


### PR DESCRIPTION
I added GIZMO_MEMBER access type for testing purposes, which will use getters/setters
if the field is not public. This change allow GIZMO to be used on all optaplanner-examples.

As for why GIZMO does not defer to getters/setters currently: users may have
complex getters/setters (validity checks, null checks, additional calculations, etc.)
which would make cloning/accessing fail in odd ways if used, and we rather fail fast and hard
than silently fail in an undetectable way. However, a large number of examples have
simple public getters/setters but have private fields (meaning GIZMO won't work on them
unless in Quarkus, but would work anywhere with GIZMO_MEMBER).

All optaplanner-examples where changed to use GIZMO_MEMBER domain access
type to determine cases where GIZMO fails.
<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.
-->

### JIRA

<!-- Add a JIRA ticket link if it exists. -->
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
* https://github.com/kiegroup/drools/pull/3000
* https://github.com/kiegroup/optaplanner/pull/899
* etc.
-->

### Checklist
- [ ] Documentation updated if applicable.
- [ ] Upgrade recipe provided if applicable.

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>full downstream build</b> please add comment: <b>Jenkins run fdb</b>
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
* for a <b>Quarkus LTS check</b> please add comment: <b>Jenkins run LTS</b>
* for a <b>Native check</b> please add comment: <b>Jenkins run native</b>
</details>
