### PR TITLE
KOGITO-5070 Setup multijob pipeline

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -31,48 +31,13 @@ How to retest this PR or trigger a specific build:
 </summary>
 
 * for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
+* for a <b>specific pull request build</b> please add comment: <b>Jenkins (re)run [optaplanner|apps|examples] tests</b>
 * for a <b>full downstream build</b> please add comment: <b>Jenkins run fdb</b>
 * for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
 * for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
 * for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
 * for a <b>Quarkus LTS check</b> please add comment: <b>Jenkins run LTS</b>
+* for a <b>specific Quarkus LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner|apps|examples] LTS</b>
 * for a <b>Native check</b> please add comment: <b>Jenkins run native</b>
-</details>
-
-<details>
-<summary>
-How to use multijob PR check:
-</summary>
-<b>To use the multijob PR check, you will need to add the `multijob-pr` label to the PR</b>
-
-The multijob PR check is running different jobs for the current repository and each downstream repository, one after the other (or parallel)
-with the following dependency graph:
-
-          optaplanner
-              |
-            -----
-            |    |
-          apps   examples
-
-Here are the different commands available to run/rerun multijob jobs:
-
-* <b>Run (or rerun) all tests</b>  
-  Please add comment: <b>Jenkins (re)run multijob tests</b> or <b>Jenkins retest this</b>
-
-* <b>Run (or rerun) dependent test(s)</b>  
-  Please add comment: <b>Jenkins (re)run multijob [apps|examples] tests</b>
-
-* <b>Run (or rerun) all LTS tests</b>  
-  Please add comment: <b>Jenkins (re)run multijob LTS</b> or <b>Jenkins run LTS</b>
-
-* <b>Run (or rerun) LTS dependent test(s)</b>  
-  Please add comment: <b>Jenkins (re)run multijob [apps|examples] LTS</b>
-
-* <b>Run (or rerun) all native tests</b>  
-  Please add comment: <b>Jenkins (re)run multijob native</b> or <b>Jenkins run native</b>
-
-* <b>Run (or rerun) native dependent test(s)</b>  
-  Please add comment: <b>Jenkins (re)run multijob [apps|examples] native</b>
-
-*NOTE: Running a dependent test will run also following dependent projects.*
+* for a <b>specific Native LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner|apps|examples] native</b>
 </details>

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -38,3 +38,41 @@ How to retest this PR or trigger a specific build:
 * for a <b>Quarkus LTS check</b> please add comment: <b>Jenkins run LTS</b>
 * for a <b>Native check</b> please add comment: <b>Jenkins run native</b>
 </details>
+
+<details>
+<summary>
+How to use multijob PR check:
+</summary>
+<b>To use the multijob PR check, you will need to add the `multijob-pr` label to the PR</b>
+
+The multijob PR check is running different jobs for the current repository and each downstream repository, one after the other (or parallel)
+with the following dependency graph:
+
+          optaplanner
+              |
+            -----
+            |    |
+          apps   examples
+
+Here are the different commands available to run/rerun multijob jobs:
+
+* <b>Run (or rerun) all tests</b>  
+  Please add comment: <b>Jenkins (re)run multijob tests</b> or <b>Jenkins retest this</b>
+
+* <b>Run (or rerun) dependent test(s)</b>  
+  Please add comment: <b>Jenkins (re)run multijob [apps|examples] tests</b>
+
+* <b>Run (or rerun) all LTS tests</b>  
+  Please add comment: <b>Jenkins (re)run multijob LTS</b> or <b>Jenkins run LTS</b>
+
+* <b>Run (or rerun) LTS dependent test(s)</b>  
+  Please add comment: <b>Jenkins (re)run multijob [apps|examples] LTS</b>
+
+* <b>Run (or rerun) all native tests</b>  
+  Please add comment: <b>Jenkins (re)run multijob native</b> or <b>Jenkins run native</b>
+
+* <b>Run (or rerun) native dependent test(s)</b>  
+  Please add comment: <b>Jenkins (re)run multijob [apps|examples] native</b>
+
+*NOTE: Running a dependent test will run also following dependent projects.*
+</details>

