### PR TITLE
Single source asciidoc attributes

### DIFF
--- a/optaplanner-docs/src/modules/ROOT/pages/_attributes.adoc
+++ b/optaplanner-docs/src/modules/ROOT/pages/_attributes.adoc
@@ -1,0 +1,5 @@
+:quickstartsCloneUrl: https://github.com/kiegroup/optaplanner-quickstarts
+:quickstartsArchiveUrl: https://www.optaplanner.org/download/download.html
+:helloWorldJavaQuickstartUrl: https://github.com/kiegroup/optaplanner-quickstarts/tree/stable/hello-world
+:springBootQuickstartUrl: https://github.com/kiegroup/optaplanner-quickstarts/tree/stable/technology/java-spring-boot
+:quarkusQuickstartUrl: https://github.com/kiegroup/optaplanner-quickstarts/tree/stable/use-cases/school-timetabling

--- a/optaplanner-docs/src/modules/ROOT/pages/_attributes.adoc
+++ b/optaplanner-docs/src/modules/ROOT/pages/_attributes.adoc
@@ -1,5 +1,6 @@
-:quickstartsCloneUrl: https://github.com/kiegroup/optaplanner-quickstarts
-:quickstartsArchiveUrl: https://www.optaplanner.org/download/download.html
-:helloWorldJavaQuickstartUrl: https://github.com/kiegroup/optaplanner-quickstarts/tree/stable/hello-world
-:springBootQuickstartUrl: https://github.com/kiegroup/optaplanner-quickstarts/tree/stable/technology/java-spring-boot
-:quarkusQuickstartUrl: https://github.com/kiegroup/optaplanner-quickstarts/tree/stable/use-cases/school-timetabling
+// Attributes derived from the maven build, typically versions, are defined in the pom.xml and antora-template.yml.
+:quickstarts-clone-url: https://github.com/kiegroup/optaplanner-quickstarts
+:quickstarts-archive-url: https://www.optaplanner.org/download/download.html
+:hello-world-java-quickstart-url: https://github.com/kiegroup/optaplanner-quickstarts/tree/stable/hello-world
+:spring-boot-quickstart-url: https://github.com/kiegroup/optaplanner-quickstarts/tree/stable/technology/java-spring-boot
+:quarkus-quickstart-url: https://github.com/kiegroup/optaplanner-quickstarts/tree/stable/use-cases/school-timetabling

--- a/optaplanner-docs/src/modules/ROOT/pages/quickstart/hello-world/hello-world-quickstart.adoc
+++ b/optaplanner-docs/src/modules/ROOT/pages/quickstart/hello-world/hello-world-quickstart.adoc
@@ -63,12 +63,12 @@ Alternatively, review the completed example:
 +
 [source,shell,subs=attributes+]
 ----
-$ git clone {quickstartsCloneUrl}
+$ git clone {quickstarts-clone-url}
 ----
 +
-.. Download an {quickstartsArchiveUrl}[archive].
+.. Download an {quickstarts-archive-url}[archive].
 
-. Find the solution in {helloWorldJavaQuickstartUrl}[the `hello-world` directory].
+. Find the solution in {hello-world-java-quickstart-url}[the `hello-world` directory].
 . Follow the instructions in the README file to run the application.
 
 == Prerequisites
@@ -579,7 +579,7 @@ Congratulations!
 You have just developed a Java application with https://www.optaplanner.org/[OptaPlanner]!
 
 If you ran into any issues,
-take a look at {helloWorldJavaQuickstartUrl}[the quickstart source code].
+take a look at {hello-world-java-quickstart-url}[the quickstart source code].
 
 Read the next guide to build a pretty web application for school timetabling
 with a REST service and database integration, by leveraging Quarkus.

--- a/optaplanner-docs/src/modules/ROOT/pages/quickstart/hello-world/hello-world-quickstart.adoc
+++ b/optaplanner-docs/src/modules/ROOT/pages/quickstart/hello-world/hello-world-quickstart.adoc
@@ -4,9 +4,7 @@
 :imagesdir: ../..
 :sectnums:
 :icons: font
-:quickstartsCloneUrl: https://github.com/kiegroup/optaplanner-quickstarts
-:quickstartsArchiveUrl: https://www.optaplanner.org/download/download.html
-:helloWorldJavaQuickstartUrl: https://github.com/kiegroup/optaplanner-quickstarts/tree/stable/hello-world
+include::../../_attributes.adoc[]
 
 This guide walks you through the process of creating a simple Java application
 with https://www.optaplanner.org/[OptaPlanner]'s constraint solving Artificial Intelligence (AI).

--- a/optaplanner-docs/src/modules/ROOT/pages/quickstart/quarkus/quarkus-quickstart.adoc
+++ b/optaplanner-docs/src/modules/ROOT/pages/quickstart/quarkus/quarkus-quickstart.adoc
@@ -46,12 +46,12 @@ Alternatively, you can also skip right to the completed example:
 +
 [source,shell,subs=attributes+]
 ----
