### PR TITLE
PLANNER-2598 Simplify how we depend on Kogito

### DIFF
--- a/build/optaplanner-build-parent/pom.xml
+++ b/build/optaplanner-build-parent/pom.xml
@@ -130,31 +130,6 @@
       </dependency>
       <dependency>
         <groupId>org.kie.kogito</groupId>
-        <artifactId>drools-core</artifactId>
-        <version>${version.org.kie.kogito}</version>
-        <exclusions>
-          <exclusion>
-            <groupId>org.kie.kogito</groupId>
-            <artifactId>kogito-timer</artifactId>
-          </exclusion>
-          <exclusion> <!-- OptaPlanner's use of Drools does not require XStream. -->
-            <groupId>com.thoughtworks.xstream</groupId>
-            <artifactId>xstream</artifactId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-      <dependency>
-        <groupId>org.kie.kogito</groupId>
-        <artifactId>drools-compiler</artifactId>
-        <version>${version.org.kie.kogito}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.kie.kogito</groupId>
-        <artifactId>kogito-drools-model</artifactId>
-        <version>${version.org.kie.kogito}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.kie.kogito</groupId>
         <artifactId>kogito-quarkus-rules</artifactId>
         <version>${version.org.kie.kogito}</version>
       </dependency>

--- a/build/optaplanner-build-parent/pom.xml
+++ b/build/optaplanner-build-parent/pom.xml
@@ -132,6 +132,12 @@
         <groupId>org.kie.kogito</groupId>
         <artifactId>kogito-drools</artifactId>
         <version>${version.org.kie.kogito}</version>
+        <exclusions>
+          <exclusion> <!-- We do not need this. -->
+            <groupId>org.kie.kogito</groupId>
+            <artifactId>kogito-ruleunits</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.kie.kogito</groupId>

--- a/build/optaplanner-build-parent/pom.xml
+++ b/build/optaplanner-build-parent/pom.xml
@@ -132,6 +132,16 @@
         <groupId>org.kie.kogito</groupId>
         <artifactId>kogito-drools</artifactId>
         <version>${version.org.kie.kogito}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>com.thoughtworks.xstream</groupId>
+            <artifactId>xstream</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.kie.kogito</groupId>
+            <artifactId>kogito-timer</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.kie.kogito</groupId>

--- a/build/optaplanner-build-parent/pom.xml
+++ b/build/optaplanner-build-parent/pom.xml
@@ -132,12 +132,6 @@
         <groupId>org.kie.kogito</groupId>
         <artifactId>kogito-drools</artifactId>
         <version>${version.org.kie.kogito}</version>
-        <exclusions>
-          <exclusion> <!-- We do not need this. -->
-            <groupId>org.kie.kogito</groupId>
-            <artifactId>kogito-ruleunits</artifactId>
-          </exclusion>
-        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.kie.kogito</groupId>

--- a/build/optaplanner-build-parent/pom.xml
+++ b/build/optaplanner-build-parent/pom.xml
@@ -130,6 +130,11 @@
       </dependency>
       <dependency>
         <groupId>org.kie.kogito</groupId>
+        <artifactId>kogito-drools</artifactId>
+        <version>${version.org.kie.kogito}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.kie.kogito</groupId>
         <artifactId>kogito-quarkus-rules</artifactId>
         <version>${version.org.kie.kogito}</version>
       </dependency>

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/drl-integration-test/pom.xml
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/drl-integration-test/pom.xml
@@ -39,6 +39,15 @@
       <groupId>org.optaplanner</groupId>
       <artifactId>optaplanner-quarkus</artifactId>
     </dependency>
+    <!-- Kogito Drools is necessary to support DRL in Quarkus -->
+    <dependency>
+      <groupId>org.kie.kogito</groupId>
+      <artifactId>kogito-drools</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.kie.kogito</groupId>
+      <artifactId>kogito-legacy-api</artifactId>
+    </dependency>
 
     <!-- test dependencies -->
     <dependency>

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/runtime/pom.xml
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/runtime/pom.xml
@@ -43,12 +43,6 @@
     <dependency>
       <groupId>org.kie.kogito</groupId>
       <artifactId>kogito-drools</artifactId>
-      <exclusions>
-        <exclusion> <!-- We do not need this. -->
-          <groupId>org.kie.kogito</groupId>
-          <artifactId>kogito-ruleunits</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.kie.kogito</groupId>

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/runtime/pom.xml
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/runtime/pom.xml
@@ -33,7 +33,7 @@
         <exclusion>
           <!--
             Dynamic is not compatible with GraalVM native compilation.
