### PR TITLE
[DROOLS-6700] fix race conditions in accumulators initialization

### DIFF
--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/common/AbstractAccumulator.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/common/AbstractAccumulator.java
@@ -31,6 +31,8 @@ abstract class AbstractAccumulator<ResultContainer_, Result_> implements Accumul
     private final Supplier<ResultContainer_> containerSupplier;
     private final Function<ResultContainer_, Result_> finisher;
 
+    private volatile boolean initialized = false;
+
     protected AbstractAccumulator(Supplier<ResultContainer_> containerSupplier,
             Function<ResultContainer_, Result_> finisher) {
         this.containerSupplier = Objects.requireNonNull(containerSupplier);
@@ -103,4 +105,17 @@ abstract class AbstractAccumulator<ResultContainer_, Result_> implements Accumul
             ReteEvaluator reteEvaluator) {
         return finisher.apply((ResultContainer_) context);
     }
+
+    protected void checkInitialized(Tuple leftTuple, Declaration[] innerDeclarations) {
+        if (!initialized) {
+            synchronized (this) {
+                if (!initialized) {
+                    init(leftTuple, innerDeclarations);
+                    initialized = true;
+                }
+            }
+        }
+    }
+
+    protected abstract void init(Tuple leftTuple, Declaration[] innerDeclarations);
 }

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/common/BiAccumulator.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/common/BiAccumulator.java
@@ -48,16 +48,15 @@ final class BiAccumulator<A, B, ResultContainer_, Result_> extends AbstractAccum
     @Override
     public Object accumulate(Object workingMemoryContext, Object context, Tuple leftTuple, InternalFactHandle handle,
             Declaration[] declarations, Declaration[] innerDeclarations, ReteEvaluator reteEvaluator) {
-        if (declarationA == null) {
-            init(leftTuple, innerDeclarations);
-        }
+        checkInitialized(leftTuple, innerDeclarations);
 
         A a = extractValue(declarationA, offsetToA, leftTuple);
         B b = extractValue(declarationB, offsetToB, leftTuple);
         return accumulator.apply((ResultContainer_) context, a, b);
     }
 
