### PR TITLE
Make Drools ANC optional but still enabled by default

### DIFF
--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/ScoreDirectorFactoryFactory.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/ScoreDirectorFactoryFactory.java
@@ -20,6 +20,7 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -223,19 +224,7 @@ public class ScoreDirectorFactoryFactory<Solution_, Score_ extends Score<Score_>
                 case BAVET:
                     return new BavetConstraintStreamScoreDirectorFactory<>(solutionDescriptor, constraintProvider);
                 case DROOLS:
-                    if (config.isDroolsAlphaNetworkCompilationEnabled()) {
-                        if (config.getGizmoKieBaseSupplier() != null) {
-                            return new DroolsAncConstraintStreamScoreDirectorFactory<>(solutionDescriptor,
-                                    config.getGizmoKieBaseSupplier());
-                        }
-                        return new DroolsAncConstraintStreamScoreDirectorFactory<>(solutionDescriptor, constraintProvider);
-                    } else {
-                        if (config.getGizmoKieBaseSupplier() != null) {
-                            return new DroolsConstraintStreamScoreDirectorFactory<>(solutionDescriptor,
-                                    config.getGizmoKieBaseSupplier());
-                        }
-                        return new DroolsConstraintStreamScoreDirectorFactory<>(solutionDescriptor, constraintProvider);
-                    }
+                    return buildDroolsConstraintStreamScoreDirectorFactory(config, solutionDescriptor, constraintProvider);
                 default:
                     throw new IllegalStateException(
                             "The constraintStreamImplType (" + constraintStreamImplType_ + ") is not implemented.");
@@ -247,6 +236,24 @@ public class ScoreDirectorFactoryFactory<Solution_, Score_ extends Score<Score_>
                         + config.getConstraintProviderCustomProperties() + ") either.");
             }
             return null;
+        }
+    }
+
+    private DroolsConstraintStreamScoreDirectorFactory<Solution_, Score_>
+            buildDroolsConstraintStreamScoreDirectorFactory(
+                    ScoreDirectorFactoryConfig config, SolutionDescriptor<Solution_> solutionDescriptor,
+                    ConstraintProvider constraintProvider) {
+        Supplier<KieBase> gizmoKieBaseSupplier = config.getGizmoKieBaseSupplier();
+        if (config.isDroolsAlphaNetworkCompilationEnabled()) {
+            if (gizmoKieBaseSupplier != null) {
+                return new DroolsAncConstraintStreamScoreDirectorFactory<>(solutionDescriptor, gizmoKieBaseSupplier);
+            }
+            return new DroolsAncConstraintStreamScoreDirectorFactory<>(solutionDescriptor, constraintProvider);
+        } else {
+            if (gizmoKieBaseSupplier != null) {
+                return new DroolsConstraintStreamScoreDirectorFactory<>(solutionDescriptor, gizmoKieBaseSupplier);
+            }
+            return new DroolsConstraintStreamScoreDirectorFactory<>(solutionDescriptor, constraintProvider);
         }
     }
 

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/KieBaseAncBuilder.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/KieBaseAncBuilder.java
@@ -16,4 +16,8 @@ public final class KieBaseAncBuilder {
         return kieBase;
     }
 
