### PR TITLE
[7.59.x] PLANNER-2563 Improve partition search tests stability

### DIFF
--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/partitionedsearch/DefaultPartitionedSearchPhaseTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/partitionedsearch/DefaultPartitionedSearchPhaseTest.java
@@ -50,16 +50,15 @@ import org.optaplanner.core.impl.testdata.domain.TestdataSolution;
 import org.optaplanner.core.impl.testdata.domain.TestdataValue;
 import org.optaplanner.core.impl.testdata.util.PlannerTestUtils;
 
+@Timeout(value = 60, unit = TimeUnit.SECONDS)
 public class DefaultPartitionedSearchPhaseTest {
 
     @Test
-    @Timeout(5)
     public void partCount() {
         partCount(SolverConfig.MOVE_THREAD_COUNT_NONE);
     }
 
     @Test
-    @Timeout(5)
     public void partCountAndMoveThreadCount() {
         partCount("2");
     }
@@ -112,7 +111,6 @@ public class DefaultPartitionedSearchPhaseTest {
     }
 
     @Test
-    @Timeout(5)
     public void exceptionPropagation() {
         final int partSize = 7;
         final int partCount = 3;
@@ -131,7 +129,6 @@ public class DefaultPartitionedSearchPhaseTest {
     }
 
     @Test
-    @Timeout(5)
     public void terminateEarly() throws InterruptedException, ExecutionException {
         final int partSize = 1;
         final int partCount = 2;
@@ -161,12 +158,11 @@ public class DefaultPartitionedSearchPhaseTest {
         assertThat(solver.isTerminateEarly()).isTrue();
 
         executor.shutdown();
-        assertThat(executor.awaitTermination(100, TimeUnit.MILLISECONDS)).isTrue();
+        assertThat(executor.awaitTermination(10, TimeUnit.SECONDS)).isTrue();
         assertThat(solutionFuture.get()).isNotNull();
     }
 
     @Test
-    @Timeout(5)
     public void shutdownMainThreadAbruptly() throws InterruptedException {
         final int partSize = 5;
         final int partCount = 3;
@@ -190,7 +186,7 @@ public class DefaultPartitionedSearchPhaseTest {
         executor.shutdownNow();
 
         // This verifies that PartitionQueue doesn't clear interrupted flag when the main solver thread is interrupted.
-        assertThat(executor.awaitTermination(100, TimeUnit.MILLISECONDS))
+        assertThat(executor.awaitTermination(10, TimeUnit.SECONDS))
                 .as("Executor must terminate successfully when it's shut down abruptly")
                 .isTrue();
 

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/partitionedsearch/DefaultPartitionedSearchPhaseTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/partitionedsearch/DefaultPartitionedSearchPhaseTest.java
@@ -33,6 +33,7 @@ import java.util.stream.IntStream;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.optaplanner.core.api.solver.Solver;
 import org.optaplanner.core.api.solver.SolverFactory;
 import org.optaplanner.core.config.constructionheuristic.ConstructionHeuristicPhaseConfig;
@@ -49,6 +50,7 @@ import org.optaplanner.core.impl.testdata.domain.TestdataEntity;
 import org.optaplanner.core.impl.testdata.domain.TestdataSolution;
 import org.optaplanner.core.impl.testdata.domain.TestdataValue;
 import org.optaplanner.core.impl.testdata.util.PlannerTestUtils;
+import org.optaplanner.core.impl.util.ThreadDumpExtension;
 
 @Timeout(value = 60, unit = TimeUnit.SECONDS)
 public class DefaultPartitionedSearchPhaseTest {
@@ -129,6 +131,7 @@ public class DefaultPartitionedSearchPhaseTest {
     }
 
     @Test
+    @ExtendWith(ThreadDumpExtension.class)
     public void terminateEarly() throws InterruptedException, ExecutionException {
         final int partSize = 1;
         final int partCount = 2;
@@ -163,6 +166,7 @@ public class DefaultPartitionedSearchPhaseTest {
     }
 
     @Test
+    @ExtendWith(ThreadDumpExtension.class)
     public void shutdownMainThreadAbruptly() throws InterruptedException {
         final int partSize = 5;
         final int partCount = 3;

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/util/ThreadDumpExtension.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/util/ThreadDumpExtension.java
@@ -1,0 +1,34 @@
+package org.optaplanner.core.impl.util;
+
+import java.lang.management.ManagementFactory;
+import java.lang.management.ThreadInfo;
+import java.lang.management.ThreadMXBean;
+
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.TestWatcher;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Dumps all threads if the test fails.
+ */
+public class ThreadDumpExtension implements TestWatcher {
+
+    private static final Logger logger = LoggerFactory.getLogger(ThreadDumpExtension.class);
+
+    @Override
+    public void testFailed(ExtensionContext context, Throwable cause) {
+        logger.error("Thread dump of a failed test ({}):{}", context.getUniqueId(), threadDump());
+    }
+
+    private static String threadDump() {
+        ThreadMXBean threadMXBean = ManagementFactory.getThreadMXBean();
+        boolean lockedMonitors = threadMXBean.isObjectMonitorUsageSupported();
+        boolean lockedSynchronizers = threadMXBean.isSynchronizerUsageSupported();
+        StringBuffer threadDump = new StringBuffer(System.lineSeparator());
+        for (ThreadInfo threadInfo : threadMXBean.dumpAllThreads(lockedMonitors, lockedSynchronizers)) {
+            threadDump.append(threadInfo.toString());
+        }
+        return threadDump.toString();
+    }
+}


### PR DESCRIPTION
I haven't found anything suspicious indicating a race condition leading to a deadlock. On the other hand the timeout for awaiting executor termination seems pretty short. Most likely the executor sometimes just cannot make it within the timeout.

Therefore:
1. I increase the timeouts to make the test more benevolent to environment fluctuations.
2. If we see another failure despite the increased timeouts, we need more information to track down the bug. For that reason I'm adding a piece of code that does a thread dump on test failure and prints that to the console.

### JIRA

https://issues.redhat.com/browse/PLANNER-2563

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
* https://github.com/kiegroup/drools/pull/3000
* https://github.com/kiegroup/optaplanner/pull/899
* etc.
-->

### Checklist
- [ ] Documentation updated if applicable.
- [ ] Upgrade recipe provided if applicable.

<details>
<summary>
How to replicate CI configuration locally?
</summary>

We do "simple" maven builds, they are just basically maven commands, but just because we have multiple repositories related between them and one change could affect several of those projects by multiple pull requests, we use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.

[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is not only a github-action tool but a CLI one, so in case you posted multiple pull requests related with this change you can easily reproduce the same build by executing it locally. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>specific pull request build</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] tests</b>
* for a <b>full downstream build</b> 
  * for <b>jenkins</b> job: please add comment: <b>Jenkins run fdb</b>
  * for <b>github actions</b> job: add the label `run_fdb`
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
* for a <b>Quarkus LTS check</b> please add comment: <b>Jenkins run LTS</b>
* for a <b>specific Quarkus LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] LTS</b>
* for a <b>Native check</b> please add comment: <b>Jenkins run native</b>
* for a <b>specific Native LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] native</b>
</details>