-$ git clone {quickstartsCloneUrl}
+$ git clone {quickstarts-clone-url}
 ----
 +
-or download an {quickstartsArchiveUrl}[archive].
+or download an {quickstarts-archive-url}[archive].
 
-. Find the solution in {quarkusQuickstartUrl}[the `use-cases` directory]
+. Find the solution in {quarkus-quickstart-url}[the `use-cases` directory]
 and run it (see its README file).
 
 == Prerequisites
@@ -731,4 +731,4 @@ public class TimeTableResourceTest {
 
 . Build an attractive web UI on top of these REST methods to visualize the timetable.
 
-Take a look at {quarkusQuickstartUrl}[the quickstart source code] to see how this all turns out.
+Take a look at {quarkus-quickstart-url}[the quickstart source code] to see how this all turns out.

--- a/optaplanner-docs/src/modules/ROOT/pages/quickstart/quarkus/quarkus-quickstart.adoc
+++ b/optaplanner-docs/src/modules/ROOT/pages/quickstart/quarkus/quarkus-quickstart.adoc
@@ -4,9 +4,7 @@
 :imagesdir: ../..
 :sectnums:
 :icons: font
-:quickstartsCloneUrl: https://github.com/kiegroup/optaplanner-quickstarts
-:quickstartsArchiveUrl: https://www.optaplanner.org/download/download.html
-:quarkusQuickstartUrl: https://github.com/kiegroup/optaplanner-quickstarts/tree/stable/use-cases/school-timetabling
+include::../../_attributes.adoc[]
 
 // Keep this in sync with the quarkus repo's copy
 // https://github.com/quarkusio/quarkus/blob/main/docs/src/main/asciidoc/optaplanner.adoc

--- a/optaplanner-docs/src/modules/ROOT/pages/quickstart/spring-boot/spring-boot-quickstart.adoc
+++ b/optaplanner-docs/src/modules/ROOT/pages/quickstart/spring-boot/spring-boot-quickstart.adoc
@@ -44,12 +44,12 @@ Alternatively, you can also skip right to the completed example:
 +
 [source,shell,subs=attributes+]
 ----
-$ git clone {quickstartsCloneUrl}
+$ git clone {quickstarts-clone-url}
 ----
 +
-or download an {quickstartsArchiveUrl}[archive].
+or download an {quickstarts-archive-url}[archive].
 
-. Find the solution in {springBootQuickstartUrl}[the `technology` directory]
+. Find the solution in {spring-boot-quickstart-url}[the `technology` directory]
 and run it (see its README file).
 
 == Prerequisites
@@ -656,4 +656,4 @@ public class TimeTableControllerTest {
 
 . Build an attractive web UI on top of these REST methods to visualize the timetable.
 
-Take a look at {springBootQuickstartUrl}[the quickstart source code] to see how this all turns out.
+Take a look at {spring-boot-quickstart-url}[the quickstart source code] to see how this all turns out.

--- a/optaplanner-docs/src/modules/ROOT/pages/quickstart/spring-boot/spring-boot-quickstart.adoc
+++ b/optaplanner-docs/src/modules/ROOT/pages/quickstart/spring-boot/spring-boot-quickstart.adoc
@@ -4,9 +4,8 @@
 :imagesdir: ../..
 :sectnums:
 :icons: font
-:quickstartsCloneUrl: https://github.com/kiegroup/optaplanner-quickstarts
-:quickstartsArchiveUrl: https://www.optaplanner.org/download/download.html
-:springBootQuickstartUrl: https://github.com/kiegroup/optaplanner-quickstarts/tree/stable/technology/java-spring-boot
+include::../../_attributes.adoc[]
+
 
 // Keep this in sync with quarkus-quickstart.adoc where applicable
 


### PR DESCRIPTION
Moving quickstarts-related attributes to a single .adoc file.
<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.
-->

### JIRA

<!-- Add a JIRA ticket link if it exists. -->
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
* https://github.com/kiegroup/drools/pull/3000
* https://github.com/kiegroup/optaplanner/pull/899
* etc.
-->

### Checklist
- [ ] Documentation updated if applicable.
- [ ] Upgrade recipe provided if applicable.

<details>
<summary>
How to replicate CI configuration locally?
</summary>

We do "simple" maven builds, they are just basically maven commands, but just because we have multiple repositories related between them and one change could affect several of those projects by multiple pull requests, we use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.

[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is not only a github-action tool but a CLI one, so in case you posted multiple pull requests related with this change you can easily reproduce the same build by executing it locally. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>specific pull request build</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] tests</b>
* for a <b>full downstream build</b> 
  * for <b>jenkins</b> job: please add comment: <b>Jenkins run fdb</b>
  * for <b>github actions</b> job: add the label `run_fdb`
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
* for a <b>Quarkus LTS check</b> please add comment: <b>Jenkins run LTS</b>
* for a <b>specific Quarkus LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] LTS</b>
* for a <b>Native check</b> please add comment: <b>Jenkins run native</b>
* for a <b>specific Native LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] native</b>
</details>
