### PR TITLE
Replace {project-version} to {optaplanner-version} in docs

### DIFF
--- a/optaplanner-docs/pom.xml
+++ b/optaplanner-docs/pom.xml
@@ -45,7 +45,7 @@
             </resource>
           </resources>
           <attributes>
-            <project-version>${project.version}</project-version>
+            <optaplanner-version>${project.version}</optaplanner-version>
             <java-version>${maven.compiler.release}</java-version>
             <maven-version>${maven.min.version}</maven-version>
             <quarkus-version>${version.io.quarkus}</quarkus-version>

--- a/optaplanner-docs/src/antora-template.yml
+++ b/optaplanner-docs/src/antora-template.yml
@@ -9,7 +9,7 @@ title: OptaPlanner User Guide ${project.version}
 version: latest
 asciidoc:
   attributes:
-    project-version: ${project.version}
+    optaplanner-version: ${project.version}
     java-version: ${maven.compiler.release}
     maven-version: ${maven.min.version}
     quarkus-version: ${version.io.quarkus}

--- a/optaplanner-docs/src/modules/ROOT/pages/quickstart/hello-world/hello-world-quickstart.adoc
+++ b/optaplanner-docs/src/modules/ROOT/pages/quickstart/hello-world/hello-world-quickstart.adoc
@@ -112,7 +112,7 @@ If you choose Maven, your `pom.xml` file has the following content:
       <dependency>
         <groupId>org.optaplanner</groupId>
         <artifactId>optaplanner-bom</artifactId>
-        <version>{project-version}</version>
+        <version>{optaplanner-version}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -167,7 +167,7 @@ plugins {
     id "application"
 }
 
-def optaplannerVersion = "{project-version}"
+def optaplannerVersion = "{optaplanner-version}"
 def logbackVersion = "1.2.3"
 
 group = "org.acme"

--- a/optaplanner-docs/src/modules/ROOT/pages/quickstart/quarkus/quarkus-quickstart.adoc
+++ b/optaplanner-docs/src/modules/ROOT/pages/quickstart/quarkus/quarkus-quickstart.adoc
@@ -104,7 +104,7 @@ If you choose Maven, your `pom.xml` file has the following content:
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
     <version.io.quarkus>{quarkus-version}</version.io.quarkus>
-    <version.org.optaplanner>{project-version}</version.org.optaplanner>
+    <version.org.optaplanner>{optaplanner-version}</version.org.optaplanner>
   </properties>
 
   <dependencyManagement>
@@ -192,7 +192,7 @@ plugins {
 }
 
 def quarkusVersion = "{quarkus-version}"
-def optaplannerVersion = "{project-version}"
+def optaplannerVersion = "{optaplanner-version}"
 
 group = "org.acme"
 version = "1.0-SNAPSHOT"

--- a/optaplanner-docs/src/modules/ROOT/pages/quickstart/spring-boot/spring-boot-quickstart.adoc
+++ b/optaplanner-docs/src/modules/ROOT/pages/quickstart/spring-boot/spring-boot-quickstart.adoc
@@ -88,7 +88,7 @@ If you choose Maven, your `pom.xml` file has the following content:
 
     <properties>
         <java.version>{java-version}</java.version>
-        <version.org.optaplanner>{project-version}</version.org.optaplanner>
+        <version.org.optaplanner>{optaplanner-version}</version.org.optaplanner>
     </properties>
 
     <dependencyManagement>
@@ -149,7 +149,7 @@ plugins {
     id "java"
 }
 
-def optaplannerVersion = "{project-version}"
+def optaplannerVersion = "{optaplanner-version}"
 
 group = "org.acme"
 version = "1.0-SNAPSHOT"


### PR DESCRIPTION
<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.
-->

### JIRA
[PLANNER-2570](https://issues.redhat.com/browse/PLANNER-2570)
<!-- Add a JIRA ticket link if it exists. -->
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
* https://github.com/kiegroup/drools/pull/3000
* https://github.com/kiegroup/optaplanner/pull/899
* etc.
-->

### Checklist
- [ ] Documentation updated if applicable.
- [ ] Upgrade recipe provided if applicable.

<details>
<summary>
How to replicate CI configuration locally?
</summary>

We do "simple" maven builds, they are just basically maven commands, but just because we have multiple repositories related between them and one change could affect several of those projects by multiple pull requests, we use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.

[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is not only a github-action tool but a CLI one, so in case you posted multiple pull requests related with this change you can easily reproduce the same build by executing it locally. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>specific pull request build</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] tests</b>
* for a <b>full downstream build</b> 
  * for <b>jenkins</b> job: please add comment: <b>Jenkins run fdb</b>
  * for <b>github actions</b> job: add the label `run_fdb`
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
* for a <b>Quarkus LTS check</b> please add comment: <b>Jenkins run LTS</b>
* for a <b>specific Quarkus LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] LTS</b>
* for a <b>Native check</b> please add comment: <b>Jenkins run native</b>
* for a <b>specific Native LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] native</b>
</details>