-    private void init(Tuple leftTuple, Declaration[] innerDeclarations) {
+    @Override
+    protected void init(Tuple leftTuple, Declaration[] innerDeclarations) {
         for (Declaration declaration : innerDeclarations) {
             if (declaration.getBindingName().equals(varA)) {
                 declarationA = declaration;

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/common/QuadAccumulator.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/common/QuadAccumulator.java
@@ -57,9 +57,7 @@ final class QuadAccumulator<A, B, C, D, ResultContainer_, Result_>
     @Override
     public Object accumulate(Object workingMemoryContext, Object context, Tuple leftTuple, InternalFactHandle handle,
             Declaration[] declarations, Declaration[] innerDeclarations, ReteEvaluator reteEvaluator) {
-        if (declarationA == null) {
-            init(leftTuple, innerDeclarations);
-        }
+        checkInitialized(leftTuple, innerDeclarations);
 
         A a = extractValue(declarationA, offsetToA, leftTuple);
         B b = extractValue(declarationB, offsetToB, leftTuple);
@@ -68,7 +66,8 @@ final class QuadAccumulator<A, B, C, D, ResultContainer_, Result_>
         return accumulator.apply((ResultContainer_) context, a, b, c, d);
     }
 
-    private void init(Tuple leftTuple, Declaration[] innerDeclarations) {
+    @Override
+    protected void init(Tuple leftTuple, Declaration[] innerDeclarations) {
         for (Declaration declaration : innerDeclarations) {
             if (declaration.getBindingName().equals(varA)) {
                 declarationA = declaration;

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/common/TriAccumulator.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/common/TriAccumulator.java
@@ -52,9 +52,7 @@ final class TriAccumulator<A, B, C, ResultContainer_, Result_> extends AbstractA
     @Override
     public Object accumulate(Object workingMemoryContext, Object context, Tuple leftTuple, InternalFactHandle handle,
             Declaration[] declarations, Declaration[] innerDeclarations, ReteEvaluator reteEvaluator) {
-        if (declarationA == null) {
-            init(leftTuple, innerDeclarations);
-        }
+        checkInitialized(leftTuple, innerDeclarations);
 
         A a = extractValue(declarationA, offsetToA, leftTuple);
         B b = extractValue(declarationB, offsetToB, leftTuple);
@@ -62,7 +60,8 @@ final class TriAccumulator<A, B, C, ResultContainer_, Result_> extends AbstractA
         return accumulator.apply((ResultContainer_) context, a, b, c);
     }
 
-    private void init(Tuple leftTuple, Declaration[] innerDeclarations) {
+    @Override
+    protected void init(Tuple leftTuple, Declaration[] innerDeclarations) {
         for (Declaration declaration : innerDeclarations) {
             if (declaration.getBindingName().equals(varA)) {
                 declarationA = declaration;

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/common/UniAccumulator.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/drools/common/UniAccumulator.java
@@ -51,16 +51,12 @@ final class UniAccumulator<A, ResultContainer_, Result_> extends AbstractAccumul
     }
 
     private InternalFactHandle getFactHandle(Tuple leftTuple, InternalFactHandle handle, Declaration[] innerDeclarations) {
-        if (declaration == null) {
-            return init(leftTuple, handle, innerDeclarations);
-        } else if (!subnetwork) {
-            return handle;
-        } else {
-            return getTuple(offset, leftTuple).getFactHandle();
-        }
+        checkInitialized(leftTuple, innerDeclarations);
+        return subnetwork ? getTuple(offset, leftTuple).getFactHandle() : handle;
     }
 
-    private InternalFactHandle init(Tuple leftTuple, InternalFactHandle handle, Declaration[] innerDeclarations) {
+    @Override
+    protected void init(Tuple leftTuple, Declaration[] innerDeclarations) {
         for (Declaration declaration : innerDeclarations) {
             if (declaration.getBindingName().equals(varA)) {
                 this.declaration = declaration;
@@ -69,12 +65,8 @@ final class UniAccumulator<A, ResultContainer_, Result_> extends AbstractAccumul
         }
 
         subnetwork = (leftTuple instanceof SubnetworkTuple);
-        if (!subnetwork) {
-            return handle;
-        } else {
+        if (subnetwork) {
             offset = findTupleOffset(declaration, leftTuple);
-            return getTuple(offset, leftTuple)
-                    .getFactHandle();
         }
     }
 


### PR DESCRIPTION
<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.
-->

### JIRA

<!-- Add a JIRA ticket link if it exists. -->
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
* https://github.com/kiegroup/drools/pull/3000
* https://github.com/kiegroup/optaplanner/pull/899
* etc.
-->

### Checklist
- [ ] Documentation updated if applicable.
- [ ] Upgrade recipe provided if applicable.

<details>
<summary>
How to replicate CI configuration locally?
</summary>

We do "simple" maven builds, they are just basically maven commands, but just because we have multiple repositories related between them and one change could affect several of those projects by multiple pull requests, we use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.

[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is not only a github-action tool but a CLI one, so in case you posted multiple pull requests related with this change you can easily reproduce the same build by executing it locally. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>specific pull request build</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] tests</b>
* for a <b>full downstream build</b> 
  * for <b>jenkins</b> job: please add comment: <b>Jenkins run fdb</b>
  * for <b>github actions</b> job: add the label `run_fdb`
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
* for a <b>Quarkus LTS check</b> please add comment: <b>Jenkins run LTS</b>
* for a <b>specific Quarkus LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] LTS</b>
* for a <b>Native check</b> please add comment: <b>Jenkins run native</b>
* for a <b>specific Native LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] native</b>
</details>
