### PR TITLE
Move meters inside the solve calls to address registration and unregistration issues

### DIFF
--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/util/TestMeterRegistry.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/util/TestMeterRegistry.java
@@ -60,10 +60,7 @@ public class TestMeterRegistry extends SimpleMeterRegistry {
 
     public void publish(Solver solver) {
         DefaultSolver defaultSolver = (DefaultSolver) solver;
-        String solverId = defaultSolver.getSolverScope().getMonitoringTags().stream()
-                .filter(tag -> tag.getKey().equals("solver.id")).findAny()
-                .orElseThrow(IllegalStateException::new).getValue();
-        this.getMeters().stream().filter(meter -> solverId.equals(meter.getId().getTag("solver.id"))).forEach(meter -> {
+        this.getMeters().stream().forEach(meter -> {
             final Map<String, BigDecimal> meterMeasurementMap = new HashMap<>();
             String meterTags = "";
             if (meter.getId().getTags().size() > 1) {


### PR DESCRIPTION
This is an alternative fix for the Micrometer bug; the other is #1586 .
This changes the order the event listeners are added, resulted
in the meters being the last meters (thus a test needed to be rewritten).
<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.
-->

### JIRA

<!-- Add a JIRA ticket link if it exists. -->
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
* https://github.com/kiegroup/drools/pull/3000
* https://github.com/kiegroup/optaplanner/pull/899
* etc.
-->

### Checklist
- [ ] Documentation updated if applicable.
- [ ] Upgrade recipe provided if applicable.

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>specific pull request build</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] tests</b>
* for a <b>full downstream build</b> 
  * for <b>jenkins</b> job: please add comment: <b>Jenkins run fdb</b>
  * for <b>github actions</b> job: add the label `run_fdb`
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
* for a <b>Quarkus LTS check</b> please add comment: <b>Jenkins run LTS</b>
* for a <b>specific Quarkus LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] LTS</b>
* for a <b>Native check</b> please add comment: <b>Jenkins run native</b>
* for a <b>specific Native LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] native</b>
</details>
