### PR TITLE
(8.5.x Backport): PLANNER-2385: Do not presume Long @PlanningId in ConstraintVerifier (#1246))

### DIFF
--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/testdata/domain/planningid/TestdataStringPlanningIdEntity.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/testdata/domain/planningid/TestdataStringPlanningIdEntity.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.core.impl.testdata.domain.planningid;
+
+import org.optaplanner.core.api.domain.entity.PlanningEntity;
+import org.optaplanner.core.api.domain.lookup.PlanningId;
+import org.optaplanner.core.api.domain.variable.PlanningVariable;
+
+@PlanningEntity
+public class TestdataStringPlanningIdEntity {
+    @PlanningId
+    private String planningId;
+
+    @PlanningVariable(valueRangeProviderRefs = "stringValueRange")
+    private String value;
+
+    public TestdataStringPlanningIdEntity(String planningId) {
+        this(planningId, null);
+    }
+
+    public TestdataStringPlanningIdEntity(String planningId, String value) {
+        this.planningId = planningId;
+        this.value = value;
+    }
+
+    public String getPlanningId() {
+        return planningId;
+    }
+
+    public void setPlanningId(String planningId) {
+        this.planningId = planningId;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+}

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/testdata/domain/planningid/TestdataStringPlanningIdSolution.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/testdata/domain/planningid/TestdataStringPlanningIdSolution.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.core.impl.testdata.domain.planningid;
+
+import java.util.List;
+
+import org.optaplanner.core.api.domain.solution.PlanningEntityCollectionProperty;
+import org.optaplanner.core.api.domain.solution.PlanningSolution;
+import org.optaplanner.core.api.domain.solution.ProblemFactCollectionProperty;
+import org.optaplanner.core.api.domain.valuerange.ValueRangeProvider;
+import org.optaplanner.core.impl.testdata.domain.TestdataSolution;
+
+@PlanningSolution
+public class TestdataStringPlanningIdSolution extends TestdataSolution {
+    private List<String> stringValueList;
+    private List<TestdataStringPlanningIdEntity> stringEntityList;
+
+    @ValueRangeProvider(id = "stringValueRange")
+    @ProblemFactCollectionProperty
+    public List<String> getStringValueList() {
+        return stringValueList;
+    }
+
+    public void setStringValueList(List<String> stringValueList) {
+        this.stringValueList = stringValueList;
+    }
+
+    @PlanningEntityCollectionProperty
+    public List<TestdataStringPlanningIdEntity> getStringEntityList() {
+        return stringEntityList;
+    }
+
+    public void setStringEntityList(List<TestdataStringPlanningIdEntity> stringEntityList) {
+        this.stringEntityList = stringEntityList;
+    }
+}

--- a/optaplanner-test/src/main/java/org/optaplanner/test/impl/score/stream/DefaultSingleConstraintVerification.java
+++ b/optaplanner-test/src/main/java/org/optaplanner/test/impl/score/stream/DefaultSingleConstraintVerification.java
@@ -66,19 +66,19 @@ public final class DefaultSingleConstraintVerification<Solution_, Score_ extends
                 return;
             }
             // Group entities by the same ID.
-            Map<Optional<Long>, List<Object>> entitiesWithSameIdMap = clzFacts.stream()
+            Map<Optional<Object>, List<Object>> entitiesWithSameIdMap = clzFacts.stream()
                     .collect(Collectors.groupingBy(fact -> {
-                        Long planningId = (Long) planningIdAccessor.executeGetter(fact);
+                        Object planningId = planningIdAccessor.executeGetter(fact);
                         return Optional.ofNullable(planningId); // Return as reference to prevent null keys.
                     }));
             // Eliminate those matches where there are no duplicate IDs and find the first one.
-            Optional<Map.Entry<Optional<Long>, List<Object>>> firstDuplicateIdEntry = entitiesWithSameIdMap.entrySet()
+            Optional<Map.Entry<Optional<Object>, List<Object>>> firstDuplicateIdEntry = entitiesWithSameIdMap.entrySet()
                     .stream()
                     .filter(e -> e.getValue().size() > 1) // More than 1 instance means there is a duplicate ID.
                     .findFirst();
             firstDuplicateIdEntry.ifPresent(entry -> {
                 String value = entry.getKey()
-                        .map(id -> Long.toString(id))
+                        .map(Objects::toString)
                         .orElse("null");
                 throw new IllegalStateException(
                         "Multiple instances of " + PlanningEntity.class.getSimpleName() + "-annotated class ("

--- a/optaplanner-test/src/test/java/org/optaplanner/test/api/score/stream/SingleConstraintAssertionTest.java
+++ b/optaplanner-test/src/test/java/org/optaplanner/test/api/score/stream/SingleConstraintAssertionTest.java
@@ -21,12 +21,16 @@ import static org.assertj.core.api.Assertions.assertThatCode;
 import org.junit.jupiter.api.Test;
 import org.optaplanner.core.impl.testdata.domain.TestdataEntity;
 import org.optaplanner.core.impl.testdata.domain.TestdataSolution;
+import org.optaplanner.core.impl.testdata.domain.planningid.TestdataStringPlanningIdEntity;
+import org.optaplanner.core.impl.testdata.domain.planningid.TestdataStringPlanningIdSolution;
 import org.optaplanner.test.api.score.stream.testdata.TestdataConstraintProvider;
 
 public class SingleConstraintAssertionTest {
 
-    private final ConstraintVerifier<TestdataConstraintProvider, TestdataSolution> constraintVerifier =
-            ConstraintVerifier.build(new TestdataConstraintProvider(), TestdataSolution.class, TestdataEntity.class);
+    private final ConstraintVerifier<TestdataConstraintProvider, TestdataStringPlanningIdSolution> constraintVerifier =
+            ConstraintVerifier.build(new TestdataConstraintProvider(), TestdataStringPlanningIdSolution.class,
+                    TestdataEntity.class,
+                    TestdataStringPlanningIdEntity.class);
 
     @Test
     void penalizesAndDoesNotReward() {
@@ -94,5 +98,23 @@ public class SingleConstraintAssertionTest {
                     .penalizes(1, "There should be penalties.");
         }).hasMessageContaining("There should be penalties")
                 .hasMessageContaining("Expected penalty");
+    }
+
+    @Test
+    void uniquePairShouldWorkOnStringPlanningId() {
+        assertThatCode(() -> {
+            constraintVerifier.verifyThat(TestdataConstraintProvider::differentStringEntityHaveDifferentValues)
+                    .given(new TestdataStringPlanningIdEntity("A", "1"),
+                            new TestdataStringPlanningIdEntity("B", "1"))
+                    .penalizes(1, "There should be penalties");
+        }).doesNotThrowAnyException();
+
+        assertThatCode(() -> {
+            constraintVerifier.verifyThat(TestdataConstraintProvider::differentStringEntityHaveDifferentValues)
+                    .given(new TestdataStringPlanningIdEntity("A", "1"),
+                            new TestdataStringPlanningIdEntity("B", "1"))
+                    .rewards(1, "There should be rewards");
+        }).hasMessageContaining("There should be rewards")
+                .hasMessageContaining("Expected reward");
     }
 }

--- a/optaplanner-test/src/test/java/org/optaplanner/test/api/score/stream/testdata/TestdataConstraintProvider.java
+++ b/optaplanner-test/src/test/java/org/optaplanner/test/api/score/stream/testdata/TestdataConstraintProvider.java
@@ -20,14 +20,17 @@ import org.optaplanner.core.api.score.buildin.simple.SimpleScore;
 import org.optaplanner.core.api.score.stream.Constraint;
 import org.optaplanner.core.api.score.stream.ConstraintFactory;
 import org.optaplanner.core.api.score.stream.ConstraintProvider;
+import org.optaplanner.core.api.score.stream.Joiners;
 import org.optaplanner.core.impl.testdata.domain.TestdataEntity;
+import org.optaplanner.core.impl.testdata.domain.planningid.TestdataStringPlanningIdEntity;
 
 public class TestdataConstraintProvider implements ConstraintProvider {
     @Override
     public Constraint[] defineConstraints(ConstraintFactory constraintFactory) {
         return new Constraint[] {
                 penalizeEveryEntity(constraintFactory),
-                rewardEveryEntity(constraintFactory)
+                rewardEveryEntity(constraintFactory),
+                differentStringEntityHaveDifferentValues(constraintFactory),
         };
     }
 
@@ -39,6 +42,12 @@ public class TestdataConstraintProvider implements ConstraintProvider {
     public Constraint rewardEveryEntity(ConstraintFactory constraintFactory) {
         return constraintFactory.from(TestdataEntity.class)
                 .reward("Reward every entity", SimpleScore.ONE);
+    }
+
+    public Constraint differentStringEntityHaveDifferentValues(ConstraintFactory constraintFactory) {
+        return constraintFactory
+                .fromUniquePair(TestdataStringPlanningIdEntity.class, Joiners.equal(TestdataStringPlanningIdEntity::getValue))
+                .penalize("Different String Entity Have Different Values", SimpleScore.ONE);
     }
 
 }


### PR DESCRIPTION
<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.
-->

### JIRA

<!-- Add a JIRA ticket link if it exists. -->
https://issues.redhat.com/browse/PLANNER-2385

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
* https://github.com/kiegroup/drools/pull/3000
* https://github.com/kiegroup/optaplanner/pull/899
* etc.
-->

### Checklist
- [ ] Documentation updated if applicable.
- [ ] Upgrade recipe provided if applicable.

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>specific pull request build</b> please add comment: <b>Jenkins (re)run [optaplanner|apps|examples] tests</b>
* for a <b>full downstream build</b> please add comment: <b>Jenkins run fdb</b>
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
* for a <b>Quarkus LTS check</b> please add comment: <b>Jenkins run LTS</b>
* for a <b>specific Quarkus LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner|apps|examples] LTS</b>
* for a <b>Native check</b> please add comment: <b>Jenkins run native</b>
* for a <b>specific Native LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner|apps|examples] native</b>
</details>