### PR TITLE
PLANNER-2485: Fail fast if KieBase properties are set in Quarkus

### DIFF
--- a/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/main/java/org/optaplanner/quarkus/deployment/OptaPlannerProcessor.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/main/java/org/optaplanner/quarkus/deployment/OptaPlannerProcessor.java
@@ -462,6 +462,12 @@ class OptaPlannerProcessor {
                                 + "\nMaybe use a " + ConstraintProvider.class.getSimpleName() + " instead of the scoreDRL.");
             }
         }
+
+        if (solverConfig.getScoreDirectorFactoryConfig().getKieBaseConfigurationProperties() != null) {
+            throw new IllegalStateException("Using kieBaseConfigurationProperties ("
+                    + solverConfig.getScoreDirectorFactoryConfig().getKieBaseConfigurationProperties()
+                    + ") in Quarkus, which is unsupported.");
+        }
     }
 
     private boolean isClassDefined(String className) {

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/test/java/org/optaplanner/quarkus/deployment/OptaPlannerProcessorTest.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/test/java/org/optaplanner/quarkus/deployment/OptaPlannerProcessorTest.java
@@ -100,6 +100,28 @@ class OptaPlannerProcessorTest {
                 .containsExactly(OptaPlannerBuildTimeConfig.DEFAULT_CONSTRAINTS_DRL_URL);
     }
 
+    @Test
+    void error_if_kie_base_configuration_properties_is_present() {
+        ScoreDirectorFactoryConfig scoreDirectorFactoryConfig = new ScoreDirectorFactoryConfig();
+        scoreDirectorFactoryConfig.setKieBaseConfigurationProperties(Collections.emptyMap());
+        SolverConfig solverConfig = new SolverConfig().withScoreDirectorFactory(scoreDirectorFactoryConfig);
+        OptaPlannerProcessor optaPlannerProcessor = mockOptaPlannerProcessor();
+        when(optaPlannerProcessor.constraintsDrl()).thenReturn(Optional.empty());
+        when(optaPlannerProcessor.defaultConstraintsDrl())
+                .thenReturn(Optional.of(OptaPlannerBuildTimeConfig.DEFAULT_CONSTRAINTS_DRL_URL));
+
+        Capabilities capabilities = new Capabilities(Collections.singleton("kogito-rules"));
+        assertThatCode(() -> optaPlannerProcessor.applyScoreDirectorFactoryProperties(mock(IndexView.class), solverConfig,
+                capabilities))
+                        .isInstanceOf(IllegalStateException.class)
+                        .hasMessage(
+                                "Using kieBaseConfigurationProperties ("
+                                        + scoreDirectorFactoryConfig.getKieBaseConfigurationProperties()
+                                        + ") in Quarkus, which is unsupported.");
+        assertThat(scoreDirectorFactoryConfig.getScoreDrlList())
+                .containsExactly(OptaPlannerBuildTimeConfig.DEFAULT_CONSTRAINTS_DRL_URL);
+    }
+
     private OptaPlannerProcessor mockOptaPlannerProcessor() {
         OptaPlannerProcessor optaPlannerProcessor = mock(OptaPlannerProcessor.class);
         doCallRealMethod().when(optaPlannerProcessor).applyScoreDirectorFactoryProperties(any(), any(), any());


### PR DESCRIPTION
<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.
-->

### JIRA

<!-- Add a JIRA ticket link if it exists. -->
https://issues.redhat.com/browse/PLANNER-2485

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
* https://github.com/kiegroup/drools/pull/3000
* https://github.com/kiegroup/optaplanner/pull/899
* etc.
-->

### Checklist
- [ ] Documentation updated if applicable.
- [ ] Upgrade recipe provided if applicable.

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>specific pull request build</b> please add comment: <b>Jenkins (re)run [optaplanner|apps|examples] tests</b>
* for a <b>full downstream build</b> please add comment: <b>Jenkins run fdb</b>
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
* for a <b>Quarkus LTS check</b> please add comment: <b>Jenkins run LTS</b>
* for a <b>specific Quarkus LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner|apps|examples] LTS</b>
* for a <b>Native check</b> please add comment: <b>Jenkins run native</b>
* for a <b>specific Native LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner|apps|examples] native</b>
</details>