### PR TITLE
PLANNER-2341: Add @Autowire support for PlannerBenchmarkFactory in Spring Boot

### DIFF
--- a/optaplanner-spring-integration/optaplanner-spring-boot-autoconfigure/pom.xml
+++ b/optaplanner-spring-integration/optaplanner-spring-boot-autoconfigure/pom.xml
@@ -40,6 +40,13 @@
       <optional>true</optional>
     </dependency>
 
+    <!-- Need this so we can @Autowire Benchmark -->
+    <dependency>
+      <groupId>org.optaplanner</groupId>
+      <artifactId>optaplanner-benchmark</artifactId>
+      <optional>true</optional>
+    </dependency>
+
     <dependency>
       <groupId>org.optaplanner</groupId>
       <artifactId>optaplanner-persistence-jackson</artifactId>

--- a/optaplanner-spring-integration/optaplanner-spring-boot-autoconfigure/src/main/java/org/optaplanner/spring/boot/autoconfigure/BenchmarkProperties.java
+++ b/optaplanner-spring-integration/optaplanner-spring-boot-autoconfigure/src/main/java/org/optaplanner/spring/boot/autoconfigure/BenchmarkProperties.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.spring.boot.autoconfigure;
+
+import org.springframework.boot.context.properties.NestedConfigurationProperty;
+
+public class BenchmarkProperties {
+    private String solverBenchmarkConfigXml;
+    private String resultDirectory;
+
+    @NestedConfigurationProperty
+    private BenchmarkSolverProperties solver;
+
+    public String getSolverBenchmarkConfigXml() {
+        return solverBenchmarkConfigXml;
+    }
+
+    public void setSolverBenchmarkConfigXml(String solverBenchmarkConfigXml) {
+        this.solverBenchmarkConfigXml = solverBenchmarkConfigXml;
+    }
+
+    public String getResultDirectory() {
+        return resultDirectory;
+    }
+
+    public void setResultDirectory(String resultDirectory) {
+        this.resultDirectory = resultDirectory;
+    }
+
+    public BenchmarkSolverProperties getSolver() {
+        return solver;
+    }
+
+    public void setSolver(BenchmarkSolverProperties solver) {
+        this.solver = solver;
+    }
+
+    public static class BenchmarkSolverProperties {
+        private TerminationProperties termination;
+
+        public TerminationProperties getTermination() {
+            return termination;
+        }
+
+        public void setTermination(TerminationProperties termination) {
+            this.termination = termination;
+        }
+    }
+}

--- a/optaplanner-spring-integration/optaplanner-spring-boot-autoconfigure/src/main/java/org/optaplanner/spring/boot/autoconfigure/OptaPlannerAutoConfiguration.java
+++ b/optaplanner-spring-integration/optaplanner-spring-boot-autoconfigure/src/main/java/org/optaplanner/spring/boot/autoconfigure/OptaPlannerAutoConfiguration.java
@@ -211,7 +211,7 @@ public class OptaPlannerAutoConfiguration implements BeanClassLoaderAware {
             if (solverProperties.getMoveThreadCount() != null) {
                 solverConfig.setMoveThreadCount(solverProperties.getMoveThreadCount());
             }
-            applyTerminationProperties(solverConfig, solverProperties);
+            applyTerminationProperties(solverConfig, solverProperties.getTermination());
         }
     }
 
@@ -357,13 +357,12 @@ public class OptaPlannerAutoConfiguration implements BeanClassLoaderAware {
         return classList.get(0);
     }
 
