### PR TITLE
KOGITO-5540 Disable Sonarcloud on release branches

### DIFF
--- a/.ci/jenkins/Jenkinsfile
+++ b/.ci/jenkins/Jenkinsfile
@@ -70,7 +70,7 @@ pipeline {
                 script {
                     mvnCmd = getMavenCommand(optaplannerRepo, true, true)
                         .withProperty('full')
-                    if (isNormalPRCheck()) {
+                    if (isNormalPRCheck() && isSonarCloudEnabled()) {
                         mvnCmd.withProfiles(['run-code-coverage'])
                     }
                     mvnCmd.run('clean install')
@@ -79,7 +79,7 @@ pipeline {
         }
         stage('Analyze OptaPlanner by SonarCloud') {
             when {
-                expression { isNormalPRCheck() }
+                expression { isNormalPRCheck() && isSonarCloudEnabled() }
             }
             steps {
                 script {
@@ -207,6 +207,10 @@ String getUpstreamTriggerProject() {
 
 boolean isNormalPRCheck() {
     return !(isDownstreamJob() || getQuarkusBranch() || isNative())
+}
+
+boolean isSonarCloudEnabled() {
+    return env['ENABLE_SONARCLOUD'] && env['ENABLE_SONARCLOUD'].toBoolean()
 }
 
 boolean isUpstreamKogitoProject() {

--- a/.ci/jenkins/dsl/jobs.groovy
+++ b/.ci/jenkins/dsl/jobs.groovy
@@ -29,6 +29,9 @@ Map getMultijobPRConfig() {
                 repository: 'kogito-examples',
                 dependsOn: 'optaplanner',
             ]
+        ],
+        extraEnv : [
+            ENABLE_SONARCLOUD: Utils.isMainBranch(this)
         ]
     ]
 }

--- a/.ci/jenkins/dsl/jobs.groovy
+++ b/.ci/jenkins/dsl/jobs.groovy
@@ -31,6 +31,8 @@ Map getMultijobPRConfig() {
             ]
         ],
         extraEnv : [
+            // Sonarcloud analysis only on main branch
+            // As we have only Community edition
             ENABLE_SONARCLOUD: Utils.isMainBranch(this)
         ]
     ]


### PR DESCRIPTION
https://issues.redhat.com/browse/KOGITO-5540

As Sonarqube is only Community Edition, it does not support branch analysis ...

Related PRs:
- https://github.com/kiegroup/kogito-runtimes/pull/1453
- https://github.com/kiegroup/optaplanner/pull/1442
- https://github.com/kiegroup/kogito-apps/pull/948

### Checklist
- [ ] Documentation updated if applicable.
- [ ] Upgrade recipe provided if applicable.

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>specific pull request build</b> please add comment: <b>Jenkins (re)run [optaplanner|apps|examples] tests</b>
* for a <b>full downstream build</b> please add comment: <b>Jenkins run fdb</b>
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
* for a <b>Quarkus LTS check</b> please add comment: <b>Jenkins run LTS</b>
* for a <b>specific Quarkus LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner|apps|examples] LTS</b>
* for a <b>Native check</b> please add comment: <b>Jenkins run native</b>
* for a <b>specific Native LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner|apps|examples] native</b>
</details>