### PR TITLE
Reduce mutability in Phase related code

### DIFF
--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/constructionheuristic/DefaultConstructionHeuristicPhase.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/constructionheuristic/DefaultConstructionHeuristicPhase.java
@@ -35,19 +35,13 @@ import org.optaplanner.core.impl.solver.termination.Termination;
 public class DefaultConstructionHeuristicPhase<Solution_> extends AbstractPhase<Solution_>
         implements ConstructionHeuristicPhase<Solution_> {
 
-    protected EntityPlacer<Solution_> entityPlacer;
-    protected ConstructionHeuristicDecider<Solution_> decider;
+    protected final EntityPlacer<Solution_> entityPlacer;
+    protected final ConstructionHeuristicDecider<Solution_> decider;
 
-    public DefaultConstructionHeuristicPhase(int phaseIndex, String logIndentation, Termination<Solution_> termination) {
-        super(phaseIndex, logIndentation, termination);
-    }
-
-    public void setEntityPlacer(EntityPlacer<Solution_> entityPlacer) {
-        this.entityPlacer = entityPlacer;
-    }
-
-    public void setDecider(ConstructionHeuristicDecider<Solution_> decider) {
-        this.decider = decider;
+    private DefaultConstructionHeuristicPhase(Builder<Solution_> builder) {
+        super(builder);
+        entityPlacer = builder.entityPlacer;
+        decider = builder.decider;
     }
 
     @Override
@@ -164,4 +158,21 @@ public class DefaultConstructionHeuristicPhase<Solution_> extends AbstractPhase<
         decider.solvingEnded(solverScope);
     }
 
+    public static class Builder<Solution_> extends AbstractPhase.Builder<Solution_> {
+
+        private final EntityPlacer<Solution_> entityPlacer;
+        private final ConstructionHeuristicDecider<Solution_> decider;
+
+        public Builder(int phaseIndex, String logIndentation, Termination<Solution_> phaseTermination,
+                EntityPlacer<Solution_> entityPlacer, ConstructionHeuristicDecider<Solution_> decider) {
+            super(phaseIndex, logIndentation, phaseTermination);
+            this.entityPlacer = entityPlacer;
+            this.decider = decider;
+        }
+
+        @Override
+        public DefaultConstructionHeuristicPhase<Solution_> build() {
+            return new DefaultConstructionHeuristicPhase<>(this);
+        }
+    }
 }

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/constructionheuristic/DefaultConstructionHeuristicPhaseFactory.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/constructionheuristic/DefaultConstructionHeuristicPhaseFactory.java
@@ -26,9 +26,11 @@ import org.optaplanner.core.config.constructionheuristic.placer.EntityPlacerConf
 import org.optaplanner.core.config.constructionheuristic.placer.PooledEntityPlacerConfig;
 import org.optaplanner.core.config.constructionheuristic.placer.QueuedEntityPlacerConfig;
 import org.optaplanner.core.config.constructionheuristic.placer.QueuedValuePlacerConfig;
+import org.optaplanner.core.config.heuristic.selector.entity.EntitySorterManner;
 import org.optaplanner.core.config.heuristic.selector.move.MoveSelectorConfig;
 import org.optaplanner.core.config.heuristic.selector.move.composite.CartesianProductMoveSelectorConfig;
 import org.optaplanner.core.config.heuristic.selector.move.composite.UnionMoveSelectorConfig;
+import org.optaplanner.core.config.heuristic.selector.value.ValueSorterManner;
 import org.optaplanner.core.config.solver.EnvironmentMode;
 import org.optaplanner.core.config.util.ConfigUtils;
 import org.optaplanner.core.impl.constructionheuristic.decider.ConstructionHeuristicDecider;