-    private void applyTerminationProperties(SolverConfig solverConfig, SolverProperties solverProperties) {
+    static void applyTerminationProperties(SolverConfig solverConfig, TerminationProperties terminationProperties) {
         TerminationConfig terminationConfig = solverConfig.getTerminationConfig();
         if (terminationConfig == null) {
             terminationConfig = new TerminationConfig();
             solverConfig.setTerminationConfig(terminationConfig);
         }
-        TerminationProperties terminationProperties = solverProperties.getTermination();
         if (terminationProperties != null) {
             if (terminationProperties.getSpentLimit() != null) {
                 terminationConfig.overwriteSpentLimit(terminationProperties.getSpentLimit());

--- a/optaplanner-spring-integration/optaplanner-spring-boot-autoconfigure/src/main/java/org/optaplanner/spring/boot/autoconfigure/OptaPlannerBenchmarkAutoConfiguration.java
+++ b/optaplanner-spring-integration/optaplanner-spring-boot-autoconfigure/src/main/java/org/optaplanner/spring/boot/autoconfigure/OptaPlannerBenchmarkAutoConfiguration.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.spring.boot.autoconfigure;
+
+import java.io.File;
+
+import org.optaplanner.benchmark.api.PlannerBenchmarkFactory;
+import org.optaplanner.benchmark.config.PlannerBenchmarkConfig;
+import org.optaplanner.core.config.solver.SolverConfig;
+import org.optaplanner.core.config.solver.termination.TerminationConfig;
+import org.springframework.beans.factory.BeanClassLoaderAware;
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@AutoConfigureAfter(OptaPlannerAutoConfiguration.class)
+@ConditionalOnClass({ PlannerBenchmarkFactory.class })
+@ConditionalOnMissingBean({ PlannerBenchmarkFactory.class })
+@EnableConfigurationProperties({ OptaPlannerProperties.class })
+public class OptaPlannerBenchmarkAutoConfiguration
+        implements BeanClassLoaderAware {
+
+    private final ApplicationContext context;
+    private final OptaPlannerProperties optaPlannerProperties;
+    private ClassLoader beanClassLoader;
+
+    protected OptaPlannerBenchmarkAutoConfiguration(ApplicationContext context,
+            OptaPlannerProperties optaPlannerProperties) {
+        this.context = context;
+        this.optaPlannerProperties = optaPlannerProperties;
+    }
+
+    @Bean
+    public PlannerBenchmarkConfig plannerBenchmarkConfig(SolverConfig solverConfig) {
+        PlannerBenchmarkConfig benchmarkConfig;
+        if (optaPlannerProperties.getBenchmark() != null
+                && optaPlannerProperties.getBenchmark().getSolverBenchmarkConfigXml() != null) {
+            if (beanClassLoader.getResource(optaPlannerProperties.getBenchmark().getSolverBenchmarkConfigXml()) == null) {
+                throw new IllegalStateException(
+                        "Invalid optaplanner.benchmark.solverBenchmarkConfigXml property ("
+                                + optaPlannerProperties.getBenchmark().getSolverBenchmarkConfigXml()
+                                + "): that classpath resource does not exist.");
+            }
+            benchmarkConfig = PlannerBenchmarkConfig
+                    .createFromXmlResource(optaPlannerProperties.getBenchmark().getSolverBenchmarkConfigXml(), beanClassLoader);
+        } else if (beanClassLoader.getResource(OptaPlannerProperties.DEFAULT_SOLVER_BENCHMARK_CONFIG_URL) != null) {
+            benchmarkConfig = PlannerBenchmarkConfig.createFromXmlResource(
+                    OptaPlannerProperties.DEFAULT_SOLVER_CONFIG_URL, beanClassLoader);
+        } else {
+            benchmarkConfig = PlannerBenchmarkConfig.createFromSolverConfig(solverConfig);
+            benchmarkConfig.setBenchmarkDirectory(new File(OptaPlannerProperties.DEFAULT_BENCHMARK_RESULT_DIRECTORY));
+        }
+
+        if (optaPlannerProperties.getBenchmark() != null && optaPlannerProperties.getBenchmark().getResultDirectory() != null) {
+            benchmarkConfig.setBenchmarkDirectory(new File(optaPlannerProperties.getBenchmark().getResultDirectory()));
+        }
+
+        if (benchmarkConfig.getBenchmarkDirectory() == null) {
+            benchmarkConfig.setBenchmarkDirectory(new File(OptaPlannerProperties.DEFAULT_BENCHMARK_RESULT_DIRECTORY));
+        }
+
+        if (optaPlannerProperties.getBenchmark() != null && optaPlannerProperties.getBenchmark().getSolver() != null) {
+            OptaPlannerAutoConfiguration
+                    .applyTerminationProperties(benchmarkConfig.getInheritedSolverBenchmarkConfig().getSolverConfig(),
+                            optaPlannerProperties.getBenchmark().getSolver().getTermination());
+        }
+
+        if (!isTerminationConfigured(
+                benchmarkConfig.getInheritedSolverBenchmarkConfig().getSolverConfig().getTerminationConfig())) {
+            throw new IllegalStateException(
+                    "Property optaplanner.benchmark.solver.termination.spentLimit is required if termination is not configured.");
+        }
+        return benchmarkConfig;
+    }
+
+    @Bean
+    public PlannerBenchmarkFactory plannerBenchmarkFactory(PlannerBenchmarkConfig benchmarkConfig) {
+        return PlannerBenchmarkFactory.create(benchmarkConfig);
+    }
+
+    @Override
+    public void setBeanClassLoader(ClassLoader classLoader) {
+        this.beanClassLoader = classLoader;
+    }
+
+    private boolean isTerminationConfigured(TerminationConfig terminationConfig) {
+        return terminationConfig.getTerminationClass() != null ||
+                terminationConfig.getSpentLimit() != null ||
+                terminationConfig.getBestScoreLimit() != null ||
+                terminationConfig.getUnimprovedSpentLimit() != null ||
+                terminationConfig.getStepCountLimit() != null ||
+                terminationConfig.getTerminationConfigList() != null;
+    }
+}

--- a/optaplanner-spring-integration/optaplanner-spring-boot-autoconfigure/src/main/java/org/optaplanner/spring/boot/autoconfigure/OptaPlannerProperties.java
+++ b/optaplanner-spring-integration/optaplanner-spring-boot-autoconfigure/src/main/java/org/optaplanner/spring/boot/autoconfigure/OptaPlannerProperties.java
@@ -28,6 +28,8 @@ public class OptaPlannerProperties {
     public static final String DEFAULT_SOLVER_CONFIG_URL = "solverConfig.xml";
     public static final String DEFAULT_CONSTRAINTS_DRL_URL = "constraints.drl";
     public static final String SCORE_DRL_PROPERTY = "optaplanner.score-drl";
+    public static final String DEFAULT_BENCHMARK_RESULT_DIRECTORY = "target/benchmarks";
+    public static final String DEFAULT_SOLVER_BENCHMARK_CONFIG_URL = "solverBenchmarkConfig.xml";
 
     @NestedConfigurationProperty
     private SolverManagerProperties solverManager;
@@ -49,6 +51,9 @@ public class OptaPlannerProperties {
 
     @NestedConfigurationProperty
     private SolverProperties solver;
+
+    @NestedConfigurationProperty
+    private BenchmarkProperties benchmark;
 
     // ************************************************************************
     // Getters/setters
@@ -86,4 +91,11 @@ public class OptaPlannerProperties {
         this.solver = solver;
     }
 
+    public BenchmarkProperties getBenchmark() {
+        return benchmark;
+    }
+
+    public void setBenchmark(BenchmarkProperties benchmark) {
+        this.benchmark = benchmark;
+    }
 }

--- a/optaplanner-spring-integration/optaplanner-spring-boot-autoconfigure/src/main/resources/META-INF/spring.factories
+++ b/optaplanner-spring-integration/optaplanner-spring-boot-autoconfigure/src/main/resources/META-INF/spring.factories
@@ -1,1 +1,1 @@
-org.springframework.boot.autoconfigure.EnableAutoConfiguration=org.optaplanner.spring.boot.autoconfigure.OptaPlannerAutoConfiguration
+org.springframework.boot.autoconfigure.EnableAutoConfiguration=org.optaplanner.spring.boot.autoconfigure.OptaPlannerAutoConfiguration,org.optaplanner.spring.boot.autoconfigure.OptaPlannerBenchmarkAutoConfiguration


### PR DESCRIPTION
<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.
-->

### JIRA

<!-- Add a JIRA ticket link if it exists. -->
https://issues.redhat.com/browse/PLANNER-2341

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
* https://github.com/kiegroup/drools/pull/3000
* https://github.com/kiegroup/optaplanner/pull/899
* etc.
-->

### Checklist
- [ ] Documentation updated if applicable.
- [ ] Upgrade recipe provided if applicable.

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>full downstream build</b> please add comment: <b>Jenkins run fdb</b>
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
* for a <b>Quarkus LTS check</b> please add comment: <b>Jenkins run LTS</b>
* for a <b>Native check</b> please add comment: <b>Jenkins run native</b>
</details>
