### PR TITLE
KOGITO-5585 Add `skip-ci` label on created PRs

### DIFF
--- a/.ci/jenkins/Jenkinsfile.deploy
+++ b/.ci/jenkins/Jenkinsfile.deploy
@@ -389,7 +389,7 @@ void commitAndCreatePR(String repo, String buildBranch) {
         })
         githubscm.pushObject('origin', getBotBranch(), getBotAuthorCredsID())
         deployProperties["${repo}.pr.link"] = isRelease() ?
-                                                githubscm.createPRWithLabels(commitMsg, prBody, buildBranch, ['DO_NOT_MERGE'] as String[], getBotAuthorCredsID()) :
+                                                githubscm.createPRWithLabels(commitMsg, prBody, buildBranch, ['DO_NOT_MERGE', 'skip-ci'] as String[], getBotAuthorCredsID()) :
                                                 githubscm.createPR(commitMsg, prBody, buildBranch, getBotAuthorCredsID())
     }
 }

--- a/.ci/jenkins/Jenkinsfile.promote
+++ b/.ci/jenkins/Jenkinsfile.promote
@@ -488,7 +488,7 @@ String commitAndCreatePR(String commitMsg, Closure precommit, String localBranch
 
     githubscm.commitChanges(commitMsg, precommit)
     githubscm.pushObject('origin', localBranch, getBotAuthorCredsID())
-    return githubscm.createPR(commitMsg, prBody, targetBranch, getBotAuthorCredsID())
+    return githubscm.createPRWithLabels(commitMsg, prBody, targetBranch, [ 'skip-ci' ] as String[], getBotAuthorCredsID())
 }
 
 void commitAndForcePushProtectedBranch(String repo, String branch) {


### PR DESCRIPTION
<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.
-->

### JIRA

<!-- Add a JIRA ticket link if it exists. -->
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
* https://github.com/kiegroup/drools/pull/3000
* https://github.com/kiegroup/optaplanner/pull/899
* etc.
-->

### Checklist
- [ ] Documentation updated if applicable.
- [ ] Upgrade recipe provided if applicable.

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>specific pull request build</b> please add comment: <b>Jenkins (re)run [optaplanner|apps|examples] tests</b>
* for a <b>full downstream build</b> please add comment: <b>Jenkins run fdb</b>
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
* for a <b>Quarkus LTS check</b> please add comment: <b>Jenkins run LTS</b>
* for a <b>specific Quarkus LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner|apps|examples] LTS</b>
* for a <b>Native check</b> please add comment: <b>Jenkins run native</b>
* for a <b>specific Native LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner|apps|examples] native</b>
</details>