### PR TITLE
BAQE-1904 - Change revapi to check against 7.52.0.Final

### DIFF
--- a/optaplanner-benchmark/src/build/revapi-config.json
+++ b/optaplanner-benchmark/src/build/revapi-config.json
@@ -25,7 +25,7 @@
   },
   "ignores": {
     "revapi": {
-      "_comment": "Changes between 7.48.0.Final and the current branch. These changes are desired and thus ignored.",
+      "_comment": "Changes between 7.52.0.Final and the current branch. These changes are desired and thus ignored.",
       "ignore": []
     }
   }

--- a/optaplanner-core/src/build/revapi-config.json
+++ b/optaplanner-core/src/build/revapi-config.json
@@ -25,7 +25,7 @@
   },
   "ignores": {
     "revapi": {
-      "_comment": "Changes between 7.48.0.Final and the current branch. These changes are desired and thus ignored.",
+      "_comment": "Changes between 7.52.0.Final and the current branch. These changes are desired and thus ignored.",
       "ignore": []
     }
   }

--- a/optaplanner-persistence/optaplanner-persistence-jpa/src/build/revapi-config.json
+++ b/optaplanner-persistence/optaplanner-persistence-jpa/src/build/revapi-config.json
@@ -16,7 +16,7 @@
   },
   "ignores": {
     "revapi": {
-      "_comment": "Changes between 7.48.0.Final and the current branch. These changes are desired and thus ignored.",
+      "_comment": "Changes between 7.52.0.Final and the current branch. These changes are desired and thus ignored.",
       "ignore": []
     }
   }

--- a/optaplanner-test/src/build/revapi-config.json
+++ b/optaplanner-test/src/build/revapi-config.json
@@ -16,7 +16,7 @@
   },
   "ignores": {
     "revapi": {
-      "_comment": "Changes between 7.48.0.Final and the current branch. These changes are desired and thus ignored.",
+      "_comment": "Changes between 7.52.0.Final and the current branch. These changes are desired and thus ignored.",
       "ignore": []
     }
   }


### PR DESCRIPTION
**JIRA**: [BAQE-1904](https://issues.redhat.com/browse/BAQE-1904)

depends on https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1665
