### PR TITLE
PLANNER-2498 Improve the error message for Quarkus

### DIFF
--- a/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/main/java/org/optaplanner/quarkus/deployment/OptaPlannerProcessor.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/main/java/org/optaplanner/quarkus/deployment/OptaPlannerProcessor.java
@@ -57,8 +57,9 @@ import org.optaplanner.core.config.solver.SolverConfig;
 import org.optaplanner.core.config.solver.SolverManagerConfig;
 import org.optaplanner.core.impl.domain.solution.descriptor.SolutionDescriptor;
 import org.optaplanner.core.impl.io.jaxb.SolverConfigIO;
-import org.optaplanner.quarkus.OptaPlannerBeanProvider;
 import org.optaplanner.quarkus.OptaPlannerRecorder;
+import org.optaplanner.quarkus.bean.DefaultOptaPlannerBeanProvider;
+import org.optaplanner.quarkus.bean.UnavailableOptaPlannerBeanProvider;
 import org.optaplanner.quarkus.config.OptaPlannerRuntimeConfig;
 import org.optaplanner.quarkus.deployment.config.OptaPlannerBuildTimeConfig;
 import org.optaplanner.quarkus.devui.OptaPlannerDevUIPropertiesSupplier;
@@ -183,6 +184,7 @@ class OptaPlannerProcessor {
                     + " the Jandex index by using the jandex-maven-plugin in that dependency, or by adding"
                     + "application.properties entries (quarkus.index-dependency.<name>.group-id"
                     + " and quarkus.index-dependency.<name>.artifact-id).");
+            additionalBeans.produce(new AdditionalBeanBuildItem(UnavailableOptaPlannerBeanProvider.class));
             return new SolverConfigBuildItem(null);
         }
 
@@ -262,7 +264,7 @@ class OptaPlannerProcessor {
                 .defaultBean()
                 .supplier(recorder.solverManagerConfig(solverManagerConfig)).done());
 
-        additionalBeans.produce(new AdditionalBeanBuildItem(OptaPlannerBeanProvider.class));
+        additionalBeans.produce(new AdditionalBeanBuildItem(DefaultOptaPlannerBeanProvider.class));
         unremovableBeans.produce(UnremovableBeanBuildItem.beanTypes(OptaPlannerRuntimeConfig.class));
         return new SolverConfigBuildItem(solverConfig);
     }

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/test/java/org/optaplanner/quarkus/OptaPlannerProcessorEmptyAppWithInjectionTest.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/test/java/org/optaplanner/quarkus/OptaPlannerProcessorEmptyAppWithInjectionTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.quarkus;
+
+import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.optaplanner.core.api.solver.SolverManager;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class OptaPlannerProcessorEmptyAppWithInjectionTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses())
+            .overrideConfigKey("quarkus.arc.unremovable-types", "org.optaplanner.core.api.solver.SolverManager");
+
+    @Test
+    public void emptyAppInjectingSolverManagerCrashes() {
+        assertThatIllegalStateException().isThrownBy(() -> Arc.container().instance(SolverManager.class).get())
+                .withMessageContaining("The " + SolverManager.class.getName() + " is not available as there are no");
+    }
+
+}

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/runtime/src/main/java/org/optaplanner/quarkus/bean/DefaultOptaPlannerBeanProvider.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/runtime/src/main/java/org/optaplanner/quarkus/bean/DefaultOptaPlannerBeanProvider.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.optaplanner.quarkus;
+package org.optaplanner.quarkus.bean;
 
 import javax.enterprise.inject.Produces;
 import javax.inject.Singleton;
@@ -40,7 +40,7 @@ import org.optaplanner.quarkus.config.OptaPlannerRuntimeConfig;
 
 import io.quarkus.arc.DefaultBean;
 
