### PR TITLE
PLANNER-2508 Add externalized index supply

### DIFF
--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/variable/index/ExternalizedIndexVariableSupply.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/variable/index/ExternalizedIndexVariableSupply.java
@@ -100,8 +100,12 @@ public class ExternalizedIndexVariableSupply<Solution_>
     }
 
     private void insert(ScoreDirector<Solution_> scoreDirector, Object entity) {
+        List<Object> listVariable = sourceVariableDescriptor.getListVariable(entity);
+        if (listVariable == null) {
+            return;
+        }
         int index = 0;
-        for (Object value : sourceVariableDescriptor.getListVariable(entity)) {
+        for (Object value : listVariable) {
             Integer oldIndex = indexMap.put(value, index);
             if (oldIndex != null) {
                 throw new IllegalStateException("The supply (" + this + ") is corrupted,"
@@ -115,8 +119,12 @@ public class ExternalizedIndexVariableSupply<Solution_>
     }
 
     private void retract(ScoreDirector<Solution_> scoreDirector, Object entity) {
+        List<Object> listVariable = sourceVariableDescriptor.getListVariable(entity);
+        if (listVariable == null) {
+            return;
+        }
         int index = 0;
-        for (Object value : sourceVariableDescriptor.getListVariable(entity)) {
+        for (Object value : listVariable) {
             Integer oldIndex = indexMap.remove(value);
             if (!Objects.equals(oldIndex, index)) {
                 throw new IllegalStateException("The supply (" + this + ") is corrupted,"

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/variable/index/ExternalizedIndexVariableSupply.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/variable/index/ExternalizedIndexVariableSupply.java
@@ -16,7 +16,7 @@
 
 package org.optaplanner.core.impl.domain.variable.index;
 
-import java.util.HashMap;
+import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -50,7 +50,7 @@ public class ExternalizedIndexVariableSupply<Solution_>
     public void resetWorkingSolution(ScoreDirector<Solution_> scoreDirector) {
         EntityDescriptor<Solution_> entityDescriptor = sourceVariableDescriptor.getEntityDescriptor();
         List<Object> entityList = entityDescriptor.extractEntities(scoreDirector.getWorkingSolution());
-        indexMap = new HashMap<>();
+        indexMap = new IdentityHashMap<>();
         for (Object entity : entityList) {
             insert(scoreDirector, entity);
         }

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/variable/index/IndexVariableDemand.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/variable/index/IndexVariableDemand.java
@@ -36,8 +36,7 @@ public class IndexVariableDemand<Solution_> implements Demand<Solution_, IndexVa
 
     @Override
     public IndexVariableSupply createExternalizedSupply(InnerScoreDirector<Solution_, ?> scoreDirector) {
-        // TODO implement this
-        throw new UnsupportedOperationException("Needs inverse relation supply.");
+        return new ExternalizedIndexVariableSupply<>(sourceVariableDescriptor);
     }
 
     // ************************************************************************

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/variable/inverserelation/ExternalizedSingletonListInverseVariableSupply.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/variable/inverserelation/ExternalizedSingletonListInverseVariableSupply.java
@@ -109,8 +109,8 @@ public class ExternalizedSingletonListInverseVariableSupply<Solution_>
                 throw new IllegalStateException("The supply (" + this + ") is corrupted,"
                         + " because the entity (" + entity
                         + ") for sourceVariable (" + sourceVariableDescriptor.getVariableName()
-                        + ") cannot be inserted: another entity (" + oldInverseEntity
-                        + ") already has that value (" + value + ").");
+                        + ") cannot be inserted: one of its values (" + value
+                        + ") already has a non-null oldInverseEntity (" + oldInverseEntity + ").");
             }
         }
     }
@@ -126,7 +126,8 @@ public class ExternalizedSingletonListInverseVariableSupply<Solution_>
                 throw new IllegalStateException("The supply (" + this + ") is corrupted,"
                         + " because the entity (" + entity
                         + ") for sourceVariable (" + sourceVariableDescriptor.getVariableName()
-                        + ") cannot be retracted: the entity was never inserted for that value (" + value + ").");
+                        + ") cannot be retracted: one of its values (" + value
+                        + ") has an unexpected oldInverseEntity (" + oldInverseEntity + ").");
             }
         }
     }

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/variable/inverserelation/ExternalizedSingletonListInverseVariableSupply.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/variable/inverserelation/ExternalizedSingletonListInverseVariableSupply.java
@@ -61,6 +61,13 @@ public class ExternalizedSingletonListInverseVariableSupply<Solution_>
     }
 
     @Override
+    public boolean requiresUniqueEntityEvents() {
+        // A move on a single entity produces multiple before/after variable changed events for the given entity
+        // but the corrupted supply checks in insert/retract methods require a unique pair of before/after events.
+        return true;
+    }
+
+    @Override
     public void beforeEntityAdded(ScoreDirector<Solution_> scoreDirector, Object entity) {
         // Do nothing
     }

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/localsearch/DefaultLocalSearchPhaseTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/localsearch/DefaultLocalSearchPhaseTest.java
@@ -33,6 +33,8 @@ import org.optaplanner.core.impl.testdata.domain.TestdataValue;
 import org.optaplanner.core.impl.testdata.domain.list.TestdataListEntity;
 import org.optaplanner.core.impl.testdata.domain.list.TestdataListSolution;
 import org.optaplanner.core.impl.testdata.domain.list.TestdataListValue;
+import org.optaplanner.core.impl.testdata.domain.list.externalized.TestdataListEntityExternalized;
+import org.optaplanner.core.impl.testdata.domain.list.externalized.TestdataListSolutionExternalized;
 import org.optaplanner.core.impl.testdata.domain.pinned.TestdataPinnedEntity;
 import org.optaplanner.core.impl.testdata.domain.pinned.TestdataPinnedSolution;
 import org.optaplanner.core.impl.testdata.util.PlannerTestUtils;
@@ -208,6 +210,17 @@ public class DefaultLocalSearchPhaseTest {
                 TestdataListSolution.class, TestdataListEntity.class, TestdataListValue.class);
 
         TestdataListSolution solution = TestdataListSolution.generateUninitializedSolution(6, 2);
+
+        solution = PlannerTestUtils.solve(solverConfig, solution);
+        assertThat(solution).isNotNull();
+    }
+
+    @Test
+    public void solveListVariableWithExternalizedInverseAndIndexSupplies() {
+        SolverConfig solverConfig = PlannerTestUtils.buildSolverConfig(
+                TestdataListSolutionExternalized.class, TestdataListEntityExternalized.class);
+
+        TestdataListSolutionExternalized solution = TestdataListSolutionExternalized.generateUninitializedSolution(6, 2);
 
         solution = PlannerTestUtils.solve(solverConfig, solution);
         assertThat(solution).isNotNull();

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/testdata/domain/list/externalized/TestdataListEntityExternalized.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/testdata/domain/list/externalized/TestdataListEntityExternalized.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.core.impl.testdata.domain.list.externalized;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.optaplanner.core.api.domain.entity.PlanningEntity;
+import org.optaplanner.core.api.domain.variable.PlanningCollectionVariable;
+import org.optaplanner.core.impl.testdata.domain.TestdataObject;
+
+@PlanningEntity
+public class TestdataListEntityExternalized extends TestdataObject {
+
+    @PlanningCollectionVariable(valueRangeProviderRefs = "valueRange")
+    private List<TestdataListValueExternalized> valueList;
+
+    public TestdataListEntityExternalized() {
+    }
+
+    public TestdataListEntityExternalized(String code, List<TestdataListValueExternalized> valueList) {
+        super(code);
+        this.valueList = valueList;
+    }
+
+    public TestdataListEntityExternalized(String code, TestdataListValueExternalized... values) {
+        this(code, new ArrayList<>(Arrays.asList(values)));
+    }
+
+    public List<TestdataListValueExternalized> getValueList() {
+        return valueList;
+    }
+}

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/testdata/domain/list/externalized/TestdataListSolutionExternalized.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/testdata/domain/list/externalized/TestdataListSolutionExternalized.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.core.impl.testdata.domain.list.externalized;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import org.optaplanner.core.api.domain.solution.PlanningEntityCollectionProperty;
+import org.optaplanner.core.api.domain.solution.PlanningScore;
+import org.optaplanner.core.api.domain.solution.PlanningSolution;
+import org.optaplanner.core.api.domain.solution.ProblemFactCollectionProperty;
+import org.optaplanner.core.api.domain.valuerange.ValueRangeProvider;
+import org.optaplanner.core.api.score.buildin.simple.SimpleScore;
+
+@PlanningSolution
+public class TestdataListSolutionExternalized {
+
+    public static TestdataListSolutionExternalized generateUninitializedSolution(int valueCount, int entityCount) {
+        List<TestdataListEntityExternalized> entityList = IntStream.range(0, entityCount)
+                .mapToObj(i -> new TestdataListEntityExternalized("Generated Entity " + i))
+                .collect(Collectors.toList());
+        List<TestdataListValueExternalized> valueList = IntStream.range(0, valueCount)
+                .mapToObj(i -> new TestdataListValueExternalized("Generated Value " + i))
+                .collect(Collectors.toList());
+        TestdataListSolutionExternalized solution = new TestdataListSolutionExternalized();
+        solution.setValueList(valueList);
+        solution.setEntityList(entityList);
+        return solution;
+    }
+
+    private List<TestdataListValueExternalized> valueList;
+    private List<TestdataListEntityExternalized> entityList;
+    private SimpleScore score;
+
+    @ValueRangeProvider(id = "valueRange")
+    @ProblemFactCollectionProperty
+    public List<TestdataListValueExternalized> getValueList() {
+        return valueList;
+    }
+
+    public void setValueList(List<TestdataListValueExternalized> valueList) {
+        this.valueList = valueList;
+    }
+
+    @PlanningEntityCollectionProperty
+    public List<TestdataListEntityExternalized> getEntityList() {
+        return entityList;
+    }
+
+    public void setEntityList(List<TestdataListEntityExternalized> entityList) {
+        this.entityList = entityList;
+    }
+
+    @PlanningScore
+    public SimpleScore getScore() {
+        return score;
+    }
+
+    public void setScore(SimpleScore score) {
+        this.score = score;
+    }
+}

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/testdata/domain/list/externalized/TestdataListValueExternalized.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/testdata/domain/list/externalized/TestdataListValueExternalized.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.core.impl.testdata.domain.list.externalized;
+
+import org.optaplanner.core.impl.testdata.domain.TestdataObject;
+
+public class TestdataListValueExternalized extends TestdataObject {
+
+    public TestdataListValueExternalized() {
+    }
+
+    public TestdataListValueExternalized(String code) {
+        super(code);
+    }
+}

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/testdata/domain/list/externalized/TestdataListValueExternalized.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/testdata/domain/list/externalized/TestdataListValueExternalized.java
@@ -26,4 +26,16 @@ public class TestdataListValueExternalized extends TestdataObject {
     public TestdataListValueExternalized(String code) {
         super(code);
     }
+
+    @Override
+    public boolean equals(Object obj) {
+        // Pretend a bad equals() design that makes all values equal. This proves that external supplies must use
+        // the IdentityHasMap to eliminate dependency on user domain implementation of equals().
+        return obj != null && obj.getClass().equals(this.getClass());
+    }
+
+    @Override
+    public int hashCode() {
+        return 0;
+    }
 }


### PR DESCRIPTION
I paid a lot of attention to keep high level of code style consistency between external supplies and listeners and with the existing code. Some changes on the older code (before this PR) reflect that.

### Question 1: uniqueness requirement

Can we afford to require unique entity events in the inverse/index listeners/supplies? It has a performance cost but is necessary to make the strict checks work.

Alternatively, I can eliminate<sup>:monkey:</sup> the redundant before/after variable changed notifications in list moves if they happen on the same entity. I could then lift the requirement for unique events but that would open the door to breaking the checks for users that implement custom moves on a list variable.

Finally, I can do :monkey: even if the requirement for unique events is kept. Simply because it makes sense.
- Pros: A few (very few) before/after notifications won't be emitted.
- Cons: A bit of extra code and a check to detect if the move happens on the same entity.
- Neutral: `SmallScalingOrderedSet` will still be used due to the uniqueness requirement.

### Question 2: a better place for the solving test?

### JIRA
https://issues.redhat.com/browse/PLANNER-2508

<details>
<summary>
How to replicate CI configuration locally?
</summary>

We do "simple" maven builds, they are just basically maven commands, but just because we have multiple repositories related between them and one change could affect several of those projects by multiple pull requests, we use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.

[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is not only a github-action tool but a CLI one, so in case you posted multiple pull requests related with this change you can easily reproduce the same build by executing it locally. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>specific pull request build</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] tests</b>
* for a <b>full downstream build</b> 
  * for <b>jenkins</b> job: please add comment: <b>Jenkins run fdb</b>
  * for <b>github actions</b> job: add the label `run_fdb`
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
* for a <b>Quarkus LTS check</b> please add comment: <b>Jenkins run LTS</b>
* for a <b>specific Quarkus LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] LTS</b>
* for a <b>Native check</b> please add comment: <b>Jenkins run native</b>
* for a <b>specific Native LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] native</b>
</details>
