### PR TITLE
KOGITO-5730 Update DSL folder structure

### DIFF
--- a/.ci/jenkins/dsl/jobs.groovy
+++ b/.ci/jenkins/dsl/jobs.groovy
@@ -1,5 +1,4 @@
 import org.kie.jenkins.jobdsl.templates.KogitoJobTemplate
-import org.kie.jenkins.jobdsl.KogitoConstants
 import org.kie.jenkins.jobdsl.FolderUtils
 import org.kie.jenkins.jobdsl.Utils
 import org.kie.jenkins.jobdsl.VersionUtils

--- a/.ci/jenkins/dsl/jobs.groovy
+++ b/.ci/jenkins/dsl/jobs.groovy
@@ -81,11 +81,11 @@ if (!Utils.isMainBranch(this)) {
 }
 
 if (Utils.isMainBranch(this)) {
-    setupOptaPlannerTurtleTestsJob(otherFolder)
+    setupOptaPlannerTurtleTestsJob()
 }
 
 if (Utils.isLTSBranch(this)) {
-    setupNativeLTSJob(nightlyBranchFolder)
+    setupNativeLTSJob()
 }
 
 /////////////////////////////////////////////////////////////////


### PR DESCRIPTION
https://issues.redhat.com/browse/KOGITO-5730

This will reorganize the different jobs in a specific branch folder and allow automatically deleting jobs when the concerned branch is removed from the [main config](https://github.com/kiegroup/kogito-pipelines/blob/main/dsl/seed/config/main.yaml#L2)

Example: https://eng-jenkins-csb-business-automation.apps.ocp-c1.prod.psi.redhat.com/job/custom/job/tradisso/job/kogito-5730/

Here are the new mapping: 
- nightly/{branch}/... => {branch}/nightly/...
- release/{branch}/... => {branch}/release/...
- pullrequest/{branch}/... => {branch}/pullrequest/...
- tools/{branch}/... => {branch}/tools/...
- other/{branch}/... => {branch}/other/...

**All PRs should be merged at the same time !!!!**

Dependent PRs:
- https://github.com/kiegroup/kogito-pipelines/pull/237
- https://github.com/kiegroup/kogito-runtimes/pull/1538
- https://github.com/kiegroup/optaplanner/pull/1517
- https://github.com/kiegroup/kogito-apps/pull/990
- https://github.com/kiegroup/kogito-examples/pull/856
- https://github.com/kiegroup/kogito-images/pull/678
- https://github.com/kiegroup/kogito-operator/pull/987
- https://github.com/kiegroup/rhpam-kogito-operator/pull/68

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>specific pull request build</b> please add comment: <b>Jenkins (re)run [optaplanner|apps|examples] tests</b>
* for a <b>full downstream build</b> please add comment: <b>Jenkins run fdb</b>
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
* for a <b>Quarkus LTS check</b> please add comment: <b>Jenkins run LTS</b>
* for a <b>specific Quarkus LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner|apps|examples] LTS</b>
* for a <b>Native check</b> please add comment: <b>Jenkins run native</b>
* for a <b>specific Native LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner|apps|examples] native</b>
</details>