### PR TITLE
PLANNER-2400: Add Micrometer Metric for Solver

### DIFF
--- a/build/optaplanner-build-parent/pom.xml
+++ b/build/optaplanner-build-parent/pom.xml
@@ -30,6 +30,7 @@
     <version.com.fasterxml.jackson.core>2.12.3</version.com.fasterxml.jackson.core>
     <version.com.h2database>1.4.197</version.com.h2database>
     <version.com.thoughtworks.xstream>1.4.17</version.com.thoughtworks.xstream>
+    <version.io.micrometer>1.6.6</version.io.micrometer>
     <version.io.quarkus>2.0.0.CR3</version.io.quarkus>
     <version.io.quarkus.gizmo>1.0.8.Final</version.io.quarkus.gizmo>
     <version.org.ow2.asm>9.1</version.org.ow2.asm>
@@ -179,6 +180,13 @@
       </dependency>
 
       <!-- Normal dependencies versions-->
+      <dependency>
+        <groupId>io.micrometer</groupId>
+        <artifactId>micrometer-bom</artifactId>
+        <version>${version.io.micrometer}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
       <dependency>
         <groupId>ch.qos.logback</groupId>
         <artifactId>logback-core</artifactId>

--- a/optaplanner-core/pom.xml
+++ b/optaplanner-core/pom.xml
@@ -101,6 +101,13 @@
       <artifactId>logback-classic</artifactId>
       <scope>test</scope>
     </dependency>
+
+    <!-- Monitoring -->
+    <dependency>
+      <groupId>io.micrometer</groupId>
+      <artifactId>micrometer-core</artifactId>
+    </dependency>
+
     <!-- XML -->
     <dependency>
       <groupId>jakarta.xml.bind</groupId>

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/solver/DefaultSolver.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/solver/DefaultSolver.java
@@ -173,16 +173,14 @@ public class DefaultSolver<Solution_> extends AbstractSolver<Solution_> {
             try {
                 solvingStarted(solverScope);
                 runPhases(solverScope);
-
                 solvingEnded(solverScope);
-                sample.stop();
-
-                restartSolver = checkProblemFactChanges();
             } catch (Exception e) {
-                sample.stop();
                 errorCounter.increment();
                 throw e;
+            } finally {
+                sample.stop();
             }
+            restartSolver = checkProblemFactChanges();
         }
         outerSolvingEnded(solverScope);
         return solverScope.getBestSolution();

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/util/TestMeterRegistry.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/util/TestMeterRegistry.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.core.impl.util;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import io.micrometer.core.instrument.MockClock;
+import io.micrometer.core.instrument.config.NamingConvention;
+import io.micrometer.core.instrument.simple.SimpleConfig;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+
+public class TestMeterRegistry extends SimpleMeterRegistry {
+    final Map<String, Map<String, String>> measurementMap;
+
+    public TestMeterRegistry() {
+        super(SimpleConfig.DEFAULT, new MockClock());
+        measurementMap = new HashMap<>();
+    }
+
+    public MockClock getClock() {
+        return MockClock.clock(this);
+    }
+
+    public String getMeasurement(String key, String statistic) {
+        if (measurementMap.containsKey(key)) {
+            Map<String, String> meterMeasurementMap = measurementMap.get(key);
+            if (meterMeasurementMap.containsKey(statistic)) {
+                return meterMeasurementMap.get(statistic);
+            } else {
+                throw new IllegalArgumentException(
+                        "Meter (" + key + ") does not have statistic (" + statistic + "). Available statistics are: "
+                                + meterMeasurementMap.keySet().stream().collect(Collectors.joining(", ", "[", "]")));
+            }
+        } else {
+            throw new IllegalArgumentException("Meter (" + key + ") does not exist. Available statistics are: "
+                    + measurementMap.keySet().stream().collect(Collectors.joining(", ", "[", "]")));
+        }
+    }
+
+    public void publish() {
+        getMeters().forEach(meter -> {
+            final Map<String, String> meterMeasurementMap = new HashMap<>();
+            measurementMap.put(meter.getId().getConventionName(NamingConvention.dot), meterMeasurementMap);
+            meter.measure().forEach(measurement -> {
+                meterMeasurementMap.put(measurement.getStatistic().name(), String.format("%.1f", measurement.getValue()));
+            });
+        });
+    }
+
+    @Override
+    protected TimeUnit getBaseTimeUnit() {
+        return TimeUnit.SECONDS;
+    }
+}


### PR DESCRIPTION
Metrics added:
- Score Calculation Speed (calculations/seconds)
- Score Calculation Count (calculations)

<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.
-->

### JIRA

<!-- Add a JIRA ticket link if it exists. -->
https://issues.redhat.com/browse/PLANNER-2400

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
* https://github.com/kiegroup/drools/pull/3000
* https://github.com/kiegroup/optaplanner/pull/899
* etc.
-->

### Checklist
- [ ] Documentation updated if applicable.
- [ ] Upgrade recipe provided if applicable.

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>full downstream build</b> please add comment: <b>Jenkins run fdb</b>
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
* for a <b>Quarkus LTS check</b> please add comment: <b>Jenkins run LTS</b>
* for a <b>Native check</b> please add comment: <b>Jenkins run native</b>
</details>
