### PR TITLE
PLANNER-2583: Add docs for Benchmarker properties

### DIFF
--- a/optaplanner-docs/src/modules/ROOT/pages/integration/config-properties.adoc
+++ b/optaplanner-docs/src/modules/ROOT/pages/integration/config-properties.adoc
@@ -60,7 +60,7 @@ Wildcards are supported to replace numbers.
 For example: `0hard/*soft` to terminate when any feasible score is reached.
 
 {property_prefix}optaplanner.benchmark.solver-benchmark-config-xml::
-A classpath resource to read the solver configuration XML.
+A classpath resource to read the benchmark configuration XML.
 Defaults to solverBenchmarkConfig.xml.
 If this property isn't specified, that solverBenchmarkConfig.xml is optional.
 

--- a/optaplanner-docs/src/modules/ROOT/pages/integration/config-properties.adoc
+++ b/optaplanner-docs/src/modules/ROOT/pages/integration/config-properties.adoc
@@ -58,3 +58,17 @@ Terminates the solver when a specific or higher score has been reached.
 For example: `0hard/-1000soft` terminates when the best score changes from `0hard/-1200soft` to `0hard/-900soft`.
 Wildcards are supported to replace numbers.
 For example: `0hard/*soft` to terminate when any feasible score is reached.
+
+{property_prefix}optaplanner.benchmark.solver-benchmark-config-xml::
+A classpath resource to read the solver configuration XML.
+Defaults to solverBenchmarkConfig.xml.
+If this property isn't specified, that solverBenchmarkConfig.xml is optional.
+
+{property_prefix}optaplanner.benchmark.result-directory::
+Where the benchmark results are written to. Defaults to
+target/benchmarks.
+
+{property_prefix}optaplanner.benchmark.solver.termination.spent-limit::
+How long solver should be run in a benchmark run.
+For example: `30s` is 30 seconds. `5m` is 5 minutes. `2h` is 2 hours. `1d` is 1 day.
+Also supports ISO-8601 format, see https://docs.oracle.com/javase/8/docs/api/java/time/Duration.html[Duration].

--- a/optaplanner-quarkus-integration/optaplanner-quarkus-benchmark/deployment/src/main/java/org/optaplanner/benchmark/quarkus/deployment/OptaPlannerBenchmarkBuildTimeConfig.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus-benchmark/deployment/src/main/java/org/optaplanner/benchmark/quarkus/deployment/OptaPlannerBenchmarkBuildTimeConfig.java
@@ -29,7 +29,7 @@ public class OptaPlannerBenchmarkBuildTimeConfig {
 
     public static final String DEFAULT_SOLVER_BENCHMARK_CONFIG_URL = "solverBenchmarkConfig.xml";
     /**
-     * A classpath resource to read the solver configuration XML.
+     * A classpath resource to read the benchmark configuration XML.
      * Defaults to {@value DEFAULT_SOLVER_BENCHMARK_CONFIG_URL}.
      * If this property isn't specified, that solverBenchmarkConfig.xml is optional.
      */

--- a/optaplanner-spring-integration/optaplanner-spring-boot-autoconfigure/src/main/java/org/optaplanner/spring/boot/autoconfigure/OptaPlannerBenchmarkAutoConfiguration.java
+++ b/optaplanner-spring-integration/optaplanner-spring-boot-autoconfigure/src/main/java/org/optaplanner/spring/boot/autoconfigure/OptaPlannerBenchmarkAutoConfiguration.java
@@ -89,7 +89,7 @@ public class OptaPlannerBenchmarkAutoConfiguration
         if (!isTerminationConfigured(
                 benchmarkConfig.getInheritedSolverBenchmarkConfig().getSolverConfig().getTerminationConfig())) {
             throw new IllegalStateException(
-                    "Property optaplanner.benchmark.solver.termination.spentLimit is required if termination is not configured.");
+                    "Property optaplanner.benchmark.solver.termination.spent-limit is required if termination is not configured.");
         }
         return benchmarkConfig;
     }


### PR DESCRIPTION
Note: Spring reuses the Solver Termination Config while Quarkus does not, meaning Spring technically has `best-score-limit` and `unimproved-time-spent` properties for benchmarker whereas Quarkus does not.

### JIRA

<!-- Add a JIRA ticket link if it exists. -->
https://issues.redhat.com/browse/PLANNER-2583

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
* https://github.com/kiegroup/drools/pull/3000
* https://github.com/kiegroup/optaplanner/pull/899
* etc.
-->

### Checklist
- [ ] Documentation updated if applicable.
- [ ] Upgrade recipe provided if applicable.

<details>
<summary>
How to replicate CI configuration locally?
</summary>

We do "simple" maven builds, they are just basically maven commands, but just because we have multiple repositories related between them and one change could affect several of those projects by multiple pull requests, we use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.

[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is not only a github-action tool but a CLI one, so in case you posted multiple pull requests related with this change you can easily reproduce the same build by executing it locally. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>specific pull request build</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] tests</b>
* for a <b>full downstream build</b> 
  * for <b>jenkins</b> job: please add comment: <b>Jenkins run fdb</b>
  * for <b>github actions</b> job: add the label `run_fdb`
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
* for a <b>Quarkus LTS check</b> please add comment: <b>Jenkins run LTS</b>
* for a <b>specific Quarkus LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] LTS</b>
* for a <b>Native check</b> please add comment: <b>Jenkins run native</b>
* for a <b>specific Native LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] native</b>
</details>
