### PR TITLE
Improve performance of Constraint Streams on select use cases

### DIFF
--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/AbstractFromConfigFactory.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/AbstractFromConfigFactory.java
@@ -77,16 +77,16 @@ public abstract class AbstractFromConfigFactory<Solution_, Config_ extends Abstr
 
     protected GenuineVariableDescriptor<Solution_> deduceVariableDescriptor(
             EntityDescriptor<Solution_> entityDescriptor) {
-        Collection<GenuineVariableDescriptor<Solution_>> variableDescriptors =
-                entityDescriptor.getGenuineVariableDescriptors();
-        if (variableDescriptors.size() != 1) {
+        List<GenuineVariableDescriptor<Solution_>> variableDescriptorList =
+                entityDescriptor.getGenuineVariableDescriptorList();
+        if (variableDescriptorList.size() != 1) {
             throw new IllegalArgumentException("The config (" + config
                     + ") has no configured variableName for entityClass (" + entityDescriptor.getEntityClass()
                     + ") and because there are multiple variableNames ("
                     + entityDescriptor.getGenuineVariableNameSet()
                     + "), it cannot be deduced automatically.");
         }
-        return variableDescriptors.iterator().next();
+        return variableDescriptorList.iterator().next();
     }
 
     protected List<GenuineVariableDescriptor<Solution_>> deduceVariableDescriptorList(

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/constructionheuristic/placer/PooledEntityPlacerFactory.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/constructionheuristic/placer/PooledEntityPlacerFactory.java
@@ -17,7 +17,6 @@
 package org.optaplanner.core.impl.constructionheuristic.placer;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 
 import org.optaplanner.core.config.constructionheuristic.placer.PooledEntityPlacerConfig;
@@ -105,7 +104,7 @@ public class PooledEntityPlacerFactory<Solution_>
         EntityDescriptor<Solution_> entityDescriptor = deduceEntityDescriptor(configPolicy.getSolutionDescriptor());
         EntitySelectorConfig entitySelectorConfig = buildEntitySelectorConfig(configPolicy, entityDescriptor);
 
-        Collection<GenuineVariableDescriptor<Solution_>> variableDescriptors = entityDescriptor.getGenuineVariableDescriptors();
+        List<GenuineVariableDescriptor<Solution_>> variableDescriptors = entityDescriptor.getGenuineVariableDescriptorList();
         List<MoveSelectorConfig> subMoveSelectorConfigList = new ArrayList<>(variableDescriptors.size());
         for (GenuineVariableDescriptor<Solution_> variableDescriptor : variableDescriptors) {
             subMoveSelectorConfigList

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/constructionheuristic/placer/QueuedEntityPlacerFactory.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/constructionheuristic/placer/QueuedEntityPlacerFactory.java
@@ -17,7 +17,6 @@
 package org.optaplanner.core.impl.constructionheuristic.placer;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
@@ -86,10 +85,10 @@ public class QueuedEntityPlacerFactory<Solution_>
         List<MoveSelectorConfig> moveSelectorConfigList_;
         if (ConfigUtils.isEmptyCollection(config.getMoveSelectorConfigList())) {
             EntityDescriptor<Solution_> entityDescriptor = entitySelector.getEntityDescriptor();
-            Collection<GenuineVariableDescriptor<Solution_>> variableDescriptors =
-                    entityDescriptor.getGenuineVariableDescriptors();
-            List<MoveSelectorConfig> subMoveSelectorConfigList = new ArrayList<>(variableDescriptors.size());
-            for (GenuineVariableDescriptor<Solution_> variableDescriptor : variableDescriptors) {
+            List<GenuineVariableDescriptor<Solution_>> variableDescriptorList =
+                    entityDescriptor.getGenuineVariableDescriptorList();
+            List<MoveSelectorConfig> subMoveSelectorConfigList = new ArrayList<>(variableDescriptorList.size());
+            for (GenuineVariableDescriptor<Solution_> variableDescriptor : variableDescriptorList) {
                 subMoveSelectorConfigList
                         .add(buildChangeMoveSelectorConfig(configPolicy, entitySelectorConfig_.getId(), variableDescriptor));
             }

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/entity/descriptor/EntityDescriptor.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/entity/descriptor/EntityDescriptor.java
@@ -99,6 +99,8 @@ public class EntityDescriptor<Solution_> {
     private Map<String, GenuineVariableDescriptor<Solution_>> effectiveGenuineVariableDescriptorMap;
     private Map<String, ShadowVariableDescriptor<Solution_>> effectiveShadowVariableDescriptorMap;
     private Map<String, VariableDescriptor<Solution_>> effectiveVariableDescriptorMap;
+    // Duplicate of effectiveGenuineVariableDescriptorMap.values() for faster iteration on the hot path.
+    private List<GenuineVariableDescriptor<Solution_>> effectiveGenuineVariableDescriptorList;
 
     // ************************************************************************
     // Constructors and simple getters/setters
@@ -329,6 +331,7 @@ public class EntityDescriptor<Solution_> {
                 effectiveGenuineVariableDescriptorMap.size() + effectiveShadowVariableDescriptorMap.size());
         effectiveVariableDescriptorMap.putAll(effectiveGenuineVariableDescriptorMap);
         effectiveVariableDescriptorMap.putAll(effectiveShadowVariableDescriptorMap);
+        effectiveGenuineVariableDescriptorList = new ArrayList<>(effectiveGenuineVariableDescriptorMap.values());
     }
 
     private void createEffectiveMovableEntitySelectionFilter() {
@@ -407,13 +410,8 @@ public class EntityDescriptor<Solution_> {
         return effectiveGenuineVariableDescriptorMap;
     }
 
-    public Collection<GenuineVariableDescriptor<Solution_>> getGenuineVariableDescriptors() {
-        return effectiveGenuineVariableDescriptorMap.values();
-    }
-
     public List<GenuineVariableDescriptor<Solution_>> getGenuineVariableDescriptorList() {
-        // TODO We might want to cache that list
-        return new ArrayList<>(effectiveGenuineVariableDescriptorMap.values());
+        return effectiveGenuineVariableDescriptorList;
     }
 
     public boolean hasGenuineVariableDescriptor(String variableName) {
@@ -505,7 +503,7 @@ public class EntityDescriptor<Solution_> {
     }
 
     public boolean hasAnyChainedGenuineVariables() {
-        for (GenuineVariableDescriptor<Solution_> variableDescriptor : effectiveGenuineVariableDescriptorMap.values()) {
+        for (GenuineVariableDescriptor<Solution_> variableDescriptor : effectiveGenuineVariableDescriptorList) {
             if (!variableDescriptor.isChained()) {
                 return true;
             }
@@ -522,12 +520,12 @@ public class EntityDescriptor<Solution_> {
     }
 
     public long getGenuineVariableCount() {
-        return effectiveGenuineVariableDescriptorMap.size();
+        return effectiveGenuineVariableDescriptorList.size();
     }
 
     public long getMaximumValueCount(Solution_ solution, Object entity) {
         long maximumValueCount = 0L;
-        for (GenuineVariableDescriptor<Solution_> variableDescriptor : effectiveGenuineVariableDescriptorMap.values()) {
+        for (GenuineVariableDescriptor<Solution_> variableDescriptor : effectiveGenuineVariableDescriptorList) {
             maximumValueCount = Math.max(maximumValueCount, variableDescriptor.getValueCount(solution, entity));
         }
         return maximumValueCount;
@@ -536,7 +534,7 @@ public class EntityDescriptor<Solution_> {
 
     public long getProblemScale(Solution_ solution, Object entity) {
         long problemScale = 1L;
-        for (GenuineVariableDescriptor<Solution_> variableDescriptor : effectiveGenuineVariableDescriptorMap.values()) {
+        for (GenuineVariableDescriptor<Solution_> variableDescriptor : effectiveGenuineVariableDescriptorList) {
             problemScale *= variableDescriptor.getValueCount(solution, entity);
         }
         return problemScale;
@@ -544,7 +542,7 @@ public class EntityDescriptor<Solution_> {
 
     public int countUninitializedVariables(Object entity) {
         int count = 0;
-        for (GenuineVariableDescriptor<Solution_> variableDescriptor : effectiveGenuineVariableDescriptorMap.values()) {
+        for (GenuineVariableDescriptor<Solution_> variableDescriptor : effectiveGenuineVariableDescriptorList) {
             if (!variableDescriptor.isInitialized(entity)) {
                 count++;
             }
@@ -553,7 +551,7 @@ public class EntityDescriptor<Solution_> {
     }
 
     public boolean isInitialized(Object entity) {
-        for (GenuineVariableDescriptor<Solution_> variableDescriptor : effectiveGenuineVariableDescriptorMap.values()) {
+        for (GenuineVariableDescriptor<Solution_> variableDescriptor : effectiveGenuineVariableDescriptorList) {
             if (!variableDescriptor.isInitialized(entity)) {
                 return false;
             }
@@ -563,7 +561,7 @@ public class EntityDescriptor<Solution_> {
 
     public int countReinitializableVariables(ScoreDirector<Solution_> scoreDirector, Object entity) {
         int count = 0;
-        for (GenuineVariableDescriptor<Solution_> variableDescriptor : effectiveGenuineVariableDescriptorMap.values()) {
+        for (GenuineVariableDescriptor<Solution_> variableDescriptor : effectiveGenuineVariableDescriptorList) {
             if (variableDescriptor.isReinitializable(scoreDirector, entity)) {
                 count++;
             }

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/solution/mutation/MutationCounter.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/solution/mutation/MutationCounter.java
@@ -50,7 +50,7 @@ public class MutationCounter<Solution_> {
                 Object aEntity = aIt.next();
                 Object bEntity = bIt.next();
                 for (GenuineVariableDescriptor<Solution_> variableDescriptor : entityDescriptor
-                        .getGenuineVariableDescriptors()) {
+                        .getGenuineVariableDescriptorList()) {
                     // TODO broken if the value is an entity, because then it's never the same
                     // But we don't want to depend on value/entity equals() => use surrogate entity IDs to compare
                     // https://issues.redhat.com/browse/PLANNER-170
@@ -61,7 +61,7 @@ public class MutationCounter<Solution_> {
             }
             if (aEntities.size() != bEntities.size()) {
                 mutationCount += Math.abs(aEntities.size() - bEntities.size())
-                        * entityDescriptor.getGenuineVariableDescriptors().size();
+                        * entityDescriptor.getGenuineVariableDescriptorList().size();
             }
         }
         return mutationCount;

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/variable/listener/support/VariableListenerSupport.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/variable/listener/support/VariableListenerSupport.java
@@ -239,7 +239,8 @@ public class VariableListenerSupport<Solution_> implements SupplyManager<Solutio
         List<Object> entityList = scoreDirector.getWorkingEntityList();
         for (Object entity : entityList) {
             EntityDescriptor<Solution_> entityDescriptor = solutionDescriptor.findEntityDescriptorOrFail(entity.getClass());
-            for (GenuineVariableDescriptor<Solution_> variableDescriptor : entityDescriptor.getGenuineVariableDescriptors()) {
+            for (GenuineVariableDescriptor<Solution_> variableDescriptor : entityDescriptor
+                    .getGenuineVariableDescriptorList()) {
                 beforeVariableChanged(variableDescriptor, entity);
                 // No change
                 afterVariableChanged(variableDescriptor, entity);

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/exhaustivesearch/DefaultExhaustiveSearchPhaseFactory.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/exhaustivesearch/DefaultExhaustiveSearchPhaseFactory.java
@@ -174,10 +174,10 @@ public class DefaultExhaustiveSearchPhaseFactory<Solution_>
             EntityDescriptor<Solution_> entityDescriptor = entitySelector.getEntityDescriptor();
             // Keep in sync with DefaultExhaustiveSearchPhase.fillLayerList()
             // which includes all genuineVariableDescriptors
-            Collection<GenuineVariableDescriptor<Solution_>> variableDescriptors =
-                    entityDescriptor.getGenuineVariableDescriptors();
-            List<MoveSelectorConfig> subMoveSelectorConfigList = new ArrayList<>(variableDescriptors.size());
-            for (GenuineVariableDescriptor<Solution_> variableDescriptor : variableDescriptors) {
+            List<GenuineVariableDescriptor<Solution_>> variableDescriptorList =
+                    entityDescriptor.getGenuineVariableDescriptorList();
+            List<MoveSelectorConfig> subMoveSelectorConfigList = new ArrayList<>(variableDescriptorList.size());
+            for (GenuineVariableDescriptor<Solution_> variableDescriptor : variableDescriptorList) {
                 ChangeMoveSelectorConfig changeMoveSelectorConfig = new ChangeMoveSelectorConfig();
                 changeMoveSelectorConfig.setEntitySelectorConfig(
                         EntitySelectorConfig.newMimicSelectorConfig(mimicSelectorId));

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/ChangeMoveSelectorFactory.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/ChangeMoveSelectorFactory.java
@@ -90,7 +90,7 @@ public class ChangeMoveSelectorFactory<Solution_>
                 }
                 variableDescriptorList.add(onlyVariableDescriptor);
             } else {
-                variableDescriptorList.addAll(entityDescriptor.getGenuineVariableDescriptors());
+                variableDescriptorList.addAll(entityDescriptor.getGenuineVariableDescriptorList());
             }
         }
         return buildUnfoldedMoveSelectorConfig(variableDescriptorList);

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/partitionedsearch/scope/PartitionChangeMove.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/partitionedsearch/scope/PartitionChangeMove.java
@@ -60,7 +60,7 @@ public final class PartitionChangeMove<Solution_> extends AbstractMove<Solution_
                     entity.getClass());
             if (entityDescriptor.isMovable(scoreDirector, entity)) {
                 for (GenuineVariableDescriptor<Solution_> variableDescriptor : entityDescriptor
-                        .getGenuineVariableDescriptors()) {
+                        .getGenuineVariableDescriptorList()) {
                     Object value = variableDescriptor.getValue(entity);
                     changeMap.get(variableDescriptor).add(Pair.of(entity, value));
                 }

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/phase/AbstractPhase.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/phase/AbstractPhase.java
@@ -214,7 +214,7 @@ public abstract class AbstractPhase<Solution_> implements Phase<Solution_> {
                 if (!entityDescriptor.isEntityInitializedOrPinned(scoreDirector, entity)) {
                     String variableRef = null;
                     for (GenuineVariableDescriptor<Solution_> variableDescriptor : entityDescriptor
-                            .getGenuineVariableDescriptors()) {
+                            .getGenuineVariableDescriptorList()) {
                         if (!variableDescriptor.isInitialized(entity)) {
                             variableRef = variableDescriptor.getSimpleEntityAndVariableName();
                             break;

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/stream/DroolsConstraintStreamScoreDirectorFactory.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/stream/DroolsConstraintStreamScoreDirectorFactory.java
@@ -155,7 +155,6 @@ public final class DroolsConstraintStreamScoreDirectorFactory<Solution_, Score_ 
     public Constraint[] getConstraints() {
         return kieBaseDescriptor.getConstraintToGlobalMap()
                 .keySet()
-                .stream()
                 .toArray(Constraint[]::new);
     }
 

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/stream/DroolsConstraintStreamScoreDirectorFactory.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/stream/DroolsConstraintStreamScoreDirectorFactory.java
@@ -181,9 +181,11 @@ public final class DroolsConstraintStreamScoreDirectorFactory<Solution_, Score_ 
                 return true;
             }
             Rule rule = match.getRule();
-            // We identify the rule by its constraint ID, which we pre-calculated during rule creation.
-            // The alternative is to pay string concat penalty (packageName + name) to calculate the ID on every rule evaluation.
-            // Since this code is on the hot path, this optimization was confirmed to bring considerable benefits.
+            /*
+             * We identify the rule by its constraint ID, which we pre-calculated during rule creation.
+             * The alternative is to pay string concat penalty (packageName + name) to calculate the ID on every match.
+             * Since this code is on the hot path, this optimization was confirmed to bring considerable benefits.
+             */
             String constraintId = (String) Objects.requireNonNull(
                     rule.getMetaData().get(CONSTRAINT_ID_RULE_METADATA_KEY),
                     () -> "Impossible state: Rule ("

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/common/AbstractRuleContext.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/common/AbstractRuleContext.java
@@ -29,6 +29,7 @@ import org.drools.model.Drools;
 import org.drools.model.RuleItemBuilder;
 import org.drools.model.view.ViewItem;
 import org.kie.api.runtime.rule.RuleContext;
+import org.optaplanner.core.impl.score.director.stream.DroolsConstraintStreamScoreDirectorFactory;
 import org.optaplanner.core.impl.score.inliner.JustificationsSupplier;
 import org.optaplanner.core.impl.score.inliner.UndoScoreImpacter;
 import org.optaplanner.core.impl.score.inliner.WeightedScoreImpacter;
@@ -76,6 +77,8 @@ abstract class AbstractRuleContext {
             List<RuleItemBuilder<?>> ruleItemBuilderList = new ArrayList<>(viewItems);
             ruleItemBuilderList.add(consequenceBuilder.apply(constraint, scoreImpacterGlobal));
             return rule(constraint.getConstraintPackage(), constraint.getConstraintName())
+                    .metadata(DroolsConstraintStreamScoreDirectorFactory.CONSTRAINT_ID_RULE_METADATA_KEY,
+                            constraint.getConstraintId())
                     .build(ruleItemBuilderList.toArray(new RuleItemBuilder[0]));
         };
     }


### PR DESCRIPTION
Improves performance of checking for disabled constraints by caching the constraint ID.
Improves performance of checking if an entity is initialized, by using a `List` instead of `Map.values()`.
The latter change has the potential to speed up many other parts of OptaPlanner as well, although that was not benchmarked.