### PR TITLE
[8.11.x] Upgrade Jenkinsfile Maven version to 3.6.3

### DIFF
--- a/.ci/jenkins/Jenkinsfile
+++ b/.ci/jenkins/Jenkinsfile
@@ -16,7 +16,7 @@ pipeline {
         label 'kie-rhel7 && kie-mem16g'
     }
     tools {
-        maven 'kie-maven-3.6.2'
+        maven 'kie-maven-3.6.3'
         jdk 'kie-jdk11'
     }
     options {

--- a/.ci/jenkins/Jenkinsfile.native
+++ b/.ci/jenkins/Jenkinsfile.native
@@ -11,7 +11,7 @@ pipeline {
         label 'kie-rhel7 && kie-mem16g'
     }
     tools {
-        maven 'kie-maven-3.6.2'
+        maven 'kie-maven-3.6.3'
         jdk 'kie-jdk11'
     }
     options {

--- a/.ci/jenkins/Jenkinsfile.promote
+++ b/.ci/jenkins/Jenkinsfile.promote
@@ -18,7 +18,7 @@ pipeline {
     }
 
     tools {
-        maven 'kie-maven-3.6.2'
+        maven 'kie-maven-3.6.3'
         jdk 'kie-jdk11'
     }
 

--- a/.ci/jenkins/Jenkinsfile.turtle
+++ b/.ci/jenkins/Jenkinsfile.turtle
@@ -9,7 +9,7 @@ pipeline {
         label 'kie-rhel7 && kie-mem16g'
     }
     tools {
-        maven 'kie-maven-3.6.2'
+        maven 'kie-maven-3.6.3'
         jdk 'kie-jdk11'
     }
     options {

--- a/build/optaplanner-build-parent/pom.xml
+++ b/build/optaplanner-build-parent/pom.xml
@@ -38,7 +38,7 @@
     <!-- Plugins -->
     <!-- ************************************************************************ -->
 
-    <maven.min.version>3.6.2</maven.min.version>
+    <maven.min.version>3.6.3</maven.min.version>
     <maven.compiler.release>11</maven.compiler.release>
     <!-- A workaround for https://youtrack.jetbrains.com/issue/IDEA-276403. -->
     <maven.compiler.target>11</maven.compiler.target>


### PR DESCRIPTION
Signed-off-by: Alberto Morales Perez <almorale@redhat.com>

After the following backport the Kogito runtimes Maven version has been enforced to be `3.6.3`. https://github.com/kiegroup/kogito-runtimes/pull/1568

The Jenkinsfile in this repository branch needs to use at least this version to execute downstream builds for Kogito runtimes.