### PR TITLE
PLANNER-2563 Show thread dump of a failed test

### DIFF
--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/partitionedsearch/DefaultPartitionedSearchPhaseTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/partitionedsearch/DefaultPartitionedSearchPhaseTest.java
@@ -31,9 +31,9 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.optaplanner.core.api.solver.Solver;
 import org.optaplanner.core.api.solver.SolverFactory;
 import org.optaplanner.core.config.constructionheuristic.ConstructionHeuristicPhaseConfig;
@@ -50,17 +50,17 @@ import org.optaplanner.core.impl.testdata.domain.TestdataEntity;
 import org.optaplanner.core.impl.testdata.domain.TestdataSolution;
 import org.optaplanner.core.impl.testdata.domain.TestdataValue;
 import org.optaplanner.core.impl.testdata.util.PlannerTestUtils;
+import org.optaplanner.core.impl.util.ThreadDumpExtension;
 
+@Timeout(value = 60, unit = TimeUnit.SECONDS)
 public class DefaultPartitionedSearchPhaseTest {
 
     @Test
-    @Timeout(5)
     public void partCount() {
         partCount(SolverConfig.MOVE_THREAD_COUNT_NONE);
     }
 
     @Test
-    @Timeout(5)
     public void partCountAndMoveThreadCount() {
         partCount("2");
     }
@@ -113,7 +113,6 @@ public class DefaultPartitionedSearchPhaseTest {
     }
 
     @Test
-    @Timeout(5)
     public void exceptionPropagation() {
         final int partSize = 7;
         final int partCount = 3;
@@ -132,7 +131,7 @@ public class DefaultPartitionedSearchPhaseTest {
     }
 
     @Test
-    @Timeout(5)
+    @ExtendWith(ThreadDumpExtension.class)
     public void terminateEarly() throws InterruptedException, ExecutionException {
         final int partSize = 1;
         final int partCount = 2;
@@ -162,13 +161,12 @@ public class DefaultPartitionedSearchPhaseTest {
         assertThat(solver.isTerminateEarly()).isTrue();
 
         executor.shutdown();
-        assertThat(executor.awaitTermination(100, TimeUnit.MILLISECONDS)).isTrue();
+        assertThat(executor.awaitTermination(10, TimeUnit.SECONDS)).isTrue();
         assertThat(solutionFuture.get()).isNotNull();
     }
 
     @Test
-    @Disabled("PLANNER-2563")
-    @Timeout(5)
+    @ExtendWith(ThreadDumpExtension.class)
     public void shutdownMainThreadAbruptly() throws InterruptedException {
         final int partSize = 5;
         final int partCount = 3;
@@ -192,7 +190,7 @@ public class DefaultPartitionedSearchPhaseTest {
         executor.shutdownNow();
 
         // This verifies that PartitionQueue doesn't clear interrupted flag when the main solver thread is interrupted.
-        assertThat(executor.awaitTermination(100, TimeUnit.MILLISECONDS))
+        assertThat(executor.awaitTermination(10, TimeUnit.SECONDS))
                 .as("Executor must terminate successfully when it's shut down abruptly")
                 .isTrue();
 

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/util/ThreadDumpExtension.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/util/ThreadDumpExtension.java
@@ -1,0 +1,34 @@
+package org.optaplanner.core.impl.util;
+
+import java.lang.management.ManagementFactory;
+import java.lang.management.ThreadInfo;
+import java.lang.management.ThreadMXBean;
+
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.TestWatcher;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Dumps all threads if the test fails.
+ */
+public class ThreadDumpExtension implements TestWatcher {
+
+    private static final Logger logger = LoggerFactory.getLogger(ThreadDumpExtension.class);
+
+    @Override
+    public void testFailed(ExtensionContext context, Throwable cause) {
+        logger.error("Thread dump of a failed test ({}):{}", context.getUniqueId(), threadDump());
+    }
+
+    private static String threadDump() {
+        ThreadMXBean threadMXBean = ManagementFactory.getThreadMXBean();
+        boolean lockedMonitors = threadMXBean.isObjectMonitorUsageSupported();
+        boolean lockedSynchronizers = threadMXBean.isSynchronizerUsageSupported();
+        StringBuffer threadDump = new StringBuffer(System.lineSeparator());
+        for (ThreadInfo threadInfo : threadMXBean.dumpAllThreads(lockedMonitors, lockedSynchronizers)) {
+            threadDump.append(threadInfo.toString());
+        }
+        return threadDump.toString();
+    }
+}

--- a/optaplanner-examples/src/test/java/org/optaplanner/examples/cloudbalancing/app/CloudBalancingDaemonTest.java
+++ b/optaplanner-examples/src/test/java/org/optaplanner/examples/cloudbalancing/app/CloudBalancingDaemonTest.java
@@ -22,10 +22,12 @@ import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Queue;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.optaplanner.core.api.solver.Solver;
 import org.optaplanner.core.api.solver.SolverFactory;
 import org.optaplanner.core.api.solver.event.BestSolutionChangedEvent;
@@ -37,7 +39,9 @@ import org.optaplanner.examples.cloudbalancing.domain.CloudProcess;
 import org.optaplanner.examples.cloudbalancing.optional.realtime.AddProcessProblemFactChange;
 import org.optaplanner.examples.cloudbalancing.persistence.CloudBalancingGenerator;
 import org.optaplanner.examples.common.app.LoggingTest;
+import org.optaplanner.examples.common.util.ThreadDumpExtension;
 
+@Timeout(value = 600, unit = TimeUnit.SECONDS)
 public class CloudBalancingDaemonTest extends LoggingTest {
 
     private Object stageLock = new Object();
@@ -51,7 +55,7 @@ public class CloudBalancingDaemonTest extends LoggingTest {
     private volatile CloudBalance currentBestSolution = null;
 
     @Test
-    @Timeout(600)
+    @ExtendWith(ThreadDumpExtension.class)
     public void daemon() throws InterruptedException {
         // In main thread
         Solver<CloudBalance> solver = buildSolver();

--- a/optaplanner-examples/src/test/java/org/optaplanner/examples/common/util/ThreadDumpExtension.java
+++ b/optaplanner-examples/src/test/java/org/optaplanner/examples/common/util/ThreadDumpExtension.java
@@ -1,0 +1,34 @@
+package org.optaplanner.examples.common.util;
+
+import java.lang.management.ManagementFactory;
+import java.lang.management.ThreadInfo;
+import java.lang.management.ThreadMXBean;
+
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.TestWatcher;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Dumps all threads if the test fails.
+ */
+public class ThreadDumpExtension implements TestWatcher {
+
+    private static final Logger logger = LoggerFactory.getLogger(ThreadDumpExtension.class);
+
+    @Override
+    public void testFailed(ExtensionContext context, Throwable cause) {
+        logger.error("Thread dump of a failed test ({}):{}", context.getUniqueId(), threadDump());
+    }
+
+    private static String threadDump() {
+        ThreadMXBean threadMXBean = ManagementFactory.getThreadMXBean();
+        boolean lockedMonitors = threadMXBean.isObjectMonitorUsageSupported();
+        boolean lockedSynchronizers = threadMXBean.isSynchronizerUsageSupported();
+        StringBuffer threadDump = new StringBuffer(System.lineSeparator());
+        for (ThreadInfo threadInfo : threadMXBean.dumpAllThreads(lockedMonitors, lockedSynchronizers)) {
+            threadDump.append(threadInfo.toString());
+        }
+        return threadDump.toString();
+    }
+}


### PR DESCRIPTION
Show tread dump for
- DefaultPartitionedSearchPhaseTest
- CloudBalancingDaemonTest

Cherry-pick [7.59.x] PLANNER-2563 Improve partition search tests stability (#1695)

<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.
-->

### JIRA
https://issues.redhat.com/browse/PLANNER-2563
<!-- Add a JIRA ticket link if it exists. -->
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
* https://github.com/kiegroup/drools/pull/3000
* https://github.com/kiegroup/optaplanner/pull/899
* etc.
-->

### Checklist
- [ ] Documentation updated if applicable.
- [ ] Upgrade recipe provided if applicable.

<details>
<summary>
How to replicate CI configuration locally?
</summary>

We do "simple" maven builds, they are just basically maven commands, but just because we have multiple repositories related between them and one change could affect several of those projects by multiple pull requests, we use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.

[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is not only a github-action tool but a CLI one, so in case you posted multiple pull requests related with this change you can easily reproduce the same build by executing it locally. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>specific pull request build</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] tests</b>
* for a <b>full downstream build</b> 
  * for <b>jenkins</b> job: please add comment: <b>Jenkins run fdb</b>
  * for <b>github actions</b> job: add the label `run_fdb`
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
* for a <b>Quarkus LTS check</b> please add comment: <b>Jenkins run LTS</b>
* for a <b>specific Quarkus LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] LTS</b>
* for a <b>Native check</b> please add comment: <b>Jenkins run native</b>
* for a <b>specific Native LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] native</b>
</details>
