### PR TITLE
PLANNER-2443: Fix Quarkus native: only check @PlanningSolution and @PlanningEntity members, make Substitute_ConfigUtil newInstance.signature match ConfigUtil.newInstance signature

### DIFF
--- a/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/main/java/org/optaplanner/quarkus/deployment/GizmoMemberAccessorEntityEnhancer.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/main/java/org/optaplanner/quarkus/deployment/GizmoMemberAccessorEntityEnhancer.java
@@ -114,7 +114,7 @@ public class GizmoMemberAccessorEntityEnhancer {
             }
         } catch (NoSuchMethodException e) {
             throw new IllegalStateException(
-                    "Class (" + clazz + ") must have a no-args constructor so it can be constructed by OptaPlanner.");
+                    "Class (" + clazz.getName() + ") must have a no-args constructor so it can be constructed by OptaPlanner.");
         }
     }
 

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/main/java/org/optaplanner/quarkus/deployment/GizmoMemberAccessorEntityEnhancer.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/main/java/org/optaplanner/quarkus/deployment/GizmoMemberAccessorEntityEnhancer.java
@@ -425,6 +425,9 @@ public class GizmoMemberAccessorEntityEnhancer {
         BytecodeCreator currentBranch = methodCreator;
 
         for (Class<?> beanClass : beanClasses) {
+            if (beanClass.isInterface() || Modifier.isAbstract(beanClass.getModifiers())) {
+                continue;
+            }
             ResultHandle beanClassHandle = currentBranch.loadClass(beanClass);
             ResultHandle isTarget = currentBranch.invokeVirtualMethod(
                     MethodDescriptor.ofMethod(Object.class, "equals", boolean.class, Object.class),

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/main/java/org/optaplanner/quarkus/deployment/OptaPlannerProcessor.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/main/java/org/optaplanner/quarkus/deployment/OptaPlannerProcessor.java
@@ -56,6 +56,7 @@ import org.optaplanner.core.api.score.stream.ConstraintStreamImplType;
 import org.optaplanner.core.config.score.director.ScoreDirectorFactoryConfig;
 import org.optaplanner.core.config.solver.SolverConfig;
 import org.optaplanner.core.config.solver.SolverManagerConfig;
+import org.optaplanner.core.impl.domain.score.descriptor.ScoreDescriptor;
 import org.optaplanner.core.impl.domain.solution.descriptor.SolutionDescriptor;
 import org.optaplanner.quarkus.OptaPlannerBeanProvider;
 import org.optaplanner.quarkus.OptaPlannerRecorder;
@@ -611,8 +612,10 @@ class OptaPlannerProcessor {
     }
 
     private boolean shouldIgnoreMember(ClassInfo declaringClass) {
-        // SolutionDescriptor PLANNING_SCORE is also picked up as a candidate, which cause problems
-        return declaringClass.name().toString().startsWith(SolutionDescriptor.class.getName());
+        // SolutionDescriptor/ScoreDescriptor PLANNING_SCORE is also picked up as a candidate, which cause problems
+        return declaringClass.name().toString().startsWith(SolutionDescriptor.class.getName())
+                || declaringClass.name().toString().startsWith(
+                        ScoreDescriptor.class.getName());
     }
 
     private void registerCustomClassesFromSolverConfig(SolverConfig solverConfig, Set<Class<?>> reflectiveClassSet) {

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/main/java/org/optaplanner/quarkus/deployment/OptaPlannerProcessor.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/main/java/org/optaplanner/quarkus/deployment/OptaPlannerProcessor.java
@@ -587,7 +587,7 @@ class OptaPlannerProcessor {
                     transformers));
         }
 
-        GizmoMemberAccessorEntityEnhancer.generateGizmoBeanFactory(beanClassOutput, reflectiveClassSet);
+        GizmoMemberAccessorEntityEnhancer.generateGizmoBeanFactory(beanClassOutput, reflectiveClassSet, transformers);
         GizmoMemberAccessorEntityEnhancer.generateKieRuntimeBuilder(beanClassOutput,
                 solverConfig, unremovableBeans, transformers);
         return new GeneratedGizmoClasses(generatedMemberAccessorsClassNameSet, gizmoSolutionClonerClassNameSet);

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/main/java/org/optaplanner/quarkus/deployment/OptaPlannerProcessor.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/main/java/org/optaplanner/quarkus/deployment/OptaPlannerProcessor.java
@@ -18,6 +18,7 @@ package org.optaplanner.quarkus.deployment;
 
 import static io.quarkus.deployment.annotations.ExecutionTime.STATIC_INIT;
 
+import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -593,20 +594,15 @@ class OptaPlannerProcessor {
     }
 
     private boolean shouldIgnoreMember(AnnotationInstance annotationInstance) {
-        ClassInfo declaringClass;
         switch (annotationInstance.target().kind()) {
             case FIELD:
-                declaringClass = annotationInstance.target().asField().declaringClass();
-                break;
+                return (annotationInstance.target().asField().flags() & Modifier.STATIC) != 0;
             case METHOD:
-                declaringClass = annotationInstance.target().asMethod().declaringClass();
-                break;
+                return (annotationInstance.target().asMethod().flags() & Modifier.STATIC) != 0;
             default:
                 throw new IllegalArgumentException(
                         "Annotation (" + annotationInstance.name() + ") can only be applied to methods and fields.");
         }
-        return !declaringClass.annotations().containsKey(DotNames.PLANNING_SOLUTION) &&
-                !declaringClass.annotations().containsKey(DotNames.PLANNING_ENTITY);
     }
 
     private void registerCustomClassesFromSolverConfig(SolverConfig solverConfig, Set<Class<?>> reflectiveClassSet) {

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/main/java/org/optaplanner/quarkus/deployment/OptaPlannerProcessor.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/main/java/org/optaplanner/quarkus/deployment/OptaPlannerProcessor.java
@@ -552,8 +552,8 @@ class OptaPlannerProcessor {
                                             classInfo, fieldInfo, transformers));
                         } catch (ClassNotFoundException | NoSuchFieldException e) {
                             throw new IllegalStateException("Fail to generate member accessor for field (" +
-                                    fieldInfo.name() + ") of class " +
-                                    classInfo.name().toString() + ".", e);
+                                    fieldInfo.name() + ") of the class( " +
+                                    classInfo.name().toString() + ").", e);
                         }
                         break;
                     }

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/test/java/org/optaplanner/quarkus/OptaPlannerProcessorGeneratedGizmoSupplierTest.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/test/java/org/optaplanner/quarkus/OptaPlannerProcessorGeneratedGizmoSupplierTest.java
@@ -18,17 +18,39 @@ package org.optaplanner.quarkus;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.Iterator;
+import java.util.List;
+import java.util.Random;
+
 import javax.inject.Inject;
 
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
-import org.optaplanner.core.config.solver.SolverConfigTest;
+import org.optaplanner.core.api.domain.entity.PlanningEntity;
+import org.optaplanner.core.api.domain.variable.CustomShadowVariable;
+import org.optaplanner.core.api.domain.variable.PlanningVariableReference;
+import org.optaplanner.core.api.score.buildin.simple.SimpleScore;
+import org.optaplanner.core.api.score.calculator.EasyScoreCalculator;
+import org.optaplanner.core.api.score.calculator.IncrementalScoreCalculator;
+import org.optaplanner.core.api.score.director.ScoreDirector;
+import org.optaplanner.core.api.score.stream.Constraint;
+import org.optaplanner.core.api.score.stream.ConstraintFactory;
+import org.optaplanner.core.api.score.stream.ConstraintProvider;
+import org.optaplanner.core.impl.heuristic.move.DummyMove;
+import org.optaplanner.core.impl.heuristic.move.Move;
+import org.optaplanner.core.impl.heuristic.selector.common.decorator.SelectionFilter;
+import org.optaplanner.core.impl.heuristic.selector.move.factory.MoveIteratorFactory;
+import org.optaplanner.core.impl.heuristic.selector.move.factory.MoveListFactory;
+import org.optaplanner.core.impl.heuristic.selector.move.generic.ChangeMove;
+import org.optaplanner.core.impl.partitionedsearch.partitioner.SolutionPartitioner;
 import org.optaplanner.core.impl.testdata.domain.TestdataEntity;
 import org.optaplanner.core.impl.testdata.domain.TestdataSolution;
