### PR TITLE
PLANNER-2341: OptaPlanner Benchmark Quarkus extension

### DIFF
--- a/optaplanner-bom/pom.xml
+++ b/optaplanner-bom/pom.xml
@@ -390,6 +390,40 @@
         <type>test-jar</type>
         <version>${version.org.optaplanner}</version>
       </dependency>
+      <dependency>
+        <groupId>org.optaplanner</groupId>
+        <artifactId>optaplanner-quarkus-benchmark</artifactId>
+        <version>${version.org.optaplanner}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.optaplanner</groupId>
+        <artifactId>optaplanner-quarkus-benchmark</artifactId>
+        <version>${version.org.optaplanner}</version>
+        <classifier>sources</classifier>
+      </dependency>
+      <dependency>
+        <groupId>org.optaplanner</groupId>
+        <artifactId>optaplanner-quarkus-benchmark</artifactId>
+        <type>test-jar</type>
+        <version>${version.org.optaplanner}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.optaplanner</groupId>
+        <artifactId>optaplanner-quarkus-benchmark-deployment</artifactId>
+        <version>${version.org.optaplanner}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.optaplanner</groupId>
+        <artifactId>optaplanner-quarkus-benchmark-deployment</artifactId>
+        <version>${version.org.optaplanner}</version>
+        <classifier>sources</classifier>
+      </dependency>
+      <dependency>
+        <groupId>org.optaplanner</groupId>
+        <artifactId>optaplanner-quarkus-benchmark-deployment</artifactId>
+        <type>test-jar</type>
+        <version>${version.org.optaplanner}</version>
+      </dependency>
       <!-- spring-integration -->
       <dependency>
         <groupId>org.optaplanner</groupId>

--- a/optaplanner-quarkus-integration/optaplanner-quarkus-benchmark/.gitignore
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus-benchmark/.gitignore
@@ -1,0 +1,10 @@
+/target
+/local
+
+# Eclipse, Netbeans and IntelliJ files
+/.*
+!.gitignore
+/nbproject
+/*.ipr
+/*.iws
+/*.iml

--- a/optaplanner-quarkus-integration/optaplanner-quarkus-benchmark/deployment/.gitignore
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus-benchmark/deployment/.gitignore
@@ -1,0 +1,10 @@
+/target
+/local
+
+# Eclipse, Netbeans and IntelliJ files
+/.*
+!.gitignore
+/nbproject
+/*.ipr
+/*.iws
+/*.iml

--- a/optaplanner-quarkus-integration/optaplanner-quarkus-benchmark/deployment/pom.xml
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus-benchmark/deployment/pom.xml
@@ -48,29 +48,10 @@
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-resteasy-deployment</artifactId>
       <scope>test</scope>
-      <exclusions>
-        <!-- Duplicates classes of jakarta.xml.bind:jakarta.xml.bind-api -->
-        <exclusion>
-          <groupId>org.jboss.spec.javax.xml.bind</groupId>
-          <artifactId>jboss-jaxb-api_2.3_spec</artifactId>
-        </exclusion>
-        <!-- Duplicates classes of jakarta.activation:jakarta.activation-api -->
-        <exclusion>
-          <groupId>com.sun.activation</groupId>
-          <artifactId>jakarta.activation</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>io.rest-assured</groupId>
       <artifactId>rest-assured</artifactId>
-      <exclusions>
-        <!-- Duplicates classes of jakarta.activation:jakarta.activation-api -->
-        <exclusion>
-          <groupId>org.apache.sling</groupId>
-          <artifactId>org.apache.sling.javax.activation</artifactId>
-        </exclusion>
-      </exclusions>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/optaplanner-quarkus-integration/optaplanner-quarkus-benchmark/deployment/pom.xml
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus-benchmark/deployment/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.optaplanner</groupId>
     <artifactId>optaplanner-quarkus-benchmark-parent</artifactId>
-    <version>8.5.0-SNAPSHOT</version>
+    <version>8.6.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>optaplanner-quarkus-benchmark-deployment</artifactId>

--- a/optaplanner-quarkus-integration/optaplanner-quarkus-benchmark/deployment/pom.xml
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus-benchmark/deployment/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.optaplanner</groupId>
     <artifactId>optaplanner-quarkus-benchmark-parent</artifactId>
-    <version>8.7.0-SNAPSHOT</version>
+    <version>8.8.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>optaplanner-quarkus-benchmark-deployment</artifactId>

--- a/optaplanner-quarkus-integration/optaplanner-quarkus-benchmark/deployment/pom.xml
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus-benchmark/deployment/pom.xml
@@ -1,0 +1,125 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.optaplanner</groupId>
+    <artifactId>optaplanner-quarkus-benchmark-parent</artifactId>
+    <version>8.5.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>optaplanner-quarkus-benchmark-deployment</artifactId>
+  <name>OptaPlanner Quarkus Benchmark - Deployment</name>
+  <description>Quarkus deployment module for optaplanner-quarkus-benchmark.</description>
+
+  <properties>
+    <java.module.name>org.optaplanner.quarkus.benchmark.deployment</java.module.name>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-core-deployment</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-arc-deployment</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.optaplanner</groupId>
+      <artifactId>optaplanner-quarkus-deployment</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.optaplanner</groupId>
+      <artifactId>optaplanner-quarkus-benchmark</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-junit5-internal</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-resteasy-deployment</artifactId>
+      <scope>test</scope>
+      <exclusions>
+        <!-- Duplicates classes of jakarta.xml.bind:jakarta.xml.bind-api -->
+        <exclusion>
+          <groupId>org.jboss.spec.javax.xml.bind</groupId>
+          <artifactId>jboss-jaxb-api_2.3_spec</artifactId>
+        </exclusion>
+        <!-- Duplicates classes of jakarta.activation:jakarta.activation-api -->
+        <exclusion>
+          <groupId>com.sun.activation</groupId>
+          <artifactId>jakarta.activation</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>io.rest-assured</groupId>
+      <artifactId>rest-assured</artifactId>
+      <exclusions>
+        <!-- Duplicates classes of jakarta.activation:jakarta.activation-api -->
+        <exclusion>
+          <groupId>org.apache.sling</groupId>
+          <artifactId>org.apache.sling.javax.activation</artifactId>
+        </exclusion>
+      </exclusions>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.optaplanner</groupId>
+      <artifactId>optaplanner-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <!-- Required to test Quarkus with constraints DRL. -->
+    <dependency>
+      <groupId>org.kie.kogito</groupId>
+      <artifactId>drools-core-dynamic</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <annotationProcessorPaths>
+            <path>
+              <groupId>io.quarkus</groupId>
+              <artifactId>quarkus-extension-processor</artifactId>
+              <version>${version.io.quarkus}</version>
+            </path>
+          </annotationProcessorPaths>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <executions>
+          <execution>
+            <!-- TODO enable dependency check later. -->
+            <id>analyze-only</id>
+            <configuration>
+              <failOnWarning>false</failOnWarning>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/optaplanner-quarkus-integration/optaplanner-quarkus-benchmark/deployment/pom.xml
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus-benchmark/deployment/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.optaplanner</groupId>
     <artifactId>optaplanner-quarkus-benchmark-parent</artifactId>
-    <version>8.6.0-SNAPSHOT</version>
+    <version>8.7.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>optaplanner-quarkus-benchmark-deployment</artifactId>

--- a/optaplanner-quarkus-integration/optaplanner-quarkus-benchmark/deployment/src/main/java/org/optaplanner/benchmark/quarkus/deployment/OptaPlannerBenchmarkBuildTimeConfig.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus-benchmark/deployment/src/main/java/org/optaplanner/benchmark/quarkus/deployment/OptaPlannerBenchmarkBuildTimeConfig.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.benchmark.quarkus.deployment;
+
+import java.util.Optional;
+
+import io.quarkus.runtime.annotations.ConfigItem;
+import io.quarkus.runtime.annotations.ConfigRoot;
+
+/**
+ * During build time, this is translated into OptaPlanner's Config classes.
+ */
+@ConfigRoot(name = "optaplanner.benchmark")
+public class OptaPlannerBenchmarkBuildTimeConfig {
+
+    public static final String DEFAULT_SOLVER_BENCHMARK_CONFIG_URL = "solverBenchmarkConfig.xml";
+    /**
+     * A classpath resource to read the solver configuration XML.
+     * Defaults to {@value DEFAULT_SOLVER_BENCHMARK_CONFIG_URL}.
+     * If this property isn't specified, that solverBenchmarkConfig.xml is optional.
+     */
+    @ConfigItem
+    Optional<String> solverBenchmarkConfigXml;
+}

