### PR TITLE
PLANNER-2441: Make tests compatiable with Quarkus 2.x

### DIFF
--- a/optaplanner-quarkus-integration/optaplanner-quarkus-benchmark/deployment/src/test/java/org/optaplanner/benchmark/quarkus/OptaPlannerBenchmarkProcessorMissingSpentLimitTest.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus-benchmark/deployment/src/test/java/org/optaplanner/benchmark/quarkus/OptaPlannerBenchmarkProcessorMissingSpentLimitTest.java
@@ -36,7 +36,7 @@ import io.quarkus.test.QuarkusUnitTest;
 public class OptaPlannerBenchmarkProcessorMissingSpentLimitTest {
 
     @RegisterExtension
-    static final QuarkusUnitTest config = new QuarkusUnitTest()
+    static final QuarkusUnitTest config = new QuarkusUnitTest().setFlatClassPath(true)
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
                     .addClasses(TestdataQuarkusEntity.class,
                             TestdataQuarkusSolution.class, TestdataQuarkusConstraintProvider.class));

--- a/optaplanner-quarkus-integration/optaplanner-quarkus-benchmark/deployment/src/test/java/org/optaplanner/benchmark/quarkus/OptaPlannerBenchmarkProcessorMissingSpentLimitTest.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus-benchmark/deployment/src/test/java/org/optaplanner/benchmark/quarkus/OptaPlannerBenchmarkProcessorMissingSpentLimitTest.java
@@ -36,7 +36,8 @@ import io.quarkus.test.QuarkusUnitTest;
 public class OptaPlannerBenchmarkProcessorMissingSpentLimitTest {
 
     @RegisterExtension
-    static final QuarkusUnitTest config = new QuarkusUnitTest().setFlatClassPath(true)
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .overrideConfigKey("quarkus.test.flat-class-path", "true")
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
                     .addClasses(TestdataQuarkusEntity.class,
                             TestdataQuarkusSolution.class, TestdataQuarkusConstraintProvider.class));

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/pom.xml
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/pom.xml
@@ -108,6 +108,15 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <systemPropertyVariables>
+            <version.io.quarkus>${version.io.quarkus}</version.io.quarkus>
+            <project.version>${project.version}</project.version>
+          </systemPropertyVariables>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/test/java/org/optaplanner/quarkus/OptaPlannerProcessorGeneratedGizmoSupplierTest.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/test/java/org/optaplanner/quarkus/OptaPlannerProcessorGeneratedGizmoSupplierTest.java
@@ -79,7 +79,8 @@ public class OptaPlannerProcessorGeneratedGizmoSupplierTest {
                             DummySolutionPartitioner.class,
                             DummyValueFilter.class))
             .addBuildChainCustomizer(buildChainBuilder -> buildChainBuilder.addBuildStep(context -> {
-                context.produce(CapabilityBuildItem.class, new CapabilityBuildItem("kogito-rules"));
+                context.produce(CapabilityBuildItem.class, new CapabilityBuildItem("kogito-rules",
+                        OptaPlannerProcessorGeneratedGizmoSupplierTest.class.getName()));
             }).produces(CapabilityBuildItem.class).build());
 
     @Inject

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/test/java/org/optaplanner/quarkus/OptaPlannerProcessorGeneratedGizmoSupplierTest.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/test/java/org/optaplanner/quarkus/OptaPlannerProcessorGeneratedGizmoSupplierTest.java
@@ -59,6 +59,7 @@ public class OptaPlannerProcessorGeneratedGizmoSupplierTest {
 
     @RegisterExtension
     static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .overrideConfigKey("quarkus.test.flat-class-path", "true")
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
                     .addAsResource("org/optaplanner/quarkus/gizmoSupplierTestSolverConfig.xml",
                             "solverConfig.xml")
@@ -79,8 +80,7 @@ public class OptaPlannerProcessorGeneratedGizmoSupplierTest {
                             DummySolutionPartitioner.class,
                             DummyValueFilter.class))
             .addBuildChainCustomizer(buildChainBuilder -> buildChainBuilder.addBuildStep(context -> {
-                context.produce(CapabilityBuildItem.class, new CapabilityBuildItem("kogito-rules",
-                        OptaPlannerProcessorGeneratedGizmoSupplierTest.class.getName()));
+                context.produce(CapabilityBuildItem.class, new CapabilityBuildItem("kogito-rules"));
             }).produces(CapabilityBuildItem.class).build());
 
     @Inject

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/test/java/org/optaplanner/quarkus/OptaPlannerProcessorOverridePropertiesAtRuntimeTest.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/test/java/org/optaplanner/quarkus/OptaPlannerProcessorOverridePropertiesAtRuntimeTest.java
@@ -46,12 +46,23 @@ import io.restassured.RestAssured;
 
 public class OptaPlannerProcessorOverridePropertiesAtRuntimeTest {
 
+    private static final String QUARKUS_VERSION = getRequiredProperty("version.io.quarkus");
+    private static final String PROJECT_VERSION = getRequiredProperty("project.version");
+
+    private static String getRequiredProperty(String name) {
+        final String v = System.getProperty(name);
+        if (v == null || v.isEmpty()) {
+            throw new IllegalStateException("System property " + name + " has not been set");
+        }
+        return v;
+    }
+
     @RegisterExtension
     static final QuarkusProdModeTest config = new QuarkusProdModeTest()
             .setForcedDependencies(Arrays.asList(
                     // TODO: Remove optaplanner-test when https://github.com/kiegroup/optaplanner/pull/1302 is merged?
-                    new AppArtifact("org.optaplanner", "optaplanner-test", "8.1.0.Final"),
-                    new AppArtifact("io.quarkus", "quarkus-resteasy", "1.11.0.Final")))
+                    new AppArtifact("org.optaplanner", "optaplanner-test", PROJECT_VERSION),
+                    new AppArtifact("io.quarkus", "quarkus-resteasy", QUARKUS_VERSION)))
             // We want to check if these are overridden at runtime
             .overrideConfigKey("quarkus.optaplanner.solver.termination.best-score-limit", "0")
             .overrideConfigKey("quarkus.optaplanner.solver.move-thread-count", "4")

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/test/java/org/optaplanner/quarkus/OptaPlannerProcessorOverridePropertiesAtRuntimeTest.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/test/java/org/optaplanner/quarkus/OptaPlannerProcessorOverridePropertiesAtRuntimeTest.java
@@ -52,7 +52,7 @@ public class OptaPlannerProcessorOverridePropertiesAtRuntimeTest {
     private static String getRequiredProperty(String name) {
         final String v = System.getProperty(name);
         if (v == null || v.isEmpty()) {
-            throw new IllegalStateException("System property " + name + " has not been set");
+            throw new IllegalStateException("The system property (" + name + ") has not been set.");
         }
         return v;
     }

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/test/java/org/optaplanner/quarkus/constraints/OptaPlannerProcessorConstraintProviderAndDrlTest.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/test/java/org/optaplanner/quarkus/constraints/OptaPlannerProcessorConstraintProviderAndDrlTest.java
@@ -49,7 +49,8 @@ public class OptaPlannerProcessorConstraintProviderAndDrlTest {
                     .addAsResource("org/optaplanner/quarkus/constraints/defaultConstraints.drl", CONSTRAINTS_DRL))
             .overrideConfigKey(OptaPlannerBuildTimeConfig.CONSTRAINTS_DRL_PROPERTY, CONSTRAINTS_DRL)
             .addBuildChainCustomizer(buildChainBuilder -> buildChainBuilder.addBuildStep(context -> {
-                context.produce(CapabilityBuildItem.class, new CapabilityBuildItem("kogito-rules"));
+                context.produce(CapabilityBuildItem.class, new CapabilityBuildItem("kogito-rules",
+                        OptaPlannerProcessorConstraintProviderAndDrlTest.class.getName()));
             }).produces(CapabilityBuildItem.class).build());
 
     @Inject

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/test/java/org/optaplanner/quarkus/constraints/OptaPlannerProcessorConstraintProviderAndDrlTest.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/test/java/org/optaplanner/quarkus/constraints/OptaPlannerProcessorConstraintProviderAndDrlTest.java
@@ -49,8 +49,7 @@ public class OptaPlannerProcessorConstraintProviderAndDrlTest {
                     .addAsResource("org/optaplanner/quarkus/constraints/defaultConstraints.drl", CONSTRAINTS_DRL))
             .overrideConfigKey(OptaPlannerBuildTimeConfig.CONSTRAINTS_DRL_PROPERTY, CONSTRAINTS_DRL)
             .addBuildChainCustomizer(buildChainBuilder -> buildChainBuilder.addBuildStep(context -> {
-                context.produce(CapabilityBuildItem.class, new CapabilityBuildItem("kogito-rules",
-                        OptaPlannerProcessorConstraintProviderAndDrlTest.class.getName()));
+                context.produce(CapabilityBuildItem.class, new CapabilityBuildItem("kogito-rules"));
             }).produces(CapabilityBuildItem.class).build());
 
     @Inject

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/test/java/org/optaplanner/quarkus/constraints/OptaPlannerProcessorConstraintsDrlDefaultTest.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/test/java/org/optaplanner/quarkus/constraints/OptaPlannerProcessorConstraintsDrlDefaultTest.java
@@ -46,7 +46,7 @@ public class OptaPlannerProcessorConstraintsDrlDefaultTest {
                     .addAsResource("org/optaplanner/quarkus/constraints/defaultConstraints.drl", "constraints.drl"))
             .addBuildChainCustomizer(buildChainBuilder -> buildChainBuilder.addBuildStep(context -> {
                 context.produce(CapabilityBuildItem.class,
-                        new CapabilityBuildItem("kogito-rules", OptaPlannerProcessorConstraintsDrlDefaultTest.class.getName()));
+                        new CapabilityBuildItem("kogito-rules"));
             }).produces(CapabilityBuildItem.class).build());
 
     @Inject

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/test/java/org/optaplanner/quarkus/constraints/OptaPlannerProcessorConstraintsDrlDefaultTest.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/test/java/org/optaplanner/quarkus/constraints/OptaPlannerProcessorConstraintsDrlDefaultTest.java
@@ -45,7 +45,8 @@ public class OptaPlannerProcessorConstraintsDrlDefaultTest {
                             TestdataQuarkusSolution.class, KieRuntimeBuilderMock.class)
                     .addAsResource("org/optaplanner/quarkus/constraints/defaultConstraints.drl", "constraints.drl"))
             .addBuildChainCustomizer(buildChainBuilder -> buildChainBuilder.addBuildStep(context -> {
-                context.produce(CapabilityBuildItem.class, new CapabilityBuildItem("kogito-rules"));
+                context.produce(CapabilityBuildItem.class,
+                        new CapabilityBuildItem("kogito-rules", OptaPlannerProcessorConstraintsDrlDefaultTest.class.getName()));
             }).produces(CapabilityBuildItem.class).build());
 
     @Inject

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/test/java/org/optaplanner/quarkus/constraints/OptaPlannerProcessorConstraintsDrlTest.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/test/java/org/optaplanner/quarkus/constraints/OptaPlannerProcessorConstraintsDrlTest.java
@@ -49,7 +49,8 @@ class OptaPlannerProcessorConstraintsDrlTest {
                     .addAsResource("org/optaplanner/quarkus/constraints/defaultConstraints.drl", CONSTRAINTS_DRL))
             .overrideConfigKey(OptaPlannerBuildTimeConfig.CONSTRAINTS_DRL_PROPERTY, CONSTRAINTS_DRL)
             .addBuildChainCustomizer(buildChainBuilder -> buildChainBuilder.addBuildStep(context -> {
-                context.produce(CapabilityBuildItem.class, new CapabilityBuildItem("kogito-rules"));
+                context.produce(CapabilityBuildItem.class,
+                        new CapabilityBuildItem("kogito-rules", OptaPlannerProcessorConstraintsDrlTest.class.getName()));
             }).produces(CapabilityBuildItem.class).build());
 
     @Inject

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/test/java/org/optaplanner/quarkus/constraints/OptaPlannerProcessorConstraintsDrlTest.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/test/java/org/optaplanner/quarkus/constraints/OptaPlannerProcessorConstraintsDrlTest.java
@@ -50,7 +50,7 @@ class OptaPlannerProcessorConstraintsDrlTest {
             .overrideConfigKey(OptaPlannerBuildTimeConfig.CONSTRAINTS_DRL_PROPERTY, CONSTRAINTS_DRL)
             .addBuildChainCustomizer(buildChainBuilder -> buildChainBuilder.addBuildStep(context -> {
                 context.produce(CapabilityBuildItem.class,
-                        new CapabilityBuildItem("kogito-rules", OptaPlannerProcessorConstraintsDrlTest.class.getName()));
+                        new CapabilityBuildItem("kogito-rules"));
             }).produces(CapabilityBuildItem.class).build());
 
     @Inject


### PR DESCRIPTION
This PR is a duplicate of https://github.com/kiegroup/optaplanner/pull/1350, rebased on master. It appears the Jenkins job on it got stuck, and the actions at the time were using an outdated master.
<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.
-->

### JIRA

<!-- Add a JIRA ticket link if it exists. -->
https://issues.redhat.com/browse/PLANNER-2441

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
* https://github.com/kiegroup/drools/pull/3000
* https://github.com/kiegroup/optaplanner/pull/899
* etc.
-->

### Checklist
- [ ] Documentation updated if applicable.
- [ ] Upgrade recipe provided if applicable.

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>specific pull request build</b> please add comment: <b>Jenkins (re)run [optaplanner|apps|examples] tests</b>
* for a <b>full downstream build</b> please add comment: <b>Jenkins run fdb</b>
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
* for a <b>Quarkus LTS check</b> please add comment: <b>Jenkins run LTS</b>
* for a <b>specific Quarkus LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner|apps|examples] LTS</b>
* for a <b>Native check</b> please add comment: <b>Jenkins run native</b>
* for a <b>specific Native LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner|apps|examples] native</b>
</details>