### PR TITLE
KOGITO-5280 Setup downstream profiles for kogito checks

### DIFF
--- a/.ci/jenkins/dsl/jobs.groovy
+++ b/.ci/jenkins/dsl/jobs.groovy
@@ -28,13 +28,13 @@ Map getMultijobPRConfig() {
                 id: 'kogito-apps',
                 repository: 'kogito-apps',
                 env : [
-                    KOGITO_APPS_BUILD_MVN_OPTS: '-Poptaplanner-downstream -am -amd'
+                    KOGITO_APPS_BUILD_MVN_OPTS: '-Poptaplanner-downstream'
                 ]
             ], [
                 id: 'kogito-examples',
                 repository: 'kogito-examples',
                 env : [
-                    KOGITO_EXAMPLES_BUILD_MVN_OPTS: '-Poptaplanner-downstream -am -amd'
+                    KOGITO_EXAMPLES_BUILD_MVN_OPTS: '-Poptaplanner-downstream'
                 ]
             ], [
                 id: 'optaweb-employee-rostering',
@@ -103,8 +103,8 @@ void setupMultijobPrDefaultChecks() {
 
 void setupMultijobPrNativeChecks() {
     def multijobConfig = getMultijobPRConfig()
-    multijobConfig.jobs.find { it.id == 'kogito-apps' }.env.KOGITO_APPS_BUILD_MVN_OPTS = '-Poptaplanner-downstream,native -am -amd'
-    multijobConfig.jobs.find { it.id == 'kogito-examples' }.env.KOGITO_EXAMPLES_BUILD_MVN_OPTS = '-Poptaplanner-downstream-native -am -amd'
+    multijobConfig.jobs.find { it.id == 'kogito-apps' }.env.KOGITO_APPS_BUILD_MVN_OPTS = '-Poptaplanner-downstream,native'
+    multijobConfig.jobs.find { it.id == 'kogito-examples' }.env.KOGITO_EXAMPLES_BUILD_MVN_OPTS = '-Poptaplanner-downstream-native'
     KogitoJobTemplate.createMultijobNativePRJobs(this, getMultijobPRConfig()) { return getDefaultJobParams() }
 }
 

--- a/.ci/jenkins/dsl/jobs.groovy
+++ b/.ci/jenkins/dsl/jobs.groovy
@@ -27,9 +27,15 @@ Map getMultijobPRConfig() {
             ], [
                 id: 'kogito-apps',
                 repository: 'kogito-apps',
+                env : [
+                    KOGITO_APPS_BUILD_MVN_OPTS: '-Poptaplanner-downstream'
+                ]
             ], [
                 id: 'kogito-examples',
-                repository: 'kogito-examples'
+                repository: 'kogito-examples',
+                env : [
+                    KOGITO_EXAMPLES_BUILD_MVN_OPTS: '-Poptaplanner-downstream'
+                ]
             ], [
                 id: 'optaweb-employee-rostering',
                 repository: 'optaweb-employee-rostering'
@@ -40,7 +46,7 @@ Map getMultijobPRConfig() {
                 id: 'optaplanner-quickstarts',
                 repository: 'optaplanner-quickstarts',
                 env : [
-                    BUILD_MVN_OPTS: '-Dfull'
+                    OPTAPLANNER_BUILD_MVN_OPTS_UPSTREAM: '-Dfull'
                 ]
             ]
         ]
@@ -96,6 +102,9 @@ void setupMultijobPrDefaultChecks() {
 }
 
 void setupMultijobPrNativeChecks() {
+    def multijobConfig = getMultijobPRConfig()
+    multijobConfig.jobs.find { it.id == 'kogito-apps' }.env.KOGITO_APPS_BUILD_MVN_OPTS = '-Poptaplanner-downstream,native'
+    multijobConfig.jobs.find { it.id == 'kogito-examples' }.env.KOGITO_EXAMPLES_BUILD_MVN_OPTS = '-Poptaplanner-downstream-native'
     KogitoJobTemplate.createMultijobNativePRJobs(this, getMultijobPRConfig()) { return getDefaultJobParams() }
 }
 

--- a/.ci/jenkins/dsl/jobs.groovy
+++ b/.ci/jenkins/dsl/jobs.groovy
@@ -28,13 +28,13 @@ Map getMultijobPRConfig() {
                 id: 'kogito-apps',
                 repository: 'kogito-apps',
                 env : [
-                    KOGITO_APPS_BUILD_MVN_OPTS: '-Poptaplanner-downstream'
+                    KOGITO_APPS_BUILD_MVN_OPTS: '-Poptaplanner-downstream -am -amd'
                 ]
             ], [
                 id: 'kogito-examples',
                 repository: 'kogito-examples',
                 env : [
-                    KOGITO_EXAMPLES_BUILD_MVN_OPTS: '-Poptaplanner-downstream'
+                    KOGITO_EXAMPLES_BUILD_MVN_OPTS: '-Poptaplanner-downstream -am -amd'
                 ]
             ], [
                 id: 'optaweb-employee-rostering',
@@ -103,8 +103,8 @@ void setupMultijobPrDefaultChecks() {
 
 void setupMultijobPrNativeChecks() {
     def multijobConfig = getMultijobPRConfig()
-    multijobConfig.jobs.find { it.id == 'kogito-apps' }.env.KOGITO_APPS_BUILD_MVN_OPTS = '-Poptaplanner-downstream,native'
-    multijobConfig.jobs.find { it.id == 'kogito-examples' }.env.KOGITO_EXAMPLES_BUILD_MVN_OPTS = '-Poptaplanner-downstream-native'
+    multijobConfig.jobs.find { it.id == 'kogito-apps' }.env.KOGITO_APPS_BUILD_MVN_OPTS = '-Poptaplanner-downstream,native -am -amd'
+    multijobConfig.jobs.find { it.id == 'kogito-examples' }.env.KOGITO_EXAMPLES_BUILD_MVN_OPTS = '-Poptaplanner-downstream-native -am -amd'
     KogitoJobTemplate.createMultijobNativePRJobs(this, getMultijobPRConfig()) { return getDefaultJobParams() }
 }
 

--- a/.github/workflows/full-downstream.yml
+++ b/.github/workflows/full-downstream.yml
@@ -59,6 +59,7 @@ jobs:
           starting-project: kiegroup/optaplanner-quickstarts
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          OPTAPLANNER_BUILD_MVN_OPTS_UPSTREAM: "-Dfull"
       - name: Check Surefire Report
         if: ${{ always() }}
         uses: ScaCap/action-surefire-report@v1.0.10


### PR DESCRIPTION
### JIRA

https://issues.redhat.com/browse/KOGITO-5280

### Referenced pull requests

https://github.com/kiegroup/kogito-apps/pull/1033
https://github.com/kiegroup/kogito-examples/pull/897
https://github.com/kiegroup/kogito-pipelines/pull/271
https://github.com/kiegroup/kogito-apps/pull/1049
https://github.com/kiegroup/optaplanner-quickstarts/pull/191

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>specific pull request build</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] tests</b>
* for a <b>full downstream build</b> 
  * for <b>jenkins</b> job: please add comment: <b>Jenkins run fdb</b>
  * for <b>github actions</b> job: add the label `run_fdb`
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
* for a <b>Quarkus LTS check</b> please add comment: <b>Jenkins run LTS</b>
* for a <b>specific Quarkus LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] LTS</b>
* for a <b>Native check</b> please add comment: <b>Jenkins run native</b>
* for a <b>specific Native LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] native</b>
</details>
