### PR TITLE
Bump Quarkus 2.3.0.Final

### DIFF
--- a/build/optaplanner-build-parent/pom.xml
+++ b/build/optaplanner-build-parent/pom.xml
@@ -25,7 +25,7 @@
     <!-- Normal dependency versions -->
     <version.ch.qos.logback>1.2.3</version.ch.qos.logback>
     <version.com.thoughtworks.xstream>1.4.18</version.com.thoughtworks.xstream>
-    <version.io.quarkus>2.2.2.Final</version.io.quarkus>
+    <version.io.quarkus>2.3.0.Final</version.io.quarkus>
     <version.org.apache.commons.math3>3.6.1</version.org.apache.commons.math3>
     <version.org.apache.poi>4.1.2</version.org.apache.poi>
     <version.org.freemarker>2.3.31</version.org.freemarker>


### PR DESCRIPTION
Related PRs:
- https://github.com/kiegroup/kogito-runtimes/pull/1634
- https://github.com/kiegroup/optaplanner/pull/1593
- https://github.com/kiegroup/kogito-apps/pull/1044
- https://github.com/kiegroup/kogito-examples/pull/909
- https://github.com/kiegroup/optaplanner-quickstarts/pull/190
- https://github.com/kiegroup/optaweb-vehicle-routing/pull/570

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>specific pull request build</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] tests</b>
* for a <b>full downstream build</b> 
  * for <b>jenkins</b> job: please add comment: <b>Jenkins run fdb</b>
  * for <b>github actions</b> job: add the label `run_fdb`
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
* for a <b>Quarkus LTS check</b> please add comment: <b>Jenkins run LTS</b>
* for a <b>specific Quarkus LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] LTS</b>
* for a <b>Native check</b> please add comment: <b>Jenkins run native</b>
* for a <b>specific Native LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] native</b>
</details>
