### PR TITLE
DRAFT - PLANNER-2397: Add an example of showing and modifying the SolverConfig

### DIFF
--- a/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/main/resources/dev-templates/embedded.html
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/main/resources/dev-templates/embedded.html
@@ -1,0 +1,4 @@
+<a href="{urlbase}/solverConfig" class="badge badge-light">
+    <i class="fas fa-wrench"></i>
+    Solver Configuration
+</a>

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/main/resources/dev-templates/solverConfig.html
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/main/resources/dev-templates/solverConfig.html
@@ -1,0 +1,64 @@
+<!--
+  ~ Copyright 2021 Red Hat, Inc. and/or its affiliates.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+{#include main}
+
+{#style}
+  .editable-property {}
+  .cancel-edit {}
+  .save-edit {}
+{/style}
+
+{#title}Solver Configuration{/title}
+
+{#body}
+
+<table class="table table-striped">
+    <script>
+
+    document.addEventListener('DOMContentLoaded', function(){
+      $(".editable-property").click(function() {
+        $(this).parent().css("display", "none");
+        $(this).parent().next().css("display", "inherit");
+      });
+
+      $(".cancel-edit").click(function() {
+        $(this).parent().parent().css("display", "none");
+        $(this).parent().parent().prev().css("display", "inherit");
+      });
+
+      $(".save-edit").click(function() {
+
+      });
+    }, false);
+
+    </script>
+    <thead class="thead-dark">
+    <tr>
+        <th scope="col">Property</th>
+        <th scope="col">Value</th>
+    </tr>
+    </thead>
+    <tbody>
+
+    {#for property in info:solverConfigProperties.solverProperties}
+    {#show-row property/}
+    {/for}
+
+    </tbody>
+</table>
+{/body}
+
+{/include}

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/main/resources/dev-templates/tags/show-row.html
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/main/resources/dev-templates/tags/show-row.html
@@ -1,0 +1,52 @@
+<!--
+  ~ Copyright 2021 Red Hat, Inc. and/or its affiliates.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<tr>
+    <td>{it.name}</td>
+    <td>
+        {it.value}
+        <button data-property="{it.name}" class="btn btn-link editable-property">
+            Edit <i class="fas fa-edit"></i>
+        </button>
+    </td>
+    <td style="display: none;">
+        <form method="post"
+              enctype="application/x-www-form-urlencoded">
+          <input type="hidden" name="name" value="{it.name}">
+          {#when it.valueType}
+            {#is ENUM}
+              <select name="value" class="form-select" aria-label="{it.name}">
+                {#for value in it.enumValueList}
+                  {#if value == it.value}
+                    <option value="{value}" selected>{value}</option>
+                  {#else}
+                    <option value="{value}">{value}</option>
+                  {/if}
+                {/for}
+              </select>
+            {#is NUMBER}
+              <input name="value" type="number" value="{it.value}" />
+            {#is STRING}
+              <input name="value" type="text" value="{it.value}" />
+          {/when}
+          <button type="reset" data-property="{it.name}" class="btn btn-link cancel-edit">
+              Cancel <i class="fas fa-times"></i>
+          </button>
+          <button type="submit" data-property="{it.name}" class="btn btn-link save-edit">
+              Save <i class="fas fa-save"></i>
+          </button>
+        </form>
+      </td>
+</tr>

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/runtime/pom.xml
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/runtime/pom.xml
@@ -26,6 +26,14 @@
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-arc</artifactId>
     </dependency>
+
+    <!-- For Dev UI POST Handler -->
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-vertx-http</artifactId>
+      <optional>true</optional>
+    </dependency>
+
     <dependency>
       <groupId>org.optaplanner</groupId>
       <artifactId>optaplanner-core</artifactId>

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/runtime/src/main/java/org/optaplanner/quarkus/devui/ConfigurationProperty.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/runtime/src/main/java/org/optaplanner/quarkus/devui/ConfigurationProperty.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.quarkus.devui;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class ConfigurationProperty {
+    String name;
+    String value;
+    ValueType valueType;
+    List<String> enumValueList;
+
+    public ConfigurationProperty(String name, String value, ValueType valueType) {
+        this(name, value, valueType, null);
+    }
+
+    public ConfigurationProperty(String name, String value, Class<? extends Enum> enumClass) {
+        this(name, value, ValueType.ENUM,
+                Arrays.stream(enumClass.getEnumConstants())
+                        .map(Enum::name)
+                        .collect(Collectors.toList()));
+    }
+
+    public ConfigurationProperty(String name, String value, ValueType valueType, List<String> enumValueList) {
+        this.name = name;
+        this.value = value;
+        this.valueType = valueType;
+
+        if (this.valueType == ValueType.ENUM && enumValueList == null) {
+            throw new IllegalArgumentException("enumValueList must be set for valueType (" + valueType + ").");
+        } else if (this.valueType != ValueType.ENUM && enumValueList != null) {
+            throw new IllegalArgumentException("enumValueList must be null for valueType (" + valueType + ").");
+        }
+
+        this.enumValueList = enumValueList;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public ValueType getValueType() {
+        return valueType;
+    }
+
+    public List<String> getEnumValueList() {
+        return enumValueList;
+    }
+
+    public enum ValueType {
+        ENUM,
+        NUMBER,
+        STRING;
+    }
+}

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/runtime/src/main/java/org/optaplanner/quarkus/devui/SolverConfigDevUIHandlerRecorder.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/runtime/src/main/java/org/optaplanner/quarkus/devui/SolverConfigDevUIHandlerRecorder.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.quarkus.devui;
+
+import java.io.FileWriter;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import org.eclipse.microprofile.config.ConfigProvider;
+import org.optaplanner.core.config.solver.EnvironmentMode;
+import org.optaplanner.core.config.solver.SolverConfig;
+import org.optaplanner.core.impl.io.jaxb.SolverConfigIO;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.devconsole.runtime.spi.DevConsolePostHandler;
+import io.quarkus.devconsole.runtime.spi.FlashScopeUtil;
+import io.quarkus.runtime.annotations.Recorder;
+import io.vertx.core.Handler;
+import io.vertx.core.MultiMap;
+import io.vertx.ext.web.RoutingContext;
+
+@Recorder
+public class SolverConfigDevUIHandlerRecorder {
+    public Handler<RoutingContext> updateSolverPropertiesHandler() {
+        return new DevConsolePostHandler() {
+            @Override
+            protected void handlePost(RoutingContext event, MultiMap form)
+                    throws Exception {
+                String property = form.get("name");
+                String value = form.get("value");
+                SolverConfig solverConfig = Arc.container().instance(SolverConfig.class).get();
+
+                switch (property) {
+                    case "Environment Mode":
+                        try {
+                            EnvironmentMode environmentMode = EnvironmentMode.valueOf(value);
+                            solverConfig.setEnvironmentMode(environmentMode);
+                        } catch (IllegalArgumentException e) {
+                            flashMessage(event, "environmentMode (" + value + ") is not a valid Environment Mode.",
+                                    FlashScopeUtil.FlashMessageStatus.ERROR);
+                            return;
+                        }
+                        break;
+
+                    default:
+                        flashMessage(event, "Property (" + property + ") is not an existing property in SolverConfig",
+                                FlashScopeUtil.FlashMessageStatus.ERROR);
+                        return;
+                }
+
+                Path solverConfigLocation =
+                        Paths.get(ConfigProvider.getConfig().getOptionalValue("solverConfigXml", String.class)
+                                .orElse("solverConfig.xml"));
+
+                if (!solverConfigLocation.isAbsolute()) {
+                    solverConfigLocation = Paths.get("..", "src", "main", "resources").toAbsolutePath().normalize()
+                            .resolve(solverConfigLocation);
+                }
+                FileWriter writer = new FileWriter(solverConfigLocation.toFile());
+                SolverConfigIO solverConfigIO = new SolverConfigIO();
+                solverConfigIO.write(solverConfig, writer);
+
+                flashMessage(event, "Updated Solver Config");
+            }
+        };
+    }
+}

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/runtime/src/main/java/org/optaplanner/quarkus/devui/SolverConfigDevUIProperties.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/runtime/src/main/java/org/optaplanner/quarkus/devui/SolverConfigDevUIProperties.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.quarkus.devui;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.optaplanner.core.config.solver.EnvironmentMode;
+import org.optaplanner.core.config.solver.SolverConfig;
+
+public class SolverConfigDevUIProperties {
+    SolverConfig solverConfig;
+
+    public SolverConfigDevUIProperties(SolverConfig solverConfig) {
+        this.solverConfig = solverConfig;
+    }
+
+    public List<ConfigurationProperty> getSolverProperties() {
+        return Arrays.asList(new ConfigurationProperty("Environment Mode", solverConfig.determineEnvironmentMode().name(),
+                EnvironmentMode.class));
+    }
+
+    public List<ConfigurationProperty> getScoreDirectorProperties() {
+        return Arrays.asList(new ConfigurationProperty("Environment Mode", solverConfig.determineEnvironmentMode().name(),
+                EnvironmentMode.class));
+    }
+}

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/runtime/src/main/java/org/optaplanner/quarkus/devui/SolverConfigDevUISupplier.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/runtime/src/main/java/org/optaplanner/quarkus/devui/SolverConfigDevUISupplier.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.quarkus.devui;
+
+import java.util.function.Supplier;
+
+import org.optaplanner.core.config.solver.SolverConfig;
+
+import io.quarkus.arc.Arc;
+
+public class SolverConfigDevUISupplier implements Supplier<SolverConfigDevUIProperties> {
+    @Override
+    public SolverConfigDevUIProperties get() {
+        return new SolverConfigDevUIProperties(Arc.container().instance(SolverConfig.class).get());
+    }
+}


### PR DESCRIPTION
This is a PoC to see what is possible in Quarkus Dev UI; I added a page that showed the SolverConfig Enviroment mode and allows you to change it. We are able to write to the solverConfig.xml location (which will cause a reload). 

Other possibilities:
- Solver performance infomation
- Open constraints in the IDE (several extension Dev UI already does this)
- link to the reference manual (there already a link to the guide)
<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.
-->

### JIRA

<!-- Add a JIRA ticket link if it exists. -->
https://issues.redhat.com/browse/PLANNER-2397

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
* https://github.com/kiegroup/drools/pull/3000
* https://github.com/kiegroup/optaplanner/pull/899
* etc.
-->

### Checklist
- [ ] Documentation updated if applicable.
- [ ] Upgrade recipe provided if applicable.

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>full downstream build</b> please add comment: <b>Jenkins run fdb</b>
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
* for a <b>Quarkus LTS check</b> please add comment: <b>Jenkins run LTS</b>
* for a <b>Native check</b> please add comment: <b>Jenkins run native</b>
</details>
