### PR TITLE
[DROOLS-6351] PredicateInformation contains only one rule name even w…

### DIFF
--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/solver/DefaultSolverTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/solver/DefaultSolverTest.java
@@ -383,7 +383,7 @@ public class DefaultSolverTest {
 
         assertThatCode(() -> {
             solver.solve(solution);
-        }).hasMessageContaining("Thrown exception in constraint provider");
+        }).hasStackTraceContaining("Thrown exception in constraint provider");
 
         meterRegistry.getClock().addSeconds(1);
         meterRegistry.publish(solver);


### PR DESCRIPTION
…hen shared

- Fixed test assertion because of error message change

### JIRA

https://issues.redhat.com/browse/DROOLS-6351

This JIRA changes error messages so it affected `DefaultSolverTest.solveMetricsError` assertion.

The fixed assertion works for both before and after DROOLS-6351.

### Referenced pull requests

The issue mentioned in the PR comment should be solved by this PR.
https://github.com/kiegroup/kogito-runtimes/pull/1628#issuecomment-927964945


<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>specific pull request build</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] tests</b>
* for a <b>full downstream build</b> 
  * for <b>jenkins</b> job: please add comment: <b>Jenkins run fdb</b>
  * for <b>github actions</b> job: add the label `run_fdb`
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
* for a <b>Quarkus LTS check</b> please add comment: <b>Jenkins run LTS</b>
* for a <b>specific Quarkus LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] LTS</b>
* for a <b>Native check</b> please add comment: <b>Jenkins run native</b>
* for a <b>specific Native LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] native</b>
</details>
