### PR TITLE
Split nightly jobs

### DIFF
--- a/.ci/jenkins/dsl/jobs.groovy
+++ b/.ci/jenkins/dsl/jobs.groovy
@@ -33,14 +33,14 @@ Map getMultijobPRConfig(Folder jobFolder) {
                 id: 'kogito-apps',
                 repository: 'kogito-apps',
                 env : [
-                    BUILD_MVN_OPTS_CURRENT: jobFolder.isNative() ? '-Poptaplanner-downstream,native' : '-Poptaplanner-downstream',
-                    ADDITIONAL_TIMEOUT: jobFolder.isNative() ? '360' : '210',
+                    BUILD_MVN_OPTS_CURRENT: jobFolder.isNative() || jobFolder.isMandrel() ? '-Poptaplanner-downstream,native' : '-Poptaplanner-downstream',
+                    ADDITIONAL_TIMEOUT: jobFolder.isNative() || jobFolder.isMandrel() ? '360' : '210',
                 ]
             ], [
                 id: 'kogito-examples',
                 repository: 'kogito-examples',
                 env : [
-                    BUILD_MVN_OPTS_CURRENT: jobFolder.isNative() ? '-Poptaplanner-downstream-native' : '-Poptaplanner-downstream'
+                    BUILD_MVN_OPTS_CURRENT: jobFolder.isNative() || jobFolder.isMandrel() ? '-Poptaplanner-downstream-native' : '-Poptaplanner-downstream'
                 ]
             ], [
                 id: 'optaweb-employee-rostering',

--- a/.ci/jenkins/dsl/test.sh
+++ b/.ci/jenkins/dsl/test.sh
@@ -1,20 +1,8 @@
 #!/bin/bash -e
 
-TEMP_DIR=`mktemp -d`
-
-branch=$1
-author=$2
-
-if [ -z $branch ]; then
-  branch='main'
-fi
-
-if [ -z $author ]; then
-  author='kiegroup'
-fi
-
-echo "----- Cloning pipelines repo from ${author} on branch ${branch}"
-git clone --single-branch --branch ${branch} https://github.com/${author}/kogito-pipelines.git $TEMP_DIR
-
-echo '----- Launching seed tests'
-${TEMP_DIR}/dsl/seed/scripts/seed_test.sh ${TEMP_DIR}
+file=$(mktemp)
+# For more usage of the script, use ./test.sh -h
+# TODO to update before merge
+curl -o ${file} https://raw.githubusercontent.com/radtriste/kogito-pipelines/kogito-6962/dsl/seed/scripts/seed_test.sh
+chmod u+x ${file}
+${file} $@

--- a/.ci/jenkins/dsl/test.sh
+++ b/.ci/jenkins/dsl/test.sh
@@ -3,6 +3,6 @@
 file=$(mktemp)
 # For more usage of the script, use ./test.sh -h
 # TODO to update before merge
-curl -o ${file} https://raw.githubusercontent.com/radtriste/kogito-pipelines/kogito-6962/dsl/seed/scripts/seed_test.sh
+curl -o ${file} https://raw.githubusercontent.com/radtriste/kogito-pipelines/split_nightly_jobs/dsl/seed/scripts/seed_test.sh
 chmod u+x ${file}
 ${file} $@

--- a/.ci/jenkins/scripts/update_version/after_main.groovy
+++ b/.ci/jenkins/scripts/update_version/after_main.groovy
@@ -1,0 +1,17 @@
+void execute(def pipelinesCommon) {
+    pipelinesCommon.getDefaultMavenCommand().withProperty('full').skipTests(params.SKIP_TESTS).run('clean install')
+    if (pipelinesCommon.isRelease()) {
+        updateAntoraYaml(pipelinesCommon)
+    }
+}
+
+void updateAntoraYaml(def pipelinesCommon) {
+    if (pipelinesCommon.isNotTestingBuild()) {
+        echo 'updateAntoraYaml'
+        sh './build/release/update_antora_yml.sh'
+    } else {
+        echo 'No updateAntoraYaml due to testing build'
+    }
+}
+
+return this

--- a/.ci/jenkins/scripts/update_version/git_stage_files.groovy
+++ b/.ci/jenkins/scripts/update_version/git_stage_files.groovy
@@ -1,0 +1,6 @@
+void execute(def pipelinesCommon) {
+    githubscm.findAndStageNotIgnoredFiles('pom.xml')
+    githubscm.findAndStageNotIgnoredFiles('antora.yml')
+}
+
+return this

--- a/.ci/jenkins/scripts/update_version/init.groovy
+++ b/.ci/jenkins/scripts/update_version/init.groovy
@@ -1,0 +1,15 @@
+void execute(def pipelinesCommon) {
+    echo 'Hello from init script'
+    if (pipelinesCommon.isRelease() || pipelinesCommon.isCreatePR()) {
+        // Verify version is set
+        assert pipelinesCommon.getKogitoVersion()
+        assert pipelinesCommon.getOptaPlannerVersion()
+
+        if (pipelinesCommon.isRelease()) {
+            // Verify if on right release branch
+            assert pipelinesCommon.getGitBranch() == util.getReleaseBranchFromVersion(pipelinesCommon.getOptaPlannerVersion())
+        }
+    }
+}
+
+return this

--- a/.ci/jenkins/scripts/update_version/main.groovy
+++ b/.ci/jenkins/scripts/update_version/main.groovy
@@ -1,0 +1,6 @@
+void execute(def pipelinesCommon) {
+    maven.mvnVersionsSet(pipelinesCommon.getDefaultMavenCommand(), pipelinesCommon.getOptaPlannerVersion(), !pipelinesCommon.isRelease())
+    maven.mvnSetVersionProperty(pipelinesCommon.getDefaultMavenCommand(), 'version.org.kie.kogito', pipelinesCommon.getKogitoVersion())
+}
+
+return this

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -15,10 +15,10 @@ a section if that type of information is not available.
 <!-- Add URLs of all referenced pull requests if they exist. This is only required when making
 changes that span multiple kiegroup repositories and depend on each other. -->
 <!-- Example:
-* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
-* https://github.com/kiegroup/drools/pull/3000
-* https://github.com/kiegroup/optaplanner/pull/899
-* etc.
+- https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
+- https://github.com/kiegroup/drools/pull/3000
+- https://github.com/kiegroup/optaplanner/pull/899
+- etc.
 -->
 
 ### Checklist
@@ -40,18 +40,58 @@ Build Chain tool does "simple" maven build(s), the builds are just Maven command
 How to retest this PR or trigger a specific build:
 </summary>
 
-* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
-* for a <b>specific pull request build</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] tests</b>
-* for a <b>full downstream build</b> 
-  * for <b>jenkins</b> job: please add comment: <b>Jenkins run fdb</b>
-  * for <b>github actions</b> job: add the label `run_fdb`
-* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
-* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
-* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
-* for a <b>Quarkus LTS check</b> please add comment: <b>Jenkins run LTS</b>
-* for a <b>specific Quarkus LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] LTS</b>
-* for a <b>Native check</b> please add comment: <b>Jenkins run native</b>
-* for a <b>specific Native LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] native</b>
+- for <b>pull request checks</b>  
+  Please add comment: <b>Jenkins retest this</b>
+
+- for a <b>specific pull request check</b>  
+  please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] tests</b>
+  
+- for a <b>full downstream build</b> 
+  - for <b>jenkins</b> job:  
+    please add comment: <b>Jenkins run fdb</b>
+  - for <b>github actions</b> job:  
+    add the label `run_fdb`
+
+- for a <b>compile downstream build</b>  
+  please add comment: <b>Jenkins run cdb</b>
+
+- for a <b>full production downstream build</b>  
+  please add comment: <b>Jenkins execute product fdb</b>
+
+- for an <b>upstream build</b>  
+  please add comment: <b>Jenkins run upstream</b>
+
+- for <b>quarkus branch checks</b>  
+  Run checks against Quarkus current used branch  
+  Please add comment: <b>Jenkins run quarkus-branch</b>
+
+- for a <b>quarkus branch specific check</b>  
+  Run checks against Quarkus current used branch  
+  Please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] quarkus-branch</b>
+
+- for <b>quarkus main checks</b>  
+  Run checks against Quarkus main branch  
+  Please add comment: <b>Jenkins run quarkus-main</b>
+
+- for a <b>specific quarkus main check</b>  
+  Run checks against Quarkus main branch  
+  Please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] quarkus-branch</b>
+
+- for <b>native checks</b>  
+  Run native checks  
+  Please add comment: <b>Jenkins run native</b>
+
+- for a <b>specific native check</b>  
+  Run native checks 
+  Please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] native</b>
+
+- for <b>mandrel checks</b>  
+  Run native checks against Mandrel image
+  Please add comment: <b>Jenkins run mandrel</b>
+
+- for a <b>specific mandrel check</b>  
+  Run native checks against Mandrel image  
+  Please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] mandrel</b>
 </details>
 
 ### CI Status