-            Replaced with org.kie.kogito:kogito-drools, which brings in org.drools:drools-wiring-static.
+            Replaced with org.drools:drools-wiring-static.
           -->
           <groupId>org.drools</groupId>
           <artifactId>drools-wiring-dynamic</artifactId>
@@ -41,12 +41,18 @@
       </exclusions>
     </dependency>
     <dependency>
+      <groupId>org.drools</groupId>
+      <artifactId>drools-wiring-static</artifactId>
+    </dependency>
+    <dependency> <!-- Optional for when DRL needs to be used. -->
       <groupId>org.kie.kogito</groupId>
       <artifactId>kogito-drools</artifactId>
+      <optional>true</optional>
     </dependency>
-    <dependency>
+    <dependency> <!-- Optional for when DRL needs to be used. -->
       <groupId>org.kie.kogito</groupId>
       <artifactId>kogito-legacy-api</artifactId>
+      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>org.graalvm.nativeimage</groupId>

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/runtime/pom.xml
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/runtime/pom.xml
@@ -33,7 +33,7 @@
         <exclusion>
           <!--
             Dynamic is not compatible with GraalVM native compilation.
-            Replaced with org.drools:drools-wiring-static.
+            Replaced with org.kie.kogito:kogito-drools, which brings in org.drools:drools-wiring-static.
           -->
           <groupId>org.drools</groupId>
           <artifactId>drools-wiring-dynamic</artifactId>
@@ -41,8 +41,14 @@
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>org.drools</groupId>
-      <artifactId>drools-wiring-static</artifactId>
+      <groupId>org.kie.kogito</groupId>
+      <artifactId>kogito-drools</artifactId>
+      <exclusions>
+        <exclusion> <!-- We do not need this. -->
+          <groupId>org.kie.kogito</groupId>
+          <artifactId>kogito-ruleunits</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.kie.kogito</groupId>

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/runtime/pom.xml
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/runtime/pom.xml
@@ -30,35 +30,10 @@
       <groupId>org.optaplanner</groupId>
       <artifactId>optaplanner-core</artifactId>
       <exclusions>
-        <!-- Drools dependencies are replaced with Kogito equivalents. -->
-        <exclusion>
-          <groupId>org.kie</groupId>
-          <artifactId>kie-api</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.kie</groupId>
-          <artifactId>kie-internal</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.drools</groupId>
-          <artifactId>drools-canonical-model</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.drools</groupId>
-          <artifactId>drools-model-compiler</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.drools</groupId>
-          <artifactId>drools-core</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.drools</groupId>
-          <artifactId>drools-compiler</artifactId>
-        </exclusion>
         <exclusion>
           <!--
             Dynamic is not compatible with GraalVM native compilation.
-            org.kie.kogito:drools-core brings in static.
+            Replaced with org.drools:drools-wiring-static.
           -->
           <groupId>org.drools</groupId>
           <artifactId>drools-wiring-dynamic</artifactId>
@@ -66,29 +41,13 @@
       </exclusions>
     </dependency>
     <dependency>
+      <groupId>org.drools</groupId>
+      <artifactId>drools-wiring-static</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.kie.kogito</groupId>
       <artifactId>kogito-legacy-api</artifactId>
-      <exclusions>
-        <!-- See the explanation at optaplanner-core dependency's exclusions above. -->
-        <exclusion>
-          <groupId>org.drools</groupId>
-          <artifactId>drools-core</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
-    <dependency>
-      <groupId>org.kie.kogito</groupId>
-      <artifactId>kogito-drools-model</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.kie.kogito</groupId>
-      <artifactId>drools-core</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.kie.kogito</groupId>
-      <artifactId>drools-compiler</artifactId>
-    </dependency>
-
     <dependency>
       <groupId>org.graalvm.nativeimage</groupId>
       <artifactId>svm</artifactId>


### PR DESCRIPTION
`optaplanner-quarkus` now depends on pure Drools, except for where DRL is necessary, at which point `kogito-rules` is brought in. We can not go any further until we have a Drools Quarkus extension. Mario is aware, but at the moment there are no plans to do that.

Downstream PRs: 
- https://github.com/kiegroup/optaplanner-quickstarts/pull/240
- https://github.com/kiegroup/kogito-apps/pull/1155