### PR TITLE
PLANNER-2603 Extract quickstarts from promote

### DIFF
--- a/.ci/jenkins/Jenkinsfile.post-release.temp
+++ b/.ci/jenkins/Jenkinsfile.post-release.temp
@@ -7,8 +7,8 @@ deployProperties = [:]
 pipelineProperties = [:]
 
 String optaplannerRepository = 'optaplanner'
-String vehicleRoutingRepository = 'optaweb-vehicle-routing'
-String employeeRosteringRepository = 'optaweb-employee-rostering'
+String quickstartsRepository = 'optaplanner-quickstarts'
+String stableBranchName = 'stable'
 
 pipeline {
     agent {
@@ -52,162 +52,115 @@ pipeline {
                     if (isRelease()) {
                         // Verify version is set and if on right release branch
                         assert getProjectVersion()
-                        assert getKogitoVersion()
 
                         assert getBuildBranch() == util.getReleaseBranchFromVersion(getProjectVersion())
                     }
+
+                    installGithubCLI()
                 }
             }
         }
 
-        stage('Merge OptaPlanner deploy PR and tag') {
+        stage('Merge OptaPlanner Quickstarts PR and tag') {
+            when {
+                expression { return isRelease() }
+            }
+            steps {
+                script {
+                    dir(quickstartsRepository) {
+                        checkoutRepo(quickstartsRepository)
+                        mergeAndPush(getDeployPrLink(quickstartsRepository))
+                        tagLatest()
+                    }
+                }
+            }
+        }
+
+        stage('Reset Quickstarts stable branch') {
+            when {
+                expression { return isRelease() }
+            }
+            steps {
+                script {
+                    dir(quickstartsRepository) {
+                        checkoutTag(quickstartsRepository, getGitTag(), stableBranchName)
+                        removeJbossNexusFromMavenAndGradle()
+                        commitAndForcePushProtectedBranch(quickstartsRepository, stableBranchName)
+                    }
+                }
+            }
+        }
+
+        stage('Upload OptaPlanner distribution from Quickstarts') {
             when {
                 expression { return isRelease() }
             }
             steps {
                 script {
                     dir(optaplannerRepository) {
-                        checkoutRepo(optaplannerRepository)
-                        mergeAndPush(getDeployPrLink(optaplannerRepository))
-                        tagLatest()
+                        checkoutTag(optaplannerRepository, getProjectVersion(), stableBranchName)
+                        getMavenCommand().withProperty('quickly').withProperty('full').run('clean install')
+                    }
+
+                    getMavenCommand().inDirectory(quickstartsRepository).skipTests(true).withProperty('full').run('clean install')
+                    uploadDistribution(quickstartsRepository)
+                }
+            }
+        }
+
+        stage('Update OptaPlanner website') {
+            when {
+                expression { return isRelease() }
+            }
+            steps {
+                script {
+                    final String websiteRepository = 'optaplanner-website'
+                    String prLink = null
+                    dir("$websiteRepository-bot") {
+                        String prBranchName = createWebsitePrBranch(websiteRepository)
+
+                        // Update versions in links on the website and in the docs.
+                        sh "./build/update-versions.sh ${getProjectVersion()} ${getNextMinorSnapshotVersion(getProjectVersion())}"
+
+                        // Update the XSDs. OptaPlanner must be cloned and build with the full profile before.
+                        String optaplannerRoot = "$WORKSPACE/optaplanner"
+                        String optaplannerWebsiteModule = 'optaplanner-website-root'
+                        String optaplannerWebsiteXsd = "$optaplannerWebsiteModule/content/xsd"
+                        String optaplannerWebsiteDocs = 'optaplanner-website-docs'
+                        sh "cp $optaplannerRoot/optaplanner-core/target/classes/solver.xsd $optaplannerWebsiteXsd/solver/solver-8.xsd"
+                        sh "cp $optaplannerRoot/optaplanner-benchmark/target/classes/benchmark.xsd $optaplannerWebsiteXsd/benchmark/benchmark-8.xsd"
+
+                        // Add changed files, commit, open and merge PR
+                        prLink = commitAndCreatePR("Release OptaPlanner ${getProjectVersion()}",
+                                { sh "git add $optaplannerWebsiteXsd/\\*.xsd $optaplannerWebsiteModule/data/pom.yml $optaplannerWebsiteDocs/antora-playbook.yml" },
+                                prBranchName, 'main')
+                    }
+                    dir(websiteRepository) {
+                        checkoutRepo(websiteRepository, 'main')
+                        mergeAndPush(prLink, 'main')
                     }
                 }
             }
         }
 
-        stage('Merge Optaweb Vehicle Routing deploy PR and tag') {
-            when {
-                expression { return isRelease() }
-            }
-            steps {
-                script {
-                    dir(vehicleRoutingRepository) {
-                        checkoutRepo(vehicleRoutingRepository)
-                        mergeAndPush(getDeployPrLink(vehicleRoutingRepository))
-                        tagLatest()
-                    }
-                }
-            }
-        }
-
-        stage('Merge Optaweb Employee Rostering deploy PR and tag') {
-            when {
-                expression { return isRelease() }
-            }
-            steps {
-                script {
-                    dir(employeeRosteringRepository) {
-                        checkoutRepo(employeeRosteringRepository)
-                        mergeAndPush(getDeployPrLink(employeeRosteringRepository))
-                        tagLatest()
-                    }
-                }
-            }
-        }
-
-        stage('Upload OptaPlanner documentation') {
-            when {
-                expression { return isRelease() }
-            }
-            steps {
-                script {
-                    getMavenCommand().inDirectory(optaplannerRepository).skipTests(true).withProperty('full').run('clean install')
-                    uploadDistribution(optaplannerRepository)
-                }
-            }
-        }
-
-        stage('Upload Vehicle Routing documentation and distribution') {
-            when {
-                expression { return isRelease() }
-            }
-            steps {
-                script {
-                    getMavenCommand().inDirectory(vehicleRoutingRepository).skipTests(true).run('clean install')
-                    uploadDistribution(vehicleRoutingRepository)
-                }
-            }
-        }
-
-        stage('Upload Employee Rostering documentation and distribution') {
-            when {
-                expression { return isRelease() }
-            }
-            steps {
-                script {
-                    getMavenCommand().inDirectory(employeeRosteringRepository).skipTests(true).run('clean install')
-                    uploadDistribution(employeeRosteringRepository)
-                }
-            }
-        }
-
-        stage('Set OptaPlanner next snapshot version') {
+        stage('Set Quickstarts next snapshot version') {
             when {
                 expression { return isRelease() }
             }
             steps {
                 script {
                     String nextMicroSnapshotVersion = getNextMicroSnapshotVersion(getProjectVersion())
+                    String botQuickstartsRepository = "${quickstartsRepository}-bot"
+                    dir(botQuickstartsRepository) {
+                        prepareForPR(quickstartsRepository)
+                        updateQuickstartsVersions(nextMicroSnapshotVersion)
 
-                    dir("${optaplannerRepository}-bot") {
-                        prepareForPR(optaplannerRepository)
-                        String nextSnapshotVersion = getNextMicroSnapshotVersion(getProjectVersion())
-                        maven.mvnVersionsSet(getMavenCommand(), nextSnapshotVersion, true)
-                        maven.mvnSetVersionProperty(getMavenCommand(), 'version.org.kie.kogito', getNextMicroSnapshotVersion(getKogitoVersion()))
-
-                        String prLink = commitAndCreatePR("[${getBuildBranch()}] Update snapshot version to ${nextMicroSnapshotVersion}")
-                        setPipelinePrLink(optaplannerRepository, prLink)
+                        String prLink = commitAndCreatePR(("[${getBuildBranch()}] Update snapshot version to ${nextMicroSnapshotVersion}"))
+                        setPipelinePrLink(quickstartsRepository, prLink)
                     }
-                    dir(optaplannerRepository) {
+                    dir(quickstartsRepository) {
                         sh "git checkout ${getBuildBranch()}"
-                        mergeAndPush(getPipelinePrLink(optaplannerRepository))
-                        runMavenDeploy(getMavenCommand())
-                    }
-                }
-            }
-        }
-
-        stage('Set Optaweb Vehicle Routing next snapshot version') {
-            when {
-                expression { return isRelease() }
-            }
-            steps {
-                script {
-                    String nextMicroSnapshotVersion = getNextMicroSnapshotVersion(getProjectVersion())
-                    dir("$vehicleRoutingRepository-bot") {
-                        prepareForPR(vehicleRoutingRepository)
-                        maven.mvnVersionsUpdateParentAndChildModules(nextMicroSnapshotVersion, true)
-
-                        String prLink = commitAndCreatePR("[${getBuildBranch()}] Update snapshot version to ${nextMicroSnapshotVersion}")
-                        setPipelinePrLink(vehicleRoutingRepository, prLink)
-                    }
-                    dir(vehicleRoutingRepository) {
-                        sh "git checkout ${getBuildBranch()}"
-                        mergeAndPush(getPipelinePrLink(vehicleRoutingRepository))
-                        runMavenDeploy(getMavenCommand())
-                    }
-                }
-            }
-        }
-
-        stage('Set Optaweb Employee Rostering next snapshot version') {
-            when {
-                expression { return isRelease() }
-            }
-            steps {
-                script {
-                    String nextMicroSnapshotVersion = getNextMicroSnapshotVersion(getProjectVersion())
-                    dir("$employeeRosteringRepository-bot") {
-                        prepareForPR(employeeRosteringRepository)
-                        maven.mvnVersionsUpdateParentAndChildModules(nextMicroSnapshotVersion, true)
-
-                        String prLink = commitAndCreatePR("[${getBuildBranch()}] Update snapshot version to ${nextMicroSnapshotVersion}")
-                        setPipelinePrLink(employeeRosteringRepository, prLink)
-                    }
-                    dir(employeeRosteringRepository) {
-                        sh "git checkout ${getBuildBranch()}"
-                        mergeAndPush(getPipelinePrLink(employeeRosteringRepository))
-                        runMavenDeploy(getMavenCommand())
+                        mergeAndPush(getPipelinePrLink(quickstartsRepository))
                     }
                 }
             }
@@ -289,10 +242,6 @@ String getProjectVersion() {
     return getParamOrDeployProperty('PROJECT_VERSION', 'project.version')
 }
 
-String getKogitoVersion() {
-    return getParamOrDeployProperty('KOGITO_VERSION', 'kogito.version')
-}
-
 String getNextMicroSnapshotVersion(String currentVersion) {
     return util.getNextVersion(currentVersion, 'micro')
 }
@@ -352,7 +301,7 @@ void checkoutRepo(String repo) {
     checkoutRepo(repo, getBuildBranch())
 }
 
-void checkoutTag(String repo, String tagName, String localBranchName) {
+void checkoutTag(String repo, String tagName, String localBranchName = tagName) {
     deleteDir()
     checkout(githubscm.resolveRepository(repo, getGitAuthor(), getBuildBranch(), false))
     // Need to manually checkout branch since we are in 'detached HEAD' state after the git checkout command.
@@ -390,11 +339,42 @@ String commitAndCreatePR(String commitMsg, Closure precommit, String localBranch
     return githubscm.createPR(commitMsg, prBody, targetBranch, getBotAuthorCredsID())
 }
 
+void commitAndForcePushProtectedBranch(String repo, String branch) {
+    githubscm.commitChanges("[${getBuildBranch()}] Update ${branch} to ${getProjectVersion()}", {
+        githubscm.findAndStageNotIgnoredFiles('pom.xml')
+        githubscm.findAndStageNotIgnoredFiles('build.gradle')
+    })
+    try {
+        forcePushProtectedBranch(repo, branch)
+    }
+    catch (exception) {
+        println "[ERROR] Force push branch: ${branch} from repo : ${repo} failed with exception: ${exception}"
+        currentBuild.result = 'UNSTABLE'
+    }
+}
+
 String commitAndCreatePR(String commitMsg) {
     return commitAndCreatePR(commitMsg, {
         githubscm.findAndStageNotIgnoredFiles('pom.xml')
         githubscm.findAndStageNotIgnoredFiles('build.gradle')
     }, getSnapshotBranch(), getBuildBranch())
+}
+
+String createWebsitePrBranch(String websiteRepository) {
+    checkoutRepo(websiteRepository, 'main') // there is no other branch
+    githubscm.forkRepo(getBotAuthorCredsID())
+    String prBranchName = "${getProjectVersion().toLowerCase()}-${env.BOT_BRANCH_HASH}"
+    githubscm.createBranch(prBranchName)
+    return prBranchName
+}
+
+void installGithubCLI() {
+    sh """
+    wget https://github.com/cli/cli/releases/download/v${env.GITHUB_CLI_VERSION}/gh_${env.GITHUB_CLI_VERSION}_linux_amd64.tar.gz
+    tar xzf gh_${env.GITHUB_CLI_VERSION}_linux_amd64.tar.gz
+    mv gh_${env.GITHUB_CLI_VERSION}_linux_amd64/bin/gh .
+    rm -r gh_${env.GITHUB_CLI_VERSION}_linux_amd64*
+    """
 }
 
 void uploadDistribution(String directory) {
@@ -444,6 +424,10 @@ void removeJbossNexusFromMavenAndGradle() {
             'cat', returnStdout: true)
 }
 
+String getGhCredsID() {
+    return env.GITHUB_TOKEN_CREDS_ID
+}
+
 //maps git branch protection response json into update request body to rewrite branch protection
 String getProtectionMapScript() {
     return "if .restrictions == null then . + {\"restrictions_used\":null}  " + //upd user set restrictions if not empty
@@ -454,4 +438,102 @@ String getProtectionMapScript() {
                 "\"enforce_admins\":(.enforce_admins.enabled)," +
                 " \"restrictions\":.restrictions_used" +
             '}'
+}
+
+def enableForcePushes(String repo, String protectedBranch) {
+    if (isBranchProtected(repo, protectedBranch)) {
+        setAllowForcePushes(repo, protectedBranch, 'true')
+    }
+}
+
+def disableForcePushes(String repo, String protectedBranch) {
+    if (isBranchProtected(repo, protectedBranch)) {
+        setAllowForcePushes(repo, protectedBranch, 'false')
+    }
+}
+
+boolean isBranchProtected(String repo, String protectedBranch, String ghPath = '../gh') {
+    assertGithubCLI(ghPath)
+    boolean isProtected = true // Suppose it is protected by default
+    withCredentials([string(credentialsId: getGhCredsID(), variable: 'GITHUB_TOKEN')]) {
+        // get current branch protection
+        int status = sh (script: "${ghPath} api 'repos/${getGitAuthor()}/${repo}/branches/${protectedBranch}/protection'", returnStatus: true)
+        isProtected = status == 0
+    }
+    return isProtected
+}
+
+def setAllowForcePushes(String repo, String protectedBranch, String enabled, String ghPath = '../gh') {
+    assertGithubCLI(ghPath)
+    //Use separate admin token credentials
+    withCredentials([string(credentialsId: getGhCredsID(), variable: 'GITHUB_TOKEN')]) {
+        //get current branch protection and remove allow force push
+        sh "${ghPath} api 'repos/${getGitAuthor()}/${repo}/branches/${protectedBranch}/protection' | " +
+                "jq 'del(.allow_force_pushes)' > protectionBefore.json"
+
+        //create new json based on current protection mapped as parameters
+        sh "jq \"${getProtectionMapScript()}\" protectionBefore.json | " +
+                "jq \". + {\"allow_force_pushes\":${enabled}}\" > protectionParameters.json"
+
+        //update protection on git
+        def allowForcePushEnabled = sh(script:
+                "${ghPath} api -XPUT 'repos/${getGitAuthor()}/${repo}/branches/${protectedBranch}/protection' " +
+                        '--input protectionParameters.json |' +
+                        " jq '.allow_force_pushes.enabled'", returnStdout: true).trim()
+        assert allowForcePushEnabled == enabled
+
+        //check that protection didn't changed except for allow_force_pushes
+        sh "${ghPath} api 'repos/${getGitAuthor()}/${repo}/branches/${protectedBranch}/protection' | " +
+                "jq 'del(.allow_force_pushes)' > protectionAfter.json"
+        def differences = sh(script: 'diff protectionBefore.json protectionAfter.json | cat', returnStdout: true)
+        if (differences) {
+            error 'Protection settings lost' +
+                    '\nBefore: ' +
+                    "\n${readFile 'protectionBefore.json'} " +
+                    '\nAfter: ' +
+                    "\n${readFile 'protectionAfter.json'} " +
+                    '\nDifferences: ' +
+                    "\n${differences} " +
+                    '\nProtection parameters: ' +
+                    "\n${readFile 'protectionParameters.json'} " +
+                    'Please rollback to Before state and update getProtectionMapScript'
+        }
+        //cleanup workspace
+        sh 'rm -f protectionParameters.json protectionBefore.json protectionAfter.json'
+    }
+}
+
+def forcePushProtectedBranch(String repo, String protectedBranch) {
+    enableForcePushes(repo, protectedBranch)
+    withCredentials([usernamePassword(credentialsId: getGitAuthorCredsID(), usernameVariable: 'GIT_USERNAME', passwordVariable: 'GIT_PASSWORD')]) {
+        // Please leave the double-quote here. They are mandatory for the shell command to work correctly.
+        sh """
+            git config --local credential.helper \"!f() { echo username=\\$GIT_USERNAME; echo password=\\$GIT_PASSWORD; }; f\"
+            git push origin ${protectedBranch} --force
+        """
+    }
+    disableForcePushes(repo, protectedBranch)
+}
+
+void gradleVersionsUpdate(String newVersion) {
+    sh "find . -name build.gradle -exec sed -i -E 's/def optaplannerVersion = \"[^\"\\s]+\"/def optaplannerVersion = \"${newVersion}\"/' {} \\;"
+}
+
+void updateQuickstartsVersions(String newVersion) {
+    maven.mvnSetVersionProperty('version.org.optaplanner', newVersion)
+    maven.mvnVersionsUpdateParentAndChildModules(newVersion, true)
+    gradleVersionsUpdate(newVersion)
+
+    assert !sh(script:
+            "grep -Rn \"${getProjectVersion()}\" --include={pom.xml,build.gradle} | " +
+             'cat', returnStdout: true)
+}
+
+void assertGithubCLI(String ghPath) {
+    if (fileExists(ghPath)) {
+        echo "[INFO] gh found at $ghPath"
+    }
+    else {
+        error "gh not found at $ghPath"
+    }
 }

--- a/.ci/jenkins/Jenkinsfile.post-release.temp
+++ b/.ci/jenkins/Jenkinsfile.post-release.temp
@@ -61,21 +61,6 @@ pipeline {
             }
         }
 
-        stage('Merge OptaPlanner Quickstarts PR and tag') {
-            when {
-                expression { return isRelease() }
-            }
-            steps {
-                script {
-                    dir(quickstartsRepository) {
-                        checkoutRepo(quickstartsRepository)
-                        mergeAndPush(getDeployPrLink(quickstartsRepository))
-                        tagLatest()
-                    }
-                }
-            }
-        }
-
         stage('Reset Quickstarts stable branch') {
             when {
                 expression { return isRelease() }
@@ -138,29 +123,6 @@ pipeline {
                     dir(websiteRepository) {
                         checkoutRepo(websiteRepository, 'main')
                         mergeAndPush(prLink, 'main')
-                    }
-                }
-            }
-        }
-
-        stage('Set Quickstarts next snapshot version') {
-            when {
-                expression { return isRelease() }
-            }
-            steps {
-                script {
-                    String nextMicroSnapshotVersion = getNextMicroSnapshotVersion(getProjectVersion())
-                    String botQuickstartsRepository = "${quickstartsRepository}-bot"
-                    dir(botQuickstartsRepository) {
-                        prepareForPR(quickstartsRepository)
-                        updateQuickstartsVersions(nextMicroSnapshotVersion)
-
-                        String prLink = commitAndCreatePR(("[${getBuildBranch()}] Update snapshot version to ${nextMicroSnapshotVersion}"))
-                        setPipelinePrLink(quickstartsRepository, prLink)
-                    }
-                    dir(quickstartsRepository) {
-                        sh "git checkout ${getBuildBranch()}"
-                        mergeAndPush(getPipelinePrLink(quickstartsRepository))
                     }
                 }
             }
@@ -517,16 +479,6 @@ def forcePushProtectedBranch(String repo, String protectedBranch) {
 
 void gradleVersionsUpdate(String newVersion) {
     sh "find . -name build.gradle -exec sed -i -E 's/def optaplannerVersion = \"[^\"\\s]+\"/def optaplannerVersion = \"${newVersion}\"/' {} \\;"
-}
-
-void updateQuickstartsVersions(String newVersion) {
-    maven.mvnSetVersionProperty('version.org.optaplanner', newVersion)
-    maven.mvnVersionsUpdateParentAndChildModules(newVersion, true)
-    gradleVersionsUpdate(newVersion)
-
-    assert !sh(script:
-            "grep -Rn \"${getProjectVersion()}\" --include={pom.xml,build.gradle} | " +
-             'cat', returnStdout: true)
 }
 
 void assertGithubCLI(String ghPath) {

--- a/.ci/jenkins/Jenkinsfile.promote
+++ b/.ci/jenkins/Jenkinsfile.promote
@@ -9,6 +9,7 @@ pipelineProperties = [:]
 String optaplannerRepository = 'optaplanner'
 String vehicleRoutingRepository = 'optaweb-vehicle-routing'
 String employeeRosteringRepository = 'optaweb-employee-rostering'
+String quickstartsRepository = 'optaplanner-quickstarts'
 
 pipeline {
     agent {
@@ -99,6 +100,21 @@ pipeline {
                     dir(employeeRosteringRepository) {
                         checkoutRepo(employeeRosteringRepository)
                         mergeAndPush(getDeployPrLink(employeeRosteringRepository))
+                        tagLatest()
+                    }
+                }
+            }
+        }
+
+        stage('Merge OptaPlanner Quickstarts PR and tag') {
+            when {
+                expression { return isRelease() }
+            }
+            steps {
+                script {
+                    dir(quickstartsRepository) {
+                        checkoutRepo(quickstartsRepository)
+                        mergeAndPush(getDeployPrLink(quickstartsRepository))
                         tagLatest()
                     }
                 }
@@ -208,6 +224,29 @@ pipeline {
                         sh "git checkout ${getBuildBranch()}"
                         mergeAndPush(getPipelinePrLink(employeeRosteringRepository))
                         runMavenDeploy(getMavenCommand())
+                    }
+                }
+            }
+        }
+
+        stage('Set Quickstarts next snapshot version') {
+            when {
+                expression { return isRelease() }
+            }
+            steps {
+                script {
+                    String nextMicroSnapshotVersion = getNextMicroSnapshotVersion(getProjectVersion())
+                    String botQuickstartsRepository = "${quickstartsRepository}-bot"
+                    dir(botQuickstartsRepository) {
+                        prepareForPR(quickstartsRepository)
+                        updateQuickstartsVersions(nextMicroSnapshotVersion)
+
+                        String prLink = commitAndCreatePR(("[${getBuildBranch()}] Update snapshot version to ${nextMicroSnapshotVersion}"))
+                        setPipelinePrLink(quickstartsRepository, prLink)
+                    }
+                    dir(quickstartsRepository) {
+                        sh "git checkout ${getBuildBranch()}"
+                        mergeAndPush(getPipelinePrLink(quickstartsRepository))
                     }
                 }
             }
@@ -434,24 +473,12 @@ void runMavenDeploy(MavenCommand mvnCmd) {
     }
 }
 
-void removeJbossNexusFromMavenAndGradle() {
-    sh "find . -name pom.xml -print0 | xargs -0 sed -i \':a;N;\$!ba;s/\\n *<repositories>.*<\\/repositories>//g\'"
-    sh "find . -name build.gradle -print0 | xargs -0 sed -i \':a;N;\$!ba;s/\\n *maven {[^{}]*mavenContent " +
-            "{[^{}]*snapshotsOnly[^{}]*}[^{}]*}//g\'"
+void updateQuickstartsVersions(String newVersion) {
+    maven.mvnSetVersionProperty('version.org.optaplanner', newVersion)
+    maven.mvnVersionsUpdateParentAndChildModules(newVersion, true)
+    gradleVersionsUpdate(newVersion)
 
-    assert !sh (script:
-            'grep -Rn "repository.jboss.org" --include={pom.xml,build.gradle} | ' +
-            'cat', returnStdout: true)
-}
-
-//maps git branch protection response json into update request body to rewrite branch protection
-String getProtectionMapScript() {
-    return "if .restrictions == null then . + {\"restrictions_used\":null}  " + //upd user set restrictions if not empty
-            "else . + {\"restrictions_used\":{\"users\":[.restrictions.users[].login], \"team\":[.restrictions.users[].slug]}} end |" +
-            ' {' +
-                "\"required_status_checks\": .required_status_checks," +
-                "\"required_pull_request_reviews\": .required_pull_request_reviews," +
-                "\"enforce_admins\":(.enforce_admins.enabled)," +
-                " \"restrictions\":.restrictions_used" +
-            '}'
+    assert !sh(script:
+            "grep -Rn \"${getProjectVersion()}\" --include={pom.xml,build.gradle} | " +
+             'cat', returnStdout: true)
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/PLANNER-2603

Another PR will come with some testing and corrections done on `Jenkins.post-release.temp` file. For now, no other job will be created. I created this file to keep an idea of what should be done and just save the work as the file might not be that different from the temp one.

<details>
<summary>
How to replicate CI configuration locally?
</summary>

We do "simple" maven builds, they are just basically maven commands, but just because we have multiple repositories related between them and one change could affect several of those projects by multiple pull requests, we use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.

[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is not only a github-action tool but a CLI one, so in case you posted multiple pull requests related with this change you can easily reproduce the same build by executing it locally. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>specific pull request build</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] tests</b>
* for a <b>full downstream build</b> 
  * for <b>jenkins</b> job: please add comment: <b>Jenkins run fdb</b>
  * for <b>github actions</b> job: add the label `run_fdb`
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
* for a <b>Quarkus LTS check</b> please add comment: <b>Jenkins run LTS</b>
* for a <b>specific Quarkus LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] LTS</b>
* for a <b>Native check</b> please add comment: <b>Jenkins run native</b>
* for a <b>specific Native LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] native</b>
</details>
