### PR TITLE
7.53.0.Final

### DIFF
--- a/build/optaplanner-build-parent/pom.xml
+++ b/build/optaplanner-build-parent/pom.xml
@@ -23,7 +23,7 @@
     <!-- SNAPSHOT and KIE dependency versions -->
     <version.org.kie.kogito>2.0.0-SNAPSHOT</version.org.kie.kogito>
     <!-- Keep in sync with version.org.kie7 in kogito-runtimes: https://github.com/kiegroup/kogito-runtimes/blob/master/kogito-build-parent/pom.xml#L185 -->
-    <version.org.kie7>7.52.0.Final</version.org.kie7>
+    <version.org.kie7>7.53.0.Final</version.org.kie7>
 
     <!-- Normal dependency versions -->
     <!-- TODO Do we want import the quarkus-bom instead of defining these ourselves? -->


### PR DESCRIPTION
- upgraded to 7.41.0-SNAPSHOT
- PLANNER-2061 Remove solution and a cloner from benchmark results
- Update GitHub actions triggers to watch 7.x branch
- PLANNER-1997 Spring Boot starter doesn't detect @planning annotations when they are in abstract classes or interfaces
- BAQE-1488 - Change revapi to check against 7.39.0.Final (#851)
- PLANNER-2068: KIE server can't handle OptaPlanner solver configs that use scanAnnotatedClasses when new task assignment extension is in classpath (regression)
- Upgraded version to 7.42.0-SNAPSHOT
- BXMSPROD-883 pull request flow on github actions (#857)
- BXMSPROD-890 pull_request.yml KIE_TOKEN to GITHUB_TOKEN (#862)
- PLANNER-1950 Add constraint provider test to quarkus-school-timetabling-quickstart
- PLANNER-1950 Add constraint provider test to spring-boot-school-timetabling-quickstart
- BXMSPROD-912 openjdk11 build execution added to pull_request.yml (#869)
- added pull request template (#880)
- upgraded to 7.43.0-SNAPSHOT
- updated pull request template (#883)
- Make the quickstart part of the build
- Revert "Make the quickstart part of the build"
- [7.x] RHDM-1430 Make the quickstart part of the build (#887)
- Upgrade quarkus to 1.7.0.Final
- PLANNER-1868 SolverManager needs an API that allows a user to listen to both best solution and solver terminated events (#894)
- PLANNER-1771 Make Quarkus extension exit if no OptaPlanner annotated classes are found
- RHDM-1430 No hard-coded versions in Spring Boot Quickstart (#898)
- RHDM-1430 Add new reference implementation for Optaplanner School Timetabling (#900)
- BXMSPROD-963 pull_request.yml updated (#901)
- Disable Maven deployment of quickstarts (#914)
- bumped up to 7.44.0-SNAPSHOT
- PLANNER-2138 Deprecate support for JavaScript expressions in configs (#917)
- use rhino version defined in kie-parent (#926)
- BXMSPROD-1003 add details section to pull request template (#934)
- PLANNER-1362 Deprecate AbstractCustomPhaseCommand
- Bump Quarkus and Kogito to fix stale optaplanner-core dep
- updated to 7.45.0-SNAPSHOT
- [7.x] PLANNER-2180 ScoreCalculators become public API (#949)
- [7.x] [KOGITO-2852] descoping of mvel/asm from the core engine (#910)
- [7.x] PLANNER-2171 avoid reflection warnings + fix mvel native + upgrade to quarkus 1.8.2 (#961)
- install takari to pull request flow
- BAQE-1567 - Change revapi to check against 7.44.0.Final (#953)
- Fix for productized assembly with spring-boot quickstart + fix for quarkus:dev
- [7.x] PLANNER-2204 VariableListener becomes public API #970 (#971)
- upgraded to next 7.46.0-SNAPSHOT
- PLANNER-2085: Include ide-configuration in distribution
- BXMSPROD-1025 pull request configuration centralized (#978)
- BXMSPROD-1005 Cache Maven packages (#1005)
- upgraded to 7.47.0-SNAPSHOT
- Disable test that failed in the 7.x FDB (#1035)
- BXMSPROD-1062 kiegroup/github-action-build-chain updated (#1013)
- upgraded to 7.48.0-SNAPSHOT
- Remove gradle builder for 7.x series
- RHPAM-3334 ConstraintCollectors.toMap(): Only remove a key when no value remains
- upgraded to 7.49.0-SNAPSHOT
- [7.x] Fix build after DROOLS-5875 was merged (#1080)
- Fix build after DROOLS-5930 (#1086)
- Only test 7.x on supported JDKs
- [DROOLS-5953] generalize accumulate function (#1107)
- PLANNER-2254 Fix flaky TimeTableControllerTest
- bumped up to next 7.50.0-SNAPSHOT version
- DROOLS-5995 Adapt to the new signature for beta indexes (#1149)
- Remove Quarkus support from OptaPlanner 7.x (#1151)
- DROOLS-5995b Adapt to the new signature for beta indexes (#1152)
- Fix update-version.sh following Quarkus quickstart removal
- BAQE-1696 - Change revapi to check against 7.48.0.Final (#1161)
- upgraded to next 7.51.0-SNAPSHOT version
- BXMSPROD-1214 M2_HOME added as a workaround (#1178)
- BXMSPROD-1216 .mvn/extensions.xml takari (#1194)
- upgraded to 7.52.0-SNAPSHOT
- BXMSPROD-494 allow GA build on windows machine (#940)
- upgraded to next 7.53.0-SNAPSHOT
- [DROOLS-6257] Move drools-mvel test-jar dependency
- Upgraded version to  7.53.0.Final
