### PR TITLE
Update turtle test trigger as dsl deprecated

### DIFF
--- a/.jenkins/dsl/jobs.groovy
+++ b/.jenkins/dsl/jobs.groovy
@@ -217,8 +217,14 @@ void setupOptaPlannerTurtleTestsJob(String jobFolder) {
     def jobParams = getJobParams('optaplanner-turtle-tests', jobFolder, 'Jenkinsfile.turtle',
             'Run OptaPlanner turtle tests on a weekly basis.')
     KogitoJobTemplate.createPipelineJob(this, jobParams).with {
-        triggers {
-            cron('H H * * 5') // Run every Friday.
+        properties {
+            pipelineTriggers {
+                triggers {
+                    cron {
+                        spec('H H * * 5') // Run every Friday.
+                    }
+                }
+            }
         }
         
         parameters {


### PR DESCRIPTION
Due to migration to CSB, with Jenkins version, direct triggers are deprecated and need to be replaced

depends on https://github.com/kiegroup/kogito-pipelines/pull/172