--- a/optaplanner-quarkus-integration/optaplanner-quarkus-benchmark/deployment/src/main/java/org/optaplanner/benchmark/quarkus/deployment/OptaPlannerBenchmarkProcessor.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus-benchmark/deployment/src/main/java/org/optaplanner/benchmark/quarkus/deployment/OptaPlannerBenchmarkProcessor.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.benchmark.quarkus.deployment;
+
+import org.jboss.logging.Logger;
+import org.optaplanner.benchmark.quarkus.OptaPlannerBenchmarkBeanProvider;
+
+import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
+import io.quarkus.deployment.annotations.BuildProducer;
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.FeatureBuildItem;
+import io.quarkus.deployment.builditem.HotDeploymentWatchedFileBuildItem;
+
+class OptaPlannerBenchmarkProcessor {
+
+    private static final Logger log = Logger.getLogger(OptaPlannerBenchmarkProcessor.class.getName());
+
+    OptaPlannerBenchmarkBuildTimeConfig optaPlannerBuildTimeConfig;
+
+    @BuildStep
+    FeatureBuildItem feature() {
+        return new FeatureBuildItem("optaplanner-benchmark");
+    }
+
+    @BuildStep
+    HotDeploymentWatchedFileBuildItem watchSolverBenchmarkConfigXml() {
+        String solverConfigXML = optaPlannerBuildTimeConfig.solverBenchmarkConfigXml
+                .orElse(OptaPlannerBenchmarkBuildTimeConfig.DEFAULT_SOLVER_BENCHMARK_CONFIG_URL);
+        return new HotDeploymentWatchedFileBuildItem(solverConfigXML);
+    }
+
+    @BuildStep
+    void registerAdditionalBeans(BuildProducer<AdditionalBeanBuildItem> additionalBeans) {
+        additionalBeans.produce(new AdditionalBeanBuildItem(OptaPlannerBenchmarkBeanProvider.class));
+    }
+
+    private boolean isClassDefined(String className) {
+        ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+        try {
+            Class.forName(className, false, classLoader);
+            return true;
+        } catch (ClassNotFoundException e) {
+            return false;
+        }
+    }
+}

--- a/optaplanner-quarkus-integration/optaplanner-quarkus-benchmark/deployment/src/test/java/org/optaplanner/benchmark/quarkus/OptaPlannerBenchmarkProcessorBenchmarkConfigTest.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus-benchmark/deployment/src/test/java/org/optaplanner/benchmark/quarkus/OptaPlannerBenchmarkProcessorBenchmarkConfigTest.java
@@ -33,12 +33,13 @@ import org.optaplanner.benchmark.quarkus.testdata.normal.domain.TestdataQuarkusS
 
 import io.quarkus.test.QuarkusUnitTest;
 
