### PR TITLE
Add maven-compiler-plugin version 3.8.1

### DIFF
--- a/build/optaplanner-build-parent/pom.xml
+++ b/build/optaplanner-build-parent/pom.xml
@@ -60,6 +60,8 @@
     <maven.min.version>3.6.2</maven.min.version>
     <!-- An upcoming minor 8.x release will change this to 11 because the 8.x series require Java 11 or higher. -->
     <maven.compiler.release>8</maven.compiler.release>
+    <!-- jboss suffixed version from jboss-parent which cannot be downloaded due to SNAPSHOT only policy for plugins from JBoss -->
+    <version.compiler.plugin>3.8.1</version.compiler.plugin>
     <!-- The first version that supports analysis of classes compiled by Java 11. -->
     <version.dependency.plugin>3.1.2</version.dependency.plugin>
     <version.surefire.plugin>2.22.2</version.surefire.plugin>


### PR DESCRIPTION
There is a policy in the optaplanner-parent pom to only allow SNAPSHOT versions for plugins from JBoss which has caused some issues for QE (Anna) where the maven-compiler-plugin version is taken from jboss-parent and its a jboss suffixed version only available in the JBoss repo.

### JIRA

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>full downstream build</b> please add comment: <b>Jenkins run fdb</b>
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
* for a <b>Quarkus LTS check</b> please add comment: <b>Jenkins run LTS</b>
* for a <b>Native check</b> please add comment: <b>Jenkins run native</b>
</details>