-public class OptaPlannerBeanProvider {
+public class DefaultOptaPlannerBeanProvider {
 
     @DefaultBean
     @Singleton
@@ -164,5 +164,4 @@ public class OptaPlannerBeanProvider {
             SolverFactory<Solution_> solverFactory) {
         return ScoreManager.create(solverFactory);
     }
-
 }

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/runtime/src/main/java/org/optaplanner/quarkus/bean/UnavailableOptaPlannerBeanProvider.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/runtime/src/main/java/org/optaplanner/quarkus/bean/UnavailableOptaPlannerBeanProvider.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.quarkus.bean;
+
+import javax.enterprise.inject.Produces;
+import javax.inject.Singleton;
+
+import org.optaplanner.core.api.domain.entity.PlanningEntity;
+import org.optaplanner.core.api.domain.solution.PlanningSolution;
+import org.optaplanner.core.api.score.ScoreManager;
+import org.optaplanner.core.api.score.buildin.bendable.BendableScore;
+import org.optaplanner.core.api.score.buildin.bendablebigdecimal.BendableBigDecimalScore;
+import org.optaplanner.core.api.score.buildin.bendablelong.BendableLongScore;
+import org.optaplanner.core.api.score.buildin.hardmediumsoft.HardMediumSoftScore;
+import org.optaplanner.core.api.score.buildin.hardmediumsoftbigdecimal.HardMediumSoftBigDecimalScore;
+import org.optaplanner.core.api.score.buildin.hardmediumsoftlong.HardMediumSoftLongScore;
+import org.optaplanner.core.api.score.buildin.hardsoft.HardSoftScore;
+import org.optaplanner.core.api.score.buildin.hardsoftbigdecimal.HardSoftBigDecimalScore;
+import org.optaplanner.core.api.score.buildin.hardsoftlong.HardSoftLongScore;
+import org.optaplanner.core.api.score.buildin.simple.SimpleScore;
+import org.optaplanner.core.api.score.buildin.simplebigdecimal.SimpleBigDecimalScore;
+import org.optaplanner.core.api.score.buildin.simplelong.SimpleLongScore;
+import org.optaplanner.core.api.solver.SolverFactory;
+import org.optaplanner.core.api.solver.SolverManager;
+
+import io.quarkus.arc.DefaultBean;
+
+/**
+ * Throws an exception if an application tries to inject beans and the OptaPlanner Quarkus extension is skipped
+ * due to missing domain classes.
+ */
+public class UnavailableOptaPlannerBeanProvider {
+
+    @DefaultBean
+    @Singleton
+    @Produces
+    <Solution_> SolverFactory<Solution_> solverFactory() {
+        throw createException(SolverFactory.class);
+    }
+
+    @DefaultBean
+    @Singleton
+    @Produces
+    <Solution_, ProblemId_> SolverManager<Solution_, ProblemId_> solverManager() {
+        throw createException(SolverManager.class);
+    }
+
+    @DefaultBean
+    @Singleton
+    @Produces
+    <Solution_> ScoreManager<Solution_, SimpleScore> scoreManager_workaroundSimpleScore() {
+        throw createException(ScoreManager.class);
+    }
+
+    @DefaultBean
+    @Singleton
+    @Produces
+    <Solution_> ScoreManager<Solution_, SimpleLongScore> scoreManager_workaroundSimpleLongScore() {
+        throw createException(ScoreManager.class);
+    }
+
+    @DefaultBean
+    @Singleton
+    @Produces
+    <Solution_> ScoreManager<Solution_, SimpleBigDecimalScore> scoreManager_workaroundSimpleBigDecimalScore() {
+        throw createException(ScoreManager.class);
+    }
+
+    @DefaultBean
+    @Singleton
+    @Produces
+    <Solution_> ScoreManager<Solution_, HardSoftScore> scoreManager_workaroundHardSoftScore() {
+        throw createException(ScoreManager.class);
+    }
+
+    @DefaultBean
+    @Singleton
+    @Produces
+    <Solution_> ScoreManager<Solution_, HardSoftLongScore> scoreManager_workaroundHardSoftLongScore() {
+        throw createException(ScoreManager.class);
+    }
+
+    @DefaultBean
+    @Singleton
+    @Produces
+    <Solution_> ScoreManager<Solution_, HardSoftBigDecimalScore> scoreManager_workaroundHardSoftBigDecimalScore() {
+        throw createException(ScoreManager.class);
+    }
+
+    @DefaultBean
+    @Singleton
+    @Produces
+    <Solution_> ScoreManager<Solution_, HardMediumSoftScore> scoreManager_workaroundHardMediumSoftScore() {
+        throw createException(ScoreManager.class);
+    }
+
+    @DefaultBean
+    @Singleton
+    @Produces
+    <Solution_> ScoreManager<Solution_, HardMediumSoftLongScore> scoreManager_workaroundHardMediumSoftLongScore() {
+        throw createException(ScoreManager.class);
+    }
+
+    @DefaultBean
+    @Singleton
+    @Produces
+    <Solution_> ScoreManager<Solution_, HardMediumSoftBigDecimalScore>
+            scoreManager_workaroundHardMediumSoftBigDecimalScore() {
+        throw createException(ScoreManager.class);
+    }
+
+    @DefaultBean
+    @Singleton
+    @Produces
+    <Solution_> ScoreManager<Solution_, BendableScore> scoreManager_workaroundBendableScore() {
+        throw createException(ScoreManager.class);
+    }
+
+    @DefaultBean
+    @Singleton
+    @Produces
+    <Solution_> ScoreManager<Solution_, BendableLongScore> scoreManager_workaroundBendableLongScore() {
+        throw createException(ScoreManager.class);
+    }
+
+    @DefaultBean
+    @Singleton
+    @Produces
+    <Solution_> ScoreManager<Solution_, BendableBigDecimalScore> scoreManager_workaroundBendableBigDecimalScore() {
+        throw createException(ScoreManager.class);
+    }
+
+    private RuntimeException createException(Class<?> beanClass) {
+        return new IllegalStateException("The " + beanClass.getName() + " is not available as there are no @"
+                + PlanningSolution.class.getSimpleName() + " or @" + PlanningEntity.class.getSimpleName()
+                + " annotated classes."
+                + "\nIf your domain classes are located in a dependency of this project, maybe try generating"
+                + " the Jandex index by using the jandex-maven-plugin in that dependency, or by adding"
+                + "application.properties entries (quarkus.index-dependency.<name>.group-id"
+                + " and quarkus.index-dependency.<name>.artifact-id).");
+    }
+}


### PR DESCRIPTION
If OptaPlanner beans cannot be injected, the exception should clearly suggest what the cause is.

<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.
-->

### JIRA
https://issues.redhat.com/browse/PLANNER-2498

<!-- Add a JIRA ticket link if it exists. -->
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
* https://github.com/kiegroup/drools/pull/3000
* https://github.com/kiegroup/optaplanner/pull/899
* etc.
-->

### Checklist
- [ ] Documentation updated if applicable.
- [ ] Upgrade recipe provided if applicable.

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>specific pull request build</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] tests</b>
* for a <b>full downstream build</b> please add comment: <b>Jenkins run fdb</b>
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
* for a <b>Quarkus LTS check</b> please add comment: <b>Jenkins run LTS</b>
* for a <b>specific Quarkus LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] LTS</b>
* for a <b>Native check</b> please add comment: <b>Jenkins run native</b>
* for a <b>specific Native LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] native</b>
</details>