--- a/.github/workflows/jenkins-tests-PR.yml
+++ b/.github/workflows/jenkins-tests-PR.yml
@@ -1,31 +1,22 @@
 # This workflow will build a Java project with Maven
 # For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
-
 name: Jenkins Tests
-
 on:
   pull_request:
-    paths:
-      - '.ci/jenkins/**'
+    paths: 
+    - '.ci/jenkins/**'
 
 jobs:
   dsl-tests:
-    strategy:
-      matrix:
-        os: [ ubuntu-latest ]
-        java-version: [ 11 ]
-        maven-version: [ '3.8.1' ]
-      fail-fast: false
-    runs-on: ${{ matrix.os }}
-    name: ${{ matrix.os }} - Java ${{ matrix.java-version }} - Maven
+    runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Java and Maven Setup
-        uses: kiegroup/kogito-pipelines/.ci/actions/maven@main
-        with:
-          java-version: ${{ matrix.java-version }}
-          maven-version: ${{ matrix.maven-version }}
-          cache-key-prefix: ${{ runner.os }}-${{ matrix.java-version }}-maven${{ matrix.maven-version }}
-      - name: Test DSL
-        run: cd .ci/jenkins/dsl && ./test.sh
+    - name: Checkout 
+      uses: actions/checkout@v2
+
+    - name: Set up JDK 1.11
+      uses: actions/setup-java@v1
+      with:
+        java-version: 11
+
+    - name: Test DSL
+      run: cd .ci/jenkins/dsl && ./test.sh -b ${{ github.head_ref }} -o ${{ github.event.pull_request.user.login }} -t ${{ github.base_ref }} -a ${{ github.event.pull_request.base.user.login }}

