### PR TITLE
PLANNER-2582 New ListVariableListener API

### DIFF
--- a/optaplanner-core/src/main/java/org/optaplanner/core/api/domain/variable/BasicVariableListener.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/api/domain/variable/BasicVariableListener.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.core.api.domain.variable;
+
+import org.optaplanner.core.api.domain.entity.PlanningEntity;
+import org.optaplanner.core.api.domain.solution.PlanningSolution;
+import org.optaplanner.core.api.score.director.ScoreDirector;
+
+/**
+ *
+ * @param <Solution_> the solution type, the class with the {@link PlanningSolution} annotation
+ * @param <Entity_> @{@link PlanningEntity} on which the source variable is declared
+ */
+public interface BasicVariableListener<Solution_, Entity_> extends VariableListener<Solution_, Entity_> {
+
+    /**
+     * @param scoreDirector never null
+     * @param entity never null
+     */
+    @Override
+    void beforeVariableChanged(ScoreDirector<Solution_> scoreDirector, Entity_ entity);
+
+    /**
+     * @param scoreDirector never null
+     * @param entity never null
+     */
+    @Override
+    void afterVariableChanged(ScoreDirector<Solution_> scoreDirector, Entity_ entity);
+}

--- a/optaplanner-core/src/main/java/org/optaplanner/core/api/domain/variable/ListVariableListener.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/api/domain/variable/ListVariableListener.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.core.api.domain.variable;
+
+import org.optaplanner.core.api.domain.entity.PlanningEntity;
+import org.optaplanner.core.api.domain.solution.PlanningSolution;
+import org.optaplanner.core.api.score.director.ScoreDirector;
+
+/**
+ *
+ * @param <Solution_> the solution type, the class with the {@link PlanningSolution} annotation
+ * @param <Entity_> @{@link PlanningEntity} on which the source variable is declared
+ */
+public interface ListVariableListener<Solution_, Entity_> extends VariableListener<Solution_, Entity_> {
+
+    /**
+     * @param scoreDirector never null
+     * @param entity never null
+     */
+    void beforeVariableChanged(ScoreDirector<Solution_> scoreDirector, Entity_ entity, Integer index);
+
+    /**
+     * @param scoreDirector never null
+     * @param entity never null
+     */
+    void afterVariableChanged(ScoreDirector<Solution_> scoreDirector, Entity_ entity, Integer index);
+}

