### PR TITLE
Fix inconsistency in the docs; made examples clearer

### DIFF
--- a/optaplanner-docs/src/main/asciidoc/PlannerConfiguration/PlannerConfiguration-chapter.adoc
+++ b/optaplanner-docs/src/main/asciidoc/PlannerConfiguration/PlannerConfiguration-chapter.adoc
@@ -1741,22 +1741,32 @@ For example in Logback, use a `SiftingAppender` in ``logback.xml``:
 [[monitoring]]
 === Monitoring
 
-OptaPlanner exposes metrics via https://micrometer.io/[Micrometer] which can be used for monitoring the Solver. OptaPlanner automatically connects to configured registries when used in Quarkus or Spring Boot. In plain Java, add the registry to the global registry:
+OptaPlanner exposes metrics via https://micrometer.io/[Micrometer] which can be used for monitoring the Solver. It'll automatically connect to configured registries when used in Quarkus or Spring Boot. In plain Java, add your favorite registry to the global registry:
 [source,java,nowrap]
 ----
-Metrics.addRegistry(new SimpleMeterRegistry());
+MeterRegistry registry;
+// Create and configure registry
+// ...
+Metrics.addRegistry(registry);
 ----
+Visit the https://micrometer.io/[Micrometer website] to see the registries available and how to configure them.
 
 The following metrics are exposed (format may differ depending on registry):
 
-- `optaplanner.solver.errors`: Count the total number of errors that occurred while solving
+- `optaplanner.solver.errors.total`:
+The total number of errors that occurred while solving since the start
+of the measuring.
 
-- `optaplanner.solver.solve-length.active-count`: The number of solvers currently active
+- `optaplanner.solver.solve-length.active-count`: The number of solvers
+currently solving.
 
-- `optaplanner.solver.solve-length.seconds-max`: Run time of the longest-running currently active solver
+- `optaplanner.solver.solve-length.seconds-max`: Run time of the
+longest-running currently active solver.
 
-- `optaplanner.solver.solve-length.seconds-duration-sum`: The sum of each active solver solve length (ex: if there are two active solvers, one running for 3 minutes and the other for 1 minute, this would be 4 minutes).
-
+- `optaplanner.solver.solve-length.seconds-duration-sum`:
+The sum of each active solvers' solve duration.
+For example, if there are two active solvers, one running for 3 minutes
+and the other for 1 minute, this would be 4 minutes.
 
 [[randomNumberGenerator]]
 === Random number generator


### PR DESCRIPTION
<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.
-->

### JIRA

<!-- Add a JIRA ticket link if it exists. -->
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
* https://github.com/kiegroup/drools/pull/3000
* https://github.com/kiegroup/optaplanner/pull/899
* etc.
-->

### Checklist
- [ ] Documentation updated if applicable.
- [ ] Upgrade recipe provided if applicable.

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>specific pull request build</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] tests</b>
* for a <b>full downstream build</b> please add comment: <b>Jenkins run fdb</b>
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
* for a <b>Quarkus LTS check</b> please add comment: <b>Jenkins run LTS</b>
* for a <b>specific Quarkus LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] LTS</b>
* for a <b>Native check</b> please add comment: <b>Jenkins run native</b>
* for a <b>specific Native LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] native</b>
</details>
