### PR TITLE
[1.15.x] Bump Quarkus version to 2.6.0.final

### DIFF
--- a/build/optaplanner-build-parent/pom.xml
+++ b/build/optaplanner-build-parent/pom.xml
@@ -25,7 +25,7 @@
     <!-- Normal dependency versions -->
     <version.ch.qos.logback>1.2.8</version.ch.qos.logback>
     <version.com.thoughtworks.xstream>1.4.18</version.com.thoughtworks.xstream>
-    <version.io.quarkus>2.6.0.CR1</version.io.quarkus>
+    <version.io.quarkus>2.6.0.Final</version.io.quarkus>
     <version.org.apache.commons.math3>3.6.1</version.org.apache.commons.math3>
     <version.org.apache.commons.text>1.9</version.org.apache.commons.text>
     <version.org.apache.poi>4.1.2</version.org.apache.poi>

--- a/build/optaplanner-build-parent/pom.xml
+++ b/build/optaplanner-build-parent/pom.xml
@@ -25,7 +25,7 @@
     <!-- Normal dependency versions -->
     <version.ch.qos.logback>1.2.8</version.ch.qos.logback>
     <version.com.thoughtworks.xstream>1.4.18</version.com.thoughtworks.xstream>
-    <version.io.quarkus>2.5.1.Final</version.io.quarkus>
+    <version.io.quarkus>2.6.0.CR1</version.io.quarkus>
     <version.org.apache.commons.math3>3.6.1</version.org.apache.commons.math3>
     <version.org.apache.commons.text>1.9</version.org.apache.commons.text>
     <version.org.apache.poi>4.1.2</version.org.apache.poi>


### PR DESCRIPTION
cherry-pick: https://github.com/kiegroup/optaplanner/pull/1717

PRs:
- https://github.com/kiegroup/kogito-runtimes/pull/1799
- https://github.com/kiegroup/optaplanner/pull/1730
- https://github.com/kiegroup/kogito-apps/pull/1167
- https://github.com/kiegroup/kogito-examples/pull/1043
- https://github.com/kiegroup/optaplanner-quickstarts/pull/246