### PR TITLE
Optimize SolutionDescriptor.findEntityDescriptor()

### DIFF
--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/solution/descriptor/SolutionDescriptor.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/solution/descriptor/SolutionDescriptor.java
@@ -39,6 +39,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentMap;
 import java.util.stream.Stream;
@@ -168,7 +169,7 @@ public class SolutionDescriptor<Solution_> {
     private ConstraintConfigurationDescriptor<Solution_> constraintConfigurationDescriptor;
     private final Map<Class<?>, EntityDescriptor<Solution_>> entityDescriptorMap;
     private final List<Class<?>> reversedEntityClassList;
-    private final ConcurrentMap<Class<?>, EntityDescriptor<Solution_>> lowestEntityDescriptorMemoization =
+    private final ConcurrentMap<Class<?>, Optional<EntityDescriptor<Solution_>>> lowestEntityDescriptorMemoization =
             new ConcurrentMemoization<>();
 
     private SolutionCloner<Solution_> solutionCloner;
@@ -202,7 +203,7 @@ public class SolutionDescriptor<Solution_> {
         }
         entityDescriptorMap.put(entityClass, entityDescriptor);
         reversedEntityClassList.add(0, entityClass);
-        lowestEntityDescriptorMemoization.put(entityClass, entityDescriptor);
+        lowestEntityDescriptorMemoization.put(entityClass, Optional.of(entityDescriptor));
     }
 
     public void processAnnotations(DescriptorPolicy descriptorPolicy,
@@ -741,11 +742,11 @@ public class SolutionDescriptor<Solution_> {
             // Reverse order to find the nearest ancestor
             for (Class<?> entityClass : reversedEntityClassList) {
                 if (entityClass.isAssignableFrom(entitySubclass)) {
-                    return entityDescriptorMap.get(entityClass);
+                    return Optional.of(entityDescriptorMap.get(entityClass));
                 }
             }
-            return null;
-        });
+            return Optional.empty();
+        }).orElse(null);
     }
 
     public GenuineVariableDescriptor<Solution_> findGenuineVariableDescriptor(Object entity, String variableName) {


### PR DESCRIPTION
This PR offers one approach to address a trivial performance issue brought up in https://github.com/kiegroup/optaplanner/pull/1698#discussion_r759236750.

Use `Optional.empty()` instead of `null` as a value in the memoization map
to designate that the search for a descriptor has been made and none has
been found. As opposed to `null` meaning the search hasn't been made yet.

This proposal doesn't include the controversial internal API change that exposes `Optional` as the `findEntityDescriptor()` return type. This is simply achieved by returning `null` if the `Optional` representing the result of the lookup is empty.

### Referenced pull requests
Split from #1698.

### Checklist
- [ ] Documentation updated if applicable.
- [ ] Upgrade recipe provided if applicable.

<details>
<summary>
How to replicate CI configuration locally?
</summary>

We do "simple" maven builds, they are just basically maven commands, but just because we have multiple repositories related between them and one change could affect several of those projects by multiple pull requests, we use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.

[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is not only a github-action tool but a CLI one, so in case you posted multiple pull requests related with this change you can easily reproduce the same build by executing it locally. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>specific pull request build</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] tests</b>
* for a <b>full downstream build</b> 
  * for <b>jenkins</b> job: please add comment: <b>Jenkins run fdb</b>
  * for <b>github actions</b> job: add the label `run_fdb`
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
* for a <b>Quarkus LTS check</b> please add comment: <b>Jenkins run LTS</b>
* for a <b>specific Quarkus LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] LTS</b>
* for a <b>Native check</b> please add comment: <b>Jenkins run native</b>
* for a <b>specific Native LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] native</b>
</details>
