### PR TITLE
[7.x] PLANNER-2476 Improve performance of SubChainSwapMove

### DIFF
--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/heuristic/move/AbstractMove.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/heuristic/move/AbstractMove.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -59,7 +59,7 @@ public abstract class AbstractMove<Solution_> implements Move<Solution_> {
     // Util methods
     // ************************************************************************
 
-    protected static <E> List<E> rebaseList(List<E> externalObjectList, ScoreDirector<?> destinationScoreDirector) {
+    public static <E> List<E> rebaseList(List<E> externalObjectList, ScoreDirector<?> destinationScoreDirector) {
         List<E> rebasedObjectList = new ArrayList<>(externalObjectList.size());
         for (E entity : externalObjectList) {
             rebasedObjectList.add(destinationScoreDirector.lookUpWorkingObject(entity));
@@ -67,7 +67,7 @@ public abstract class AbstractMove<Solution_> implements Move<Solution_> {
         return rebasedObjectList;
     }
 
-    protected static Object[] rebaseArray(Object[] externalObjects, ScoreDirector<?> destinationScoreDirector) {
+    public static Object[] rebaseArray(Object[] externalObjects, ScoreDirector<?> destinationScoreDirector) {
         Object[] rebasedObjects = new Object[externalObjects.length];
         for (int i = 0; i < externalObjects.length; i++) {
             rebasedObjects[i] = destinationScoreDirector.lookUpWorkingObject(externalObjects[i]);

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/chained/SubChainReversingSwapMove.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/chained/SubChainReversingSwapMove.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -77,13 +77,8 @@ public class SubChainReversingSwapMove<Solution_> extends AbstractMove<Solution_
 
     @Override
     public boolean isMoveDoable(ScoreDirector<Solution_> scoreDirector) {
-        for (Object leftEntity : leftSubChain.getEntityList()) {
-            if (rightSubChain.getEntityList().contains(leftEntity)) {
-                return false;
-            }
-        }
         // Because leftFirstEntity and rightFirstEntity are unequal, chained guarantees their values are unequal too.
-        return true;
+        return !SubChainSwapMove.containsAnyOf(rightSubChain, leftSubChain);
     }
 
     @Override

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/chained/SubChainSwapMove.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/chained/SubChainSwapMove.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,8 +18,10 @@ package org.optaplanner.core.impl.heuristic.selector.move.generic.chained;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 
 import org.optaplanner.core.api.domain.solution.PlanningSolution;
 import org.optaplanner.core.impl.domain.variable.descriptor.GenuineVariableDescriptor;
@@ -81,13 +83,30 @@ public class SubChainSwapMove<Solution_> extends AbstractMove<Solution_> {
 
     @Override
     public boolean isMoveDoable(ScoreDirector<Solution_> scoreDirector) {
+        return !containsAnyOf(rightSubChain, leftSubChain);
+    }
+
+    static boolean containsAnyOf(SubChain rightSubChain, SubChain leftSubChain) {
+        int leftSubChainSize = leftSubChain.getSize();
+        if (leftSubChainSize == 0) {
+            return false;
+        } else if (leftSubChainSize == 1) { // No optimization possible.
+            return rightSubChain.getEntityList().contains(leftSubChain.getFirstEntity());
+        }
+        /*
+         * In order to find an entity in another subchain, we need to do contains() on a List.
+         * List.contains() is O(n), the performance gets worse with increasing size.
+         * Subchains here can easily have hundreds, thousands of elements.
+         * As Set.contains() is O(1), independent of set size, copying the list outperforms the lookup by a lot.
+         * Therefore this code converts the List lookup to HashSet lookup, in situations with repeat lookup.
+         */
+        Set<Object> rightSubChainEntityFastLookupSet = new HashSet<>(rightSubChain.getEntityList());
         for (Object leftEntity : leftSubChain.getEntityList()) {
-            if (rightSubChain.getEntityList().contains(leftEntity)) {
-                return false;
+            if (rightSubChainEntityFastLookupSet.contains(leftEntity)) {
+                return true;
             }
         }
-        // Because leftFirstEntity and rightFirstEntity are unequal, chained guarantees their values are unequal too.
-        return true;
+        return false;
     }
 
     @Override

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/heuristic/selector/value/chained/SubChain.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/heuristic/selector/value/chained/SubChain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import org.optaplanner.core.impl.heuristic.move.AbstractMove;
 import org.optaplanner.core.impl.score.director.ScoreDirector;
 
 /**
@@ -72,11 +73,7 @@ public class SubChain {
     }
 
     public <Solution_> SubChain rebase(ScoreDirector<Solution_> destinationScoreDirector) {
-        List<Object> rebasedEntityList = new ArrayList<>(entityList.size());
-        for (Object entity : entityList) {
-            rebasedEntityList.add(destinationScoreDirector.lookUpWorkingObject(entity));
-        }
-        return new SubChain(rebasedEntityList);
+        return new SubChain(AbstractMove.rebaseList(entityList, destinationScoreDirector));
     }
 
     @Override


### PR DESCRIPTION
Backports the fix of https://issues.redhat.com/browse/PLANNER-2476 to the `7.x` branch.
<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.
-->

### JIRA
https://issues.redhat.com/browse/PLANNER-2476

<!-- Add a JIRA ticket link if it exists. -->
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
* https://github.com/kiegroup/drools/pull/3000
* https://github.com/kiegroup/optaplanner/pull/899
* etc.
-->

### Checklist
- [ ] Documentation updated if applicable.
- [ ] Upgrade recipe provided if applicable.

<details>
<summary>
How to replicate CI configuration locally?
</summary>

We do "simple" maven builds, they are just basically maven commands, but just because we have multiple repositories related between them and one change could affect several of those projects by multiple pull requests, we use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.

[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is not only a github-action tool but a CLI one, so in case you posted multiple pull requests related with this change you can easily reproduce the same build by executing it locally. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>specific pull request build</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] tests</b>
* for a <b>full downstream build</b> 
  * for <b>jenkins</b> job: please add comment: <b>Jenkins run fdb</b>
  * for <b>github actions</b> job: add the label `run_fdb`
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
* for a <b>Quarkus LTS check</b> please add comment: <b>Jenkins run LTS</b>
* for a <b>specific Quarkus LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] LTS</b>
* for a <b>Native check</b> please add comment: <b>Jenkins run native</b>
* for a <b>specific Native LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] native</b>
</details>
