### PR TITLE
Add missing `@Override` annotations

### DIFF
--- a/optaplanner-core/src/main/java/org/optaplanner/core/api/score/stream/ConstraintCollectors.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/api/score/stream/ConstraintCollectors.java
@@ -1777,6 +1777,7 @@ public final class ConstraintCollectors {
             this.result = Objects.requireNonNull(resultSupplier).apply(0);
         }
 
+        @Override
         public void add(Key key, Value value) {
             ToMapPerKeyCounter<Value> counter = valueCounts.computeIfAbsent(key, k -> new ToMapPerKeyCounter<>());
             long newCount = counter.add(value);
@@ -1787,6 +1788,7 @@ public final class ConstraintCollectors {
             }
         }
 
+        @Override
         public void remove(Key key, Value value) {
             ToMapPerKeyCounter<Value> counter = valueCounts.get(key);
             long newCount = counter.remove(value);
@@ -1826,6 +1828,7 @@ public final class ConstraintCollectors {
             this.result = Objects.requireNonNull(resultFunction).apply(0);
         }
 
+        @Override
         public void add(Key key, Value value) {
             ToMapPerKeyCounter<Value> counter = valueCounts.computeIfAbsent(key, k -> new ToMapPerKeyCounter<>());
             counter.add(value);
@@ -1833,6 +1836,7 @@ public final class ConstraintCollectors {
                     .add(value);
         }
 
+        @Override
         public void remove(Key key, Value value) {
             ToMapPerKeyCounter<Value> counter = valueCounts.get(key);
             long newCount = counter.remove(value);

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/common/accessor/gizmo/GizmoMemberAccessorImplementor.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/common/accessor/gizmo/GizmoMemberAccessorImplementor.java
@@ -56,6 +56,7 @@ public class GizmoMemberAccessorImplementor {
      */
     private static ClassLoader gizmoClassLoader = new ClassLoader() {
         // getName() is an abstract method in Java 11 but not in Java 8
+        @Override
         public String getName() {
             return "OptaPlanner Gizmo MemberAccessor ClassLoader";
         }

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/solution/cloner/gizmo/GizmoSolutionClonerImplementor.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/solution/cloner/gizmo/GizmoSolutionClonerImplementor.java
@@ -64,6 +64,7 @@ public class GizmoSolutionClonerImplementor {
      */
     private static ClassLoader gizmoClassLoader = new ClassLoader() {
         // getName() is an abstract method in Java 11 but not in Java 8
+        @Override
         public String getName() {
             return "OptaPlanner Gizmo SolutionCloner ClassLoader";
         }

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/common/AbstractConstraintStream.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/stream/common/AbstractConstraintStream.java
@@ -99,6 +99,7 @@ public abstract class AbstractConstraintStream<Solution_> implements ConstraintS
     // Getters/setters
     // ************************************************************************
 
+    @Override
     public abstract InnerConstraintFactory<Solution_, ?> getConstraintFactory();
 
     @Override

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/solver/DefaultSolver.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/solver/DefaultSolver.java
@@ -92,16 +92,6 @@ public class DefaultSolver<Solution_> extends AbstractSolver<Solution_> {
         return solverScope.getScoreDirector().getScoreDirectorFactory();
     }
 
-    @Override
-    public BestSolutionRecaller<Solution_> getBestSolutionRecaller() {
-        return bestSolutionRecaller;
-    }
-
-    @Override
-    public List<Phase<Solution_>> getPhaseList() {
-        return phaseList;
-    }
-
     public SolverScope<Solution_> getSolverScope() {
         return solverScope;
     }

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/solver/DefaultSolver.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/solver/DefaultSolver.java
@@ -92,10 +92,12 @@ public class DefaultSolver<Solution_> extends AbstractSolver<Solution_> {
         return solverScope.getScoreDirector().getScoreDirectorFactory();
     }
 
+    @Override
     public BestSolutionRecaller<Solution_> getBestSolutionRecaller() {
         return bestSolutionRecaller;
     }
 
+    @Override
     public List<Phase<Solution_>> getPhaseList() {
         return phaseList;
     }

--- a/optaplanner-core/src/test/java/org/optaplanner/core/config/util/ConfigUtilsTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/config/util/ConfigUtilsTest.java
@@ -313,10 +313,12 @@ public class ConfigUtilsTest {
     }
 
     public static class ClassWithBridgeMethod extends ClassWithBridgeMethodParent<Integer> {
+        @Override
         public Integer getScore() {
             return 0;
         }
 
+        @Override
         @PlanningScore
         public void setScore(Integer score) {
         }

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/domain/common/accessor/gizmo/GizmoMemberAccessorFactoryTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/domain/common/accessor/gizmo/GizmoMemberAccessorFactoryTest.java
@@ -57,6 +57,7 @@ public class GizmoMemberAccessorFactoryTest {
     public void testGizmoNotOnClasspathThrowsException() throws NoSuchMethodException {
         Member member = TestdataEntity.class.getMethod("getValue");
         Thread.currentThread().setContextClassLoader(new ClassLoader() {
+            @Override
             public String getName() {
                 return "ClassLoader without Gizmo";
             }

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/domain/solution/cloner/GizmoSolutionClonerTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/domain/solution/cloner/GizmoSolutionClonerTest.java
@@ -87,6 +87,7 @@ public class GizmoSolutionClonerTest extends AbstractSolutionClonerTest {
 
         ClassLoader gizmoClassLoader = new ClassLoader() {
             // getName() is an abstract method in Java 11 but not in Java 8
+            @Override
             public String getName() {
                 return "OptaPlanner Gizmo SolutionCloner Test ClassLoader";
             }

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/testdata/domain/comparable/TestdataCodeComparator.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/testdata/domain/comparable/TestdataCodeComparator.java
@@ -8,6 +8,7 @@ public class TestdataCodeComparator implements Comparator<TestdataObject> {
 
     private static final Comparator<TestdataObject> COMPARATOR = Comparator.comparing(TestdataObject::getCode);
 
+    @Override
     public int compare(TestdataObject a, TestdataObject b) {
         return COMPARATOR.compare(a, b);
     }

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/batchscheduling/optional/score/BatchSchedulingEasyScoreCalculator.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/batchscheduling/optional/score/BatchSchedulingEasyScoreCalculator.java
@@ -31,6 +31,7 @@ import org.optaplanner.examples.batchscheduling.domain.RoutePath;
 
 public class BatchSchedulingEasyScoreCalculator implements EasyScoreCalculator<BatchSchedule, BendableLongScore> {
 
+    @Override
     public BendableLongScore calculateScore(BatchSchedule schedule) {
         // Refer to incremental score calculator for comments on hard and soft scores.
         long hard0Score = 0;

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/batchscheduling/score/BatchSchedulingIncrementalScoreCalculator.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/batchscheduling/score/BatchSchedulingIncrementalScoreCalculator.java
@@ -817,6 +817,7 @@ public class BatchSchedulingIncrementalScoreCalculator
         return segmentStringMap.size() - segmentSet.size();
     }
 
+    @Override
     public BendableLongScore calculateScore() {
         return BendableLongScore.of(new long[] { hard0Score, hard1Score, hard2Score },
                 new long[] { soft0Score, soft1Score });

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/batchscheduling/swingui/BatchSchedulingPanel.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/batchscheduling/swingui/BatchSchedulingPanel.java
@@ -43,6 +43,7 @@ public class BatchSchedulingPanel extends SolutionPanel<BatchSchedule> {
         setLayout(new BorderLayout());
     }
 
+    @Override
     public void resetPanel(BatchSchedule solution) {
         removeAll();
         repaint();

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/meetingscheduling/persistence/MeetingSchedulingXlsxFileIO.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/meetingscheduling/persistence/MeetingSchedulingXlsxFileIO.java
@@ -98,6 +98,7 @@ public class MeetingSchedulingXlsxFileIO extends AbstractXlsxSolutionFileIO<Meet
             super(workbook, MeetingSchedulingApp.SOLVER_CONFIG);
         }
 
+        @Override
         public MeetingSchedule read() {
             solution = new MeetingSchedule();
             readConfiguration();


### PR DESCRIPTION

<details>
<summary>
How to replicate CI configuration locally?
</summary>

We do "simple" maven builds, they are just basically maven commands, but just because we have multiple repositories related between them and one change could affect several of those projects by multiple pull requests, we use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.

[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is not only a github-action tool but a CLI one, so in case you posted multiple pull requests related with this change you can easily reproduce the same build by executing it locally. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>specific pull request build</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] tests</b>
* for a <b>full downstream build</b> 
  * for <b>jenkins</b> job: please add comment: <b>Jenkins run fdb</b>
  * for <b>github actions</b> job: add the label `run_fdb`
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
* for a <b>Quarkus LTS check</b> please add comment: <b>Jenkins run LTS</b>
* for a <b>specific Quarkus LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] LTS</b>
* for a <b>Native check</b> please add comment: <b>Jenkins run native</b>
* for a <b>specific Native LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] native</b>
</details>