+import org.optaplanner.core.impl.testdata.domain.TestdataValue;
 import org.optaplanner.core.impl.testdata.domain.extended.TestdataAnnotatedExtendedEntity;
 import org.optaplanner.quarkus.gizmo.OptaPlannerGizmoBeanFactory;
+import org.optaplanner.quarkus.testdata.gizmo.DummyVariableListener;
 
 import io.quarkus.deployment.builditem.CapabilityBuildItem;
 import io.quarkus.test.QuarkusUnitTest;
@@ -38,21 +60,24 @@ public class OptaPlannerProcessorGeneratedGizmoSupplierTest {
     @RegisterExtension
     static final QuarkusUnitTest config = new QuarkusUnitTest()
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
-                    .addAsResource("org/optaplanner/core/config/solver/testSolverConfigWithoutNamespace.xml",
+                    .addAsResource("org/optaplanner/quarkus/gizmoSupplierTestSolverConfig.xml",
                             "solverConfig.xml")
                     .addClasses(
                             TestdataSolution.class,
                             TestdataEntity.class,
                             TestdataAnnotatedExtendedEntity.class,
-                            SolverConfigTest.DummyChangeMoveFilter.class,
-                            SolverConfigTest.DummyConstraintProvider.class,
-                            SolverConfigTest.DummyEasyScoreCalculator.class,
-                            SolverConfigTest.DummyEntityFilter.class,
-                            SolverConfigTest.DummyIncrementalScoreCalculator.class,
-                            SolverConfigTest.DummyMoveIteratorFactory.class,
-                            SolverConfigTest.DummyMoveListFactory.class,
-                            SolverConfigTest.DummySolutionPartitioner.class,
-                            SolverConfigTest.DummyValueFilter.class))
+                            DummyInterfaceEntity.class,
+                            DummyAbstractEntity.class,
+                            DummyVariableListener.class,
+                            DummyChangeMoveFilter.class,
+                            DummyConstraintProvider.class,
+                            DummyEasyScoreCalculator.class,
+                            DummyEntityFilter.class,
+                            DummyIncrementalScoreCalculator.class,
+                            DummyMoveIteratorFactory.class,
+                            DummyMoveListFactory.class,
+                            DummySolutionPartitioner.class,
+                            DummyValueFilter.class))
             .addBuildChainCustomizer(buildChainBuilder -> buildChainBuilder.addBuildStep(context -> {
                 context.produce(CapabilityBuildItem.class, new CapabilityBuildItem("kogito-rules"));
             }).produces(CapabilityBuildItem.class).build());