--- a/optaplanner-core/src/main/java/org/optaplanner/core/api/domain/variable/VariableListener.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/api/domain/variable/VariableListener.java
@@ -66,13 +66,15 @@ public interface VariableListener<Solution_, Entity_> extends Closeable {
      * @param scoreDirector never null
      * @param entity never null
      */
-    void beforeVariableChanged(ScoreDirector<Solution_> scoreDirector, Entity_ entity);
+    default void beforeVariableChanged(ScoreDirector<Solution_> scoreDirector, Entity_ entity) {
+    }
 
     /**
      * @param scoreDirector never null
      * @param entity never null
      */
-    void afterVariableChanged(ScoreDirector<Solution_> scoreDirector, Entity_ entity);
+    default void afterVariableChanged(ScoreDirector<Solution_> scoreDirector, Entity_ entity) {
+    }
 
     /**
      * @param scoreDirector never null

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/variable/listener/support/VariableListenerNotifiable.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/variable/listener/support/VariableListenerNotifiable.java
@@ -19,9 +19,9 @@ package org.optaplanner.core.impl.domain.variable.listener.support;
 import java.util.ArrayDeque;
 import java.util.Collection;
 import java.util.Iterator;
-import java.util.function.Consumer;
 
 import org.optaplanner.core.api.domain.variable.VariableListener;
+import org.optaplanner.core.api.score.director.ScoreDirector;
 
 public class VariableListenerNotifiable
         implements Comparable<VariableListenerNotifiable>, Iterable<VariableListenerNotification> {
@@ -45,9 +45,9 @@ public class VariableListenerNotifiable
         return variableListener;
     }
 
-    public void addNotification(VariableListenerNotification notification, Consumer<VariableListener> actionIfAdded) {
+    public void addNotification(VariableListenerNotification notification, ScoreDirector<?> scoreDirector) {
         if (notificationQueue.add(notification)) {
-            actionIfAdded.accept(variableListener);
+            notification.notifyBefore(variableListener, scoreDirector);
         }
     }
 

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/variable/listener/support/VariableListenerNotifiable.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/variable/listener/support/VariableListenerNotifiable.java
@@ -18,6 +18,7 @@ package org.optaplanner.core.impl.domain.variable.listener.support;
 
 import java.util.ArrayDeque;
 import java.util.Collection;
+import java.util.function.Consumer;
 
 import org.optaplanner.core.api.domain.variable.VariableListener;
 
@@ -42,12 +43,22 @@ public class VariableListenerNotifiable implements Comparable<VariableListenerNo
         return variableListener;
     }
 
-    public int getGlobalOrder() {
-        return globalOrder;
+    public void addNotification(VariableListenerNotification notification, Consumer<VariableListener> actionIfAdded) {
+        if (notificationQueue.add(notification)) {
+            actionIfAdded.accept(variableListener);
+        }
     }
 
-    public Collection<VariableListenerNotification> getNotificationQueue() {
+    public Iterable<VariableListenerNotification> iterateNotifications() {
         return notificationQueue;
+    }
+
+    public int getNotificationCount() {
+        return notificationQueue.size();
+    }
+
+    public void clearNotifications() {
+        notificationQueue.clear();
     }
 
     @Override

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/variable/listener/support/VariableListenerNotifiable.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/variable/listener/support/VariableListenerNotifiable.java
@@ -18,11 +18,13 @@ package org.optaplanner.core.impl.domain.variable.listener.support;
 
 import java.util.ArrayDeque;
 import java.util.Collection;
+import java.util.Iterator;
 import java.util.function.Consumer;
 
 import org.optaplanner.core.api.domain.variable.VariableListener;
 
-public class VariableListenerNotifiable implements Comparable<VariableListenerNotifiable> {
+public class VariableListenerNotifiable
+        implements Comparable<VariableListenerNotifiable>, Iterable<VariableListenerNotification> {
 
     protected final VariableListener variableListener;
     protected final int globalOrder;
@@ -49,10 +51,6 @@ public class VariableListenerNotifiable implements Comparable<VariableListenerNo
         }
     }
 
-    public Iterable<VariableListenerNotification> iterateNotifications() {
-        return notificationQueue;
-    }
-
     public int getNotificationCount() {
         return notificationQueue.size();
     }
@@ -70,6 +68,11 @@ public class VariableListenerNotifiable implements Comparable<VariableListenerNo
         } else {
             return 0;
         }
+    }
+
+    @Override
+    public Iterator<VariableListenerNotification> iterator() {
+        return notificationQueue.iterator();
     }
 
     @Override

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/variable/listener/support/VariableListenerNotificationType.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/variable/listener/support/VariableListenerNotificationType.java
@@ -18,6 +18,7 @@ package org.optaplanner.core.impl.domain.variable.listener.support;
 
 public enum VariableListenerNotificationType {
     ENTITY_ADDED,
+    LIST_VARIABLE_CHANGED,
     VARIABLE_CHANGED,
     ENTITY_REMOVED;
 }

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/variable/listener/support/VariableListenerSupport.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/variable/listener/support/VariableListenerSupport.java
@@ -193,7 +193,7 @@ public class VariableListenerSupport<Solution_> implements SupplyManager<Solutio
         for (VariableListenerNotifiable notifiable : notifiableList) {
             int notifiedCount = 0;
             VariableListener<Solution_, Object> variableListener = notifiable.getVariableListener();
-            for (VariableListenerNotification notification : notifiable.iterateNotifications()) {
+            for (VariableListenerNotification notification : notifiable) {
                 Object entity = notification.getEntity();
                 switch (notification.getType()) {
                     case ENTITY_ADDED:

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/ListAssignMove.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/ListAssignMove.java
@@ -49,9 +49,9 @@ public class ListAssignMove<Solution_> extends AbstractMove<Solution_> {
     protected void doMoveOnGenuineVariables(ScoreDirector<Solution_> scoreDirector) {
         InnerScoreDirector<Solution_, ?> innerScoreDirector = (InnerScoreDirector<Solution_, ?>) scoreDirector;
         // Add planningValue to destinationEntity's list variable (at destinationIndex).
-        innerScoreDirector.beforeVariableChanged(variableDescriptor, destinationEntity);
+        innerScoreDirector.beforeVariableChanged(variableDescriptor, destinationEntity, destinationIndex);
         variableDescriptor.addElement(destinationEntity, destinationIndex, planningValue);
-        innerScoreDirector.afterVariableChanged(variableDescriptor, destinationEntity);
+        innerScoreDirector.afterVariableChanged(variableDescriptor, destinationEntity, destinationIndex);
     }
 
     @Override

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/ListChangeMove.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/ListChangeMove.java
@@ -118,13 +118,13 @@ public class ListChangeMove<Solution_> extends AbstractMove<Solution_> {
     protected void doMoveOnGenuineVariables(ScoreDirector<Solution_> scoreDirector) {
         InnerScoreDirector<Solution_, ?> innerScoreDirector = (InnerScoreDirector<Solution_, ?>) scoreDirector;
         // Remove element from the source entity.
-        innerScoreDirector.beforeVariableChanged(variableDescriptor, sourceEntity);
+        innerScoreDirector.beforeVariableChanged(variableDescriptor, sourceEntity, sourceIndex);
         Object element = variableDescriptor.removeElement(sourceEntity, sourceIndex);
-        innerScoreDirector.afterVariableChanged(variableDescriptor, sourceEntity);
+        innerScoreDirector.afterVariableChanged(variableDescriptor, sourceEntity, sourceIndex);
         // Add element to the destination entity.
-        innerScoreDirector.beforeVariableChanged(variableDescriptor, destinationEntity);
+        innerScoreDirector.beforeVariableChanged(variableDescriptor, destinationEntity, destinationIndex);
         variableDescriptor.addElement(destinationEntity, destinationIndex, element);
-        innerScoreDirector.afterVariableChanged(variableDescriptor, destinationEntity);
+        innerScoreDirector.afterVariableChanged(variableDescriptor, destinationEntity, destinationIndex);
     }
 
     @Override

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/ListSwapMove.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/ListSwapMove.java
@@ -105,13 +105,13 @@ public class ListSwapMove<Solution_> extends AbstractMove<Solution_> {
         Object leftElement = variableDescriptor.getElement(leftEntity, leftIndex);
         Object rightElement = variableDescriptor.getElement(rightEntity, rightIndex);
 
-        innerScoreDirector.beforeVariableChanged(variableDescriptor, leftEntity);
+        innerScoreDirector.beforeVariableChanged(variableDescriptor, leftEntity, leftIndex);
         variableDescriptor.setElement(leftEntity, leftIndex, rightElement);
-        innerScoreDirector.afterVariableChanged(variableDescriptor, leftEntity);
+        innerScoreDirector.afterVariableChanged(variableDescriptor, leftEntity, leftIndex);
 
-        innerScoreDirector.beforeVariableChanged(variableDescriptor, rightEntity);
+        innerScoreDirector.beforeVariableChanged(variableDescriptor, rightEntity, rightIndex);
         variableDescriptor.setElement(rightEntity, rightIndex, leftElement);
-        innerScoreDirector.afterVariableChanged(variableDescriptor, rightEntity);
+        innerScoreDirector.afterVariableChanged(variableDescriptor, rightEntity, rightIndex);
     }
 
     @Override

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/ListUnassignMove.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/ListUnassignMove.java
@@ -47,9 +47,9 @@ public class ListUnassignMove<Solution_> extends AbstractMove<Solution_> {
     protected void doMoveOnGenuineVariables(ScoreDirector<Solution_> scoreDirector) {
         InnerScoreDirector<Solution_, ?> innerScoreDirector = (InnerScoreDirector<Solution_, ?>) scoreDirector;
         // Remove a planning value from sourceEntity's list variable (at sourceIndex).
-        innerScoreDirector.beforeVariableChanged(variableDescriptor, sourceEntity);
+        innerScoreDirector.beforeVariableChanged(variableDescriptor, sourceEntity, sourceIndex);
         variableDescriptor.removeElement(sourceEntity, sourceIndex);
-        innerScoreDirector.afterVariableChanged(variableDescriptor, sourceEntity);
+        innerScoreDirector.afterVariableChanged(variableDescriptor, sourceEntity, sourceIndex);
     }
 
     @Override

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/AbstractScoreDirector.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/AbstractScoreDirector.java
@@ -409,8 +409,6 @@ public abstract class AbstractScoreDirector<Solution_, Score_ extends Score<Scor
     public void beforeVariableChanged(VariableDescriptor<Solution_> variableDescriptor, Object entity) {
         if (variableDescriptor.isGenuineAndUninitialized(entity)) {
             workingInitScore++;
-        } else if (variableDescriptor.isGenuineListVariable()) {
-            workingInitScore -= ((ListVariableDescriptor<Solution_>) variableDescriptor).getListSize(entity);
         }
         variableListenerSupport.beforeVariableChanged(variableDescriptor, entity);
     }
@@ -419,10 +417,20 @@ public abstract class AbstractScoreDirector<Solution_, Score_ extends Score<Scor
     public void afterVariableChanged(VariableDescriptor<Solution_> variableDescriptor, Object entity) {
         if (variableDescriptor.isGenuineAndUninitialized(entity)) {
             workingInitScore--;
-        } else if (variableDescriptor.isGenuineListVariable()) {
-            workingInitScore += ((ListVariableDescriptor<Solution_>) variableDescriptor).getListSize(entity);
         }
         variableListenerSupport.afterVariableChanged(variableDescriptor, entity);
+    }
+
+    @Override
+    public void beforeVariableChanged(ListVariableDescriptor<Solution_> variableDescriptor, Object entity, Integer index) {
+        workingInitScore -= variableDescriptor.getListSize(entity);
+        variableListenerSupport.beforeListVariableChanged(variableDescriptor, entity, index);
+    }
+
+    @Override
+    public void afterVariableChanged(ListVariableDescriptor<Solution_> variableDescriptor, Object entity, Integer index) {
+        workingInitScore += variableDescriptor.getListSize(entity);
+        variableListenerSupport.afterListVariableChanged(variableDescriptor, entity, index);
     }
 
     @Override

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/InnerScoreDirector.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/InnerScoreDirector.java
@@ -33,6 +33,7 @@ import org.optaplanner.core.api.score.constraint.Indictment;
 import org.optaplanner.core.api.score.director.ScoreDirector;
 import org.optaplanner.core.api.score.stream.Constraint;
 import org.optaplanner.core.impl.domain.solution.descriptor.SolutionDescriptor;
+import org.optaplanner.core.impl.domain.variable.descriptor.ListVariableDescriptor;
 import org.optaplanner.core.impl.domain.variable.descriptor.VariableDescriptor;
 import org.optaplanner.core.impl.domain.variable.supply.SupplyManager;
 import org.optaplanner.core.impl.heuristic.move.Move;
@@ -303,6 +304,11 @@ public interface InnerScoreDirector<Solution_, Score_ extends Score<Score_>>
     void beforeVariableChanged(VariableDescriptor<Solution_> variableDescriptor, Object entity);
 
     void afterVariableChanged(VariableDescriptor<Solution_> variableDescriptor, Object entity);
+
+    // TODO naming: beforeListVariableChanged()?
+    void beforeVariableChanged(ListVariableDescriptor<Solution_> variableDescriptor, Object entity, Integer index);
+
+    void afterVariableChanged(ListVariableDescriptor<Solution_> variableDescriptor, Object entity, Integer index);
 
     void changeVariableFacade(VariableDescriptor<Solution_> variableDescriptor, Object entity, Object newValue);
 

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/DroolsScoreDirector.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/DroolsScoreDirector.java
@@ -31,6 +31,7 @@ import org.optaplanner.core.api.score.constraint.ConstraintMatchTotal;
 import org.optaplanner.core.api.score.constraint.Indictment;
 import org.optaplanner.core.api.score.director.ScoreDirector;
 import org.optaplanner.core.impl.domain.entity.descriptor.EntityDescriptor;
+import org.optaplanner.core.impl.domain.variable.descriptor.ListVariableDescriptor;
 import org.optaplanner.core.impl.domain.variable.descriptor.VariableDescriptor;
 import org.optaplanner.core.impl.score.director.AbstractScoreDirector;
 import org.optaplanner.core.impl.score.holder.AbstractScoreHolder;
@@ -177,9 +178,17 @@ public class DroolsScoreDirector<Solution_, Score_ extends Score<Score_>>
     // public void beforeVariableChanged(VariableDescriptor variableDescriptor, Object entity) // Do nothing
 
     @Override
-    public void afterVariableChanged(VariableDescriptor variableDescriptor, Object entity) {
+    public void afterVariableChanged(VariableDescriptor<Solution_> variableDescriptor, Object entity) {
         update(entity, variableDescriptor.getVariableName());
         super.afterVariableChanged(variableDescriptor, entity);
+    }
+
+    // public void beforeVariableChanged(ListVariableDescriptor variableDescriptor, Object entity, Integer index) // Do nothing
+
+    @Override
+    public void afterVariableChanged(ListVariableDescriptor<Solution_> variableDescriptor, Object entity, Integer index) {
+        update(entity, variableDescriptor.getVariableName());
+        super.afterVariableChanged(variableDescriptor, entity, index);
     }
 
     private void update(Object entity, String variableName) {

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/incremental/IncrementalScoreDirector.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/incremental/IncrementalScoreDirector.java
@@ -177,6 +177,10 @@ public class IncrementalScoreDirector<Solution_, Score_ extends Score<Score_>>
         super.afterVariableChanged(variableDescriptor, entity);
     }
 
+    // TODO
+    // public void beforeVariableChanged(ListVariableDescriptor variableDescriptor, Object entity, Integer index)
+    // public void afterVariableChanged(ListVariableDescriptor variableDescriptor, Object entity, Integer index)
+
     @Override
     public void beforeEntityRemoved(EntityDescriptor<Solution_> entityDescriptor, Object entity) {
         incrementalScoreCalculator.beforeEntityRemoved(entity);

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/stream/BavetConstraintStreamScoreDirector.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/stream/BavetConstraintStreamScoreDirector.java
@@ -136,6 +136,10 @@ public final class BavetConstraintStreamScoreDirector<Solution_, Score_ extends 
         super.afterVariableChanged(variableDescriptor, entity);
     }
 
+    // TODO
+    // public void beforeVariableChanged(ListVariableDescriptor variableDescriptor, Object entity, Integer index)
+    // public void afterVariableChanged(ListVariableDescriptor variableDescriptor, Object entity, Integer index)
+
     // public void beforeEntityRemoved(EntityDescriptor entityDescriptor, Object entity) // Do nothing
 
     @Override

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/stream/DroolsConstraintStreamScoreDirector.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/stream/DroolsConstraintStreamScoreDirector.java
@@ -30,6 +30,7 @@ import org.optaplanner.core.api.score.constraint.Indictment;
 import org.optaplanner.core.api.score.director.ScoreDirector;
 import org.optaplanner.core.impl.domain.entity.descriptor.EntityDescriptor;
 import org.optaplanner.core.impl.domain.solution.descriptor.SolutionDescriptor;
+import org.optaplanner.core.impl.domain.variable.descriptor.ListVariableDescriptor;
 import org.optaplanner.core.impl.domain.variable.descriptor.VariableDescriptor;
 import org.optaplanner.core.impl.score.director.AbstractScoreDirector;
 import org.optaplanner.core.impl.score.inliner.ScoreInliner;
@@ -159,6 +160,14 @@ public final class DroolsConstraintStreamScoreDirector<Solution_, Score_ extends
     public void afterVariableChanged(VariableDescriptor<Solution_> variableDescriptor, Object entity) {
         update(entity);
         super.afterVariableChanged(variableDescriptor, entity);
+    }
+
+    // public void beforeVariableChanged(ListVariableDescriptor variableDescriptor, Object entity, Integer index) // Do nothing
+
+    @Override
+    public void afterVariableChanged(ListVariableDescriptor<Solution_> variableDescriptor, Object entity, Integer index) {
+        update(entity);
+        super.afterVariableChanged(variableDescriptor, entity, index);
     }
 
     // public void beforeEntityRemoved(EntityDescriptor entityDescriptor, Object entity) // Do nothing

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/taskassigning_listvariable/domain/solver/StartTimeUpdatingVariableListener.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/taskassigning_listvariable/domain/solver/StartTimeUpdatingVariableListener.java
@@ -18,13 +18,13 @@ package org.optaplanner.examples.taskassigning_listvariable.domain.solver;
 
 import java.util.Objects;
 
-import org.optaplanner.core.api.domain.variable.VariableListener;
+import org.optaplanner.core.api.domain.variable.ListVariableListener;
 import org.optaplanner.core.api.score.director.ScoreDirector;
 import org.optaplanner.examples.taskassigning_listvariable.domain.Employee;
 import org.optaplanner.examples.taskassigning_listvariable.domain.Task;
 import org.optaplanner.examples.taskassigning_listvariable.domain.TaskAssigningSolution;
 
-public class StartTimeUpdatingVariableListener implements VariableListener<TaskAssigningSolution, Employee> {
+public class StartTimeUpdatingVariableListener implements ListVariableListener<TaskAssigningSolution, Employee> {
 
     @Override
     public void beforeEntityAdded(ScoreDirector<TaskAssigningSolution> scoreDirector, Employee employee) {
@@ -33,17 +33,17 @@ public class StartTimeUpdatingVariableListener implements VariableListener<TaskA
 
     @Override
     public void afterEntityAdded(ScoreDirector<TaskAssigningSolution> scoreDirector, Employee employee) {
-        updateStartTime(scoreDirector, employee);
+        updateStartTime(scoreDirector, employee, null);
     }
 
     @Override
-    public void beforeVariableChanged(ScoreDirector<TaskAssigningSolution> scoreDirector, Employee employee) {
+    public void beforeVariableChanged(ScoreDirector<TaskAssigningSolution> scoreDirector, Employee employee, Integer index) {
         // Do nothing
     }
 
     @Override
-    public void afterVariableChanged(ScoreDirector<TaskAssigningSolution> scoreDirector, Employee employee) {
-        updateStartTime(scoreDirector, employee);
+    public void afterVariableChanged(ScoreDirector<TaskAssigningSolution> scoreDirector, Employee employee, Integer index) {
+        updateStartTime(scoreDirector, employee, index);
     }
 
     @Override
@@ -56,7 +56,7 @@ public class StartTimeUpdatingVariableListener implements VariableListener<TaskA
         // Do nothing
     }
 
-    protected void updateStartTime(ScoreDirector<TaskAssigningSolution> scoreDirector, Employee sourceEmployee) {
+    protected void updateStartTime(ScoreDirector<TaskAssigningSolution> scoreDirector, Employee sourceEmployee, Integer index) {
         if (sourceEmployee.getTasks() == null) {
             return;
         }


### PR DESCRIPTION
### JIRA
https://issues.redhat.com/browse/PLANNER-2582

<details>
<summary>
How to replicate CI configuration locally?
</summary>

We do "simple" maven builds, they are just basically maven commands, but just because we have multiple repositories related between them and one change could affect several of those projects by multiple pull requests, we use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.

[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is not only a github-action tool but a CLI one, so in case you posted multiple pull requests related with this change you can easily reproduce the same build by executing it locally. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>specific pull request build</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] tests</b>
* for a <b>full downstream build</b> 
  * for <b>jenkins</b> job: please add comment: <b>Jenkins run fdb</b>
  * for <b>github actions</b> job: add the label `run_fdb`
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
* for a <b>Quarkus LTS check</b> please add comment: <b>Jenkins run LTS</b>
* for a <b>specific Quarkus LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] LTS</b>
* for a <b>Native check</b> please add comment: <b>Jenkins run native</b>
* for a <b>specific Native LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] native</b>
</details>
