### PR TITLE
PLANNER-2504: GIZMO - Make final fields non-final in Quarkus; fail fast in plain java

### DIFF
--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/common/accessor/gizmo/GizmoMemberDescriptor.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/common/accessor/gizmo/GizmoMemberDescriptor.java
@@ -180,7 +180,7 @@ public class GizmoMemberDescriptor {
                     bytecodeCreator.writeInstanceField(fd, thisObj, newValue);
                 }
             } catch (NoSuchFieldException e) {
-                throw new IllegalStateException("Field (" + name + ") of class (" + declaringClass + ") does not exist", e);
+                throw new IllegalStateException("Field (" + name + ") of class (" + declaringClass + ") does not exist.", e);
             }
             return true;
         } else if (memberDescriptor instanceof MethodDescriptor) {

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/test/java/org/optaplanner/quarkus/testdata/gizmo/PrivateNoArgsConstructorEntity.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/test/java/org/optaplanner/quarkus/testdata/gizmo/PrivateNoArgsConstructorEntity.java
@@ -23,13 +23,13 @@ import org.optaplanner.core.api.domain.variable.PlanningVariable;
 @PlanningEntity
 public class PrivateNoArgsConstructorEntity {
     @PlanningId
-    String id;
+    final String id;
 
     @PlanningVariable(valueRangeProviderRefs = "valueRange")
     String value;
 
     private PrivateNoArgsConstructorEntity() {
-
+        id = null;
     }
 
     public PrivateNoArgsConstructorEntity(String id) {

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/test/java/org/optaplanner/quarkus/testdata/gizmo/PrivateNoArgsConstructorSolution.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/test/java/org/optaplanner/quarkus/testdata/gizmo/PrivateNoArgsConstructorSolution.java
@@ -31,13 +31,15 @@ public class PrivateNoArgsConstructorSolution {
     List<PrivateNoArgsConstructorEntity> planningEntityList;
 
     @PlanningScore
-    public SimpleScore score;
+    public final SimpleScore score;
 
     private PrivateNoArgsConstructorSolution() {
+        score = null;
     }
 
     public PrivateNoArgsConstructorSolution(List<PrivateNoArgsConstructorEntity> planningEntityList) {
         this.planningEntityList = planningEntityList;
+        score = null;
     }
 
     @ValueRangeProvider(id = "valueRange")


### PR DESCRIPTION
<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.
-->

### JIRA

<!-- Add a JIRA ticket link if it exists. -->
https://issues.redhat.com/browse/PLANNER-2504

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
* https://github.com/kiegroup/drools/pull/3000
* https://github.com/kiegroup/optaplanner/pull/899
* etc.
-->

### Checklist
- [ ] Documentation updated if applicable.
- [ ] Upgrade recipe provided if applicable.

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>specific pull request build</b> please add comment: <b>Jenkins (re)run [optaplanner|apps|examples] tests</b>
* for a <b>full downstream build</b> please add comment: <b>Jenkins run fdb</b>
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
* for a <b>Quarkus LTS check</b> please add comment: <b>Jenkins run LTS</b>
* for a <b>specific Quarkus LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner|apps|examples] LTS</b>
* for a <b>Native check</b> please add comment: <b>Jenkins run native</b>
* for a <b>specific Native LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner|apps|examples] native</b>
</details>