+    private KieBaseAncBuilder() {
+        // No instances allowed.
+    }
+
 }

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/KieBaseAncBuilder.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/KieBaseAncBuilder.java
@@ -1,0 +1,19 @@
+package org.optaplanner.core.impl.score.director.drools;
+
+import org.drools.ancompiler.KieBaseUpdaterANC;
+import org.kie.api.KieBase;
+import org.optaplanner.core.config.score.director.ScoreDirectorFactoryConfig;
+
+/**
+ * Exists so that ANC references can be decoupled from the base functionality,
+ * and therefore ANC can be removed from the classpath entirely if necessary.
+ */
+public final class KieBaseAncBuilder {
+
+    public static KieBase build(ScoreDirectorFactoryConfig config, ClassLoader classLoader) {
+        KieBase kieBase = KieBaseBuilder.build(config, classLoader);
+        KieBaseUpdaterANC.generateAndSetInMemoryANC(kieBase);
+        return kieBase;
+    }
+
+}

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/KieBaseBuilder.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/KieBaseBuilder.java
@@ -1,0 +1,53 @@
+package org.optaplanner.core.impl.score.director.drools;
+
+import java.io.File;
+import java.util.Map;
+
+import org.drools.core.io.impl.ClassPathResource;
+import org.drools.core.io.impl.FileSystemResource;
+import org.drools.modelcompiler.ExecutableModelProject;
+import org.kie.api.KieBase;
+import org.kie.api.KieBaseConfiguration;
+import org.kie.api.KieServices;
+import org.kie.api.conf.KieBaseMutabilityOption;
+import org.kie.internal.builder.conf.PropertySpecificOption;
+import org.kie.internal.utils.KieHelper;
+import org.optaplanner.core.config.score.director.ScoreDirectorFactoryConfig;
+import org.optaplanner.core.config.util.ConfigUtils;
+
+public final class KieBaseBuilder {
+
+    public static KieBase build(ScoreDirectorFactoryConfig config, ClassLoader classLoader) {
+        // Can't put this code in KieBaseExtractor since it reference
+        // KieRuntimeBuilder, which is an optional dependency
+        KieHelper kieHelper = new KieHelper(PropertySpecificOption.ALLOWED)
+                .setClassLoader(classLoader);
+        if (!ConfigUtils.isEmptyCollection(config.getScoreDrlList())) {
+            for (String scoreDrl : config.getScoreDrlList()) {
+                if (scoreDrl == null) {
+                    throw new IllegalArgumentException("The scoreDrl (" + scoreDrl + ") cannot be null.");
+                }
+                kieHelper.addResource(new ClassPathResource(scoreDrl, classLoader));
+            }
+        }
+        if (!ConfigUtils.isEmptyCollection(config.getScoreDrlFileList())) {
+            for (File scoreDrlFile : config.getScoreDrlFileList()) {
+                kieHelper.addResource(new FileSystemResource(scoreDrlFile));
+            }
+        }
+        KieBaseConfiguration kieBaseConfiguration = buildKieBaseConfiguration(config, KieServices.get());
+        kieBaseConfiguration.setOption(KieBaseMutabilityOption.DISABLED); // Performance improvement.
+        return kieHelper.build(ExecutableModelProject.class, kieBaseConfiguration);
+    }
+
+    private static KieBaseConfiguration buildKieBaseConfiguration(ScoreDirectorFactoryConfig config, KieServices kieServices) {
+        KieBaseConfiguration kieBaseConfiguration = kieServices.newKieBaseConfiguration();
+        if (config.getKieBaseConfigurationProperties() != null) {
+            for (Map.Entry<String, String> entry : config.getKieBaseConfigurationProperties().entrySet()) {
+                kieBaseConfiguration.setProperty(entry.getKey(), entry.getValue());
+            }
+        }
+        return kieBaseConfiguration;
+    }
+
+}

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/KieBaseBuilder.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/KieBaseBuilder.java
@@ -50,4 +50,8 @@ public final class KieBaseBuilder {
         return kieBaseConfiguration;
     }
 
