### PR TITLE
PLANNER-2411: Add solver config, constraint list, and model to Quarkus Dev UI

### DIFF
--- a/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/main/java/org/optaplanner/quarkus/deployment/OptaPlannerProcessor.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/main/java/org/optaplanner/quarkus/deployment/OptaPlannerProcessor.java
@@ -18,6 +18,7 @@ package org.optaplanner.quarkus.deployment;
 
 import static io.quarkus.deployment.annotations.ExecutionTime.STATIC_INIT;
 
+import java.io.StringWriter;
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -54,10 +55,12 @@ import org.optaplanner.core.config.score.director.ScoreDirectorFactoryConfig;
 import org.optaplanner.core.config.solver.SolverConfig;
 import org.optaplanner.core.config.solver.SolverManagerConfig;
 import org.optaplanner.core.impl.domain.solution.descriptor.SolutionDescriptor;
+import org.optaplanner.core.impl.io.jaxb.SolverConfigIO;
 import org.optaplanner.quarkus.OptaPlannerBeanProvider;
 import org.optaplanner.quarkus.OptaPlannerRecorder;
 import org.optaplanner.quarkus.config.OptaPlannerRuntimeConfig;
 import org.optaplanner.quarkus.deployment.config.OptaPlannerBuildTimeConfig;
+import org.optaplanner.quarkus.devui.OptaPlannerDevUIPropertiesSupplier;
 import org.optaplanner.quarkus.gizmo.OptaPlannerGizmoBeanFactory;
 
 import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
@@ -67,6 +70,7 @@ import io.quarkus.arc.deployment.SyntheticBeanBuildItem;
 import io.quarkus.arc.deployment.UnremovableBeanBuildItem;
 import io.quarkus.deployment.Capabilities;
 import io.quarkus.deployment.GeneratedClassGizmoAdaptor;
+import io.quarkus.deployment.IsDevelopment;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.Record;
@@ -79,6 +83,7 @@ import io.quarkus.deployment.builditem.IndexDependencyBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveHierarchyBuildItem;
 import io.quarkus.deployment.pkg.steps.NativeBuild;
 import io.quarkus.deployment.recording.RecorderContext;
+import io.quarkus.devconsole.spi.DevConsoleRuntimeTemplateInfoBuildItem;
 import io.quarkus.gizmo.ClassOutput;
 import io.quarkus.gizmo.MethodDescriptor;
 import io.quarkus.gizmo.ResultHandle;
@@ -120,9 +125,24 @@ class OptaPlannerProcessor {
         unremovableBeans.produce(UnremovableBeanBuildItem.beanTypes(OptaPlannerGizmoBeanFactory.class));
     }
 
+    @BuildStep(onlyIf = IsDevelopment.class)
+    public DevConsoleRuntimeTemplateInfoBuildItem getSolverConfig(SolverConfigBuildStep solverConfigBuildStep) {
+        SolverConfig solverConfig = solverConfigBuildStep.getSolverConfig();
+        if (solverConfig != null) {
+            StringWriter effectiveSolverConfigWriter = new StringWriter();
+            SolverConfigIO solverConfigIO = new SolverConfigIO();
+            solverConfigIO.write(solverConfig, effectiveSolverConfigWriter);
+            return new DevConsoleRuntimeTemplateInfoBuildItem("solverConfigProperties",
+                    new OptaPlannerDevUIPropertiesSupplier(effectiveSolverConfigWriter.toString()));
+        } else {
+            return new DevConsoleRuntimeTemplateInfoBuildItem("solverConfigProperties",
+                    new OptaPlannerDevUIPropertiesSupplier());
+        }
+    }
+
     @BuildStep
     @Record(STATIC_INIT)
-    void recordAndRegisterBeans(OptaPlannerRecorder recorder, RecorderContext recorderContext,
+    SolverConfigBuildStep recordAndRegisterBeans(OptaPlannerRecorder recorder, RecorderContext recorderContext,
             CombinedIndexBuildItem combinedIndex, Capabilities capabilities,
             BuildProducer<ReflectiveHierarchyBuildItem> reflectiveHierarchyClass,
             BuildProducer<SyntheticBeanBuildItem> syntheticBeanBuildItemBuildProducer,
@@ -142,7 +162,7 @@ class OptaPlannerProcessor {
                     + " the Jandex index by using the jandex-maven-plugin in that dependency, or by adding"
                     + "application.properties entries (quarkus.index-dependency.<name>.group-id"
                     + " and quarkus.index-dependency.<name>.artifact-id).");
-            return;
+            return new SolverConfigBuildStep(null);
         }
 
         // Quarkus extensions must always use getContextClassLoader()
@@ -204,6 +224,10 @@ class OptaPlannerProcessor {
                         GizmoMemberAccessorEntityEnhancer.getDroolsInitializer(recorderContext)))
                 .done());
 
+        StringWriter effectiveSolverConfigXMLWriter = new StringWriter();
+        SolverConfigIO solverConfigIO = new SolverConfigIO();
+        solverConfigIO.write(solverConfig, effectiveSolverConfigXMLWriter);
+
         syntheticBeanBuildItemBuildProducer.produce(SyntheticBeanBuildItem.configure(SolverManagerConfig.class)
                 .scope(Singleton.class)
                 .defaultBean()
@@ -211,6 +235,7 @@ class OptaPlannerProcessor {
 
         additionalBeans.produce(new AdditionalBeanBuildItem(OptaPlannerBeanProvider.class));
         unremovableBeans.produce(UnremovableBeanBuildItem.beanTypes(OptaPlannerRuntimeConfig.class));
+        return new SolverConfigBuildStep(solverConfig);
     }
 
     private void generateConstraintVerifier(SolverConfig solverConfig,

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/main/java/org/optaplanner/quarkus/deployment/OptaPlannerProcessor.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/main/java/org/optaplanner/quarkus/deployment/OptaPlannerProcessor.java
@@ -224,10 +224,6 @@ class OptaPlannerProcessor {
                         GizmoMemberAccessorEntityEnhancer.getDroolsInitializer(recorderContext)))
                 .done());
 
