### PR TITLE
Make JBoss Java Release profiles not active by default

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -140,71 +140,65 @@
       </modules>
     </profile>
 
-    <!-- Disable Java 8 active by default profiles from JBoss -->
+    <!--
+      Disable modules that would cause the overriding of Maven compiler target.
+      This is not an issue for Maven itself, but IntelliJ IDEA seems to set the target from these profiles.
+      These modules come from JBoss Parent and these overrides may be removed when these modules are removed from there.
+     -->
     <profile>
       <id>include-jdk-misc</id>
       <activation>
         <activeByDefault>false</activeByDefault>
       </activation>
     </profile>
-
     <profile>
       <id>compile-java8-release-flag</id>
       <activation>
         <activeByDefault>false</activeByDefault>
       </activation>
     </profile>
-
     <profile>
       <id>java8-test</id>
       <activation>
         <activeByDefault>false</activeByDefault>
       </activation>
     </profile>
-
     <profile>
       <id>doclint-java8-disable</id>
       <activation>
         <activeByDefault>false</activeByDefault>
       </activation>
     </profile>
-
     <profile>
       <id>java9-mr-build</id>
       <activation>
         <activeByDefault>false</activeByDefault>
       </activation>
     </profile>
-
     <profile>
       <id>java9-test</id>
       <activation>
         <activeByDefault>false</activeByDefault>
       </activation>
     </profile>
-
-
     <profile>
       <id>java10-mr-build</id>
       <activation>
         <activeByDefault>false</activeByDefault>
       </activation>
     </profile>
-
     <profile>
       <id>java10-test</id>
       <activation>
         <activeByDefault>false</activeByDefault>
       </activation>
     </profile>
-
     <profile>
       <id>java11-mr-build</id>
       <activation>
         <activeByDefault>false</activeByDefault>
       </activation>
     </profile>
-
     <profile>
       <id>java11-test</id>
       <activation>

--- a/pom.xml
+++ b/pom.xml
@@ -139,6 +139,78 @@
         <module>optaplanner-distribution</module>
       </modules>
     </profile>
+
+    <!-- Disable Java 8 active by default profiles from JBoss -->
+    <profile>
+      <id>include-jdk-misc</id>
+      <activation>
+        <activeByDefault>false</activeByDefault>
+      </activation>
+    </profile>
+
+    <profile>
+      <id>compile-java8-release-flag</id>
+      <activation>
+        <activeByDefault>false</activeByDefault>
+      </activation>
+    </profile>
+
+    <profile>
+      <id>java8-test</id>
+      <activation>
+        <activeByDefault>false</activeByDefault>
+      </activation>
+    </profile>
+
+    <profile>
+      <id>doclint-java8-disable</id>
+      <activation>
+        <activeByDefault>false</activeByDefault>
+      </activation>
+    </profile>
+
+    <profile>
+      <id>java9-mr-build</id>
+      <activation>
+        <activeByDefault>false</activeByDefault>
+      </activation>
+    </profile>
+
+    <profile>
+      <id>java9-test</id>
+      <activation>
+        <activeByDefault>false</activeByDefault>
+      </activation>
+    </profile>
+
+
+    <profile>
+      <id>java10-mr-build</id>
+      <activation>
+        <activeByDefault>false</activeByDefault>
+      </activation>
+    </profile>
+
+    <profile>
+      <id>java10-test</id>
+      <activation>
+        <activeByDefault>false</activeByDefault>
+      </activation>
+    </profile>
+
+    <profile>
+      <id>java11-mr-build</id>
+      <activation>
+        <activeByDefault>false</activeByDefault>
+      </activation>
+    </profile>
+
+    <profile>
+      <id>java11-test</id>
+      <activation>
+        <activeByDefault>false</activeByDefault>
+      </activation>
+    </profile>
   </profiles>
 
 </project>


### PR DESCRIPTION
<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.
-->

### JIRA

<!-- Add a JIRA ticket link if it exists. -->
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
* https://github.com/kiegroup/drools/pull/3000
* https://github.com/kiegroup/optaplanner/pull/899
* etc.
-->

### Checklist
- [ ] Documentation updated if applicable.
- [ ] Upgrade recipe provided if applicable.

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>specific pull request build</b> please add comment: <b>Jenkins (re)run [optaplanner|apps|examples] tests</b>
* for a <b>full downstream build</b> please add comment: <b>Jenkins run fdb</b>
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
* for a <b>Quarkus LTS check</b> please add comment: <b>Jenkins run LTS</b>
* for a <b>specific Quarkus LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner|apps|examples] LTS</b>
* for a <b>Native check</b> please add comment: <b>Jenkins run native</b>
* for a <b>specific Native LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner|apps|examples] native</b>
</details>