### PR TITLE
Replace depreacted isEqualToComparingFieldByField()

### DIFF
--- a/optaplanner-core/src/test/java/org/optaplanner/core/config/heuristic/selector/common/nearby/NearbySelectionConfigTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/config/heuristic/selector/common/nearby/NearbySelectionConfigTest.java
@@ -186,7 +186,8 @@ public class NearbySelectionConfigTest {
         nearbySelectionConfig.setBlockDistributionUniformDistributionProbability(probability);
 
         assertThat(NearbyRandomFactory.create(nearbySelectionConfig).buildNearbyRandom(true))
-                .isEqualToComparingFieldByField(new BlockDistributionNearbyRandom(minimum, maximum, sizeRatio, probability));
+                .usingRecursiveComparison()
+                .isEqualTo(new BlockDistributionNearbyRandom(minimum, maximum, sizeRatio, probability));
     }
 
     @Test
@@ -196,7 +197,8 @@ public class NearbySelectionConfigTest {
         nearbySelectionConfig.setLinearDistributionSizeMaximum(maximum);
 
         assertThat(NearbyRandomFactory.create(nearbySelectionConfig).buildNearbyRandom(true))
-                .isEqualToComparingFieldByField(new LinearDistributionNearbyRandom(maximum));
+                .usingRecursiveComparison()
+                .isEqualTo(new LinearDistributionNearbyRandom(maximum));
     }
 
     @Test
@@ -206,7 +208,8 @@ public class NearbySelectionConfigTest {
         nearbySelectionConfig.setParabolicDistributionSizeMaximum(maximum);
 
         assertThat(NearbyRandomFactory.create(nearbySelectionConfig).buildNearbyRandom(true))
-                .isEqualToComparingFieldByField(new ParabolicDistributionNearbyRandom(maximum));
+                .usingRecursiveComparison()
+                .isEqualTo(new ParabolicDistributionNearbyRandom(maximum));
     }
 
     @Test
@@ -228,7 +231,8 @@ public class NearbySelectionConfigTest {
         NearbySelectionConfig nearbySelectionConfig = buildNearbySelectionConfig();
 
         assertThat(NearbyRandomFactory.create(nearbySelectionConfig).buildNearbyRandom(true))
-                .isEqualToComparingFieldByField(new LinearDistributionNearbyRandom(Integer.MAX_VALUE));
+                .usingRecursiveComparison()
+                .isEqualTo(new LinearDistributionNearbyRandom(Integer.MAX_VALUE));
     }
 
     private NearbySelectionConfig buildNearbySelectionConfig() {


### PR DESCRIPTION

<details>
<summary>
How to replicate CI configuration locally?
</summary>

We do "simple" maven builds, they are just basically maven commands, but just because we have multiple repositories related between them and one change could affect several of those projects by multiple pull requests, we use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.

[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is not only a github-action tool but a CLI one, so in case you posted multiple pull requests related with this change you can easily reproduce the same build by executing it locally. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>specific pull request build</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] tests</b>
* for a <b>full downstream build</b> 
  * for <b>jenkins</b> job: please add comment: <b>Jenkins run fdb</b>
  * for <b>github actions</b> job: add the label `run_fdb`
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
* for a <b>Quarkus LTS check</b> please add comment: <b>Jenkins run LTS</b>
* for a <b>specific Quarkus LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] LTS</b>
* for a <b>Native check</b> please add comment: <b>Jenkins run native</b>
* for a <b>specific Native LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] native</b>
</details>
