### PR TITLE
OptaPlanner on code.quarkus.io should just be called "OptaPlanner"

### DIFF
--- a/optaplanner-quarkus-integration/optaplanner-quarkus-benchmark/runtime/pom.xml
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus-benchmark/runtime/pom.xml
@@ -11,7 +11,7 @@
 
   <artifactId>optaplanner-quarkus-benchmark</artifactId>
   <name>OptaPlanner Quarkus Benchmark - Runtime</name>
-  <description>Benchmark an OptaPlanner project to tweak the solver configuration for speed and scalability.</description>
+  <description>Benchmark an OptaPlanner project to power tweak the solver configuration for speed and scalability.</description>
 
   <properties>
     <java.module.name>org.optaplanner.quarkus.benchmark</java.module.name>

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/runtime/pom.xml
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/runtime/pom.xml
@@ -11,7 +11,7 @@
 
   <artifactId>optaplanner-quarkus</artifactId>
   <name>OptaPlanner Quarkus - Runtime</name>
-  <description>Optimize planning of vehicle routes, employee rosters, maintenance schedules, task assignments, school timetables, conference schedules, etc.</description>
+  <description>Solve planning and scheduling with AI constraint optimization of vehicle routes, employee rosters, maintenance, tasks, lessons, conferences, ...</description>
 
   <properties>
     <java.module.name>org.optaplanner.quarkus</java.module.name>

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -1,5 +1,5 @@
 ---
-name: "OptaPlanner (AI constraint solver)"
+name: "OptaPlanner"
 metadata:
   keywords:
     - "optaplanner"


### PR DESCRIPTION
Fixes this
![image](https://user-images.githubusercontent.com/176880/141483491-7edfa427-2932-4191-bb8c-8f6d1173caae.png)
