### PR TITLE
Combine the first/last/consecutiveFreeDays constraints to improve performance

### DIFF
--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/common/experimental/api/Break.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/common/experimental/api/Break.java
@@ -36,6 +36,20 @@ public interface Break<Value_, Difference_ extends Comparable<Difference_>> {
     Sequence<Value_, Difference_> getNextSequence();
 
     /**
+     * @return true if and only if this is the first break
+     */
+    default boolean isFirst() {
+        return getPreviousSequence().isFirst();
+    }
+
+    /**
+     * @return true if and only if this is the last break
+     */
+    default boolean isLast() {
+        return getNextSequence().isLast();
+    }
+
+    /**
      * Return the end of the sequence before this break. For the
      * break between 6 and 10, this will return 6.
      * 

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/common/experimental/api/Sequence.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/common/experimental/api/Sequence.java
@@ -35,6 +35,26 @@ public interface Sequence<Value_, Difference_ extends Comparable<Difference_>> {
     Value_ getLastItem();
 
     /**
+     * @return true if and only if this is the first Sequence
+     */
+    boolean isFirst();
+
+    /**
+     * @return true if and only if this is the last Sequence
+     */
+    boolean isLast();
+
+    /**
+     * @return If this is not the first sequence, the break before it. Otherwise, null.
+     */
+    Break<Value_, Difference_> getPreviousBreak();
+
+    /**
+     * @return If this is not the last sequence, the break after it. Otherwise, null.
+     */
+    Break<Value_, Difference_> getNextBreak();
+
+    /**
      * @return never null, an iterable that can iterate through this sequence
      */
     Iterable<Value_> getItems();

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/common/experimental/impl/ConsecutiveSetTree.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/common/experimental/impl/ConsecutiveSetTree.java
@@ -194,6 +194,17 @@ public final class ConsecutiveSetTree<Value_, Point_ extends Comparable<Point_>,
     }
 
     // Protected API