+    private KieBaseBuilder() {
+        // No instances allowed.
+    }
+
 }

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/KieBaseBuilder.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/KieBaseBuilder.java
@@ -18,8 +18,6 @@ import org.optaplanner.core.config.util.ConfigUtils;
 public final class KieBaseBuilder {
 
     public static KieBase build(ScoreDirectorFactoryConfig config, ClassLoader classLoader) {
-        // Can't put this code in KieBaseExtractor since it reference
-        // KieRuntimeBuilder, which is an optional dependency
         KieHelper kieHelper = new KieHelper(PropertySpecificOption.ALLOWED)
                 .setClassLoader(classLoader);
         if (!ConfigUtils.isEmptyCollection(config.getScoreDrlList())) {

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/stream/DroolsAncConstraintStreamScoreDirectorFactory.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/stream/DroolsAncConstraintStreamScoreDirectorFactory.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.core.impl.score.director.stream;
+
+import java.util.function.Supplier;
+
+import org.drools.ancompiler.KieBaseUpdaterANC;
+import org.kie.api.KieBase;
+import org.optaplanner.core.api.score.Score;
+import org.optaplanner.core.api.score.stream.ConstraintProvider;
+import org.optaplanner.core.impl.domain.solution.descriptor.SolutionDescriptor;
+
+/**
+ * Exists so that ANC references can be decoupled from the base CS functionality,
+ * and therefore ANC can be removed from the classpath entirely if necessary.
+ *
+ * @param <Solution_>
+ * @param <Score_>
+ */
+public final class DroolsAncConstraintStreamScoreDirectorFactory<Solution_, Score_ extends Score<Score_>>
+        extends DroolsConstraintStreamScoreDirectorFactory<Solution_, Score_> {
+
+    public DroolsAncConstraintStreamScoreDirectorFactory(SolutionDescriptor<Solution_> solutionDescriptor,
+            ConstraintProvider constraintProvider) {
+        super(solutionDescriptor, buildKieBase(solutionDescriptor, constraintProvider));
+    }
+
+    public DroolsAncConstraintStreamScoreDirectorFactory(SolutionDescriptor<Solution_> solutionDescriptor,
+            Supplier<KieBase> kieBaseDescriptorSupplier) {
+        super(solutionDescriptor, kieBaseDescriptorSupplier);
+    }
+
+    public static <Solution_> KieBaseDescriptor<Solution_> buildKieBase(SolutionDescriptor<Solution_> solutionDescriptor,
+            ConstraintProvider constraintProvider) {
+        KieBaseDescriptor<Solution_> kieBaseDescriptor =
+                DroolsConstraintStreamScoreDirectorFactory.buildKieBase(solutionDescriptor, constraintProvider);
+        KieBaseUpdaterANC.generateAndSetInMemoryANC(kieBaseDescriptor.get());
+        return kieBaseDescriptor;
+    }
+
+}

--- a/optaplanner-core/src/test/java/org/optaplanner/core/api/score/stream/AbstractConstraintStreamTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/api/score/stream/AbstractConstraintStreamTest.java
@@ -36,7 +36,7 @@ import org.optaplanner.core.api.score.constraint.ConstraintMatchTotal;
 import org.optaplanner.core.impl.domain.solution.descriptor.SolutionDescriptor;
 import org.optaplanner.core.impl.score.director.InnerScoreDirector;
 import org.optaplanner.core.impl.score.director.stream.BavetConstraintStreamScoreDirectorFactory;
-import org.optaplanner.core.impl.score.director.stream.DroolsConstraintStreamScoreDirectorFactory;
+import org.optaplanner.core.impl.score.director.stream.DroolsAncConstraintStreamScoreDirectorFactory;
 import org.optaplanner.core.impl.testdata.domain.score.lavish.TestdataLavishSolution;
 
 @ExtendWith(ConstraintStreamTestExtension.class)
@@ -81,8 +81,8 @@ public abstract class AbstractConstraintStreamTest {
                         solutionDescriptorSupplier, constraintProvider)
                                 .buildScoreDirector(false, constraintMatchEnabled);
             case DROOLS:
-                return (InnerScoreDirector<Solution_, Score_>) new DroolsConstraintStreamScoreDirectorFactory<>(
-                        solutionDescriptorSupplier, constraintProvider, true)
+                return (InnerScoreDirector<Solution_, Score_>) new DroolsAncConstraintStreamScoreDirectorFactory<>(
+                        solutionDescriptorSupplier, constraintProvider)
                                 .buildScoreDirector(false, constraintMatchEnabled);
             default:
                 throw new UnsupportedOperationException(

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/score/director/ScoreDirectorFactoryFactoryTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/score/director/ScoreDirectorFactoryFactoryTest.java
@@ -38,6 +38,7 @@ import org.optaplanner.core.impl.score.director.easy.EasyScoreDirector;
 import org.optaplanner.core.impl.score.director.incremental.IncrementalScoreDirector;
 import org.optaplanner.core.impl.score.director.stream.AbstractConstraintStreamScoreDirectorFactory;
 import org.optaplanner.core.impl.score.director.stream.BavetConstraintStreamScoreDirectorFactory;
+import org.optaplanner.core.impl.score.director.stream.DroolsAncConstraintStreamScoreDirectorFactory;
 import org.optaplanner.core.impl.score.director.stream.DroolsConstraintStreamScoreDirectorFactory;
 import org.optaplanner.core.impl.testdata.domain.TestdataSolution;
 
@@ -128,7 +129,7 @@ class ScoreDirectorFactoryFactoryTest {
         assertThat(uncastScoreDirectorFactory).isInstanceOf(DroolsConstraintStreamScoreDirectorFactory.class);
         DroolsConstraintStreamScoreDirectorFactory<TestdataSolution, SimpleScore> scoreDirectorFactory =
                 (DroolsConstraintStreamScoreDirectorFactory<TestdataSolution, SimpleScore>) uncastScoreDirectorFactory;
-        assertThat(scoreDirectorFactory.isDroolsAlphaNetworkCompilationEnabled()).isTrue();
+        assertThat(scoreDirectorFactory).isInstanceOf(DroolsAncConstraintStreamScoreDirectorFactory.class);
     }
 
     @Test
@@ -188,7 +189,7 @@ class ScoreDirectorFactoryFactoryTest {
         assertThat(uncastScoreDirectorFactory).isInstanceOf(DroolsConstraintStreamScoreDirectorFactory.class);
         DroolsConstraintStreamScoreDirectorFactory<TestdataSolution, SimpleScore> scoreDirectorFactory =
                 (DroolsConstraintStreamScoreDirectorFactory<TestdataSolution, SimpleScore>) uncastScoreDirectorFactory;
-        assertThat(scoreDirectorFactory.isDroolsAlphaNetworkCompilationEnabled()).isFalse();
+        assertThat(scoreDirectorFactory).isNotInstanceOf(DroolsAncConstraintStreamScoreDirectorFactory.class);
     }
 
     @Test

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/main/java/org/optaplanner/quarkus/deployment/GizmoMemberAccessorEntityEnhancer.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/main/java/org/optaplanner/quarkus/deployment/GizmoMemberAccessorEntityEnhancer.java
@@ -81,6 +81,7 @@ import org.optaplanner.core.impl.domain.solution.cloner.gizmo.GizmoSolutionClone
 import org.optaplanner.core.impl.domain.solution.cloner.gizmo.GizmoSolutionClonerImplementor;
 import org.optaplanner.core.impl.domain.solution.cloner.gizmo.GizmoSolutionOrEntityDescriptor;
 import org.optaplanner.core.impl.domain.solution.descriptor.SolutionDescriptor;
+import org.optaplanner.core.impl.score.director.stream.DroolsAncConstraintStreamScoreDirectorFactory;
 import org.optaplanner.core.impl.score.director.stream.DroolsConstraintStreamScoreDirectorFactory;
 import org.optaplanner.core.impl.score.director.stream.KieBaseDescriptor;
 import org.optaplanner.quarkus.gizmo.OptaPlannerDroolsInitializer;
@@ -578,13 +579,15 @@ public class GizmoMemberAccessorEntityEnhancer {
                         methodCreator.loadNull(),
                         methodCreator.loadNull(),
                         entityClassList);
-                ResultHandle isDroolsAlphaNetworkCompilationEnabled =
-                        methodCreator.load(config.getScoreDirectorFactoryConfig().isDroolsAlphaNetworkCompilationEnabled());
+                boolean isDroolsAlphaNetworkCompilationEnabled =
+                        config.getScoreDirectorFactoryConfig().isDroolsAlphaNetworkCompilationEnabled();
+                Class<?> scoreDirectorFactoryClass =
+                        isDroolsAlphaNetworkCompilationEnabled ? DroolsAncConstraintStreamScoreDirectorFactory.class
+                                : DroolsConstraintStreamScoreDirectorFactory.class;
                 ResultHandle kieBaseDescriptor = methodCreator.invokeStaticMethod(
-                        MethodDescriptor.ofMethod(DroolsConstraintStreamScoreDirectorFactory.class, "buildKieBase",
-                                KieBaseDescriptor.class,
-                                SolutionDescriptor.class, ConstraintProvider.class, boolean.class),
-                        solutionDescriptor, constraintProvider, isDroolsAlphaNetworkCompilationEnabled);
+                        MethodDescriptor.ofMethod(scoreDirectorFactoryClass, "buildKieBase", KieBaseDescriptor.class,
+                                SolutionDescriptor.class, ConstraintProvider.class),
+                        solutionDescriptor, constraintProvider);
                 methodCreator.invokeVirtualMethod(
                         MethodDescriptor.ofMethod(ScoreDirectorFactoryConfig.class, "setGizmoKieBaseSupplier",
                                 void.class,

--- a/optaplanner-test/src/main/java/org/optaplanner/test/impl/score/stream/DefaultConstraintVerifier.java
+++ b/optaplanner-test/src/main/java/org/optaplanner/test/impl/score/stream/DefaultConstraintVerifier.java
@@ -30,6 +30,7 @@ import org.optaplanner.core.api.score.stream.ConstraintStreamImplType;
 import org.optaplanner.core.impl.domain.solution.descriptor.SolutionDescriptor;
 import org.optaplanner.core.impl.score.director.stream.AbstractConstraintStreamScoreDirectorFactory;
 import org.optaplanner.core.impl.score.director.stream.BavetConstraintStreamScoreDirectorFactory;
+import org.optaplanner.core.impl.score.director.stream.DroolsAncConstraintStreamScoreDirectorFactory;
 import org.optaplanner.core.impl.score.director.stream.DroolsConstraintStreamScoreDirectorFactory;
 import org.optaplanner.test.api.score.stream.ConstraintVerifier;
 
@@ -95,8 +96,11 @@ public final class DefaultConstraintVerifier<ConstraintProvider_ extends Constra
         ConstraintStreamImplType constraintStreamImplType_ = getConstraintStreamImplType();
         switch (constraintStreamImplType_) {
             case DROOLS:
-                return new DroolsConstraintStreamScoreDirectorFactory<>(solutionDescriptor, constraintProvider,
-                        isDroolsAlphaNetworkCompilationEnabled());
+                if (isDroolsAlphaNetworkCompilationEnabled()) {
+                    return new DroolsAncConstraintStreamScoreDirectorFactory<>(solutionDescriptor, constraintProvider);
+                } else {
+                    return new DroolsConstraintStreamScoreDirectorFactory<>(solutionDescriptor, constraintProvider);
+                }
             case BAVET:
                 if (droolsAlphaNetworkCompilationEnabled != null && droolsAlphaNetworkCompilationEnabled) {
                     throw new IllegalArgumentException("Constraint stream implementation (" + constraintStreamImplType_ +


### PR DESCRIPTION
Signed-off-by: Lukáš Petrovický <lpetrovi@redhat.com>

<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.
-->

### JIRA

<!-- Add a JIRA ticket link if it exists. -->
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
* https://github.com/kiegroup/drools/pull/3000
* https://github.com/kiegroup/optaplanner/pull/899
* etc.
-->

### Checklist
- [ ] Documentation updated if applicable.
- [ ] Upgrade recipe provided if applicable.

<details>
<summary>
How to replicate CI configuration locally?
</summary>

We do "simple" maven builds, they are just basically maven commands, but just because we have multiple repositories related between them and one change could affect several of those projects by multiple pull requests, we use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.

[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is not only a github-action tool but a CLI one, so in case you posted multiple pull requests related with this change you can easily reproduce the same build by executing it locally. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>specific pull request build</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] tests</b>
* for a <b>full downstream build</b> 
  * for <b>jenkins</b> job: please add comment: <b>Jenkins run fdb</b>
  * for <b>github actions</b> job: add the label `run_fdb`
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
* for a <b>Quarkus LTS check</b> please add comment: <b>Jenkins run LTS</b>
* for a <b>specific Quarkus LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] LTS</b>
* for a <b>Native check</b> please add comment: <b>Jenkins run native</b>
* for a <b>specific Native LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] native</b>
</details>
