### PR TITLE
KOGITO-5635 Added native LTS check

### DIFF
--- a/.ci/jenkins/Jenkinsfile.native
+++ b/.ci/jenkins/Jenkinsfile.native
@@ -104,7 +104,7 @@ pipeline {
 }
 
 void sendNotification() {
-    emailext body: "**Native check job** #${BUILD_NUMBER} was: ${currentBuild.currentResult}\nPlease look here: ${BUILD_URL}",
+    emailext body: "**${NOTIFICATION_JOB_NAME}** #${BUILD_NUMBER} was: ${currentBuild.currentResult}\nPlease look here: ${BUILD_URL}",
              subject: "[${params.BUILD_BRANCH_NAME}] Optaplanner",
              to: env.KOGITO_CI_EMAIL_TO
 }
@@ -160,13 +160,23 @@ MavenCommand getMavenCommand(String directory) {
 }
 
 MavenCommand getNativeMavenCommand(String directory) {
-    return getMavenCommand(directory)
+    def mvnCmd = getMavenCommand(directory)
                 .withProfiles(['native'])
                 .withProperty('quarkus.native.container-build', true)
                 .withProperty('quarkus.native.container-runtime', 'docker')
                 .withProperty('quarkus.profile', 'native') // Added due to https://github.com/quarkusio/quarkus/issues/13341
+    
+    if (getNativeBuilderImage()) {
+        mvnCmd.withProperty('quarkus.native.builder-image', getNativeBuilderImage())
+    }
+
+    return mvnCmd
 }
 
 void cleanContainers() {
     cloud.cleanContainersAndImages('docker')
+}
+
+String getNativeBuilderImage() {
+    return params.NATIVE_BUILDER_IMAGE
 }

--- a/.ci/jenkins/Jenkinsfile.native
+++ b/.ci/jenkins/Jenkinsfile.native
@@ -159,7 +159,7 @@ MavenCommand getMavenCommand(String directory) {
                 .inDirectory(directory)
 }
 
-MavenCommand getNativeMavenCommand(String directory) {
+MavenCommand getNativeMavenCommand(String directory, String builderImage = getNativeBuilderImage()) {
     def mvnCmd = getMavenCommand(directory)
                 .withProfiles(['native'])
                 .withProperty('quarkus.native.container-build', true)

--- a/.ci/jenkins/Jenkinsfile.native
+++ b/.ci/jenkins/Jenkinsfile.native
@@ -166,8 +166,8 @@ MavenCommand getNativeMavenCommand(String directory, String builderImage = getNa
                 .withProperty('quarkus.native.container-runtime', 'docker')
                 .withProperty('quarkus.profile', 'native') // Added due to https://github.com/quarkusio/quarkus/issues/13341
     
-    if (getNativeBuilderImage()) {
-        mvnCmd.withProperty('quarkus.native.builder-image', getNativeBuilderImage())
+    if (builderImage) {
+        mvnCmd.withProperty('quarkus.native.builder-image', builderImage)
     }
 
     return mvnCmd

--- a/.ci/jenkins/dsl/jobs.groovy
+++ b/.ci/jenkins/dsl/jobs.groovy
@@ -91,6 +91,10 @@ if (Utils.isMainBranch(this)) {
     setupOptaPlannerTurtleTestsJob(otherFolder)
 }
 
+if (Utils.isLTSBranch(this)) {
+    setupNativeLTSJob(nightlyBranchFolder)
+}
+
 /////////////////////////////////////////////////////////////////
 // Methods
 /////////////////////////////////////////////////////////////////
@@ -152,6 +156,24 @@ void setupNativeJob(String jobFolder) {
         }
         environmentVariables {
             env('JENKINS_EMAIL_CREDS_ID', "${JENKINS_EMAIL_CREDS_ID}")
+            env('NOTIFICATION_JOB_NAME', 'Native check')
+        }
+    }
+}
+
+void setupNativeLTSJob(String jobFolder) {
+    def jobParams = getJobParams('optaplanner-native-lts', jobFolder, 'Jenkinsfile.native', 'Optaplanner Native LTS Testing')
+    jobParams.triggers = [ cron : 'H 8 * * *' ]
+    KogitoJobTemplate.createPipelineJob(this, jobParams).with {
+        parameters {
+            stringParam('BUILD_BRANCH_NAME', "${GIT_BRANCH}", 'Set the Git branch to checkout')
+            stringParam('GIT_AUTHOR', "${GIT_AUTHOR_NAME}", 'Set the Git author to checkout')
+
+            stringParam('NATIVE_BUILDER_IMAGE', Utils.getLTSNativeBuilderImage(this), 'Which native builder image to use ?')
+        }
+        environmentVariables {
+            env('JENKINS_EMAIL_CREDS_ID', "${JENKINS_EMAIL_CREDS_ID}")
+            env('NOTIFICATION_JOB_NAME', 'Native LTS check')
         }
     }
 }

--- a/.ci/jenkins/dsl/jobs.groovy
+++ b/.ci/jenkins/dsl/jobs.groovy
@@ -147,7 +147,7 @@ void setupMultijobPrLTSChecks() {
 }
 
 void setupNativeJob(String jobFolder) {
-    def jobParams = getJobParams('optaplanner-native', jobFolder, 'Jenkinsfile.native', 'Optaplanner Native Testing')
+    def jobParams = getJobParams('optaplanner-native', jobFolder, "${OPTAPLANNER_JENKINS_PATH}/Jenkinsfile.native", 'Optaplanner Native Testing')
     jobParams.triggers = [ cron : 'H 6 * * *' ]
     KogitoJobTemplate.createPipelineJob(this, jobParams).with {
         parameters {
@@ -162,7 +162,7 @@ void setupNativeJob(String jobFolder) {
 }
 
 void setupNativeLTSJob(String jobFolder) {
-    def jobParams = getJobParams('optaplanner-native-lts', jobFolder, 'Jenkinsfile.native', 'Optaplanner Native LTS Testing')
+    def jobParams = getJobParams('optaplanner-native-lts', jobFolder, "${OPTAPLANNER_JENKINS_PATH}/Jenkinsfile.native", 'Optaplanner Native LTS Testing')
     jobParams.triggers = [ cron : 'H 8 * * *' ]
     KogitoJobTemplate.createPipelineJob(this, jobParams).with {
         parameters {


### PR DESCRIPTION
https://issues.redhat.com/browse/KOGITO-5635

Related PRs:
- https://github.com/kiegroup/kogito-pipelines/pull/229
- https://github.com/kiegroup/kogito-runtimes/pull/1491
- https://github.com/kiegroup/optaplanner/pull/1483
- https://github.com/kiegroup/kogito-apps/pull/973
- https://github.com/kiegroup/kogito-examples/pull/827



<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>specific pull request build</b> please add comment: <b>Jenkins (re)run [optaplanner|apps|examples] tests</b>
* for a <b>full downstream build</b> please add comment: <b>Jenkins run fdb</b>
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
* for a <b>Quarkus LTS check</b> please add comment: <b>Jenkins run LTS</b>
* for a <b>specific Quarkus LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner|apps|examples] LTS</b>
* for a <b>Native check</b> please add comment: <b>Jenkins run native</b>
* for a <b>specific Native LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner|apps|examples] native</b>
</details>