### PR TITLE
PLANNER-2593 Implement list moves' getPlanningEntities(), getPlanningValues(), equals(), hashCode() and rebase()

### DIFF
--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/ListAssignMove.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/ListAssignMove.java
@@ -75,6 +75,15 @@ public class ListAssignMove<Solution_> extends AbstractMove<Solution_> {
         innerScoreDirector.afterVariableChanged(variableDescriptor, destinationEntity);
     }
 
+    @Override
+    public ListAssignMove<Solution_> rebase(ScoreDirector<Solution_> destinationScoreDirector) {
+        return new ListAssignMove<>(
+                variableDescriptor,
+                destinationScoreDirector.lookUpWorkingObject(planningValue),
+                destinationScoreDirector.lookUpWorkingObject(destinationEntity),
+                destinationIndex);
+    }
+
     // ************************************************************************
     // Introspection methods
     // ************************************************************************

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/ListAssignMove.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/ListAssignMove.java
@@ -89,12 +89,14 @@ public class ListAssignMove<Solution_> extends AbstractMove<Solution_> {
         if (this == o) {
             return true;
         }
-        if (!(o instanceof ListAssignMove)) {
+        if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        ListAssignMove<?> that = (ListAssignMove<?>) o;
-        return destinationIndex == that.destinationIndex && variableDescriptor.equals(that.variableDescriptor)
-                && planningValue.equals(that.planningValue) && destinationEntity.equals(that.destinationEntity);
+        ListAssignMove<?> other = (ListAssignMove<?>) o;
+        return destinationIndex == other.destinationIndex
+                && Objects.equals(variableDescriptor, other.variableDescriptor)
+                && Objects.equals(planningValue, other.planningValue)
+                && Objects.equals(destinationEntity, other.destinationEntity);
     }
 
     @Override

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/ListAssignMove.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/ListAssignMove.java
@@ -40,8 +40,29 @@ public class ListAssignMove<Solution_> extends AbstractMove<Solution_> {
         this.destinationIndex = destinationIndex;
     }
 
+    public Object getDestinationEntity() {
+        return destinationEntity;
+    }
+
+    public int getDestinationIndex() {
+        return destinationIndex;
+    }
+
+    public Object getMovedValue() {
+        return planningValue;
+    }
+
+    // ************************************************************************
+    // Worker methods
+    // ************************************************************************
+
     @Override
-    protected AbstractMove<Solution_> createUndoMove(ScoreDirector<Solution_> scoreDirector) {
+    public boolean isMoveDoable(ScoreDirector<Solution_> scoreDirector) {
+        return true;
+    }
+
+    @Override
+    public ListUnassignMove<Solution_> createUndoMove(ScoreDirector<Solution_> scoreDirector) {
         return new ListUnassignMove<>(variableDescriptor, destinationEntity, destinationIndex);
     }
 
@@ -54,11 +75,6 @@ public class ListAssignMove<Solution_> extends AbstractMove<Solution_> {
         innerScoreDirector.afterVariableChanged(variableDescriptor, destinationEntity);
     }
 
-    @Override
-    public boolean isMoveDoable(ScoreDirector<Solution_> scoreDirector) {
-        return true;
-    }
-
     // ************************************************************************
     // Introspection methods
     // ************************************************************************
@@ -66,22 +82,6 @@ public class ListAssignMove<Solution_> extends AbstractMove<Solution_> {
     @Override
     public String getSimpleMoveTypeDescription() {
         return getClass().getSimpleName() + "(" + variableDescriptor.getSimpleEntityAndVariableName() + ")";
-    }
-
-    // ************************************************************************
-    // Testing methods
-    // ************************************************************************
-
-    public Object getDestinationEntity() {
-        return destinationEntity;
-    }
-
-    public int getDestinationIndex() {
-        return destinationIndex;
-    }
-
-    public Object getMovedValue() {
-        return planningValue;
     }
 
     @Override

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/ListChangeMove.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/ListChangeMove.java
@@ -16,7 +16,11 @@
 
 package org.optaplanner.core.impl.heuristic.selector.move.generic.list;
 
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashSet;
 import java.util.Objects;
+import java.util.Set;
 
 import org.optaplanner.core.api.domain.solution.PlanningSolution;
 import org.optaplanner.core.api.domain.variable.PlanningCollectionVariable;
@@ -143,6 +147,20 @@ public class ListChangeMove<Solution_> extends AbstractMove<Solution_> {
     @Override
     public String getSimpleMoveTypeDescription() {
         return getClass().getSimpleName() + "(" + variableDescriptor.getSimpleEntityAndVariableName() + ")";
+    }
+
+    @Override
+    public Collection<Object> getPlanningEntities() {
+        // Use LinkedHashSet for predictable iteration order.
+        Set<Object> entities = new LinkedHashSet<>(2);
+        entities.add(sourceEntity);
+        entities.add(destinationEntity);
+        return entities;
+    }
+
+    @Override
+    public Collection<Object> getPlanningValues() {
+        return Collections.singleton(getMovedValue());
     }
 
     // ************************************************************************

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/ListChangeMove.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/ListChangeMove.java
@@ -113,8 +113,41 @@ public class ListChangeMove<Solution_> extends AbstractMove<Solution_> {
         this.destinationIndex = destinationIndex;
     }
 
+    public Object getSourceEntity() {
+        return sourceEntity;
+    }
+
+    public int getSourceIndex() {
+        return sourceIndex;
+    }
+
+    public Object getDestinationEntity() {
+        return destinationEntity;
+    }
+
+    public int getDestinationIndex() {
+        return destinationIndex;
+    }
+
+    public Object getMovedValue() {
+        return variableDescriptor.getElement(sourceEntity, sourceIndex);
+    }
+
+    // ************************************************************************
+    // Worker methods
+    // ************************************************************************
+
     @Override
-    protected AbstractMove<Solution_> createUndoMove(ScoreDirector<Solution_> scoreDirector) {
+    public boolean isMoveDoable(ScoreDirector<Solution_> scoreDirector) {
+        // TODO maybe remove this because no such move should be generated
+        // Do not use Object#equals on user-provided domain objects. Relying on user's implementation of Object#equals
+        // opens the opportunity to shoot themselves in the foot if different entities can be equal.
+        return destinationEntity != sourceEntity
+                || (destinationIndex != sourceIndex && destinationIndex != variableDescriptor.getListSize(sourceEntity));
+    }
+
+    @Override
+    public ListChangeMove<Solution_> createUndoMove(ScoreDirector<Solution_> scoreDirector) {
         return new ListChangeMove<>(variableDescriptor, destinationEntity, destinationIndex, sourceEntity, sourceIndex);
     }
 
@@ -129,15 +162,6 @@ public class ListChangeMove<Solution_> extends AbstractMove<Solution_> {
         innerScoreDirector.beforeVariableChanged(variableDescriptor, destinationEntity);
         variableDescriptor.addElement(destinationEntity, destinationIndex, element);
         innerScoreDirector.afterVariableChanged(variableDescriptor, destinationEntity);
-    }
-
-    @Override
-    public boolean isMoveDoable(ScoreDirector<Solution_> scoreDirector) {
-        // TODO maybe remove this because no such move should be generated
-        // Do not use Object#equals on user-provided domain objects. Relying on user's implementation of Object#equals
-        // opens the opportunity to shoot themselves in the foot if different entities can be equal.
-        return destinationEntity != sourceEntity
-                || (destinationIndex != sourceIndex && destinationIndex != variableDescriptor.getListSize(sourceEntity));
     }
 
     // ************************************************************************
@@ -161,30 +185,6 @@ public class ListChangeMove<Solution_> extends AbstractMove<Solution_> {
     @Override
     public Collection<Object> getPlanningValues() {
         return Collections.singleton(getMovedValue());
-    }
-
-    // ************************************************************************
-    // Testing methods
-    // ************************************************************************
-
-    public Object getSourceEntity() {
-        return sourceEntity;
-    }
-
-    public int getSourceIndex() {
-        return sourceIndex;
-    }
-
-    public Object getDestinationEntity() {
-        return destinationEntity;
-    }
-
-    public int getDestinationIndex() {
-        return destinationIndex;
-    }
-
-    public Object getMovedValue() {
-        return variableDescriptor.getElement(sourceEntity, sourceIndex);
     }
 
     @Override

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/ListChangeMove.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/ListChangeMove.java
@@ -164,6 +164,14 @@ public class ListChangeMove<Solution_> extends AbstractMove<Solution_> {
         innerScoreDirector.afterVariableChanged(variableDescriptor, destinationEntity);
     }
 
+    @Override
+    public ListChangeMove<Solution_> rebase(ScoreDirector<Solution_> destinationScoreDirector) {
+        return new ListChangeMove<>(
+                variableDescriptor,
+                destinationScoreDirector.lookUpWorkingObject(sourceEntity), sourceIndex,
+                destinationScoreDirector.lookUpWorkingObject(destinationEntity), destinationIndex);
+    }
+
     // ************************************************************************
     // Introspection methods
     // ************************************************************************

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/ListSwapMove.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/ListSwapMove.java
@@ -100,8 +100,44 @@ public class ListSwapMove<Solution_> extends AbstractMove<Solution_> {
         this.rightIndex = rightIndex;
     }
 
+    public Object getLeftEntity() {
+        return leftEntity;
+    }
+
+    public int getLeftIndex() {
+        return leftIndex;
+    }
+
+    public Object getRightEntity() {
+        return rightEntity;
+    }
+
+    public int getRightIndex() {
+        return rightIndex;
+    }
+
+    public Object getLeftValue() {
+        return variableDescriptor.getElement(leftEntity, leftIndex);
+    }
+
+    public Object getRightValue() {
+        return variableDescriptor.getElement(rightEntity, rightIndex);
+    }
+
+    // ************************************************************************
+    // Worker methods
+    // ************************************************************************
+
     @Override
-    protected AbstractMove<Solution_> createUndoMove(ScoreDirector<Solution_> scoreDirector) {
+    public boolean isMoveDoable(ScoreDirector<Solution_> scoreDirector) {
+        // TODO maybe do not generate such moves
+        // Do not use Object#equals on user-provided domain objects. Relying on user's implementation of Object#equals
+        // opens the opportunity to shoot themselves in the foot if different entities can be equal.
+        return !(rightEntity == leftEntity && leftIndex == rightIndex);
+    }
+
+    @Override
+    public ListSwapMove<Solution_> createUndoMove(ScoreDirector<Solution_> scoreDirector) {
         return new ListSwapMove<>(variableDescriptor, rightEntity, rightIndex, leftEntity, leftIndex);
     }
 
@@ -118,14 +154,6 @@ public class ListSwapMove<Solution_> extends AbstractMove<Solution_> {
         innerScoreDirector.beforeVariableChanged(variableDescriptor, rightEntity);
         variableDescriptor.setElement(rightEntity, rightIndex, leftElement);
         innerScoreDirector.afterVariableChanged(variableDescriptor, rightEntity);
-    }
-
-    @Override
-    public boolean isMoveDoable(ScoreDirector<Solution_> scoreDirector) {
-        // TODO maybe do not generate such moves
-        // Do not use Object#equals on user-provided domain objects. Relying on user's implementation of Object#equals
-        // opens the opportunity to shoot themselves in the foot if different entities can be equal.
-        return !(rightEntity == leftEntity && leftIndex == rightIndex);
     }
 
     // ************************************************************************
@@ -149,34 +177,6 @@ public class ListSwapMove<Solution_> extends AbstractMove<Solution_> {
     @Override
     public Collection<Object> getPlanningValues() {
         return Arrays.asList(getLeftValue(), getRightValue());
-    }
-
-    // ************************************************************************
-    // Testing methods
-    // ************************************************************************
-
-    public Object getLeftEntity() {
-        return leftEntity;
-    }
-
-    public int getLeftIndex() {
-        return leftIndex;
-    }
-
-    public Object getRightEntity() {
-        return rightEntity;
-    }
-
-    public int getRightIndex() {
-        return rightIndex;
-    }
-
-    public Object getLeftValue() {
-        return variableDescriptor.getElement(leftEntity, leftIndex);
-    }
-
-    public Object getRightValue() {
-        return variableDescriptor.getElement(rightEntity, rightIndex);
     }
 
     @Override

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/ListSwapMove.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/ListSwapMove.java
@@ -16,6 +16,8 @@
 
 package org.optaplanner.core.impl.heuristic.selector.move.generic.list;
 
+import java.util.Objects;
+
 import org.optaplanner.core.api.domain.solution.PlanningSolution;
 import org.optaplanner.core.api.domain.variable.PlanningCollectionVariable;
 import org.optaplanner.core.api.score.director.ScoreDirector;
@@ -157,6 +159,26 @@ public class ListSwapMove<Solution_> extends AbstractMove<Solution_> {
 
     public Object getRightValue() {
         return variableDescriptor.getElement(rightEntity, rightIndex);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ListSwapMove<?> other = (ListSwapMove<?>) o;
+        return leftIndex == other.leftIndex && rightIndex == other.rightIndex
+                && Objects.equals(variableDescriptor, other.variableDescriptor)
+                && Objects.equals(leftEntity, other.leftEntity)
+                && Objects.equals(rightEntity, other.rightEntity);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(variableDescriptor, leftEntity, leftIndex, rightEntity, rightIndex);
     }
 
     @Override

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/ListSwapMove.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/ListSwapMove.java
@@ -156,6 +156,14 @@ public class ListSwapMove<Solution_> extends AbstractMove<Solution_> {
         innerScoreDirector.afterVariableChanged(variableDescriptor, rightEntity);
     }
 
+    @Override
+    public ListSwapMove<Solution_> rebase(ScoreDirector<Solution_> destinationScoreDirector) {
+        return new ListSwapMove<>(
+                variableDescriptor,
+                destinationScoreDirector.lookUpWorkingObject(leftEntity), leftIndex,
+                destinationScoreDirector.lookUpWorkingObject(rightEntity), rightIndex);
+    }
+
     // ************************************************************************
     // Introspection methods
     // ************************************************************************

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/ListSwapMove.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/ListSwapMove.java
@@ -16,7 +16,11 @@
 
 package org.optaplanner.core.impl.heuristic.selector.move.generic.list;
 
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.LinkedHashSet;
 import java.util.Objects;
+import java.util.Set;
 
 import org.optaplanner.core.api.domain.solution.PlanningSolution;
 import org.optaplanner.core.api.domain.variable.PlanningCollectionVariable;
@@ -131,6 +135,20 @@ public class ListSwapMove<Solution_> extends AbstractMove<Solution_> {
     @Override
     public String getSimpleMoveTypeDescription() {
         return getClass().getSimpleName() + "(" + variableDescriptor.getSimpleEntityAndVariableName() + ")";
+    }
+
+    @Override
+    public Collection<Object> getPlanningEntities() {
+        // Use LinkedHashSet for predictable iteration order.
+        Set<Object> entities = new LinkedHashSet<>(2);
+        entities.add(leftEntity);
+        entities.add(rightEntity);
+        return entities;
+    }
+
+    @Override
+    public Collection<Object> getPlanningValues() {
+        return Arrays.asList(getLeftValue(), getRightValue());
     }
 
     // ************************************************************************

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/ListUnassignMove.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/ListUnassignMove.java
@@ -75,12 +75,13 @@ public class ListUnassignMove<Solution_> extends AbstractMove<Solution_> {
         if (this == o) {
             return true;
         }
-        if (!(o instanceof ListUnassignMove)) {
+        if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        ListUnassignMove<?> that = (ListUnassignMove<?>) o;
-        return sourceIndex == that.sourceIndex && variableDescriptor.equals(that.variableDescriptor)
-                && sourceEntity.equals(that.sourceEntity);
+        ListUnassignMove<?> other = (ListUnassignMove<?>) o;
+        return sourceIndex == other.sourceIndex
+                && Objects.equals(variableDescriptor, other.variableDescriptor)
+                && Objects.equals(sourceEntity, other.sourceEntity);
     }
 
     @Override

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/ListUnassignMove.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/ListUnassignMove.java
@@ -37,8 +37,21 @@ public class ListUnassignMove<Solution_> extends AbstractMove<Solution_> {
         this.sourceIndex = sourceIndex;
     }
 
+    private Object getMovedValue() {
+        return variableDescriptor.getElement(sourceEntity, sourceIndex);
+    }
+
+    // ************************************************************************
+    // Worker methods
+    // ************************************************************************
+
     @Override
-    protected AbstractMove<Solution_> createUndoMove(ScoreDirector<Solution_> scoreDirector) {
+    public boolean isMoveDoable(ScoreDirector<Solution_> scoreDirector) {
+        return true;
+    }
+
+    @Override
+    public AbstractMove<Solution_> createUndoMove(ScoreDirector<Solution_> scoreDirector) {
         // No need to create an undo move because the unassign move is never being undone.
         return null;
     }
@@ -52,11 +65,6 @@ public class ListUnassignMove<Solution_> extends AbstractMove<Solution_> {
         innerScoreDirector.afterVariableChanged(variableDescriptor, sourceEntity);
     }
 
-    @Override
-    public boolean isMoveDoable(ScoreDirector<Solution_> scoreDirector) {
-        return true;
-    }
-
     // ************************************************************************
     // Introspection methods
     // ************************************************************************
@@ -64,10 +72,6 @@ public class ListUnassignMove<Solution_> extends AbstractMove<Solution_> {
     @Override
     public String getSimpleMoveTypeDescription() {
         return getClass().getSimpleName() + "(" + variableDescriptor.getSimpleEntityAndVariableName() + ")";
-    }
-
-    private Object getMovedValue() {
-        return variableDescriptor.getElement(sourceEntity, sourceIndex);
     }
 
     @Override

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/ListAssignMoveTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/ListAssignMoveTest.java
@@ -18,9 +18,11 @@ package org.optaplanner.core.impl.heuristic.selector.move.generic.list;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
+import static org.optaplanner.core.impl.testdata.util.PlannerTestUtils.mockRebasingScoreDirector;
 
 import org.junit.jupiter.api.Test;
 import org.optaplanner.core.api.score.buildin.simple.SimpleScore;
+import org.optaplanner.core.api.score.director.ScoreDirector;
 import org.optaplanner.core.impl.domain.variable.descriptor.ListVariableDescriptor;
 import org.optaplanner.core.impl.heuristic.move.AbstractMove;
 import org.optaplanner.core.impl.score.director.InnerScoreDirector;
@@ -57,6 +59,36 @@ class ListAssignMoveTest {
         // v1 -> e1[0]
         new ListAssignMove<>(variableDescriptor, v1, e1, 0).doMove(scoreDirector);
         assertThat(e1.getValueList()).containsExactly(v1, v2, v3);
+    }
+
+    @Test
+    public void rebase() {
+        TestdataListValue v1 = new TestdataListValue("1");
+        TestdataListEntity e1 = new TestdataListEntity("e1");
+
+        TestdataListValue destinationV1 = new TestdataListValue("1");
+        TestdataListEntity destinationE1 = new TestdataListEntity("e1");
+
+        ListVariableDescriptor<TestdataListSolution> variableDescriptor =
+                TestdataListEntity.buildVariableDescriptorForValueList();
+
+        ScoreDirector<TestdataListSolution> destinationScoreDirector = mockRebasingScoreDirector(
+                variableDescriptor.getEntityDescriptor().getSolutionDescriptor(), new Object[][] {
+                        { v1, destinationV1 },
+                        { e1, destinationE1 },
+                });
+
+        assertSameProperties(
+                destinationV1, destinationE1, 0,
+                new ListAssignMove<>(variableDescriptor, v1, e1, 0).rebase(destinationScoreDirector));
+    }
+
+    private static void assertSameProperties(
+            Object movedValue, Object destinationEntity, int destinationIndex,
+            ListAssignMove<?> move) {
+        assertThat(move.getMovedValue()).isSameAs(movedValue);
+        assertThat(move.getDestinationEntity()).isSameAs(destinationEntity);
+        assertThat(move.getDestinationIndex()).isEqualTo(destinationIndex);
     }
 
     @Test

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/ListChangeMoveTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/ListChangeMoveTest.java
@@ -41,6 +41,28 @@ import org.optaplanner.core.impl.testdata.domain.list.TestdataListValue;
 class ListChangeMoveTest {
 
     @Test
+    void isMoveDoable() {
+        TestdataListValue v1 = new TestdataListValue("1");
+        TestdataListValue v2 = new TestdataListValue("2");
+        TestdataListValue v3 = new TestdataListValue("3");
+        TestdataListEntity e1 = new TestdataListEntity("e1", v1, v2);
+        TestdataListEntity e2 = new TestdataListEntity("e2", v3);
+
+        ScoreDirector<TestdataListSolution> scoreDirector = mock(ScoreDirector.class);
+        ListVariableDescriptor<TestdataListSolution> variableDescriptor =
+                TestdataListEntity.buildVariableDescriptorForValueList();
+
+        // same entity, same index => not doable because the move doesn't change anything
+        assertThat(new ListChangeMove<>(variableDescriptor, e1, 1, e1, 1).isMoveDoable(scoreDirector)).isFalse();
+        // same entity, different index => doable
+        assertThat(new ListChangeMove<>(variableDescriptor, e1, 0, e1, 1).isMoveDoable(scoreDirector)).isTrue();
+        // same entity, index == list size => not doable because the element is first removed (list size is reduced by 1)
+        assertThat(new ListChangeMove<>(variableDescriptor, e1, 0, e1, 2).isMoveDoable(scoreDirector)).isFalse();
+        // different entity => doable
+        assertThat(new ListChangeMove<>(variableDescriptor, e1, 0, e2, 0).isMoveDoable(scoreDirector)).isTrue();
+    }
+
+    @Test
     void doMove() {
         TestdataListValue v1 = new TestdataListValue("1");
         TestdataListValue v2 = new TestdataListValue("2");
@@ -63,28 +85,6 @@ class ListChangeMoveTest {
 
         assertThat(e1.getValueList()).containsExactly(v1, v2);
         assertThat(e2.getValueList()).containsExactly(v3);
-    }
-
-    @Test
-    void isMoveDoable() {
-        TestdataListValue v1 = new TestdataListValue("1");
-        TestdataListValue v2 = new TestdataListValue("2");
-        TestdataListValue v3 = new TestdataListValue("3");
-        TestdataListEntity e1 = new TestdataListEntity("e1", v1, v2);
-        TestdataListEntity e2 = new TestdataListEntity("e2", v3);
-
-        ScoreDirector<TestdataListSolution> scoreDirector = mock(ScoreDirector.class);
-        ListVariableDescriptor<TestdataListSolution> variableDescriptor =
-                TestdataListEntity.buildVariableDescriptorForValueList();
-
-        // same entity, same index => not doable because the move doesn't change anything
-        assertThat(new ListChangeMove<>(variableDescriptor, e1, 1, e1, 1).isMoveDoable(scoreDirector)).isFalse();
-        // same entity, different index => doable
-        assertThat(new ListChangeMove<>(variableDescriptor, e1, 0, e1, 1).isMoveDoable(scoreDirector)).isTrue();
-        // same entity, index == list size => not doable because the element is first removed (list size is reduced by 1)
-        assertThat(new ListChangeMove<>(variableDescriptor, e1, 0, e1, 2).isMoveDoable(scoreDirector)).isFalse();
-        // different entity => doable
-        assertThat(new ListChangeMove<>(variableDescriptor, e1, 0, e2, 0).isMoveDoable(scoreDirector)).isTrue();
     }
 
     static Stream<Arguments> doAndUndoMoveOnTheSameEntity() {

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/ListChangeMoveTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/ListChangeMoveTest.java
@@ -148,6 +148,26 @@ class ListChangeMoveTest {
     }
 
     @Test
+    void tabuIntrospection() {
+        TestdataListValue v1 = new TestdataListValue("1");
+        TestdataListValue v2 = new TestdataListValue("2");
+        TestdataListValue v3 = new TestdataListValue("3");
+        TestdataListEntity e1 = new TestdataListEntity("e1", v1, v2);
+        TestdataListEntity e2 = new TestdataListEntity("e2", v3);
+
+        ListVariableDescriptor<TestdataListSolution> variableDescriptor =
+                TestdataListEntity.buildVariableDescriptorForValueList();
+
+        ListChangeMove<TestdataListSolution> moveTwoEntities = new ListChangeMove<>(variableDescriptor, e1, 1, e2, 1);
+        assertThat(moveTwoEntities.getPlanningEntities()).containsExactly(e1, e2);
+        assertThat(moveTwoEntities.getPlanningValues()).containsExactly(v2);
+
+        ListChangeMove<TestdataListSolution> moveOneEntity = new ListChangeMove<>(variableDescriptor, e1, 0, e1, 1);
+        assertThat(moveOneEntity.getPlanningEntities()).containsExactly(e1);
+        assertThat(moveOneEntity.getPlanningValues()).containsExactly(v1);
+    }
+
+    @Test
     void toStringTest() {
         TestdataListValue v1 = new TestdataListValue("1");
         TestdataListValue v2 = new TestdataListValue("2");

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/ListSwapMoveTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/ListSwapMoveTest.java
@@ -87,6 +87,28 @@ class ListSwapMoveTest {
     }
 
     @Test
+    void tabuIntrospection() {
+        TestdataListValue v1 = new TestdataListValue("1");
+        TestdataListValue v2 = new TestdataListValue("2");
+        TestdataListValue v3 = new TestdataListValue("3");
+        TestdataListEntity e1 = new TestdataListEntity("e1", v1, v2);
+        TestdataListEntity e2 = new TestdataListEntity("e2", v3);
+
+        ListVariableDescriptor<TestdataListSolution> variableDescriptor =
+                TestdataListEntity.buildVariableDescriptorForValueList();
+
+        // Swap Move 1: between two entities
+        ListSwapMove<TestdataListSolution> move1 = new ListSwapMove<>(variableDescriptor, e1, 0, e2, 0);
+        assertThat(move1.getPlanningEntities()).containsExactly(e1, e2);
+        assertThat(move1.getPlanningValues()).containsExactly(v1, v3);
+
+        // Swap Move 2: same entity
+        ListSwapMove<TestdataListSolution> move2 = new ListSwapMove<>(variableDescriptor, e1, 0, e1, 1);
+        assertThat(move2.getPlanningEntities()).containsExactly(e1);
+        assertThat(move2.getPlanningValues()).containsExactly(v1, v2);
+    }
+
+    @Test
     void toStringTest() {
         TestdataListValue v1 = new TestdataListValue("1");
         TestdataListValue v2 = new TestdataListValue("2");

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/ListSwapMoveTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/ListSwapMoveTest.java
@@ -32,6 +32,26 @@ import org.optaplanner.core.impl.testdata.domain.list.TestdataListValue;
 class ListSwapMoveTest {
 
     @Test
+    void isMoveDoable() {
+        TestdataListValue v1 = new TestdataListValue("1");
+        TestdataListValue v2 = new TestdataListValue("2");
+        TestdataListValue v3 = new TestdataListValue("3");
+        TestdataListEntity e1 = new TestdataListEntity("e1", v1, v2);
+        TestdataListEntity e2 = new TestdataListEntity("e2", v3);
+
+        ScoreDirector<TestdataListSolution> scoreDirector = mock(ScoreDirector.class);
+        ListVariableDescriptor<TestdataListSolution> variableDescriptor =
+                TestdataListEntity.buildVariableDescriptorForValueList();
+
+        // same entity, same index => not doable because the move doesn't change anything
+        assertThat(new ListSwapMove<>(variableDescriptor, e1, 1, e1, 1).isMoveDoable(scoreDirector)).isFalse();
+        // same entity, different index => doable
+        assertThat(new ListSwapMove<>(variableDescriptor, e1, 0, e1, 1).isMoveDoable(scoreDirector)).isTrue();
+        // different entity => doable
+        assertThat(new ListSwapMove<>(variableDescriptor, e1, 0, e2, 0).isMoveDoable(scoreDirector)).isTrue();
+    }
+
+    @Test
     void doMove() {
         TestdataListValue v1 = new TestdataListValue("1");
         TestdataListValue v2 = new TestdataListValue("2");
@@ -64,26 +84,6 @@ class ListSwapMoveTest {
         // undo
         undoMove2.doMove(scoreDirector);
         assertThat(e1.getValueList()).containsExactly(v1, v2);
-    }
-
-    @Test
-    void isMoveDoable() {
-        TestdataListValue v1 = new TestdataListValue("1");
-        TestdataListValue v2 = new TestdataListValue("2");
-        TestdataListValue v3 = new TestdataListValue("3");
-        TestdataListEntity e1 = new TestdataListEntity("e1", v1, v2);
-        TestdataListEntity e2 = new TestdataListEntity("e2", v3);
-
-        ScoreDirector<TestdataListSolution> scoreDirector = mock(ScoreDirector.class);
-        ListVariableDescriptor<TestdataListSolution> variableDescriptor =
-                TestdataListEntity.buildVariableDescriptorForValueList();
-
-        // same entity, same index => not doable because the move doesn't change anything
-        assertThat(new ListSwapMove<>(variableDescriptor, e1, 1, e1, 1).isMoveDoable(scoreDirector)).isFalse();
-        // same entity, different index => doable
-        assertThat(new ListSwapMove<>(variableDescriptor, e1, 0, e1, 1).isMoveDoable(scoreDirector)).isTrue();
-        // different entity => doable
-        assertThat(new ListSwapMove<>(variableDescriptor, e1, 0, e2, 0).isMoveDoable(scoreDirector)).isTrue();
     }
 
     @Test


### PR DESCRIPTION
### JIRA
https://issues.redhat.com/browse/PLANNER-2593

<details>
<summary>
How to replicate CI configuration locally?
</summary>

We do "simple" maven builds, they are just basically maven commands, but just because we have multiple repositories related between them and one change could affect several of those projects by multiple pull requests, we use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.

[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is not only a github-action tool but a CLI one, so in case you posted multiple pull requests related with this change you can easily reproduce the same build by executing it locally. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>specific pull request build</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] tests</b>
* for a <b>full downstream build</b> 
  * for <b>jenkins</b> job: please add comment: <b>Jenkins run fdb</b>
  * for <b>github actions</b> job: add the label `run_fdb`
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
* for a <b>Quarkus LTS check</b> please add comment: <b>Jenkins run LTS</b>
* for a <b>specific Quarkus LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] LTS</b>
* for a <b>Native check</b> please add comment: <b>Jenkins run native</b>
* for a <b>specific Native LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] native</b>
</details>
