### PR TITLE
Fix Cypress tests disabled in nightly

### DIFF
--- a/Jenkinsfile.deploy
+++ b/Jenkinsfile.deploy
@@ -239,7 +239,7 @@ void buildOptaweb(MavenCommand optawebCommand){
 
 void archiveCypressArtifacts() {
     if (!skipIntegrationTests()) {
-        archiveArtifacts(artifacts: "**/cypress/screenshots/**,**/cypress/videos/**", fingerprint: false, allowEmptyArchive: false)
+        archiveArtifacts(artifacts: "**/cypress/screenshots/**,**/cypress/videos/**", fingerprint: false, allowEmptyArchive: true)
     }
 }
 


### PR DESCRIPTION
Following on https://github.com/kiegroup/optaweb-vehicle-routing/pull/461

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>full downstream build</b> please add comment: <b>Jenkins run fdb</b>
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
* for a <b>Quarkus LTS check</b> please add comment: <b>Jenkins run LTS</b>
* for a <b>Native check</b> please add comment: <b>Jenkins run native</b>
</details>
