### PR TITLE
Align Hibernate version with Quarkus 2.0.0.CR3

### DIFF
--- a/build/optaplanner-build-parent/pom.xml
+++ b/build/optaplanner-build-parent/pom.xml
@@ -40,7 +40,7 @@
     <version.org.apache.poi>4.1.2</version.org.apache.poi>
     <version.org.assertj>3.19.0</version.org.assertj>
     <version.org.freemarker>2.3.31</version.org.freemarker>
-    <version.org.hibernate>5.4.29.Final</version.org.hibernate>
+    <version.org.hibernate>5.5.0.Final</version.org.hibernate>
     <version.org.jboss.jandex>2.3.0.Final</version.org.jboss.jandex>
     <version.org.jdom>1.1.3</version.org.jdom>
     <version.org.jfree.jfreechart>1.5.3</version.org.jfree.jfreechart>


### PR DESCRIPTION
- [`quarkus-hibernate-orm`](https://mvnrepository.com/artifact/io.quarkus/quarkus-hibernate-orm/2.0.0.CR3) uses Hibernate 5.5.0.Final.
- `optaplanner-persistence-jpa` uses Hibernate as well (`hibernate-core`).
- Since `optaplanner-build-parent` does not import `quarkus-bom` it has to manage Hibernate version by itself.

When Quarkus was upgraded to 2.0.0.CR3 (#1379), Hibernate version was not updated and so, `optaplanner-build-parent` effectively downgraded `hibernate-core` to 5.4.29, which is incompatible with other Hibernate 5.5.0 components used by `quarkus-orm-hibernate`. This isn't a problem in the `optaplanner` repository as none of its modules uses `quarkus-orm-hibernate` but it starts to be a problem in OptaWeb repos.

### Referenced pull requests
Fixes up #1379.

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
* https://github.com/kiegroup/drools/pull/3000
* https://github.com/kiegroup/optaplanner/pull/899
* etc.
-->

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>specific pull request build</b> please add comment: <b>Jenkins (re)run [optaplanner|apps|examples] tests</b>
* for a <b>full downstream build</b> please add comment: <b>Jenkins run fdb</b>
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
* for a <b>Quarkus LTS check</b> please add comment: <b>Jenkins run LTS</b>
* for a <b>specific Quarkus LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner|apps|examples] LTS</b>
* for a <b>Native check</b> please add comment: <b>Jenkins run native</b>
* for a <b>specific Native LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner|apps|examples] native</b>
</details>