### PR TITLE
Make Dev UI tests use id selectors

### DIFF
--- a/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/main/resources/dev-templates/constraints.html
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/main/resources/dev-templates/constraints.html
@@ -19,7 +19,7 @@
 {#title}Constraints{/title}
 
 {#body}
-<table class="table table-striped">
+<table class="table table-striped" id="constraints">
     <thead class="thead-dark">
     <tr>
         <th scope="col">Constraints</th>

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/main/resources/dev-templates/constraints.html
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/main/resources/dev-templates/constraints.html
@@ -19,7 +19,7 @@
 {#title}Constraints{/title}
 
 {#body}
-<table class="table table-striped" id="constraints">
+<table class="table table-striped" id="optaplanner-constraints">
     <thead class="thead-dark">
     <tr>
         <th scope="col">Constraints</th>

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/main/resources/dev-templates/model.html
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/main/resources/dev-templates/model.html
@@ -34,7 +34,7 @@
   -->
 
 {#body}
-<div class="card h-100 shadow">
+<div class="card h-100 shadow" id="model">
     <div class="card-header bg-primary text-light">Solution: {info:solverConfigProperties.optaPlannerModelProperties.solutionClass}</div>
     <div class="card-body">
     {#for entityClass in info:solverConfigProperties.optaPlannerModelProperties.entityClassList}

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/main/resources/dev-templates/model.html
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/main/resources/dev-templates/model.html
@@ -34,7 +34,7 @@
   -->
 
 {#body}
-<div class="card h-100 shadow" id="model">
+<div class="card h-100 shadow" id="optaplanner-model">
     <div class="card-header bg-primary text-light">Solution: {info:solverConfigProperties.optaPlannerModelProperties.solutionClass}</div>
     <div class="card-body">
     {#for entityClass in info:solverConfigProperties.optaPlannerModelProperties.entityClassList}

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/main/resources/dev-templates/solverConfig.html
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/main/resources/dev-templates/solverConfig.html
@@ -17,7 +17,7 @@
 
 {#title}Solver Configuration{/title}
 {#body}
-<pre id="solver-config">
+<pre id="optaplanner-solver-config">
 {info:solverConfigProperties.effectiveSolverConfig}
 </pre>
 {/body}

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/main/resources/dev-templates/solverConfig.html
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/main/resources/dev-templates/solverConfig.html
@@ -17,7 +17,7 @@
 
 {#title}Solver Configuration{/title}
 {#body}
-<pre>
+<pre id="solver-config">
 {info:solverConfigProperties.effectiveSolverConfig}
 </pre>
 {/body}

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/devui-integration-test/src/test/java/org/optaplanner/quarkus/it/devui/OptaPlannerDevUITest.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/devui-integration-test/src/test/java/org/optaplanner/quarkus/it/devui/OptaPlannerDevUITest.java
@@ -55,7 +55,7 @@ public class OptaPlannerDevUITest {
                 .asPrettyString();
         XmlParser xmlParser = new XmlParser();
         Node node = xmlParser.parseText(body);
-        String solverConfig = Objects.requireNonNull(findById("solver-config", node)).text();
+        String solverConfig = Objects.requireNonNull(findById("optaplanner-solver-config", node)).text();
         assertThat(solverConfig).isEqualToIgnoringWhitespace(
                 "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
                         + "<!--Properties that can be set at runtime are not included-->\n"
@@ -78,7 +78,7 @@ public class OptaPlannerDevUITest {
                 .asPrettyString();
         XmlParser xmlParser = new XmlParser();
         Node node = xmlParser.parseText(body);
-        String model = Objects.requireNonNull(findById("model", node)).toString();
+        String model = Objects.requireNonNull(findById("optaplanner-model", node)).toString();
         assertThat(model)
                 .contains("value=[Solution: org.optaplanner.quarkus.it.devui.domain.TestdataStringLengthShadowSolution]");
         assertThat(model).contains("value=[Entity: org.optaplanner.quarkus.it.devui.domain.TestdataStringLengthShadowEntity]");
@@ -97,7 +97,7 @@ public class OptaPlannerDevUITest {
                 .asPrettyString();
         XmlParser xmlParser = new XmlParser();
         Node node = xmlParser.parseText(body);
-        String constraints = Objects.requireNonNull(findById("constraints", node)).text();
+        String constraints = Objects.requireNonNull(findById("optaplanner-constraints", node)).text();
         assertThat(constraints).contains("org.optaplanner.quarkus.it.devui.domain/Don't assign 2 entities the same value");
         assertThat(constraints).contains("org.optaplanner.quarkus.it.devui.domain/Maximize value length");
     }

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/devui-integration-test/src/test/java/org/optaplanner/quarkus/it/devui/OptaPlannerDevUITest.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/devui-integration-test/src/test/java/org/optaplanner/quarkus/it/devui/OptaPlannerDevUITest.java
@@ -19,6 +19,7 @@ package org.optaplanner.quarkus.it.devui;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
+import java.util.Objects;
 
 import javax.xml.parsers.ParserConfigurationException;
 
@@ -28,7 +29,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.xml.sax.SAXException;
 
-import groovy.namespace.QName;
 import groovy.util.Node;
 import groovy.xml.XmlParser;
 import io.quarkus.test.QuarkusDevModeTest;
@@ -55,10 +55,7 @@ public class OptaPlannerDevUITest {
                 .asPrettyString();
         XmlParser xmlParser = new XmlParser();
         Node node = xmlParser.parseText(body);
-        String solverConfig = ((Node) (node.getAt(QName.valueOf("body"))
-                .getAt(QName.valueOf("div"))
-                .getAt(QName.valueOf("pre"))
-                .get(0))).text();
+        String solverConfig = Objects.requireNonNull(findById("solver-config", node)).text();
         assertThat(solverConfig).isEqualToIgnoringWhitespace(
                 "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
                         + "<!--Properties that can be set at runtime are not included-->\n"
@@ -81,10 +78,7 @@ public class OptaPlannerDevUITest {
                 .asPrettyString();
         XmlParser xmlParser = new XmlParser();
         Node node = xmlParser.parseText(body);
-        String model = ((Node) (node.getAt(QName.valueOf("body"))
-                .getAt(QName.valueOf("div"))
-                .getAt(QName.valueOf("div"))
-                .get(0))).toString();
+        String model = Objects.requireNonNull(findById("model", node)).toString();
         assertThat(model)
                 .contains("value=[Solution: org.optaplanner.quarkus.it.devui.domain.TestdataStringLengthShadowSolution]");
         assertThat(model).contains("value=[Entity: org.optaplanner.quarkus.it.devui.domain.TestdataStringLengthShadowEntity]");
@@ -103,11 +97,23 @@ public class OptaPlannerDevUITest {
                 .asPrettyString();
         XmlParser xmlParser = new XmlParser();
         Node node = xmlParser.parseText(body);
-        String constraints = ((Node) (node.getAt(QName.valueOf("body"))
-                .getAt(QName.valueOf("div"))
-                .getAt(QName.valueOf("table"))
-                .get(0))).text();
+        String constraints = Objects.requireNonNull(findById("constraints", node)).text();
         assertThat(constraints).contains("org.optaplanner.quarkus.it.devui.domain/Don't assign 2 entities the same value");
         assertThat(constraints).contains("org.optaplanner.quarkus.it.devui.domain/Maximize value length");
+    }
+
+    private Node findById(String id, Node node) {
+        if (id.equals(node.attribute("id"))) {
+            return node;
+        }
+        for (Object child : node.children()) {
+            if (child instanceof Node) {
+                Node maybeFoundNodeText = findById(id, (Node) child);
+                if (maybeFoundNodeText != null) {
+                    return maybeFoundNodeText;
+                }
+            }
+        }
+        return null;
     }
 }


### PR DESCRIPTION
Should close https://github.com/quarkusio/quarkus/issues/11563

Made the selectors looks for particular id instead of path, so changes to the dev ui base template should not affect this test.
<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.
-->

### JIRA

<!-- Add a JIRA ticket link if it exists. -->
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
* https://github.com/kiegroup/drools/pull/3000
* https://github.com/kiegroup/optaplanner/pull/899
* etc.
-->

### Checklist
- [ ] Documentation updated if applicable.
- [ ] Upgrade recipe provided if applicable.

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>specific pull request build</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] tests</b>
* for a <b>full downstream build</b> please add comment: <b>Jenkins run fdb</b>
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
* for a <b>Quarkus LTS check</b> please add comment: <b>Jenkins run LTS</b>
* for a <b>specific Quarkus LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] LTS</b>
* for a <b>Native check</b> please add comment: <b>Jenkins run native</b>
* for a <b>specific Native LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] native</b>
</details>
