### PR TITLE
KOGITO-5597 Separate native checks

### DIFF
--- a/.ci/jenkins/Jenkinsfile
+++ b/.ci/jenkins/Jenkinsfile
@@ -59,8 +59,7 @@ pipeline {
             steps {
                 script {
                     getMavenCommand(kogitoRuntimesRepo)
-                        .skipTests(true)
-                        .withProperty('skipITs', true)
+                        .withProperty('quickly')
                         .run('clean install')
                 }
             }

--- a/.ci/jenkins/Jenkinsfile.native
+++ b/.ci/jenkins/Jenkinsfile.native
@@ -50,8 +50,12 @@ pipeline {
         stage('Build optaplanner') {
             steps {
                 script {
-                    getNativeMavenCommand('optaplanner')
-                        .run('clean install')
+                    try {
+                        getNativeMavenCommand('optaplanner')
+                            .run('clean install')
+                    }catch(err) {
+                        unstable("optaplanner test not finish correctly")
+                    }
                 }
             }
             post {
@@ -65,8 +69,12 @@ pipeline {
         stage('Build optaplanner-quickstarts') {
             steps {
                 script {
-                    getNativeMavenCommand('optaplanner-quickstarts')
-                        .run('clean install')
+                    try {
+                        getNativeMavenCommand('optaplanner-quickstarts')
+                            .run('clean install')
+                    }catch(err) {
+                        unstable("optaplanner-quickstarts test not finish correctly")
+                    }
                 }
             }
             post {

--- a/.ci/jenkins/Jenkinsfile.native
+++ b/.ci/jenkins/Jenkinsfile.native
@@ -1,0 +1,164 @@
+@Library('jenkins-pipeline-shared-libraries')_
+
+import org.kie.jenkins.MavenCommand
+
+optaplannerRepo = 'optaplanner'
+quickstartsRepo = 'optaplanner-quickstarts'
+kogitoRuntimesRepo = 'kogito-runtimes'
+
+pipeline {
+    agent {
+        label 'kie-rhel7 && kie-mem16g'
+    }
+    tools {
+        maven 'kie-maven-3.6.2'
+        jdk 'kie-jdk11'
+    }
+    options {
+        timestamps()
+        timeout(time: 360, unit: 'MINUTES')
+    }
+    environment {
+        KOGITO_CI_EMAIL_TO = credentials("${JENKINS_EMAIL_CREDS_ID}")
+    }
+    stages {
+        stage('Initialize') {
+            steps {
+                script {
+                    checkoutRuntimesRepo()
+                    checkoutOptaplannerRepo()
+                    checkoutOptaplannerQuickstartsRepo()
+                }
+            }
+        }
+        stage('Build quickly kogito-runtimes') {
+            steps {
+                script {
+                    getMavenCommand(kogitoRuntimesRepo)
+                        .withProperty('quickly')
+                        .run('clean install')
+                }
+            }
+            post {
+                always {
+                    script {
+                        cleanContainers()
+                    }
+                }
+            }
+        }
+        stage('Build optaplanner') {
+            steps {
+                script {
+                    getNativeMavenCommand('optaplanner')
+                        .run('clean install')
+                }
+            }
+            post {
+                always {
+                    script {
+                        cleanContainers()
+                    }
+                }
+            }
+        }
+        stage('Build optaplanner-quickstarts') {
+            steps {
+                script {
+                    getNativeMavenCommand('optaplanner-quickstarts')
+                        .run('clean install')
+                }
+            }
+            post {
+                always {
+                    script {
+                        cleanContainers()
+                    }
+                }
+            }
+        }
+    }
+    post {
+        unsuccessful {
+            sendNotification()
+        }
+        always {
+            script {
+                junit '**/target/surefire-reports/**/*.xml, **/target/failsafe-reports/**/*.xml'
+            }
+        }
+        cleanup {
+            script {
+                util.cleanNode('docker')
+            }
+        }
+    }
+}
+
+void sendNotification() {
+    emailext body: "**Native check job** #${BUILD_NUMBER} was: ${currentBuild.currentResult}\nPlease look here: ${BUILD_URL}",
+             subject: "[${params.BUILD_BRANCH_NAME}] Optaplanner",
+             to: env.KOGITO_CI_EMAIL_TO
+}
+
+void checkoutRuntimesRepo() {
+    dir(kogitoRuntimesRepo) {
+        checkout(githubscm.resolveRepository(kogitoRuntimesRepo, params.GIT_AUTHOR, getKogitoTargetBranch(), false))
+    }
+}
+
+void checkoutOptaplannerRepo() {
+    dir(optaplannerRepo) {
+        checkout(githubscm.resolveRepository(optaplannerRepo, params.GIT_AUTHOR, getOptaplannerTargetBranch(), false))
+    }
+}
+
+void checkoutOptaplannerQuickstartsRepo() {
+    // If the PR to OptaPlanner targets the 'main' branch, we assume the branch 'development' for quickstarts.
+    String quickstartsChangeTarget = params.BUILD_BRANCH_NAME == 'main' ? 'development' : getOptaplannerTargetBranch()
+
+    dir(quickstartsRepo) {
+        checkout(githubscm.resolveRepository(quickstartsRepo, params.GIT_AUTHOR, quickstartsChangeTarget, false))
+    }
+}
+
+String getKogitoTargetBranch() {
+    return getTargetBranch(-7)
+}
+
+String getOptaplannerTargetBranch() {
+    return getTargetBranch(0)
+}
+
+String getTargetBranch(Integer addToMajor) {
+    String targetBranch = params.BUILD_BRANCH_NAME
+    String [] versionSplit = targetBranch.split("\\.")
+    if (versionSplit.length == 3
+        && versionSplit[0].isNumber()
+        && versionSplit[1].isNumber()
+        && versionSplit[2] == 'x') {
+        targetBranch = "${Integer.parseInt(versionSplit[0]) + addToMajor}.${versionSplit[1]}.x"
+    } else {
+        echo "Cannot parse targetBranch as release branch so going further with current value: ${targetBranch}"
+        }
+    return targetBranch
+}
+
+MavenCommand getMavenCommand(String directory) {
+    return new MavenCommand(this, ['-fae'])
+                .withSettingsXmlId('kogito_release_settings')
+                .withProperty('java.net.preferIPv4Stack', true)
+                .inDirectory(directory)
+}
+
+MavenCommand getNativeMavenCommand(String directory) {
+    return getMavenCommand(directory)
+                .withProfiles(['native'])
+                .withProperty('quarkus.native.container-build', true)
+                .withProperty('quarkus.native.container-runtime', 'docker')
+                .withProperty('quarkus.profile', 'native') // Added due to https://github.com/quarkusio/quarkus/issues/13341
+}
+
+void cleanContainers() {
+    cloud.cleanContainersAndImages('docker')
+}

--- a/.ci/jenkins/dsl/jobs.groovy
+++ b/.ci/jenkins/dsl/jobs.groovy
@@ -76,6 +76,7 @@ setupMultijobPrNativeChecks()
 setupMultijobPrLTSChecks()
 
 // Nightly jobs
+setupNativeJob(nightlyBranchFolder)
 setupDeployJob(nightlyBranchFolder, KogitoJobType.NIGHTLY)
 setupPromoteJob(nightlyBranchFolder, KogitoJobType.NIGHTLY)
 
@@ -139,6 +140,20 @@ void setupMultijobPrNativeChecks() {
 
 void setupMultijobPrLTSChecks() {
     KogitoJobTemplate.createMultijobLTSPRJobs(this, getMultijobPRConfig()) { return getDefaultJobParams() }
+}
+
+void setupNativeJob(String jobFolder) {
+    def jobParams = getJobParams('optaplanner-native', jobFolder, 'Jenkinsfile.native', 'Optaplanner Native Testing')
+    jobParams.triggers = [ cron : 'H 6 * * *' ]
+    KogitoJobTemplate.createPipelineJob(this, jobParams).with {
+        parameters {
+            stringParam('BUILD_BRANCH_NAME', "${GIT_BRANCH}", 'Set the Git branch to checkout')
+            stringParam('GIT_AUTHOR', "${GIT_AUTHOR_NAME}", 'Set the Git author to checkout')
+        }
+        environmentVariables {
+            env('JENKINS_EMAIL_CREDS_ID', "${JENKINS_EMAIL_CREDS_ID}")
+        }
+    }
 }
 
 void setupDeployJob(String jobFolder, KogitoJobType jobType) {

--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@
 # Eclipse, Netbeans and IntelliJ files
 /.*
 !/.github
-!/.jenkins
+!/.ci
 !.gitignore
 !.gitattributes
 !/.mvn


### PR DESCRIPTION
https://issues.redhat.com/browse/KOGITO-5597

Related PRs:
- https://github.com/kiegroup/kogito-runtimes/pull/1482
- https://github.com/kiegroup/optaplanner/pull/1472
- https://github.com/kiegroup/kogito-apps/pull/965
- https://github.com/kiegroup/kogito-examples/pull/818

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>specific pull request build</b> please add comment: <b>Jenkins (re)run [optaplanner|apps|examples] tests</b>
* for a <b>full downstream build</b> please add comment: <b>Jenkins run fdb</b>
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
* for a <b>Quarkus LTS check</b> please add comment: <b>Jenkins run LTS</b>
* for a <b>specific Quarkus LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner|apps|examples] LTS</b>
* for a <b>Native check</b> please add comment: <b>Jenkins run native</b>
* for a <b>specific Native LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner|apps|examples] native</b>
</details>