### PR TITLE
PLANNER-2611: Fix rare race condition in DefaultSolverJob terminateEarly

### DIFF
--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/solver/DefaultSolverJob.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/solver/DefaultSolverJob.java
@@ -31,9 +31,7 @@ import org.optaplanner.core.api.domain.solution.PlanningSolution;
 import org.optaplanner.core.api.solver.Solver;
 import org.optaplanner.core.api.solver.SolverJob;
 import org.optaplanner.core.api.solver.SolverStatus;
-import org.optaplanner.core.impl.phase.event.PhaseLifecycleListener;
-import org.optaplanner.core.impl.phase.scope.AbstractPhaseScope;
-import org.optaplanner.core.impl.phase.scope.AbstractStepScope;
+import org.optaplanner.core.impl.phase.event.PhaseLifecycleListenerAdapter;
 import org.optaplanner.core.impl.solver.scope.SolverScope;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -204,7 +202,7 @@ public final class DefaultSolverJob<Solution_, ProblemId_> implements SolverJob<
     /**
      * A listener that unlocks the solverStatusModifyingLock when Solving has started.
      *
-     * It to prevent the following scenario caused by unlocking before Solving started:
+     * It prevents the following scenario caused by unlocking before Solving started:
      *
      * Thread 1:
      * solverStatusModifyingLock.unlock()
@@ -222,37 +220,10 @@ public final class DefaultSolverJob<Solution_, ProblemId_> implements SolverJob<
      * solvingStarted phase lifecycle event is fired, meaning the terminateEarly flag will not be
      * reset and thus the solver will actually terminate.
      */
-    private final class UnlockLockPhaseLifecycleListener implements PhaseLifecycleListener<Solution_> {
-
+    private final class UnlockLockPhaseLifecycleListener extends PhaseLifecycleListenerAdapter<Solution_> {
         @Override
         public void solvingStarted(SolverScope<Solution_> solverScope) {
             solverStatusModifyingLock.unlock();
-        }
-
-        // Do nothing for everything else
-        @Override
-        public void solvingEnded(SolverScope<Solution_> solverScope) {
-            // Do nothing
-        }
-
-        @Override
-        public void phaseStarted(AbstractPhaseScope<Solution_> phaseScope) {
-            // Do nothing
-        }
-
-        @Override
-        public void stepStarted(AbstractStepScope<Solution_> stepScope) {
-            // Do nothing
-        }
-
-        @Override
-        public void stepEnded(AbstractStepScope<Solution_> stepScope) {
-            // Do nothing
-        }
-
-        @Override
-        public void phaseEnded(AbstractPhaseScope<Solution_> phaseScope) {
-            // Do nothing
         }
     }
 }


### PR DESCRIPTION
There was a race condition where a SolverJob can cancel
the completition of a different SolverJob with the same
problem id. In particular, the old code did not have any locking
on SolverStatus changes, which allowed the following sequence
of operations on three threads (T1, T2, T3):

Preconditions:
solverManager.getSolverStatus(1L) == SOLVING_SCHEDULED

```
---
T1: solverManager.terminateEarly(1L)
T2: solverManager.terminateEarly(1L)
T3: solverJob = solverManager.solve(1L, problem)

---

T1: solvingTerminated() (in SolverJob.terminateEarly, under SOLVING_SCHEDULED)
T2: solvingTerminated() (in SolverJob.terminateEarly, under SOLVING_SCHEDULED)
T3: solverJob = solverManager.solve(1L, problem) (No Action Yet)

---

T1: Thread Ended (the old SolverJob was removed from SolverManager)
T2: solvingTerminated() (No Action Yet)
T3: solverJob = solverManager.solve(1L, problem) (No Action Yet)

---

T1: Thread Ended
T2: solvingTerminated() (No Action Yet)
T3: assert solverJob.getStatus() == solverManager.getSolverStatus(1L)
    // (A new SolverJob was successfully created)

---

T1: Thread Ended
T2: Thread Ended (The new SolverJob was removed)
T3: assert solverJob.getStatus() == solverManager.getSolverStatus(1L)
    // No Action Yet

---

T1: Thread Ended
T2: Thread Ended
T3: AssertionError("SOLVING_SCHEDULED != NOT_SOLVING")

---
```

This create an inconsistency in the SolverManager, and allows
two SolverJobs with the same ProblemId to be active at the
same time (which can have strange side effects, like one
SolverJob cancelling the other).

The solution I came up with was to lock whenever SolverStatus
was going to be potentially written to. A new
PhaseLifecycleEventListener was added that unlock said lock when
Solving started to prevent a race condition where terminateEarly
is called on the SolverJob but the Solver did not start yet,
which will cause the Solver to continue solving and not cancel
the Job.

<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.
-->

### JIRA

<!-- Add a JIRA ticket link if it exists. -->
https://issues.redhat.com/browse/PLANNER-2611

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
* https://github.com/kiegroup/drools/pull/3000
* https://github.com/kiegroup/optaplanner/pull/899
* etc.
-->

### Checklist
- [ ] Documentation updated if applicable.
- [ ] Upgrade recipe provided if applicable.

<details>
<summary>
How to replicate CI configuration locally?
</summary>

We do "simple" maven builds, they are just basically maven commands, but just because we have multiple repositories related between them and one change could affect several of those projects by multiple pull requests, we use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.

[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is not only a github-action tool but a CLI one, so in case you posted multiple pull requests related with this change you can easily reproduce the same build by executing it locally. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>specific pull request build</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] tests</b>
* for a <b>full downstream build</b> 
  * for <b>jenkins</b> job: please add comment: <b>Jenkins run fdb</b>
  * for <b>github actions</b> job: add the label `run_fdb`
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
* for a <b>Quarkus LTS check</b> please add comment: <b>Jenkins run LTS</b>
* for a <b>specific Quarkus LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] LTS</b>
* for a <b>Native check</b> please add comment: <b>Jenkins run native</b>
* for a <b>specific Native LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] native</b>
</details>
