### PR TITLE
PLANNER-2413: Make classes @ClassReactive by default in Quarkus

### DIFF
--- a/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/main/java/org/optaplanner/quarkus/deployment/OptaPlannerProcessor.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/main/java/org/optaplanner/quarkus/deployment/OptaPlannerProcessor.java
@@ -432,6 +432,8 @@ class OptaPlannerProcessor {
 
         if (solverConfig.getScoreDirectorFactoryConfig().getScoreDrlList() != null) {
             boolean isKogitoExtensionPresent = capabilities.isPresent("kogito-rules");
+            // Rules do not fire when Drools Alpha Network Compilation is enabled
+            solverConfig.getScoreDirectorFactoryConfig().setDroolsAlphaNetworkCompilationEnabled(false);
             if (!isKogitoExtensionPresent) {
                 throw new IllegalStateException(
                         "Using scoreDRL in Quarkus, but the dependency org.kie.kogito:kogito-quarkus-rules is not on the classpath.\n"
@@ -612,7 +614,7 @@ class OptaPlannerProcessor {
 
         GizmoMemberAccessorEntityEnhancer.generateGizmoBeanFactory(beanClassOutput, reflectiveClassSet);
         GizmoMemberAccessorEntityEnhancer.generateKieRuntimeBuilder(beanClassOutput,
-                solverConfig.getScoreDirectorFactoryConfig(), unremovableBeans);
+                solverConfig, unremovableBeans, transformers);
         return new GeneratedGizmoClasses(generatedMemberAccessorsClassNameSet, gizmoSolutionClonerClassNameSet);
     }
 

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/drl-integration-test/src/main/java/org/optaplanner/quarkus/drl/it/OptaPlannerTestResource.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/drl-integration-test/src/main/java/org/optaplanner/quarkus/drl/it/OptaPlannerTestResource.java
@@ -44,10 +44,17 @@ public class OptaPlannerTestResource {
         planningProblem.setEntityList(Arrays.asList(
                 new TestdataQuarkusEntity(),
                 new TestdataQuarkusEntity()));
-        planningProblem.setValueList(Arrays.asList("a", "b", "c"));
+        planningProblem.setLeftValueList(Arrays.asList("a", "b", "c"));
+        planningProblem.setRightValueList(Arrays.asList("1", "2", "3"));
         SolverJob<TestdataQuarkusSolution, Long> solverJob = solverManager.solve(1L, planningProblem);
         try {
-            return solverJob.getFinalBestSolution().getScore().toString();
+            TestdataQuarkusSolution sol = solverJob.getFinalBestSolution();
+            StringBuilder out = new StringBuilder();
+            out.append("score=").append(sol.getScore()).append('\n');
+            for (int i = 0; i < sol.getEntityList().size(); i++) {
+                out.append("entity." + i + ".fullValue=").append(sol.getEntityList().get(i).getFullValue()).append('\n');
+            }
+            return out.toString();
         } catch (InterruptedException | ExecutionException e) {
             throw new IllegalStateException("Solving failed.", e);
         }

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/drl-integration-test/src/main/java/org/optaplanner/quarkus/drl/it/domain/TestdataQuarkusEntity.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/drl-integration-test/src/main/java/org/optaplanner/quarkus/drl/it/domain/TestdataQuarkusEntity.java
@@ -16,21 +16,40 @@
 
 package org.optaplanner.quarkus.drl.it.domain;
 
+import org.apache.commons.lang3.ObjectUtils;
 import org.optaplanner.core.api.domain.entity.PlanningEntity;
 import org.optaplanner.core.api.domain.variable.PlanningVariable;
 
 @PlanningEntity
 public class TestdataQuarkusEntity {
+    @PlanningVariable(valueRangeProviderRefs = "leftValueRange")
+    public String leftValue;
 
-    private String value;
+    @PlanningVariable(valueRangeProviderRefs = "rightValueRange")
+    public String rightValue;
 
-    @PlanningVariable(valueRangeProviderRefs = "valueRange")
-    public String getValue() {
-        return value;
+    public String getLeftValue() {
+        return leftValue;
     }
 
-    public void setValue(String value) {
-        this.value = value;
+    public String getRightValue() {
+        return rightValue;
     }
 
+    public void setLeftValue(String leftValue) {
+        this.leftValue = leftValue;
+    }
+
+    public void setRightValue(String rightValue) {
+        this.rightValue = rightValue;
+    }
+
+    public String getFullValue() {
+        return ObjectUtils.defaultIfNull(leftValue, "") + ObjectUtils.defaultIfNull(rightValue, "");
+    }
+
+    @Override
+    public String toString() {
+        return "TestdataQuarkusEntity(" + "leftValue=" + leftValue + ";rightValue=" + rightValue + ";)";
+    }
 }

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/drl-integration-test/src/main/java/org/optaplanner/quarkus/drl/it/domain/TestdataQuarkusSolution.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/drl-integration-test/src/main/java/org/optaplanner/quarkus/drl/it/domain/TestdataQuarkusSolution.java
@@ -28,19 +28,30 @@ import org.optaplanner.core.api.score.buildin.simple.SimpleScore;
 @PlanningSolution
 public class TestdataQuarkusSolution {
 
-    private List<String> valueList;
+    private List<String> leftValueList;
+    private List<String> rightValueList;
     private List<TestdataQuarkusEntity> entityList;
 
     private SimpleScore score;
 
-    @ValueRangeProvider(id = "valueRange")
+    @ValueRangeProvider(id = "leftValueRange")
     @ProblemFactCollectionProperty
-    public List<String> getValueList() {
-        return valueList;
+    public List<String> getLeftValueList() {
+        return leftValueList;
     }
 
-    public void setValueList(List<String> valueList) {
-        this.valueList = valueList;
+    public void setLeftValueList(List<String> valueList) {
+        this.leftValueList = valueList;
+    }
+
+    @ValueRangeProvider(id = "rightValueRange")
+    @ProblemFactCollectionProperty
+    public List<String> getRightValueList() {
+        return rightValueList;
+    }
+
+    public void setRightValueList(List<String> valueList) {
+        this.rightValueList = valueList;
     }
 
     @PlanningEntityCollectionProperty

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/drl-integration-test/src/main/resources/constraints.drl
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/drl-integration-test/src/main/resources/constraints.drl
@@ -9,9 +9,8 @@ global SimpleScoreHolder scoreHolder;
 
 rule "Don't assign 2 entities the same value."
     when
-        TestdataQuarkusEntity()
-        $a : TestdataQuarkusEntity(value != null, $v : value)
-        TestdataQuarkusEntity(value == $v, this != $a)
+        $a : TestdataQuarkusEntity($fullValue: fullValue)
+        TestdataQuarkusEntity($fullValue == fullValue, this != $a)
     then
         scoreHolder.addConstraintMatch(kcontext, -1);
 end

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/drl-integration-test/src/test/java/org/optaplanner/quarkus/drl/it/OptaPlannerTestResourceTest.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/drl-integration-test/src/test/java/org/optaplanner/quarkus/drl/it/OptaPlannerTestResourceTest.java
@@ -16,8 +16,10 @@
 
 package org.optaplanner.quarkus.drl.it;
 
-import static org.hamcrest.Matchers.is;
+import java.io.StringReader;
+import java.util.Properties;
 
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
@@ -34,13 +36,18 @@ public class OptaPlannerTestResourceTest {
     @Test
     @Timeout(600)
     public void solveWithSolverFactory() throws Exception {
-        RestAssured.given()
+        Properties result = new Properties();
+        result.load(new StringReader(RestAssured.given()
                 .header("Content-Type", "application/json")
                 .when()
                 .post("/optaplanner/test/solver-factory")
                 .then()
-                .body(is(
-                        "0"));
+                .extract().body().asString()));
+        Assertions.assertEquals("0", result.get("score"));
+        Assertions.assertNotNull(result.get("entity.0.fullValue"));
+        Assertions.assertNotNull(result.get("entity.1.fullValue"));
+        Assertions.assertNotEquals(result.get("entity.0.fullValue"), result.get("entity.1.fullValue"),
+                "Both entities have the same value. Maybe property reactive is set to ALWAYS, or maybe Drools Alpha Network Compilation is enabled");
     }
 
 }


### PR DESCRIPTION
This able disables drools alpha compilation when DRL is used
in Quarkus (which cause rules to not fire) and make the DRL integration
test more robust.

<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.
-->

### JIRA

<!-- Add a JIRA ticket link if it exists. -->
https://issues.redhat.com/browse/PLANNER-2413

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
* https://github.com/kiegroup/drools/pull/3000
* https://github.com/kiegroup/optaplanner/pull/899
* etc.
-->

### Checklist
- [ ] Documentation updated if applicable.
- [ ] Upgrade recipe provided if applicable.

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>full downstream build</b> please add comment: <b>Jenkins run fdb</b>
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
* for a <b>Quarkus LTS check</b> please add comment: <b>Jenkins run LTS</b>
* for a <b>Native check</b> please add comment: <b>Jenkins run native</b>
</details>
