### PR TITLE
Fix Javadoc issues

### DIFF
--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/common/experimental/ExperimentalConstraintCollectors.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/common/experimental/ExperimentalConstraintCollectors.java
@@ -193,7 +193,7 @@ public class ExperimentalConstraintCollectors {
     /**
      * Specialized version of {@link #consecutiveIntervals(Function,Function,BiFunction)} for
      * {@link Temporal} types.
-     * 
+     *
      * @param <A> type of the first mapped fact
      * @param <PointType_> temporal type of the endpoints
      * @param startMap Maps the fact to its start
@@ -296,7 +296,7 @@ public class ExperimentalConstraintCollectors {
      * @param startMap Maps the item to its start
      * @param endMap Maps the item to its end
      * @param differenceFunction Computes the difference between two points. The second argument is always
-     *        larger than the first (ex: {@link Duration#between)}
+     *        larger than the first (ex: {@link Duration#between}
      *        or (a,b) -> b - a).
      * @param <A> type of the first mapped fact
      * @param <B> type of the second mapped fact

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/common/experimental/impl/ConsecutiveSetTree.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/common/experimental/impl/ConsecutiveSetTree.java
@@ -30,10 +30,13 @@ import org.optaplanner.examples.common.experimental.api.ConsecutiveInfo;
 import org.optaplanner.examples.common.experimental.api.Sequence;
 
 /**
- * A ConsecutiveSetTree determine what value are consecutive. A sequence x1,x2,x3,...,xn
- * is understood to be consecutive by d iff x2 - x1 <= d, x3 -x2 <= d, ..., xn - x(n-1) <= d.
- * This datastructure can be thought as an interval tree that maps the point p to
- * the interval [p, p + d].
+ * A {@code ConsecutiveSetTree} determines what values are consecutive. A sequence
+ * <i>x<sub>1</sub>,&nbsp;x<sub>2</sub>,&nbsp;x<sub>3</sub>,&nbsp;...,&nbsp;x<sub>n</sub></i>
+ * is understood to be consecutive by <i>d</i> iff
+ * <i>x<sub>2</sub> &minus; x<sub>1</sub> &le; d, x<sub>3</sub> &minus; x<sub>2</sub> &le; d, ..., x<sub>n</sub> &minus;
+ * x<sub>n-1</sub> &le; d</i>.
+ * This data structure can be thought as an interval tree that maps the point <i>p</i> to
+ * the interval <i>[p, p + d]</i>.
  *
  * @param <Value_> The type of value stored (examples: shifts)
  * @param <Point_> The type of the point (examples: int, LocalDateTime)


### PR DESCRIPTION
Issues addressed:
* `[WARNING] /home/jlocker/src/github.com/kiegroup/optaplanner/optaplanner-examples/src/main/java/org/optaplanner/examples/common/experimental/ExperimentalConstraintCollectors.java:299: warning - invalid usage of tag {@link Duration#between)`
* `[WARNING] /home/jlocker/src/github.com/kiegroup/optaplanner/optaplanner-examples/src/main/java/org/optaplanner/examples/common/experimental/impl/ConsecutiveSetTree.java:34: warning - invalid usage of tag <`
* `[WARNING] /home/jlocker/src/github.com/kiegroup/optaplanner/optaplanner-examples/src/main/java/org/optaplanner/examples/common/experimental/impl/ConsecutiveSetTree.java:34: warning - invalid usage of tag <`
* `[WARNING] /home/jlocker/src/github.com/kiegroup/optaplanner/optaplanner-examples/src/main/java/org/optaplanner/examples/common/experimental/impl/ConsecutiveSetTree.java:34: warning - invalid usage of tag <`

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>specific pull request build</b> please add comment: <b>Jenkins (re)run [optaplanner|apps|examples] tests</b>
* for a <b>full downstream build</b> please add comment: <b>Jenkins run fdb</b>
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
* for a <b>Quarkus LTS check</b> please add comment: <b>Jenkins run LTS</b>
* for a <b>specific Quarkus LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner|apps|examples] LTS</b>
* for a <b>Native check</b> please add comment: <b>Jenkins run native</b>
* for a <b>specific Native LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner|apps|examples] native</b>
</details>