@@ -70,18 +95,156 @@ public class OptaPlannerProcessorGeneratedGizmoSupplierTest {
 
     @Test
     public void gizmoFactoryContainClassesReferencedInSolverConfig() {
-        // TODO: Create a org/optaplanner/core/config/solver/testSolverConfigWithoutNamespace.xml
-        //       that does not use abstract classes (since they cause issues in native
-        //       compilation).
-        assertFactoryNotContains(SolverConfigTest.DummyChangeMoveFilter.class);
-        assertFactoryNotContains(SolverConfigTest.DummyConstraintProvider.class);
-        assertFactoryNotContains(SolverConfigTest.DummyEasyScoreCalculator.class);
-        assertFactoryNotContains(SolverConfigTest.DummyEntityFilter.class);
-        assertFactoryNotContains(SolverConfigTest.DummyIncrementalScoreCalculator.class);
-        assertFactoryNotContains(SolverConfigTest.DummyMoveIteratorFactory.class);
-        assertFactoryNotContains(SolverConfigTest.DummyMoveListFactory.class);
-        assertFactoryNotContains(SolverConfigTest.DummySolutionPartitioner.class);
-        assertFactoryNotContains(SolverConfigTest.DummyValueFilter.class);
+        assertFactoryContains(DummyChangeMoveFilter.class);
+        assertFactoryContains(DummyConstraintProvider.class);
+        assertFactoryContains(DummyEasyScoreCalculator.class);
+        assertFactoryContains(DummyEntityFilter.class);
+        assertFactoryContains(DummyIncrementalScoreCalculator.class);
+        assertFactoryContains(DummyMoveIteratorFactory.class);
+        assertFactoryContains(DummyMoveListFactory.class);
+        assertFactoryContains(DummySolutionPartitioner.class);
+        assertFactoryContains(DummyValueFilter.class);
+        assertFactoryContains(DummyVariableListener.class);
+
+        assertFactoryNotContains(DummyInterfaceEntity.class);
+        assertFactoryNotContains(DummyAbstractEntity.class);
+    }
+
+    /* Dummy classes below are referenced from the testSolverConfig.xml used in this test case. */
+
+    @PlanningEntity
+    public interface DummyInterfaceEntity {
+        @CustomShadowVariable(
+                sources = {
+                        @PlanningVariableReference(entityClass = TestdataEntity.class,
+                                variableName = "value")
+                },
+                variableListenerClass = DummyVariableListener.class)
+        Integer getLength();
+    }
+
+    @PlanningEntity
+    public static abstract class DummyAbstractEntity {
+        @CustomShadowVariable(
+                sources = {
+                        @PlanningVariableReference(entityClass = TestdataEntity.class,
+                                variableName = "value")
+                },
+                variableListenerClass = DummyVariableListener.class)
+        abstract Integer getLength();
+    }
+
+    public static class DummySolutionPartitioner implements SolutionPartitioner<TestdataSolution> {
+        @Override
+        public List<TestdataSolution> splitWorkingSolution(ScoreDirector<TestdataSolution> scoreDirector,
+                Integer runnablePartThreadLimit) {
+            return null;
+        }
+    }
+
+    public static class DummyEasyScoreCalculator
+            implements EasyScoreCalculator<TestdataSolution, SimpleScore> {
+        @Override
+        public SimpleScore calculateScore(TestdataSolution testdataSolution) {
+            return null;
+        }
+    }
+
+    public static class DummyIncrementalScoreCalculator
+            implements IncrementalScoreCalculator<TestdataSolution, SimpleScore> {
+        @Override
+        public void resetWorkingSolution(TestdataSolution workingSolution) {
+
+        }
+
+        @Override
+        public void beforeEntityAdded(Object entity) {
+
+        }
+
+        @Override
+        public void afterEntityAdded(Object entity) {
+
+        }
+
+        @Override
+        public void beforeVariableChanged(Object entity, String variableName) {
+
+        }
+
+        @Override
+        public void afterVariableChanged(Object entity, String variableName) {
+
+        }
+
+        @Override
+        public void beforeEntityRemoved(Object entity) {
+
+        }
+
+        @Override
+        public void afterEntityRemoved(Object entity) {
+
+        }
+
+        @Override
+        public SimpleScore calculateScore() {
+            return null;
+        }
+    }
+
+    public static class DummyConstraintProvider implements ConstraintProvider {
+        @Override
+        public Constraint[] defineConstraints(ConstraintFactory constraintFactory) {
+            return new Constraint[0];
+        }
+    }
+
+    public static class DummyValueFilter implements SelectionFilter<TestdataSolution, TestdataValue> {
+        @Override
+        public boolean accept(ScoreDirector<TestdataSolution> scoreDirector, TestdataValue selection) {
+            return false;
+        }
+    }
+
+    public static class DummyEntityFilter implements SelectionFilter<TestdataSolution, TestdataEntity> {
+        @Override
+        public boolean accept(ScoreDirector<TestdataSolution> scoreDirector, TestdataEntity selection) {
+            return false;
+        }
+    }
+
+    public static class DummyChangeMoveFilter
+            implements SelectionFilter<TestdataSolution, ChangeMove<TestdataSolution>> {
+        @Override
+        public boolean accept(ScoreDirector<TestdataSolution> scoreDirector, ChangeMove<TestdataSolution> selection) {
+            return false;
+        }
+    }
+
+    public static class DummyMoveIteratorFactory implements MoveIteratorFactory<TestdataSolution, DummyMove> {
+        @Override
+        public long getSize(ScoreDirector<TestdataSolution> scoreDirector) {
+            return 0;
+        }
+
+        @Override
+        public Iterator<DummyMove> createOriginalMoveIterator(ScoreDirector<TestdataSolution> scoreDirector) {
+            return null;
+        }
+
+        @Override
+        public Iterator<DummyMove> createRandomMoveIterator(ScoreDirector<TestdataSolution> scoreDirector,
+                Random workingRandom) {
+            return null;
+        }
+    }
+
+    public static class DummyMoveListFactory implements MoveListFactory<TestdataSolution> {
+        @Override
+        public List<? extends Move<TestdataSolution>> createMoveList(TestdataSolution testdataSolution) {
+            return null;
+        }
     }
 
 }

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/test/java/org/optaplanner/quarkus/OptaPlannerProcessorGeneratedGizmoSupplierTest.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/test/java/org/optaplanner/quarkus/OptaPlannerProcessorGeneratedGizmoSupplierTest.java
@@ -16,6 +16,7 @@
 
 package org.optaplanner.quarkus;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 
 import javax.inject.Inject;
