### PR TITLE
Change optaplanner.solver.solve-length to optaplanner.solver.solve.duration

### DIFF
--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/solver/DefaultSolver.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/solver/DefaultSolver.java
@@ -76,7 +76,7 @@ public class DefaultSolver<Solution_> extends AbstractSolver<Solution_> {
         this.basicPlumbingTermination = basicPlumbingTermination;
         this.solverScope = solverScope;
         this.moveThreadCountDescription = moveThreadCountDescription;
-        this.solveLengthTimer = Metrics.more().longTaskTimer("optaplanner.solver.solve-length");
+        this.solveLengthTimer = Metrics.more().longTaskTimer("optaplanner.solver.solve.duration");
         this.errorCounter = Metrics.counter("optaplanner.solver.errors");
     }
 

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/solver/DefaultSolverTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/solver/DefaultSolverTest.java
@@ -82,7 +82,7 @@ public class DefaultSolverTest {
         Solver<TestdataSolution> solver = solverFactory.buildSolver();
         meterRegistry.publish();
         assertThat(meterRegistry.getMeasurement("optaplanner.solver.errors", "COUNT")).isZero();
-        assertThat(meterRegistry.getMeasurement("optaplanner.solver.solve-length", "ACTIVE_TASKS")).isZero();
+        assertThat(meterRegistry.getMeasurement("optaplanner.solver.solve.duration", "ACTIVE_TASKS")).isZero();
 
         TestdataSolution solution = new TestdataSolution("s1");
         solution.setValueList(Arrays.asList(new TestdataValue("v1"), new TestdataValue("v2")));
@@ -93,8 +93,8 @@ public class DefaultSolverTest {
             if (!updatedTime.get()) {
                 meterRegistry.getClock().addSeconds(2);
                 meterRegistry.publish();
-                assertThat(meterRegistry.getMeasurement("optaplanner.solver.solve-length", "ACTIVE_TASKS")).isOne();
-                assertThat(meterRegistry.getMeasurement("optaplanner.solver.solve-length", "DURATION").longValue())
+                assertThat(meterRegistry.getMeasurement("optaplanner.solver.solve.duration", "ACTIVE_TASKS")).isOne();
+                assertThat(meterRegistry.getMeasurement("optaplanner.solver.solve.duration", "DURATION").longValue())
                         .isEqualTo(TimeUnit.SECONDS.toNanos(2));
                 updatedTime.set(true);
             }
@@ -105,8 +105,8 @@ public class DefaultSolverTest {
         assertThat(solution).isNotNull();
         assertThat(solution.getScore().isSolutionInitialized()).isTrue();
 
-        assertThat(meterRegistry.getMeasurement("optaplanner.solver.solve-length", "DURATION")).isZero();
-        assertThat(meterRegistry.getMeasurement("optaplanner.solver.solve-length", "ACTIVE_TASKS")).isZero();
+        assertThat(meterRegistry.getMeasurement("optaplanner.solver.solve.duration", "DURATION")).isZero();
+        assertThat(meterRegistry.getMeasurement("optaplanner.solver.solve.duration", "ACTIVE_TASKS")).isZero();
         assertThat(meterRegistry.getMeasurement("optaplanner.solver.errors", "COUNT")).isZero();
     }
 
@@ -139,7 +139,7 @@ public class DefaultSolverTest {
         Solver<TestdataSolution> solver = solverFactory.buildSolver();
         meterRegistry.publish();
         assertThat(meterRegistry.getMeasurement("optaplanner.solver.errors", "COUNT")).isZero();
-        assertThat(meterRegistry.getMeasurement("optaplanner.solver.solve-length", "ACTIVE_TASKS")).isZero();
+        assertThat(meterRegistry.getMeasurement("optaplanner.solver.solve.duration", "ACTIVE_TASKS")).isZero();
 
         TestdataSolution solution = new TestdataSolution("s1");
         solution.setValueList(Arrays.asList(new TestdataValue("v1"), new TestdataValue("v2")));
@@ -153,8 +153,8 @@ public class DefaultSolverTest {
 
         meterRegistry.getClock().addSeconds(1);
         meterRegistry.publish();
-        assertThat(meterRegistry.getMeasurement("optaplanner.solver.solve-length", "ACTIVE_TASKS")).isZero();
-        assertThat(meterRegistry.getMeasurement("optaplanner.solver.solve-length", "DURATION")).isZero();
+        assertThat(meterRegistry.getMeasurement("optaplanner.solver.solve.duration", "ACTIVE_TASKS")).isZero();
+        assertThat(meterRegistry.getMeasurement("optaplanner.solver.solve.duration", "DURATION")).isZero();
         assertThat(meterRegistry.getMeasurement("optaplanner.solver.errors", "COUNT")).isOne();
     }
 

--- a/optaplanner-docs/src/main/asciidoc/PlannerConfiguration/PlannerConfiguration-chapter.adoc
+++ b/optaplanner-docs/src/main/asciidoc/PlannerConfiguration/PlannerConfiguration-chapter.adoc
@@ -1788,10 +1788,10 @@ The names and format of the metrics vary depending on the registry.
 +
 * `optaplanner.solver.errors.total`: the total number of errors that occurred while solving since the start
 of the measuring.
-* `optaplanner.solver.solve-length.active-count`: the number of solvers currently solving.
-* `optaplanner.solver.solve-length.seconds-max`: run time of the
+* `optaplanner.solver.solve.duration.active-count`: the number of solvers currently solving.
+* `optaplanner.solver.solve.duration.seconds-max`: run time of the
 longest-running currently active solver.
-* `optaplanner.solver.solve-length.seconds-duration-sum`: the sum of each active solver's solve duration. For example, if there are two active solvers, one running for three minutes and the other for one minute, the total solve time is four minutes.
+* `optaplanner.solver.solve.duration.seconds-duration-sum`: the sum of each active solver's solve duration. For example, if there are two active solvers, one running for three minutes and the other for one minute, the total solve time is four minutes.
 
 [[randomNumberGenerator]]
 === Random number generator


### PR DESCRIPTION
Motivation: optaplanner.solver.solve-length does not follow Micrometer naming
Convention (https://micrometer.io/docs/concepts#_naming_meters) which causes it
to look arkward in some monitoring systems (ex: optaplannerSolverSolve-length).

<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.
-->

### JIRA

<!-- Add a JIRA ticket link if it exists. -->
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
* https://github.com/kiegroup/drools/pull/3000
* https://github.com/kiegroup/optaplanner/pull/899
* etc.
-->

### Checklist
- [ ] Documentation updated if applicable.
- [ ] Upgrade recipe provided if applicable.

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>specific pull request build</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] tests</b>
* for a <b>full downstream build</b> please add comment: <b>Jenkins run fdb</b>
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
* for a <b>Quarkus LTS check</b> please add comment: <b>Jenkins run LTS</b>
* for a <b>specific Quarkus LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] LTS</b>
* for a <b>Native check</b> please add comment: <b>Jenkins run native</b>
* for a <b>specific Native LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] native</b>
</details>