-        StringWriter effectiveSolverConfigXMLWriter = new StringWriter();
-        SolverConfigIO solverConfigIO = new SolverConfigIO();
-        solverConfigIO.write(solverConfig, effectiveSolverConfigXMLWriter);
-
         syntheticBeanBuildItemBuildProducer.produce(SyntheticBeanBuildItem.configure(SolverManagerConfig.class)
                 .scope(Singleton.class)
                 .defaultBean()

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/main/java/org/optaplanner/quarkus/deployment/SolverConfigBuildStep.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/main/java/org/optaplanner/quarkus/deployment/SolverConfigBuildStep.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.quarkus.deployment;
+
+import org.optaplanner.core.config.solver.SolverConfig;
+
+import io.quarkus.builder.item.SimpleBuildItem;
+
+public final class SolverConfigBuildStep extends SimpleBuildItem {
+    SolverConfig solverConfig;
+
+    public SolverConfigBuildStep(SolverConfig solverConfig) {
+        this.solverConfig = solverConfig;
+    }
+
+    public SolverConfig getSolverConfig() {
+        return solverConfig;
+    }
+}

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/main/resources/dev-templates/constraints.html
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/main/resources/dev-templates/constraints.html
@@ -1,0 +1,35 @@
+<!--
+  ~ Copyright 2021 Red Hat, Inc. and/or its affiliates.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+{#include main}
+
+{#title}Constraints{/title}
+
+{#body}
+<table class="table table-striped">
+    <thead class="thead-dark">
+    <tr>
+        <th scope="col">Constraints</th>
+    </tr>
+    </thead>
+    <tbody>
+    {#for constraint in info:solverConfigProperties.constraintList}
+        <tr><td>{constraint}</td></tr>
+    {/for}
+    </tbody>
+</table>
+{/body}
+{/include}

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/main/resources/dev-templates/embedded.html
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/main/resources/dev-templates/embedded.html
@@ -1,0 +1,27 @@
+<!--
+  ~ Copyright 2021 Red Hat, Inc. and/or its affiliates.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<a href="{urlbase}/solverConfig" class="badge badge-light">
+    <i class="fas fa-wrench"></i>
+    View Effective Solver Configuration
+</a>
+<a href="{urlbase}/model" class="badge badge-light">
+    <i class="fas fa-wrench"></i>
+    View Model
+</a>
+<a href="{urlbase}/constraints" class="badge badge-light">
+    <i class="fas fa-wrench"></i>
+    View Constraints
+</a>

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/main/resources/dev-templates/model.html
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/main/resources/dev-templates/model.html
@@ -1,0 +1,74 @@
+<!--
+~ Copyright 2021 Red Hat, Inc. and/or its affiliates.
+~
+~ Licensed under the Apache License, Version 2.0 (the "License");
+~ you may not use this file except in compliance with the License.
+~ You may obtain a copy of the License at
+~
+~      http://www.apache.org/licenses/LICENSE-2.0
+~
+~ Unless required by applicable law or agreed to in writing, software
+~ distributed under the License is distributed on an "AS IS" BASIS,
+~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+~ See the License for the specific language governing permissions and
+~ limitations under the License.
+-->
+{#include main}
+
+{#title}Model{/title}
+
+<!--
+  ~ Copyright 2021 Red Hat, Inc. and/or its affiliates.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+{#body}
+<div class="card h-100 shadow">
+    <div class="card-header bg-primary text-light">Solution: {info:solverConfigProperties.optaPlannerModelProperties.solutionClass}</div>
+    <div class="card-body">
+    {#for entityClass in info:solverConfigProperties.optaPlannerModelProperties.entityClassList}
+    <div class="card h-100 shadow">
+        <div class="card-header">Entity: {entityClass}</div>
+        <div class="card-body">
+            <table class="table table-striped">
+                <thead class="thead-dark">
+                    <tr>
+                        <th scope="col">Genuine Variables</th>
+                    </tr>
+                </thead>
+                <tbody>
+                {#for genuineVariable in info:solverConfigProperties.optaPlannerModelProperties.entityClassToGenuineVariableListMap.get(entityClass)}
+                    <tr><td>{genuineVariable}</td></tr>
+                {/for}
+                </tbody>
+            </table>
+            <table class="table table-striped">
+                <thead class="thead-dark">
+                <tr>
+                    <th scope="col">Shadow Variables</th>
+                </tr>
+                </thead>
+                <tbody>
+                {#for shadowVariable in info:solverConfigProperties.optaPlannerModelProperties.entityClassToShadowVariableListMap.get(entityClass)}
+                    <tr><td>{shadowVariable}</td></tr>
+                {/for}
+                </tbody>
+            </table>
+        </div>
+    </div>
+    {/for}
+    </div>
+</div>
+{/body}
+{/include}

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/main/resources/dev-templates/model.html
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/main/resources/dev-templates/model.html
@@ -38,9 +38,10 @@
     <div class="card-header bg-primary text-light">Solution: {info:solverConfigProperties.optaPlannerModelProperties.solutionClass}</div>
     <div class="card-body">
     {#for entityClass in info:solverConfigProperties.optaPlannerModelProperties.entityClassList}
-    <div class="card h-100 shadow">
+        <div class="card h-100 shadow">
         <div class="card-header">Entity: {entityClass}</div>
         <div class="card-body">
+            {#if !info:solverConfigProperties.optaPlannerModelProperties.entityClassToGenuineVariableListMap.get(entityClass).isEmpty()}
             <table class="table table-striped">
                 <thead class="thead-dark">
                     <tr>
@@ -53,6 +54,8 @@
                 {/for}
                 </tbody>
             </table>
+            {/if}
+            {#if !info:solverConfigProperties.optaPlannerModelProperties.entityClassToShadowVariableListMap.get(entityClass).isEmpty()}
             <table class="table table-striped">
                 <thead class="thead-dark">
                 <tr>
@@ -65,6 +68,7 @@
                 {/for}
                 </tbody>
             </table>
+            {/if}
         </div>
     </div>
     {/for}

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/main/resources/dev-templates/solverConfig.html
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/main/resources/dev-templates/solverConfig.html
@@ -1,0 +1,47 @@
+<!--
+~ Copyright 2021 Red Hat, Inc. and/or its affiliates.
+~
+~ Licensed under the Apache License, Version 2.0 (the "License");
+~ you may not use this file except in compliance with the License.
+~ You may obtain a copy of the License at
+~
+~      http://www.apache.org/licenses/LICENSE-2.0
+~
+~ Unless required by applicable law or agreed to in writing, software
+~ distributed under the License is distributed on an "AS IS" BASIS,
+~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+~ See the License for the specific language governing permissions and
+~ limitations under the License.
+-->
+{#include main}
+
+{#style}
+.solver-config {
+white-space: pre-wrap;
+}
+{/style}
+
+{#title}Solver Configuration{/title}
+
+<!--
+  ~ Copyright 2021 Red Hat, Inc. and/or its affiliates.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+{#body}
+<div class="solver-config">
+    {info:solverConfigProperties.effectiveSolverConfig}
+</div>
+{/body}
+{/include}

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/main/resources/dev-templates/solverConfig.html
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/main/resources/dev-templates/solverConfig.html
@@ -15,33 +15,10 @@
 -->
 {#include main}
 
-{#style}
-.solver-config {
-white-space: pre-wrap;
-}
-{/style}
-
 {#title}Solver Configuration{/title}
-
-<!--
-  ~ Copyright 2021 Red Hat, Inc. and/or its affiliates.
-  ~
-  ~ Licensed under the Apache License, Version 2.0 (the "License");
-  ~ you may not use this file except in compliance with the License.
-  ~ You may obtain a copy of the License at
-  ~
-  ~      http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing, software
-  ~ distributed under the License is distributed on an "AS IS" BASIS,
-  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~ See the License for the specific language governing permissions and
-  ~ limitations under the License.
-  -->
-
 {#body}
-<div class="solver-config">
-    {info:solverConfigProperties.effectiveSolverConfig}
-</div>
+<pre>
+{info:solverConfigProperties.effectiveSolverConfig}
+</pre>
 {/body}
 {/include}

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/devui-integration-test/.gitignore
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/devui-integration-test/.gitignore
@@ -1,0 +1,10 @@
+/target
+/local
+
+# Eclipse, Netbeans and IntelliJ files
+/.*
+!.gitignore
+/nbproject
+/*.ipr
+/*.iws
+/*.iml

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/devui-integration-test/pom.xml
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/devui-integration-test/pom.xml
@@ -1,0 +1,125 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.optaplanner</groupId>
+    <artifactId>optaplanner-quarkus-parent</artifactId>
+    <version>8.9.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>optaplanner-quarkus-devui-integration-test</artifactId>
+  <name>OptaPlanner Quarkus - Dev UI Integration tests</name>
+  <description>Quarkus Dev UI integration tests for OptaPlanner</description>
+
+  <properties>
+    <java.module.name>org.optaplanner.quarkus</java.module.name>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-arc</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-resteasy</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.optaplanner</groupId>
+      <artifactId>optaplanner-quarkus</artifactId>
+    </dependency>
+
+    <!-- test dependencies -->
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-junit5</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.rest-assured</groupId>
+      <artifactId>rest-assured</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-junit5-internal</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>io.quarkus</groupId>
+        <artifactId>quarkus-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <goals>
+              <goal>build</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <executions>
+          <execution>
+            <!-- Transitive dependencies through quarkus are expected in this module. -->
+            <id>analyze-only</id>
+            <phase>none</phase>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <artifactId>maven-failsafe-plugin</artifactId>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+  <profiles>
+    <profile>
+      <id>native</id>
+      <activation>
+        <property>
+          <name>native</name>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-failsafe-plugin</artifactId>
+            <configuration>
+              <skip>false</skip>
+            </configuration>
+            <executions>
+              <execution>
+                <goals>
+                  <goal>integration-test</goal>
+                  <goal>verify</goal>
+                </goals>
+                <configuration>
+                  <systemPropertyVariables>
+                    <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
+                  </systemPropertyVariables>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+      <properties>
+        <quarkus.package.type>native</quarkus.package.type>
+      </properties>
+    </profile>
+  </profiles>
+</project>

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/devui-integration-test/pom.xml
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/devui-integration-test/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.optaplanner</groupId>
     <artifactId>optaplanner-quarkus-parent</artifactId>
-    <version>8.9.0-SNAPSHOT</version>
+    <version>8.10.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>optaplanner-quarkus-devui-integration-test</artifactId>

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/devui-integration-test/src/main/java/org/optaplanner/quarkus/it/devui/OptaPlannerTestResource.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/devui-integration-test/src/main/java/org/optaplanner/quarkus/it/devui/OptaPlannerTestResource.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.quarkus.it.devui;
+
+import java.util.Arrays;
+import java.util.concurrent.ExecutionException;
+
+import javax.inject.Inject;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import org.optaplanner.core.api.solver.SolverJob;
+import org.optaplanner.core.api.solver.SolverManager;
+import org.optaplanner.quarkus.it.devui.domain.TestdataStringLengthShadowEntity;
+import org.optaplanner.quarkus.it.devui.domain.TestdataStringLengthShadowSolution;
+
+@Path("/optaplanner/test")
+public class OptaPlannerTestResource {
+
+    @Inject
+    SolverManager<TestdataStringLengthShadowSolution, Long> solverManager;
+
+    @POST
+    @Path("/solver-factory")
+    @Produces(MediaType.TEXT_PLAIN)
+    public String solveWithSolverFactory() {
+        TestdataStringLengthShadowSolution planningProblem = new TestdataStringLengthShadowSolution();
+        planningProblem.setEntityList(Arrays.asList(
+                new TestdataStringLengthShadowEntity(),
+                new TestdataStringLengthShadowEntity()));
+        planningProblem.setValueList(Arrays.asList("a", "bb", "ccc"));
+        SolverJob<TestdataStringLengthShadowSolution, Long> solverJob = solverManager.solve(1L, planningProblem);
+        try {
+            return solverJob.getFinalBestSolution().getScore().toString();
+        } catch (InterruptedException | ExecutionException e) {
+            throw new IllegalStateException("Solving failed.", e);
+        }
+    }
+
+}

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/devui-integration-test/src/main/java/org/optaplanner/quarkus/it/devui/domain/StringLengthVariableListener.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/devui-integration-test/src/main/java/org/optaplanner/quarkus/it/devui/domain/StringLengthVariableListener.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.quarkus.it.devui.domain;
+
+import org.optaplanner.core.api.domain.variable.VariableListener;
+import org.optaplanner.core.api.score.director.ScoreDirector;
+
+public class StringLengthVariableListener
+        implements VariableListener<TestdataStringLengthShadowSolution, TestdataStringLengthShadowEntity> {
+
+    @Override
+    public void beforeEntityAdded(ScoreDirector<TestdataStringLengthShadowSolution> scoreDirector,
+            TestdataStringLengthShadowEntity entity) {
+        /* Nothing to do */
+    }
+
+    @Override
+    public void afterEntityAdded(ScoreDirector<TestdataStringLengthShadowSolution> scoreDirector,
+            TestdataStringLengthShadowEntity entity) {
+        /* Nothing to do */
+    }
+
+    @Override
+    public void beforeVariableChanged(ScoreDirector<TestdataStringLengthShadowSolution> scoreDirector,
+            TestdataStringLengthShadowEntity entity) {
+        /* Nothing to do */
+    }
+
+    @Override
+    public void afterVariableChanged(ScoreDirector<TestdataStringLengthShadowSolution> scoreDirector,
+            TestdataStringLengthShadowEntity entity) {
+        int oldLength = (entity.getLength() != null) ? entity.getLength() : 0;
+        int newLength = getLength(entity.getValue());
+        if (oldLength != newLength) {
+            scoreDirector.beforeVariableChanged(entity, "length");
+            entity.setLength(getLength(entity.getValue()));
+            scoreDirector.afterVariableChanged(entity, "length");
+        }
+    }
+
+    @Override
+    public void beforeEntityRemoved(ScoreDirector<TestdataStringLengthShadowSolution> scoreDirector,
+            TestdataStringLengthShadowEntity entity) {
+        /* Nothing to do */
+    }
+
+    @Override
+    public void afterEntityRemoved(ScoreDirector<TestdataStringLengthShadowSolution> scoreDirector,
+            TestdataStringLengthShadowEntity entity) {
+        /* Nothing to do */
+    }
+
+    private static int getLength(String value) {
+        if (value != null) {
+            return value.length();
+        } else {
+            return 0;
+        }
+    }
+}

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/devui-integration-test/src/main/java/org/optaplanner/quarkus/it/devui/domain/TestdataStringLengthShadowEntity.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/devui-integration-test/src/main/java/org/optaplanner/quarkus/it/devui/domain/TestdataStringLengthShadowEntity.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.quarkus.it.devui.domain;
+
+import org.optaplanner.core.api.domain.entity.PlanningEntity;
+import org.optaplanner.core.api.domain.variable.CustomShadowVariable;
+import org.optaplanner.core.api.domain.variable.PlanningVariable;
+import org.optaplanner.core.api.domain.variable.PlanningVariableReference;
+
+@PlanningEntity
+public class TestdataStringLengthShadowEntity {
+
+    @PlanningVariable(valueRangeProviderRefs = "valueRange")
+    private String value;
+
+    @CustomShadowVariable(variableListenerClass = StringLengthVariableListener.class,
+            sources = {
+                    @PlanningVariableReference(entityClass = TestdataStringLengthShadowEntity.class,
+                            variableName = "value")
+            })
+    private Integer length;
+
+    // ************************************************************************
+    // Getters/setters
+    // ************************************************************************
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+
+    public Integer getLength() {
+        return length;
+    }
+
+    public void setLength(Integer length) {
+        this.length = length;
+    }
+
+}

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/devui-integration-test/src/main/java/org/optaplanner/quarkus/it/devui/domain/TestdataStringLengthShadowSolution.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/devui-integration-test/src/main/java/org/optaplanner/quarkus/it/devui/domain/TestdataStringLengthShadowSolution.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.quarkus.it.devui.domain;
+
+import java.util.List;
+
+import org.optaplanner.core.api.domain.solution.PlanningEntityCollectionProperty;
+import org.optaplanner.core.api.domain.solution.PlanningScore;
+import org.optaplanner.core.api.domain.solution.PlanningSolution;
+import org.optaplanner.core.api.domain.valuerange.ValueRangeProvider;
+import org.optaplanner.core.api.score.buildin.hardsoft.HardSoftScore;
+
+@PlanningSolution
+public class TestdataStringLengthShadowSolution {
+
+    @ValueRangeProvider(id = "valueRange")
+    private List<String> valueList;
+    @PlanningEntityCollectionProperty
+    private List<TestdataStringLengthShadowEntity> entityList;
+
+    @PlanningScore
+    private HardSoftScore score;
+
+    // ************************************************************************
+    // Getters/setters
+    // ************************************************************************
+
+    public List<String> getValueList() {
+        return valueList;
+    }
+
+    public void setValueList(List<String> valueList) {
+        this.valueList = valueList;
+    }
+
+    public List<TestdataStringLengthShadowEntity> getEntityList() {
+        return entityList;
+    }
+
+    public void setEntityList(List<TestdataStringLengthShadowEntity> entityList) {
+        this.entityList = entityList;
+    }
+
+    public HardSoftScore getScore() {
+        return score;
+    }
+
+    public void setScore(HardSoftScore score) {
+        this.score = score;
+    }
+}

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/devui-integration-test/src/main/java/org/optaplanner/quarkus/it/devui/solver/TestdataStringLengthConstraintProvider.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/devui-integration-test/src/main/java/org/optaplanner/quarkus/it/devui/solver/TestdataStringLengthConstraintProvider.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.quarkus.it.devui.solver;
+
+import org.optaplanner.core.api.score.buildin.hardsoft.HardSoftScore;
+import org.optaplanner.core.api.score.stream.Constraint;
+import org.optaplanner.core.api.score.stream.ConstraintFactory;
+import org.optaplanner.core.api.score.stream.ConstraintProvider;
+import org.optaplanner.core.api.score.stream.Joiners;
+import org.optaplanner.quarkus.it.devui.domain.TestdataStringLengthShadowEntity;
+
+public class TestdataStringLengthConstraintProvider implements ConstraintProvider {
+
+    @Override
+    public Constraint[] defineConstraints(ConstraintFactory factory) {
+        return new Constraint[] {
+                factory.from(TestdataStringLengthShadowEntity.class)
+                        .join(TestdataStringLengthShadowEntity.class, Joiners.equal(TestdataStringLengthShadowEntity::getValue))
+                        .filter((a, b) -> a != b)
+                        .penalize("Don't assign 2 entities the same value.", HardSoftScore.ONE_HARD),
+                factory.from(TestdataStringLengthShadowEntity.class)
+                        .reward("Maximize value length", HardSoftScore.ONE_SOFT,
+                                TestdataStringLengthShadowEntity::getLength)
+        };
+    }
+
+}

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/devui-integration-test/src/main/resources/application.properties
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/devui-integration-test/src/main/resources/application.properties
@@ -1,0 +1,18 @@
+#
+# Copyright 2020 Red Hat, Inc. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# The solver runs only for few milliseconds to avoid a HTTP timeout in this simple implementation.
+quarkus.optaplanner.solver.termination.best-score-limit=0hard/5soft

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/devui-integration-test/src/test/java/org/optaplanner/quarkus/it/devui/OptaPlannerDevUITest.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/devui-integration-test/src/test/java/org/optaplanner/quarkus/it/devui/OptaPlannerDevUITest.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.quarkus.it.devui;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+
+import javax.xml.parsers.ParserConfigurationException;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.xml.sax.SAXException;
+
+import groovy.namespace.QName;
+import groovy.util.Node;
+import groovy.xml.XmlParser;
+import io.quarkus.test.QuarkusDevModeTest;
+import io.restassured.RestAssured;
+
+public class OptaPlannerDevUITest {
+    @RegisterExtension
+    static final QuarkusDevModeTest config = new QuarkusDevModeTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addPackages(true, "org.optaplanner.quarkus.it.devui"));
+
+    static final String OPTAPLANNER_DEV_UI_BASE_URL = "/q/dev/org.optaplanner.optaplanner-quarkus/";
+
+    public static String getPage(String pageName) {
+        return OPTAPLANNER_DEV_UI_BASE_URL + pageName;
+    }
+
+    @Test
+    public void testSolverConfigPage() throws ParserConfigurationException, SAXException, IOException {
+        String body = RestAssured.get(getPage("solverConfig"))
+                .then()
+                .extract()
+                .body()
+                .asPrettyString();
+        XmlParser xmlParser = new XmlParser();
+        Node node = xmlParser.parseText(body);
+        String solverConfig = ((Node) (node.getAt(QName.valueOf("body"))
+                .getAt(QName.valueOf("div"))
+                .getAt(QName.valueOf("div"))
+                .get(0))).text();
+        assertThat(solverConfig).isEqualToIgnoringWhitespace(
+                "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+                        + "<!--Properties that can be set at runtime are not included-->\n"
+                        + "<solver>\n"
+                        + "  <solutionClass>org.optaplanner.quarkus.it.devui.domain.TestdataStringLengthShadowSolution</solutionClass>\n"
+                        + "  <entityClass>org.optaplanner.quarkus.it.devui.domain.TestdataStringLengthShadowEntity</entityClass>\n"
+                        + "  <domainAccessType>GIZMO</domainAccessType>\n"
+                        + "  <scoreDirectorFactory>\n"
+                        + "    <constraintProviderClass>org.optaplanner.quarkus.it.devui.solver.TestdataStringLengthConstraintProvider</constraintProviderClass>\n"
+                        + "  </scoreDirectorFactory>\n"
+                        + "</solver>");
+    }
+
+    @Test
+    public void testModelPage() throws ParserConfigurationException, SAXException, IOException {
+        String body = RestAssured.get(getPage("model"))
+                .then()
+                .extract()
+                .body()
+                .asPrettyString();
+        XmlParser xmlParser = new XmlParser();
+        Node node = xmlParser.parseText(body);
+        String model = ((Node) (node.getAt(QName.valueOf("body"))
+                .getAt(QName.valueOf("div"))
+                .getAt(QName.valueOf("div"))
+                .get(0))).toString();
+        assertThat(model)
+                .contains("value=[Solution: org.optaplanner.quarkus.it.devui.domain.TestdataStringLengthShadowSolution]");
+        assertThat(model).contains("value=[Entity: org.optaplanner.quarkus.it.devui.domain.TestdataStringLengthShadowEntity]");
+        assertThat(model).contains(
+                "value=[Genuine Variables]]]]]], tbody[attributes={}; value=[tr[attributes={}; value=[td[attributes={colspan=1, rowspan=1}; value=[value]]");
+        assertThat(model).contains(
+                "value=[Shadow Variables]]]]]], tbody[attributes={}; value=[tr[attributes={}; value=[td[attributes={colspan=1, rowspan=1}; value=[length]]");
+    }
+
+    @Test
+    public void testConstraintsPage() throws ParserConfigurationException, SAXException, IOException {
+        String body = RestAssured.get(getPage("constraints"))
+                .then()
+                .extract()
+                .body()
+                .asPrettyString();
+        XmlParser xmlParser = new XmlParser();
+        Node node = xmlParser.parseText(body);
+        String constraints = ((Node) (node.getAt(QName.valueOf("body"))
+                .getAt(QName.valueOf("div"))
+                .getAt(QName.valueOf("table"))
+                .get(0))).text();
+        assertThat(constraints).contains("org.optaplanner.quarkus.it.devui.domain/Don't assign 2 entities the same value");
+        assertThat(constraints).contains("org.optaplanner.quarkus.it.devui.domain/Maximize value length");
+    }
+}

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/devui-integration-test/src/test/java/org/optaplanner/quarkus/it/devui/OptaPlannerDevUITest.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/devui-integration-test/src/test/java/org/optaplanner/quarkus/it/devui/OptaPlannerDevUITest.java
@@ -57,7 +57,7 @@ public class OptaPlannerDevUITest {
         Node node = xmlParser.parseText(body);
         String solverConfig = ((Node) (node.getAt(QName.valueOf("body"))
                 .getAt(QName.valueOf("div"))
-                .getAt(QName.valueOf("div"))
+                .getAt(QName.valueOf("pre"))
                 .get(0))).text();
         assertThat(solverConfig).isEqualToIgnoringWhitespace(
                 "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/pom.xml
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/pom.xml
@@ -17,6 +17,7 @@
     <module>runtime</module>
     <module>deployment</module>
     <module>integration-test</module>
+    <module>devui-integration-test</module>
     <module>drl-integration-test</module>
   </modules>
 </project>

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/runtime/src/main/java/org/optaplanner/quarkus/devui/OptaPlannerDevUIProperties.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/runtime/src/main/java/org/optaplanner/quarkus/devui/OptaPlannerDevUIProperties.java
@@ -19,9 +19,9 @@ package org.optaplanner.quarkus.devui;
 import java.util.List;
 
 public class OptaPlannerDevUIProperties {
-    OptaPlannerModelProperties optaPlannerModelProperties;
-    String effectiveSolverConfigXML;
-    List<String> constraintList;
+    private final OptaPlannerModelProperties optaPlannerModelProperties;
+    private final String effectiveSolverConfigXML;
+    private final List<String> constraintList;
 
     public OptaPlannerDevUIProperties(OptaPlannerModelProperties optaPlannerModelProperties, String effectiveSolverConfigXML,
             List<String> constraintList) {

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/runtime/src/main/java/org/optaplanner/quarkus/devui/OptaPlannerDevUIProperties.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/runtime/src/main/java/org/optaplanner/quarkus/devui/OptaPlannerDevUIProperties.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.quarkus.devui;
+
+import java.util.List;
+
+public class OptaPlannerDevUIProperties {
+    OptaPlannerModelProperties optaPlannerModelProperties;
+    String effectiveSolverConfigXML;
+    List<String> constraintList;
+
+    public OptaPlannerDevUIProperties(OptaPlannerModelProperties optaPlannerModelProperties, String effectiveSolverConfigXML,
+            List<String> constraintList) {
+        this.optaPlannerModelProperties = optaPlannerModelProperties;
+        this.effectiveSolverConfigXML = effectiveSolverConfigXML;
+        this.constraintList = constraintList;
+    }
+
+    public OptaPlannerModelProperties getOptaPlannerModelProperties() {
+        return optaPlannerModelProperties;
+    }
+
+    public String getEffectiveSolverConfig() {
+        return effectiveSolverConfigXML;
+    }
+
+    public List<String> getConstraintList() {
+        return constraintList;
+    }
+}

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/runtime/src/main/java/org/optaplanner/quarkus/devui/OptaPlannerDevUIPropertiesSupplier.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/runtime/src/main/java/org/optaplanner/quarkus/devui/OptaPlannerDevUIPropertiesSupplier.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.quarkus.devui;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+import org.optaplanner.core.api.domain.entity.PlanningEntity;
+import org.optaplanner.core.api.domain.solution.PlanningSolution;
+import org.optaplanner.core.api.score.stream.Constraint;
+import org.optaplanner.core.api.solver.SolverFactory;
+import org.optaplanner.core.impl.domain.entity.descriptor.EntityDescriptor;
+import org.optaplanner.core.impl.domain.solution.descriptor.SolutionDescriptor;
+import org.optaplanner.core.impl.domain.variable.descriptor.GenuineVariableDescriptor;
+import org.optaplanner.core.impl.domain.variable.descriptor.VariableDescriptor;
+import org.optaplanner.core.impl.score.director.stream.AbstractConstraintStreamScoreDirectorFactory;
+import org.optaplanner.core.impl.solver.DefaultSolverFactory;
+
+import io.quarkus.arc.Arc;
+
+public class OptaPlannerDevUIPropertiesSupplier implements Supplier<OptaPlannerDevUIProperties> {
+    String effectiveSolverConfigXml;
+
+    public OptaPlannerDevUIPropertiesSupplier() {
+        this.effectiveSolverConfigXml = null;
+    }
+
+    public OptaPlannerDevUIPropertiesSupplier(String effectiveSolverConfigXml) {
+        this.effectiveSolverConfigXml = effectiveSolverConfigXml;
+    }
+
+    public String getEffectiveSolverConfigXml() {
+        return effectiveSolverConfigXml;
+    }
+
+    public void setEffectiveSolverConfigXml(String effectiveSolverConfigXml) {
+        this.effectiveSolverConfigXml = effectiveSolverConfigXml;
+    }
+
+    @Override
+    public OptaPlannerDevUIProperties get() {
+        if (effectiveSolverConfigXml != null) {
+            // SolverConfigIO does not work at runtime,
+            // but the build time SolverConfig does not have properties
+            // that can be set at runtime (ex: termination), so the
+            // effective solver config will be missing some properties
+            return new OptaPlannerDevUIProperties(getModelInfo(),
+                    getXmlContentWithComment("Properties that can be set at runtime are not included"),
+                    getConstraintList());
+        } else {
+            return new OptaPlannerDevUIProperties(getModelInfo(),
+                    "<!-- Plugin execution was skipped " + "because there are no @" + PlanningSolution.class.getSimpleName()
+                            + " or @" + PlanningEntity.class.getSimpleName() + " annotated classes. -->\n<solver />",
+                    Collections.emptyList());
+        }
+    }
+
+    private OptaPlannerModelProperties getModelInfo() {
+        if (effectiveSolverConfigXml != null) {
+            DefaultSolverFactory<?> solverFactory =
+                    (DefaultSolverFactory<?>) Arc.container().instance(SolverFactory.class).get();
+            SolutionDescriptor<?> solutionDescriptor = solverFactory.getScoreDirectorFactory().getSolutionDescriptor();
+            OptaPlannerModelProperties out = new OptaPlannerModelProperties();
+            out.setSolutionClass(solutionDescriptor.getSolutionClass().getName());
+            List<String> entityClassList = new ArrayList<>();
+            Map<String, List<String>> entityClassToGenuineVariableListMap = new HashMap<>();
+            Map<String, List<String>> entityClassToShadowVariableListMap = new HashMap<>();
+            for (EntityDescriptor<?> entityDescriptor : solutionDescriptor.getEntityDescriptors()) {
+                entityClassList.add(entityDescriptor.getEntityClass().getName());
+                List<String> entityClassToGenuineVariableList = new ArrayList<>();
+                List<String> entityClassToShadowVariableList = new ArrayList<>();
+                for (VariableDescriptor<?> variableDescriptor : entityDescriptor.getDeclaredVariableDescriptors()) {
+                    if (variableDescriptor instanceof GenuineVariableDescriptor) {
+                        entityClassToGenuineVariableList.add(variableDescriptor.getVariableName());
+                    } else {
+                        entityClassToShadowVariableList.add(variableDescriptor.getVariableName());
+                    }
+                }
+                entityClassToGenuineVariableListMap.put(entityDescriptor.getEntityClass().getName(),
+                        entityClassToGenuineVariableList);
+                entityClassToShadowVariableListMap.put(entityDescriptor.getEntityClass().getName(),
+                        entityClassToShadowVariableList);
+            }
+            out.setEntityClassList(entityClassList);
+            out.setEntityClassToGenuineVariableListMap(entityClassToGenuineVariableListMap);
+            out.setEntityClassToShadowVariableListMap(entityClassToShadowVariableListMap);
+            return out;
+        } else {
+            return new OptaPlannerModelProperties();
+        }
+    }
+
+    private List<String> getConstraintList() {
+        if (effectiveSolverConfigXml != null) {
+            DefaultSolverFactory<?> solverFactory =
+                    (DefaultSolverFactory<?>) Arc.container().instance(SolverFactory.class).get();
+            if (solverFactory.getScoreDirectorFactory() instanceof AbstractConstraintStreamScoreDirectorFactory) {
+                AbstractConstraintStreamScoreDirectorFactory<?, ?> scoreDirectorFactory =
+                        (AbstractConstraintStreamScoreDirectorFactory<?, ?>) solverFactory.getScoreDirectorFactory();
+                return Arrays.stream(scoreDirectorFactory.getConstraints()).map(Constraint::getConstraintId)
+                        .collect(Collectors.toList());
+            }
+        }
+        return Collections.emptyList();
+    }
+
+    private String getXmlContentWithComment(String comment) {
+        int indexOfPreambleEnd = effectiveSolverConfigXml.indexOf("?>");
+        if (indexOfPreambleEnd != -1) {
+            return effectiveSolverConfigXml.substring(0, indexOfPreambleEnd + 2) +
+                    "\n<!--" + comment + "-->\n"
+                    + effectiveSolverConfigXml.substring(indexOfPreambleEnd + 2);
+        } else {
+            return "<!--" + comment + "-->\n" + effectiveSolverConfigXml;
+        }
+    }
+}

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/runtime/src/main/java/org/optaplanner/quarkus/devui/OptaPlannerDevUIPropertiesSupplier.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/runtime/src/main/java/org/optaplanner/quarkus/devui/OptaPlannerDevUIPropertiesSupplier.java
@@ -39,7 +39,7 @@ import org.optaplanner.core.impl.solver.DefaultSolverFactory;
 import io.quarkus.arc.Arc;
 
 public class OptaPlannerDevUIPropertiesSupplier implements Supplier<OptaPlannerDevUIProperties> {
-    String effectiveSolverConfigXml;
+    private String effectiveSolverConfigXml;
 
     public OptaPlannerDevUIPropertiesSupplier() {
         this.effectiveSolverConfigXml = null;
@@ -49,6 +49,7 @@ public class OptaPlannerDevUIPropertiesSupplier implements Supplier<OptaPlannerD
         this.effectiveSolverConfigXml = effectiveSolverConfigXml;
     }
 
+    // Needed for Quarkus Dev UI serialization
     public String getEffectiveSolverConfigXml() {
         return effectiveSolverConfigXml;
     }

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/runtime/src/main/java/org/optaplanner/quarkus/devui/OptaPlannerModelProperties.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/runtime/src/main/java/org/optaplanner/quarkus/devui/OptaPlannerModelProperties.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.quarkus.devui;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+public class OptaPlannerModelProperties {
+    String solutionClass;
+    List<String> entityClassList;
+    Map<String, List<String>> entityClassToGenuineVariableListMap;
+    Map<String, List<String>> entityClassToShadowVariableListMap;
+
+    public OptaPlannerModelProperties() {
+        solutionClass = "null";
+        entityClassList = Collections.emptyList();
+        entityClassToGenuineVariableListMap = Collections.emptyMap();
+        entityClassToShadowVariableListMap = Collections.emptyMap();
+    }
+
+    public String getSolutionClass() {
+        return solutionClass;
+    }
+
+    public void setSolutionClass(String solutionClass) {
+        this.solutionClass = solutionClass;
+    }
+
+    public List<String> getEntityClassList() {
+        return entityClassList;
+    }
+
+    public void setEntityClassList(List<String> entityClassList) {
+        this.entityClassList = entityClassList;
+    }
+
+    public Map<String, List<String>> getEntityClassToGenuineVariableListMap() {
+        return entityClassToGenuineVariableListMap;
+    }
+
+    public void setEntityClassToGenuineVariableListMap(
+            Map<String, List<String>> entityClassToGenuineVariableListMap) {
+        this.entityClassToGenuineVariableListMap = entityClassToGenuineVariableListMap;
+    }
+
+    public Map<String, List<String>> getEntityClassToShadowVariableListMap() {
+        return entityClassToShadowVariableListMap;
+    }
+
+    public void setEntityClassToShadowVariableListMap(
+            Map<String, List<String>> entityClassToShadowVariableListMap) {
+        this.entityClassToShadowVariableListMap = entityClassToShadowVariableListMap;
+    }
+}


### PR DESCRIPTION
Don't know how to test this, since in order to verify it works, we need to visit the Dev UI pages.

### JIRA

<!-- Add a JIRA ticket link if it exists. -->
https://issues.redhat.com/browse/PLANNER-2411

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
* https://github.com/kiegroup/drools/pull/3000
* https://github.com/kiegroup/optaplanner/pull/899
* etc.
-->

### Checklist
- [ ] Documentation updated if applicable.
- [ ] Upgrade recipe provided if applicable.

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>specific pull request build</b> please add comment: <b>Jenkins (re)run [optaplanner|apps|examples] tests</b>
* for a <b>full downstream build</b> please add comment: <b>Jenkins run fdb</b>
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
* for a <b>Quarkus LTS check</b> please add comment: <b>Jenkins run LTS</b>
* for a <b>specific Quarkus LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner|apps|examples] LTS</b>
* for a <b>Native check</b> please add comment: <b>Jenkins run native</b>
* for a <b>specific Native LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner|apps|examples] native</b>
</details>