### PR TITLE
PLANNER-2528: Update break when interval cluster start changes

### DIFF
--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/common/experimental/impl/ConsecutiveIntervalInfoImpl.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/common/experimental/impl/ConsecutiveIntervalInfoImpl.java
@@ -98,6 +98,12 @@ public final class ConsecutiveIntervalInfoImpl<Interval_, Point_ extends Compara
             clusterStartSplitPointToCluster.remove(oldStartSplitPoint);
             clusterStartSplitPointToCluster.put(firstIntersectedIntervalCluster.getStartSplitPoint(),
                     firstIntersectedIntervalCluster);
+            var nextBreak = clusterStartSplitPointToNextBreak.get(firstIntersectedIntervalCluster.getStartSplitPoint());
+            if (nextBreak != null) {
+                nextBreak.setPreviousCluster(firstIntersectedIntervalCluster);
+                nextBreak.setLength(differenceFunction.apply(nextBreak.getPreviousIntervalClusterEnd(),
+                        nextBreak.getNextIntervalClusterStart()));
+            }
         }
     }
 

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/common/experimental/impl/IntervalTree.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/common/experimental/impl/IntervalTree.java
@@ -86,9 +86,9 @@ public final class IntervalTree<Interval_, Point_ extends Comparable<Point_>, Di
         if (ceilingEndSplitPoint == null || !ceilingEndSplitPoint.equals(endSplitPoint)) {
             splitPointSet.add(endSplitPoint);
             endSplitPoint.createCollections();
-            endSplitPoint.addIntervalEndingAtSplitPoint(interval);
+            isChanged |= endSplitPoint.addIntervalEndingAtSplitPoint(interval);
         } else {
-            ceilingEndSplitPoint.addIntervalEndingAtSplitPoint(interval);
+            isChanged |= ceilingEndSplitPoint.addIntervalEndingAtSplitPoint(interval);
         }
 
         if (isChanged) {

--- a/optaplanner-examples/src/test/java/org/optaplanner/examples/common/experimental/impl/IntervalTreeTest.java
+++ b/optaplanner-examples/src/test/java/org/optaplanner/examples/common/experimental/impl/IntervalTreeTest.java
@@ -153,6 +153,31 @@ public class IntervalTreeTest {
     }
 
     @Test
+    public void testIntervalAddUpdatingOldBreak() {
+        IntervalTree<Interval, Integer, Integer> tree = getIntegerIntervalTree();
+        Interval beforeAll = new Interval(1, 2);
+        Interval newStart = new Interval(3, 8);
+        Interval oldStart = new Interval(4, 5);
+        Interval betweenOldAndNewStart = new Interval(6, 7);
+        Interval afterAll = new Interval(9, 10);
+
+        tree.add(beforeAll);
+        verifyBreaks(tree);
+
+        tree.add(afterAll);
+        verifyBreaks(tree);
+
+        tree.add(oldStart);
+        verifyBreaks(tree);
+
+        tree.add(betweenOldAndNewStart);
+        verifyBreaks(tree);
+
+        tree.add(newStart);
+        verifyBreaks(tree);
+    }
+
+    @Test
     public void testOverlappingInterval() {
         IntervalTree<Interval, Integer, Integer> tree = getIntegerIntervalTree();
         Interval a = new Interval(0, 2);
@@ -232,6 +257,9 @@ public class IntervalTreeTest {
         IterableList<IntervalBreak<Interval, Integer, Integer>> breakList =
                 new IterableList<>(tree.getConsecutiveIntervalData().getBreaks());
 
+        if (clusterList.size() == 0) {
+            return;
+        }
         assertThat(breakList).hasSize(clusterList.size() - 1);
         for (int i = 0; i < clusterList.size() - 1; i++) {
             assertThat(breakList.get(i).getPreviousIntervalCluster()).isSameAs(clusterList.get(i));
@@ -315,6 +343,7 @@ public class IntervalTreeTest {
                 }
 
                 // Verify the mutable version matches the recompute version
+                verifyBreaks(tree);
                 assertThat(tree.getConsecutiveIntervalData().getIntervalClusters())
                         .as(op + " interval " + interval + " to " + old).containsExactlyElementsOf(intervalClusterList);
                 assertThat(tree.getConsecutiveIntervalData().getBreaks()).as(op + " interval " + interval + " to " + old)


### PR DESCRIPTION
<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.
-->

### JIRA

<!-- Add a JIRA ticket link if it exists. -->
https://issues.redhat.com/browse/PLANNER-2528

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
* https://github.com/kiegroup/drools/pull/3000
* https://github.com/kiegroup/optaplanner/pull/899
* etc.
-->

### Checklist
- [ ] Documentation updated if applicable.
- [ ] Upgrade recipe provided if applicable.

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>specific pull request build</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] tests</b>
* for a <b>full downstream build</b> please add comment: <b>Jenkins run fdb</b>
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
* for a <b>Quarkus LTS check</b> please add comment: <b>Jenkins run LTS</b>
* for a <b>specific Quarkus LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] LTS</b>
* for a <b>Native check</b> please add comment: <b>Jenkins run native</b>
* for a <b>specific Native LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] native</b>
</details>
