### PR TITLE
Adjust column widths to avoid line breaks in tables

### DIFF
--- a/optaplanner-docs/src/modules/ROOT/pages/constraint-streams/constraint-streams.adoc
+++ b/optaplanner-docs/src/modules/ROOT/pages/constraint-streams/constraint-streams.adoc
@@ -161,6 +161,7 @@ The latter can also decrease stream cardinality:
 
 The following constraint stream cardinalities are currently supported:
 
+[cols="1,1,2"]
 |===
 |Cardinality|Prefix|Defining interface
 |1          |   Uni|`UniConstraintStream<A>`
@@ -328,6 +329,7 @@ constraint matches and only then filters some of them out.
 
 The following functions are required for filtering constraint streams of different cardinality:
 
+[cols="1,3"]
 |===
 |Cardinality|Filtering Predicate
 |1          |`java.util.function.Predicate<A>`

--- a/optaplanner-docs/src/modules/ROOT/pages/optimization-algorithms/optimization-algorithms.adoc
+++ b/optaplanner-docs/src/modules/ROOT/pages/optimization-algorithms/optimization-algorithms.adoc
@@ -99,7 +99,7 @@ image::optimization-algorithms/scalabilityOfOptimizationAlgorithms.png[align="ce
 Each of these algorithm families have multiple optimization algorithms:
 
 .Optimization Algorithms Overview
-[cols="1,1,1,1,1,1", options="header"]
+[cols="15,^7,^7,^7,^7,^8", options="header"]
 |===
 |Algorithm |Scalable? |Optimal? |Easy to use? |Tweakable? |Requires CH?
 

--- a/optaplanner-docs/src/modules/ROOT/pages/use-cases-and-examples/cloud-balancing/cloud-balancing.adoc
+++ b/optaplanner-docs/src/modules/ROOT/pages/use-cases-and-examples/cloud-balancing/cloud-balancing.adoc
@@ -44,13 +44,13 @@ image::use-cases-and-examples/cloud-balancing/cloudOptimizationValueProposition.
 === Problem size
 
 .Cloud Balancing Problem Size
-[cols="1,1,1,1", options="header"]
+[cols="2,1,1,1", options="header"]
 |===
 |Problem Size |Computers |Processes |Search Space
 
 |2computers-6processes |2 |6 |64
 |3computers-9processes |3 |9 |10^4
-|4computers-012processes |4 |12 |10^7
+|4computers-12processes |4 |12 |10^7
 |100computers-300processes |100 |300 |10^600
 |200computers-600processes |200 |600 |10^1380
 |400computers-1200processes |400 |1200 |10^3122


### PR DESCRIPTION
[skip ci]
<details>
<summary>
How to replicate CI configuration locally?
</summary>

We do "simple" maven builds, they are just basically maven commands, but just because we have multiple repositories related between them and one change could affect several of those projects by multiple pull requests, we use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.

[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is not only a github-action tool but a CLI one, so in case you posted multiple pull requests related with this change you can easily reproduce the same build by executing it locally. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>specific pull request build</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] tests</b>
* for a <b>full downstream build</b> 
  * for <b>jenkins</b> job: please add comment: <b>Jenkins run fdb</b>
  * for <b>github actions</b> job: add the label `run_fdb`
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
* for a <b>Quarkus LTS check</b> please add comment: <b>Jenkins run LTS</b>
* for a <b>specific Quarkus LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] LTS</b>
* for a <b>Native check</b> please add comment: <b>Jenkins run native</b>
* for a <b>specific Native LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] native</b>
</details>
