### PR TITLE
PLANNER-2387: Make moveThreadCount and parallelSolverCount runtime configs

### DIFF
--- a/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/main/java/org/optaplanner/quarkus/deployment/OptaPlannerProcessor.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/main/java/org/optaplanner/quarkus/deployment/OptaPlannerProcessor.java
@@ -59,6 +59,7 @@ import org.optaplanner.core.config.solver.SolverManagerConfig;
 import org.optaplanner.core.impl.domain.solution.descriptor.SolutionDescriptor;
 import org.optaplanner.quarkus.OptaPlannerBeanProvider;
 import org.optaplanner.quarkus.OptaPlannerRecorder;
+import org.optaplanner.quarkus.config.OptaPlannerRuntimeConfig;
 import org.optaplanner.quarkus.deployment.config.OptaPlannerBuildTimeConfig;
 import org.optaplanner.quarkus.gizmo.OptaPlannerGizmoBeanFactory;
 
@@ -125,8 +126,8 @@ class OptaPlannerProcessor {
             BuildProducer<ReflectiveHierarchyBuildItem> reflectiveHierarchyClass,
             BuildProducer<SyntheticBeanBuildItem> syntheticBeanBuildItemBuildProducer,
             BuildProducer<AdditionalBeanBuildItem> additionalBeans,
-            BuildProducer<GeneratedBeanBuildItem> generatedBeans,
             BuildProducer<UnremovableBeanBuildItem> unremovableBeans,
+            BuildProducer<GeneratedBeanBuildItem> generatedBeans,
             BuildProducer<GeneratedClassBuildItem> generatedClasses,
             BuildProducer<BytecodeTransformerBuildItem> transformers) {
         IndexView indexView = combinedIndex.getIndex();
@@ -220,6 +221,7 @@ class OptaPlannerProcessor {
                 .supplier(recorder.solverManagerConfig(solverManagerConfig)).done());
 
         additionalBeans.produce(new AdditionalBeanBuildItem(OptaPlannerBeanProvider.class));
+        unremovableBeans.produce(UnremovableBeanBuildItem.beanTypes(OptaPlannerRuntimeConfig.class));
     }
 
     private void generateConstraintVerifier(SolverConfig solverConfig,
@@ -301,7 +303,6 @@ class OptaPlannerProcessor {
         applyScoreDirectorFactoryProperties(indexView, solverConfig, capabilities);
         optaPlannerBuildTimeConfig.solver.environmentMode.ifPresent(solverConfig::setEnvironmentMode);
         optaPlannerBuildTimeConfig.solver.daemon.ifPresent(solverConfig::setDaemon);
-        optaPlannerBuildTimeConfig.solver.moveThreadCount.ifPresent(solverConfig::setMoveThreadCount);
         optaPlannerBuildTimeConfig.solver.domainAccessType.ifPresent(solverConfig::setDomainAccessType);
         if (solverConfig.getDomainAccessType() == null) {
             solverConfig.setDomainAccessType(DomainAccessType.REFLECTION);

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/main/java/org/optaplanner/quarkus/deployment/OptaPlannerProcessor.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/main/java/org/optaplanner/quarkus/deployment/OptaPlannerProcessor.java
@@ -202,7 +202,6 @@ class OptaPlannerProcessor {
                         transformers, reflectiveClassSet);
 
         SolverManagerConfig solverManagerConfig = new SolverManagerConfig();
-        optaPlannerBuildTimeConfig.solverManager.parallelSolverCount.ifPresent(solverManagerConfig::setParallelSolverCount);
 
         syntheticBeanBuildItemBuildProducer.produce(SyntheticBeanBuildItem.configure(SolverConfig.class)
                 .scope(Singleton.class)

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/main/java/org/optaplanner/quarkus/deployment/OptaPlannerProcessor.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/main/java/org/optaplanner/quarkus/deployment/OptaPlannerProcessor.java
@@ -63,7 +63,11 @@ import org.optaplanner.quarkus.config.OptaPlannerRuntimeConfig;
 import org.optaplanner.quarkus.deployment.config.OptaPlannerBuildTimeConfig;
 import org.optaplanner.quarkus.gizmo.OptaPlannerGizmoBeanFactory;
 
-import io.quarkus.arc.deployment.*;
+import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
+import io.quarkus.arc.deployment.GeneratedBeanBuildItem;
+import io.quarkus.arc.deployment.GeneratedBeanGizmoAdaptor;
+import io.quarkus.arc.deployment.SyntheticBeanBuildItem;
+import io.quarkus.arc.deployment.UnremovableBeanBuildItem;
 import io.quarkus.deployment.Capabilities;
 import io.quarkus.deployment.GeneratedClassGizmoAdaptor;
 import io.quarkus.deployment.annotations.BuildProducer;

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/main/java/org/optaplanner/quarkus/deployment/config/OptaPlannerBuildTimeConfig.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/main/java/org/optaplanner/quarkus/deployment/config/OptaPlannerBuildTimeConfig.java
@@ -22,7 +22,6 @@ import org.optaplanner.core.api.score.calculator.EasyScoreCalculator;
 import org.optaplanner.core.api.score.calculator.IncrementalScoreCalculator;
 import org.optaplanner.core.api.score.stream.ConstraintProvider;
 import org.optaplanner.core.config.solver.SolverConfig;
-import org.optaplanner.core.config.solver.SolverManagerConfig;
 
 import io.quarkus.runtime.annotations.ConfigItem;
 import io.quarkus.runtime.annotations.ConfigRoot;
@@ -59,9 +58,5 @@ public class OptaPlannerBuildTimeConfig {
      */
     @ConfigItem
     public SolverBuildTimeConfig solver;
-    /**
-     * Configuration properties that overwrite OptaPlanner's {@link SolverManagerConfig}.
-     */
-    @ConfigItem
-    public SolverManagerBuildTimeConfig solverManager;
+
 }

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/main/java/org/optaplanner/quarkus/deployment/config/SolverBuildTimeConfig.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/main/java/org/optaplanner/quarkus/deployment/config/SolverBuildTimeConfig.java
@@ -51,15 +51,6 @@ public class SolverBuildTimeConfig {
     public Optional<Boolean> daemon;
 
     /**
-     * Enable multithreaded solving for a single problem, which increases CPU consumption.
-     * Defaults to {@value SolverConfig#MOVE_THREAD_COUNT_NONE}.
-     * Other options include {@value SolverConfig#MOVE_THREAD_COUNT_AUTO}, a number
-     * or formula based on the available processor count.
-     */
-    @ConfigItem
-    public Optional<String> moveThreadCount;
-
-    /**
      * Determines how to access the fields and methods of domain classes.
      * Defaults to {@link DomainAccessType#GIZMO}.
      */

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/test/java/org/optaplanner/quarkus/OptaPlannerProcessorOverridePropertiesAtRuntimeTest.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/test/java/org/optaplanner/quarkus/OptaPlannerProcessorOverridePropertiesAtRuntimeTest.java
@@ -17,13 +17,18 @@
 package org.optaplanner.quarkus;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-import java.util.Optional;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
 
-import javax.enterprise.context.ApplicationScoped;
-import javax.enterprise.inject.Alternative;
 import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
 
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
@@ -31,66 +36,95 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.optaplanner.core.config.solver.SolverConfig;
 import org.optaplanner.core.config.solver.SolverManagerConfig;
-import org.optaplanner.quarkus.config.OptaPlannerRuntimeConfig;
-import org.optaplanner.quarkus.config.SolverManagerRuntimeConfig;
-import org.optaplanner.quarkus.config.SolverRuntimeConfig;
-import org.optaplanner.quarkus.config.TerminationRuntimeConfig;
 import org.optaplanner.quarkus.testdata.normal.constraints.TestdataQuarkusConstraintProvider;
 import org.optaplanner.quarkus.testdata.normal.domain.TestdataQuarkusEntity;
 import org.optaplanner.quarkus.testdata.normal.domain.TestdataQuarkusSolution;
 
-import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.bootstrap.model.AppArtifact;
+import io.quarkus.test.QuarkusProdModeTest;
+import io.restassured.RestAssured;
 
 public class OptaPlannerProcessorOverridePropertiesAtRuntimeTest {
 
     @RegisterExtension
-    static final QuarkusUnitTest config = new QuarkusUnitTest()
-            // We want to check if these are overridden by our runtime alternative
+    static final QuarkusProdModeTest config = new QuarkusProdModeTest()
+            .setForcedDependencies(Arrays.asList(
+                    // TODO: Remove optaplanner-test when https://github.com/kiegroup/optaplanner/pull/1302 is merged?
+                    new AppArtifact("org.optaplanner", "optaplanner-test", "8.1.0.Final"),
+                    new AppArtifact("io.quarkus", "quarkus-resteasy", "1.11.0.Final")))
+            // We want to check if these are overridden at runtime
             .overrideConfigKey("quarkus.optaplanner.solver.termination.best-score-limit", "0")
             .overrideConfigKey("quarkus.optaplanner.solver.move-thread-count", "4")
             .overrideConfigKey("quarkus.optaplanner.solver-manager.parallel-solver-count", "1")
-            // MyOptaPlannerRuntimeConfig is an alternative for OptaPlannerRuntimeConfig,
-            // and simulates setting the values at runtime.
-            .overrideConfigKey("quarkus.arc.selected-alternatives", "MyOptaPlannerRuntimeConfig")
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
                     .addClasses(TestdataQuarkusEntity.class,
                             TestdataQuarkusSolution.class,
                             TestdataQuarkusConstraintProvider.class,
-                            MyOptaPlannerRuntimeConfig.class));
+                            OptaPlannerTestResource.class))
+            .setRuntimeProperties(getRuntimeProperties())
+            .setRun(true);
 
-    @Inject
-    SolverConfig solverConfig;
-
-    @Inject
-    SolverManagerConfig solverManagerConfig;
-
-    @Test
-    public void solverConfigPropertiesShouldBeOverwritten() {
-        assertNotNull(solverConfig);
-        assertEquals("7", solverConfig.getTerminationConfig().getBestScoreLimit());
-        assertEquals("3", solverConfig.getMoveThreadCount());
+    private static Map<String, String> getRuntimeProperties() {
+        Map<String, String> out = new HashMap<>();
+        out.put("quarkus.optaplanner.solver.termination.best-score-limit", "7");
+        out.put("quarkus.optaplanner.solver.move-thread-count", "3");
+        out.put("quarkus.optaplanner.solver-manager.parallel-solver-count", "10");
+        return out;
     }
 
-    @Test
-    public void solverManagerConfigPropertiesShouldBeOverwritten() {
-        assertNotNull(solverManagerConfig);
-        assertEquals("10", solverManagerConfig.getParallelSolverCount());
-    }
+    // Can't use injection, so we need a resource to fetch the properties
+    @Path("/optaplanner/test")
+    public static class OptaPlannerTestResource {
+        @Inject
+        SolverConfig solverConfig;
 
-    @Alternative
-    @ApplicationScoped
-    public static class MyOptaPlannerRuntimeConfig extends OptaPlannerRuntimeConfig {
-        public MyOptaPlannerRuntimeConfig() {
-            solver = new SolverRuntimeConfig();
-            solver.termination = new TerminationRuntimeConfig();
-            solver.termination.bestScoreLimit = Optional.of("7");
-            solver.termination.spentLimit = Optional.empty();
-            solver.termination.unimprovedSpentLimit = Optional.empty();
-            solver.moveThreadCount = Optional.of("3");
+        @Inject
+        SolverManagerConfig solverManagerConfig;
 
-            solverManager = new SolverManagerRuntimeConfig();
-            solverManager.parallelSolverCount = Optional.of("10");
+        @GET
+        @Path("/solver-config")
+        @Produces(MediaType.TEXT_PLAIN)
+        public String getSolverConfig() {
+            StringBuilder sb = new StringBuilder();
+            sb.append("termination.bestScoreLimit=").append(solverConfig.getTerminationConfig().getBestScoreLimit())
+                    .append("\n");
+            sb.append("moveThreadCount=").append(solverConfig.getMoveThreadCount()).append("\n");
+            return sb.toString();
         }
+
+        @GET
+        @Path("/solver-manager-config")
+        @Produces(MediaType.TEXT_PLAIN)
+        public String getSolverManagerConfig() {
+            StringBuilder sb = new StringBuilder();
+            sb.append("parallelSolverCount=").append(solverManagerConfig.getParallelSolverCount()).append("\n");
+            return sb.toString();
+        }
+    }
+
+    @Test
+    public void solverConfigPropertiesShouldBeOverwritten() throws IOException {
+        Properties solverConfigProperties = new Properties();
+        solverConfigProperties.load(RestAssured.given()
+                .contentType(MediaType.TEXT_PLAIN)
+                .accept(MediaType.TEXT_PLAIN)
+                .when()
+                .get("/optaplanner/test/solver-config")
+                .asInputStream());
+        assertEquals("7", solverConfigProperties.get("termination.bestScoreLimit"));
+        assertEquals("3", solverConfigProperties.get("moveThreadCount"));
+    }
+
+    @Test
+    public void solverManagerConfigPropertiesShouldBeOverwritten() throws IOException {
+        Properties solverManagerProperties = new Properties();
+        solverManagerProperties.load(RestAssured.given()
+                .contentType(MediaType.TEXT_PLAIN)
+                .accept(MediaType.TEXT_PLAIN)
+                .when()
+                .get("/optaplanner/test/solver-manager-config")
+                .asInputStream());
+        assertEquals("10", solverManagerProperties.get("parallelSolverCount"));
     }
 
 }

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/runtime/src/main/java/org/optaplanner/quarkus/OptaPlannerBeanProvider.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/runtime/src/main/java/org/optaplanner/quarkus/OptaPlannerBeanProvider.java
@@ -36,7 +36,6 @@ import org.optaplanner.core.api.solver.SolverFactory;
 import org.optaplanner.core.api.solver.SolverManager;
 import org.optaplanner.core.config.solver.SolverConfig;
 import org.optaplanner.core.config.solver.SolverManagerConfig;
-import org.optaplanner.core.config.solver.termination.TerminationConfig;
 import org.optaplanner.quarkus.config.OptaPlannerRuntimeConfig;
 
 import io.quarkus.arc.DefaultBean;

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/runtime/src/main/java/org/optaplanner/quarkus/OptaPlannerBeanProvider.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/runtime/src/main/java/org/optaplanner/quarkus/OptaPlannerBeanProvider.java
@@ -43,25 +43,11 @@ import io.quarkus.arc.DefaultBean;
 
 public class OptaPlannerBeanProvider {
 
-    private void updateSolverConfigWithRuntimeProperties(SolverConfig solverConfig,
-            OptaPlannerRuntimeConfig optaPlannerRunTimeConfig) {
-        TerminationConfig terminationConfig = solverConfig.getTerminationConfig();
-        if (terminationConfig == null) {
-            terminationConfig = new TerminationConfig();
-            solverConfig.setTerminationConfig(terminationConfig);
-        }
-        optaPlannerRunTimeConfig.solver.termination.spentLimit.ifPresent(terminationConfig::setSpentLimit);
-        optaPlannerRunTimeConfig.solver.termination.unimprovedSpentLimit
-                .ifPresent(terminationConfig::setUnimprovedSpentLimit);
-        optaPlannerRunTimeConfig.solver.termination.bestScoreLimit.ifPresent(terminationConfig::setBestScoreLimit);
-    }
-
     @DefaultBean
     @Singleton
     @Produces
     <Solution_> SolverFactory<Solution_> solverFactory(SolverConfig solverConfig,
             OptaPlannerRuntimeConfig optaPlannerRunTimeConfig) {
-        updateSolverConfigWithRuntimeProperties(solverConfig, optaPlannerRunTimeConfig);
         SolverFactory<Solution_> solverFactory = SolverFactory.create(solverConfig);
         return solverFactory;
     }

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/runtime/src/main/java/org/optaplanner/quarkus/OptaPlannerRecorder.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/runtime/src/main/java/org/optaplanner/quarkus/OptaPlannerRecorder.java
@@ -23,22 +23,25 @@ import java.util.function.Supplier;
 import org.optaplanner.core.api.domain.solution.cloner.SolutionCloner;
 import org.optaplanner.core.config.solver.SolverConfig;
 import org.optaplanner.core.config.solver.SolverManagerConfig;
+import org.optaplanner.core.config.solver.termination.TerminationConfig;
+import org.optaplanner.quarkus.config.OptaPlannerRuntimeConfig;
 import org.optaplanner.core.impl.domain.common.accessor.MemberAccessor;
 import org.optaplanner.quarkus.gizmo.OptaPlannerDroolsInitializer;
 
+import io.quarkus.arc.Arc;
 import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.runtime.annotations.Recorder;
 
 @Recorder
 public class OptaPlannerRecorder {
 
-    public Supplier<SolverConfig> solverConfigSupplier(final SolverConfig solverConfig,
-            Map<String, RuntimeValue<MemberAccessor>> generatedGizmoMemberAccessorMap,
-            Map<String, RuntimeValue<SolutionCloner>> generatedGizmoSolutionClonerMap,
-            RuntimeValue<OptaPlannerDroolsInitializer> droolsInitializer) {
+    public Supplier<SolverConfig> solverConfigSupplier(final SolverConfig solverConfig) {
         return new Supplier<SolverConfig>() {
             @Override
             public SolverConfig get() {
+                OptaPlannerRuntimeConfig optaPlannerRuntimeConfig =
+                        Arc.container().instance(OptaPlannerRuntimeConfig.class).get();
+                updateSolverConfigWithRuntimeProperties(solverConfig, optaPlannerRuntimeConfig);
                 Map<String, MemberAccessor> memberAccessorMap = new HashMap<>();
                 Map<String, SolutionCloner> solutionClonerMap = new HashMap<>();
                 generatedGizmoMemberAccessorMap
@@ -58,9 +61,31 @@ public class OptaPlannerRecorder {
         return new Supplier<SolverManagerConfig>() {
             @Override
             public SolverManagerConfig get() {
+                OptaPlannerRuntimeConfig optaPlannerRuntimeConfig =
+                        Arc.container().instance(OptaPlannerRuntimeConfig.class).get();
+                updateSolverManagerConfigWithRuntimeProperties(solverManagerConfig, optaPlannerRuntimeConfig);
                 return solverManagerConfig;
             }
         };
+    }
+
+    private void updateSolverConfigWithRuntimeProperties(SolverConfig solverConfig,
+            OptaPlannerRuntimeConfig optaPlannerRunTimeConfig) {
+        TerminationConfig terminationConfig = solverConfig.getTerminationConfig();
+        if (terminationConfig == null) {
+            terminationConfig = new TerminationConfig();
+            solverConfig.setTerminationConfig(terminationConfig);
+        }
+        optaPlannerRunTimeConfig.solver.termination.spentLimit.ifPresent(terminationConfig::setSpentLimit);
+        optaPlannerRunTimeConfig.solver.termination.unimprovedSpentLimit
+                .ifPresent(terminationConfig::setUnimprovedSpentLimit);
+        optaPlannerRunTimeConfig.solver.termination.bestScoreLimit.ifPresent(terminationConfig::setBestScoreLimit);
+        optaPlannerRunTimeConfig.solver.moveThreadCount.ifPresent(solverConfig::setMoveThreadCount);
+    }
+
+    private void updateSolverManagerConfigWithRuntimeProperties(SolverManagerConfig solverManagerConfig,
+            OptaPlannerRuntimeConfig optaPlannerRunTimeConfig) {
+        optaPlannerRunTimeConfig.solverManager.parallelSolverCount.ifPresent(solverManagerConfig::setParallelSolverCount);
     }
 
 }

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/runtime/src/main/java/org/optaplanner/quarkus/OptaPlannerRecorder.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/runtime/src/main/java/org/optaplanner/quarkus/OptaPlannerRecorder.java
@@ -24,8 +24,8 @@ import org.optaplanner.core.api.domain.solution.cloner.SolutionCloner;
 import org.optaplanner.core.config.solver.SolverConfig;
 import org.optaplanner.core.config.solver.SolverManagerConfig;
 import org.optaplanner.core.config.solver.termination.TerminationConfig;
-import org.optaplanner.quarkus.config.OptaPlannerRuntimeConfig;
 import org.optaplanner.core.impl.domain.common.accessor.MemberAccessor;
+import org.optaplanner.quarkus.config.OptaPlannerRuntimeConfig;
 import org.optaplanner.quarkus.gizmo.OptaPlannerDroolsInitializer;
 
 import io.quarkus.arc.Arc;
@@ -35,7 +35,10 @@ import io.quarkus.runtime.annotations.Recorder;
 @Recorder
 public class OptaPlannerRecorder {
 
-    public Supplier<SolverConfig> solverConfigSupplier(final SolverConfig solverConfig) {
+    public Supplier<SolverConfig> solverConfigSupplier(final SolverConfig solverConfig,
+            Map<String, RuntimeValue<MemberAccessor>> generatedGizmoMemberAccessorMap,
+            Map<String, RuntimeValue<SolutionCloner>> generatedGizmoSolutionClonerMap,
+            RuntimeValue<OptaPlannerDroolsInitializer> droolsInitializer) {
         return new Supplier<SolverConfig>() {
             @Override
             public SolverConfig get() {

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/runtime/src/main/java/org/optaplanner/quarkus/config/OptaPlannerRuntimeConfig.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/runtime/src/main/java/org/optaplanner/quarkus/config/OptaPlannerRuntimeConfig.java
@@ -17,6 +17,7 @@
 package org.optaplanner.quarkus.config;
 
 import org.optaplanner.core.config.solver.SolverConfig;
+import org.optaplanner.core.config.solver.SolverManagerConfig;
 
 import io.quarkus.runtime.annotations.ConfigItem;
 import io.quarkus.runtime.annotations.ConfigPhase;
@@ -30,4 +31,10 @@ public class OptaPlannerRuntimeConfig {
      */
     @ConfigItem
     public SolverRuntimeConfig solver;
+
+    /**
+     * Configuration properties that overwrite OptaPlanner's {@link SolverManagerConfig}.
+     */
+    @ConfigItem
+    public SolverManagerRuntimeConfig solverManager;
 }

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/runtime/src/main/java/org/optaplanner/quarkus/config/SolverManagerRuntimeConfig.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/runtime/src/main/java/org/optaplanner/quarkus/config/SolverManagerRuntimeConfig.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.optaplanner.quarkus.deployment.config;
+package org.optaplanner.quarkus.config;
 
 import java.util.Optional;
 
@@ -27,7 +27,7 @@ import io.quarkus.runtime.annotations.ConfigItem;
  * During build time, this is translated into OptaPlanner's {@link SolverManagerConfig}.
  */
 @ConfigGroup
-public class SolverManagerBuildTimeConfig {
+public class SolverManagerRuntimeConfig {
 
     /**
      * The number of solvers that run in parallel. This directly influences CPU consumption.

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/runtime/src/main/java/org/optaplanner/quarkus/config/SolverRuntimeConfig.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/runtime/src/main/java/org/optaplanner/quarkus/config/SolverRuntimeConfig.java
@@ -16,6 +16,8 @@
 
 package org.optaplanner.quarkus.config;
 
+import java.util.Optional;
+
 import org.optaplanner.core.config.solver.SolverConfig;
 import org.optaplanner.core.config.solver.termination.TerminationConfig;
 
@@ -33,4 +35,13 @@ public class SolverRuntimeConfig {
      */
     @ConfigItem
     public TerminationRuntimeConfig termination;
+
+    /**
+     * Enable multithreaded solving for a single problem, which increases CPU consumption.
+     * Defaults to {@value SolverConfig#MOVE_THREAD_COUNT_NONE}.
+     * Other options include {@value SolverConfig#MOVE_THREAD_COUNT_AUTO}, a number
+     * or formula based on the available processor count.
+     */
+    @ConfigItem
+    public Optional<String> moveThreadCount;
 }

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/runtime/src/main/java/org/optaplanner/quarkus/config/SolverRuntimeConfig.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/runtime/src/main/java/org/optaplanner/quarkus/config/SolverRuntimeConfig.java
@@ -31,12 +31,6 @@ import io.quarkus.runtime.annotations.ConfigItem;
 @ConfigGroup
 public class SolverRuntimeConfig {
     /**
-     * Configuration properties that overwrite OptaPlanner's {@link TerminationConfig}.
-     */
-    @ConfigItem
-    public TerminationRuntimeConfig termination;
-
-    /**
      * Enable multithreaded solving for a single problem, which increases CPU consumption.
      * Defaults to {@value SolverConfig#MOVE_THREAD_COUNT_NONE}.
      * Other options include {@value SolverConfig#MOVE_THREAD_COUNT_AUTO}, a number
@@ -44,4 +38,10 @@ public class SolverRuntimeConfig {
      */
     @ConfigItem
     public Optional<String> moveThreadCount;
+
+    /**
+     * Configuration properties that overwrite OptaPlanner's {@link TerminationConfig}.
+     */
+    @ConfigItem
+    public TerminationRuntimeConfig termination;
 }


### PR DESCRIPTION

<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.
-->

### JIRA

<!-- Add a JIRA ticket link if it exists. -->
https://issues.redhat.com/browse/PLANNER-2387

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
* https://github.com/kiegroup/drools/pull/3000
* https://github.com/kiegroup/optaplanner/pull/899
* etc.
-->

### Checklist
- [ ] Documentation updated if applicable.
- [ ] Upgrade recipe provided if applicable.

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>full downstream build</b> please add comment: <b>Jenkins run fdb</b>
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
* for a <b>Quarkus LTS check</b> please add comment: <b>Jenkins run LTS</b>
* for a <b>Native check</b> please add comment: <b>Jenkins run native</b>
</details>