--- a/.jenkins/dsl/jobs.groovy
+++ b/.jenkins/dsl/jobs.groovy
@@ -60,6 +60,11 @@ def nightlyBranchFolder = "${KogitoConstants.KOGITO_DSL_NIGHTLY_FOLDER}/${JOB_BR
 def releaseBranchFolder = "${KogitoConstants.KOGITO_DSL_RELEASE_FOLDER}/${JOB_BRANCH_FOLDER}"
 
 if (isMainBranch()) {
+    // Old PR checks. To be removed once supported release branches (<= 8.7.x) are no more there.
+    setupOptaplannerPrJob()
+    setupOptaplannerQuarkusLTSPrJob()
+    setupOptaplannerNativePrJob()
+
     // Optaplanner PR checks
     setupMultijobPrDefaultChecks()
     setupMultijobPrNativeChecks()
@@ -100,6 +105,24 @@ if (isMainBranch()) {
 // Methods
 /////////////////////////////////////////////////////////////////
 
+void setupOptaplannerPrJob() {
+    def jobParams = getDefaultJobParams()
+    jobParams.pr.whiteListTargetBranches = ['8.5.x', '8.7.x']
+    KogitoJobTemplate.createPRJob(this, jobParams)
+}
+
+void setupOptaplannerQuarkusLTSPrJob() {
+    def jobParams = getDefaultJobParams()
+    jobParams.pr.whiteListTargetBranches = ['8.5.x', '8.7.x']
+    KogitoJobTemplate.createQuarkusLTSPRJob(this, jobParams)
+}
+
+void setupOptaplannerNativePrJob() {
+    def jobParams = getDefaultJobParams()
+    jobParams.pr.whiteListTargetBranches = ['8.5.x', '8.7.x']
+    KogitoJobTemplate.createNativePRJob(this, jobParams)
+}
+
 void setupOptawebEmployeeRosteringPrJob() {
     def jobParams = getDefaultJobParams('optaweb-employee-rostering')
     jobParams.pr = [ whiteListTargetBranches: ['master'] ]
@@ -115,7 +138,7 @@ void setupOptawebVehicleRoutingPrJob() {
 void setupMultijobPrDefaultChecks() {
     KogitoJobTemplate.createMultijobPRJobs(this, getMultijobPRConfig()) {
         def jobParams = getDefaultJobParams()
-        jobParams.pr.blackListTargetBranches = ['7.x']
+        jobParams.pr.blackListTargetBranches = ['7.x', '8.5.x', '8.7.x']
         return jobParams
     }
 }
@@ -123,7 +146,7 @@ void setupMultijobPrDefaultChecks() {
 void setupMultijobPrNativeChecks() {
     KogitoJobTemplate.createMultijobNativePRJobs(this, getMultijobPRConfig()) {
         def jobParams = getDefaultJobParams()
-        jobParams.pr.blackListTargetBranches = ['7.x']
+        jobParams.pr.blackListTargetBranches = ['7.x', '8.5.x', '8.7.x']
         return jobParams
     }
 }
@@ -131,7 +154,7 @@ void setupMultijobPrNativeChecks() {
 void setupMultijobPrLTSChecks() {
     KogitoJobTemplate.createMultijobLTSPRJobs(this, getMultijobPRConfig()) {
         def jobParams = getDefaultJobParams()
-        jobParams.pr.blackListTargetBranches = ['7.x']
+        jobParams.pr.blackListTargetBranches = ['7.x', '8.5.x', '8.7.x']
         return jobParams
     }
 }

--- a/.jenkins/dsl/jobs.groovy
+++ b/.jenkins/dsl/jobs.groovy
@@ -61,6 +61,7 @@ def releaseBranchFolder = "${KogitoConstants.KOGITO_DSL_RELEASE_FOLDER}/${JOB_BR
 
 if (isMainBranch()) {
     // Old PR checks. To be removed once supported release branches (<= 8.7.x) are no more there.
+    // TODO remove method calls once 8.5.x and 8.7.x are no more supported
     setupOptaplannerPrJob()
     setupOptaplannerQuarkusLTSPrJob()
     setupOptaplannerNativePrJob()
@@ -105,18 +106,21 @@ if (isMainBranch()) {
 // Methods
 /////////////////////////////////////////////////////////////////
 
+// TODO remove method once 8.5.x and 8.7.x are no more supported
 void setupOptaplannerPrJob() {
     def jobParams = getDefaultJobParams()
     jobParams.pr.whiteListTargetBranches = ['8.5.x', '8.7.x']
     KogitoJobTemplate.createPRJob(this, jobParams)
 }
 
+// TODO remove method once 8.5.x and 8.7.x are no more supported
 void setupOptaplannerQuarkusLTSPrJob() {
     def jobParams = getDefaultJobParams()
     jobParams.pr.whiteListTargetBranches = ['8.5.x', '8.7.x']
     KogitoJobTemplate.createQuarkusLTSPRJob(this, jobParams)
 }
 
+// TODO remove method once 8.5.x and 8.7.x are no more supported
 void setupOptaplannerNativePrJob() {
     def jobParams = getDefaultJobParams()
     jobParams.pr.whiteListTargetBranches = ['8.5.x', '8.7.x']
@@ -138,6 +142,7 @@ void setupOptawebVehicleRoutingPrJob() {
 void setupMultijobPrDefaultChecks() {
     KogitoJobTemplate.createMultijobPRJobs(this, getMultijobPRConfig()) {
         def jobParams = getDefaultJobParams()
+        // TODO remove 8.* branches once 8.5.x and 8.7.x are no more supported
         jobParams.pr.blackListTargetBranches = ['7.x', '8.5.x', '8.7.x']
         return jobParams
     }
@@ -146,6 +151,7 @@ void setupMultijobPrDefaultChecks() {
 void setupMultijobPrNativeChecks() {
     KogitoJobTemplate.createMultijobNativePRJobs(this, getMultijobPRConfig()) {
         def jobParams = getDefaultJobParams()
+        // TODO remove 8.* branches once 8.5.x and 8.7.x are no more supported
         jobParams.pr.blackListTargetBranches = ['7.x', '8.5.x', '8.7.x']
         return jobParams
     }
@@ -154,6 +160,7 @@ void setupMultijobPrNativeChecks() {
 void setupMultijobPrLTSChecks() {
     KogitoJobTemplate.createMultijobLTSPRJobs(this, getMultijobPRConfig()) {
         def jobParams = getDefaultJobParams()
+        // TODO remove 8.* branches once 8.5.x and 8.7.x are no more supported
         jobParams.pr.blackListTargetBranches = ['7.x', '8.5.x', '8.7.x']
         return jobParams
     }

--- a/.jenkins/dsl/jobs.groovy
+++ b/.jenkins/dsl/jobs.groovy
@@ -26,18 +26,19 @@ def getDefaultJobParams(String repoName = 'optaplanner') {
 
 Map getMultijobPRConfig() {
     return [
+        parallel: true,
         jobs : [
             [
-                id: 'Tests',
+                id: 'Optaplanner',
                 primary: true,
             ], [
                 id: 'Apps',
-                waitForId: 'Tests',
-                repository: 'kogito-apps'
+                repository: 'kogito-apps',
+                dependsOn: 'Optaplanner',
             ], [
                 id: 'Examples',
-                waitForId: 'Tests',
-                repository: 'kogito-examples'
+                repository: 'kogito-examples',
+                dependsOn: 'Optaplanner',
             ]
         ]
     ]

--- a/.jenkins/dsl/jobs.groovy
+++ b/.jenkins/dsl/jobs.groovy
@@ -29,16 +29,16 @@ Map getMultijobPRConfig() {
         parallel: true,
         jobs : [
             [
-                id: 'Optaplanner',
+                id: 'optaplanner',
                 primary: true,
             ], [
-                id: 'Apps',
+                id: 'apps',
                 repository: 'kogito-apps',
-                dependsOn: 'Optaplanner',
+                dependsOn: 'optaplanner',
             ], [
-                id: 'Examples',
+                id: 'examples',
                 repository: 'kogito-examples',
-                dependsOn: 'Optaplanner',
+                dependsOn: 'optaplanner',
             ]
         ]
     ]

--- a/.jenkins/dsl/jobs.groovy
+++ b/.jenkins/dsl/jobs.groovy
@@ -60,17 +60,14 @@ def nightlyBranchFolder = "${KogitoConstants.KOGITO_DSL_NIGHTLY_FOLDER}/${JOB_BR
 def releaseBranchFolder = "${KogitoConstants.KOGITO_DSL_RELEASE_FOLDER}/${JOB_BRANCH_FOLDER}"
 
 if (isMainBranch()) {
-    // Normal PR checks
-    setupOptaplannerPrJob()
-    setupOptaplannerQuarkusLTSPrJob()
-    setupOptaplannerNativePrJob()
-    setupOptawebEmployeeRosteringPrJob()
-    setupOptawebVehicleRoutingPrJob()
-
-    // Multijob PR checks
+    // Optaplanner PR checks
     setupMultijobPrDefaultChecks()
     setupMultijobPrNativeChecks()
     setupMultijobPrLTSChecks()
+
+    // Optaweb PR checks
+    setupOptawebEmployeeRosteringPrJob()
+    setupOptawebVehicleRoutingPrJob()
 
     // For BDD runtimes PR job
     folder(KogitoConstants.KOGITO_DSL_PULLREQUEST_FOLDER)
@@ -96,33 +93,12 @@ if (!isMainBranch()) {
 def otherFolder = KogitoConstants.KOGITO_DSL_OTHER_FOLDER
 if (isMainBranch()) {
     folder(otherFolder)
-    setupOptaPlannerTurtleTestsJob(otherFolder);
+    setupOptaPlannerTurtleTestsJob(otherFolder)
 }
 
 /////////////////////////////////////////////////////////////////
 // Methods
 /////////////////////////////////////////////////////////////////
-
-void setupOptaplannerPrJob() {
-    def jobParams = getDefaultJobParams()
-    jobParams.pr.ignore_for_labels = [ KogitoConstants.KOGITO_PR_MULTIJOB_LABEL ]
-    jobParams.pr.blackListTargetBranches = ['7.x']
-    KogitoJobTemplate.createPRJob(this, jobParams)
-}
-
-void setupOptaplannerQuarkusLTSPrJob() {
-    def jobParams = getDefaultJobParams()
-    jobParams.pr.ignore_for_labels = [ KogitoConstants.KOGITO_PR_MULTIJOB_LABEL ]
-    jobParams.pr.blackListTargetBranches = ['7.x']
-    KogitoJobTemplate.createQuarkusLTSPRJob(this, jobParams)
-}
-
-void setupOptaplannerNativePrJob() {
-    def jobParams = getDefaultJobParams()
-    jobParams.pr.ignore_for_labels = [ KogitoConstants.KOGITO_PR_MULTIJOB_LABEL ]
-    jobParams.pr.blackListTargetBranches = ['7.x']
-    KogitoJobTemplate.createNativePRJob(this, jobParams)
-}
 
 void setupOptawebEmployeeRosteringPrJob() {
     def jobParams = getDefaultJobParams('optaweb-employee-rostering')
@@ -138,19 +114,25 @@ void setupOptawebVehicleRoutingPrJob() {
 
 void setupMultijobPrDefaultChecks() {
     KogitoJobTemplate.createMultijobPRJobs(this, getMultijobPRConfig()) {
-        return getDefaultJobParams()
+        def jobParams = getDefaultJobParams()
+        jobParams.pr.blackListTargetBranches = ['7.x']
+        return jobParams
     }
 }
 
 void setupMultijobPrNativeChecks() {
     KogitoJobTemplate.createMultijobNativePRJobs(this, getMultijobPRConfig()) {
-        return getDefaultJobParams()
+        def jobParams = getDefaultJobParams()
+        jobParams.pr.blackListTargetBranches = ['7.x']
+        return jobParams
     }
 }
 
 void setupMultijobPrLTSChecks() {
     KogitoJobTemplate.createMultijobLTSPRJobs(this, getMultijobPRConfig()) {
-        return getDefaultJobParams()
+        def jobParams = getDefaultJobParams()
+        jobParams.pr.blackListTargetBranches = ['7.x']
+        return jobParams
     }
 }
 
@@ -269,7 +251,7 @@ void setupOptaPlannerTurtleTestsJob(String jobFolder) {
                 }
             }
         }
-        
+
         parameters {
             stringParam('BUILD_BRANCH_NAME', "${GIT_BRANCH}", 'Git branch to checkout')
             stringParam('GIT_AUTHOR', "${GIT_AUTHOR_NAME}", 'Git author or an organization.')

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -36,7 +36,7 @@ pipeline {
                     checkoutOptaplannerRepo()
                     dir(quickstartsRepo) {
                         // If the PR to OptaPlanner targets the 'master' branch, we assume the branch 'development' for quickstarts.
-                        String quickstartsChangeTarget = changeTarget == 'master' ? 'development' : changeTarget
+                        String quickstartsChangeTarget = changeTarget == 'master' ? 'development' : getOptaplannerTargetBranch()
                         githubscm.checkoutIfExists(quickstartsRepo, changeAuthor, changeBranch, 'kiegroup', quickstartsChangeTarget, true)
                     }
                 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -214,7 +214,7 @@ boolean isUpstreamKogitoProject() {
 }
 
 boolean isUpstreamOptaplannerProject() {
-    return getUpstreamTriggerProject() && getUpstreamTriggerProject().startsWith('opta')
+    return getUpstreamTriggerProject() && getUpstreamTriggerProject() == 'optaplanner'
 }
 
 Integer getTimeoutValue() {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -210,11 +210,11 @@ boolean isNormalPRCheck() {
 }
 
 boolean isUpstreamKogitoProject() {
-    return getUpstreamTriggerProject() && getUpstreamTriggerProject.startsWith('kogito')
+    return getUpstreamTriggerProject() && getUpstreamTriggerProject().startsWith('kogito')
 }
 
 boolean isUpstreamOptaplannerProject() {
-    return getUpstreamTriggerProject() && getUpstreamTriggerProject.startsWith('opta')
+    return getUpstreamTriggerProject() && getUpstreamTriggerProject().startsWith('opta')
 }
 
 Integer getTimeoutValue() {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -20,7 +20,8 @@ pipeline {
         jdk 'kie-jdk11'
     }
     options {
-        timeout(time: 120, unit: 'MINUTES')
+        timestamps()
+        timeout(time: getTimeoutValue(), unit: 'MINUTES')
     }
     environment {
         MAVEN_OPTS = '-Xms1024m -Xmx4g'
@@ -182,6 +183,18 @@ boolean isNative() {
     return env['NATIVE'] && env['NATIVE'].toBoolean()
 }
 
+boolean isDownstreamJob() {
+    return env['DOWNSTREAM'] && env['DOWNSTREAM'].toBoolean()
+}
+
 boolean isNormalPRCheck() {
-    return !(getQuarkusBranch() || isNative())
+    return !(isDownstreamJob() || getQuarkusBranch() || isNative())
+}
+
+boolean isMultijobPRCheck() {
+    return env['MULTIJOB_PR_CHECK'] && env['MULTIJOB_PR_CHECK'].toBoolean()
+}
+
+Integer getTimeoutValue() {
+    return isNative() ? 240 : 120
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -150,7 +150,7 @@ void checkoutQuarkusRepo() {
 }
 
 String getKogitoTargetBranch() {
-    return getTargetBranch(isUpstreamOptaplannerProject() ? -7 : 0)
+    return getTargetBranch(isUpstreamKogitoProject() ? 0 : -7)
 }
 
 String getOptaplannerTargetBranch() {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -138,8 +138,8 @@ void checkoutRuntimesRepo() {
 }
 
 void checkoutOptaplannerRepo() {
-    dir('optaplanner') {
-        githubscm.checkoutIfExists('optaplanner', changeAuthor, changeBranch, 'kiegroup', getOptaplannerTargetBranch(), true)
+    dir(optaplannerRepo) {
+        githubscm.checkoutIfExists(optaplannerRepo, changeAuthor, changeBranch, 'kiegroup', getOptaplannerTargetBranch(), true)
     }
 }
 


### PR DESCRIPTION
https://issues.redhat.com/browse/KOGITO-5070

This will allow to run Jenkins pr check, if `multijob-pr` label is set, in separate jobs.
Also, each project check is responsible to set correct Jenkinsfile and this avoids to rewrite the commands to run in each repo for the downstream projects.
Also, this add `kogito-apps` and `kogito-examples` checks to Optaplanner (but can be removed if needed).

_For now, this does not replace the current global PR check. It is only activated with the `multijob-pr` label._

Depends on https://github.com/kiegroup/kogito-pipelines/pull/148

Related PRs:
- https://github.com/kiegroup/kogito-runtimes/pull/1284
- https://github.com/kiegroup/optaplanner/pull/1304
- https://github.com/kiegroup/kogito-apps/pull/805
- https://github.com/kiegroup/kogito-examples/pull/671

_Final note: Current run PR checks for this PR are from my custom folder on Jenkins and will be moved to Kogito folder once all the PRs are merged. Please do not use before ..._