### PR TITLE
Change default domain access type to GIZMO in Quarkus

### DIFF
--- a/optaplanner-core/src/test/java/org/optaplanner/core/config/solver/SolverConfigTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/config/solver/SolverConfigTest.java
@@ -54,6 +54,7 @@ import org.optaplanner.core.impl.testdata.domain.TestdataEntity;
 import org.optaplanner.core.impl.testdata.domain.TestdataSolution;
 import org.optaplanner.core.impl.testdata.domain.TestdataValue;
 import org.optaplanner.core.impl.testdata.domain.extended.TestdataAnnotatedExtendedEntity;
+import org.optaplanner.core.impl.testdata.domain.extended.TestdataAnnotatedExtendedSolution;
 
 public class SolverConfigTest {
 
@@ -174,7 +175,7 @@ public class SolverConfigTest {
         SolverConfig solverConfig = readSolverConfig(TEST_SOLVER_CONFIG_WITHOUT_NAMESPACE);
         Consumer<Class<?>> classVisitor = Mockito.mock(Consumer.class);
         solverConfig.visitReferencedClasses(classVisitor);
-        Mockito.verify(classVisitor, Mockito.atLeastOnce()).accept(TestdataSolution.class);
+        Mockito.verify(classVisitor, Mockito.atLeastOnce()).accept(TestdataAnnotatedExtendedSolution.class);
         Mockito.verify(classVisitor, Mockito.atLeastOnce()).accept(TestdataEntity.class);
         Mockito.verify(classVisitor, Mockito.atLeastOnce()).accept(TestdataAnnotatedExtendedEntity.class);
         Mockito.verify(classVisitor, Mockito.atLeastOnce()).accept(DummyEasyScoreCalculator.class);

--- a/optaplanner-core/src/test/resources/org/optaplanner/core/config/solver/testSolverConfigWithoutNamespace.xml
+++ b/optaplanner-core/src/test/resources/org/optaplanner/core/config/solver/testSolverConfigWithoutNamespace.xml
@@ -2,7 +2,7 @@
 <solver>
   <environmentMode>FULL_ASSERT</environmentMode>
   <moveThreadCount>AUTO</moveThreadCount>
-  <solutionClass>org.optaplanner.core.impl.testdata.domain.TestdataSolution</solutionClass>
+  <solutionClass>org.optaplanner.core.impl.testdata.domain.extended.TestdataAnnotatedExtendedSolution</solutionClass>
   <entityClass>org.optaplanner.core.impl.testdata.domain.TestdataEntity</entityClass>
   <entityClass>org.optaplanner.core.impl.testdata.domain.extended.TestdataAnnotatedExtendedEntity</entityClass>
   <scoreDirectorFactory>

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/main/java/org/optaplanner/quarkus/deployment/OptaPlannerProcessor.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/main/java/org/optaplanner/quarkus/deployment/OptaPlannerProcessor.java
@@ -298,7 +298,7 @@ class OptaPlannerProcessor {
         optaPlannerBuildTimeConfig.solver.daemon.ifPresent(solverConfig::setDaemon);
         optaPlannerBuildTimeConfig.solver.domainAccessType.ifPresent(solverConfig::setDomainAccessType);
         if (solverConfig.getDomainAccessType() == null) {
-            solverConfig.setDomainAccessType(DomainAccessType.REFLECTION);
+            solverConfig.setDomainAccessType(DomainAccessType.GIZMO);
         }
         // Termination properties are set at runtime
     }

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/test/java/org/optaplanner/quarkus/OptaPlannerProcessorGeneratedGizmoSupplierTest.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/test/java/org/optaplanner/quarkus/OptaPlannerProcessorGeneratedGizmoSupplierTest.java
@@ -37,6 +37,10 @@ public class OptaPlannerProcessorGeneratedGizmoSupplierTest {
 
     @RegisterExtension
     static final QuarkusUnitTest config = new QuarkusUnitTest()
+            // Use Reflection since this SolverConfig is invalid
+            // (solution class should be TestdataAnnotatedExtendedSolution,
+            //  but is TestdataSolution in the xml)
+            .overrideConfigKey("quarkus.optaplanner.solver.domain-access-type", "REFLECTION")
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
                     .addAsResource("org/optaplanner/core/config/solver/testSolverConfigWithoutNamespace.xml",
                             "solverConfig.xml")

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/test/java/org/optaplanner/quarkus/OptaPlannerProcessorGeneratedGizmoSupplierTest.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/test/java/org/optaplanner/quarkus/OptaPlannerProcessorGeneratedGizmoSupplierTest.java
@@ -37,10 +37,6 @@ public class OptaPlannerProcessorGeneratedGizmoSupplierTest {
 
     @RegisterExtension
     static final QuarkusUnitTest config = new QuarkusUnitTest()
-            // Use Reflection since this SolverConfig is invalid
-            // (solution class should be TestdataAnnotatedExtendedSolution,
-            //  but is TestdataSolution in the xml)
-            .overrideConfigKey("quarkus.optaplanner.solver.domain-access-type", "REFLECTION")
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
                     .addAsResource("org/optaplanner/core/config/solver/testSolverConfigWithoutNamespace.xml",
                             "solverConfig.xml")

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/test/java/org/optaplanner/quarkus/OptaPlannerProcessorXMLDefaultTest.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/test/java/org/optaplanner/quarkus/OptaPlannerProcessorXMLDefaultTest.java
@@ -54,7 +54,7 @@ public class OptaPlannerProcessorXMLDefaultTest {
     public void solverConfigXml_default() {
         assertNotNull(solverConfig);
         assertEquals(TestdataQuarkusSolution.class, solverConfig.getSolutionClass());
-        assertEquals(DomainAccessType.REFLECTION, solverConfig.getDomainAccessType());
+        assertEquals(DomainAccessType.GIZMO, solverConfig.getDomainAccessType());
         assertEquals(Collections.singletonList(TestdataQuarkusEntity.class), solverConfig.getEntityClassList());
         assertEquals(TestdataQuarkusConstraintProvider.class,
                 solverConfig.getScoreDirectorFactoryConfig().getConstraintProviderClass());

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/test/java/org/optaplanner/quarkus/OptaPlannerProcessorXMLNoneTest.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/test/java/org/optaplanner/quarkus/OptaPlannerProcessorXMLNoneTest.java
@@ -54,7 +54,7 @@ public class OptaPlannerProcessorXMLNoneTest {
     public void solverConfigXml_default() {
         assertNotNull(solverConfig);
         assertEquals(TestdataQuarkusSolution.class, solverConfig.getSolutionClass());
-        assertEquals(DomainAccessType.REFLECTION, solverConfig.getDomainAccessType());
+        assertEquals(DomainAccessType.GIZMO, solverConfig.getDomainAccessType());
         assertEquals(Collections.singletonList(TestdataQuarkusEntity.class), solverConfig.getEntityClassList());
         assertEquals(TestdataQuarkusConstraintProvider.class,
                 solverConfig.getScoreDirectorFactoryConfig().getConstraintProviderClass());

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/test/java/org/optaplanner/quarkus/OptaPlannerProcessorXMLPropertyTest.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/test/java/org/optaplanner/quarkus/OptaPlannerProcessorXMLPropertyTest.java
@@ -54,7 +54,7 @@ public class OptaPlannerProcessorXMLPropertyTest {
     @Test
     public void solverConfigXml_property() {
         assertNotNull(solverConfig);
-        assertEquals(DomainAccessType.REFLECTION, solverConfig.getDomainAccessType());
+        assertEquals(DomainAccessType.GIZMO, solverConfig.getDomainAccessType());
         assertEquals(TestdataQuarkusSolution.class, solverConfig.getSolutionClass());
         assertEquals(Collections.singletonList(TestdataQuarkusEntity.class), solverConfig.getEntityClassList());
         assertEquals(TestdataQuarkusConstraintProvider.class,


### PR DESCRIPTION
GIZMO has been fixed for a while. The only commit content missing in master from the GIZMO_MEMBER PR is the content that adds GIZMO_MEMBER (And the GIZMO_MEMBER PR works on all of optaplanner-examples => GIZMO on master would work on all of optaplanner-examples if they were written in Quarkus). This PR change the default back to GIZMO.

Side note: `optaplanner-core/src/test/resources/org/optaplanner/core/config/solver/testSolverConfigWithoutNamespace.xml` appears to be an invalid SolverConfig; it references `TestdataAnnotatedExtendedEntity`, which references a valueRangeProvider not in the solution class `TestdataSolution`. For GIZMO, this fails the build (as it need to build a solution descriptor). In REFLECTION, the build won't fail since the SolverDescriptor is not created until a Solver is (and in the test, we don't inject SolverFactory, so it isn't ever created).
<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.
-->

### JIRA

<!-- Add a JIRA ticket link if it exists. -->
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
* https://github.com/kiegroup/drools/pull/3000
* https://github.com/kiegroup/optaplanner/pull/899
* etc.
-->

### Checklist
- [ ] Documentation updated if applicable.
- [ ] Upgrade recipe provided if applicable.

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>full downstream build</b> please add comment: <b>Jenkins run fdb</b>
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
* for a <b>Quarkus LTS check</b> please add comment: <b>Jenkins run LTS</b>
* for a <b>Native check</b> please add comment: <b>Jenkins run native</b>
</details>