+    Break<Value_, Difference_> getBreakBefore(Value_ item) {
+        return startItemToPreviousBreak.get(item);
+    }
+
+    Break<Value_, Difference_> getBreakAfter(Value_ item) {
+        Map.Entry<Value_, BreakImpl<Value_, Difference_>> entry = startItemToPreviousBreak.higherEntry(item);
+        if (entry != null) {
+            return entry.getValue();
+        }
+        return null;
+    }
 
     NavigableSet<Value_> getItemSet() {
         return (NavigableSet<Value_>) itemToCountMap.keySet();

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/common/experimental/impl/SequenceImpl.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/common/experimental/impl/SequenceImpl.java
@@ -20,6 +20,7 @@ import java.util.NavigableSet;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
+import org.optaplanner.examples.common.experimental.api.Break;
 import org.optaplanner.examples.common.experimental.api.Sequence;
 
 final class SequenceImpl<Value_, Difference_ extends Comparable<Difference_>> implements Sequence<Value_, Difference_> {
@@ -52,6 +53,26 @@ final class SequenceImpl<Value_, Difference_ extends Comparable<Difference_>> im
     @Override
     public Value_ getLastItem() {
         return lastItem;
+    }
+
+    @Override
+    public Break<Value_, Difference_> getPreviousBreak() {
+        return sourceTree.getBreakBefore(firstItem);
+    }
+
+    @Override
+    public Break<Value_, Difference_> getNextBreak() {
+        return sourceTree.getBreakAfter(lastItem);
+    }
+
+    @Override
+    public boolean isFirst() {
+        return firstItem == sourceTree.getItemSet().first();
+    }
+
+    @Override
+    public boolean isLast() {
+        return lastItem == sourceTree.getItemSet().last();
     }
 
     @Override

--- a/optaplanner-examples/src/test/java/org/optaplanner/examples/nurserostering/score/NurseRosteringConstraintProviderTest.java
+++ b/optaplanner-examples/src/test/java/org/optaplanner/examples/nurserostering/score/NurseRosteringConstraintProviderTest.java
@@ -518,33 +518,52 @@ public class NurseRosteringConstraintProviderTest {
         // ShiftAssignment shift6 = getShiftAssignment(5, employee);
         ShiftAssignment shift7 = getShiftAssignment(6, employee);
 
+        NurseRosterParametrization nurseRosterParametrization = new NurseRosterParametrization();
+
+        nurseRosterParametrization.setId(idSupplier.incrementAndGet());
+        nurseRosterParametrization.setPlanningWindowStart(getShiftDate(0));
+        nurseRosterParametrization.setFirstShiftDate(getShiftDate(0));
+        nurseRosterParametrization.setLastShiftDate(getShiftDate(6));
+
         constraintVerifier.verifyThat(NurseRosteringConstraintProvider::consecutiveFreeDays)
                 .given(contract.getContractLineList().get(0),
                         employee,
+                        nurseRosterParametrization,
                         shift1, shift7)
                 .penalizesBy(8);
 
         constraintVerifier.verifyThat(NurseRosteringConstraintProvider::consecutiveFreeDays)
                 .given(contract.getContractLineList().get(0),
                         employee,
+                        nurseRosterParametrization,
                         shift1, shift3)
-                .penalizesBy(2);
+                .penalizesBy(6);
 
         constraintVerifier.verifyThat(NurseRosteringConstraintProvider::consecutiveFreeDays)
                 .given(contract.getContractLineList().get(0),
                         employee,
+                        nurseRosterParametrization,
                         shift1, shift5)
                 .penalizesBy(0);
         constraintVerifier.verifyThat(NurseRosteringConstraintProvider::consecutiveFreeDays)
                 .given(contract.getContractLineList().get(0),
                         employee,
+                        nurseRosterParametrization,
                         shift1, shift4)
                 .penalizesBy(0);
         constraintVerifier.verifyThat(NurseRosteringConstraintProvider::consecutiveFreeDays)
                 .given(contract.getContractLineList().get(0),
                         employee,
+                        nurseRosterParametrization,
                         shift1, shift4, shift7)
                 .penalizesBy(0);
+
+        constraintVerifier.verifyThat(NurseRosteringConstraintProvider::consecutiveFreeDays)
+                .given(contract.getContractLineList().get(0),
+                        employee,
+                        nurseRosterParametrization,
+                        shift7)
+                .penalizesBy(12);
     }
 
     @Test
@@ -570,86 +589,6 @@ public class NurseRosteringConstraintProviderTest {
                         employeeNoShifts, employeeWithShifts,
                         shift, nurseRosterParametrization)
                 .penalizesBy(5);
-    }
-
-    @Test
-    public void consecutiveFreeDaysFirstBreak() {
-        Contract contract = new MinMaxContractBuilder(ContractLineType.CONSECUTIVE_FREE_DAYS)
-                .withMinimum(2)
-                .withMaximum(3)
-                .withMinimumWeight(2)
-                .withMaximumWeight(4)
-                .build();
-
-        Employee employee = getEmployee(contract);
-
-        // ShiftAssignment shift1 = getShiftAssignment(0, employee);
-        ShiftAssignment shift2 = getShiftAssignment(1, employee);
-        ShiftAssignment shift3 = getShiftAssignment(2, employee);
-        // ShiftAssignment shift4 = getShiftAssignment(3, employee);
-        ShiftAssignment shift5 = getShiftAssignment(4, employee);
-        NurseRosterParametrization nurseRosterParametrization = new NurseRosterParametrization();
-
-        nurseRosterParametrization.setId(idSupplier.incrementAndGet());
-        nurseRosterParametrization.setPlanningWindowStart(getShiftDate(0));
-        nurseRosterParametrization.setFirstShiftDate(getShiftDate(0));
-        nurseRosterParametrization.setLastShiftDate(getShiftDate(5));
-
-        constraintVerifier.verifyThat(NurseRosteringConstraintProvider::consecutiveFreeDaysFirstBreak)
-                .given(contract.getContractLineList().get(0),
-                        employee,
-                        shift2, nurseRosterParametrization)
-                .penalizesBy(2);
-        constraintVerifier.verifyThat(NurseRosteringConstraintProvider::consecutiveFreeDaysFirstBreak)
-                .given(contract.getContractLineList().get(0),
-                        employee,
-                        shift5, nurseRosterParametrization)
-                .penalizesBy(4);
-        constraintVerifier.verifyThat(NurseRosteringConstraintProvider::consecutiveFreeDaysFirstBreak)
-                .given(contract.getContractLineList().get(0),
-                        employee,
-                        shift3, shift5, nurseRosterParametrization)
-                .penalizesBy(0);
-    }
-
-    @Test
-    public void consecutiveFreeDaysFinalBreak() {
-        Contract contract = new MinMaxContractBuilder(ContractLineType.CONSECUTIVE_FREE_DAYS)
-                .withMinimum(2)
-                .withMaximum(3)
-                .withMinimumWeight(2)
-                .withMaximumWeight(4)
-                .build();
-
-        Employee employee = getEmployee(contract);
-
-        ShiftAssignment shift1 = getShiftAssignment(0, employee);
-        ShiftAssignment shift2 = getShiftAssignment(1, employee);
-        // ShiftAssignment shift3 = getShiftAssignment(2, employee);
-        ShiftAssignment shift4 = getShiftAssignment(3, employee);
-        ShiftAssignment shift5 = getShiftAssignment(4, employee);
-        NurseRosterParametrization nurseRosterParametrization = new NurseRosterParametrization();
-
-        nurseRosterParametrization.setId(idSupplier.incrementAndGet());
-        nurseRosterParametrization.setPlanningWindowStart(getShiftDate(0));
-        nurseRosterParametrization.setFirstShiftDate(getShiftDate(0));
-        nurseRosterParametrization.setLastShiftDate(getShiftDate(5));
-
-        constraintVerifier.verifyThat(NurseRosteringConstraintProvider::consecutiveFreeDaysFinalBreak)
-                .given(contract.getContractLineList().get(0),
-                        employee,
-                        shift5, nurseRosterParametrization)
-                .penalizesBy(2);
-        constraintVerifier.verifyThat(NurseRosteringConstraintProvider::consecutiveFreeDaysFinalBreak)
-                .given(contract.getContractLineList().get(0),
-                        employee,
-                        shift2, nurseRosterParametrization)
-                .penalizesBy(4);
-        constraintVerifier.verifyThat(NurseRosteringConstraintProvider::consecutiveFreeDaysFinalBreak)
-                .given(contract.getContractLineList().get(0),
-                        employee,
-                        shift1, shift4, nurseRosterParametrization)
-                .penalizesBy(0);
     }
 
     @Test


### PR DESCRIPTION
<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.
-->

### JIRA

<!-- Add a JIRA ticket link if it exists. -->
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
* https://github.com/kiegroup/drools/pull/3000
* https://github.com/kiegroup/optaplanner/pull/899
* etc.
-->

### Checklist
- [ ] Documentation updated if applicable.
- [ ] Upgrade recipe provided if applicable.

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>specific pull request build</b> please add comment: <b>Jenkins (re)run [optaplanner|apps|examples] tests</b>
* for a <b>full downstream build</b> please add comment: <b>Jenkins run fdb</b>
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
* for a <b>Quarkus LTS check</b> please add comment: <b>Jenkins run LTS</b>
* for a <b>specific Quarkus LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner|apps|examples] LTS</b>
* for a <b>Native check</b> please add comment: <b>Jenkins run native</b>
* for a <b>specific Native LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner|apps|examples] native</b>
</details>