### PR TITLE
Remove tags for solve.duration and error.count

### DIFF
--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/solver/DefaultSolver.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/solver/DefaultSolver.java
@@ -172,9 +172,12 @@ public class DefaultSolver<Solution_> extends AbstractSolver<Solution_> {
         if (problem == null) {
             throw new IllegalArgumentException("The problem (" + problem + ") must not be null.");
         }
-        LongTaskTimer solveLengthTimer = Metrics.more().longTaskTimer(SolverMetric.SOLVE_DURATION.getMeterId(),
-                solverScope.getMonitoringTags());
-        Counter errorCounter = Metrics.counter(SolverMetric.ERROR_COUNT.getMeterId(), solverScope.getMonitoringTags());
+
+        // No tags for these metrics; they are global
+        LongTaskTimer solveLengthTimer = Metrics.more().longTaskTimer(SolverMetric.SOLVE_DURATION.getMeterId());
+        Counter errorCounter = Metrics.counter(SolverMetric.ERROR_COUNT.getMeterId());
+
+        // Score Calculation Count is specific per solver
         Metrics.gauge(SolverMetric.SCORE_CALCULATION_COUNT.getMeterId(), solverScope.getMonitoringTags(),
                 solverScope, SolverScope::getScoreCalculationCount);
         solverScope.getSolverMetricSet().forEach(solverMetric -> solverMetric.register(this));

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/solver/DefaultSolverTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/solver/DefaultSolverTest.java
@@ -177,12 +177,12 @@ public class DefaultSolverTest {
                 assertThat(meterRegistry.getMeters().stream().map(Meter::getId))
                         .containsExactlyInAnyOrder(
                                 new Meter.Id(SolverMetric.SOLVE_DURATION.getMeterId(),
-                                        Tags.of("tag.key", "tag.value"),
+                                        Tags.empty(),
                                         null,
                                         null,
                                         Meter.Type.LONG_TASK_TIMER),
                                 new Meter.Id(SolverMetric.ERROR_COUNT.getMeterId(),
-                                        Tags.of("tag.key", "tag.value"),
+                                        Tags.empty(),
                                         null,
                                         null,
                                         Meter.Type.COUNTER),
@@ -204,12 +204,12 @@ public class DefaultSolverTest {
         assertThat(meterRegistry.getMeters().stream().map(Meter::getId))
                 .containsExactlyInAnyOrder(
                         new Meter.Id(SolverMetric.SOLVE_DURATION.getMeterId(),
-                                Tags.of("tag.key", "tag.value"),
+                                Tags.empty(),
                                 null,
                                 null,
                                 Meter.Type.LONG_TASK_TIMER),
                         new Meter.Id(SolverMetric.ERROR_COUNT.getMeterId(),
-                                Tags.of("tag.key", "tag.value"),
+                                Tags.empty(),
                                 null,
                                 null,
                                 Meter.Type.COUNTER));


### PR DESCRIPTION
<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.
-->

### JIRA

<!-- Add a JIRA ticket link if it exists. -->
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
* https://github.com/kiegroup/drools/pull/3000
* https://github.com/kiegroup/optaplanner/pull/899
* etc.
-->

### Checklist
- [ ] Documentation updated if applicable.
- [ ] Upgrade recipe provided if applicable.

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>specific pull request build</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] tests</b>
* for a <b>full downstream build</b> 
  * for <b>jenkins</b> job: please add comment: <b>Jenkins run fdb</b>
  * for <b>github actions</b> job: add the label `run_fdb`
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
* for a <b>Quarkus LTS check</b> please add comment: <b>Jenkins run LTS</b>
* for a <b>specific Quarkus LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] LTS</b>
* for a <b>Native check</b> please add comment: <b>Jenkins run native</b>
* for a <b>specific Native LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] native</b>
</details>
