### PR TITLE
Bump Surefire to 3.0.0-M5 to fix some tests not launching

### DIFF
--- a/build/optaplanner-build-parent/pom.xml
+++ b/build/optaplanner-build-parent/pom.xml
@@ -63,7 +63,7 @@
     <version.compiler.plugin>3.8.1</version.compiler.plugin>
     <!-- The first version that supports analysis of classes compiled by Java 11. -->
     <version.dependency.plugin>3.1.2</version.dependency.plugin>
-    <version.surefire.plugin>2.22.2</version.surefire.plugin>
+    <version.surefire.plugin>3.0.0-M5</version.surefire.plugin>
     <!-- Versions plugin should stay on version 2.5
       until https://github.com/mojohaus/versions-maven-plugin/issues/312 is fixed -->
     <version.versions.plugin>2.5</version.versions.plugin>
@@ -832,7 +832,13 @@
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>${version.surefire.plugin}</version>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-failsafe-plugin</artifactId>
+        <version>${version.surefire.plugin}</version>
       </plugin>
       <!-- Do not move to full profile. Otherwise upstream Kogito dependency changes can break our build without Kogito CI catching it. -->
       <plugin>


### PR DESCRIPTION
Surefire was not properly finding and running tests in the `optaplanner-test` module. 
Version 2.22 doesn't play with JUnit 5 too well.