--- a/.github/workflows/jenkins-tests-PR.yml
+++ b/.github/workflows/jenkins-tests-PR.yml
@@ -12,7 +12,6 @@ jobs:
     steps:
     - name: Checkout 
       uses: actions/checkout@v2
-
     - name: Set up JDK 1.11
       uses: actions/setup-java@v1
       with:


### PR DESCRIPTION
<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.
-->

### JIRA

<!-- Add a JIRA ticket link if it exists. -->
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
* https://github.com/kiegroup/drools/pull/3000
* https://github.com/kiegroup/optaplanner/pull/899
* etc.
-->

### Checklist
- [ ] Documentation updated if applicable.
- [ ] Upgrade recipe provided if applicable.

<details>
<summary>
How to replicate CI configuration locally?
</summary>

We do "simple" maven builds, they are just basically maven commands, but just because we have multiple repositories related between them and one change could affect several of those projects by multiple pull requests, we use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.

[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is not only a github-action tool but a CLI one, so in case you posted multiple pull requests related with this change you can easily reproduce the same build by executing it locally. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>specific pull request build</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] tests</b>
* for a <b>full downstream build</b> 
  * for <b>jenkins</b> job: please add comment: <b>Jenkins run fdb</b>
  * for <b>github actions</b> job: add the label `run_fdb`
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
* for a <b>Quarkus LTS check</b> please add comment: <b>Jenkins run LTS</b>
* for a <b>specific Quarkus LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] LTS</b>
* for a <b>Native check</b> please add comment: <b>Jenkins run native</b>
* for a <b>specific Native LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] native</b>
</details>
