### PR TITLE
Simplify PlannerAssert

### DIFF
--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/heuristic/selector/entity/pillar/DefaultPillarSelectorTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/heuristic/selector/entity/pillar/DefaultPillarSelectorTest.java
@@ -16,12 +16,12 @@
 
 package org.optaplanner.core.impl.heuristic.selector.entity.pillar;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.anyInt;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertAllCodesOfIterator;
-import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertCodesOfIterator;
+import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertAllCodesOfPillarSelector;
+import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertCodesOfNeverEndingPillarSelector;
+import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertEmptyNeverEndingPillarSelector;
 import static org.optaplanner.core.impl.testdata.util.PlannerAssert.verifyPhaseLifecycle;
 
 import java.util.Arrays;
@@ -399,13 +399,13 @@ public class DefaultPillarSelectorTest {
         AbstractStepScope stepScopeA1 = mock(AbstractStepScope.class);
         when(stepScopeA1.getPhaseScope()).thenReturn(phaseScopeA);
         pillarSelector.stepStarted(stepScopeA1);
-        assertCodesOfNeverEndingPillarSelector(pillarSelector);
+        assertEmptyNeverEndingPillarSelector(pillarSelector);
         pillarSelector.stepEnded(stepScopeA1);
 
         AbstractStepScope stepScopeA2 = mock(AbstractStepScope.class);
         when(stepScopeA2.getPhaseScope()).thenReturn(phaseScopeA);
         pillarSelector.stepStarted(stepScopeA2);
-        assertCodesOfNeverEndingPillarSelector(pillarSelector);
+        assertEmptyNeverEndingPillarSelector(pillarSelector);
         pillarSelector.stepEnded(stepScopeA2);
 
         pillarSelector.phaseEnded(phaseScopeA);
@@ -417,7 +417,7 @@ public class DefaultPillarSelectorTest {
         AbstractStepScope stepScopeB1 = mock(AbstractStepScope.class);
         when(stepScopeB1.getPhaseScope()).thenReturn(phaseScopeB);
         pillarSelector.stepStarted(stepScopeB1);
-        assertCodesOfNeverEndingPillarSelector(pillarSelector);
+        assertEmptyNeverEndingPillarSelector(pillarSelector);
         pillarSelector.stepEnded(stepScopeB1);
 
         pillarSelector.phaseEnded(phaseScopeB);
@@ -425,19 +425,6 @@ public class DefaultPillarSelectorTest {
         pillarSelector.solvingEnded(solverScope);
 
         verifyPhaseLifecycle(entitySelector, 1, 2, 3);
-    }
-
-    private void assertAllCodesOfPillarSelector(PillarSelector pillarSelector, String... codes) {
-        assertAllCodesOfIterator(pillarSelector.iterator(), codes);
-        assertThat(pillarSelector.isCountable()).isTrue();
-        assertThat(pillarSelector.isNeverEnding()).isFalse();
-        assertThat(pillarSelector.getSize()).isEqualTo(codes.length);
-    }
-
-    private void assertCodesOfNeverEndingPillarSelector(PillarSelector pillarSelector, String... codes) {
-        assertCodesOfIterator(pillarSelector.iterator(), codes);
-        assertThat(pillarSelector.isCountable()).isTrue();
-        assertThat(pillarSelector.isNeverEnding()).isTrue();
     }
 
 }

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/heuristic/selector/move/generic/PillarChangeMoveTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/heuristic/selector/move/generic/PillarChangeMoveTest.java
@@ -20,7 +20,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertAllCodesOfCollection;
 import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertCode;
-import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertListElementsSameExactly;
 import static org.optaplanner.core.impl.testdata.util.PlannerTestUtils.mockRebasingScoreDirector;
 
 import java.util.Arrays;
@@ -167,7 +166,7 @@ public class PillarChangeMoveTest {
     }
 
     public void assertSameProperties(List<Object> pillar, Object toPlanningVariable, PillarChangeMove<?> move) {
-        assertListElementsSameExactly(pillar, move.getPillar());
+        assertThat(move.getPillar()).hasSameElementsAs(pillar);
         assertThat(move.getToPlanningValue()).isSameAs(toPlanningVariable);
     }
 

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/heuristic/selector/move/generic/PillarSwapMoveTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/heuristic/selector/move/generic/PillarSwapMoveTest.java
@@ -19,7 +19,6 @@ package org.optaplanner.core.impl.heuristic.selector.move.generic;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertAllCodesOfCollection;
-import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertListElementsSameExactly;
 import static org.optaplanner.core.impl.testdata.util.PlannerTestUtils.mockRebasingScoreDirector;
 
 import java.util.Arrays;
@@ -274,8 +273,8 @@ public class PillarSwapMoveTest {
     }
 
     public void assertSameProperties(List<Object> leftPillar, List<Object> rightPillar, PillarSwapMove<?> move) {
-        assertListElementsSameExactly(leftPillar, move.getLeftPillar());
-        assertListElementsSameExactly(rightPillar, move.getRightPillar());
+        assertThat(move.getLeftPillar()).hasSameElementsAs(leftPillar);
+        assertThat(move.getRightPillar()).hasSameElementsAs(rightPillar);
     }
 
     @Test

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/heuristic/selector/move/generic/chained/KOptMoveTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/heuristic/selector/move/generic/chained/KOptMoveTest.java
@@ -18,7 +18,6 @@ package org.optaplanner.core.impl.heuristic.selector.move.generic.chained;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
-import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertArrayElementsSameExactly;
 import static org.optaplanner.core.impl.testdata.util.PlannerTestUtils.mockRebasingScoreDirector;
 
 import java.util.Arrays;
@@ -292,17 +291,17 @@ public class KOptMoveTest {
         SingletonInverseVariableSupply inverseVariableSupply = mock(SingletonInverseVariableSupply.class);
         AnchorVariableSupply anchorVariableSupply = mock(AnchorVariableSupply.class);
 
-        assertSameProperties(destinationA1, new Object[] { destinationC1, destinationB0 },
+        assertSameProperties(destinationA1, Arrays.asList(destinationC1, destinationB0),
                 new KOptMove<>(variableDescriptor, inverseVariableSupply, anchorVariableSupply, a1, new Object[] { c1, b0 })
                         .rebase(destinationScoreDirector));
-        assertSameProperties(destinationA3, new Object[] { destinationA0, destinationB0 },
+        assertSameProperties(destinationA3, Arrays.asList(destinationA0, destinationB0),
                 new KOptMove<>(variableDescriptor, inverseVariableSupply, anchorVariableSupply, a3, new Object[] { a0, b0 })
                         .rebase(destinationScoreDirector));
     }
 
-    public void assertSameProperties(Object leftentity, Object[] values, KOptMove<TestdataChainedSolution> move) {
-        assertThat(move.getEntity()).isSameAs(leftentity);
-        assertArrayElementsSameExactly(values, move.getValues());
+    public void assertSameProperties(Object leftEntity, Iterable<Object> values, KOptMove<TestdataChainedSolution> move) {
+        assertThat(move.getEntity()).isSameAs(leftEntity);
+        assertThat(move.getValues()).hasSameElementsAs(values);
     }
 
     @Test

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/heuristic/selector/move/generic/chained/SubChainChangeMoveTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/heuristic/selector/move/generic/chained/SubChainChangeMoveTest.java
@@ -19,7 +19,6 @@ package org.optaplanner.core.impl.heuristic.selector.move.generic.chained;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
-import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertListElementsSameExactly;
 import static org.optaplanner.core.impl.testdata.util.PlannerTestUtils.mockRebasingScoreDirector;
 
 import java.util.Arrays;
@@ -186,7 +185,7 @@ public class SubChainChangeMoveTest {
     }
 
     public void assertSameProperties(List<Object> entityList, Object toPlanningVariable, SubChainChangeMove move) {
-        assertListElementsSameExactly(entityList, move.getSubChain().getEntityList());
+        assertThat(move.getSubChain().getEntityList()).hasSameElementsAs(entityList);
         assertThat(move.getToPlanningValue()).isSameAs(toPlanningVariable);
     }
 

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/heuristic/selector/move/generic/chained/SubChainReversingChangeMoveTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/heuristic/selector/move/generic/chained/SubChainReversingChangeMoveTest.java
@@ -19,7 +19,6 @@ package org.optaplanner.core.impl.heuristic.selector.move.generic.chained;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
-import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertListElementsSameExactly;
 import static org.optaplanner.core.impl.testdata.util.PlannerTestUtils.mockRebasingScoreDirector;
 
 import java.util.Arrays;
@@ -259,7 +258,7 @@ public class SubChainReversingChangeMoveTest {
     }
 
     public void assertSameProperties(List<Object> entityList, Object toPlanningVariable, SubChainReversingChangeMove move) {
-        assertListElementsSameExactly(entityList, move.getSubChain().getEntityList());
+        assertThat(move.getSubChain().getEntityList()).hasSameElementsAs(entityList);
         assertThat(move.getToPlanningValue()).isSameAs(toPlanningVariable);
     }
 

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/heuristic/selector/move/generic/chained/SubChainReversingSwapMoveTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/heuristic/selector/move/generic/chained/SubChainReversingSwapMoveTest.java
@@ -19,7 +19,6 @@ package org.optaplanner.core.impl.heuristic.selector.move.generic.chained;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
-import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertListElementsSameExactly;
 import static org.optaplanner.core.impl.testdata.util.PlannerTestUtils.mockRebasingScoreDirector;
 
 import java.util.Arrays;
@@ -289,8 +288,8 @@ public class SubChainReversingSwapMoveTest {
 
     public void assertSameProperties(List<Object> leftEntityList, List<Object> rightEntityList,
             SubChainReversingSwapMove move) {
-        assertListElementsSameExactly(leftEntityList, move.getLeftSubChain().getEntityList());
-        assertListElementsSameExactly(rightEntityList, move.getRightSubChain().getEntityList());
+        assertThat(move.getLeftSubChain().getEntityList()).hasSameElementsAs(leftEntityList);
+        assertThat(move.getRightSubChain().getEntityList()).hasSameElementsAs(rightEntityList);
     }
 
     @Test

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/heuristic/selector/move/generic/chained/SubChainSwapMoveTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/heuristic/selector/move/generic/chained/SubChainSwapMoveTest.java
@@ -19,7 +19,6 @@ package org.optaplanner.core.impl.heuristic.selector.move.generic.chained;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
-import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertListElementsSameExactly;
 import static org.optaplanner.core.impl.testdata.util.PlannerTestUtils.mockRebasingScoreDirector;
 
 import java.util.Arrays;
@@ -199,8 +198,8 @@ public class SubChainSwapMoveTest {
     }
 
     public void assertSameProperties(List<Object> leftEntityList, List<Object> rightEntityList, SubChainSwapMove move) {
-        assertListElementsSameExactly(leftEntityList, move.getLeftSubChain().getEntityList());
-        assertListElementsSameExactly(rightEntityList, move.getRightSubChain().getEntityList());
+        assertThat(move.getLeftSubChain().getEntityList()).hasSameElementsAs(leftEntityList);
+        assertThat(move.getRightSubChain().getEntityList()).hasSameElementsAs(rightEntityList);
     }
 
     @Test

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/heuristic/selector/value/chained/DefaultSubChainSelectorTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/heuristic/selector/value/chained/DefaultSubChainSelectorTest.java
@@ -21,7 +21,7 @@ import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException
 import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertAllCodesOfIterator;
+import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertAllCodesOfSubChainSelector;
 import static org.optaplanner.core.impl.testdata.util.PlannerAssert.verifyPhaseLifecycle;
 
 import java.util.Arrays;
@@ -286,13 +286,6 @@ public class DefaultSubChainSelectorTest {
         subChainSelector.solvingEnded(solverScope);
 
         verifyPhaseLifecycle(valueSelector, 1, 2, 3);
-    }
-
-    private void assertAllCodesOfSubChainSelector(SubChainSelector subChainSelector, String... codes) {
-        assertAllCodesOfIterator(subChainSelector.iterator(), codes);
-        assertThat(subChainSelector.isCountable()).isTrue();
-        assertThat(subChainSelector.isNeverEnding()).isFalse();
-        assertThat(subChainSelector.getSize()).isEqualTo(codes.length);
     }
 
     @Test

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/testdata/util/CodeAssertable.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/testdata/util/CodeAssertable.java
@@ -29,25 +29,25 @@ public interface CodeAssertable {
 
     String getCode();
 
-    static CodeAssertable convertToCodeAssertable(Object o) {
+    static CodeAssertable convert(Object o) {
         Objects.requireNonNull(o);
         if (o instanceof CodeAssertable) {
             return (CodeAssertable) o;
         } else if (o instanceof ChangeMove) {
             ChangeMove<?> changeMove = (ChangeMove) o;
-            final String code = convertToCodeAssertable(changeMove.getEntity()).getCode()
-                    + "->" + convertToCodeAssertable(changeMove.getToPlanningValue()).getCode();
+            final String code = convert(changeMove.getEntity()).getCode()
+                    + "->" + convert(changeMove.getToPlanningValue()).getCode();
             return () -> code;
         } else if (o instanceof SwapMove) {
             SwapMove<?> swapMove = (SwapMove) o;
-            final String code = convertToCodeAssertable(swapMove.getLeftEntity()).getCode()
-                    + "<->" + convertToCodeAssertable(swapMove.getRightEntity()).getCode();
+            final String code = convert(swapMove.getLeftEntity()).getCode()
+                    + "<->" + convert(swapMove.getRightEntity()).getCode();
             return () -> code;
         } else if (o instanceof CompositeMove) {
             CompositeMove<?> compositeMove = (CompositeMove) o;
             StringBuilder codeBuilder = new StringBuilder(compositeMove.getMoves().length * 80);
             for (Move<?> move : compositeMove.getMoves()) {
-                codeBuilder.append("+").append(convertToCodeAssertable(move).getCode());
+                codeBuilder.append("+").append(convert(move).getCode());
             }
             final String code = codeBuilder.substring(1);
             return () -> code;
@@ -61,14 +61,14 @@ public interface CodeAssertable {
                 } else {
                     codeBuilder.append(", ");
                 }
-                codeBuilder.append(convertToCodeAssertable(element).getCode());
+                codeBuilder.append(convert(element).getCode());
             }
             codeBuilder.append("]");
             final String code = codeBuilder.toString();
             return () -> code;
         } else if (o instanceof SubChain) {
             SubChain subChain = (SubChain) o;
-            final String code = convertToCodeAssertable(subChain.getEntityList()).getCode();
+            final String code = convert(subChain.getEntityList()).getCode();
             return () -> code;
         }
         throw new AssertionError(("o's class (" + o.getClass() + ") cannot be converted to CodeAssertable."));

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/testdata/util/PlannerAssert.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/testdata/util/PlannerAssert.java
@@ -149,13 +149,6 @@ public final class PlannerAssert {
         }
     }
 
-    public static <E> void assertListElementsSameExactly(List<E> expectedList, List<E> actualList) {
-        assertThat(actualList.size()).isEqualTo(expectedList.size());
-        for (int i = 0; i < expectedList.size(); i++) {
-            assertThat(actualList.get(i)).isSameAs(expectedList.get(i));
-        }
-    }
-
     public static <E> void assertArrayElementsSameExactly(E[] expectedArray, E[] actualArray) {
         assertThat(actualArray.length).isEqualTo(expectedArray.length);
         for (int i = 0; i < expectedArray.length; i++) {

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/testdata/util/PlannerAssert.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/testdata/util/PlannerAssert.java
@@ -48,7 +48,6 @@ import org.optaplanner.core.impl.phase.event.PhaseLifecycleListener;
 import org.optaplanner.core.impl.phase.scope.AbstractPhaseScope;
 import org.optaplanner.core.impl.phase.scope.AbstractStepScope;
 import org.optaplanner.core.impl.solver.scope.SolverScope;
-import org.optaplanner.core.impl.testdata.domain.TestdataEntity;
 import org.optaplanner.core.impl.testdata.domain.TestdataSolution;
 
 /**
@@ -67,8 +66,8 @@ public final class PlannerAssert {
         for (int i = 0; i < objects.length; i++) {
             for (int j = i + 1; j < objects.length; j++) {
                 assertThat(objects[j]).isEqualTo(objects[i]);
-                assertThat(objects[j].hashCode()).isEqualTo(objects[i].hashCode());
-                assertThat(objects[i].compareTo(objects[j])).isEqualTo(0);
+                assertThat(objects[j]).hasSameHashCodeAs(objects[i]);
+                assertThat(objects[i]).isEqualByComparingTo(objects[j]);
             }
         }
     }
@@ -87,7 +86,7 @@ public final class PlannerAssert {
         for (int i = 0; i < objects.length; i++) {
             for (int j = i + 1; j < objects.length; j++) {
                 assertThat(objects[j]).isNotEqualTo(objects[i]);
-                assertThat(objects[i].compareTo(objects[j])).isNotEqualTo(0);
+                assertThat(objects[i]).isNotEqualByComparingTo(objects[j]);
             }
         }
     }
@@ -184,7 +183,7 @@ public final class PlannerAssert {
     public static <O> void assertElementsOfIterator(Iterator<O> iterator, O... elements) {
         assertThat(iterator).isNotNull();
         for (O element : elements) {
-            assertThat(iterator.hasNext()).isTrue();
+            assertThat(iterator).hasNext();
             assertThat(iterator.next()).isEqualTo(element);
         }
     }
@@ -192,7 +191,7 @@ public final class PlannerAssert {
     @SafeVarargs
     public static <O> void assertAllElementsOfIterator(Iterator<O> iterator, O... elements) {
         assertElementsOfIterator(iterator, elements);
-        assertThat(iterator.hasNext()).isFalse();
+        assertThat(iterator).isExhausted();
         try {
             iterator.next();
             fail("The iterator with hasNext() (" + false + ") is expected to throw a "
@@ -224,7 +223,7 @@ public final class PlannerAssert {
 
     public static <O> void assertAllCodesOfArray(O[] array, String... codes) {
         assertThat(array).isNotNull();
-        assertThat(array.length).isEqualTo(codes.length);
+        assertThat(array).hasSameSizeAs(codes);
         for (int i = 0; i < array.length; i++) {
             assertCode(codes[i], array[i]);
         }
@@ -251,7 +250,7 @@ public final class PlannerAssert {
 
     public static void assertAllCodesOfIterator(Iterator<?> iterator, String... codes) {
         assertCodesOfIterator(iterator, codes);
-        assertThat(iterator.hasNext()).isFalse();
+        assertThat(iterator).isExhausted();
     }
 
     public static void assertAllCodesOfCollection(Collection<?> collection, String... codes) {
@@ -270,7 +269,7 @@ public final class PlannerAssert {
     public static void assertCodesOfNeverEndingIterableSelector(IterableSelector<?, ?> selector, long size, String... codes) {
         Iterator<?> iterator = selector.iterator();
         assertCodesOfNeverEndingIterator(iterator, codes);
-        assertThat(iterator.hasNext()).isTrue();
+        assertThat(iterator).hasNext();
         assertThat(selector.isCountable()).isTrue();
         assertThat(selector.isNeverEnding()).isTrue();
         if (size != DO_NOT_ASSERT_SIZE) {
@@ -279,7 +278,7 @@ public final class PlannerAssert {
     }
 
     public static void assertEmptyNeverEndingIterableSelector(IterableSelector<?, ?> selector, long size) {
-        assertThat(selector.iterator().hasNext()).isFalse();
+        assertThat(selector.iterator()).isExhausted();
         assertThat(selector.isCountable()).isTrue();
         assertThat(selector.isNeverEnding()).isTrue();
         if (size != DO_NOT_ASSERT_SIZE) {
@@ -382,15 +381,13 @@ public final class PlannerAssert {
 
     public static void assertSolutionInitialized(TestdataSolution solution) {
         assertThat(solution).isNotNull();
-        List<TestdataEntity> entityList = solution.getEntityList();
-        assertThat(entityList.isEmpty()).isFalse();
-        for (TestdataEntity entity : entityList) {
-            assertThat(entity.getValue()).isNotNull();
-        }
+        assertThat(solution.getEntityList())
+                .isNotEmpty()
+                .noneMatch(entity -> entity.getValue() == null);
     }
 
     public static <E> E extractSingleton(List<E> singletonList) {
-        assertThat(singletonList.size()).isEqualTo(1);
+        assertThat(singletonList).hasSize(1);
         return singletonList.get(0);
     }
 

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/testdata/util/PlannerAssert.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/testdata/util/PlannerAssert.java
@@ -23,7 +23,6 @@ import static org.assertj.core.api.SoftAssertions.assertSoftly;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.optaplanner.core.impl.testdata.util.CodeAssertable.convertToCodeAssertable;
 
 import java.util.Collection;
 import java.util.Comparator;
@@ -211,8 +210,7 @@ public final class PlannerAssert {
         if (expectedCode == null) {
             assertThat(o).isNull();
         } else {
-            CodeAssertable codeAssertable = convertToCodeAssertable(o);
-            assertCode(expectedCode, codeAssertable);
+            assertCode(expectedCode, CodeAssertable.convert(o));
         }
     }
 
@@ -233,7 +231,7 @@ public final class PlannerAssert {
     }
 
     private static String codeIfNotNull(Object o) {
-        return o == null ? null : convertToCodeAssertable(o).getCode();
+        return o == null ? null : CodeAssertable.convert(o).getCode();
     }
 
     public static <O> void assertCodesOfNeverEndingIterator(Iterator<O> iterator, String... codes) {

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/testdata/util/PlannerAssert.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/testdata/util/PlannerAssert.java
@@ -34,7 +34,7 @@ import java.util.NoSuchElementException;
 import org.optaplanner.core.impl.constructionheuristic.event.ConstructionHeuristicPhaseLifecycleListener;
 import org.optaplanner.core.impl.constructionheuristic.scope.ConstructionHeuristicPhaseScope;
 import org.optaplanner.core.impl.constructionheuristic.scope.ConstructionHeuristicStepScope;
-import org.optaplanner.core.impl.heuristic.move.Move;
+import org.optaplanner.core.impl.heuristic.selector.IterableSelector;
 import org.optaplanner.core.impl.heuristic.selector.entity.EntitySelector;
 import org.optaplanner.core.impl.heuristic.selector.entity.pillar.PillarSelector;
 import org.optaplanner.core.impl.heuristic.selector.move.MoveSelector;
@@ -215,20 +215,13 @@ public final class PlannerAssert {
         }
     }
 
-    public static void assertCode(String message, String expectedCode, Object o) {
-        CodeAssertable codeAssertable = convertToCodeAssertable(o);
-        assertCode(message, expectedCode, codeAssertable);
-    }
-
     public static void assertCode(String expectedCode, CodeAssertable codeAssertable) {
         assertThat(codeAssertable.getCode()).isEqualTo(expectedCode);
     }
 
-    public static void assertCode(String message, String expectedCode, CodeAssertable codeAssertable) {
-        assertThat(codeAssertable.getCode())
-                .as(message)
-                .isEqualTo(expectedCode);
-    }
+    // ************************************************************************
+    // Generic sequences
+    // ************************************************************************
 
     public static <O> void assertAllCodesOfArray(O[] array, String... codes) {
         assertThat(array).isNotNull();
@@ -238,7 +231,7 @@ public final class PlannerAssert {
         }
     }
 
-    public static <O> void assertCodesOfIterator(Iterator<O> iterator, String... codes) {
+    public static void assertCodesOfIterator(Iterator<?> iterator, String... codes) {
         assertThat(iterator).isNotNull();
         for (String code : codes) {
             if (!iterator.hasNext()) {
@@ -248,140 +241,130 @@ public final class PlannerAssert {
         }
     }
 
-    public static <O> void assertAllCodesOfIterator(Iterator<O> iterator, String... codes) {
+    public static void assertAllCodesOfIterator(Iterator<?> iterator, String... codes) {
         assertCodesOfIterator(iterator, codes);
         assertThat(iterator.hasNext()).isFalse();
     }
 
-    public static <O> void assertAllCodesOfCollection(Collection<O> collection, String... codes) {
+    public static void assertAllCodesOfCollection(Collection<?> collection, String... codes) {
         assertAllCodesOfIterator(collection.iterator(), codes);
     }
 
-    public static void assertAllCodesOfMoveSelector(MoveSelector moveSelector, String... codes) {
-        assertAllCodesOfMoveSelector(moveSelector, codes.length, codes);
-    }
-
-    public static void assertAllCodesOfMoveSelector(MoveSelector moveSelector, long size, String... codes) {
-        assertAllCodesOfIterator(moveSelector.iterator(), codes);
-        assertThat(moveSelector.isCountable()).isTrue();
-        assertThat(moveSelector.isNeverEnding()).isFalse();
+    public static void assertAllCodesOfIterableSelector(IterableSelector<?, ?> selector, long size, String... codes) {
+        assertAllCodesOfIterator(selector.iterator(), codes);
+        assertThat(selector.isCountable()).isTrue();
+        assertThat(selector.isNeverEnding()).isFalse();
         if (size != DO_NOT_ASSERT_SIZE) {
-            assertThat(moveSelector.getSize()).isEqualTo(size);
+            assertThat(selector.getSize()).isEqualTo(size);
         }
     }
 
-    public static void assertCodesOfNeverEndingMoveSelector(MoveSelector moveSelector, String... codes) {
-        assertCodesOfNeverEndingMoveSelector(moveSelector, DO_NOT_ASSERT_SIZE, codes);
-    }
-
-    public static void assertCodesOfNeverEndingMoveSelector(MoveSelector moveSelector, long size, String... codes) {
-        Iterator<Move> iterator = moveSelector.iterator();
+    public static void assertCodesOfNeverEndingIterableSelector(IterableSelector<?, ?> selector, long size, String... codes) {
+        Iterator<?> iterator = selector.iterator();
         assertCodesOfIterator(iterator, codes);
         assertThat(iterator.hasNext()).isTrue();
-        assertThat(moveSelector.isCountable()).isTrue();
-        assertThat(moveSelector.isNeverEnding()).isTrue();
+        assertThat(selector.isCountable()).isTrue();
+        assertThat(selector.isNeverEnding()).isTrue();
         if (size != DO_NOT_ASSERT_SIZE) {
-            assertThat(moveSelector.getSize()).isEqualTo(size);
+            assertThat(selector.getSize()).isEqualTo(size);
         }
     }
 
-    public static void assertEmptyNeverEndingMoveSelector(MoveSelector moveSelector) {
-        assertEmptyNeverEndingMoveSelector(moveSelector, 0L);
-    }
-
-    public static void assertEmptyNeverEndingMoveSelector(MoveSelector moveSelector, long size) {
-        Iterator<Move> iterator = moveSelector.iterator();
-        assertThat(iterator.hasNext()).isFalse();
-        assertThat(moveSelector.isCountable()).isTrue();
-        assertThat(moveSelector.isNeverEnding()).isTrue();
+    public static void assertEmptyNeverEndingIterableSelector(IterableSelector<?, ?> selector, long size) {
+        assertThat(selector.iterator().hasNext()).isFalse();
+        assertThat(selector.isCountable()).isTrue();
+        assertThat(selector.isNeverEnding()).isTrue();
         if (size != DO_NOT_ASSERT_SIZE) {
-            assertThat(moveSelector.getSize()).isEqualTo(size);
+            assertThat(selector.getSize()).isZero();
         }
     }
 
-    public static void assertAllCodesOfEntitySelector(EntitySelector entitySelector, String... codes) {
-        assertAllCodesOfEntitySelector(entitySelector, codes.length, codes);
+    // ************************************************************************
+    // Aliases for IterableSelector assert
+    // ************************************************************************
+
+    // ---- Move
+
+    public static void assertAllCodesOfMoveSelector(MoveSelector<?> moveSelector, String... codes) {
+        assertAllCodesOfIterableSelector(moveSelector, codes.length, codes);
     }
 
-    public static void assertAllCodesOfEntitySelector(EntitySelector entitySelector, long size, String... codes) {
-        assertAllCodesOfIterator(entitySelector.iterator(), codes);
-        assertThat(entitySelector.isCountable()).isTrue();
-        assertThat(entitySelector.isNeverEnding()).isFalse();
-        if (size != DO_NOT_ASSERT_SIZE) {
-            assertThat(entitySelector.getSize()).isEqualTo(size);
-        }
+    public static void assertAllCodesOfMoveSelector(MoveSelector<?> moveSelector, long size, String... codes) {
+        assertAllCodesOfIterableSelector(moveSelector, size, codes);
     }
 
-    public static void assertCodesOfNeverEndingOfEntitySelector(EntitySelector entitySelector, String... codes) {
-        assertCodesOfNeverEndingOfEntitySelector(entitySelector, DO_NOT_ASSERT_SIZE, codes);
+    public static void assertCodesOfNeverEndingMoveSelector(MoveSelector<?> moveSelector, String... codes) {
+        assertCodesOfNeverEndingIterableSelector(moveSelector, DO_NOT_ASSERT_SIZE, codes);
     }
 
-    public static void assertCodesOfNeverEndingOfEntitySelector(EntitySelector entitySelector, long size, String... codes) {
-        Iterator<Object> iterator = entitySelector.iterator();
-        assertCodesOfIterator(iterator, codes);
-        assertThat(iterator.hasNext()).isTrue();
-        assertThat(entitySelector.isCountable()).isTrue();
-        assertThat(entitySelector.isNeverEnding()).isTrue();
-        if (size != DO_NOT_ASSERT_SIZE) {
-            assertThat(entitySelector.getSize()).isEqualTo(size);
-        }
+    public static void assertCodesOfNeverEndingMoveSelector(MoveSelector<?> moveSelector, long size, String... codes) {
+        assertCodesOfNeverEndingIterableSelector(moveSelector, size, codes);
     }
 
-    public static void assertAllCodesOfPillarSelector(PillarSelector pillarSelector, String... codes) {
-        assertAllCodesOfPillarSelector(pillarSelector, codes.length, codes);
+    public static void assertEmptyNeverEndingMoveSelector(MoveSelector<?> moveSelector) {
+        assertEmptyNeverEndingIterableSelector(moveSelector, 0);
     }
 
-    public static void assertAllCodesOfPillarSelector(PillarSelector pillarSelector, long size, String... codes) {
-        assertAllCodesOfIterator(pillarSelector.iterator(), codes);
-        assertThat(pillarSelector.isCountable()).isTrue();
-        assertThat(pillarSelector.isNeverEnding()).isFalse();
-        if (size != DO_NOT_ASSERT_SIZE) {
-            assertThat(pillarSelector.getSize()).isEqualTo(size);
-        }
+    // ---- Entity
+
+    public static void assertAllCodesOfEntitySelector(EntitySelector<?> entitySelector, String... codes) {
+        assertAllCodesOfIterableSelector(entitySelector, codes.length, codes);
     }
 
-    public static void assertAllCodesOfValueSelector(EntityIndependentValueSelector valueSelector,
+    public static void assertAllCodesOfEntitySelector(EntitySelector<?> entitySelector, long size, String... codes) {
+        assertAllCodesOfIterableSelector(entitySelector, size, codes);
+    }
+
+    public static void assertCodesOfNeverEndingOfEntitySelector(EntitySelector<?> entitySelector, long size, String... codes) {
+        assertCodesOfNeverEndingIterableSelector(entitySelector, size, codes);
+    }
+
+    // ---- Pillar
+
+    public static void assertAllCodesOfPillarSelector(PillarSelector<?> pillarSelector, String... codes) {
+        assertAllCodesOfIterableSelector(pillarSelector, codes.length, codes);
+    }
+
+    public static void assertCodesOfNeverEndingPillarSelector(PillarSelector<?> pillarSelector, String... codes) {
+        assertCodesOfNeverEndingIterableSelector(pillarSelector, DO_NOT_ASSERT_SIZE, codes);
+    }
+
+    public static void assertEmptyNeverEndingPillarSelector(PillarSelector<?> pillarSelector) {
+        assertEmptyNeverEndingIterableSelector(pillarSelector, DO_NOT_ASSERT_SIZE);
+    }
+
+    // ---- Sub Chain
+
+    public static void assertAllCodesOfSubChainSelector(SubChainSelector<?> selector, String... codes) {
+        assertAllCodesOfIterableSelector(selector, codes.length, codes);
+    }
+
+    // ---- Value
+
+    public static void assertAllCodesOfValueSelector(EntityIndependentValueSelector<?> valueSelector, String... codes) {
+        assertAllCodesOfIterableSelector(valueSelector, codes.length, codes);
+    }
+
+    public static void assertAllCodesOfValueSelector(EntityIndependentValueSelector<?> valueSelector, long size,
             String... codes) {
-        assertAllCodesOfValueSelector(valueSelector, codes.length, codes);
+        assertAllCodesOfIterableSelector(valueSelector, size, codes);
     }
 
-    public static void assertAllCodesOfValueSelector(EntityIndependentValueSelector valueSelector, long size,
-            String... codes) {
-        assertAllCodesOfIterator(valueSelector.iterator(), codes);
-        assertThat(valueSelector.isCountable()).isTrue();
-        assertThat(valueSelector.isNeverEnding()).isFalse();
-        if (size != DO_NOT_ASSERT_SIZE) {
-            assertThat(valueSelector.getSize()).isEqualTo(size);
-        }
-    }
+    // ************************************************************************
+    // Entity dependent
+    // ************************************************************************
 
-    public static void assertAllCodesOfValueSelectorForEntity(ValueSelector valueSelector, Object entity,
-            String... codes) {
+    public static void assertAllCodesOfValueSelectorForEntity(ValueSelector<?> valueSelector, Object entity, String... codes) {
         assertAllCodesOfValueSelectorForEntity(valueSelector, entity, codes.length, codes);
     }
 
-    public static void assertAllCodesOfValueSelectorForEntity(ValueSelector valueSelector, Object entity,
+    public static void assertAllCodesOfValueSelectorForEntity(ValueSelector<?> valueSelector, Object entity,
             long size, String... codes) {
         assertAllCodesOfIterator(valueSelector.iterator(entity), codes);
         assertThat(valueSelector.isCountable()).isTrue();
         assertThat(valueSelector.isNeverEnding()).isFalse();
         if (size != DO_NOT_ASSERT_SIZE) {
             assertThat(valueSelector.getSize(entity)).isEqualTo(size);
-        }
-    }
-
-    public static void assertAllCodesOfSubChainSelector(SubChainSelector subChainSelector,
-            String... codes) {
-        assertAllCodesOfSubChainSelector(subChainSelector, codes.length, codes);
-    }
-
-    public static void assertAllCodesOfSubChainSelector(SubChainSelector subChainSelector, long size,
-            String... codes) {
-        assertAllCodesOfIterator(subChainSelector.iterator(), codes);
-        assertThat(subChainSelector.isCountable()).isTrue();
-        assertThat(subChainSelector.isNeverEnding()).isFalse();
-        if (size != DO_NOT_ASSERT_SIZE) {
-            assertThat(subChainSelector.getSize()).isEqualTo(size);
         }
     }
 

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/testdata/util/PlannerAssert.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/testdata/util/PlannerAssert.java
@@ -149,13 +149,6 @@ public final class PlannerAssert {
         }
     }
 
-    public static <E> void assertArrayElementsSameExactly(E[] expectedArray, E[] actualArray) {
-        assertThat(actualArray.length).isEqualTo(expectedArray.length);
-        for (int i = 0; i < expectedArray.length; i++) {
-            assertThat(actualArray[i]).isSameAs(expectedArray[i]);
-        }
-    }
-
     // ************************************************************************
     // PhaseLifecycleListener methods
     // ************************************************************************

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/testdata/util/PlannerAssert.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/testdata/util/PlannerAssert.java
@@ -23,6 +23,7 @@ import static org.assertj.core.api.SoftAssertions.assertSoftly;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.optaplanner.core.impl.testdata.util.CodeAssertable.convertToCodeAssertable;
 
 import java.util.Collection;
 import java.util.Comparator;
@@ -33,16 +34,12 @@ import java.util.NoSuchElementException;
 import org.optaplanner.core.impl.constructionheuristic.event.ConstructionHeuristicPhaseLifecycleListener;
 import org.optaplanner.core.impl.constructionheuristic.scope.ConstructionHeuristicPhaseScope;
 import org.optaplanner.core.impl.constructionheuristic.scope.ConstructionHeuristicStepScope;
-import org.optaplanner.core.impl.heuristic.move.CompositeMove;
 import org.optaplanner.core.impl.heuristic.move.Move;
 import org.optaplanner.core.impl.heuristic.selector.entity.EntitySelector;
 import org.optaplanner.core.impl.heuristic.selector.entity.pillar.PillarSelector;
 import org.optaplanner.core.impl.heuristic.selector.move.MoveSelector;
-import org.optaplanner.core.impl.heuristic.selector.move.generic.ChangeMove;
-import org.optaplanner.core.impl.heuristic.selector.move.generic.SwapMove;
 import org.optaplanner.core.impl.heuristic.selector.value.EntityIndependentValueSelector;
 import org.optaplanner.core.impl.heuristic.selector.value.ValueSelector;
-import org.optaplanner.core.impl.heuristic.selector.value.chained.SubChain;
 import org.optaplanner.core.impl.heuristic.selector.value.chained.SubChainSelector;
 import org.optaplanner.core.impl.localsearch.event.LocalSearchPhaseLifecycleListener;
 import org.optaplanner.core.impl.localsearch.scope.LocalSearchPhaseScope;
@@ -208,51 +205,6 @@ public final class PlannerAssert {
     // ************************************************************************
     // CodeAssertable methods
     // ************************************************************************
-
-    private static CodeAssertable convertToCodeAssertable(Object o) {
-        assertThat(o).isNotNull();
-        if (o instanceof CodeAssertable) {
-            return (CodeAssertable) o;
-        } else if (o instanceof ChangeMove) {
-            ChangeMove<?> changeMove = (ChangeMove) o;
-            final String code = convertToCodeAssertable(changeMove.getEntity()).getCode()
-                    + "->" + convertToCodeAssertable(changeMove.getToPlanningValue()).getCode();
-            return () -> code;
-        } else if (o instanceof SwapMove) {
-            SwapMove<?> swapMove = (SwapMove) o;
-            final String code = convertToCodeAssertable(swapMove.getLeftEntity()).getCode()
-                    + "<->" + convertToCodeAssertable(swapMove.getRightEntity()).getCode();
-            return () -> code;
-        } else if (o instanceof CompositeMove) {
-            CompositeMove<?> compositeMove = (CompositeMove) o;
-            StringBuilder codeBuilder = new StringBuilder(compositeMove.getMoves().length * 80);
-            for (Move<?> move : compositeMove.getMoves()) {
-                codeBuilder.append("+").append(convertToCodeAssertable(move).getCode());
-            }
-            final String code = codeBuilder.substring(1);
-            return () -> code;
-        } else if (o instanceof List) {
-            List<?> list = (List) o;
-            StringBuilder codeBuilder = new StringBuilder("[");
-            boolean firstElement = true;
-            for (Object element : list) {
-                if (firstElement) {
-                    firstElement = false;
-                } else {
-                    codeBuilder.append(", ");
-                }
-                codeBuilder.append(convertToCodeAssertable(element).getCode());
-            }
-            codeBuilder.append("]");
-            final String code = codeBuilder.toString();
-            return () -> code;
-        } else if (o instanceof SubChain) {
-            SubChain subChain = (SubChain) o;
-            final String code = convertToCodeAssertable(subChain.getEntityList()).getCode();
-            return () -> code;
-        }
-        throw new AssertionError(("o's class (" + o.getClass() + ") cannot be converted to CodeAssertable."));
-    }
 
     public static void assertCode(String expectedCode, Object o) {
         if (expectedCode == null) {


### PR DESCRIPTION
- Remove unused methods.
- Reduce code duplication.
- More specific assertions for better messages.
- And most importantly...

## Show the complete sequence when a selector assertion fails
### Given

A SwapMoveSelector that produces `"a<->b", "a<->c", "a<->d", "b<->c", "b<->d", "c<->d"` moves.

And an intentionally modified assertion with three modifications:
```java
assertAllCodesOfMoveSelector(moveSelector, "a<->b", "a<->b", "a<->d", "c<->b", "b<->d", "c<->d", "xxxxx");
//                                                   ^mod1             ^mod2                      ^mod3
```

### Before
```
expected: "a<->b"
 but was: "a<->c"
```
Only describes the first error in the sequence. It's not clear whether the problem is with the first element or with the second one.

### After
```
Expecting actual:
  ["a<->b", "a<->c", "a<->d", "b<->c", "b<->d", "c<->d"]
to contain exactly (and in same order):
  ["a<->b", "a<->b", "a<->d", "c<->b", "b<->d", "c<->d", "xxxxx"]
but some elements were not found:
  ["a<->b", "c<->b", "XXXXX"]
and others were not expected:
  ["a<->c", "b<->c"]
```
Shows the whole actual sequence. All the issues are visible. Makes TDD much easier.

### Checklist
- [ ] Documentation updated if applicable.
- [ ] Upgrade recipe provided if applicable.

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>specific pull request build</b> please add comment: <b>Jenkins (re)run [optaplanner|apps|examples] tests</b>
* for a <b>full downstream build</b> please add comment: <b>Jenkins run fdb</b>
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
* for a <b>Quarkus LTS check</b> please add comment: <b>Jenkins run LTS</b>
* for a <b>specific Quarkus LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner|apps|examples] LTS</b>
* for a <b>Native check</b> please add comment: <b>Jenkins run native</b>
* for a <b>specific Native LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner|apps|examples] native</b>
</details>