@@ -67,17 +68,26 @@ public class OptaPlannerProcessorGeneratedGizmoSupplierTest {
                 .isInstanceOf(InstantiationError.class).hasMessage(clazz.getName());
     }
 
+    private void assertFactoryNotContains(Class<?> clazz) {
+        // All the classes are abstract, so they throw Instantiation Error,
+        // yet you can still call new on them in bytecode
+        assertThat(gizmoBeanFactory.newInstance(clazz)).isNull();
+    }
+
     @Test
     public void gizmoFactoryContainClassesReferencedInSolverConfig() {
-        assertFactoryContains(SolverConfigTest.DummyChangeMoveFilter.class);
-        assertFactoryContains(SolverConfigTest.DummyConstraintProvider.class);
-        assertFactoryContains(SolverConfigTest.DummyEasyScoreCalculator.class);
-        assertFactoryContains(SolverConfigTest.DummyEntityFilter.class);
-        assertFactoryContains(SolverConfigTest.DummyIncrementalScoreCalculator.class);
-        assertFactoryContains(SolverConfigTest.DummyMoveIteratorFactory.class);
-        assertFactoryContains(SolverConfigTest.DummyMoveListFactory.class);
-        assertFactoryContains(SolverConfigTest.DummySolutionPartitioner.class);
-        assertFactoryContains(SolverConfigTest.DummyValueFilter.class);
+        // TODO: Create a org/optaplanner/core/config/solver/testSolverConfigWithoutNamespace.xml
+        //       that does not use abstract classes (since they cause issues in native
+        //       compilation).
+        assertFactoryNotContains(SolverConfigTest.DummyChangeMoveFilter.class);
+        assertFactoryNotContains(SolverConfigTest.DummyConstraintProvider.class);
+        assertFactoryNotContains(SolverConfigTest.DummyEasyScoreCalculator.class);
+        assertFactoryNotContains(SolverConfigTest.DummyEntityFilter.class);
+        assertFactoryNotContains(SolverConfigTest.DummyIncrementalScoreCalculator.class);
+        assertFactoryNotContains(SolverConfigTest.DummyMoveIteratorFactory.class);
+        assertFactoryNotContains(SolverConfigTest.DummyMoveListFactory.class);
+        assertFactoryNotContains(SolverConfigTest.DummySolutionPartitioner.class);
+        assertFactoryNotContains(SolverConfigTest.DummyValueFilter.class);
     }
 
 }

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/test/java/org/optaplanner/quarkus/OptaPlannerProcessorGeneratedGizmoSupplierTest.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/test/java/org/optaplanner/quarkus/OptaPlannerProcessorGeneratedGizmoSupplierTest.java
@@ -62,15 +62,10 @@ public class OptaPlannerProcessorGeneratedGizmoSupplierTest {
     OptaPlannerGizmoBeanFactory gizmoBeanFactory;
 
     private void assertFactoryContains(Class<?> clazz) {
-        // All the classes are abstract, so they throw Instantiation Error,
-        // yet you can still call new on them in bytecode
-        assertThatCode(() -> gizmoBeanFactory.newInstance(clazz))
-                .isInstanceOf(InstantiationError.class).hasMessage(clazz.getName());
+        assertThat(gizmoBeanFactory.newInstance(clazz)).isNotNull();
     }
 
     private void assertFactoryNotContains(Class<?> clazz) {
-        // All the classes are abstract, so they throw Instantiation Error,
-        // yet you can still call new on them in bytecode
         assertThat(gizmoBeanFactory.newInstance(clazz)).isNull();
     }
 

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/test/java/org/optaplanner/quarkus/OptaPlannerProcessorGeneratedGizmoSupplierTest.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/test/java/org/optaplanner/quarkus/OptaPlannerProcessorGeneratedGizmoSupplierTest.java
@@ -17,7 +17,6 @@
 package org.optaplanner.quarkus;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatCode;
 
 import javax.inject.Inject;
 

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/test/java/org/optaplanner/quarkus/OptaPlannerProcessorOnlyMultiConstructorTest.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/test/java/org/optaplanner/quarkus/OptaPlannerProcessorOnlyMultiConstructorTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.quarkus;
+
+import java.util.concurrent.ExecutionException;
+
+import javax.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.optaplanner.core.api.solver.SolverManager;
+import org.optaplanner.quarkus.testdata.gizmo.OnlyMultiArgsConstructorEntity;
+import org.optaplanner.quarkus.testdata.gizmo.PrivateNoArgsConstructorConstraintProvider;
+import org.optaplanner.quarkus.testdata.gizmo.PrivateNoArgsConstructorEntity;
+import org.optaplanner.quarkus.testdata.gizmo.PrivateNoArgsConstructorSolution;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class OptaPlannerProcessorOnlyMultiConstructorTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .overrideConfigKey("quarkus.optaplanner.solver.termination.best-score-limit", "0")
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(PrivateNoArgsConstructorConstraintProvider.class,
+                            PrivateNoArgsConstructorSolution.class,
+                            PrivateNoArgsConstructorEntity.class,
+                            OnlyMultiArgsConstructorEntity.class))
+            .assertException(throwable -> {
+                Assertions.assertEquals(
+                        "Class (" + OnlyMultiArgsConstructorEntity.class.getName()
+                                + ") must have a no-args constructor so it can be constructed by OptaPlanner.",
+                        throwable.getMessage());
+            });
+
+    @Inject
+    SolverManager<PrivateNoArgsConstructorSolution, Long> solverManager;
+
+    @Test
+    public void canConstructBeansWithPrivateConstructors() throws ExecutionException, InterruptedException {
+    }
+
+}

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/test/java/org/optaplanner/quarkus/OptaPlannerProcessorPrivateConstructorTest.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/test/java/org/optaplanner/quarkus/OptaPlannerProcessorPrivateConstructorTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.quarkus;
+
+import java.util.Arrays;
+import java.util.concurrent.ExecutionException;
+
+import javax.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.optaplanner.core.api.solver.SolverManager;
+import org.optaplanner.quarkus.testdata.gizmo.PrivateNoArgsConstructorConstraintProvider;
+import org.optaplanner.quarkus.testdata.gizmo.PrivateNoArgsConstructorEntity;
+import org.optaplanner.quarkus.testdata.gizmo.PrivateNoArgsConstructorSolution;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class OptaPlannerProcessorPrivateConstructorTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .overrideConfigKey("quarkus.optaplanner.solver.termination.best-score-limit", "0")
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(PrivateNoArgsConstructorConstraintProvider.class,
+                            PrivateNoArgsConstructorSolution.class,
+                            PrivateNoArgsConstructorEntity.class));
+
+    @Inject
+    SolverManager<PrivateNoArgsConstructorSolution, Long> solverManager;
+
+    @Test
+    public void canConstructBeansWithPrivateConstructors() throws ExecutionException, InterruptedException {
+        PrivateNoArgsConstructorSolution problem = new PrivateNoArgsConstructorSolution(
+                Arrays.asList(
+                        new PrivateNoArgsConstructorEntity("1"),
+                        new PrivateNoArgsConstructorEntity("2"),
+                        new PrivateNoArgsConstructorEntity("3")));
+        PrivateNoArgsConstructorSolution solution = solverManager.solve(1L, problem).getFinalBestSolution();
+        Assertions.assertEquals(solution.score.getScore(), 0);
+    }
+
+}

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/test/java/org/optaplanner/quarkus/testdata/gizmo/OnlyMultiArgsConstructorEntity.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/test/java/org/optaplanner/quarkus/testdata/gizmo/OnlyMultiArgsConstructorEntity.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.quarkus.testdata.gizmo;
+
+import org.optaplanner.core.api.domain.entity.PlanningEntity;
+import org.optaplanner.core.api.domain.variable.PlanningVariable;
+
+@PlanningEntity
+public class OnlyMultiArgsConstructorEntity extends PrivateNoArgsConstructorEntity {
+    @PlanningVariable(valueRangeProviderRefs = "valueRange")
+    String anotherValue;
+
+    public OnlyMultiArgsConstructorEntity(String id) {
+        super(id);
+    }
+}

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/test/java/org/optaplanner/quarkus/testdata/gizmo/PrivateNoArgsConstructorConstraintProvider.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/test/java/org/optaplanner/quarkus/testdata/gizmo/PrivateNoArgsConstructorConstraintProvider.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.quarkus.testdata.gizmo;
+
+import org.optaplanner.core.api.score.buildin.simple.SimpleScore;
+import org.optaplanner.core.api.score.stream.Constraint;
+import org.optaplanner.core.api.score.stream.ConstraintFactory;
+import org.optaplanner.core.api.score.stream.ConstraintProvider;
+import org.optaplanner.core.api.score.stream.Joiners;
+
+public class PrivateNoArgsConstructorConstraintProvider implements ConstraintProvider {
+
+    private PrivateNoArgsConstructorConstraintProvider() {
+    }
+
+    @Override
+    public Constraint[] defineConstraints(ConstraintFactory constraintFactory) {
+        return new Constraint[] {
+                constraintFactory.fromUniquePair(PrivateNoArgsConstructorEntity.class,
+                        Joiners.equal(p -> p.value))
+                        .penalize("Same value", SimpleScore.ONE)
+        };
+    }
+}

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/test/java/org/optaplanner/quarkus/testdata/gizmo/PrivateNoArgsConstructorEntity.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/test/java/org/optaplanner/quarkus/testdata/gizmo/PrivateNoArgsConstructorEntity.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.quarkus.testdata.gizmo;
+
+import org.optaplanner.core.api.domain.entity.PlanningEntity;
+import org.optaplanner.core.api.domain.lookup.PlanningId;
+import org.optaplanner.core.api.domain.variable.PlanningVariable;
+
+@PlanningEntity
+public class PrivateNoArgsConstructorEntity {
+    @PlanningId
+    String id;
+
+    @PlanningVariable(valueRangeProviderRefs = "valueRange")
+    String value;
+
+    private PrivateNoArgsConstructorEntity() {
+
+    }
+
+    public PrivateNoArgsConstructorEntity(String id) {
+        this.id = id;
+    }
+}

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/test/java/org/optaplanner/quarkus/testdata/gizmo/PrivateNoArgsConstructorSolution.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/test/java/org/optaplanner/quarkus/testdata/gizmo/PrivateNoArgsConstructorSolution.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.quarkus.testdata.gizmo;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.optaplanner.core.api.domain.solution.PlanningEntityCollectionProperty;
+import org.optaplanner.core.api.domain.solution.PlanningScore;
+import org.optaplanner.core.api.domain.solution.PlanningSolution;
+import org.optaplanner.core.api.domain.valuerange.ValueRangeProvider;
+import org.optaplanner.core.api.score.buildin.simple.SimpleScore;
+
+@PlanningSolution
+public class PrivateNoArgsConstructorSolution {
+    @PlanningEntityCollectionProperty
+    List<PrivateNoArgsConstructorEntity> planningEntityList;
+
+    @PlanningScore
+    public SimpleScore score;
+
+    private PrivateNoArgsConstructorSolution() {
+    }
+
+    public PrivateNoArgsConstructorSolution(List<PrivateNoArgsConstructorEntity> planningEntityList) {
+        this.planningEntityList = planningEntityList;
+    }
+
+    @ValueRangeProvider(id = "valueRange")
+    public List<String> valueRange() {
+        return Arrays.asList("1", "2", "3");
+    }
+}

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/test/resources/org/optaplanner/quarkus/gizmoSupplierTestSolverConfig.xml
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/test/resources/org/optaplanner/quarkus/gizmoSupplierTestSolverConfig.xml
@@ -1,0 +1,176 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2021 Red Hat, Inc. and/or its affiliates.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<solver>
+    <environmentMode>FULL_ASSERT</environmentMode>
+    <moveThreadCount>AUTO</moveThreadCount>
+    <solutionClass>org.optaplanner.core.impl.testdata.domain.extended.TestdataAnnotatedExtendedSolution</solutionClass>
+    <entityClass>org.optaplanner.core.impl.testdata.domain.TestdataEntity</entityClass>
+    <entityClass>org.optaplanner.core.impl.testdata.domain.extended.TestdataAnnotatedExtendedEntity</entityClass>
+    <entityClass>org.optaplanner.quarkus.OptaPlannerProcessorGeneratedGizmoSupplierTest$DummyInterfaceEntity</entityClass>
+    <entityClass>org.optaplanner.quarkus.OptaPlannerProcessorGeneratedGizmoSupplierTest$DummyAbstractEntity</entityClass>
+    <scoreDirectorFactory>
+        <easyScoreCalculatorClass>org.optaplanner.quarkus.OptaPlannerProcessorGeneratedGizmoSupplierTest$DummyEasyScoreCalculator</easyScoreCalculatorClass>
+        <constraintProviderClass>org.optaplanner.quarkus.OptaPlannerProcessorGeneratedGizmoSupplierTest$DummyConstraintProvider</constraintProviderClass>
+        <incrementalScoreCalculatorClass>org.optaplanner.quarkus.OptaPlannerProcessorGeneratedGizmoSupplierTest$DummyIncrementalScoreCalculator</incrementalScoreCalculatorClass>
+        <scoreDrl>org/optaplanner/config/firstNonExistingConstraints.drl</scoreDrl>
+        <scoreDrl>org/optaplanner/config/secondNonExistingConstraints.drl</scoreDrl>
+        <initializingScoreTrend>ONLY_DOWN</initializingScoreTrend>
+    </scoreDirectorFactory>
+    <constructionHeuristic>
+        <constructionHeuristicType>FIRST_FIT_DECREASING</constructionHeuristicType>
+        <queuedEntityPlacer>
+            <entitySelector id="placerEntitySelector">
+                <entityClass>org.optaplanner.core.impl.testdata.domain.TestdataEntity</entityClass>
+                <cacheType>PHASE</cacheType>
+                <selectionOrder>SORTED</selectionOrder>
+                <filterClass>org.optaplanner.quarkus.OptaPlannerProcessorGeneratedGizmoSupplierTest$DummyEntityFilter</filterClass>
+                <sorterManner>DECREASING_DIFFICULTY</sorterManner>
+            </entitySelector>
+            <cartesianProductMoveSelector>
+                <changeMoveSelector>
+                    <entitySelector mimicSelectorRef="placerEntitySelector"/>
+                    <valueSelector variableName="subValue">
+                        <downcastEntityClass>org.optaplanner.core.impl.testdata.domain.extended.TestdataAnnotatedExtendedEntity</downcastEntityClass>
+                        <cacheType>PHASE</cacheType>
+                        <selectionOrder>SORTED</selectionOrder>
+                        <sorterManner>INCREASING_STRENGTH</sorterManner>
+                    </valueSelector>
+                </changeMoveSelector>
+                <changeMoveSelector>
+                    <filterClass>org.optaplanner.quarkus.OptaPlannerProcessorGeneratedGizmoSupplierTest$DummyChangeMoveFilter</filterClass>
+                    <entitySelector mimicSelectorRef="placerEntitySelector"/>
+                    <valueSelector variableName="value">
+                        <cacheType>PHASE</cacheType>
+                        <selectionOrder>SORTED</selectionOrder>
+                        <filterClass>org.optaplanner.quarkus.OptaPlannerProcessorGeneratedGizmoSupplierTest$DummyValueFilter</filterClass>
+                        <sorterManner>INCREASING_STRENGTH</sorterManner>
+                    </valueSelector>
+                </changeMoveSelector>
+            </cartesianProductMoveSelector>
+        </queuedEntityPlacer>
+        <swapMoveSelector>
+            <variableNameIncludes>
+                <variableNameInclude>variableA</variableNameInclude>
+                <variableNameInclude>variableB</variableNameInclude>
+            </variableNameIncludes>
+        </swapMoveSelector>
+        <forager>
+            <pickEarlyType>FIRST_FEASIBLE_SCORE_OR_NON_DETERIORATING_HARD</pickEarlyType>
+        </forager>
+    </constructionHeuristic>
+    <customPhase>
+        <customPhaseCommandClass>org.optaplanner.core.impl.phase.custom.CustomPhaseCommand</customPhaseCommandClass>
+    </customPhase>
+    <exhaustiveSearch>
+        <exhaustiveSearchType>BRANCH_AND_BOUND</exhaustiveSearchType>
+        <nodeExplorationType>BREADTH_FIRST</nodeExplorationType>
+        <changeMoveSelector>
+            <valueSelector variableName="value">
+                <filterClass>org.optaplanner.quarkus.OptaPlannerProcessorGeneratedGizmoSupplierTest$DummyValueFilter</filterClass>
+            </valueSelector>
+        </changeMoveSelector>
+    </exhaustiveSearch>
+    <localSearch>
+        <termination>
+            <terminationCompositionStyle>AND</terminationCompositionStyle>
+            <spentLimit>PT2S</spentLimit>
+            <unimprovedSecondsSpentLimit>10</unimprovedSecondsSpentLimit>
+            <termination>
+                <terminationCompositionStyle>OR</terminationCompositionStyle>
+                <secondsSpentLimit>20</secondsSpentLimit>
+                <unimprovedStepCountLimit>1000</unimprovedStepCountLimit>
+            </termination>
+        </termination>
+        <localSearchType>TABU_SEARCH</localSearchType>
+        <unionMoveSelector>
+            <pillarChangeMoveSelector>
+                <subPillarType>SEQUENCE</subPillarType>
+            </pillarChangeMoveSelector>
+            <pillarSwapMoveSelector>
+                <pillarSelector>
+                    <entitySelector>
+                        <filterClass>org.optaplanner.quarkus.OptaPlannerProcessorGeneratedGizmoSupplierTest$DummyEntityFilter</filterClass>
+                    </entitySelector>
+                    <minimumSubPillarSize>5</minimumSubPillarSize>
+                    <maximumSubPillarSize>10</maximumSubPillarSize>
+                </pillarSelector>
+            </pillarSwapMoveSelector>
+            <moveIteratorFactory>
+                <fixedProbabilityWeight>30.0</fixedProbabilityWeight>
+                <moveIteratorFactoryClass>org.optaplanner.quarkus.OptaPlannerProcessorGeneratedGizmoSupplierTest$DummyMoveIteratorFactory</moveIteratorFactoryClass>
+                <moveIteratorFactoryCustomProperties>
+                    <property name="moveIteratorProperty" value="moveIteratorPropertyValue"/>
+                </moveIteratorFactoryCustomProperties>
+            </moveIteratorFactory>
+            <moveListFactory>
+                <selectedCountLimit>500</selectedCountLimit>
+                <moveListFactoryClass>org.optaplanner.quarkus.OptaPlannerProcessorGeneratedGizmoSupplierTest$DummyMoveListFactory</moveListFactoryClass>
+                <moveListFactoryCustomProperties>
+                    <property name="moveListProperty" value="moveListPropertyValue"/>
+                </moveListFactoryCustomProperties>
+            </moveListFactory>
+        </unionMoveSelector>
+        <acceptor>
+            <acceptorType>ENTITY_TABU</acceptorType>
+            <acceptorType>STEP_COUNTING_HILL_CLIMBING</acceptorType>
+            <entityTabuSize>5</entityTabuSize>
+            <entityTabuRatio>2.0</entityTabuRatio>
+            <stepCountingHillClimbingSize>10</stepCountingHillClimbingSize>
+            <stepCountingHillClimbingType>EQUAL_OR_IMPROVING_STEP</stepCountingHillClimbingType>
+        </acceptor>
+        <forager>
+            <pickEarlyType>FIRST_LAST_STEP_SCORE_IMPROVING</pickEarlyType>
+            <acceptedCountLimit>1000</acceptedCountLimit>
+            <finalistPodiumType>STRATEGIC_OSCILLATION</finalistPodiumType>
+            <breakTieRandomly>true</breakTieRandomly>
+        </forager>
+    </localSearch>
+    <noChangePhase/>
+    <partitionedSearch>
+        <solutionPartitionerClass>org.optaplanner.quarkus.OptaPlannerProcessorGeneratedGizmoSupplierTest$DummySolutionPartitioner</solutionPartitionerClass>
+        <solutionPartitionerCustomProperties>
+            <property name="minimumProcessListSize" value="300"/>
+            <property name="partCount" value="4"/>
+        </solutionPartitionerCustomProperties>
+        <constructionHeuristic>
+            <pooledEntityPlacer>
+                <changeMoveSelector/>
+            </pooledEntityPlacer>
+        </constructionHeuristic>
+        <localSearch>
+            <termination>
+                <minutesSpentLimit>5</minutesSpentLimit>
+                <bestScoreLimit>0hard/0soft</bestScoreLimit>
+            </termination>
+            <unionMoveSelector>
+                <subChainChangeMoveSelector>
+                    <subChainSelector>
+                        <maximumSubChainSize>50</maximumSubChainSize>
+                    </subChainSelector>
+                    <selectReversingMoveToo>true</selectReversingMoveToo>
+                </subChainChangeMoveSelector>
+                <subChainSwapMoveSelector>
+                    <selectReversingMoveToo>false</selectReversingMoveToo>
+                </subChainSwapMoveSelector>
+                <tailChainSwapMoveSelector/>
+            </unionMoveSelector>
+            <acceptor>
+                <simulatedAnnealingStartingTemperature>2hard/10000soft</simulatedAnnealingStartingTemperature>
+            </acceptor>
+        </localSearch>
+    </partitionedSearch>
+</solver>

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/runtime/src/main/java/org/optaplanner/quarkus/nativeimage/Substitute_ConfigUtils.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/runtime/src/main/java/org/optaplanner/quarkus/nativeimage/Substitute_ConfigUtils.java
@@ -16,6 +16,8 @@
 
 package org.optaplanner.quarkus.nativeimage;
 
