### PR TITLE
PLANNER-2425: Move @PlanningScore annotation processing to ScoreDescriptor

### DIFF
--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/score/descriptor/ScoreDescriptor.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/score/descriptor/ScoreDescriptor.java
@@ -1,0 +1,238 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.core.impl.domain.score.descriptor;
+
+import static org.optaplanner.core.impl.domain.common.accessor.MemberAccessorFactory.MemberAccessorType.FIELD_OR_GETTER_METHOD_WITH_SETTER;
+
+import java.lang.reflect.Member;
+
+import org.optaplanner.core.api.domain.solution.PlanningScore;
+import org.optaplanner.core.api.score.AbstractBendableScore;
+import org.optaplanner.core.api.score.Score;
+import org.optaplanner.core.api.score.buildin.bendable.BendableScore;
+import org.optaplanner.core.api.score.buildin.bendablebigdecimal.BendableBigDecimalScore;
+import org.optaplanner.core.api.score.buildin.bendablelong.BendableLongScore;
+import org.optaplanner.core.api.score.buildin.hardmediumsoft.HardMediumSoftScore;
+import org.optaplanner.core.api.score.buildin.hardmediumsoftbigdecimal.HardMediumSoftBigDecimalScore;
+import org.optaplanner.core.api.score.buildin.hardmediumsoftlong.HardMediumSoftLongScore;
+import org.optaplanner.core.api.score.buildin.hardsoft.HardSoftScore;
+import org.optaplanner.core.api.score.buildin.hardsoftbigdecimal.HardSoftBigDecimalScore;
+import org.optaplanner.core.api.score.buildin.hardsoftlong.HardSoftLongScore;
+import org.optaplanner.core.api.score.buildin.simple.SimpleScore;
+import org.optaplanner.core.api.score.buildin.simplebigdecimal.SimpleBigDecimalScore;
+import org.optaplanner.core.api.score.buildin.simplelong.SimpleLongScore;
+import org.optaplanner.core.config.util.ConfigUtils;
+import org.optaplanner.core.impl.domain.common.accessor.MemberAccessor;
+import org.optaplanner.core.impl.domain.common.accessor.MemberAccessorFactory;
+import org.optaplanner.core.impl.domain.policy.DescriptorPolicy;
+import org.optaplanner.core.impl.score.buildin.bendable.BendableScoreDefinition;
+import org.optaplanner.core.impl.score.buildin.bendablebigdecimal.BendableBigDecimalScoreDefinition;
+import org.optaplanner.core.impl.score.buildin.bendablelong.BendableLongScoreDefinition;
+import org.optaplanner.core.impl.score.buildin.hardmediumsoft.HardMediumSoftScoreDefinition;
+import org.optaplanner.core.impl.score.buildin.hardmediumsoftbigdecimal.HardMediumSoftBigDecimalScoreDefinition;
+import org.optaplanner.core.impl.score.buildin.hardmediumsoftlong.HardMediumSoftLongScoreDefinition;
+import org.optaplanner.core.impl.score.buildin.hardsoft.HardSoftScoreDefinition;
+import org.optaplanner.core.impl.score.buildin.hardsoftbigdecimal.HardSoftBigDecimalScoreDefinition;
+import org.optaplanner.core.impl.score.buildin.hardsoftlong.HardSoftLongScoreDefinition;
+import org.optaplanner.core.impl.score.buildin.simple.SimpleScoreDefinition;
+import org.optaplanner.core.impl.score.buildin.simplebigdecimal.SimpleBigDecimalScoreDefinition;
+import org.optaplanner.core.impl.score.buildin.simplelong.SimpleLongScoreDefinition;
+import org.optaplanner.core.impl.score.definition.ScoreDefinition;
+
+public class ScoreDescriptor {
+
+    // Used to obtain default @PlanningScore attribute values from a score member that was auto-discovered,
+    // as if it had an empty @PlanningScore annotation on it.
+    @PlanningScore
+    private static final Object PLANNING_SCORE = new Object();
+
+    private final MemberAccessor scoreMemberAccessor;
+    private final ScoreDefinition<?> scoreDefinition;
+
+    private ScoreDescriptor(MemberAccessor scoreMemberAccessor, ScoreDefinition<?> scoreDefinition) {
+        this.scoreMemberAccessor = scoreMemberAccessor;
+        this.scoreDefinition = scoreDefinition;
+    }
+
+    public static ScoreDescriptor buildScoreDescriptor(
+            DescriptorPolicy descriptorPolicy,
+            Member member,
+            Class<?> solutionClass) {
+        MemberAccessor scoreMemberAccessor = buildScoreMemberAccessor(descriptorPolicy, member);
+        Class<? extends Score<?>> scoreType = extractScoreType(scoreMemberAccessor, solutionClass);
+        PlanningScore annotation = extractPlanningScoreAnnotation(scoreMemberAccessor);
+        ScoreDefinition<?> scoreDefinition = buildScoreDefinition(solutionClass, scoreMemberAccessor, scoreType, annotation);
+        return new ScoreDescriptor(scoreMemberAccessor, scoreDefinition);
+    }
+
+    private static MemberAccessor buildScoreMemberAccessor(DescriptorPolicy descriptorPolicy, Member member) {
+        return MemberAccessorFactory.buildMemberAccessor(
+                member,
+                FIELD_OR_GETTER_METHOD_WITH_SETTER,
+                PlanningScore.class,
+                descriptorPolicy.getDomainAccessType(),
+                descriptorPolicy.getGeneratedMemberAccessorMap());
+    }
+
+    private static Class<? extends Score<?>> extractScoreType(MemberAccessor scoreMemberAccessor, Class<?> solutionClass) {
+        Class<?> memberType = scoreMemberAccessor.getType();
+        if (!Score.class.isAssignableFrom(memberType)) {
+            throw new IllegalStateException("The solutionClass (" + solutionClass
+                    + ") has a @" + PlanningScore.class.getSimpleName()
+                    + " annotated member (" + scoreMemberAccessor + ") that does not return a subtype of Score.");
+        }
+        if (memberType == Score.class) {
+            throw new IllegalStateException("The solutionClass (" + solutionClass
+                    + ") has a @" + PlanningScore.class.getSimpleName()
+                    + " annotated member (" + scoreMemberAccessor
+                    + ") that doesn't return a non-abstract " + Score.class.getSimpleName() + " class.\n"
+                    + "Maybe make it return " + HardSoftScore.class.getSimpleName()
+                    + " or another specific " + Score.class.getSimpleName() + " implementation.");
+        }
+        return (Class<? extends Score<?>>) memberType;
+    }
+
+    private static PlanningScore extractPlanningScoreAnnotation(MemberAccessor scoreMemberAccessor) {
+        PlanningScore annotation = scoreMemberAccessor.getAnnotation(PlanningScore.class);
+        if (annotation != null) {
+            return annotation;
+        }
+        // The member was auto-discovered.
+        try {
+            return ScoreDescriptor.class.getDeclaredField("PLANNING_SCORE").getAnnotation(PlanningScore.class);
+        } catch (NoSuchFieldException e) {
+            throw new IllegalStateException("Impossible situation: the field (PLANNING_SCORE) must exist.", e);
+        }
+    }
+
+    private static ScoreDefinition<?> buildScoreDefinition(
+            Class<?> solutionClass,
+            MemberAccessor scoreMemberAccessor,
+            Class<? extends Score<?>> scoreType,
+            PlanningScore annotation) {
+        Class<? extends ScoreDefinition> scoreDefinitionClass = annotation.scoreDefinitionClass();
+        int bendableHardLevelsSize = annotation.bendableHardLevelsSize();
+        int bendableSoftLevelsSize = annotation.bendableSoftLevelsSize();
+        if (scoreDefinitionClass != PlanningScore.NullScoreDefinition.class) {
+            if (bendableHardLevelsSize != PlanningScore.NO_LEVEL_SIZE
+                    || bendableSoftLevelsSize != PlanningScore.NO_LEVEL_SIZE) {
+                throw new IllegalArgumentException("The solutionClass (" + solutionClass
+                        + ") has a @" + PlanningScore.class.getSimpleName()
+                        + " annotated member (" + scoreMemberAccessor
+                        + ") that has a scoreDefinition (" + scoreDefinitionClass
+                        + ") that must not have a bendableHardLevelsSize (" + bendableHardLevelsSize
+                        + ") or a bendableSoftLevelsSize (" + bendableSoftLevelsSize + ").");
+            }
+            // TODO verify whether the 1st arg should be "annotation" or "this"
+            return ConfigUtils.newInstance(annotation, "scoreDefinitionClass", scoreDefinitionClass);
+        }
+        if (!AbstractBendableScore.class.isAssignableFrom(scoreType)) {
+            if (bendableHardLevelsSize != PlanningScore.NO_LEVEL_SIZE
+                    || bendableSoftLevelsSize != PlanningScore.NO_LEVEL_SIZE) {
+                throw new IllegalArgumentException("The solutionClass (" + solutionClass
+                        + ") has a @" + PlanningScore.class.getSimpleName()
+                        + " annotated member (" + scoreMemberAccessor
+                        + ") that returns a scoreType (" + scoreType
+                        + ") that must not have a bendableHardLevelsSize (" + bendableHardLevelsSize
+                        + ") or a bendableSoftLevelsSize (" + bendableSoftLevelsSize + ").");
+            }
+            if (scoreType.equals(SimpleScore.class)) {
+                return new SimpleScoreDefinition();
+            } else if (scoreType.equals(SimpleLongScore.class)) {
+                return new SimpleLongScoreDefinition();
+            } else if (scoreType.equals(SimpleBigDecimalScore.class)) {
+                return new SimpleBigDecimalScoreDefinition();
+            } else if (scoreType.equals(HardSoftScore.class)) {
+                return new HardSoftScoreDefinition();
+            } else if (scoreType.equals(HardSoftLongScore.class)) {
+                return new HardSoftLongScoreDefinition();
+            } else if (scoreType.equals(HardSoftBigDecimalScore.class)) {
+                return new HardSoftBigDecimalScoreDefinition();
+            } else if (scoreType.equals(HardMediumSoftScore.class)) {
+                return new HardMediumSoftScoreDefinition();
+            } else if (scoreType.equals(HardMediumSoftLongScore.class)) {
+                return new HardMediumSoftLongScoreDefinition();
+            } else if (scoreType.equals(HardMediumSoftBigDecimalScore.class)) {
+                return new HardMediumSoftBigDecimalScoreDefinition();
+            } else {
+                throw new IllegalArgumentException("The solutionClass (" + solutionClass
+                        + ") has a @" + PlanningScore.class.getSimpleName()
+                        + " annotated member (" + scoreMemberAccessor
+                        + ") that returns a scoreType (" + scoreType
+                        + ") that is not recognized as a default " + Score.class.getSimpleName() + " implementation.\n"
+                        + "  If you intend to use a custom implementation,"
+                        + " maybe set a scoreDefinition in the @" + PlanningScore.class.getSimpleName()
+                        + " annotation.");
+            }
+        } else {
+            if (bendableHardLevelsSize == PlanningScore.NO_LEVEL_SIZE
+                    || bendableSoftLevelsSize == PlanningScore.NO_LEVEL_SIZE) {
+                throw new IllegalArgumentException("The solutionClass (" + solutionClass
+                        + ") has a @" + PlanningScore.class.getSimpleName()
+                        + " annotated member (" + scoreMemberAccessor
+                        + ") that returns a scoreType (" + scoreType
+                        + ") that must have a bendableHardLevelsSize (" + bendableHardLevelsSize
+                        + ") and a bendableSoftLevelsSize (" + bendableSoftLevelsSize + ").");
+            }
+            if (scoreType.equals(BendableScore.class)) {
+                return new BendableScoreDefinition(bendableHardLevelsSize, bendableSoftLevelsSize);
+            } else if (scoreType.equals(BendableLongScore.class)) {
+                return new BendableLongScoreDefinition(bendableHardLevelsSize, bendableSoftLevelsSize);
+            } else if (scoreType.equals(BendableBigDecimalScore.class)) {
+                return new BendableBigDecimalScoreDefinition(bendableHardLevelsSize, bendableSoftLevelsSize);
+            } else {
+                throw new IllegalArgumentException("The solutionClass (" + solutionClass
+                        + ") has a @" + PlanningScore.class.getSimpleName()
+                        + " annotated member (" + scoreMemberAccessor
+                        + ") that returns a bendable scoreType (" + scoreType
+                        + ") that is not recognized as a default " + Score.class.getSimpleName() + " implementation.\n"
+                        + "  If you intend to use a custom implementation,"
+                        + " maybe set a scoreDefinition in the annotation.");
+            }
+        }
+    }
+
+    public ScoreDefinition<?> getScoreDefinition() {
+        return scoreDefinition;
+    }
+
+    public Class<? extends Score<?>> getScoreClass() {
+        return scoreDefinition.getScoreClass();
+    }
+
+    public Score<?> getScore(Object solution) {
+        return (Score<?>) scoreMemberAccessor.executeGetter(solution);
+    }
+
+    public void setScore(Object solution, Score<?> score) {
+        scoreMemberAccessor.executeSetter(solution, score);
+    }
+
+    public void failFastOnDuplicateMember(DescriptorPolicy descriptorPolicy, Member member, Class<?> solutionClass) {
+        MemberAccessor memberAccessor = buildScoreMemberAccessor(descriptorPolicy, member);
+        // A solution class cannot have more than one score field or bean property (name check), and the @PlanningScore
+        // annotation cannot appear on both the score field and its getter (member accessor class check).
+        if (!scoreMemberAccessor.getName().equals(memberAccessor.getName())
+                || !scoreMemberAccessor.getClass().equals(memberAccessor.getClass())) {
+            throw new IllegalStateException("The solutionClass (" + solutionClass
+                    + ") has a @" + PlanningScore.class.getSimpleName()
+                    + " annotated member (" + memberAccessor
+                    + ") that is duplicated by another member (" + scoreMemberAccessor + ").\n"
+                    + "Maybe the annotation is defined on both the field and its getter.");
+        }
+    }
+}

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/domain/score/descriptor/ScoreDescriptorTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/domain/score/descriptor/ScoreDescriptorTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.core.impl.domain.score.descriptor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.optaplanner.core.api.score.buildin.simple.SimpleScore;
+import org.optaplanner.core.impl.domain.solution.descriptor.SolutionDescriptor;
+import org.optaplanner.core.impl.score.buildin.simple.SimpleScoreDefinition;
+import org.optaplanner.core.impl.score.definition.ScoreDefinition;
+import org.optaplanner.core.impl.testdata.domain.TestdataSolution;
+
+class ScoreDescriptorTest {
+
+    @Test
+    void scoreDefinition() {
+        SolutionDescriptor<TestdataSolution> solutionDescriptor = TestdataSolution.buildSolutionDescriptor();
+        ScoreDefinition<?> scoreDefinition = solutionDescriptor.getScoreDefinition();
+        assertThat(scoreDefinition).isInstanceOf(SimpleScoreDefinition.class);
+        assertThat(scoreDefinition.getScoreClass()).isEqualTo(SimpleScore.class);
+    }
+
+    @Test
+    void scoreAccess() {
+        SolutionDescriptor<TestdataSolution> solutionDescriptor = TestdataSolution.buildSolutionDescriptor();
+        TestdataSolution solution = new TestdataSolution();
+
+        assertThat((SimpleScore) solutionDescriptor.getScore(solution)).isNull();
+
+        SimpleScore score = SimpleScore.of(-2);
+        solutionDescriptor.setScore(solution, score);
+        assertThat((SimpleScore) solutionDescriptor.getScore(solution)).isSameAs(score);
+    }
+}

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/domain/solution/descriptor/SolutionDescriptorTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/domain/solution/descriptor/SolutionDescriptorTest.java
@@ -50,6 +50,7 @@ import org.optaplanner.core.impl.testdata.domain.solutionproperties.autodiscover
 import org.optaplanner.core.impl.testdata.domain.solutionproperties.invalid.TestdataDuplicatePlanningEntityCollectionPropertySolution;
 import org.optaplanner.core.impl.testdata.domain.solutionproperties.invalid.TestdataDuplicatePlanningScorePropertySolution;
 import org.optaplanner.core.impl.testdata.domain.solutionproperties.invalid.TestdataDuplicateProblemFactCollectionPropertySolution;
