### PR TITLE
Remove non-inclusive words from 7.x

### DIFF
--- a/optaplanner-benchmark/src/main/resources/org/optaplanner/benchmark/impl/report/twitterbootstrap/js/jquery.js
+++ b/optaplanner-benchmark/src/main/resources/org/optaplanner/benchmark/impl/report/twitterbootstrap/js/jquery.js
@@ -1261,7 +1261,7 @@ jQuery.extend({
 			// the count of uncompleted subordinates
 			remaining = length !== 1 || ( subordinate && jQuery.isFunction( subordinate.promise ) ) ? length : 0,
 
-			// the master Deferred. If resolveValues consist of only a single Deferred, just use that.
+			// If resolveValues consist of only a single Deferred, just use that.
 			deferred = remaining === 1 ? subordinate : jQuery.Deferred(),
 
 			// Update function for both resolve and progress values
@@ -1296,7 +1296,7 @@ jQuery.extend({
 			}
 		}
 
-		// if we're not waiting on anything, resolve the master
+		// if we're not waiting on anything, resolve the Deferred
 		if ( !remaining ) {
 			deferred.resolveWith( resolveContexts, resolveValues );
 		}

--- a/optaplanner-core/src/main/java/org/optaplanner/core/api/domain/variable/InverseRelationShadowVariable.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/api/domain/variable/InverseRelationShadowVariable.java
@@ -37,8 +37,8 @@ import org.optaplanner.core.api.solver.Solver;
 public @interface InverseRelationShadowVariable {
 
     /**
-     * In a bidirectional relationship, the shadow side (= the slave side) uses this property
-     * (and nothing else) to declare for which {@link PlanningVariable} (= the master side) it is a shadow.
+     * In a bidirectional relationship, the shadow side (= the follower side) uses this property
+     * (and nothing else) to declare for which {@link PlanningVariable} it is a shadow.
      * <p>
      * Both sides of a bidirectional relationship should be consistent: if A points to B, then B must point to A.
      * <p>

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/variable/inverserelation/InverseRelationShadowVariableDescriptor.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/variable/inverserelation/InverseRelationShadowVariableDescriptor.java
@@ -61,25 +61,25 @@ public class InverseRelationShadowVariableDescriptor<Solution_> extends ShadowVa
         InverseRelationShadowVariable shadowVariableAnnotation = variableMemberAccessor
                 .getAnnotation(InverseRelationShadowVariable.class);
         Class<?> variablePropertyType = getVariablePropertyType();
-        Class<?> masterClass;
+        Class<?> sourceClass;
         if (Collection.class.isAssignableFrom(variablePropertyType)) {
             Type genericType = variableMemberAccessor.getGenericType();
-            masterClass = ConfigUtils.extractCollectionGenericTypeParameter(
+            sourceClass = ConfigUtils.extractCollectionGenericTypeParameter(
                     "entityClass", entityDescriptor.getEntityClass(),
                     variablePropertyType, genericType,
                     InverseRelationShadowVariable.class, variableMemberAccessor.getName());
             singleton = false;
         } else {
-            masterClass = variablePropertyType;
+            sourceClass = variablePropertyType;
             singleton = true;
         }
         EntityDescriptor<Solution_> sourceEntityDescriptor = getEntityDescriptor().getSolutionDescriptor()
-                .findEntityDescriptor(masterClass);
+                .findEntityDescriptor(sourceClass);
         if (sourceEntityDescriptor == null) {
             throw new IllegalArgumentException("The entityClass (" + entityDescriptor.getEntityClass()
                     + ") has a " + InverseRelationShadowVariable.class.getSimpleName()
                     + " annotated property (" + variableMemberAccessor.getName()
-                    + ") with a masterClass (" + masterClass
+                    + ") with a sourceClass (" + sourceClass
                     + ") which is not a valid planning entity.");
         }
         String sourceVariableName = shadowVariableAnnotation.sourceVariableName();

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/mutation/TestGenRemoveRandomBlockMutator.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/mutation/TestGenRemoveRandomBlockMutator.java
@@ -42,13 +42,13 @@ public class TestGenRemoveRandomBlockMutator<T> {
         }
 
         if (removedIndex >= 0) {
-            // last mutation was successful => clear the blacklist
+            // last mutation was successful => clear the denylist
             indexBlacklist.clear();
         }
 
         int blockSize = Math.max(list.size() / blockPortion, 1);
         if (indexBlacklist.size() == list.size() / blockSize && list.size() / blockPortion > 1) {
-            // we've tried all blocks without success => try smaller blocks and clear the blacklist
+            // we've tried all blocks without success => try smaller blocks and clear the denylist
             blockPortion *= 2;
             indexBlacklist.clear();
         }

--- a/optaplanner-docs/src/main/asciidoc/BenchmarkingAndTweaking/BenchmarkingAndTweaking-chapter.adoc
+++ b/optaplanner-docs/src/main/asciidoc/BenchmarkingAndTweaking/BenchmarkingAndTweaking-chapter.adoc
@@ -219,7 +219,7 @@ if it contains malicious data, it can be exploited.
 The `XStreamSolutionFileIO` disables the `XStream` security framework, so it just works out of the box.
 
 If you expose benchmarking in production, use `XStreamSolutionFileIO.getXStream()`
-to enable the security framework and explicitly whitelist all marshalled classes.
+to enable the security framework and explicitly allow all marshalled classes.
 ====
 
 Add XStream annotations (such as ``@XStreamAlias``) on your domain classes to use a less verbose XML format.

--- a/optaplanner-docs/src/main/asciidoc/ShadowVariable/ShadowVariable-chapter.adoc
+++ b/optaplanner-docs/src/main/asciidoc/ShadowVariable/ShadowVariable-chapter.adoc
@@ -44,7 +44,7 @@ So if A references B, then B references A.
 image::ShadowVariable/bidirectionalVariable.png[align="center"]
 
 For a non-chained planning variable, the bi-directional relationship must be a many to one relationship.
-To map a bi-directional relationship between two planning variables, annotate the master side (which is the genuine side) as a normal planning variable:
+To map a bi-directional relationship between two planning variables, annotate the source side (which is the genuine side) as a normal planning variable:
 
 [source,java,options="nowrap"]
 ----


### PR DESCRIPTION
Replaced non-inclusive words according to changes in main

<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.
-->

### JIRA

<!-- Add a JIRA ticket link if it exists. -->
See the https://issues.redhat.com/browse/BAPL-1990 initiative
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
* https://github.com/kiegroup/drools/pull/3000
* https://github.com/kiegroup/optaplanner/pull/899
* etc.
-->

### Checklist
- [ ] Documentation updated if applicable.
- [ ] Upgrade recipe provided if applicable.

<details>
<summary>
How to replicate CI configuration locally?
</summary>

We do "simple" maven builds, they are just basically maven commands, but just because we have multiple repositories related between them and one change could affect several of those projects by multiple pull requests, we use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.

[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is not only a github-action tool but a CLI one, so in case you posted multiple pull requests related with this change you can easily reproduce the same build by executing it locally. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>specific pull request build</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] tests</b>
* for a <b>full downstream build</b> 
  * for <b>jenkins</b> job: please add comment: <b>Jenkins run fdb</b>
  * for <b>github actions</b> job: add the label `run_fdb`
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
* for a <b>Quarkus LTS check</b> please add comment: <b>Jenkins run LTS</b>
* for a <b>specific Quarkus LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] LTS</b>
* for a <b>Native check</b> please add comment: <b>Jenkins run native</b>
* for a <b>specific Native LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] native</b>
</details>
