### PR TITLE
KOGITO-6236 Add a workaround for DRL support in Quarkus

### DIFF
--- a/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/pom.xml
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/pom.xml
@@ -77,6 +77,12 @@
       <groupId>org.kie.kogito</groupId>
       <artifactId>kogito-legacy-api</artifactId>
     </dependency>
+    <!-- TODO: Remove this dependency when https://issues.redhat.com/browse/KOGITO-6236 is resolved. -->
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-resteasy-jackson</artifactId>
+      <scope>test</scope>
+    </dependency>
     <dependency>
       <groupId>org.kie.kogito</groupId>
       <artifactId>drools-core-dynamic</artifactId>

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/main/java/org/optaplanner/quarkus/deployment/OptaPlannerProcessor.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/main/java/org/optaplanner/quarkus/deployment/OptaPlannerProcessor.java
@@ -71,6 +71,7 @@ import io.quarkus.arc.deployment.GeneratedBeanGizmoAdaptor;
 import io.quarkus.arc.deployment.SyntheticBeanBuildItem;
 import io.quarkus.arc.deployment.UnremovableBeanBuildItem;
 import io.quarkus.deployment.Capabilities;
+import io.quarkus.deployment.Capability;
 import io.quarkus.deployment.GeneratedClassGizmoAdaptor;
 import io.quarkus.deployment.IsDevelopment;
 import io.quarkus.deployment.annotations.BuildProducer;
@@ -490,8 +491,18 @@ class OptaPlannerProcessor {
             boolean isKogitoExtensionPresent = capabilities.isPresent("kogito-rules");
             if (!isKogitoExtensionPresent) {
                 throw new IllegalStateException(
-                        "Using scoreDRL in Quarkus, but the dependency org.kie.kogito:kogito-quarkus-rules is not on the classpath.\n"
+                        "Using scoreDRL in Quarkus, but the dependency org.kie.kogito:kogito-quarkus-rules is not "
+                                + "on the classpath.\n"
                                 + "Maybe add the dependency org.kie.kogito:kogito-quarkus-rules"
+                                + "\nMaybe use a " + ConstraintProvider.class.getSimpleName() + " instead of the scoreDRL.");
+            }
+            // TODO: Remove this check when https://issues.redhat.com/browse/KOGITO-6236 is resolved.
+            boolean isResteasyJacksonExtensionPresent = capabilities.isPresent(Capability.RESTEASY_JSON_JACKSON);
+            if (!isResteasyJacksonExtensionPresent) {
+                throw new IllegalStateException(
+                        "Using scoreDRL in Quarkus, but the dependency org.kie.kogito:kogito-quarkus-rules requires "
+                                + "also io.quarkus:quarkus-resteasy-jackson to be on the classpath.\n"
+                                + "Maybe add the dependency io.quarkus:quarkus-resteasy-jackson"
                                 + "\nMaybe use a " + ConstraintProvider.class.getSimpleName() + " instead of the scoreDRL.");
             }
         }

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/test/java/org/optaplanner/quarkus/deployment/OptaPlannerProcessorTest.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/test/java/org/optaplanner/quarkus/deployment/OptaPlannerProcessorTest.java
@@ -22,6 +22,7 @@ import static org.mockito.Mockito.*;
 
 import java.util.Collections;
 import java.util.Optional;
+import java.util.Set;
 
 import org.jboss.jandex.IndexView;
 import org.junit.jupiter.api.Test;
@@ -31,8 +32,12 @@ import org.optaplanner.core.config.solver.SolverConfig;
 import org.optaplanner.quarkus.deployment.config.OptaPlannerBuildTimeConfig;
 
 import io.quarkus.deployment.Capabilities;
