### PR TITLE
Make KieModuleMarshaller run time initialized

### DIFF
--- a/optaplanner-quarkus-integration/optaplanner-quarkus/runtime/src/main/java/org/optaplanner/quarkus/runtime/graal/OptaPlannerFeature.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/runtime/src/main/java/org/optaplanner/quarkus/runtime/graal/OptaPlannerFeature.java
@@ -1,0 +1,17 @@
+package org.optaplanner.quarkus.runtime.graal;
+
+import org.graalvm.nativeimage.ImageSingletons;
+import org.graalvm.nativeimage.hosted.Feature;
+import org.graalvm.nativeimage.impl.RuntimeClassInitializationSupport;
+
+import com.oracle.svm.core.annotate.AutomaticFeature;
+
+@AutomaticFeature
+public class OptaPlannerFeature implements Feature {
+    @Override
+    public void afterRegistration(AfterRegistrationAccess access) {
+        final RuntimeClassInitializationSupport runtimeInit = ImageSingletons.lookup(RuntimeClassInitializationSupport.class);
+        final String reason = "Quarkus run time init for OptaPlanner";
+        runtimeInit.initializeAtRunTime("org.drools.compiler.kproject.models.KieModuleMarshaller", reason);
+    }
+}


### PR DESCRIPTION
Closes https://github.com/quarkusio/quarkus/issues/20491

A simple way to fix the issue is to make `KieModuleMarshaller` run-time initialized.

@Sanne mentioned [here](https://github.com/quarkusio/quarkus/issues/11563#issuecomment-926479069):
> I had a quick look at java.awt.datatransfer.DataFlavor.. I could be wrong but it looks like a perfect candidate to be optimized via build time initialization.

Not sure exactly what he means, but at a first glance, everything awt related/dependant should really be runtime initialized to start with. Then, you can always optimize further things as needed/required.