@@ -57,16 +59,21 @@ public class DefaultConstructionHeuristicPhaseFactory<Solution_>
     public ConstructionHeuristicPhase<Solution_> buildPhase(int phaseIndex,
             HeuristicConfigPolicy<Solution_> solverConfigPolicy, BestSolutionRecaller<Solution_> bestSolutionRecaller,
             Termination<Solution_> solverTermination) {
-        HeuristicConfigPolicy<Solution_> phaseConfigPolicy = solverConfigPolicy.createFilteredPhaseConfigPolicy();
         ConstructionHeuristicType constructionHeuristicType_ = Objects.requireNonNullElse(
                 phaseConfig.getConstructionHeuristicType(),
                 ConstructionHeuristicType.ALLOCATE_ENTITY_FROM_QUEUE);
-        phaseConfigPolicy.setEntitySorterManner(Objects.requireNonNullElse(
+        EntitySorterManner entitySorterManner = Objects.requireNonNullElse(
                 phaseConfig.getEntitySorterManner(),
-                constructionHeuristicType_.getDefaultEntitySorterManner()));
-        phaseConfigPolicy.setValueSorterManner(Objects.requireNonNullElse(
+                constructionHeuristicType_.getDefaultEntitySorterManner());
+        ValueSorterManner valueSorterManner = Objects.requireNonNullElse(
                 phaseConfig.getValueSorterManner(),
-                constructionHeuristicType_.getDefaultValueSorterManner()));
+                constructionHeuristicType_.getDefaultValueSorterManner());
+        HeuristicConfigPolicy<Solution_> phaseConfigPolicy = solverConfigPolicy.cloneBuilder()
+                .withReinitializeVariableFilterEnabled(true)
+                .withInitializedChainedValueFilterEnabled(true)
+                .withEntitySorterManner(entitySorterManner)
+                .withValueSorterManner(valueSorterManner)
+                .build();
         Termination<Solution_> phaseTermination = buildPhaseTermination(phaseConfigPolicy, solverTermination);
         EntityPlacerConfig entityPlacerConfig_;
         if (phaseConfig.getEntityPlacerConfig() == null) {

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/constructionheuristic/DefaultConstructionHeuristicPhaseFactory.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/constructionheuristic/DefaultConstructionHeuristicPhaseFactory.java
@@ -58,14 +58,15 @@ public class DefaultConstructionHeuristicPhaseFactory<Solution_>
             HeuristicConfigPolicy<Solution_> solverConfigPolicy, BestSolutionRecaller<Solution_> bestSolutionRecaller,
             Termination<Solution_> solverTermination) {
         HeuristicConfigPolicy<Solution_> phaseConfigPolicy = solverConfigPolicy.createFilteredPhaseConfigPolicy();
-        ConstructionHeuristicType constructionHeuristicType_ =
-                Objects.requireNonNullElse(phaseConfig.getConstructionHeuristicType(),
-                        ConstructionHeuristicType.ALLOCATE_ENTITY_FROM_QUEUE);
-        phaseConfigPolicy
-                .setEntitySorterManner(phaseConfig.getEntitySorterManner() != null ? phaseConfig.getEntitySorterManner()
-                        : constructionHeuristicType_.getDefaultEntitySorterManner());
-        phaseConfigPolicy.setValueSorterManner(phaseConfig.getValueSorterManner() != null ? phaseConfig.getValueSorterManner()
-                : constructionHeuristicType_.getDefaultValueSorterManner());
+        ConstructionHeuristicType constructionHeuristicType_ = Objects.requireNonNullElse(
+                phaseConfig.getConstructionHeuristicType(),
+                ConstructionHeuristicType.ALLOCATE_ENTITY_FROM_QUEUE);
+        phaseConfigPolicy.setEntitySorterManner(Objects.requireNonNullElse(
+                phaseConfig.getEntitySorterManner(),
+                constructionHeuristicType_.getDefaultEntitySorterManner()));
+        phaseConfigPolicy.setValueSorterManner(Objects.requireNonNullElse(
+                phaseConfig.getValueSorterManner(),
+                constructionHeuristicType_.getDefaultValueSorterManner()));
         Termination<Solution_> phaseTermination = buildPhaseTermination(phaseConfigPolicy, solverTermination);
         EntityPlacerConfig entityPlacerConfig_;
         if (phaseConfig.getEntityPlacerConfig() == null) {
@@ -107,12 +108,10 @@ public class DefaultConstructionHeuristicPhaseFactory<Solution_>
 
     private ConstructionHeuristicDecider<Solution_> buildDecider(HeuristicConfigPolicy<Solution_> configPolicy,
             Termination<Solution_> termination) {
-        ConstructionHeuristicForagerConfig foragerConfig_ = phaseConfig.getForagerConfig() == null
-                ? new ConstructionHeuristicForagerConfig()
-                : phaseConfig.getForagerConfig();
+        ConstructionHeuristicForagerConfig foragerConfig_ =
+                Objects.requireNonNullElseGet(phaseConfig.getForagerConfig(), ConstructionHeuristicForagerConfig::new);
         ConstructionHeuristicForager<Solution_> forager =
-                ConstructionHeuristicForagerFactory.<Solution_> create(foragerConfig_)
-                        .buildForager(configPolicy);
+                ConstructionHeuristicForagerFactory.<Solution_> create(foragerConfig_).buildForager(configPolicy);
         EnvironmentMode environmentMode = configPolicy.getEnvironmentMode();
         ConstructionHeuristicDecider<Solution_> decider;
         Integer moveThreadCount = configPolicy.getMoveThreadCount();

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/exhaustivesearch/DefaultExhaustiveSearchPhase.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/exhaustivesearch/DefaultExhaustiveSearchPhase.java
@@ -46,47 +46,21 @@ import org.optaplanner.core.impl.solver.termination.Termination;
 public class DefaultExhaustiveSearchPhase<Solution_> extends AbstractPhase<Solution_>
         implements ExhaustiveSearchPhase<Solution_> {
 
-    protected Comparator<ExhaustiveSearchNode> nodeComparator;
-    protected EntitySelector<Solution_> entitySelector;
-    protected ExhaustiveSearchDecider<Solution_> decider;
+    protected final Comparator<ExhaustiveSearchNode> nodeComparator;
+    protected final EntitySelector<Solution_> entitySelector;
+    protected final ExhaustiveSearchDecider<Solution_> decider;
 
-    protected boolean assertWorkingSolutionScoreFromScratch = false;
-    protected boolean assertExpectedWorkingSolutionScore = false;
+    protected final boolean assertWorkingSolutionScoreFromScratch;
+    protected final boolean assertExpectedWorkingSolutionScore;
 
-    public DefaultExhaustiveSearchPhase(int phaseIndex, String logIndentation, Termination<Solution_> termination) {
-        super(phaseIndex, logIndentation, termination);
-    }
+    private DefaultExhaustiveSearchPhase(Builder<Solution_> builder) {
+        super(builder);
+        nodeComparator = builder.nodeComparator;
+        entitySelector = builder.entitySelector;
+        decider = builder.decider;
 
-    public Comparator<ExhaustiveSearchNode> getNodeComparator() {
-        return nodeComparator;
-    }
-
-    public void setNodeComparator(Comparator<ExhaustiveSearchNode> nodeComparator) {
-        this.nodeComparator = nodeComparator;
-    }
-
-    public EntitySelector<Solution_> getEntitySelector() {
-        return entitySelector;
-    }
-
-    public void setEntitySelector(EntitySelector<Solution_> entitySelector) {
-        this.entitySelector = entitySelector;
-    }
-
-    public ExhaustiveSearchDecider<Solution_> getDecider() {
-        return decider;
-    }
-
-    public void setDecider(ExhaustiveSearchDecider<Solution_> decider) {
-        this.decider = decider;
-    }
-
-    public void setAssertWorkingSolutionScoreFromScratch(boolean assertWorkingSolutionScoreFromScratch) {
-        this.assertWorkingSolutionScoreFromScratch = assertWorkingSolutionScoreFromScratch;
-    }
-
-    public void setAssertExpectedWorkingSolutionScore(boolean assertExpectedWorkingSolutionScore) {
-        this.assertExpectedWorkingSolutionScore = assertExpectedWorkingSolutionScore;
+        assertWorkingSolutionScoreFromScratch = builder.assertWorkingSolutionScoreFromScratch;
+        assertExpectedWorkingSolutionScore = builder.assertExpectedWorkingSolutionScore;
     }
 
     @Override
@@ -269,4 +243,35 @@ public class DefaultExhaustiveSearchPhase<Solution_> extends AbstractPhase<Solut
         decider.solvingEnded(solverScope);
     }
 
+    public static class Builder<Solution_> extends AbstractPhase.Builder<Solution_> {
+
+        private final Comparator<ExhaustiveSearchNode> nodeComparator;
+        private final EntitySelector<Solution_> entitySelector;
+        private final ExhaustiveSearchDecider<Solution_> decider;
+
+        private boolean assertWorkingSolutionScoreFromScratch = false;
+        private boolean assertExpectedWorkingSolutionScore = false;
+
+        public Builder(int phaseIndex, String logIndentation, Termination<Solution_> phaseTermination,
+                Comparator<ExhaustiveSearchNode> nodeComparator, EntitySelector<Solution_> entitySelector,
+                ExhaustiveSearchDecider<Solution_> decider) {
+            super(phaseIndex, logIndentation, phaseTermination);
+            this.nodeComparator = nodeComparator;
+            this.entitySelector = entitySelector;
+            this.decider = decider;
+        }
+
+        public void setAssertWorkingSolutionScoreFromScratch(boolean assertWorkingSolutionScoreFromScratch) {
+            this.assertWorkingSolutionScoreFromScratch = assertWorkingSolutionScoreFromScratch;
+        }
+
+        public void setAssertExpectedWorkingSolutionScore(boolean assertExpectedWorkingSolutionScore) {
+            this.assertExpectedWorkingSolutionScore = assertExpectedWorkingSolutionScore;
+        }
+
+        @Override
+        public DefaultExhaustiveSearchPhase<Solution_> build() {
+            return new DefaultExhaustiveSearchPhase<>(this);
+        }
+    }
 }

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/exhaustivesearch/DefaultExhaustiveSearchPhaseFactory.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/exhaustivesearch/DefaultExhaustiveSearchPhaseFactory.java
@@ -60,14 +60,15 @@ public class DefaultExhaustiveSearchPhaseFactory<Solution_>
             HeuristicConfigPolicy<Solution_> solverConfigPolicy, BestSolutionRecaller<Solution_> bestSolutionRecaller,
             Termination<Solution_> solverTermination) {
         HeuristicConfigPolicy<Solution_> phaseConfigPolicy = solverConfigPolicy.createFilteredPhaseConfigPolicy();
-        ExhaustiveSearchType exhaustiveSearchType_ = phaseConfig.getExhaustiveSearchType() == null
-                ? ExhaustiveSearchType.BRANCH_AND_BOUND
-                : phaseConfig.getExhaustiveSearchType();
-        phaseConfigPolicy
-                .setEntitySorterManner(phaseConfig.getEntitySorterManner() != null ? phaseConfig.getEntitySorterManner()
-                        : exhaustiveSearchType_.getDefaultEntitySorterManner());
-        phaseConfigPolicy.setValueSorterManner(phaseConfig.getValueSorterManner() != null ? phaseConfig.getValueSorterManner()
-                : exhaustiveSearchType_.getDefaultValueSorterManner());
+        ExhaustiveSearchType exhaustiveSearchType_ = Objects.requireNonNullElse(
+                phaseConfig.getExhaustiveSearchType(),
+                ExhaustiveSearchType.BRANCH_AND_BOUND);
+        phaseConfigPolicy.setEntitySorterManner(Objects.requireNonNullElse(
+                phaseConfig.getEntitySorterManner(),
+                exhaustiveSearchType_.getDefaultEntitySorterManner()));
+        phaseConfigPolicy.setValueSorterManner(Objects.requireNonNullElse(
+                phaseConfig.getValueSorterManner(),
+                exhaustiveSearchType_.getDefaultValueSorterManner()));
         Termination<Solution_> phaseTermination = buildPhaseTermination(phaseConfigPolicy, solverTermination);
         boolean scoreBounderEnabled = exhaustiveSearchType_.isScoreBounderEnabled();
         NodeExplorationType nodeExplorationType_;

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/localsearch/DefaultLocalSearchPhase.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/localsearch/DefaultLocalSearchPhase.java
@@ -47,7 +47,7 @@ import io.micrometer.core.instrument.Tags;
 public class DefaultLocalSearchPhase<Solution_> extends AbstractPhase<Solution_> implements LocalSearchPhase<Solution_>,
         LocalSearchPhaseLifecycleListener<Solution_> {
 
-    protected LocalSearchDecider<Solution_> decider;
+    protected final LocalSearchDecider<Solution_> decider;
     protected final AtomicLong acceptedMoveCountPerStep = new AtomicLong(0);
     protected final AtomicLong selectedMoveCountPerStep = new AtomicLong(0);
     protected final Map<Tags, AtomicLong> constraintMatchTotalTagsToStepCount = new ConcurrentHashMap<>();
@@ -55,16 +55,9 @@ public class DefaultLocalSearchPhase<Solution_> extends AbstractPhase<Solution_>
     protected final Map<Tags, List<AtomicReference<Number>>> constraintMatchTotalStepScoreMap = new ConcurrentHashMap<>();
     protected final Map<Tags, List<AtomicReference<Number>>> constraintMatchTotalBestScoreMap = new ConcurrentHashMap<>();
 
-    public DefaultLocalSearchPhase(int phaseIndex, String logIndentation, Termination<Solution_> termination) {
-        super(phaseIndex, logIndentation, termination);
-    }
-
-    public LocalSearchDecider<Solution_> getDecider() {
-        return decider;
-    }
-
-    public void setDecider(LocalSearchDecider<Solution_> decider) {
-        this.decider = decider;
+    private DefaultLocalSearchPhase(Builder<Solution_> builder) {
+        super(builder);
+        decider = builder.decider;
     }
 
     @Override
@@ -235,4 +228,19 @@ public class DefaultLocalSearchPhase<Solution_> extends AbstractPhase<Solution_>
         decider.solvingEnded(solverScope);
     }
 
+    public static class Builder<Solution_> extends AbstractPhase.Builder<Solution_> {
+
+        private final LocalSearchDecider<Solution_> decider;
+
+        public Builder(int phaseIndex, String logIndentation, Termination<Solution_> phaseTermination,
+                LocalSearchDecider<Solution_> decider) {
+            super(phaseIndex, logIndentation, phaseTermination);
+            this.decider = decider;
+        }
+
+        @Override
+        public DefaultLocalSearchPhase<Solution_> build() {
+            return new DefaultLocalSearchPhase<>(this);
+        }
+    }
 }

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/localsearch/DefaultLocalSearchPhaseFactory.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/localsearch/DefaultLocalSearchPhaseFactory.java
@@ -48,8 +48,7 @@ import org.optaplanner.core.impl.solver.recaller.BestSolutionRecaller;
 import org.optaplanner.core.impl.solver.termination.Termination;
 import org.optaplanner.core.impl.solver.thread.ChildThreadType;
 
-public class DefaultLocalSearchPhaseFactory<Solution_>
-        extends AbstractPhaseFactory<Solution_, LocalSearchPhaseConfig> {
+public class DefaultLocalSearchPhaseFactory<Solution_> extends AbstractPhaseFactory<Solution_, LocalSearchPhaseConfig> {
 
     public DefaultLocalSearchPhaseFactory(LocalSearchPhaseConfig phaseConfig) {
         super(phaseConfig);
@@ -59,20 +58,21 @@ public class DefaultLocalSearchPhaseFactory<Solution_>
     public LocalSearchPhase<Solution_> buildPhase(int phaseIndex, HeuristicConfigPolicy<Solution_> solverConfigPolicy,
             BestSolutionRecaller<Solution_> bestSolutionRecaller, Termination<Solution_> solverTermination) {
         HeuristicConfigPolicy<Solution_> phaseConfigPolicy = solverConfigPolicy.createPhaseConfigPolicy();
-        DefaultLocalSearchPhase<Solution_> phase =
-                new DefaultLocalSearchPhase<>(phaseIndex, solverConfigPolicy.getLogIndentation(),
-                        buildPhaseTermination(phaseConfigPolicy, solverTermination));
-        phase.setDecider(buildDecider(phaseConfigPolicy,
-                phase.getPhaseTermination()));
+        Termination<Solution_> phaseTermination = buildPhaseTermination(phaseConfigPolicy, solverTermination);
+        DefaultLocalSearchPhase.Builder<Solution_> builder = new DefaultLocalSearchPhase.Builder<>(
+                phaseIndex,
+                solverConfigPolicy.getLogIndentation(),
+                phaseTermination,
+                buildDecider(phaseConfigPolicy, phaseTermination));
         EnvironmentMode environmentMode = phaseConfigPolicy.getEnvironmentMode();
         if (environmentMode.isNonIntrusiveFullAsserted()) {
-            phase.setAssertStepScoreFromScratch(true);
+            builder.setAssertStepScoreFromScratch(true);
         }
         if (environmentMode.isIntrusiveFastAsserted()) {
-            phase.setAssertExpectedStepScore(true);
-            phase.setAssertShadowVariablesAreNotStaleAfterStep(true);
+            builder.setAssertExpectedStepScore(true);
+            builder.setAssertShadowVariablesAreNotStaleAfterStep(true);
         }
-        return phase;
+        return builder.build();
     }
 
     private LocalSearchDecider<Solution_> buildDecider(HeuristicConfigPolicy<Solution_> configPolicy,

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/partitionedsearch/DefaultPartitionedSearchPhase.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/partitionedsearch/DefaultPartitionedSearchPhase.java
@@ -60,24 +60,16 @@ public class DefaultPartitionedSearchPhase<Solution_> extends AbstractPhase<Solu
     protected final ThreadFactory threadFactory;
     protected final Integer runnablePartThreadLimit;
 
-    protected List<PhaseConfig> phaseConfigList;
-    protected HeuristicConfigPolicy<Solution_> configPolicy;
+    protected final List<PhaseConfig> phaseConfigList;
+    protected final HeuristicConfigPolicy<Solution_> configPolicy;
 
-    public DefaultPartitionedSearchPhase(int phaseIndex, String logIndentation, Termination<Solution_> termination,
-            SolutionPartitioner<Solution_> solutionPartitioner, ThreadFactory threadFactory,
-            Integer runnablePartThreadLimit) {
-        super(phaseIndex, logIndentation, termination);
-        this.solutionPartitioner = solutionPartitioner;
-        this.threadFactory = threadFactory;
-        this.runnablePartThreadLimit = runnablePartThreadLimit;
-    }
-
-    public void setPhaseConfigList(List<PhaseConfig> phaseConfigList) {
-        this.phaseConfigList = phaseConfigList;
-    }
-
-    public void setConfigPolicy(HeuristicConfigPolicy<Solution_> configPolicy) {
-        this.configPolicy = configPolicy;
+    private DefaultPartitionedSearchPhase(Builder<Solution_> builder) {
+        super(builder);
+        solutionPartitioner = builder.solutionPartitioner;
+        threadFactory = builder.threadFactory;
+        runnablePartThreadLimit = builder.runnablePartThreadLimit;
+        phaseConfigList = builder.phaseConfigList;
+        configPolicy = builder.configPolicy;
     }
 
     @Override
@@ -236,4 +228,30 @@ public class DefaultPartitionedSearchPhase<Solution_> extends AbstractPhase<Solu
                 runnablePartThreadLimit);
     }
 
+    public static class Builder<Solution_> extends AbstractPhase.Builder<Solution_> {
+
+        private final SolutionPartitioner<Solution_> solutionPartitioner;
+        private final ThreadFactory threadFactory;
+        private final Integer runnablePartThreadLimit;
+
+        private final List<PhaseConfig> phaseConfigList;
+        private final HeuristicConfigPolicy<Solution_> configPolicy;
+
+        public Builder(int phaseIndex, String logIndentation, Termination<Solution_> phaseTermination,
+                SolutionPartitioner<Solution_> solutionPartitioner, ThreadFactory threadFactory,
+                Integer runnablePartThreadLimit, List<PhaseConfig> phaseConfigList,
+                HeuristicConfigPolicy<Solution_> configPolicy) {
+            super(phaseIndex, logIndentation, phaseTermination);
+            this.solutionPartitioner = solutionPartitioner;
+            this.threadFactory = threadFactory;
+            this.runnablePartThreadLimit = runnablePartThreadLimit;
+            this.phaseConfigList = List.copyOf(phaseConfigList);
+            this.configPolicy = configPolicy;
+        }
+
+        @Override
+        public DefaultPartitionedSearchPhase<Solution_> build() {
+            return new DefaultPartitionedSearchPhase<>(this);
+        }
+    }
 }

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/partitionedsearch/DefaultPartitionedSearchPhaseFactory.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/partitionedsearch/DefaultPartitionedSearchPhaseFactory.java
@@ -55,24 +55,30 @@ public class DefaultPartitionedSearchPhaseFactory<Solution_>
         ThreadFactory threadFactory = solverConfigPolicy.buildThreadFactory(ChildThreadType.PART_THREAD);
         Termination<Solution_> phaseTermination = buildPhaseTermination(phaseConfigPolicy, solverTermination);
         Integer resolvedActiveThreadCount = resolveActiveThreadCount(phaseConfig.getRunnablePartThreadLimit());
-        DefaultPartitionedSearchPhase<Solution_> phase =
-                new DefaultPartitionedSearchPhase<>(phaseIndex, solverConfigPolicy.getLogIndentation(),
-                        phaseTermination, buildSolutionPartitioner(), threadFactory, resolvedActiveThreadCount);
         List<PhaseConfig> phaseConfigList_ = phaseConfig.getPhaseConfigList();
         if (ConfigUtils.isEmptyCollection(phaseConfigList_)) {
             phaseConfigList_ = Arrays.asList(new ConstructionHeuristicPhaseConfig(), new LocalSearchPhaseConfig());
         }
-        phase.setPhaseConfigList(phaseConfigList_);
-        phase.setConfigPolicy(phaseConfigPolicy.createChildThreadConfigPolicy(ChildThreadType.PART_THREAD));
+
+        DefaultPartitionedSearchPhase.Builder<Solution_> builder = new DefaultPartitionedSearchPhase.Builder<>(
+                phaseIndex,
+                solverConfigPolicy.getLogIndentation(),
+                phaseTermination,
+                buildSolutionPartitioner(),
+                threadFactory,
+                resolvedActiveThreadCount,
+                phaseConfigList_,
+                phaseConfigPolicy.createChildThreadConfigPolicy(ChildThreadType.PART_THREAD));
+
         EnvironmentMode environmentMode = phaseConfigPolicy.getEnvironmentMode();
         if (environmentMode.isNonIntrusiveFullAsserted()) {
-            phase.setAssertStepScoreFromScratch(true);
+            builder.setAssertStepScoreFromScratch(true);
         }
         if (environmentMode.isIntrusiveFastAsserted()) {
-            phase.setAssertExpectedStepScore(true);
-            phase.setAssertShadowVariablesAreNotStaleAfterStep(true);
+            builder.setAssertExpectedStepScore(true);
+            builder.setAssertShadowVariablesAreNotStaleAfterStep(true);
         }
-        return phase;
+        return builder.build();
     }
 
     private SolutionPartitioner<Solution_> buildSolutionPartitioner() {

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/phase/AbstractPhase.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/phase/AbstractPhase.java
@@ -58,19 +58,22 @@ public abstract class AbstractPhase<Solution_> implements Phase<Solution_> {
     // Called "phaseTermination" to clearly distinguish from "solverTermination" inside AbstractSolver.
     protected final Termination<Solution_> phaseTermination;
 
+    protected final boolean assertStepScoreFromScratch;
+    protected final boolean assertExpectedStepScore;
+    protected final boolean assertShadowVariablesAreNotStaleAfterStep;
+
     /** Used for {@link #addPhaseLifecycleListener(PhaseLifecycleListener)}. */
     protected PhaseLifecycleSupport<Solution_> phaseLifecycleSupport = new PhaseLifecycleSupport<>();
 
     protected AbstractSolver<Solution_> solver;
 
-    protected boolean assertStepScoreFromScratch = false;
-    protected boolean assertExpectedStepScore = false;
-    protected boolean assertShadowVariablesAreNotStaleAfterStep = false;
-
-    public AbstractPhase(int phaseIndex, String logIndentation, Termination<Solution_> phaseTermination) {
-        this.phaseIndex = phaseIndex;
-        this.logIndentation = logIndentation;
-        this.phaseTermination = phaseTermination;
+    protected AbstractPhase(Builder<Solution_> builder) {
+        phaseIndex = builder.phaseIndex;
+        logIndentation = builder.logIndentation;
+        phaseTermination = builder.phaseTermination;
+        assertStepScoreFromScratch = builder.assertStepScoreFromScratch;
+        assertExpectedStepScore = builder.assertExpectedStepScore;
+        assertShadowVariablesAreNotStaleAfterStep = builder.assertShadowVariablesAreNotStaleAfterStep;
     }
 
     public int getPhaseIndex() {
@@ -93,24 +96,12 @@ public abstract class AbstractPhase<Solution_> implements Phase<Solution_> {
         return assertStepScoreFromScratch;
     }
 
-    public void setAssertStepScoreFromScratch(boolean assertStepScoreFromScratch) {
-        this.assertStepScoreFromScratch = assertStepScoreFromScratch;
-    }
-
     public boolean isAssertExpectedStepScore() {
         return assertExpectedStepScore;
     }
 
-    public void setAssertExpectedStepScore(boolean assertExpectedStepScore) {
-        this.assertExpectedStepScore = assertExpectedStepScore;
-    }
-
     public boolean isAssertShadowVariablesAreNotStaleAfterStep() {
         return assertShadowVariablesAreNotStaleAfterStep;
-    }
-
-    public void setAssertShadowVariablesAreNotStaleAfterStep(boolean assertShadowVariablesAreNotStaleAfterStep) {
-        this.assertShadowVariablesAreNotStaleAfterStep = assertShadowVariablesAreNotStaleAfterStep;
     }
 
     public abstract String getPhaseTypeString();
@@ -245,4 +236,34 @@ public abstract class AbstractPhase<Solution_> implements Phase<Solution_> {
         }
     }
 
+    protected abstract static class Builder<Solution_> {
+
+        private final int phaseIndex;
+        private final String logIndentation;
+        private final Termination<Solution_> phaseTermination;
+
+        private boolean assertStepScoreFromScratch = false;
+        private boolean assertExpectedStepScore = false;
+        private boolean assertShadowVariablesAreNotStaleAfterStep = false;
+
+        protected Builder(int phaseIndex, String logIndentation, Termination<Solution_> phaseTermination) {
+            this.phaseIndex = phaseIndex;
+            this.logIndentation = logIndentation;
+            this.phaseTermination = phaseTermination;
+        }
+
+        public void setAssertStepScoreFromScratch(boolean assertStepScoreFromScratch) {
+            this.assertStepScoreFromScratch = assertStepScoreFromScratch;
+        }
+
+        public void setAssertExpectedStepScore(boolean assertExpectedStepScore) {
+            this.assertExpectedStepScore = assertExpectedStepScore;
+        }
+
+        public void setAssertShadowVariablesAreNotStaleAfterStep(boolean assertShadowVariablesAreNotStaleAfterStep) {
+            this.assertShadowVariablesAreNotStaleAfterStep = assertShadowVariablesAreNotStaleAfterStep;
+        }
+
+        protected abstract AbstractPhase<Solution_> build();
+    }
 }

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/phase/AbstractPhaseFactory.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/phase/AbstractPhaseFactory.java
@@ -16,6 +16,8 @@
 
 package org.optaplanner.core.impl.phase;
 
+import java.util.Objects;
+
 import org.optaplanner.core.config.phase.PhaseConfig;
 import org.optaplanner.core.config.solver.termination.TerminationConfig;
 import org.optaplanner.core.impl.heuristic.HeuristicConfigPolicy;
@@ -34,12 +36,11 @@ public abstract class AbstractPhaseFactory<Solution_, PhaseConfig_ extends Phase
 
     protected Termination<Solution_> buildPhaseTermination(HeuristicConfigPolicy<Solution_> configPolicy,
             Termination<Solution_> solverTermination) {
-        TerminationConfig terminationConfig_ = phaseConfig.getTerminationConfig() == null ? new TerminationConfig()
-                : phaseConfig.getTerminationConfig();
+        TerminationConfig terminationConfig_ =
+                Objects.requireNonNullElseGet(phaseConfig.getTerminationConfig(), TerminationConfig::new);
         // In case of childThread PART_THREAD, the solverTermination is actually the parent phase's phaseTermination
         // with the bridge removed, so it's ok to add it again
         Termination<Solution_> phaseTermination = new PhaseToSolverTerminationBridge<>(solverTermination);
-        return TerminationFactory.<Solution_> create(terminationConfig_)
-                .buildTermination(configPolicy, phaseTermination);
+        return TerminationFactory.<Solution_> create(terminationConfig_).buildTermination(configPolicy, phaseTermination);
     }
 }

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/phase/NoChangePhase.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/phase/NoChangePhase.java
@@ -29,8 +29,8 @@ import org.optaplanner.core.impl.solver.termination.Termination;
  */
 public class NoChangePhase<Solution_> extends AbstractPhase<Solution_> {
 
-    public NoChangePhase(int phaseIndex, String logIndentation, Termination<Solution_> termination) {
-        super(phaseIndex, logIndentation, termination);
+    private NoChangePhase(Builder<Solution_> builder) {
+        super(builder);
     }
 
     @Override
@@ -49,4 +49,15 @@ public class NoChangePhase<Solution_> extends AbstractPhase<Solution_> {
                 phaseIndex);
     }
 
+    public static class Builder<Solution_> extends AbstractPhase.Builder<Solution_> {
+
+        public Builder(int phaseIndex, String logIndentation, Termination<Solution_> phaseTermination) {
+            super(phaseIndex, logIndentation, phaseTermination);
+        }
+
+        @Override
+        public NoChangePhase<Solution_> build() {
+            return new NoChangePhase<>(this);
+        }
+    }
 }

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/phase/NoChangePhaseFactory.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/phase/NoChangePhaseFactory.java
@@ -31,7 +31,7 @@ public class NoChangePhaseFactory<Solution_> extends AbstractPhaseFactory<Soluti
     public NoChangePhase<Solution_> buildPhase(int phaseIndex, HeuristicConfigPolicy<Solution_> solverConfigPolicy,
             BestSolutionRecaller<Solution_> bestSolutionRecaller, Termination<Solution_> solverTermination) {
         HeuristicConfigPolicy<Solution_> phaseConfigPolicy = solverConfigPolicy.createPhaseConfigPolicy();
-        return new NoChangePhase<>(phaseIndex, solverConfigPolicy.getLogIndentation(),
-                buildPhaseTermination(phaseConfigPolicy, solverTermination));
+        return new NoChangePhase.Builder<>(phaseIndex, solverConfigPolicy.getLogIndentation(),
+                buildPhaseTermination(phaseConfigPolicy, solverTermination)).build();
     }
 }

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/phase/custom/DefaultCustomPhase.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/phase/custom/DefaultCustomPhase.java
@@ -33,14 +33,11 @@ import org.optaplanner.core.impl.solver.termination.Termination;
  */
 public class DefaultCustomPhase<Solution_> extends AbstractPhase<Solution_> implements CustomPhase<Solution_> {
 
-    protected List<CustomPhaseCommand<Solution_>> customPhaseCommandList;
+    protected final List<CustomPhaseCommand<Solution_>> customPhaseCommandList;
 
-    public DefaultCustomPhase(int phaseIndex, String logIndentation, Termination<Solution_> termination) {
-        super(phaseIndex, logIndentation, termination);
-    }
-
-    public void setCustomPhaseCommandList(List<CustomPhaseCommand<Solution_>> customPhaseCommandList) {
-        this.customPhaseCommandList = customPhaseCommandList;
+    private DefaultCustomPhase(Builder<Solution_> builder) {
+        super(builder);
+        customPhaseCommandList = builder.customPhaseCommandList;
     }
 
     @Override
@@ -118,4 +115,19 @@ public class DefaultCustomPhase<Solution_> extends AbstractPhase<Solution_> impl
                 phaseScope.getNextStepIndex());
     }
 
+    public static class Builder<Solution_> extends AbstractPhase.Builder<Solution_> {
+
+        private final List<CustomPhaseCommand<Solution_>> customPhaseCommandList;
+
+        public Builder(int phaseIndex, String logIndentation, Termination<Solution_> phaseTermination,
+                List<CustomPhaseCommand<Solution_>> customPhaseCommandList) {
+            super(phaseIndex, logIndentation, phaseTermination);
+            this.customPhaseCommandList = List.copyOf(customPhaseCommandList);
+        }
+
+        @Override
+        public DefaultCustomPhase<Solution_> build() {
+            return new DefaultCustomPhase<>(this);
+        }
+    }
 }

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/phase/custom/DefaultCustomPhaseFactory.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/phase/custom/DefaultCustomPhaseFactory.java
@@ -38,8 +38,6 @@ public class DefaultCustomPhaseFactory<Solution_> extends AbstractPhaseFactory<S
     public CustomPhase<Solution_> buildPhase(int phaseIndex, HeuristicConfigPolicy<Solution_> solverConfigPolicy,
             BestSolutionRecaller<Solution_> bestSolutionRecaller, Termination<Solution_> solverTermination) {
         HeuristicConfigPolicy<Solution_> phaseConfigPolicy = solverConfigPolicy.createPhaseConfigPolicy();
-        DefaultCustomPhase<Solution_> phase = new DefaultCustomPhase<>(phaseIndex,
-                solverConfigPolicy.getLogIndentation(), buildPhaseTermination(phaseConfigPolicy, solverTermination));
         if (ConfigUtils.isEmptyCollection(phaseConfig.getCustomPhaseCommandClassList())
                 && ConfigUtils.isEmptyCollection(phaseConfig.getCustomPhaseCommandList())) {
             throw new IllegalArgumentException(
@@ -55,12 +53,16 @@ public class DefaultCustomPhaseFactory<Solution_> extends AbstractPhaseFactory<S
         if (phaseConfig.getCustomPhaseCommandList() != null) {
             customPhaseCommandList_.addAll((Collection) phaseConfig.getCustomPhaseCommandList());
         }
-        phase.setCustomPhaseCommandList(customPhaseCommandList_);
+        DefaultCustomPhase.Builder<Solution_> builder = new DefaultCustomPhase.Builder<>(
+                phaseIndex,
+                solverConfigPolicy.getLogIndentation(),
+                buildPhaseTermination(phaseConfigPolicy, solverTermination),
+                customPhaseCommandList_);
         EnvironmentMode environmentMode = phaseConfigPolicy.getEnvironmentMode();
         if (environmentMode.isNonIntrusiveFullAsserted()) {
-            phase.setAssertStepScoreFromScratch(true);
+            builder.setAssertStepScoreFromScratch(true);
         }
-        return phase;
+        return builder.build();
     }
 
     private CustomPhaseCommand<Solution_>

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/solver/DefaultSolverFactory.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/solver/DefaultSolverFactory.java
@@ -114,11 +114,9 @@ public final class DefaultSolverFactory<Solution_> implements SolverFactory<Solu
         Termination<Solution_> termination = TerminationFactory.<Solution_> create(terminationConfig_)
                 .buildTermination(configPolicy, basicPlumbingTermination);
         List<Phase<Solution_>> phaseList = buildPhaseList(configPolicy, bestSolutionRecaller, termination);
-        Solver<Solution_> out =
-                new DefaultSolver<>(environmentMode_, randomFactory, bestSolutionRecaller, basicPlumbingTermination,
-                        termination, phaseList, solverScope,
-                        moveThreadCount_ == null ? SolverConfig.MOVE_THREAD_COUNT_NONE : Integer.toString(moveThreadCount_));
-        return out;
+        return new DefaultSolver<>(environmentMode_, randomFactory, bestSolutionRecaller, basicPlumbingTermination,
+                termination, phaseList, solverScope,
+                moveThreadCount_ == null ? SolverConfig.MOVE_THREAD_COUNT_NONE : Integer.toString(moveThreadCount_));
     }
 
     /**

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/solver/DefaultSolverFactory.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/solver/DefaultSolverFactory.java
@@ -111,9 +111,8 @@ public final class DefaultSolverFactory<Solution_> implements SolverFactory<Solu
         HeuristicConfigPolicy<Solution_> configPolicy = new HeuristicConfigPolicy<>(environmentMode_,
                 moveThreadCount_, solverConfig.getMoveThreadBufferSize(), solverConfig.getThreadFactoryClass(),
                 scoreDirectorFactory);
-        TerminationConfig terminationConfig_ = solverConfig.getTerminationConfig() == null
-                ? new TerminationConfig()
-                : solverConfig.getTerminationConfig();
+        TerminationConfig terminationConfig_ =
+                Objects.requireNonNullElseGet(solverConfig.getTerminationConfig(), TerminationConfig::new);
         BasicPlumbingTermination<Solution_> basicPlumbingTermination = new BasicPlumbingTermination<>(daemon_);
         Termination<Solution_> termination = TerminationFactory.<Solution_> create(terminationConfig_)
                 .buildTermination(configPolicy, basicPlumbingTermination);
@@ -131,9 +130,8 @@ public final class DefaultSolverFactory<Solution_> implements SolverFactory<Solu
      */
     public InnerScoreDirectorFactory<Solution_, ?> buildScoreDirectorFactory(EnvironmentMode environmentMode) {
         SolutionDescriptor<Solution_> solutionDescriptor = buildSolutionDescriptor(environmentMode);
-        ScoreDirectorFactoryConfig scoreDirectorFactoryConfig_ = solverConfig.getScoreDirectorFactoryConfig() == null
-                ? new ScoreDirectorFactoryConfig()
-                : solverConfig.getScoreDirectorFactoryConfig();
+        ScoreDirectorFactoryConfig scoreDirectorFactoryConfig_ =
+                Objects.requireNonNullElseGet(solverConfig.getScoreDirectorFactoryConfig(), ScoreDirectorFactoryConfig::new);
         ScoreDirectorFactoryFactory<Solution_, ?> scoreDirectorFactoryFactory =
                 new ScoreDirectorFactoryFactory<>(scoreDirectorFactoryConfig_);
         return scoreDirectorFactoryFactory.buildScoreDirectorFactory(solverConfig.getClassLoader(), environmentMode,

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/solver/DefaultSolverFactory.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/solver/DefaultSolverFactory.java
@@ -105,9 +105,9 @@ public final class DefaultSolverFactory<Solution_> implements SolverFactory<Solu
 
         BestSolutionRecaller<Solution_> bestSolutionRecaller =
                 BestSolutionRecallerFactory.create().buildBestSolutionRecaller(environmentMode_);
-        HeuristicConfigPolicy<Solution_> configPolicy = new HeuristicConfigPolicy<>(environmentMode_,
+        HeuristicConfigPolicy<Solution_> configPolicy = new HeuristicConfigPolicy.Builder<>(environmentMode_,
                 moveThreadCount_, solverConfig.getMoveThreadBufferSize(), solverConfig.getThreadFactoryClass(),
-                scoreDirectorFactory);
+                scoreDirectorFactory).build();
         TerminationConfig terminationConfig_ =
                 Objects.requireNonNullElseGet(solverConfig.getTerminationConfig(), TerminationConfig::new);
         BasicPlumbingTermination<Solution_> basicPlumbingTermination = new BasicPlumbingTermination<>(daemon_);

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/solver/DefaultSolverFactory.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/solver/DefaultSolverFactory.java
@@ -67,10 +67,7 @@ public final class DefaultSolverFactory<Solution_> implements SolverFactory<Solu
     private final SolverConfig solverConfig;
 
     public DefaultSolverFactory(SolverConfig solverConfig) {
-        if (solverConfig == null) {
-            throw new IllegalStateException("The solverConfig (" + solverConfig + ") cannot be null.");
-        }
-        this.solverConfig = solverConfig;
+        this.solverConfig = Objects.requireNonNull(solverConfig, "The solverConfig (" + solverConfig + ") cannot be null.");
     }
 
     public InnerScoreDirectorFactory<Solution_, ?> getScoreDirectorFactory() {

--- a/optaplanner-core/src/test/java/org/optaplanner/core/config/constructionheuristic/placer/PooledEntityPlacerFactoryTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/config/constructionheuristic/placer/PooledEntityPlacerFactoryTest.java
@@ -42,8 +42,7 @@ public class PooledEntityPlacerFactoryTest {
         moveSelectorConfig.setValueSelectorConfig(new ValueSelectorConfig("value"));
 
         HeuristicConfigPolicy<TestdataSolution> configPolicy = buildHeuristicConfigPolicy(solutionDescriptor);
-        PooledEntityPlacerConfig placerConfig =
-                PooledEntityPlacerFactory.unfoldNew(configPolicy, moveSelectorConfig);
+        PooledEntityPlacerConfig placerConfig = PooledEntityPlacerFactory.unfoldNew(configPolicy, moveSelectorConfig);
 
         assertThat(placerConfig.getMoveSelectorConfig())
                 .isNotNull()
@@ -61,6 +60,7 @@ public class PooledEntityPlacerFactoryTest {
             buildHeuristicConfigPolicy(SolutionDescriptor<TestdataSolution> solutionDescriptor) {
         InnerScoreDirectorFactory<TestdataSolution, SimpleScore> scoreDirectorFactory = mock(InnerScoreDirectorFactory.class);
         when(scoreDirectorFactory.getSolutionDescriptor()).thenReturn(solutionDescriptor);
-        return new HeuristicConfigPolicy<>(EnvironmentMode.REPRODUCIBLE, null, null, null, scoreDirectorFactory);
+        return new HeuristicConfigPolicy.Builder<>(EnvironmentMode.REPRODUCIBLE, null, null, null, scoreDirectorFactory)
+                .build();
     }
 }

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/constructionheuristic/DefaultConstructionHeuristicPhaseTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/constructionheuristic/DefaultConstructionHeuristicPhaseTest.java
@@ -36,8 +36,7 @@ public class DefaultConstructionHeuristicPhaseTest {
 
     @Test
     public void solveWithInitializedEntities() {
-        SolverConfig solverConfig = PlannerTestUtils.buildSolverConfig(
-                TestdataSolution.class, TestdataEntity.class);
+        SolverConfig solverConfig = PlannerTestUtils.buildSolverConfig(TestdataSolution.class, TestdataEntity.class);
         solverConfig.setPhaseConfigList(Collections.singletonList(new ConstructionHeuristicPhaseConfig()));
 
         TestdataSolution solution = new TestdataSolution("s1");

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/constructionheuristic/placer/entity/QueuedEntityPlacerFactoryTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/constructionheuristic/placer/entity/QueuedEntityPlacerFactoryTest.java
@@ -93,7 +93,8 @@ public class QueuedEntityPlacerFactoryTest extends AbstractEntityPlacerTest {
                 mock(InnerScoreDirectorFactory.class);
         when(scoreDirectorFactory.getSolutionDescriptor()).thenReturn(solutionDescriptor);
         when(scoreDirectorFactory.getScoreDefinition()).thenReturn(new SimpleScoreDefinition());
-        return new HeuristicConfigPolicy<>(EnvironmentMode.REPRODUCIBLE, null, null, null, scoreDirectorFactory);
+        return new HeuristicConfigPolicy.Builder<>(EnvironmentMode.REPRODUCIBLE, null, null, null, scoreDirectorFactory)
+                .build();
     }
 
     private TestdataMultiVarSolution generateTestdataSolution() {

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/constructionheuristic/placer/entity/QueuedValuePlacerFactoryTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/constructionheuristic/placer/entity/QueuedValuePlacerFactoryTest.java
@@ -77,7 +77,8 @@ class QueuedValuePlacerFactoryTest extends AbstractEntityPlacerTest {
         InnerScoreDirectorFactory<TestdataSolution, SimpleScore> scoreDirectorFactory = mock(InnerScoreDirectorFactory.class);
         when(scoreDirectorFactory.getSolutionDescriptor()).thenReturn(solutionDescriptor);
         when(scoreDirectorFactory.getScoreDefinition()).thenReturn(new SimpleScoreDefinition());
-        return new HeuristicConfigPolicy<>(EnvironmentMode.REPRODUCIBLE, null, null, null, scoreDirectorFactory);
+        return new HeuristicConfigPolicy.Builder<>(EnvironmentMode.REPRODUCIBLE, null, null, null, scoreDirectorFactory)
+                .build();
     }
 
     private TestdataSolution generateSolution() {

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/exhaustivesearch/DefaultExhaustiveSearchPhaseTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/exhaustivesearch/DefaultExhaustiveSearchPhaseTest.java
@@ -95,9 +95,8 @@ public class DefaultExhaustiveSearchPhaseTest {
         when(lastCompletedStepScope.getExpandingNode()).thenReturn(node3A);
         when(stepScope.getExpandingNode()).thenReturn(node4B);
 
-        DefaultExhaustiveSearchPhase<TestdataSolution> phase = new DefaultExhaustiveSearchPhase<>(0, "", null);
-        phase.setEntitySelector(mock(EntitySelector.class));
-        phase.setDecider(mock(ExhaustiveSearchDecider.class));
+        DefaultExhaustiveSearchPhase<TestdataSolution> phase = new DefaultExhaustiveSearchPhase.Builder<>(0, "", null, null,
+                mock(EntitySelector.class), mock(ExhaustiveSearchDecider.class)).build();
         phase.restoreWorkingSolution(stepScope);
 
         verify(node0.getMove(), times(0)).doMove(any(ScoreDirector.class));

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/heuristic/selector/AbstractSelectorFactoryTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/heuristic/selector/AbstractSelectorFactoryTest.java
@@ -38,7 +38,8 @@ public abstract class AbstractSelectorFactoryTest {
         InnerScoreDirectorFactory<Solution_, SimpleScore> scoreDirectorFactory = mock(InnerScoreDirectorFactory.class);
         when(scoreDirectorFactory.getSolutionDescriptor()).thenReturn(solutionDescriptor);
         when(scoreDirectorFactory.getScoreDefinition()).thenReturn(new SimpleScoreDefinition());
-        return new HeuristicConfigPolicy<>(EnvironmentMode.REPRODUCIBLE, null, null, null, scoreDirectorFactory);
+        return new HeuristicConfigPolicy.Builder<>(EnvironmentMode.REPRODUCIBLE, null, null, null, scoreDirectorFactory)
+                .build();
     }
 
 }

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/localsearch/DefaultLocalSearchPhaseTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/localsearch/DefaultLocalSearchPhaseTest.java
@@ -38,12 +38,10 @@ public class DefaultLocalSearchPhaseTest {
 
     @Test
     public void solveWithInitializedEntities() {
-        SolverConfig solverConfig = PlannerTestUtils.buildSolverConfig(
-                TestdataSolution.class, TestdataEntity.class);
+        SolverConfig solverConfig = PlannerTestUtils.buildSolverConfig(TestdataSolution.class, TestdataEntity.class);
         LocalSearchPhaseConfig phaseConfig = new LocalSearchPhaseConfig();
         phaseConfig.setTerminationConfig(new TerminationConfig().withScoreCalculationCountLimit(10L));
-        solverConfig.setPhaseConfigList(Collections.singletonList(
-                phaseConfig));
+        solverConfig.setPhaseConfigList(Collections.singletonList(phaseConfig));
 
         TestdataSolution solution = new TestdataSolution("s1");
         TestdataValue v1 = new TestdataValue("v1");
@@ -70,12 +68,11 @@ public class DefaultLocalSearchPhaseTest {
 
     @Test
     public void solveWithPinnedEntities() {
-        SolverConfig solverConfig = PlannerTestUtils.buildSolverConfig(
-                TestdataPinnedSolution.class, TestdataPinnedEntity.class);
+        SolverConfig solverConfig =
+                PlannerTestUtils.buildSolverConfig(TestdataPinnedSolution.class, TestdataPinnedEntity.class);
         LocalSearchPhaseConfig phaseConfig = new LocalSearchPhaseConfig();
         phaseConfig.setTerminationConfig(new TerminationConfig().withScoreCalculationCountLimit(10L));
-        solverConfig.setPhaseConfigList(Collections.singletonList(
-                phaseConfig));
+        solverConfig.setPhaseConfigList(Collections.singletonList(phaseConfig));
 
         TestdataPinnedSolution solution = new TestdataPinnedSolution("s1");
         TestdataValue v1 = new TestdataValue("v1");
@@ -102,12 +99,10 @@ public class DefaultLocalSearchPhaseTest {
 
     @Test
     public void solveWithEmptyEntityList() {
-        SolverConfig solverConfig = PlannerTestUtils.buildSolverConfig(
-                TestdataSolution.class, TestdataEntity.class);
+        SolverConfig solverConfig = PlannerTestUtils.buildSolverConfig(TestdataSolution.class, TestdataEntity.class);
         LocalSearchPhaseConfig phaseConfig = new LocalSearchPhaseConfig();
         phaseConfig.setTerminationConfig(new TerminationConfig().withScoreCalculationCountLimit(10L));
-        solverConfig.setPhaseConfigList(Collections.singletonList(
-                phaseConfig));
+        solverConfig.setPhaseConfigList(Collections.singletonList(phaseConfig));
 
         TestdataSolution solution = new TestdataSolution("s1");
         TestdataValue v1 = new TestdataValue("v1");
@@ -123,13 +118,11 @@ public class DefaultLocalSearchPhaseTest {
 
     @Test
     public void solveTabuSearchWithInitializedEntities() {
-        SolverConfig solverConfig = PlannerTestUtils.buildSolverConfig(
-                TestdataSolution.class, TestdataEntity.class);
+        SolverConfig solverConfig = PlannerTestUtils.buildSolverConfig(TestdataSolution.class, TestdataEntity.class);
         LocalSearchPhaseConfig phaseConfig = new LocalSearchPhaseConfig();
         phaseConfig.setLocalSearchType(LocalSearchType.TABU_SEARCH);
         phaseConfig.setTerminationConfig(new TerminationConfig().withScoreCalculationCountLimit(10L));
-        solverConfig.setPhaseConfigList(Collections.singletonList(
-                phaseConfig));
+        solverConfig.setPhaseConfigList(Collections.singletonList(phaseConfig));
 
         TestdataSolution solution = new TestdataSolution("s1");
         TestdataValue v1 = new TestdataValue("v1");
@@ -156,13 +149,12 @@ public class DefaultLocalSearchPhaseTest {
 
     @Test
     public void solveTabuSearchWithPinnedEntities() {
-        SolverConfig solverConfig = PlannerTestUtils.buildSolverConfig(
-                TestdataPinnedSolution.class, TestdataPinnedEntity.class);
+        SolverConfig solverConfig =
+                PlannerTestUtils.buildSolverConfig(TestdataPinnedSolution.class, TestdataPinnedEntity.class);
         LocalSearchPhaseConfig phaseConfig = new LocalSearchPhaseConfig();
         phaseConfig.setLocalSearchType(LocalSearchType.TABU_SEARCH);
         phaseConfig.setTerminationConfig(new TerminationConfig().withScoreCalculationCountLimit(10L));
-        solverConfig.setPhaseConfigList(Collections.singletonList(
-                phaseConfig));
+        solverConfig.setPhaseConfigList(Collections.singletonList(phaseConfig));
 
         TestdataPinnedSolution solution = new TestdataPinnedSolution("s1");
         TestdataValue v1 = new TestdataValue("v1");
@@ -189,13 +181,11 @@ public class DefaultLocalSearchPhaseTest {
 
     @Test
     public void solveTabuSearchWithEmptyEntityList() {
-        SolverConfig solverConfig = PlannerTestUtils.buildSolverConfig(
-                TestdataSolution.class, TestdataEntity.class);
+        SolverConfig solverConfig = PlannerTestUtils.buildSolverConfig(TestdataSolution.class, TestdataEntity.class);
         LocalSearchPhaseConfig phaseConfig = new LocalSearchPhaseConfig();
         phaseConfig.setLocalSearchType(LocalSearchType.TABU_SEARCH);
         phaseConfig.setTerminationConfig(new TerminationConfig().withScoreCalculationCountLimit(10L));
-        solverConfig.setPhaseConfigList(Collections.singletonList(
-                phaseConfig));
+        solverConfig.setPhaseConfigList(Collections.singletonList(phaseConfig));
 
         TestdataSolution solution = new TestdataSolution("s1");
         TestdataValue v1 = new TestdataValue("v1");

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/partitionedsearch/DefaultPartitionedSearchPhaseTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/partitionedsearch/DefaultPartitionedSearchPhaseTest.java
@@ -152,9 +152,7 @@ public class DefaultPartitionedSearchPhaseTest {
                 });
 
         ExecutorService executor = Executors.newSingleThreadExecutor();
-        Future<TestdataSolution> solutionFuture = executor.submit(() -> {
-            return solver.solve(solution);
-        });
+        Future<TestdataSolution> solutionFuture = executor.submit(() -> solver.solve(solution));
 
         // make sure solver has started solving before terminating early
         solvingStarted.await();
@@ -182,9 +180,7 @@ public class DefaultPartitionedSearchPhaseTest {
         Solver<TestdataSolution> solver = solverFactory.buildSolver();
 
         ExecutorService executor = Executors.newSingleThreadExecutor();
-        Future<TestdataSolution> solutionFuture = executor.submit(() -> {
-            return solver.solve(solution);
-        });
+        Future<TestdataSolution> solutionFuture = executor.submit(() -> solver.solve(solution));
 
         sleepAnnouncement.await();
         // Now we know the sleeping entity is sleeping so we can attempt to shut down.

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/phase/NoChangePhaseTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/phase/NoChangePhaseTest.java
@@ -34,10 +34,8 @@ public class NoChangePhaseTest {
 
     @Test
     public void solve() {
-        SolverConfig solverConfig = PlannerTestUtils.buildSolverConfig(
-                TestdataSolution.class, TestdataEntity.class);
-        solverConfig.setPhaseConfigList(Collections.singletonList(
-                new NoChangePhaseConfig()));
+        SolverConfig solverConfig = PlannerTestUtils.buildSolverConfig(TestdataSolution.class, TestdataEntity.class);
+        solverConfig.setPhaseConfigList(Collections.singletonList(new NoChangePhaseConfig()));
 
         TestdataSolution solution = new TestdataSolution("s1");
         TestdataValue v1 = new TestdataValue("v1");


### PR DESCRIPTION
The goal of this PR is to make it easier to understand and reason about the Phases code. Declaring fields `final` and eliminating the corresponding setters reduces the effort of searching for the places from where the field can be changed. With `final`, the intention is clear: the value is determined during object construction and then never changes.

The Builder pattern is taken from Item 2, Effective Java. In this case it solves the problem with optional assertion flags. The Builder has a named setter method for each optional argument, so instead of something like
```java
XyPhase phase;
if (environment.isLevelA() && environment.isLevelB()) {
    phase = new XyPhase(requiredArgs, true, true);
}
if (environment.isLevelA()) {
    phase = new XyPhase(requiredArgs, true);
}
// etc.
```
and multiple telescoping constructors for `XyPhase`, we have something where the client code is almost the same as before but immutability is achieved once the object is built:
```java
// Initilialize builder with mandatory arguments.
Builder builder = new XyPhase.Builder(requiredArgs);
// Conditionally enable any combination of optional assertion flags.
if (environment.isLevelA()) {
    builder.setAssertStepScoreFromScratch(true);
}
if (environment.isLevelB()) {
    builder.setAssertExpectedStepScore(true);
}
// Once the object is built, even the optional arguments become final.
XyPhase phase = builder.build();
```


<details>
<summary>
How to replicate CI configuration locally?
</summary>

We do "simple" maven builds, they are just basically maven commands, but just because we have multiple repositories related between them and one change could affect several of those projects by multiple pull requests, we use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.

[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is not only a github-action tool but a CLI one, so in case you posted multiple pull requests related with this change you can easily reproduce the same build by executing it locally. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>specific pull request build</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] tests</b>
* for a <b>full downstream build</b> 
  * for <b>jenkins</b> job: please add comment: <b>Jenkins run fdb</b>
  * for <b>github actions</b> job: add the label `run_fdb`
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
* for a <b>Quarkus LTS check</b> please add comment: <b>Jenkins run LTS</b>
* for a <b>specific Quarkus LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] LTS</b>
* for a <b>Native check</b> please add comment: <b>Jenkins run native</b>
* for a <b>specific Native LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] native</b>
</details>