+import io.quarkus.deployment.Capability;
 
 class OptaPlannerProcessorTest {
+
+    // TODO: Remove the Capability.RESTEASY_JSON_JACKSON after https://issues.redhat.com/browse/KOGITO-6236 is resolved.
+    private final static Set<String> KOGITO_CAPABILITIES = Set.of("kogito-rules", Capability.RESTEASY_JSON_JACKSON);
 
     @Test
     void customScoreDrl_overrides_solverConfig() {
@@ -42,7 +47,7 @@ class OptaPlannerProcessorTest {
         OptaPlannerProcessor optaPlannerProcessor = mockOptaPlannerProcessor();
         when(optaPlannerProcessor.constraintsDrl()).thenReturn(Optional.of("some.drl"));
 
-        Capabilities capabilities = new Capabilities(Collections.singleton("kogito-rules"));
+        Capabilities capabilities = new Capabilities(KOGITO_CAPABILITIES);
         optaPlannerProcessor.applyScoreDirectorFactoryProperties(mock(IndexView.class), solverConfig, capabilities);
         assertThat(scoreDirectorFactoryConfig.getScoreDrlList()).containsExactly("some.drl");
     }
@@ -57,7 +62,7 @@ class OptaPlannerProcessorTest {
         when(optaPlannerProcessor.defaultConstraintsDrl())
                 .thenReturn(Optional.of(OptaPlannerBuildTimeConfig.DEFAULT_CONSTRAINTS_DRL_URL));
 
-        Capabilities capabilities = new Capabilities(Collections.singleton("kogito-rules"));
+        Capabilities capabilities = new Capabilities(KOGITO_CAPABILITIES);
         optaPlannerProcessor.applyScoreDirectorFactoryProperties(mock(IndexView.class), solverConfig, capabilities);
         assertThat(scoreDirectorFactoryConfig.getScoreDrlList())
                 .containsExactly("config_constraints.drl");
@@ -72,7 +77,7 @@ class OptaPlannerProcessorTest {
         when(optaPlannerProcessor.defaultConstraintsDrl())
                 .thenReturn(Optional.of(OptaPlannerBuildTimeConfig.DEFAULT_CONSTRAINTS_DRL_URL));
 
-        Capabilities capabilities = new Capabilities(Collections.singleton("kogito-rules"));
+        Capabilities capabilities = new Capabilities(KOGITO_CAPABILITIES);
         optaPlannerProcessor.applyScoreDirectorFactoryProperties(mock(IndexView.class), solverConfig, capabilities);
         assertThat(scoreDirectorFactoryConfig.getScoreDrlList())
                 .containsExactly(OptaPlannerBuildTimeConfig.DEFAULT_CONSTRAINTS_DRL_URL);
@@ -110,7 +115,7 @@ class OptaPlannerProcessorTest {
         when(optaPlannerProcessor.defaultConstraintsDrl())
                 .thenReturn(Optional.of(OptaPlannerBuildTimeConfig.DEFAULT_CONSTRAINTS_DRL_URL));
 
-        Capabilities capabilities = new Capabilities(Collections.singleton("kogito-rules"));
+        Capabilities capabilities = new Capabilities(KOGITO_CAPABILITIES);
         assertThatCode(() -> optaPlannerProcessor.applyScoreDirectorFactoryProperties(mock(IndexView.class), solverConfig,
                 capabilities))
                         .isInstanceOf(IllegalStateException.class)

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/drl-integration-test/pom.xml
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/drl-integration-test/pom.xml
@@ -26,6 +26,11 @@
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-resteasy</artifactId>
     </dependency>
+    <!-- TODO: Remove this dependency when https://issues.redhat.com/browse/KOGITO-6236 is resolved. -->
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-resteasy-jackson</artifactId>
+    </dependency>
     <dependency>
       <groupId>org.kie.kogito</groupId>
       <artifactId>kogito-quarkus-rules</artifactId>


### PR DESCRIPTION
A temporary workaround for https://issues.redhat.com/browse/KOGITO-6236.

In short, we fail fast if the dependency that the Kogito extension needs is not there with a clear message and a suggestion. This way, we don't drag the dependency on the classpath unnecessarily when the user is not using the DRL.

<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.
-->

### JIRA
https://issues.redhat.com/browse/PLANNER-2572

<!-- Add a JIRA ticket link if it exists. -->
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
* https://github.com/kiegroup/drools/pull/3000
* https://github.com/kiegroup/optaplanner/pull/899
* etc.
-->

### Checklist
- [ ] Documentation updated if applicable.
- [ ] Upgrade recipe provided if applicable.

<details>
<summary>
How to replicate CI configuration locally?
</summary>

We do "simple" maven builds, they are just basically maven commands, but just because we have multiple repositories related between them and one change could affect several of those projects by multiple pull requests, we use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.

[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is not only a github-action tool but a CLI one, so in case you posted multiple pull requests related with this change you can easily reproduce the same build by executing it locally. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>specific pull request build</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] tests</b>
* for a <b>full downstream build</b> 
  * for <b>jenkins</b> job: please add comment: <b>Jenkins run fdb</b>
  * for <b>github actions</b> job: add the label `run_fdb`
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
* for a <b>Quarkus LTS check</b> please add comment: <b>Jenkins run LTS</b>
* for a <b>specific Quarkus LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] LTS</b>
* for a <b>Native check</b> please add comment: <b>Jenkins run native</b>
* for a <b>specific Native LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] native</b>
</details>
