### PR TITLE
[7.x] [DROOLS-6257] Move drools-mvel test-jar dependency

### DIFF
--- a/optaplanner-benchmark/pom.xml
+++ b/optaplanner-benchmark/pom.xml
@@ -72,7 +72,7 @@
     </dependency>
     <dependency>
       <groupId>org.drools</groupId>
-      <artifactId>drools-mvel</artifactId>
+      <artifactId>drools-legacy-test-util</artifactId>
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>

--- a/optaplanner-core/pom.xml
+++ b/optaplanner-core/pom.xml
@@ -50,7 +50,7 @@
     </dependency>
     <dependency>
       <groupId>org.drools</groupId>
-      <artifactId>drools-mvel</artifactId>
+      <artifactId>drools-legacy-test-util</artifactId>
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>


### PR DESCRIPTION
### JIRA

https://issues.redhat.com/browse/DROOLS-6257

As we plan to refactor drools-mvel, we are moving test util classes/resources from drools-mvel to drools-legacy-test-util (already copied).

In optaplanner 7.x branch, optaplanner-core and optaplanner-benchmark have drools-mvel test-jar dependency so changing it to drools-legacy-test-util test-jar dependency.

### Checklist
- [ ] Documentation updated if applicable.
- [ ] Upgrade recipe provided if applicable.

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>full downstream build</b> please add comment: <b>Jenkins run fdb</b>
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
* for a <b>Quarkus LTS check</b> please add comment: <b>Jenkins run LTS</b>
* for a <b>Native check</b> please add comment: <b>Jenkins run native</b>
</details>
