### PR TITLE
Fix broken links in quarkus docs

### DIFF
--- a/optaplanner-docs/src/modules/ROOT/pages/quickstart/quarkus/quarkus-quickstart.adoc
+++ b/optaplanner-docs/src/modules/ROOT/pages/quickstart/quarkus/quarkus-quickstart.adoc
@@ -488,9 +488,9 @@ You have just developed a Quarkus application with https://www.optaplanner.org/[
 
 Now try adding database and UI integration:
 
-. Store `Timeslot`, `Room`, and `Lesson` in the database with link:hibernate-orm-panache[Hibernate and Panache].
+. Store `Timeslot`, `Room`, and `Lesson` in the database with https://quarkus.io/guides/hibernate-orm-panache[Hibernate and Panache].
 
-. link:rest-json[Expose them through REST].
+. https://quarkus.io/guides/rest-json[Expose them through REST].
 
 . Adjust the `TimeTableResource` to read and write a `TimeTable` instance in a single transaction
 and use those accordingly:


### PR DESCRIPTION
These were my mistake.
Antora exposed these broken links on the website, and the sixtrix SEO report complained about it.
Interestingly enough, these mistakes were around for a while.