+import org.optaplanner.core.impl.testdata.domain.solutionproperties.invalid.TestdataMissingScorePropertySolution;
 import org.optaplanner.core.impl.testdata.domain.solutionproperties.invalid.TestdataProblemFactCollectionPropertyWithArgumentSolution;
 import org.optaplanner.core.impl.testdata.domain.solutionproperties.invalid.TestdataProblemFactIsPlanningEntityCollectionPropertySolution;
 import org.optaplanner.core.impl.testdata.domain.solutionproperties.invalid.TestdataUnknownFactTypeSolution;
@@ -103,6 +104,12 @@ public class SolutionDescriptorTest {
     public void duplicatePlanningScorePropertyProperty() {
         assertThatIllegalStateException().isThrownBy(
                 TestdataDuplicatePlanningScorePropertySolution::buildSolutionDescriptor);
+    }
+
+    @Test
+    public void missingPlanningScorePropertyProperty() {
+        assertThatIllegalStateException().isThrownBy(
+                TestdataMissingScorePropertySolution::buildSolutionDescriptor);
     }
 
     @Test
@@ -247,7 +254,7 @@ public class SolutionDescriptorTest {
     }
 
     @Test
-    public void autoDiscoverFieldsFactCollectionOverridenToSingleProperty() {
+    public void autoDiscoverFieldsFactCollectionOverriddenToSingleProperty() {
         SolutionDescriptor<TestdataAutoDiscoverFieldOverrideSolution> solutionDescriptor =
                 TestdataAutoDiscoverFieldOverrideSolution.buildSolutionDescriptor();
         assertThat(solutionDescriptor.getProblemFactMemberAccessorMap()).containsOnlyKeys("singleProblemFact",
@@ -269,7 +276,7 @@ public class SolutionDescriptorTest {
     }
 
     @Test
-    public void autoDiscoverGettersFactCollectionOverridenToSingleProperty() {
+    public void autoDiscoverGettersFactCollectionOverriddenToSingleProperty() {
         SolutionDescriptor<TestdataAutoDiscoverGetterOverrideSolution> solutionDescriptor =
                 TestdataAutoDiscoverGetterOverrideSolution.buildSolutionDescriptor();
         assertThat(solutionDescriptor.getProblemFactMemberAccessorMap()).containsOnlyKeys("singleProblemFact",

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/domain/solution/descriptor/SolutionDescriptorTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/domain/solution/descriptor/SolutionDescriptorTest.java
@@ -24,8 +24,10 @@ import java.util.Arrays;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
+import org.optaplanner.core.api.score.buildin.simple.SimpleScore;
 import org.optaplanner.core.api.solver.Solver;
 import org.optaplanner.core.api.solver.SolverFactory;
+import org.optaplanner.core.impl.score.buildin.simple.SimpleScoreDefinition;
 import org.optaplanner.core.impl.testdata.domain.TestdataEntity;
 import org.optaplanner.core.impl.testdata.domain.TestdataObject;
 import org.optaplanner.core.impl.testdata.domain.TestdataValue;
@@ -202,6 +204,8 @@ public class SolutionDescriptorTest {
     public void autoDiscoverFields() {
         SolutionDescriptor<TestdataAutoDiscoverFieldSolution> solutionDescriptor = TestdataAutoDiscoverFieldSolution
                 .buildSolutionDescriptor();
+        assertThat(solutionDescriptor.getScoreDefinition()).isInstanceOf(SimpleScoreDefinition.class);
+        assertThat(solutionDescriptor.getScoreDefinition().getScoreClass()).isEqualTo(SimpleScore.class);
         assertThat(solutionDescriptor.getConstraintConfigurationMemberAccessor().getName())
                 .isEqualTo("constraintConfiguration");
         assertThat(solutionDescriptor.getProblemFactMemberAccessorMap()).containsOnlyKeys("constraintConfiguration",

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/testdata/domain/solutionproperties/invalid/TestdataMissingScorePropertySolution.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/testdata/domain/solutionproperties/invalid/TestdataMissingScorePropertySolution.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.core.impl.testdata.domain.solutionproperties.invalid;
+
+import java.util.List;
+
+import org.optaplanner.core.api.domain.solution.PlanningEntityCollectionProperty;
+import org.optaplanner.core.api.domain.solution.PlanningSolution;
+import org.optaplanner.core.api.domain.solution.ProblemFactCollectionProperty;
+import org.optaplanner.core.api.domain.valuerange.ValueRangeProvider;
+import org.optaplanner.core.impl.domain.solution.descriptor.SolutionDescriptor;
+import org.optaplanner.core.impl.testdata.domain.TestdataEntity;
+import org.optaplanner.core.impl.testdata.domain.TestdataObject;
+import org.optaplanner.core.impl.testdata.domain.TestdataValue;
+
+@PlanningSolution
+public class TestdataMissingScorePropertySolution extends TestdataObject {
+
+    public static SolutionDescriptor<TestdataMissingScorePropertySolution> buildSolutionDescriptor() {
+        return SolutionDescriptor.buildSolutionDescriptor(TestdataMissingScorePropertySolution.class, TestdataEntity.class);
+    }
+
+    private List<TestdataValue> valueList;
+    private List<TestdataEntity> entityList;
+
+    @ValueRangeProvider(id = "valueRange")
+    @ProblemFactCollectionProperty
+    public List<TestdataValue> getValueList() {
+        return valueList;
+    }
+
+    public void setValueList(List<TestdataValue> valueList) {
+        this.valueList = valueList;
+    }
+
+    @PlanningEntityCollectionProperty
+    public List<TestdataEntity> getEntityList() {
+        return entityList;
+    }
+
+    public void setEntityList(List<TestdataEntity> entityList) {
+        this.entityList = entityList;
+    }
+
+}


### PR DESCRIPTION
<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.
-->

### JIRA

<!-- Add a JIRA ticket link if it exists. -->
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
* https://github.com/kiegroup/drools/pull/3000
* https://github.com/kiegroup/optaplanner/pull/899
* etc.
-->

### Checklist
- [ ] Documentation updated if applicable.
- [ ] Upgrade recipe provided if applicable.

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>full downstream build</b> please add comment: <b>Jenkins run fdb</b>
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
* for a <b>Quarkus LTS check</b> please add comment: <b>Jenkins run LTS</b>
* for a <b>Native check</b> please add comment: <b>Jenkins run native</b>
</details>
