### PR TITLE
PLANNER-2368 Unify LOGGER naming

### DIFF
--- a/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/impl/DefaultPlannerBenchmark.java
+++ b/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/impl/DefaultPlannerBenchmark.java
@@ -49,8 +49,8 @@ import org.slf4j.LoggerFactory;
 
 public class DefaultPlannerBenchmark implements PlannerBenchmark {
 
-    private static final transient Logger LOGGER = LoggerFactory.getLogger(DefaultPlannerBenchmark.class);
-    private static final transient Logger SINGLE_BENCHMARK_RUNNER_EXCEPTION_LOGGER =
+    private static final Logger LOGGER = LoggerFactory.getLogger(DefaultPlannerBenchmark.class);
+    private static final Logger SINGLE_BENCHMARK_RUNNER_EXCEPTION_LOGGER =
             LoggerFactory.getLogger(DefaultPlannerBenchmark.class + ".singleBenchmarkRunnerException");
 
     private final PlannerBenchmarkResult plannerBenchmarkResult;

--- a/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/impl/DefaultPlannerBenchmark.java
+++ b/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/impl/DefaultPlannerBenchmark.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -49,9 +49,9 @@ import org.slf4j.LoggerFactory;
 
 public class DefaultPlannerBenchmark implements PlannerBenchmark {
 
-    protected final transient Logger logger = LoggerFactory.getLogger(getClass());
-    protected final transient Logger singleBenchmarkRunnerExceptionLogger = LoggerFactory.getLogger(
-            getClass().getName() + ".singleBenchmarkRunnerException");
+    private static final transient Logger LOGGER = LoggerFactory.getLogger(DefaultPlannerBenchmark.class);
+    private static final transient Logger SINGLE_BENCHMARK_RUNNER_EXCEPTION_LOGGER =
+            LoggerFactory.getLogger(DefaultPlannerBenchmark.class + ".singleBenchmarkRunnerException");
 
     private final PlannerBenchmarkResult plannerBenchmarkResult;
 
@@ -113,7 +113,7 @@ public class DefaultPlannerBenchmark implements PlannerBenchmark {
         }
         initBenchmarkDirectoryAndSubdirectories();
         plannerBenchmarkResult.initSystemProperties();
-        logger.info("Benchmarking started: parallelBenchmarkCount ({})"
+        LOGGER.info("Benchmarking started: parallelBenchmarkCount ({})"
                 + " for problemCount ({}), solverCount ({}), totalSubSingleCount ({}).",
                 plannerBenchmarkResult.getParallelBenchmarkCount(),
                 plannerBenchmarkResult.getUnifiedProblemBenchmarkResultList().size(),
@@ -134,9 +134,9 @@ public class DefaultPlannerBenchmark implements PlannerBenchmark {
         if (plannerBenchmarkResult.getWarmUpTimeMillisSpentLimit() <= 0L) {
             return;
         }
-        logger.info("================================================================================");
-        logger.info("Warm up started");
-        logger.info("================================================================================");
+        LOGGER.info("================================================================================");
+        LOGGER.info("Warm up started");
+        LOGGER.info("================================================================================");
         long timeLeftTotal = plannerBenchmarkResult.getWarmUpTimeMillisSpentLimit();
         int parallelBenchmarkCount = plannerBenchmarkResult.getParallelBenchmarkCount();
         int solverBenchmarkResultCount = plannerBenchmarkResult.getSolverBenchmarkResultList().size();
@@ -169,9 +169,9 @@ public class DefaultPlannerBenchmark implements PlannerBenchmark {
             throw new IllegalStateException("Impossible state: notFinishedWarmUpList (" + notFinishedWarmUpList
                     + ") is not empty.");
         }
-        logger.info("================================================================================");
-        logger.info("Warm up ended");
-        logger.info("================================================================================");
+        LOGGER.info("================================================================================");
+        LOGGER.info("Warm up ended");
+        LOGGER.info("================================================================================");
     }
 
     private void warmUpPopulate(Map<Future<SubSingleBenchmarkRunner>, SubSingleBenchmarkRunner> futureMap,
@@ -222,14 +222,14 @@ public class DefaultPlannerBenchmark implements PlannerBenchmark {
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
                 subSingleBenchmarkRunner = futureMap.get(future);
-                singleBenchmarkRunnerExceptionLogger.error(
+                SINGLE_BENCHMARK_RUNNER_EXCEPTION_LOGGER.error(
                         "The warm up singleBenchmarkRunner ({}) with random seed ({}) was interrupted.",
                         subSingleBenchmarkRunner, subSingleBenchmarkRunner.getRandomSeed(), e);
                 failureThrowable = e;
             } catch (ExecutionException e) {
                 Throwable cause = e.getCause();
                 subSingleBenchmarkRunner = futureMap.get(future);
-                singleBenchmarkRunnerExceptionLogger.warn(
+                SINGLE_BENCHMARK_RUNNER_EXCEPTION_LOGGER.warn(
                         "The warm up singleBenchmarkRunner ({}) with random seed ({}) failed.",
                         subSingleBenchmarkRunner, subSingleBenchmarkRunner.getRandomSeed(), cause);
                 failureThrowable = cause;
@@ -276,13 +276,13 @@ public class DefaultPlannerBenchmark implements PlannerBenchmark {
                 subSingleBenchmarkRunner = future.get();
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
-                singleBenchmarkRunnerExceptionLogger.error(
+                SINGLE_BENCHMARK_RUNNER_EXCEPTION_LOGGER.error(
                         "The subSingleBenchmarkRunner ({}) with random seed ({}) was interrupted.",
                         subSingleBenchmarkRunner, subSingleBenchmarkRunner.getRandomSeed(), e);
                 failureThrowable = e;
             } catch (ExecutionException e) {
                 Throwable cause = e.getCause();
-                singleBenchmarkRunnerExceptionLogger.warn("The subSingleBenchmarkRunner ({}) with random seed ({}) failed.",
+                SINGLE_BENCHMARK_RUNNER_EXCEPTION_LOGGER.warn("The subSingleBenchmarkRunner ({}) with random seed ({}) failed.",
                         subSingleBenchmarkRunner, subSingleBenchmarkRunner.getRandomSeed(), cause);
                 failureThrowable = cause;
             }
@@ -309,12 +309,12 @@ public class DefaultPlannerBenchmark implements PlannerBenchmark {
                 plannerBenchmarkResult);
         benchmarkReport.writeReport();
         if (plannerBenchmarkResult.getFailureCount() == 0) {
-            logger.info("Benchmarking ended: time spent ({}), favoriteSolverBenchmark ({}), statistic html overview ({}).",
+            LOGGER.info("Benchmarking ended: time spent ({}), favoriteSolverBenchmark ({}), statistic html overview ({}).",
                     plannerBenchmarkResult.getBenchmarkTimeMillisSpent(),
                     plannerBenchmarkResult.getFavoriteSolverBenchmarkResult().getName(),
                     benchmarkReport.getHtmlOverviewFile().getAbsolutePath());
         } else {
-            logger.info("Benchmarking failed: time spent ({}), failureCount ({}), statistic html overview ({}).",
+            LOGGER.info("Benchmarking failed: time spent ({}), failureCount ({}), statistic html overview ({}).",
                     plannerBenchmarkResult.getBenchmarkTimeMillisSpent(),
                     plannerBenchmarkResult.getFailureCount(),
                     benchmarkReport.getHtmlOverviewFile().getAbsolutePath());
@@ -428,7 +428,7 @@ public class DefaultPlannerBenchmark implements PlannerBenchmark {
         File htmlOverviewFile = benchmarkReport.getHtmlOverviewFile();
         Desktop desktop = Desktop.isDesktopSupported() ? Desktop.getDesktop() : null;
         if (desktop == null || !desktop.isSupported(Desktop.Action.BROWSE)) {
-            logger.warn("The default browser can't be opened to show htmlOverviewFile ({}).", htmlOverviewFile);
+            LOGGER.warn("The default browser can't be opened to show htmlOverviewFile ({}).", htmlOverviewFile);
             return;
         }
         try {

--- a/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/impl/DefaultPlannerBenchmarkFactory.java
+++ b/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/impl/DefaultPlannerBenchmarkFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,8 +16,6 @@
 
 package org.optaplanner.benchmark.impl;
 
-import static org.apache.commons.lang3.ObjectUtils.defaultIfNull;
-
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
@@ -27,7 +25,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
 import java.util.regex.Pattern;
-
 import org.optaplanner.benchmark.api.PlannerBenchmark;
 import org.optaplanner.benchmark.api.PlannerBenchmarkFactory;
 import org.optaplanner.benchmark.config.PlannerBenchmarkConfig;
@@ -42,13 +39,15 @@ import org.optaplanner.core.impl.solver.thread.DefaultSolverThreadFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static org.apache.commons.lang3.ObjectUtils.defaultIfNull;
+
 /**
  * @see PlannerBenchmarkFactory
  */
 public class DefaultPlannerBenchmarkFactory extends PlannerBenchmarkFactory {
 
     public static final Pattern VALID_NAME_PATTERN = Pattern.compile("(?U)^[\\w\\d _\\-\\.\\(\\)]+$");
-    private static final Logger logger = LoggerFactory.getLogger(DefaultPlannerBenchmarkFactory.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(DefaultPlannerBenchmarkFactory.class);
 
     protected final PlannerBenchmarkConfig plannerBenchmarkConfig;
 
@@ -201,7 +200,7 @@ public class DefaultPlannerBenchmarkFactory extends PlannerBenchmarkFactory {
                             + ") that is lower than 1.");
         }
         if (resolvedParallelBenchmarkCount > availableProcessorCount) {
-            logger.warn("Because the resolvedParallelBenchmarkCount ({}) is higher "
+            LOGGER.warn("Because the resolvedParallelBenchmarkCount ({}) is higher "
                     + "than the availableProcessorCount ({}), it is reduced to "
                     + "availableProcessorCount.", resolvedParallelBenchmarkCount, availableProcessorCount);
             resolvedParallelBenchmarkCount = availableProcessorCount;

--- a/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/impl/DefaultPlannerBenchmarkFactory.java
+++ b/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/impl/DefaultPlannerBenchmarkFactory.java
@@ -16,6 +16,8 @@
 
 package org.optaplanner.benchmark.impl;
 
+import static org.apache.commons.lang3.ObjectUtils.defaultIfNull;
+
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
@@ -25,6 +27,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
 import java.util.regex.Pattern;
+
 import org.optaplanner.benchmark.api.PlannerBenchmark;
 import org.optaplanner.benchmark.api.PlannerBenchmarkFactory;
 import org.optaplanner.benchmark.config.PlannerBenchmarkConfig;
@@ -38,8 +41,6 @@ import org.optaplanner.core.config.util.ConfigUtils;
 import org.optaplanner.core.impl.solver.thread.DefaultSolverThreadFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import static org.apache.commons.lang3.ObjectUtils.defaultIfNull;
 
 /**
  * @see PlannerBenchmarkFactory

--- a/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/impl/SubSingleBenchmarkRunner.java
+++ b/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/impl/SubSingleBenchmarkRunner.java
@@ -36,7 +36,7 @@ public class SubSingleBenchmarkRunner<Solution_> implements Callable<SubSingleBe
 
     public static final String NAME_MDC = "subSingleBenchmark.name";
 
-    protected final transient Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger LOGGER = LoggerFactory.getLogger(SubSingleBenchmarkRunner.class);
 
     private final SubSingleBenchmarkResult subSingleBenchmarkResult;
     private final boolean warmUp;
@@ -84,7 +84,7 @@ public class SubSingleBenchmarkRunner<Solution_> implements Callable<SubSingleBe
             runtime.gc();
             subSingleBenchmarkResult.setUsedMemoryAfterInputSolution(runtime.totalMemory() - runtime.freeMemory());
         }
-        logger.trace("Benchmark problem has been read for subSingleBenchmarkResult ({}).",
+        LOGGER.trace("Benchmark problem has been read for subSingleBenchmarkResult ({}).",
                 subSingleBenchmarkResult);
 
         SolverConfig solverConfig = singleBenchmarkResult.getSolverBenchmarkResult()

--- a/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/impl/aggregator/BenchmarkAggregator.java
+++ b/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/impl/aggregator/BenchmarkAggregator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,7 +34,7 @@ import org.slf4j.LoggerFactory;
 
 public class BenchmarkAggregator {
 
-    protected final transient Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger LOGGER = LoggerFactory.getLogger(BenchmarkAggregator.class);
 
     private File benchmarkDirectory = null;
     private BenchmarkReportConfig benchmarkReportConfig = null;
@@ -108,7 +108,7 @@ public class BenchmarkAggregator {
         plannerBenchmarkResult.accumulateResults(benchmarkReport);
         benchmarkReport.writeReport();
 
-        logger.info("Aggregation ended: statistic html overview ({}).",
+        LOGGER.info("Aggregation ended: statistic html overview ({}).",
                 benchmarkReport.getHtmlOverviewFile().getAbsolutePath());
         return benchmarkReport.getHtmlOverviewFile().getAbsoluteFile();
     }

--- a/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/impl/aggregator/swingui/BenchmarkAggregatorFrame.java
+++ b/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/impl/aggregator/swingui/BenchmarkAggregatorFrame.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,7 +36,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
-
 import javax.swing.AbstractAction;
 import javax.swing.BorderFactory;
 import javax.swing.ImageIcon;
@@ -61,7 +60,6 @@ import javax.swing.text.StyledDocument;
 import javax.swing.tree.DefaultMutableTreeNode;
 import javax.swing.tree.DefaultTreeModel;
 import javax.swing.tree.TreePath;
-
 import org.apache.commons.lang3.StringUtils;
 import org.optaplanner.benchmark.api.PlannerBenchmarkFactory;
 import org.optaplanner.benchmark.config.PlannerBenchmarkConfig;
@@ -77,8 +75,6 @@ import org.optaplanner.benchmark.impl.result.SolverBenchmarkResult;
 import org.optaplanner.benchmark.impl.statistic.common.MillisecondsSpentNumberFormat;
 import org.optaplanner.swing.impl.SwingUncaughtExceptionHandler;
 import org.optaplanner.swing.impl.SwingUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class BenchmarkAggregatorFrame extends JFrame {
 
@@ -128,8 +124,6 @@ public class BenchmarkAggregatorFrame extends JFrame {
         benchmarkAggregatorFrame.init();
         benchmarkAggregatorFrame.setVisible(true);
     }
-
-    protected final transient Logger logger = LoggerFactory.getLogger(getClass());
 
     private final BenchmarkAggregator benchmarkAggregator;
     private final BenchmarkResultIO benchmarkResultIO;

--- a/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/impl/aggregator/swingui/BenchmarkAggregatorFrame.java
+++ b/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/impl/aggregator/swingui/BenchmarkAggregatorFrame.java
@@ -36,6 +36,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
+
 import javax.swing.AbstractAction;
 import javax.swing.BorderFactory;
 import javax.swing.ImageIcon;
@@ -60,6 +61,7 @@ import javax.swing.text.StyledDocument;
 import javax.swing.tree.DefaultMutableTreeNode;
 import javax.swing.tree.DefaultTreeModel;
 import javax.swing.tree.TreePath;
+
 import org.apache.commons.lang3.StringUtils;
 import org.optaplanner.benchmark.api.PlannerBenchmarkFactory;
 import org.optaplanner.benchmark.config.PlannerBenchmarkConfig;

--- a/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/impl/report/BenchmarkReport.java
+++ b/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/impl/report/BenchmarkReport.java
@@ -16,9 +16,7 @@
 
 package org.optaplanner.benchmark.impl.report;
 
-import freemarker.template.Configuration;
-import freemarker.template.Template;
-import freemarker.template.TemplateException;
+import static java.lang.Double.isFinite;
 
 import java.awt.BasicStroke;
 import java.awt.image.BufferedImage;
@@ -38,7 +36,9 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.NavigableSet;
 import java.util.TreeSet;
+
 import javax.imageio.ImageIO;
+
 import org.jfree.chart.JFreeChart;
 import org.jfree.chart.axis.CategoryAxis;
 import org.jfree.chart.axis.LogarithmicAxis;
@@ -74,7 +74,9 @@ import org.optaplanner.core.impl.score.ScoreUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static java.lang.Double.isFinite;
+import freemarker.template.Configuration;
+import freemarker.template.Template;
+import freemarker.template.TemplateException;
 
 public class BenchmarkReport {
 

--- a/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/impl/report/BenchmarkReport.java
+++ b/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/impl/report/BenchmarkReport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,9 @@
 
 package org.optaplanner.benchmark.impl.report;
 
-import static java.lang.Double.isFinite;
+import freemarker.template.Configuration;
+import freemarker.template.Template;
+import freemarker.template.TemplateException;
 
 import java.awt.BasicStroke;
 import java.awt.image.BufferedImage;
@@ -36,9 +38,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.NavigableSet;
 import java.util.TreeSet;
-
 import javax.imageio.ImageIO;
-
 import org.jfree.chart.JFreeChart;
 import org.jfree.chart.axis.CategoryAxis;
 import org.jfree.chart.axis.LogarithmicAxis;
@@ -74,13 +74,11 @@ import org.optaplanner.core.impl.score.ScoreUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import freemarker.template.Configuration;
-import freemarker.template.Template;
-import freemarker.template.TemplateException;
+import static java.lang.Double.isFinite;
 
 public class BenchmarkReport {
 
-    protected final transient Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger LOGGER = LoggerFactory.getLogger(BenchmarkReport.class);
 
     public static final int CHARTED_SCORE_LEVEL_SIZE = 15;
     public static final int LOG_SCALE_MIN_DATASETS_COUNT = 5;
@@ -238,7 +236,7 @@ public class BenchmarkReport {
     // ************************************************************************
 
     public void writeReport() {
-        logger.info("Generating benchmark report...");
+        LOGGER.info("Generating benchmark report...");
         summaryDirectory = new File(plannerBenchmarkResult.getBenchmarkReportDirectory(), "summary");
         summaryDirectory.mkdir();
         plannerBenchmarkResult.accumulateResults(this);
@@ -271,7 +269,7 @@ public class BenchmarkReport {
                                         + subSingleStatistic + ") of SubSingleBenchmark (" + subSingleBenchmarkResult + ").",
                                         e);
                             }
-                            logger.trace("This is expected, aggregator doesn't copy CSV files. Could not read CSV file "
+                            LOGGER.trace("This is expected, aggregator doesn't copy CSV files. Could not read CSV file "
                                     + "({}) of sub single statistic ({}).", subSingleStatistic.getCsvFile().getAbsolutePath(),
                                     subSingleStatistic);
                         }

--- a/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/impl/result/BenchmarkResultIO.java
+++ b/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/impl/result/BenchmarkResultIO.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -46,7 +46,7 @@ public class BenchmarkResultIO {
     private static final String SOLVER_CONFIG_XML_ELEMENT_NAME = "solverConfig";
     private static final String PLANNER_BENCHMARK_RESULT_FILENAME = "plannerBenchmarkResult.xml";
 
-    protected final transient Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger LOGGER = LoggerFactory.getLogger(BenchmarkResultIO.class);
 
     private final GenericJaxbIO<PlannerBenchmarkResult> genericJaxbIO = new GenericJaxbIO<>(PlannerBenchmarkResult.class);
 
@@ -92,7 +92,7 @@ public class BenchmarkResultIO {
         try (Reader reader = new InputStreamReader(new FileInputStream(plannerBenchmarkResultFile), StandardCharsets.UTF_8)) {
             plannerBenchmarkResult = read(reader);
         } catch (OptaPlannerXmlSerializationException e) {
-            logger.warn("Failed reading plannerBenchmarkResultFile ({}).", plannerBenchmarkResultFile, e);
+            LOGGER.warn("Failed reading plannerBenchmarkResultFile ({}).", plannerBenchmarkResultFile, e);
             // If the plannerBenchmarkResultFile's format has changed, the app should not crash entirely
             String benchmarkReportDirectoryName = plannerBenchmarkResultFile.getParentFile().getName();
             plannerBenchmarkResult = PlannerBenchmarkResult.createUnmarshallingFailedResult(

--- a/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/impl/result/ProblemBenchmarkResult.java
+++ b/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/impl/result/ProblemBenchmarkResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -64,7 +64,7 @@ import org.slf4j.LoggerFactory;
  */
 public class ProblemBenchmarkResult<Solution_> {
 
-    protected final transient Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger LOGGER = LoggerFactory.getLogger(ProblemBenchmarkResult.class);
 
     @XmlTransient // Bi-directional relationship restored through BenchmarkResultIO
     private PlannerBenchmarkResult plannerBenchmarkResult;
@@ -439,7 +439,7 @@ public class ProblemBenchmarkResult<Solution_> {
         if (entityCount == null) {
             entityCount = registeringEntityCount;
         } else if (entityCount.longValue() != registeringEntityCount) {
-            logger.warn("The problemBenchmarkResult ({}) has different entityCount values ([{},{}]).\n"
+            LOGGER.warn("The problemBenchmarkResult ({}) has different entityCount values ([{},{}]).\n"
                     + "This is normally impossible for 1 inputSolutionFile.",
                     getName(), entityCount, registeringEntityCount);
             // The entityCount is not unknown (null), but known to be ambiguous
@@ -448,7 +448,7 @@ public class ProblemBenchmarkResult<Solution_> {
         if (variableCount == null) {
             variableCount = registeringVariableCount;
         } else if (variableCount.longValue() != registeringVariableCount) {
-            logger.warn("The problemBenchmarkResult ({}) has different variableCount values ([{},{}]).\n"
+            LOGGER.warn("The problemBenchmarkResult ({}) has different variableCount values ([{},{}]).\n"
                     + "This is normally impossible for 1 inputSolutionFile.",
                     getName(), variableCount, registeringVariableCount);
             // The variableCount is not unknown (null), but known to be ambiguous
@@ -457,7 +457,7 @@ public class ProblemBenchmarkResult<Solution_> {
         if (maximumValueCount == null) {
             maximumValueCount = registeringMaximumValueCount;
         } else if (maximumValueCount.longValue() != registeringMaximumValueCount) {
-            logger.warn("The problemBenchmarkResult ({}) has different maximumValueCount values ([{},{}]).\n"
+            LOGGER.warn("The problemBenchmarkResult ({}) has different maximumValueCount values ([{},{}]).\n"
                     + "This is normally impossible for 1 inputSolutionFile.",
                     getName(), maximumValueCount, registeringMaximumValueCount);
             // The maximumValueCount is not unknown (null), but known to be ambiguous
@@ -466,7 +466,7 @@ public class ProblemBenchmarkResult<Solution_> {
         if (problemScale == null) {
             problemScale = registeringProblemScale;
         } else if (problemScale.longValue() != registeringProblemScale) {
-            logger.warn("The problemBenchmarkResult ({}) has different problemScale values ([{},{}]).\n"
+            LOGGER.warn("The problemBenchmarkResult ({}) has different problemScale values ([{},{}]).\n"
                     + "This is normally impossible for 1 inputSolutionFile.",
                     getName(), problemScale, registeringProblemScale);
             // The problemScale is not unknown (null), but known to be ambiguous

--- a/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/impl/result/SubSingleBenchmarkResult.java
+++ b/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/impl/result/SubSingleBenchmarkResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -46,7 +46,7 @@ import org.slf4j.LoggerFactory;
  */
 public class SubSingleBenchmarkResult implements BenchmarkResult {
 
-    private static final Logger logger = LoggerFactory.getLogger(SubSingleBenchmarkResult.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(SubSingleBenchmarkResult.class);
 
     @XmlTransient // Bi-directional relationship restored through BenchmarkResultIO
     private SingleBenchmarkResult singleBenchmarkResult;
@@ -288,7 +288,7 @@ public class SubSingleBenchmarkResult implements BenchmarkResult {
             if (!oldSubSingleStatistic.getCsvFile().exists()) {
                 if (oldResult.hasAnyFailure()) {
                     newSubSingleStatistic.initPointList();
-                    logger.debug("Old result ({}) is a failure, skipping merge of its sub single statistic ({}).",
+                    LOGGER.debug("Old result ({}) is a failure, skipping merge of its sub single statistic ({}).",
                             oldResult, oldSubSingleStatistic);
                     continue;
                 } else {

--- a/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/impl/statistic/ProblemStatistic.java
+++ b/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/impl/statistic/ProblemStatistic.java
@@ -19,10 +19,12 @@ package org.optaplanner.benchmark.impl.statistic;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
+
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlSeeAlso;
 import javax.xml.bind.annotation.XmlTransient;
+
 import org.jfree.chart.JFreeChart;
 import org.optaplanner.benchmark.config.statistic.ProblemStatisticType;
 import org.optaplanner.benchmark.impl.report.BenchmarkReport;

--- a/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/impl/statistic/ProblemStatistic.java
+++ b/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/impl/statistic/ProblemStatistic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,12 +19,10 @@ package org.optaplanner.benchmark.impl.statistic;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
-
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlSeeAlso;
 import javax.xml.bind.annotation.XmlTransient;
-
 import org.jfree.chart.JFreeChart;
 import org.optaplanner.benchmark.config.statistic.ProblemStatisticType;
 import org.optaplanner.benchmark.impl.report.BenchmarkReport;
@@ -39,8 +37,6 @@ import org.optaplanner.benchmark.impl.statistic.memoryuse.MemoryUseProblemStatis
 import org.optaplanner.benchmark.impl.statistic.movecountperstep.MoveCountPerStepProblemStatistic;
 import org.optaplanner.benchmark.impl.statistic.scorecalculationspeed.ScoreCalculationSpeedProblemStatistic;
 import org.optaplanner.benchmark.impl.statistic.stepscore.StepScoreProblemStatistic;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * 1 statistic of {@link ProblemBenchmarkResult}.
@@ -55,8 +51,6 @@ import org.slf4j.LoggerFactory;
         MemoryUseProblemStatistic.class
 })
 public abstract class ProblemStatistic {
-
-    protected final transient Logger logger = LoggerFactory.getLogger(getClass());
 
     @XmlTransient // Bi-directional relationship restored through BenchmarkResultIO
     protected ProblemBenchmarkResult<Object> problemBenchmarkResult;

--- a/optaplanner-benchmark/src/main/java/org/optaplanner/swing/impl/SwingUtils.java
+++ b/optaplanner-benchmark/src/main/java/org/optaplanner/swing/impl/SwingUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,15 @@
 
 package org.optaplanner.swing.impl;
 
+import java.awt.Color;
+import java.awt.Insets;
+import javax.swing.JButton;
+import javax.swing.UIDefaults;
+import javax.swing.UIManager;
+import javax.swing.UnsupportedLookAndFeelException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import static org.optaplanner.swing.impl.TangoColorFactory.ALUMINIUM_1;
 import static org.optaplanner.swing.impl.TangoColorFactory.ALUMINIUM_2;
 import static org.optaplanner.swing.impl.TangoColorFactory.ALUMINIUM_3;
@@ -30,22 +39,9 @@ import static org.optaplanner.swing.impl.TangoColorFactory.SKY_BLUE_1;
 import static org.optaplanner.swing.impl.TangoColorFactory.SKY_BLUE_2;
 import static org.optaplanner.swing.impl.TangoColorFactory.SKY_BLUE_3;
 
-import java.awt.Color;
-import java.awt.Insets;
-import java.util.Enumeration;
-
-import javax.swing.JButton;
-import javax.swing.UIDefaults;
-import javax.swing.UIManager;
-import javax.swing.UnsupportedLookAndFeelException;
-import javax.swing.plaf.FontUIResource;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 public class SwingUtils {
 
-    private static final Logger logger = LoggerFactory.getLogger(SwingUtils.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(SwingUtils.class);
 
     private static final UIDefaults smallButtonUIDefaults;
 
@@ -112,19 +108,8 @@ public class SwingUtils {
             lookAndFeelException = e;
         }
         if (lookAndFeelException != null) {
-            logger.warn("Could not switch to lookAndFeel ({}). Layout might be incorrect.", lookAndFeelName,
+            LOGGER.warn("Could not switch to lookAndFeel ({}). Layout might be incorrect.", lookAndFeelName,
                     lookAndFeelException);
-        }
-    }
-
-    public static void increaseDefaultFont(float multiplier) {
-        for (Enumeration keys = UIManager.getDefaults().keys(); keys.hasMoreElements();) {
-            Object key = keys.nextElement();
-            Object value = UIManager.get(key);
-            if (value != null && value instanceof FontUIResource) {
-                FontUIResource fontUIResource = (FontUIResource) value;
-                UIManager.put(key, fontUIResource.deriveFont(fontUIResource.getSize() * multiplier));
-            }
         }
     }
 

--- a/optaplanner-benchmark/src/main/java/org/optaplanner/swing/impl/SwingUtils.java
+++ b/optaplanner-benchmark/src/main/java/org/optaplanner/swing/impl/SwingUtils.java
@@ -16,15 +16,6 @@
 
 package org.optaplanner.swing.impl;
 
-import java.awt.Color;
-import java.awt.Insets;
-import javax.swing.JButton;
-import javax.swing.UIDefaults;
-import javax.swing.UIManager;
-import javax.swing.UnsupportedLookAndFeelException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import static org.optaplanner.swing.impl.TangoColorFactory.ALUMINIUM_1;
 import static org.optaplanner.swing.impl.TangoColorFactory.ALUMINIUM_2;
 import static org.optaplanner.swing.impl.TangoColorFactory.ALUMINIUM_3;
@@ -38,6 +29,17 @@ import static org.optaplanner.swing.impl.TangoColorFactory.SCARLET_2;
 import static org.optaplanner.swing.impl.TangoColorFactory.SKY_BLUE_1;
 import static org.optaplanner.swing.impl.TangoColorFactory.SKY_BLUE_2;
 import static org.optaplanner.swing.impl.TangoColorFactory.SKY_BLUE_3;
+
+import java.awt.Color;
+import java.awt.Insets;
+
+import javax.swing.JButton;
+import javax.swing.UIDefaults;
+import javax.swing.UIManager;
+import javax.swing.UnsupportedLookAndFeelException;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class SwingUtils {
 

--- a/optaplanner-core/src/main/java/org/optaplanner/core/config/solver/SolverManagerConfig.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/config/solver/SolverManagerConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,7 +33,7 @@ public class SolverManagerConfig extends AbstractConfig<SolverManagerConfig> {
 
     public static final String PARALLEL_SOLVER_COUNT_AUTO = "AUTO";
 
-    private static final Logger logger = LoggerFactory.getLogger(SolverManagerConfig.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(SolverManagerConfig.class);
 
     protected String parallelSolverCount = null;
     protected Class<? extends ThreadFactory> threadFactoryClass = null;
@@ -98,7 +98,7 @@ public class SolverManagerConfig extends AbstractConfig<SolverManagerConfig> {
                     + ") that is lower than 1.");
         }
         if (resolvedParallelSolverCount > availableProcessorCount) {
-            logger.warn("The resolvedParallelSolverCount ({}) is higher "
+            LOGGER.warn("The resolvedParallelSolverCount ({}) is higher "
                     + "than the availableProcessorCount ({}), which is counter-efficient.",
                     resolvedParallelSolverCount, availableProcessorCount);
             // Still allow it, to reproduce issues of a high-end server machine on a low-end developer machine

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/entity/descriptor/EntityDescriptor.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/entity/descriptor/EntityDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,10 +16,6 @@
 
 package org.optaplanner.core.impl.domain.entity.descriptor;
 
-import static org.optaplanner.core.impl.domain.common.accessor.MemberAccessorFactory.MemberAccessorType.FIELD_OR_GETTER_METHOD;
-import static org.optaplanner.core.impl.domain.common.accessor.MemberAccessorFactory.MemberAccessorType.FIELD_OR_GETTER_METHOD_WITH_SETTER;
-import static org.optaplanner.core.impl.domain.common.accessor.MemberAccessorFactory.MemberAccessorType.FIELD_OR_READ_METHOD;
-
 import java.lang.annotation.Annotation;
 import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Member;
@@ -30,7 +26,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Predicate;
-
 import org.optaplanner.core.api.domain.entity.PinningFilter;
 import org.optaplanner.core.api.domain.entity.PlanningEntity;
 import org.optaplanner.core.api.domain.entity.PlanningPin;
@@ -64,6 +59,10 @@ import org.optaplanner.core.impl.heuristic.selector.entity.decorator.PinEntityFi
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static org.optaplanner.core.impl.domain.common.accessor.MemberAccessorFactory.MemberAccessorType.FIELD_OR_GETTER_METHOD;
+import static org.optaplanner.core.impl.domain.common.accessor.MemberAccessorFactory.MemberAccessorType.FIELD_OR_GETTER_METHOD_WITH_SETTER;
+import static org.optaplanner.core.impl.domain.common.accessor.MemberAccessorFactory.MemberAccessorType.FIELD_OR_READ_METHOD;
+
 /**
  * @param <Solution_> the solution type, the class with the {@link PlanningSolution} annotation
  */
@@ -74,7 +73,7 @@ public class EntityDescriptor<Solution_> {
             InverseRelationShadowVariable.class, AnchorShadowVariable.class,
             CustomShadowVariable.class };
 
-    protected final transient Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger LOGGER = LoggerFactory.getLogger(EntityDescriptor.class);
 
     private final SolutionDescriptor<Solution_> solutionDescriptor;
 
@@ -109,7 +108,7 @@ public class EntityDescriptor<Solution_> {
         this.entityClass = entityClass;
         isInitializedPredicate = this::isInitialized;
         if (entityClass.getPackage() == null) {
-            logger.warn("The entityClass ({}) should be in a proper java package.", entityClass);
+            LOGGER.warn("The entityClass ({}) should be in a proper java package.", entityClass);
         }
     }
 

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/entity/descriptor/EntityDescriptor.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/entity/descriptor/EntityDescriptor.java
@@ -16,6 +16,10 @@
 
 package org.optaplanner.core.impl.domain.entity.descriptor;
 
+import static org.optaplanner.core.impl.domain.common.accessor.MemberAccessorFactory.MemberAccessorType.FIELD_OR_GETTER_METHOD;
+import static org.optaplanner.core.impl.domain.common.accessor.MemberAccessorFactory.MemberAccessorType.FIELD_OR_GETTER_METHOD_WITH_SETTER;
+import static org.optaplanner.core.impl.domain.common.accessor.MemberAccessorFactory.MemberAccessorType.FIELD_OR_READ_METHOD;
+
 import java.lang.annotation.Annotation;
 import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Member;
@@ -26,6 +30,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Predicate;
+
 import org.optaplanner.core.api.domain.entity.PinningFilter;
 import org.optaplanner.core.api.domain.entity.PlanningEntity;
 import org.optaplanner.core.api.domain.entity.PlanningPin;
@@ -58,10 +63,6 @@ import org.optaplanner.core.impl.heuristic.selector.common.decorator.WeightFacto
 import org.optaplanner.core.impl.heuristic.selector.entity.decorator.PinEntityFilter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import static org.optaplanner.core.impl.domain.common.accessor.MemberAccessorFactory.MemberAccessorType.FIELD_OR_GETTER_METHOD;
-import static org.optaplanner.core.impl.domain.common.accessor.MemberAccessorFactory.MemberAccessorType.FIELD_OR_GETTER_METHOD_WITH_SETTER;
-import static org.optaplanner.core.impl.domain.common.accessor.MemberAccessorFactory.MemberAccessorType.FIELD_OR_READ_METHOD;
 
 /**
  * @param <Solution_> the solution type, the class with the {@link PlanningSolution} annotation

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/solution/descriptor/SolutionDescriptor.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/solution/descriptor/SolutionDescriptor.java
@@ -16,6 +16,12 @@
 
 package org.optaplanner.core.impl.domain.solution.descriptor;
 
+import static java.util.stream.Collectors.toSet;
+import static java.util.stream.Stream.concat;
+import static org.optaplanner.core.impl.domain.common.accessor.MemberAccessorFactory.MemberAccessorType.FIELD_OR_GETTER_METHOD;
+import static org.optaplanner.core.impl.domain.common.accessor.MemberAccessorFactory.MemberAccessorType.FIELD_OR_GETTER_METHOD_WITH_SETTER;
+import static org.optaplanner.core.impl.domain.common.accessor.MemberAccessorFactory.MemberAccessorType.FIELD_OR_READ_METHOD;
+
 import java.lang.annotation.Annotation;
 import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Field;
@@ -35,6 +41,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentMap;
 import java.util.stream.Stream;
+
 import org.apache.commons.lang3.tuple.MutablePair;
 import org.apache.commons.lang3.tuple.Pair;
 import org.optaplanner.core.api.domain.autodiscover.AutoDiscoverMemberType;
@@ -96,12 +103,6 @@ import org.optaplanner.core.impl.score.definition.AbstractBendableScoreDefinitio
 import org.optaplanner.core.impl.score.definition.ScoreDefinition;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import static java.util.stream.Collectors.toSet;
-import static java.util.stream.Stream.concat;
-import static org.optaplanner.core.impl.domain.common.accessor.MemberAccessorFactory.MemberAccessorType.FIELD_OR_GETTER_METHOD;
-import static org.optaplanner.core.impl.domain.common.accessor.MemberAccessorFactory.MemberAccessorType.FIELD_OR_GETTER_METHOD_WITH_SETTER;
-import static org.optaplanner.core.impl.domain.common.accessor.MemberAccessorFactory.MemberAccessorType.FIELD_OR_READ_METHOD;
 
 /**
  * @param <Solution_> the solution type, the class with the {@link PlanningSolution} annotation

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/solution/descriptor/SolutionDescriptor.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/solution/descriptor/SolutionDescriptor.java
@@ -16,12 +16,6 @@
 
 package org.optaplanner.core.impl.domain.solution.descriptor;
 
-import static java.util.stream.Collectors.toSet;
-import static java.util.stream.Stream.concat;
-import static org.optaplanner.core.impl.domain.common.accessor.MemberAccessorFactory.MemberAccessorType.FIELD_OR_GETTER_METHOD;
-import static org.optaplanner.core.impl.domain.common.accessor.MemberAccessorFactory.MemberAccessorType.FIELD_OR_GETTER_METHOD_WITH_SETTER;
-import static org.optaplanner.core.impl.domain.common.accessor.MemberAccessorFactory.MemberAccessorType.FIELD_OR_READ_METHOD;
-
 import java.lang.annotation.Annotation;
 import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Field;
@@ -41,7 +35,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentMap;
 import java.util.stream.Stream;
-
 import org.apache.commons.lang3.tuple.MutablePair;
 import org.apache.commons.lang3.tuple.Pair;
 import org.optaplanner.core.api.domain.autodiscover.AutoDiscoverMemberType;
@@ -104,10 +97,18 @@ import org.optaplanner.core.impl.score.definition.ScoreDefinition;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static java.util.stream.Collectors.toSet;
+import static java.util.stream.Stream.concat;
+import static org.optaplanner.core.impl.domain.common.accessor.MemberAccessorFactory.MemberAccessorType.FIELD_OR_GETTER_METHOD;
+import static org.optaplanner.core.impl.domain.common.accessor.MemberAccessorFactory.MemberAccessorType.FIELD_OR_GETTER_METHOD_WITH_SETTER;
+import static org.optaplanner.core.impl.domain.common.accessor.MemberAccessorFactory.MemberAccessorType.FIELD_OR_READ_METHOD;
+
 /**
  * @param <Solution_> the solution type, the class with the {@link PlanningSolution} annotation
  */
 public class SolutionDescriptor<Solution_> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(SolutionDescriptor.class);
 
     public static <Solution_> SolutionDescriptor<Solution_> buildSolutionDescriptor(Class<Solution_> solutionClass,
             Class<?>... entityClasses) {
@@ -165,8 +166,6 @@ public class SolutionDescriptor<Solution_> {
     // Non-static members
     // ************************************************************************
 
-    protected final transient Logger logger = LoggerFactory.getLogger(getClass());
-
     private final Class<Solution_> solutionClass;
     private SolutionCloner<Solution_> solutionCloner;
 
@@ -203,7 +202,7 @@ public class SolutionDescriptor<Solution_> {
         reversedEntityClassList = new ArrayList<>();
         domainAccessType = DomainAccessType.REFLECTION;
         if (solutionClass.getPackage() == null) {
-            logger.warn("The solutionClass ({}) should be in a proper java package.", solutionClass);
+            LOGGER.warn("The solutionClass ({}) should be in a proper java package.", solutionClass);
         }
     }
 
@@ -696,13 +695,13 @@ public class SolutionDescriptor<Solution_> {
         }
         problemFactOrEntityClassSet = problemFactOrEntityClassStream.collect(toSet());
         // And finally log the successful completion of processing.
-        if (logger.isTraceEnabled()) {
-            logger.trace("    Model annotations parsed for solution {}:", solutionClass.getSimpleName());
+        if (LOGGER.isTraceEnabled()) {
+            LOGGER.trace("    Model annotations parsed for solution {}:", solutionClass.getSimpleName());
             for (Map.Entry<Class<?>, EntityDescriptor<Solution_>> entry : entityDescriptorMap.entrySet()) {
                 EntityDescriptor<Solution_> entityDescriptor = entry.getValue();
-                logger.trace("        Entity {}:", entityDescriptor.getEntityClass().getSimpleName());
+                LOGGER.trace("        Entity {}:", entityDescriptor.getEntityClass().getSimpleName());
                 for (VariableDescriptor<Solution_> variableDescriptor : entityDescriptor.getDeclaredVariableDescriptors()) {
-                    logger.trace("            {} variable {} ({})",
+                    LOGGER.trace("            {} variable {} ({})",
                             variableDescriptor instanceof GenuineVariableDescriptor ? "Genuine" : "Shadow",
                             variableDescriptor.getVariableName(),
                             variableDescriptor.getMemberAccessorSpeedNote());

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/exhaustivesearch/decider/ExhaustiveSearchDecider.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/exhaustivesearch/decider/ExhaustiveSearchDecider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,7 +35,7 @@ import org.slf4j.LoggerFactory;
 
 public class ExhaustiveSearchDecider<Solution_> implements ExhaustiveSearchPhaseLifecycleListener<Solution_> {
 
-    protected final transient Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger LOGGER = LoggerFactory.getLogger(ExhaustiveSearchDecider.class);
 
     protected final String logIndentation;
     protected final BestSolutionRecaller<Solution_> bestSolutionRecaller;
@@ -157,7 +157,7 @@ public class ExhaustiveSearchDecider<Solution_> implements ExhaustiveSearchPhase
                 scoreDirector.assertExpectedUndoMoveScore(move, (Score_) stepScope.getStartingStepScore());
             }
         }
-        logger.trace("{}        Move treeId ({}), score ({}), expandable ({}), move ({}).",
+        LOGGER.trace("{}        Move treeId ({}), score ({}), expandable ({}), move ({}).",
                 logIndentation,
                 moveNode.getTreeId(), moveNode.getScore(), moveNode.isExpandable(), moveNode.getMove());
     }

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/partitionedsearch/DefaultPartitionedSearchPhaseFactory.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/partitionedsearch/DefaultPartitionedSearchPhaseFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,13 +16,9 @@
 
 package org.optaplanner.core.impl.partitionedsearch;
 
-import static org.optaplanner.core.config.partitionedsearch.PartitionedSearchPhaseConfig.ACTIVE_THREAD_COUNT_AUTO;
-import static org.optaplanner.core.config.partitionedsearch.PartitionedSearchPhaseConfig.ACTIVE_THREAD_COUNT_UNLIMITED;
-
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.ThreadFactory;
-
 import org.optaplanner.core.config.constructionheuristic.ConstructionHeuristicPhaseConfig;
 import org.optaplanner.core.config.localsearch.LocalSearchPhaseConfig;
 import org.optaplanner.core.config.partitionedsearch.PartitionedSearchPhaseConfig;
@@ -38,10 +34,13 @@ import org.optaplanner.core.impl.solver.thread.ChildThreadType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static org.optaplanner.core.config.partitionedsearch.PartitionedSearchPhaseConfig.ACTIVE_THREAD_COUNT_AUTO;
+import static org.optaplanner.core.config.partitionedsearch.PartitionedSearchPhaseConfig.ACTIVE_THREAD_COUNT_UNLIMITED;
+
 public class DefaultPartitionedSearchPhaseFactory<Solution_>
         extends AbstractPhaseFactory<Solution_, PartitionedSearchPhaseConfig> {
 
-    private static final Logger logger = LoggerFactory.getLogger(DefaultPartitionedSearchPhaseFactory.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(DefaultPartitionedSearchPhaseFactory.class);
 
     public DefaultPartitionedSearchPhaseFactory(PartitionedSearchPhaseConfig phaseConfig) {
         super(phaseConfig);
@@ -113,7 +112,7 @@ public class DefaultPartitionedSearchPhaseFactory<Solution_>
                         + ") that is lower than 1.");
             }
             if (resolvedActiveThreadCount > availableProcessorCount) {
-                logger.debug("The resolvedActiveThreadCount ({}) is higher than "
+                LOGGER.debug("The resolvedActiveThreadCount ({}) is higher than "
                         + "the availableProcessorCount ({}), so the JVM will "
                         + "round-robin the CPU instead.", resolvedActiveThreadCount, availableProcessorCount);
             }

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/partitionedsearch/DefaultPartitionedSearchPhaseFactory.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/partitionedsearch/DefaultPartitionedSearchPhaseFactory.java
@@ -16,9 +16,13 @@
 
 package org.optaplanner.core.impl.partitionedsearch;
 
+import static org.optaplanner.core.config.partitionedsearch.PartitionedSearchPhaseConfig.ACTIVE_THREAD_COUNT_AUTO;
+import static org.optaplanner.core.config.partitionedsearch.PartitionedSearchPhaseConfig.ACTIVE_THREAD_COUNT_UNLIMITED;
+
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.ThreadFactory;
+
 import org.optaplanner.core.config.constructionheuristic.ConstructionHeuristicPhaseConfig;
 import org.optaplanner.core.config.localsearch.LocalSearchPhaseConfig;
 import org.optaplanner.core.config.partitionedsearch.PartitionedSearchPhaseConfig;
@@ -33,9 +37,6 @@ import org.optaplanner.core.impl.solver.termination.Termination;
 import org.optaplanner.core.impl.solver.thread.ChildThreadType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import static org.optaplanner.core.config.partitionedsearch.PartitionedSearchPhaseConfig.ACTIVE_THREAD_COUNT_AUTO;
-import static org.optaplanner.core.config.partitionedsearch.PartitionedSearchPhaseConfig.ACTIVE_THREAD_COUNT_UNLIMITED;
 
 public class DefaultPartitionedSearchPhaseFactory<Solution_>
         extends AbstractPhaseFactory<Solution_, PartitionedSearchPhaseConfig> {

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/partitionedsearch/queue/PartitionQueue.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/partitionedsearch/queue/PartitionQueue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,7 +38,7 @@ import org.slf4j.LoggerFactory;
  */
 public class PartitionQueue<Solution_> implements Iterable<PartitionChangeMove<Solution_>> {
 
-    protected final transient Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger LOGGER = LoggerFactory.getLogger(PartitionQueue.class);
 
     private BlockingQueue<PartitionChangedEvent<Solution_>> queue;
     private Map<Integer, PartitionChangedEvent<Solution_>> moveEventMap; // Key is partIndex
@@ -140,7 +140,7 @@ public class PartitionQueue<Solution_> implements Iterable<PartitionChangeMove<S
                         long processedEventIndex = processedEventIndexMap.get(partIndex);
                         if (triggerEvent.getEventIndex() <= processedEventIndex) {
                             // Skip this one because it or a better version was already processed
-                            logger.trace("    Skipped event of partIndex ({}).", partIndex);
+                            LOGGER.trace("    Skipped event of partIndex ({}).", partIndex);
                             continue;
                         }
                         PartitionChangedEvent<Solution_> latestMoveEvent = moveEventMap.get(partIndex);

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/TestGenKieSessionJournal.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/TestGenKieSessionJournal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,7 +36,7 @@ import org.slf4j.LoggerFactory;
 
 public class TestGenKieSessionJournal {
 
-    private static final Logger logger = LoggerFactory.getLogger(TestGenKieSessionJournal.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(TestGenKieSessionJournal.class);
     private final TestGenKieSessionEventSupport eventSupport = new TestGenKieSessionEventSupport();
     private final HashMap<Object, TestGenFact> existingInstances = new HashMap<>();
     private final List<TestGenFact> facts;
@@ -86,7 +86,7 @@ public class TestGenKieSessionJournal {
     public void addFacts(Collection<Object> workingFacts) {
         int i = 0;
         for (Object instance : workingFacts) {
-            logger.trace("        Working fact added: {}[{}]", instance.getClass().getSimpleName(), instance);
+            LOGGER.trace("        Working fact added: {}[{}]", instance.getClass().getSimpleName(), instance);
             TestGenFact fact = new TestGenValueFact(i++, instance);
             facts.add(fact);
             existingInstances.put(instance, fact);
@@ -133,7 +133,7 @@ public class TestGenKieSessionJournal {
 
     public void fireAllRules() {
         TestGenKieSessionFireAllRules fire = new TestGenKieSessionFireAllRules(operationId++, assertMode);
-        logger.trace("        FIRE ALL RULES ({})", fire);
+        LOGGER.trace("        FIRE ALL RULES ({})", fire);
         updateJournal.add(fire);
     }
 

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/TestGenTestWriter.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/TestGenTestWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,7 +40,7 @@ import org.slf4j.LoggerFactory;
 
 class TestGenTestWriter {
 
-    private static final Logger logger = LoggerFactory.getLogger(TestGenTestWriter.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(TestGenTestWriter.class);
     private StringBuilder sb;
     private TestGenKieSessionJournal journal;
     private String className;
@@ -188,18 +188,18 @@ class TestGenTestWriter {
         File parent = file.getAbsoluteFile().getParentFile();
         if (!parent.exists()) {
             if (!parent.mkdirs()) {
-                logger.warn("Couldn't create directory: {}", parent);
+                LOGGER.warn("Couldn't create directory: {}", parent);
             }
         }
         try (FileOutputStream fos = new FileOutputStream(file);
                 OutputStreamWriter osw = new OutputStreamWriter(fos, StandardCharsets.UTF_8.name())) {
             osw.append(sb);
         } catch (FileNotFoundException e) {
-            logger.error("Failed to open test file ({}).", file, e);
+            LOGGER.error("Failed to open test file ({}).", file, e);
         } catch (UnsupportedEncodingException e) {
-            logger.error("Failed to open writer.", e);
+            LOGGER.error("Failed to open writer.", e);
         } catch (IOException e) {
-            logger.error("Failed to write test file ({}).", file, e);
+            LOGGER.error("Failed to write test file ({}).", file, e);
         }
     }
 

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/operation/TestGenKieSessionFireAllRules.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/operation/TestGenKieSessionFireAllRules.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@ import org.slf4j.LoggerFactory;
 
 public class TestGenKieSessionFireAllRules implements TestGenKieSessionOperation {
 
-    private static final Logger logger = LoggerFactory.getLogger(TestGenKieSessionFireAllRules.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(TestGenKieSessionFireAllRules.class);
     private static int fireCounter = 0;
     private final int fireId;
     private final int id;
@@ -43,7 +43,7 @@ public class TestGenKieSessionFireAllRules implements TestGenKieSessionOperation
 
     @Override
     public void invoke(KieSession kieSession) {
-        logger.trace("        [{}] FIRE ALL RULES", id);
+        LOGGER.trace("        [{}] FIRE ALL RULES", id);
         kieSession.fireAllRules();
     }
 

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/operation/TestGenKieSessionUpdate.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/operation/TestGenKieSessionUpdate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,7 +29,7 @@ import org.slf4j.LoggerFactory;
 
 public class TestGenKieSessionUpdate implements TestGenKieSessionOperation {
 
-    private static final Logger logger = LoggerFactory.getLogger(TestGenKieSessionUpdate.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(TestGenKieSessionUpdate.class);
     private final int id;
     private final TestGenFact entity;
     private final String variableName;
@@ -66,8 +66,8 @@ public class TestGenKieSessionUpdate implements TestGenKieSessionOperation {
 
     @Override
     public void invoke(KieSession kieSession) {
-        if (logger.isTraceEnabled()) {
-            logger.trace("        [{}] {}.{}: {} → {}",
+        if (LOGGER.isTraceEnabled()) {
+            LOGGER.trace("        [{}] {}.{}: {} → {}",
                     id,
                     entity.getInstance(),
                     accessor.getName(),

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/reproducer/TestGenCorruptedScoreReproducer.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/reproducer/TestGenCorruptedScoreReproducer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,7 +34,7 @@ import org.slf4j.LoggerFactory;
  */
 public class TestGenCorruptedScoreReproducer implements TestGenOriginalProblemReproducer, TestGenKieSessionListener {
 
-    private static final Logger logger = LoggerFactory.getLogger(TestGenCorruptedScoreReproducer.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(TestGenCorruptedScoreReproducer.class);
     private final String analysis;
     private final TestGenDroolsScoreDirector<?, ?> scoreDirector;
 
@@ -67,12 +67,12 @@ public class TestGenCorruptedScoreReproducer implements TestGenOriginalProblemRe
         } catch (RuntimeException e) {
             if (e.getMessage() != null && e.getMessage().startsWith("No fact handle for ")) {
                 // this is common when removing insert of a fact that is later updated - not interesting
-                logger.debug("    Can't remove insert: {}", e.toString());
+                LOGGER.debug("    Can't remove insert: {}", e.toString());
             } else if (e.getMessage() != null && e.getMessage().startsWith("Error evaluating constraint '")) {
                 // this is common after pruning setup code, which can lead to NPE during rule evaluation
-                logger.debug("    Can't drop field setup: {}", e.toString());
+                LOGGER.debug("    Can't drop field setup: {}", e.toString());
             } else {
-                logger.info("Unexpected exception", e);
+                LOGGER.info("Unexpected exception", e);
             }
             return false;
         }
@@ -91,7 +91,7 @@ public class TestGenCorruptedScoreReproducer implements TestGenOriginalProblemRe
         Score<?> uncorruptedScore = extractScore(uncorruptedSession);
         Score<?> workingScore = extractScore(kieSession);
         if (!workingScore.equals(uncorruptedScore)) {
-            logger.debug("    Score: working[{}], uncorrupted[{}]", workingScore, uncorruptedScore);
+            LOGGER.debug("    Score: working[{}], uncorrupted[{}]", workingScore, uncorruptedScore);
             throw new TestGenCorruptedScoreException(workingScore, uncorruptedScore);
         }
     }

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/reproducer/TestGenCorruptedVariableListenerReproducer.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/reproducer/TestGenCorruptedVariableListenerReproducer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,7 +36,7 @@ public class TestGenCorruptedVariableListenerReproducer implements
         TestGenOriginalProblemReproducer,
         TestGenKieSessionListener {
 
-    private static final Logger logger = LoggerFactory.getLogger(TestGenCorruptedVariableListenerReproducer.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(TestGenCorruptedVariableListenerReproducer.class);
     private final String analysis;
     private final TestGenDroolsScoreDirector<?, ?> scoreDirector;
     private Score<?> lastWorkingScore;
@@ -70,17 +70,17 @@ public class TestGenCorruptedVariableListenerReproducer implements
         } catch (TestGenCorruptedScoreException e) {
             return true;
         } catch (ConsequenceException e) {
-            logger.debug("    Journal pruning not possible: {}", e.toString());
+            LOGGER.debug("    Journal pruning not possible: {}", e.toString());
             return false;
         } catch (RuntimeException e) {
             if (e.getMessage() != null && e.getMessage().startsWith("No fact handle for ")) {
                 // this is common when removing insert of a fact that is later updated - not interesting
-                logger.debug("    Can't remove insert: {}", e.toString());
+                LOGGER.debug("    Can't remove insert: {}", e.toString());
             } else if (e.getMessage() != null && e.getMessage().startsWith("Error evaluating constraint '")) {
                 // this is common after pruning setup code, which can lead to NPE during rule evaluation
-                logger.debug("    Can't drop field setup: {}", e.toString());
+                LOGGER.debug("    Can't drop field setup: {}", e.toString());
             } else {
-                logger.info("Unexpected exception", e);
+                LOGGER.info("Unexpected exception", e);
             }
             return false;
         }
@@ -91,7 +91,7 @@ public class TestGenCorruptedVariableListenerReproducer implements
             TestGenKieSessionFireAllRules fire) {
         Score<?> workingScore = extractScore(kieSession);
         if (fire.isAssertFire()) {
-            logger.debug("    [Assert mode] Score: working[{}], uncorrupted[{}] ({})",
+            LOGGER.debug("    [Assert mode] Score: working[{}], uncorrupted[{}] ({})",
                     workingScore, lastWorkingScore, fire);
             // if this assertion fire's score is different from the previous fire it means that a shadow variable
             // update was corrupted
@@ -100,7 +100,7 @@ public class TestGenCorruptedVariableListenerReproducer implements
                 throw new TestGenCorruptedScoreException(workingScore, lastWorkingScore);
             }
         } else {
-            logger.debug("      Score: {} ({})", workingScore, fire);
+            LOGGER.debug("      Score: {} ({})", workingScore, fire);
         }
         lastWorkingScore = workingScore;
         lastFireId = fire.getFireId();

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/reproducer/TestGenDroolsExceptionReproducer.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/reproducer/TestGenDroolsExceptionReproducer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,7 +27,7 @@ import org.slf4j.LoggerFactory;
  */
 public class TestGenDroolsExceptionReproducer implements TestGenOriginalProblemReproducer {
 
-    private static final Logger logger = LoggerFactory.getLogger(TestGenDroolsExceptionReproducer.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(TestGenDroolsExceptionReproducer.class);
     private final RuntimeException originalException;
     private final TestGenDroolsScoreDirector<?, ?> scoreDirector;
 
@@ -49,13 +49,13 @@ public class TestGenDroolsExceptionReproducer implements TestGenOriginalProblemR
                 if (reproducedException.getMessage() != null
                         && reproducedException.getMessage().startsWith("No fact handle for ")) {
                     // this is common when removing insert of a fact that is later updated - not interesting
-                    logger.debug("    Can't remove insert: {}", reproducedException.toString());
+                    LOGGER.debug("    Can't remove insert: {}", reproducedException.toString());
                 } else if (reproducedException.getMessage() != null
                         && reproducedException.getMessage().startsWith("Error evaluating constraint '")) {
                     // this is common after pruning setup code, which can lead to NPE during rule evaluation
-                    logger.debug("    Can't drop field setup: {}", reproducedException.toString());
+                    LOGGER.debug("    Can't drop field setup: {}", reproducedException.toString());
                 } else {
-                    logger.info("Unexpected exception", reproducedException);
+                    LOGGER.info("Unexpected exception", reproducedException);
                 }
                 return false;
             }

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/solver/DefaultSolverFactory.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/solver/DefaultSolverFactory.java
@@ -16,9 +16,12 @@
 
 package org.optaplanner.core.impl.solver;
 
+import static org.apache.commons.lang3.ObjectUtils.defaultIfNull;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+
 import org.optaplanner.core.api.domain.solution.PlanningSolution;
 import org.optaplanner.core.api.solver.Solver;
 import org.optaplanner.core.api.solver.SolverFactory;
@@ -47,8 +50,6 @@ import org.optaplanner.core.impl.solver.termination.Termination;
 import org.optaplanner.core.impl.solver.termination.TerminationFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import static org.apache.commons.lang3.ObjectUtils.defaultIfNull;
 
 /**
  * @param <Solution_> the solution type, the class with the {@link PlanningSolution} annotation

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/solver/DefaultSolverFactory.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/solver/DefaultSolverFactory.java
@@ -16,12 +16,9 @@
 
 package org.optaplanner.core.impl.solver;
 
-import static org.apache.commons.lang3.ObjectUtils.defaultIfNull;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-
 import org.optaplanner.core.api.domain.solution.PlanningSolution;
 import org.optaplanner.core.api.solver.Solver;
 import org.optaplanner.core.api.solver.SolverFactory;
@@ -51,13 +48,15 @@ import org.optaplanner.core.impl.solver.termination.TerminationFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static org.apache.commons.lang3.ObjectUtils.defaultIfNull;
+
 /**
  * @param <Solution_> the solution type, the class with the {@link PlanningSolution} annotation
  * @see SolverFactory
  */
 public final class DefaultSolverFactory<Solution_> implements SolverFactory<Solution_> {
 
-    private static final Logger logger = LoggerFactory.getLogger(DefaultSolverFactory.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(DefaultSolverFactory.class);
     private static final long DEFAULT_RANDOM_SEED = 0L;
 
     private final SolverConfig solverConfig;
@@ -201,7 +200,7 @@ public final class DefaultSolverFactory<Solution_> implements SolverFactory<Solu
                         + ") that is lower than 1.");
             }
             if (resolvedMoveThreadCount > availableProcessorCount) {
-                logger.warn("The resolvedMoveThreadCount ({}) is higher "
+                LOGGER.warn("The resolvedMoveThreadCount ({}) is higher "
                         + "than the availableProcessorCount ({}), which is counter-efficient.",
                         resolvedMoveThreadCount, availableProcessorCount);
                 // Still allow it, to reproduce issues of a high-end server machine on a low-end developer machine

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/solver/DefaultSolverJob.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/solver/DefaultSolverJob.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,7 +41,7 @@ import org.slf4j.LoggerFactory;
  */
 public final class DefaultSolverJob<Solution_, ProblemId_> implements SolverJob<Solution_, ProblemId_>, Callable<Solution_> {
 
-    protected final transient Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger LOGGER = LoggerFactory.getLogger(DefaultSolverJob.class);
 
     private final DefaultSolverManager<Solution_, ProblemId_> solverManager;
     private final DefaultSolver<Solution_> solver;
@@ -153,7 +153,7 @@ public final class DefaultSolverJob<Solution_, ProblemId_> implements SolverJob<
             terminatedLatch.await();
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
-            logger.warn("The terminateEarly() call is interrupted.", e);
+            LOGGER.warn("The terminateEarly() call is interrupted.", e);
         }
     }
 

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/solver/DefaultSolverManager.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/solver/DefaultSolverManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -42,7 +42,7 @@ import org.slf4j.LoggerFactory;
  */
 public final class DefaultSolverManager<Solution_, ProblemId_> implements SolverManager<Solution_, ProblemId_> {
 
-    protected final transient Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger LOGGER = LoggerFactory.getLogger(DefaultSolverManager.class);
 
     private final BiConsumer<ProblemId_, Throwable> defaultExceptionHandler;
     private final SolverFactory<Solution_> solverFactory;
@@ -53,7 +53,7 @@ public final class DefaultSolverManager<Solution_, ProblemId_> implements Solver
 
     public DefaultSolverManager(SolverFactory<Solution_> solverFactory,
             SolverManagerConfig solverManagerConfig) {
-        defaultExceptionHandler = (problemId, throwable) -> logger.error(
+        defaultExceptionHandler = (problemId, throwable) -> LOGGER.error(
                 "Solving failed for problemId ({}).", problemId, throwable);
         this.solverFactory = solverFactory;
         validateSolverFactory();
@@ -157,7 +157,7 @@ public final class DefaultSolverManager<Solution_, ProblemId_> implements Solver
         DefaultSolverJob<Solution_, ProblemId_> solverJob = problemIdToSolverJobMap.get(problemId);
         if (solverJob == null) {
             // We cannot distinguish between "already terminated" and "never solved" without causing a memory leak.
-            logger.debug("Ignoring terminateEarly() call because problemId ({}) is not solving.", problemId);
+            LOGGER.debug("Ignoring terminateEarly() call because problemId ({}) is not solving.", problemId);
             return;
         }
         solverJob.terminateEarly();

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/solver/recaller/BestSolutionRecaller.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/solver/recaller/BestSolutionRecaller.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,8 +25,6 @@ import org.optaplanner.core.impl.phase.scope.AbstractStepScope;
 import org.optaplanner.core.impl.score.director.InnerScoreDirector;
 import org.optaplanner.core.impl.solver.event.SolverEventSupport;
 import org.optaplanner.core.impl.solver.scope.SolverScope;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Remembers the {@link PlanningSolution best solution} that a {@link Solver} encounters.
@@ -34,8 +32,6 @@ import org.slf4j.LoggerFactory;
  * @param <Solution_> the solution type, the class with the {@link PlanningSolution} annotation
  */
 public class BestSolutionRecaller<Solution_> extends PhaseLifecycleListenerAdapter<Solution_> {
-
-    protected final transient Logger logger = LoggerFactory.getLogger(getClass());
 
     protected boolean assertInitialScoreFromScratch = false;
     protected boolean assertShadowVariablesAreNotStale = false;

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/solver/scope/SolverScope.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/solver/scope/SolverScope.java
@@ -19,6 +19,7 @@ package org.optaplanner.core.impl.solver.scope;
 import java.util.List;
 import java.util.Random;
 import java.util.concurrent.Semaphore;
+
 import org.optaplanner.core.api.domain.solution.PlanningSolution;
 import org.optaplanner.core.api.score.Score;
 import org.optaplanner.core.api.solver.Solver;

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/solver/scope/SolverScope.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/solver/scope/SolverScope.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,6 @@ package org.optaplanner.core.impl.solver.scope;
 import java.util.List;
 import java.util.Random;
 import java.util.concurrent.Semaphore;
-
 import org.optaplanner.core.api.domain.solution.PlanningSolution;
 import org.optaplanner.core.api.score.Score;
 import org.optaplanner.core.api.solver.Solver;
@@ -29,15 +28,11 @@ import org.optaplanner.core.impl.score.definition.ScoreDefinition;
 import org.optaplanner.core.impl.score.director.InnerScoreDirector;
 import org.optaplanner.core.impl.solver.termination.Termination;
 import org.optaplanner.core.impl.solver.thread.ChildThreadType;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * @param <Solution_> the solution type, the class with the {@link PlanningSolution} annotation
  */
 public class SolverScope<Solution_> {
-
-    protected final transient Logger logger = LoggerFactory.getLogger(getClass());
 
     protected int startingSolverCount;
     protected Random workingRandom;

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/solver/thread/ThreadUtils.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/solver/thread/ThreadUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@ import org.slf4j.LoggerFactory;
 
 public class ThreadUtils {
 
-    private static final Logger logger = LoggerFactory.getLogger(ThreadUtils.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(ThreadUtils.class);
 
     public static void shutdownAwaitOrKill(ExecutorService executor, String logIndentation, String name) {
         // Intentionally clearing the interrupted flag so that awaitTermination() in step 3 works.
@@ -46,7 +46,7 @@ public class ThreadUtils {
                 // Some solvers refused to complete. Busy threads will be interrupted in the finally block.
                 // We're only logging the error instead throwing an exception to prevent eating the original
                 // exception.
-                logger.error(
+                LOGGER.error(
                         "{}{}'s ExecutorService didn't terminate within timeout ({} seconds).",
                         logIndentation, name,
                         awaitingSeconds);

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/heuristic/thread/OrderByMoveIndexBlockingQueueTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/heuristic/thread/OrderByMoveIndexBlockingQueueTest.java
@@ -16,11 +16,16 @@
 
 package org.optaplanner.core.impl.heuristic.thread;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertCode;
+
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.optaplanner.core.api.score.buildin.simple.SimpleScore;
@@ -28,10 +33,6 @@ import org.optaplanner.core.impl.heuristic.move.DummyMove;
 import org.optaplanner.core.impl.testdata.domain.TestdataSolution;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertCode;
 
 public class OrderByMoveIndexBlockingQueueTest {
 

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/heuristic/thread/OrderByMoveIndexBlockingQueueTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/heuristic/thread/OrderByMoveIndexBlockingQueueTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,28 +16,26 @@
 
 package org.optaplanner.core.impl.heuristic.thread;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertCode;
-
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
-
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.optaplanner.core.api.score.buildin.simple.SimpleScore;
 import org.optaplanner.core.impl.heuristic.move.DummyMove;
-import org.optaplanner.core.impl.partitionedsearch.queue.PartitionQueueTest;
 import org.optaplanner.core.impl.testdata.domain.TestdataSolution;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertCode;
+
 public class OrderByMoveIndexBlockingQueueTest {
 
-    private static final Logger logger = LoggerFactory.getLogger(PartitionQueueTest.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(OrderByMoveIndexBlockingQueueTest.class);
 
     private final ExecutorService executorService = Executors.newFixedThreadPool(2);
 
@@ -45,7 +43,7 @@ public class OrderByMoveIndexBlockingQueueTest {
     public void tearDown() throws InterruptedException {
         executorService.shutdownNow();
         if (!executorService.awaitTermination(1, TimeUnit.MILLISECONDS)) {
-            logger.warn("Thread pool didn't terminate within the timeout.");
+            LOGGER.warn("Thread pool didn't terminate within the timeout.");
         }
     }
 

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/partitionedsearch/TestdataFaultyEntity.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/partitionedsearch/TestdataFaultyEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,7 +22,7 @@ import org.slf4j.LoggerFactory;
 
 public class TestdataFaultyEntity extends TestdataEntity {
 
-    private static final Logger logger = LoggerFactory.getLogger(TestdataFaultyEntity.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(TestdataFaultyEntity.class);
 
     public TestdataFaultyEntity() {
     }
@@ -35,7 +35,7 @@ public class TestdataFaultyEntity extends TestdataEntity {
     public void setValue(TestdataValue value) {
         super.setValue(value);
         if (Thread.currentThread().getName().matches("OptaPool-\\d+-PartThread-\\d+")) {
-            logger.info("Throwing exception on a partition thread.");
+            LOGGER.info("Throwing exception on a partition thread.");
             throw new TestException();
         }
     }

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/partitionedsearch/TestdataSleepingEntity.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/partitionedsearch/TestdataSleepingEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@ import org.slf4j.LoggerFactory;
 
 public class TestdataSleepingEntity extends TestdataEntity {
 
-    private static final Logger logger = LoggerFactory.getLogger(TestdataSleepingEntity.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(TestdataSleepingEntity.class);
     private CountDownLatch latch;
 
     public TestdataSleepingEntity() {
@@ -47,19 +47,19 @@ public class TestdataSleepingEntity extends TestdataEntity {
     public void setValue(TestdataValue value) {
         super.setValue(value);
         if (latch.getCount() == 0) {
-            logger.debug("This entity was already interrupted in the past. Not going to sleep again.");
+            LOGGER.debug("This entity was already interrupted in the past. Not going to sleep again.");
             return;
         }
         latch.countDown();
         long start = System.currentTimeMillis();
-        logger.info("{}.setValue() started and going to sleep.", TestdataSleepingEntity.class.getSimpleName());
+        LOGGER.info("{}.setValue() started and going to sleep.", TestdataSleepingEntity.class.getSimpleName());
         try {
             Thread.sleep(Long.MAX_VALUE);
         } catch (InterruptedException ex) {
             Thread.currentThread().interrupt();
             throw new RuntimeException("Interrupted while sleeping", ex);
         }
-        logger.info("{}.setValue() interrupted after {}ms.",
+        LOGGER.info("{}.setValue() interrupted after {}ms.",
                 TestdataSleepingEntity.class.getSimpleName(),
                 System.currentTimeMillis() - start);
     }

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/partitionedsearch/queue/PartitionQueueTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/partitionedsearch/queue/PartitionQueueTest.java
@@ -16,20 +16,21 @@
 
 package org.optaplanner.core.impl.partitionedsearch.queue;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
+
 import java.util.Iterator;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.optaplanner.core.impl.partitionedsearch.scope.PartitionChangeMove;
 import org.optaplanner.core.impl.testdata.domain.TestdataSolution;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
 
 public class PartitionQueueTest {
 

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/partitionedsearch/queue/PartitionQueueTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/partitionedsearch/queue/PartitionQueueTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,15 +16,11 @@
 
 package org.optaplanner.core.impl.partitionedsearch.queue;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
-
 import java.util.Iterator;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
-
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.optaplanner.core.impl.partitionedsearch.scope.PartitionChangeMove;
@@ -32,9 +28,12 @@ import org.optaplanner.core.impl.testdata.domain.TestdataSolution;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
+
 public class PartitionQueueTest {
 
-    private static final Logger logger = LoggerFactory.getLogger(PartitionQueueTest.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(PartitionQueueTest.class);
 
     private final ExecutorService executorService = Executors.newFixedThreadPool(2);
 
@@ -42,7 +41,7 @@ public class PartitionQueueTest {
     public void tearDown() throws InterruptedException {
         executorService.shutdownNow();
         if (!executorService.awaitTermination(1, TimeUnit.MILLISECONDS)) {
-            logger.warn("Thread pool didn't terminate within the timeout.");
+            LOGGER.warn("Thread pool didn't terminate within the timeout.");
         }
     }
 

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/cheaptime/score/CheapTimeIncrementalScoreCalculator.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/cheaptime/score/CheapTimeIncrementalScoreCalculator.java
@@ -22,6 +22,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+
 import org.optaplanner.core.api.score.buildin.hardmediumsoftlong.HardMediumSoftLongScore;
 import org.optaplanner.core.api.score.calculator.ConstraintMatchAwareIncrementalScoreCalculator;
 import org.optaplanner.core.api.score.calculator.IncrementalScoreCalculator;

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/cheaptime/score/CheapTimeIncrementalScoreCalculator.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/cheaptime/score/CheapTimeIncrementalScoreCalculator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,7 +22,6 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-
 import org.optaplanner.core.api.score.buildin.hardmediumsoftlong.HardMediumSoftLongScore;
 import org.optaplanner.core.api.score.calculator.ConstraintMatchAwareIncrementalScoreCalculator;
 import org.optaplanner.core.api.score.calculator.IncrementalScoreCalculator;
@@ -36,16 +35,12 @@ import org.optaplanner.examples.cheaptime.domain.Resource;
 import org.optaplanner.examples.cheaptime.domain.Task;
 import org.optaplanner.examples.cheaptime.domain.TaskAssignment;
 import org.optaplanner.examples.cheaptime.domain.TaskRequirement;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class CheapTimeIncrementalScoreCalculator
         implements ConstraintMatchAwareIncrementalScoreCalculator<CheapTimeSolution, HardMediumSoftLongScore>,
         IncrementalScoreCalculator<CheapTimeSolution, HardMediumSoftLongScore> {
 
     protected static final String CONSTRAINT_PACKAGE = "org.optaplanner.examples.cheaptime.solver";
-
-    protected final transient Logger logger = LoggerFactory.getLogger(getClass());
 
     private CheapTimeSolution cheapTimeSolution;
 

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/common/business/SolutionBusiness.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/common/business/SolutionBusiness.java
@@ -16,13 +16,17 @@
 
 package org.optaplanner.examples.common.business;
 
+import static java.util.stream.Collectors.toList;
+
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
+
 import javax.swing.SwingUtilities;
+
 import org.apache.commons.io.FileUtils;
 import org.optaplanner.core.api.domain.solution.PlanningSolution;
 import org.optaplanner.core.api.score.Score;
@@ -53,8 +57,6 @@ import org.optaplanner.examples.common.swingui.SolverAndPersistenceFrame;
 import org.optaplanner.persistence.common.api.domain.solution.SolutionFileIO;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import static java.util.stream.Collectors.toList;
 
 /**
  * @param <Solution_> the solution type, the class with the {@link PlanningSolution} annotation

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/common/business/SolutionBusiness.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/common/business/SolutionBusiness.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,17 +16,13 @@
 
 package org.optaplanner.examples.common.business;
 
-import static java.util.stream.Collectors.toList;
-
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
-
 import javax.swing.SwingUtilities;
-
 import org.apache.commons.io.FileUtils;
 import org.optaplanner.core.api.domain.solution.PlanningSolution;
 import org.optaplanner.core.api.score.Score;
@@ -58,6 +54,8 @@ import org.optaplanner.persistence.common.api.domain.solution.SolutionFileIO;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static java.util.stream.Collectors.toList;
+
 /**
  * @param <Solution_> the solution type, the class with the {@link PlanningSolution} annotation
  */
@@ -65,7 +63,7 @@ public class SolutionBusiness<Solution_, Score_ extends Score<Score_>> {
 
     private static final ProblemFileComparator FILE_COMPARATOR = new ProblemFileComparator();
 
-    protected final transient Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger LOGGER = LoggerFactory.getLogger(SolutionBusiness.class);
 
     private final CommonApp app;
     private File dataDir;
@@ -301,7 +299,7 @@ public class SolutionBusiness<Solution_, Score_ extends Score<Score_>> {
 
     public void openSolution(File file) {
         Solution_ solution = solutionFileIO.read(file);
-        logger.info("Opened: {}", file);
+        LOGGER.info("Opened: {}", file);
         solutionFileName = file.getName();
         guiScoreDirector.setWorkingSolution(solution);
     }
@@ -309,7 +307,7 @@ public class SolutionBusiness<Solution_, Score_ extends Score<Score_>> {
     public void saveSolution(File file) {
         Solution_ solution = guiScoreDirector.getWorkingSolution();
         solutionFileIO.write(solution, file);
-        logger.info("Saved: {}", file);
+        LOGGER.info("Saved: {}", file);
     }
 
     public void exportSolution(AbstractSolutionExporter<Solution_> exporter, File file) {
@@ -319,14 +317,14 @@ public class SolutionBusiness<Solution_, Score_ extends Score<Score_>> {
 
     public void doMove(Move<Solution_> move) {
         if (solver.isSolving()) {
-            logger.error("Not doing user move ({}) because the solver is solving.", move);
+            LOGGER.error("Not doing user move ({}) because the solver is solving.", move);
             return;
         }
         if (!move.isMoveDoable(guiScoreDirector)) {
-            logger.warn("Not doing user move ({}) because it is not doable.", move);
+            LOGGER.warn("Not doing user move ({}) because it is not doable.", move);
             return;
         }
-        logger.info("Doing user move ({}).", move);
+        LOGGER.info("Doing user move ({}).", move);
         move.doMove(guiScoreDirector);
         guiScoreDirector.calculateScore();
     }

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/common/swingui/ConstraintMatchesDialog.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/common/swingui/ConstraintMatchesDialog.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,7 +22,6 @@ import java.awt.FlowLayout;
 import java.awt.event.ActionEvent;
 import java.util.List;
 import java.util.Set;
-
 import javax.swing.AbstractAction;
 import javax.swing.Action;
 import javax.swing.BorderFactory;
@@ -38,17 +37,12 @@ import javax.swing.SwingConstants;
 import javax.swing.table.AbstractTableModel;
 import javax.swing.table.DefaultTableCellRenderer;
 import javax.swing.table.TableColumnModel;
-
 import org.optaplanner.core.api.score.Score;
 import org.optaplanner.core.api.score.constraint.ConstraintMatch;
 import org.optaplanner.core.api.score.constraint.ConstraintMatchTotal;
 import org.optaplanner.examples.common.business.SolutionBusiness;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class ConstraintMatchesDialog extends JDialog {
-
-    protected final transient Logger logger = LoggerFactory.getLogger(getClass());
 
     protected final SolutionBusiness solutionBusiness;
 

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/common/swingui/ConstraintMatchesDialog.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/common/swingui/ConstraintMatchesDialog.java
@@ -22,6 +22,7 @@ import java.awt.FlowLayout;
 import java.awt.event.ActionEvent;
 import java.util.List;
 import java.util.Set;
+
 import javax.swing.AbstractAction;
 import javax.swing.Action;
 import javax.swing.BorderFactory;
@@ -37,6 +38,7 @@ import javax.swing.SwingConstants;
 import javax.swing.table.AbstractTableModel;
 import javax.swing.table.DefaultTableCellRenderer;
 import javax.swing.table.TableColumnModel;
+
 import org.optaplanner.core.api.score.Score;
 import org.optaplanner.core.api.score.constraint.ConstraintMatch;
 import org.optaplanner.core.api.score.constraint.ConstraintMatchTotal;

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/common/swingui/SolverAndPersistenceFrame.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/common/swingui/SolverAndPersistenceFrame.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,7 +32,6 @@ import java.io.File;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.function.BiConsumer;
-
 import javax.swing.AbstractAction;
 import javax.swing.Action;
 import javax.swing.BorderFactory;
@@ -56,7 +55,6 @@ import javax.swing.LayoutStyle;
 import javax.swing.ListSelectionModel;
 import javax.swing.SwingWorker;
 import javax.swing.filechooser.FileFilter;
-
 import org.apache.commons.io.FilenameUtils;
 import org.optaplanner.core.api.domain.solution.PlanningSolution;
 import org.optaplanner.core.api.score.Score;
@@ -65,15 +63,11 @@ import org.optaplanner.examples.common.business.SolutionBusiness;
 import org.optaplanner.examples.common.persistence.AbstractSolutionExporter;
 import org.optaplanner.examples.common.persistence.AbstractSolutionImporter;
 import org.optaplanner.swing.impl.TangoColorFactory;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * @param <Solution_> the solution type, the class with the {@link PlanningSolution} annotation
  */
 public class SolverAndPersistenceFrame<Solution_> extends JFrame {
-
-    protected final transient Logger logger = LoggerFactory.getLogger(getClass());
 
     public static final ImageIcon OPTA_PLANNER_ICON = new ImageIcon(
             SolverAndPersistenceFrame.class.getResource("optaPlannerIcon.png"));

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/common/swingui/SolverAndPersistenceFrame.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/common/swingui/SolverAndPersistenceFrame.java
@@ -32,6 +32,7 @@ import java.io.File;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.function.BiConsumer;
+
 import javax.swing.AbstractAction;
 import javax.swing.Action;
 import javax.swing.BorderFactory;
@@ -55,6 +56,7 @@ import javax.swing.LayoutStyle;
 import javax.swing.ListSelectionModel;
 import javax.swing.SwingWorker;
 import javax.swing.filechooser.FileFilter;
+
 import org.apache.commons.io.FilenameUtils;
 import org.optaplanner.core.api.domain.solution.PlanningSolution;
 import org.optaplanner.core.api.score.Score;

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/investment/optional/score/InvestmentIncrementalScoreCalculator.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/investment/optional/score/InvestmentIncrementalScoreCalculator.java
@@ -19,6 +19,7 @@ package org.optaplanner.examples.investment.optional.score;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
 import org.optaplanner.core.api.score.buildin.hardsoftlong.HardSoftLongScore;
 import org.optaplanner.core.api.score.calculator.IncrementalScoreCalculator;
 import org.optaplanner.examples.investment.domain.AssetClassAllocation;

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/investment/optional/score/InvestmentIncrementalScoreCalculator.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/investment/optional/score/InvestmentIncrementalScoreCalculator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,20 +19,15 @@ package org.optaplanner.examples.investment.optional.score;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
 import org.optaplanner.core.api.score.buildin.hardsoftlong.HardSoftLongScore;
 import org.optaplanner.core.api.score.calculator.IncrementalScoreCalculator;
 import org.optaplanner.examples.investment.domain.AssetClassAllocation;
 import org.optaplanner.examples.investment.domain.InvestmentSolution;
 import org.optaplanner.examples.investment.domain.Region;
 import org.optaplanner.examples.investment.domain.Sector;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class InvestmentIncrementalScoreCalculator
         implements IncrementalScoreCalculator<InvestmentSolution, HardSoftLongScore> {
-
-    protected final transient Logger logger = LoggerFactory.getLogger(getClass());
 
     private InvestmentSolution solution;
 

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/investment/solver/solution/initializer/InvestmentAllocationSolutionInitializer.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/investment/solver/solution/initializer/InvestmentAllocationSolutionInitializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,12 +21,8 @@ import org.optaplanner.core.impl.phase.custom.CustomPhaseCommand;
 import org.optaplanner.examples.investment.domain.AssetClassAllocation;
 import org.optaplanner.examples.investment.domain.InvestmentSolution;
 import org.optaplanner.examples.investment.domain.util.InvestmentNumericUtil;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class InvestmentAllocationSolutionInitializer implements CustomPhaseCommand<InvestmentSolution> {
-
-    protected final transient Logger logger = LoggerFactory.getLogger(getClass());
 
     @Override
     public void changeWorkingSolution(ScoreDirector<InvestmentSolution> scoreDirector) {

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/machinereassignment/score/MachineReassignmentIncrementalScoreCalculator.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/machinereassignment/score/MachineReassignmentIncrementalScoreCalculator.java
@@ -22,6 +22,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
 import org.optaplanner.core.api.score.buildin.hardsoftlong.HardSoftLongScore;
 import org.optaplanner.core.api.score.calculator.ConstraintMatchAwareIncrementalScoreCalculator;
 import org.optaplanner.core.api.score.calculator.IncrementalScoreCalculator;

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/machinereassignment/score/MachineReassignmentIncrementalScoreCalculator.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/machinereassignment/score/MachineReassignmentIncrementalScoreCalculator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,7 +22,6 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
 import org.optaplanner.core.api.score.buildin.hardsoftlong.HardSoftLongScore;
 import org.optaplanner.core.api.score.calculator.ConstraintMatchAwareIncrementalScoreCalculator;
 import org.optaplanner.core.api.score.calculator.IncrementalScoreCalculator;
@@ -39,16 +38,12 @@ import org.optaplanner.examples.machinereassignment.domain.MrNeighborhood;
 import org.optaplanner.examples.machinereassignment.domain.MrProcessAssignment;
 import org.optaplanner.examples.machinereassignment.domain.MrResource;
 import org.optaplanner.examples.machinereassignment.domain.MrService;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class MachineReassignmentIncrementalScoreCalculator
         implements ConstraintMatchAwareIncrementalScoreCalculator<MachineReassignment, HardSoftLongScore>,
         IncrementalScoreCalculator<MachineReassignment, HardSoftLongScore> {
 
     protected static final String CONSTRAINT_PACKAGE = "org.optaplanner.examples.machinereassignment.solver";
-
-    protected final transient Logger logger = LoggerFactory.getLogger(getClass());
 
     private MachineReassignment machineReassignment;
     private MrGlobalPenaltyInfo globalPenaltyInfo;

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/machinereassignment/solver/solution/initializer/ToOriginalMachineSolutionInitializer.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/machinereassignment/solver/solution/initializer/ToOriginalMachineSolutionInitializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,12 +21,8 @@ import org.optaplanner.core.impl.phase.custom.CustomPhaseCommand;
 import org.optaplanner.examples.machinereassignment.domain.MachineReassignment;
 import org.optaplanner.examples.machinereassignment.domain.MrMachine;
 import org.optaplanner.examples.machinereassignment.domain.MrProcessAssignment;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class ToOriginalMachineSolutionInitializer implements CustomPhaseCommand<MachineReassignment> {
-
-    protected final transient Logger logger = LoggerFactory.getLogger(getClass());
 
     @Override
     public void changeWorkingSolution(ScoreDirector<MachineReassignment> scoreDirector) {

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/nqueens/optional/solver/solution/CheatingNQueensPhaseCommand.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/nqueens/optional/solver/solution/CheatingNQueensPhaseCommand.java
@@ -17,6 +17,7 @@
 package org.optaplanner.examples.nqueens.optional.solver.solution;
 
 import java.util.List;
+
 import org.optaplanner.core.api.score.director.ScoreDirector;
 import org.optaplanner.core.impl.phase.custom.CustomPhaseCommand;
 import org.optaplanner.examples.nqueens.domain.NQueens;

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/nqueens/optional/solver/solution/CheatingNQueensPhaseCommand.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/nqueens/optional/solver/solution/CheatingNQueensPhaseCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,14 +17,11 @@
 package org.optaplanner.examples.nqueens.optional.solver.solution;
 
 import java.util.List;
-
 import org.optaplanner.core.api.score.director.ScoreDirector;
 import org.optaplanner.core.impl.phase.custom.CustomPhaseCommand;
 import org.optaplanner.examples.nqueens.domain.NQueens;
 import org.optaplanner.examples.nqueens.domain.Queen;
 import org.optaplanner.examples.nqueens.domain.Row;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Because N Queens is not NP-complete or NP-hard, it can be cheated.
@@ -34,8 +31,6 @@ import org.slf4j.LoggerFactory;
  * (<a href="https://en.wikipedia.org/wiki/Eight_queens_puzzle#Explicit_solutions">explicit solutions algorithm</a>).
  */
 public class CheatingNQueensPhaseCommand implements CustomPhaseCommand<NQueens> {
-
-    protected final transient Logger logger = LoggerFactory.getLogger(getClass());
 
     @Override
     public void changeWorkingSolution(ScoreDirector<NQueens> scoreDirector) {

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/vehiclerouting/optional/solver/solution/initializer/BuoyVehicleRoutingSolutionInitializer.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/vehiclerouting/optional/solver/solution/initializer/BuoyVehicleRoutingSolutionInitializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,7 +37,7 @@ import org.slf4j.LoggerFactory;
 // TODO PLANNER-380 Delete this class. Temporary implementation until BUOY_FIT is implemented as a Construction Heuristic
 public class BuoyVehicleRoutingSolutionInitializer implements CustomPhaseCommand<VehicleRoutingSolution> {
 
-    protected final transient Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger LOGGER = LoggerFactory.getLogger(BuoyVehicleRoutingSolutionInitializer.class);
 
     @Override
     public void changeWorkingSolution(ScoreDirector<VehicleRoutingSolution> scoreDirector) {
@@ -47,21 +47,18 @@ public class BuoyVehicleRoutingSolutionInitializer implements CustomPhaseCommand
         List<Standstill> standstillList = new ArrayList<>(vehicleList.size() + customerList.size());
         standstillList.addAll(vehicleList);
         standstillList.addAll(customerList);
-        logger.info("Starting sorting");
+        LOGGER.info("Starting sorting");
         Map<Standstill, Customer[]> nearbyMap = new HashMap<>(standstillList.size());
         for (final Standstill origin : standstillList) {
             Customer[] nearbyCustomers = customerList.toArray(new Customer[0]);
-            Arrays.sort(nearbyCustomers, new Comparator<Standstill>() {
-                @Override
-                public int compare(Standstill a, Standstill b) {
-                    double aDistance = origin.getLocation().getDistanceTo(a.getLocation());
-                    double bDistance = origin.getLocation().getDistanceTo(b.getLocation());
-                    return Double.compare(aDistance, bDistance);
-                }
+            Arrays.sort(nearbyCustomers, (Comparator<Standstill>) (a, b) -> {
+                double aDistance = origin.getLocation().getDistanceTo(a.getLocation());
+                double bDistance = origin.getLocation().getDistanceTo(b.getLocation());
+                return Double.compare(aDistance, bDistance);
             });
             nearbyMap.put(origin, nearbyCustomers);
         }
-        logger.info("Done sorting");
+        LOGGER.info("Done sorting");
 
         List<Standstill> buoyList = new ArrayList<>(vehicleList);
 
@@ -107,7 +104,7 @@ public class BuoyVehicleRoutingSolutionInitializer implements CustomPhaseCommand
             stepEntity.setPreviousStandstill(stepValue);
             scoreDirector.afterVariableChanged(stepEntity, "previousStandstill");
             scoreDirector.triggerVariableListeners();
-            logger.debug("    Score ({}), assigned customer ({}) to stepValue ({}).", stepScore, stepEntity, stepValue);
+            LOGGER.debug("    Score ({}), assigned customer ({}) to stepValue ({}).", stepScore, stepEntity, stepValue);
         }
     }
 


### PR DESCRIPTION
I have applied the following criteria:

- Abstract classes keep their `protected final transient Logger logger`. Messing with that could alter the performance characteristics of those classes, and that would not be worth it.
- Classes that do not expose their loggers all get converted to `private static final Logger LOGGER`.
- In some cases, this uncovered unused loggers, which were therefore removed.