-public class OptaPlannerProcessorSolveTest {
+public class OptaPlannerBenchmarkProcessorBenchmarkConfigTest {
 
     @RegisterExtension
     static final QuarkusUnitTest config = new QuarkusUnitTest()
             .overrideConfigKey("quarkus.optaplanner.benchmark.solver.termination.spent-limit", "5s")
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addAsResource("solverBenchmarkConfig.xml")
                     .addClasses(TestdataQuarkusEntity.class,
                             TestdataQuarkusSolution.class, TestdataQuarkusConstraintProvider.class));
 
@@ -46,7 +47,7 @@ public class OptaPlannerProcessorSolveTest {
     PlannerBenchmarkFactory benchmarkFactory;
 
     @Test
-    public void solve() throws ExecutionException, InterruptedException {
+    public void benchmark() throws ExecutionException, InterruptedException {
         TestdataQuarkusSolution problem = new TestdataQuarkusSolution();
         problem.setValueList(IntStream.range(1, 3)
                 .mapToObj(i -> "v" + i)

--- a/optaplanner-quarkus-integration/optaplanner-quarkus-benchmark/deployment/src/test/java/org/optaplanner/benchmark/quarkus/OptaPlannerBenchmarkProcessorMissingSpentLimitTest.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus-benchmark/deployment/src/test/java/org/optaplanner/benchmark/quarkus/OptaPlannerBenchmarkProcessorMissingSpentLimitTest.java
@@ -16,25 +16,22 @@
 
 package org.optaplanner.benchmark.quarkus;
 
-import io.quarkus.arc.Arc;
-import io.quarkus.test.QuarkusUnitTest;
+import java.util.concurrent.ExecutionException;
+
+import javax.inject.Inject;
+
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.extension.RegisterExtension;
-import org.optaplanner.benchmark.api.PlannerBenchmarkFactory;
 import org.optaplanner.benchmark.config.PlannerBenchmarkConfig;
 import org.optaplanner.benchmark.quarkus.testdata.normal.constraints.TestdataQuarkusConstraintProvider;
 import org.optaplanner.benchmark.quarkus.testdata.normal.domain.TestdataQuarkusEntity;
 import org.optaplanner.benchmark.quarkus.testdata.normal.domain.TestdataQuarkusSolution;
 import org.optaplanner.core.config.solver.SolverConfig;
 
-import javax.inject.Inject;
-import java.util.concurrent.ExecutionException;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
+import io.quarkus.test.QuarkusUnitTest;
 
 public class OptaPlannerBenchmarkProcessorMissingSpentLimitTest {
 
@@ -44,8 +41,10 @@ public class OptaPlannerBenchmarkProcessorMissingSpentLimitTest {
                     .addClasses(TestdataQuarkusEntity.class,
                             TestdataQuarkusSolution.class, TestdataQuarkusConstraintProvider.class));
 
-    @Inject SolverConfig solverConfig;
-    @Inject OptaPlannerBenchmarkRuntimeConfig runtimeConfig;
+    @Inject
+    SolverConfig solverConfig;
+    @Inject
+    OptaPlannerBenchmarkRuntimeConfig runtimeConfig;
 
     @Test
     public void benchmark() throws ExecutionException, InterruptedException {

--- a/optaplanner-quarkus-integration/optaplanner-quarkus-benchmark/deployment/src/test/java/org/optaplanner/benchmark/quarkus/OptaPlannerBenchmarkProcessorMissingSpentLimitTest.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus-benchmark/deployment/src/test/java/org/optaplanner/benchmark/quarkus/OptaPlannerBenchmarkProcessorMissingSpentLimitTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.benchmark.quarkus;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.test.QuarkusUnitTest;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.optaplanner.benchmark.api.PlannerBenchmarkFactory;
+import org.optaplanner.benchmark.config.PlannerBenchmarkConfig;
+import org.optaplanner.benchmark.quarkus.testdata.normal.constraints.TestdataQuarkusConstraintProvider;
+import org.optaplanner.benchmark.quarkus.testdata.normal.domain.TestdataQuarkusEntity;
+import org.optaplanner.benchmark.quarkus.testdata.normal.domain.TestdataQuarkusSolution;
+import org.optaplanner.core.config.solver.SolverConfig;
+
+import javax.inject.Inject;
+import java.util.concurrent.ExecutionException;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+public class OptaPlannerBenchmarkProcessorMissingSpentLimitTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(TestdataQuarkusEntity.class,
+                            TestdataQuarkusSolution.class, TestdataQuarkusConstraintProvider.class));
+
+    @Inject SolverConfig solverConfig;
+    @Inject OptaPlannerBenchmarkRuntimeConfig runtimeConfig;
+
+    @Test
+    public void benchmark() throws ExecutionException, InterruptedException {
+        Assertions.assertThrows(IllegalStateException.class, () -> {
+            new OptaPlannerBenchmarkBeanProvider().benchmarkFactory(new PlannerBenchmarkConfig(),
+                    runtimeConfig, solverConfig);
+        }, "Property quarkus.optaplanner.benchmark.solver.termination.spent-limit is required if the inherited solver config does not have termination configured.");
+
+    }
+
+}

--- a/optaplanner-quarkus-integration/optaplanner-quarkus-benchmark/deployment/src/test/java/org/optaplanner/benchmark/quarkus/OptaPlannerBenchmarkProcessorNoBenchmarkConfigTest.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus-benchmark/deployment/src/test/java/org/optaplanner/benchmark/quarkus/OptaPlannerBenchmarkProcessorNoBenchmarkConfigTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.benchmark.quarkus;
+
+import java.util.concurrent.ExecutionException;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import javax.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.optaplanner.benchmark.api.PlannerBenchmarkFactory;
+import org.optaplanner.benchmark.quarkus.testdata.normal.constraints.TestdataQuarkusConstraintProvider;
+import org.optaplanner.benchmark.quarkus.testdata.normal.domain.TestdataQuarkusEntity;
+import org.optaplanner.benchmark.quarkus.testdata.normal.domain.TestdataQuarkusSolution;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class OptaPlannerBenchmarkProcessorNoBenchmarkConfigTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .overrideConfigKey("quarkus.optaplanner.benchmark.solver.termination.spent-limit", "5s")
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(TestdataQuarkusEntity.class,
+                            TestdataQuarkusSolution.class, TestdataQuarkusConstraintProvider.class));
+
+    @Inject
+    PlannerBenchmarkFactory benchmarkFactory;
+
+    @Test
+    public void benchmark() throws ExecutionException, InterruptedException {
+        TestdataQuarkusSolution problem = new TestdataQuarkusSolution();
+        problem.setValueList(IntStream.range(1, 3)
+                .mapToObj(i -> "v" + i)
+                .collect(Collectors.toList()));
+        problem.setEntityList(IntStream.range(1, 3)
+                .mapToObj(i -> new TestdataQuarkusEntity())
+                .collect(Collectors.toList()));
+        benchmarkFactory.buildPlannerBenchmark(problem).benchmark();
+    }
+
+}

--- a/optaplanner-quarkus-integration/optaplanner-quarkus-benchmark/deployment/src/test/java/org/optaplanner/benchmark/quarkus/OptaPlannerProcessorSolveTest.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus-benchmark/deployment/src/test/java/org/optaplanner/benchmark/quarkus/OptaPlannerProcessorSolveTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.benchmark.quarkus;
+
+import java.util.concurrent.ExecutionException;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import javax.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.optaplanner.benchmark.api.PlannerBenchmarkFactory;
+import org.optaplanner.benchmark.quarkus.testdata.normal.constraints.TestdataQuarkusConstraintProvider;
+import org.optaplanner.benchmark.quarkus.testdata.normal.domain.TestdataQuarkusEntity;
+import org.optaplanner.benchmark.quarkus.testdata.normal.domain.TestdataQuarkusSolution;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class OptaPlannerProcessorSolveTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .overrideConfigKey("quarkus.optaplanner.benchmark.solver.termination.spent-limit", "5s")
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(TestdataQuarkusEntity.class,
+                            TestdataQuarkusSolution.class, TestdataQuarkusConstraintProvider.class));
+
+    @Inject
+    PlannerBenchmarkFactory benchmarkFactory;
+
+    @Test
+    public void solve() throws ExecutionException, InterruptedException {
+        TestdataQuarkusSolution problem = new TestdataQuarkusSolution();
+        problem.setValueList(IntStream.range(1, 3)
+                .mapToObj(i -> "v" + i)
+                .collect(Collectors.toList()));
+        problem.setEntityList(IntStream.range(1, 3)
+                .mapToObj(i -> new TestdataQuarkusEntity())
+                .collect(Collectors.toList()));
+        benchmarkFactory.buildPlannerBenchmark(problem).benchmark();
+    }
+
+}

--- a/optaplanner-quarkus-integration/optaplanner-quarkus-benchmark/deployment/src/test/java/org/optaplanner/benchmark/quarkus/testdata/normal/constraints/TestdataQuarkusConstraintProvider.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus-benchmark/deployment/src/test/java/org/optaplanner/benchmark/quarkus/testdata/normal/constraints/TestdataQuarkusConstraintProvider.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.benchmark.quarkus.testdata.normal.constraints;
+
+import org.optaplanner.benchmark.quarkus.testdata.normal.domain.TestdataQuarkusEntity;
+import org.optaplanner.core.api.score.buildin.simple.SimpleScore;
+import org.optaplanner.core.api.score.stream.Constraint;
+import org.optaplanner.core.api.score.stream.ConstraintFactory;
+import org.optaplanner.core.api.score.stream.ConstraintProvider;
+import org.optaplanner.core.api.score.stream.Joiners;
+
+public class TestdataQuarkusConstraintProvider implements ConstraintProvider {
+
+    @Override
+    public Constraint[] defineConstraints(ConstraintFactory factory) {
+        return new Constraint[] {
+                factory.from(TestdataQuarkusEntity.class)
+                        .join(TestdataQuarkusEntity.class, Joiners.equal(TestdataQuarkusEntity::getValue))
+                        .filter((a, b) -> a != b)
+                        .penalize("Don't assign 2 entities the same value.", SimpleScore.ONE)
+        };
+    }
+
+}

--- a/optaplanner-quarkus-integration/optaplanner-quarkus-benchmark/deployment/src/test/java/org/optaplanner/benchmark/quarkus/testdata/normal/domain/TestdataQuarkusEntity.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus-benchmark/deployment/src/test/java/org/optaplanner/benchmark/quarkus/testdata/normal/domain/TestdataQuarkusEntity.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.benchmark.quarkus.testdata.normal.domain;
+
+import org.optaplanner.core.api.domain.entity.PlanningEntity;
+import org.optaplanner.core.api.domain.variable.PlanningVariable;
+
+@PlanningEntity
+public class TestdataQuarkusEntity {
+
+    private String value;
+
+    @PlanningVariable(valueRangeProviderRefs = "valueRange")
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+
+}

--- a/optaplanner-quarkus-integration/optaplanner-quarkus-benchmark/deployment/src/test/java/org/optaplanner/benchmark/quarkus/testdata/normal/domain/TestdataQuarkusSolution.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus-benchmark/deployment/src/test/java/org/optaplanner/benchmark/quarkus/testdata/normal/domain/TestdataQuarkusSolution.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.benchmark.quarkus.testdata.normal.domain;
+
+import java.util.List;
+
+import org.optaplanner.core.api.domain.solution.PlanningEntityCollectionProperty;
+import org.optaplanner.core.api.domain.solution.PlanningScore;
+import org.optaplanner.core.api.domain.solution.PlanningSolution;
+import org.optaplanner.core.api.domain.solution.ProblemFactCollectionProperty;
+import org.optaplanner.core.api.domain.valuerange.ValueRangeProvider;
+import org.optaplanner.core.api.score.buildin.simple.SimpleScore;
+
+@PlanningSolution
+public class TestdataQuarkusSolution {
+
+    private List<String> valueList;
+    private List<TestdataQuarkusEntity> entityList;
+
+    private SimpleScore score;
+
+    @ValueRangeProvider(id = "valueRange")
+    @ProblemFactCollectionProperty
+    public List<String> getValueList() {
+        return valueList;
+    }
+
+    public void setValueList(List<String> valueList) {
+        this.valueList = valueList;
+    }
+
+    @PlanningEntityCollectionProperty
+    public List<TestdataQuarkusEntity> getEntityList() {
+        return entityList;
+    }
+
+    public void setEntityList(List<TestdataQuarkusEntity> entityList) {
+        this.entityList = entityList;
+    }
+
+    @PlanningScore
+    public SimpleScore getScore() {
+        return score;
+    }
+
+    public void setScore(SimpleScore score) {
+        this.score = score;
+    }
+
+}

--- a/optaplanner-quarkus-integration/optaplanner-quarkus-benchmark/deployment/src/test/resources/org/optaplanner/quarkus/bavetSolverConfig.xml
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus-benchmark/deployment/src/test/resources/org/optaplanner/quarkus/bavetSolverConfig.xml
@@ -1,0 +1,25 @@
+<!--
+  ~ Copyright 2020 Red Hat, Inc. and/or its affiliates.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<solver>
+  <scoreDirectorFactory>
+    <constraintStreamImplType>BAVET</constraintStreamImplType>
+    <constraintProviderClass>org.optaplanner.benchmark.quarkus.testdata.normal.constraints.TestdataQuarkusConstraintProvider</constraintProviderClass>
+  </scoreDirectorFactory>
+  <termination>
+    <secondsSpentLimit>2</secondsSpentLimit>
+  </termination>
+</solver>

--- a/optaplanner-quarkus-integration/optaplanner-quarkus-benchmark/deployment/src/test/resources/org/optaplanner/quarkus/constraints/defaultConstraints.drl
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus-benchmark/deployment/src/test/resources/org/optaplanner/quarkus/constraints/defaultConstraints.drl
@@ -1,0 +1,17 @@
+package org.optaplanner.quarkus.constraints;
+    dialect "java"
+
+import org.optaplanner.core.api.score.buildin.simple.SimpleScoreHolder;
+
+import org.optaplanner.quarkus.testdata.normal.domain.TestdataQuarkusEntity;
+
+global SimpleScoreHolder scoreHolder;
+
+rule "Don't assign 2 entities the same value."
+    when
+        TestdataQuarkusEntity()
+        $a : TestdataQuarkusEntity(value != null, $v : value)
+        TestdataQuarkusEntity(value == $v, this != $a)
+    then
+        scoreHolder.addConstraintMatch(kcontext, -1);
+end

--- a/optaplanner-quarkus-integration/optaplanner-quarkus-benchmark/deployment/src/test/resources/org/optaplanner/quarkus/customSolverConfig.xml
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus-benchmark/deployment/src/test/resources/org/optaplanner/quarkus/customSolverConfig.xml
@@ -1,0 +1,21 @@
+<!--
+  ~ Copyright 2020 Red Hat, Inc. and/or its affiliates.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<solver>
+  <termination>
+    <secondsSpentLimit>3</secondsSpentLimit>
+  </termination>
+</solver>

--- a/optaplanner-quarkus-integration/optaplanner-quarkus-benchmark/deployment/src/test/resources/solverBenchmarkConfig.xml
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus-benchmark/deployment/src/test/resources/solverBenchmarkConfig.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plannerBenchmark xmlns="https://www.optaplanner.org/xsd/benchmark" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="https://www.optaplanner.org/xsd/benchmark https://www.optaplanner.org/xsd/benchmark/benchmark.xsd">
+
+    <solverBenchmarkBluePrint>
+        <solverBenchmarkBluePrintType>EVERY_LOCAL_SEARCH_TYPE</solverBenchmarkBluePrintType>
+    </solverBenchmarkBluePrint>
+</plannerBenchmark>

--- a/optaplanner-quarkus-integration/optaplanner-quarkus-benchmark/deployment/src/test/resources/solverConfig.xml
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus-benchmark/deployment/src/test/resources/solverConfig.xml
@@ -1,0 +1,21 @@
+<!--
+  ~ Copyright 2020 Red Hat, Inc. and/or its affiliates.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<solver>
+  <termination>
+    <secondsSpentLimit>2</secondsSpentLimit>
+  </termination>
+</solver>

--- a/optaplanner-quarkus-integration/optaplanner-quarkus-benchmark/pom.xml
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus-benchmark/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.optaplanner</groupId>
     <artifactId>optaplanner-quarkus-integration</artifactId>
-    <version>8.7.0-SNAPSHOT</version>
+    <version>8.8.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/optaplanner-quarkus-integration/optaplanner-quarkus-benchmark/pom.xml
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus-benchmark/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.optaplanner</groupId>
     <artifactId>optaplanner-quarkus-integration</artifactId>
-    <version>8.5.0-SNAPSHOT</version>
+    <version>8.6.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/optaplanner-quarkus-integration/optaplanner-quarkus-benchmark/pom.xml
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus-benchmark/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.optaplanner</groupId>
     <artifactId>optaplanner-quarkus-integration</artifactId>
-    <version>8.6.0-SNAPSHOT</version>
+    <version>8.7.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/optaplanner-quarkus-integration/optaplanner-quarkus-benchmark/pom.xml
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus-benchmark/pom.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <groupId>org.optaplanner</groupId>
+    <artifactId>optaplanner-quarkus-integration</artifactId>
+    <version>8.5.0-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>optaplanner-quarkus-benchmark-parent</artifactId>
+  <name>OptaPlanner Quarkus Benchmark</name>
+  <packaging>pom</packaging>
+
+  <modules>
+    <module>runtime</module>
+    <module>deployment</module>
+  </modules>
+
+</project>

--- a/optaplanner-quarkus-integration/optaplanner-quarkus-benchmark/runtime/.gitignore
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus-benchmark/runtime/.gitignore
@@ -1,0 +1,10 @@
+/target
+/local
+
+# Eclipse, Netbeans and IntelliJ files
+/.*
+!.gitignore
+/nbproject
+/*.ipr
+/*.iws
+/*.iml

--- a/optaplanner-quarkus-integration/optaplanner-quarkus-benchmark/runtime/pom.xml
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus-benchmark/runtime/pom.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.optaplanner</groupId>
+    <artifactId>optaplanner-quarkus-benchmark-parent</artifactId>
+    <version>8.5.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>optaplanner-quarkus-benchmark</artifactId>
+  <name>OptaPlanner Quarkus Benchmark - Runtime</name>
+  <description>Optimize planning of vehicle routes, employee rosters, maintenance schedules, task assignments, school timetables, conference schedules, etc.</description>
+
+  <properties>
+    <java.module.name>org.optaplanner.quarkus.benchmark</java.module.name>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-arc</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.optaplanner</groupId>
+      <artifactId>optaplanner-quarkus</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.optaplanner</groupId>
+      <artifactId>optaplanner-benchmark</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.optaplanner</groupId>
+          <artifactId>optaplanner-core</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>io.quarkus</groupId>
+        <artifactId>quarkus-bootstrap-maven-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <annotationProcessorPaths>
+            <path>
+              <groupId>io.quarkus</groupId>
+              <artifactId>quarkus-extension-processor</artifactId>
+              <version>${version.io.quarkus}</version>
+            </path>
+          </annotationProcessorPaths>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <executions>
+          <execution>
+            <!-- TODO enable dependency check later. -->
+            <id>analyze-only</id>
+            <configuration>
+              <failOnWarning>false</failOnWarning>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/optaplanner-quarkus-integration/optaplanner-quarkus-benchmark/runtime/pom.xml
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus-benchmark/runtime/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.optaplanner</groupId>
     <artifactId>optaplanner-quarkus-benchmark-parent</artifactId>
-    <version>8.5.0-SNAPSHOT</version>
+    <version>8.6.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>optaplanner-quarkus-benchmark</artifactId>

--- a/optaplanner-quarkus-integration/optaplanner-quarkus-benchmark/runtime/pom.xml
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus-benchmark/runtime/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.optaplanner</groupId>
     <artifactId>optaplanner-quarkus-benchmark-parent</artifactId>
-    <version>8.6.0-SNAPSHOT</version>
+    <version>8.7.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>optaplanner-quarkus-benchmark</artifactId>

--- a/optaplanner-quarkus-integration/optaplanner-quarkus-benchmark/runtime/pom.xml
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus-benchmark/runtime/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.optaplanner</groupId>
     <artifactId>optaplanner-quarkus-benchmark-parent</artifactId>
-    <version>8.7.0-SNAPSHOT</version>
+    <version>8.8.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>optaplanner-quarkus-benchmark</artifactId>

--- a/optaplanner-quarkus-integration/optaplanner-quarkus-benchmark/runtime/src/main/java/org/optaplanner/benchmark/quarkus/OptaPlannerBenchmarkBeanProvider.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus-benchmark/runtime/src/main/java/org/optaplanner/benchmark/quarkus/OptaPlannerBenchmarkBeanProvider.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.benchmark.quarkus;
+
+import java.io.File;
+import java.util.Collections;
+
+import javax.enterprise.inject.Produces;
+import javax.inject.Singleton;
+
+import org.optaplanner.benchmark.api.PlannerBenchmarkFactory;
+import org.optaplanner.benchmark.config.PlannerBenchmarkConfig;
+import org.optaplanner.benchmark.config.ProblemBenchmarksConfig;
+import org.optaplanner.benchmark.config.SolverBenchmarkConfig;
+import org.optaplanner.core.config.solver.SolverConfig;
+import org.optaplanner.core.config.solver.termination.TerminationConfig;
+
+import io.quarkus.arc.DefaultBean;
+
+public class OptaPlannerBenchmarkBeanProvider {
+
+    @DefaultBean
+    @Singleton
+    @Produces
+    PlannerBenchmarkFactory benchmarkFactory(OptaPlannerBenchmarkRuntimeConfig benchmarkRuntimeConfig,
+            SolverConfig solverConfig) {
+        ProblemBenchmarksConfig problemBenchmarksConfig = new ProblemBenchmarksConfig();
+        problemBenchmarksConfig.setWriteOutputSolutionEnabled(false);
+
+        SolverBenchmarkConfig solverBenchmarkConfig = new SolverBenchmarkConfig();
+        SolverConfig benchmarkSolverConfig = new SolverConfig();
+        benchmarkSolverConfig.inherit(solverConfig);
+        benchmarkSolverConfig.setTerminationConfig(new TerminationConfig()
+                .withSpentLimit(benchmarkRuntimeConfig.terminationBuildTimeConfig.spentLimit));
+
+        solverBenchmarkConfig.setSolverConfig(benchmarkSolverConfig);
+        solverBenchmarkConfig.setProblemBenchmarksConfig(problemBenchmarksConfig);
+
+        PlannerBenchmarkConfig plannerBenchmarkConfig = new PlannerBenchmarkConfig();
+        plannerBenchmarkConfig.setBenchmarkDirectory(new File(benchmarkRuntimeConfig.resultDirectory));
+        plannerBenchmarkConfig.setSolverBenchmarkConfigList(Collections.singletonList(solverBenchmarkConfig));
+
+        return PlannerBenchmarkFactory.create(plannerBenchmarkConfig);
+    }
+
+}

--- a/optaplanner-quarkus-integration/optaplanner-quarkus-benchmark/runtime/src/main/java/org/optaplanner/benchmark/quarkus/OptaPlannerBenchmarkBeanProvider.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus-benchmark/runtime/src/main/java/org/optaplanner/benchmark/quarkus/OptaPlannerBenchmarkBeanProvider.java
@@ -52,7 +52,8 @@ public class OptaPlannerBenchmarkBeanProvider {
             plannerBenchmarkConfig.setInheritedSolverBenchmarkConfig(solverBenchmarkConfig);
         }
 
-        if (plannerBenchmarkConfig.getInheritedSolverBenchmarkConfig().getSolverConfig().getTerminationConfig().getTerminationClass() == null
+        if (plannerBenchmarkConfig.getInheritedSolverBenchmarkConfig().getSolverConfig().getTerminationConfig()
+                .getTerminationClass() == null
                 || benchmarkRuntimeConfig.terminationBuildTimeConfig.spentLimit.isPresent()) {
             plannerBenchmarkConfig.getInheritedSolverBenchmarkConfig().getSolverConfig()
                     .setTerminationConfig(new TerminationConfig()

--- a/optaplanner-quarkus-integration/optaplanner-quarkus-benchmark/runtime/src/main/java/org/optaplanner/benchmark/quarkus/OptaPlannerBenchmarkBeanProvider.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus-benchmark/runtime/src/main/java/org/optaplanner/benchmark/quarkus/OptaPlannerBenchmarkBeanProvider.java
@@ -52,7 +52,7 @@ public class OptaPlannerBenchmarkBeanProvider {
             plannerBenchmarkConfig.setInheritedSolverBenchmarkConfig(solverBenchmarkConfig);
         }
 
-        if (plannerBenchmarkConfig.getInheritedSolverBenchmarkConfig().getSolverConfig().getTerminationConfig() == null
+        if (plannerBenchmarkConfig.getInheritedSolverBenchmarkConfig().getSolverConfig().getTerminationConfig().getTerminationClass() == null
                 || benchmarkRuntimeConfig.terminationBuildTimeConfig.spentLimit.isPresent()) {
             plannerBenchmarkConfig.getInheritedSolverBenchmarkConfig().getSolverConfig()
                     .setTerminationConfig(new TerminationConfig()

--- a/optaplanner-quarkus-integration/optaplanner-quarkus-benchmark/runtime/src/main/java/org/optaplanner/benchmark/quarkus/OptaPlannerBenchmarkRecorder.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus-benchmark/runtime/src/main/java/org/optaplanner/benchmark/quarkus/OptaPlannerBenchmarkRecorder.java
@@ -16,24 +16,15 @@
 
 package org.optaplanner.benchmark.quarkus;
 
-import java.time.Duration;
-import java.util.Optional;
+import java.util.function.Supplier;
 
-import org.optaplanner.core.config.solver.termination.TerminationConfig;
+import org.optaplanner.benchmark.config.PlannerBenchmarkConfig;
 
-import io.quarkus.runtime.annotations.ConfigGroup;
+import io.quarkus.runtime.annotations.Recorder;
 
-/**
- * During build time, this is translated into OptaPlanner's {@link TerminationConfig}.
- */
-@ConfigGroup
-public class TerminationBuildTimeConfig {
-
-    /**
-     * How long solver should be run in a benchmark run.
-     * For example: "30s" is 30 seconds. "5m" is 5 minutes. "2h" is 2 hours. "1d" is 1 day.
-     * Also supports ISO-8601 format, see {@link Duration}.
-     */
-    public Optional<Duration> spentLimit;
-
+@Recorder
+public class OptaPlannerBenchmarkRecorder {
+    public Supplier<PlannerBenchmarkConfig> benchmarkConfigSupplier(PlannerBenchmarkConfig benchmarkConfig) {
+        return () -> benchmarkConfig;
+    }
 }

--- a/optaplanner-quarkus-integration/optaplanner-quarkus-benchmark/runtime/src/main/java/org/optaplanner/benchmark/quarkus/OptaPlannerBenchmarkRuntimeConfig.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus-benchmark/runtime/src/main/java/org/optaplanner/benchmark/quarkus/OptaPlannerBenchmarkRuntimeConfig.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.benchmark.quarkus;
+
+import io.quarkus.runtime.annotations.ConfigItem;
+import io.quarkus.runtime.annotations.ConfigPhase;
+import io.quarkus.runtime.annotations.ConfigRoot;
+
+@ConfigRoot(name = "optaplanner.benchmark", phase = ConfigPhase.RUN_TIME)
+public class OptaPlannerBenchmarkRuntimeConfig {
+    public static final String DEFAULT_BENCHMARK_RESULT_DIRECTORY = "target/benchmarks";
+
+    /**
+     * Where the benchmark results are written to. Defaults to
+     * {@link DEFAULT_BENCHMARK_RESULT_DIRECTORY}.
+     */
+    @ConfigItem(defaultValue = DEFAULT_BENCHMARK_RESULT_DIRECTORY)
+    public String resultDirectory;
+
+    /**
+     * Termination configuration for the solvers run in the benchmark.
+     */
+    @ConfigItem(name = "solver.termination")
+    public TerminationBuildTimeConfig terminationBuildTimeConfig;
+}

--- a/optaplanner-quarkus-integration/optaplanner-quarkus-benchmark/runtime/src/main/java/org/optaplanner/benchmark/quarkus/TerminationBuildTimeConfig.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus-benchmark/runtime/src/main/java/org/optaplanner/benchmark/quarkus/TerminationBuildTimeConfig.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.benchmark.quarkus;
+
+import java.time.Duration;
+
+import org.optaplanner.core.config.solver.termination.TerminationConfig;
+
+import io.quarkus.runtime.annotations.ConfigGroup;
+
+/**
+ * During build time, this is translated into OptaPlanner's {@link TerminationConfig}.
+ */
+@ConfigGroup
+public class TerminationBuildTimeConfig {
+
+    /**
+     * How long solver should be run in a benchmark run.
+     * For example: "30s" is 30 seconds. "5m" is 5 minutes. "2h" is 2 hours. "1d" is 1 day.
+     * Also supports ISO-8601 format, see {@link Duration}.
+     */
+    public Duration spentLimit;
+
+}

--- a/optaplanner-quarkus-integration/optaplanner-quarkus-benchmark/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus-benchmark/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -1,0 +1,16 @@
+---
+name: "OptaPlanner AI constraint solver"
+metadata:
+  keywords:
+    - "optaplanner"
+    - "kogito"
+    - "constraint-solver"
+    - "artificial-intelligence"
+    - "employee-rostering"
+    - "vehicle-routing-problem"
+    - "maintenance-scheduling"
+    - "timetabling"
+  guide: "https://quarkus.io/guides/optaplanner"
+  categories:
+    - "business-automation"
+  status: "stable"

--- a/optaplanner-quarkus-integration/optaplanner-quarkus-benchmark/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus-benchmark/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -1,15 +1,12 @@
 ---
-name: "OptaPlanner AI constraint solver"
+name: "OptaPlanner AI constraint solver benchmark"
 metadata:
   keywords:
     - "optaplanner"
-    - "kogito"
-    - "constraint-solver"
-    - "artificial-intelligence"
-    - "employee-rostering"
-    - "vehicle-routing-problem"
-    - "maintenance-scheduling"
-    - "timetabling"
+    - "benchmark"
+    - "performance"
+    - "scaling"
+    - "tweaking"
   guide: "https://quarkus.io/guides/optaplanner"
   categories:
     - "business-automation"

--- a/optaplanner-quarkus-integration/optaplanner-quarkus-jackson/integration-test/pom.xml
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus-jackson/integration-test/pom.xml
@@ -25,24 +25,10 @@
     <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-resteasy</artifactId>
-      <exclusions>
-        <!-- Duplicates classes of jakarta.xml.bind:jakarta.xml.bind-api -->
-        <exclusion>
-          <groupId>org.jboss.spec.javax.xml.bind</groupId>
-          <artifactId>jboss-jaxb-api_2.3_spec</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-resteasy-jackson</artifactId>
-      <exclusions>
-        <!-- Duplicates classes of jakarta.xml.bind:jakarta.xml.bind-api -->
-        <exclusion>
-          <groupId>org.jboss.spec.javax.xml.bind</groupId>
-          <artifactId>jboss-jaxb-api_2.3_spec</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.optaplanner</groupId>
@@ -62,13 +48,6 @@
     <dependency>
       <groupId>io.rest-assured</groupId>
       <artifactId>rest-assured</artifactId>
-      <exclusions>
-        <!-- Duplicates classes of jakarta.activation:jakarta.activation-api -->
-        <exclusion>
-          <groupId>org.apache.sling</groupId>
-          <artifactId>org.apache.sling.javax.activation</artifactId>
-        </exclusion>
-      </exclusions>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/optaplanner-quarkus-integration/optaplanner-quarkus-jsonb/integration-test/pom.xml
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus-jsonb/integration-test/pom.xml
@@ -25,13 +25,6 @@
     <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-resteasy</artifactId>
-      <exclusions>
-        <!-- Duplicates classes of jakarta.xml.bind:jakarta.xml.bind-api -->
-        <exclusion>
-          <groupId>org.jboss.spec.javax.xml.bind</groupId>
-          <artifactId>jboss-jaxb-api_2.3_spec</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/pom.xml
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/pom.xml
@@ -45,29 +45,10 @@
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-resteasy-deployment</artifactId>
       <scope>test</scope>
-      <exclusions>
-        <!-- Duplicates classes of jakarta.xml.bind:jakarta.xml.bind-api -->
-        <exclusion>
-          <groupId>org.jboss.spec.javax.xml.bind</groupId>
-          <artifactId>jboss-jaxb-api_2.3_spec</artifactId>
-        </exclusion>
-        <!-- Duplicates classes of jakarta.activation:jakarta.activation-api -->
-        <exclusion>
-          <groupId>com.sun.activation</groupId>
-          <artifactId>jakarta.activation</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>io.rest-assured</groupId>
       <artifactId>rest-assured</artifactId>
-      <exclusions>
-        <!-- Duplicates classes of jakarta.activation:jakarta.activation-api -->
-        <exclusion>
-          <groupId>org.apache.sling</groupId>
-          <artifactId>org.apache.sling.javax.activation</artifactId>
-        </exclusion>
-      </exclusions>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/drl-integration-test/pom.xml
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/drl-integration-test/pom.xml
@@ -25,13 +25,6 @@
     <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-resteasy</artifactId>
-      <exclusions>
-        <!-- Duplicates classes of jakarta.xml.bind:jakarta.xml.bind-api -->
-        <exclusion>
-          <groupId>org.jboss.spec.javax.xml.bind</groupId>
-          <artifactId>jboss-jaxb-api_2.3_spec</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.kie.kogito</groupId>
@@ -51,13 +44,6 @@
     <dependency>
       <groupId>io.rest-assured</groupId>
       <artifactId>rest-assured</artifactId>
-      <exclusions>
-        <!-- Duplicates classes of jakarta.activation:jakarta.activation-api -->
-        <exclusion>
-          <groupId>org.apache.sling</groupId>
-          <artifactId>org.apache.sling.javax.activation</artifactId>
-        </exclusion>
-      </exclusions>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/integration-test/pom.xml
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/integration-test/pom.xml
@@ -25,13 +25,6 @@
     <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-resteasy</artifactId>
-      <exclusions>
-        <!-- Duplicates classes of jakarta.xml.bind:jakarta.xml.bind-api -->
-        <exclusion>
-          <groupId>org.jboss.spec.javax.xml.bind</groupId>
-          <artifactId>jboss-jaxb-api_2.3_spec</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.optaplanner</groupId>
@@ -47,13 +40,6 @@
     <dependency>
       <groupId>io.rest-assured</groupId>
       <artifactId>rest-assured</artifactId>
-      <exclusions>
-        <!-- Duplicates classes of jakarta.activation:jakarta.activation-api -->
-        <exclusion>
-          <groupId>org.apache.sling</groupId>
-          <artifactId>org.apache.sling.javax.activation</artifactId>
-        </exclusion>
-      </exclusions>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/optaplanner-quarkus-integration/pom.xml
+++ b/optaplanner-quarkus-integration/pom.xml
@@ -30,6 +30,7 @@
 
   <modules>
     <module>optaplanner-quarkus</module>
+    <module>optaplanner-quarkus-benchmark</module>
     <module>optaplanner-quarkus-jackson</module>
     <module>optaplanner-quarkus-jsonb</module>
   </modules>


### PR DESCRIPTION
<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.
-->

### JIRA

<!-- Add a JIRA ticket link if it exists. -->
https://issues.redhat.com/browse/PLANNER-2341

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
* https://github.com/kiegroup/drools/pull/3000
* https://github.com/kiegroup/optaplanner/pull/899
* etc.
-->

### Checklist
- [ ] Documentation updated if applicable.
- [ ] Upgrade recipe provided if applicable.

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>full downstream build</b> please add comment: <b>Jenkins run fdb</b>
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
* for a <b>Quarkus LTS check</b> please add comment: <b>Jenkins run LTS</b>
* for a <b>Native check</b> please add comment: <b>Jenkins run native</b>
</details>