+import java.util.function.Supplier;
+
 import javax.enterprise.inject.spi.CDI;
 
 import org.optaplanner.quarkus.gizmo.OptaPlannerGizmoBeanFactory;
@@ -27,13 +29,13 @@ import com.oracle.svm.core.annotate.TargetClass;
 public final class Substitute_ConfigUtils {
 
     @Substitute
-    public static <T> T newInstance(Object bean, String propertyName, Class<T> clazz) {
+    public static <T> T newInstance(Supplier<String> ownerDescriptor, String propertyName, Class<T> clazz) {
         T out = CDI.current().getBeanManager().createInstance().select(OptaPlannerGizmoBeanFactory.class)
                 .get().newInstance(clazz);
         if (out != null) {
             return out;
         } else {
-            throw new IllegalArgumentException("Impossible state: could not find the " + bean.getClass().getSimpleName() +
+            throw new IllegalArgumentException("Impossible state: could not find the " + ownerDescriptor.get() +
                     "'s " + propertyName + " (" + clazz.getName() + ") generated Gizmo supplier.");
         }
     }


### PR DESCRIPTION
I noticed the native build was broken when trying CR3; it appears the PLANNING_SCORE member was either copied or moved to ScoreDescriptor, causing code to be generated for it (although it a static field, which cause issues, thus native build failing)
<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.
-->

### JIRA

<!-- Add a JIRA ticket link if it exists. -->
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
* https://github.com/kiegroup/drools/pull/3000
* https://github.com/kiegroup/optaplanner/pull/899
* etc.
-->

### Checklist
- [ ] Documentation updated if applicable.
- [ ] Upgrade recipe provided if applicable.

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>full downstream build</b> please add comment: <b>Jenkins run fdb</b>
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
* for a <b>Quarkus LTS check</b> please add comment: <b>Jenkins run LTS</b>
* for a <b>Native check</b> please add comment: <b>Jenkins run native</b>
</details>
