### PR TITLE
[8.15.x] Corrected Jenkinsfile.deploy

### DIFF
--- a/.ci/jenkins/Jenkinsfile.deploy
+++ b/.ci/jenkins/Jenkinsfile.deploy
@@ -326,7 +326,7 @@ void updateQuickstartsVersions() {
         dir(quickstartsRepository) {
             assert !sh (script:
                     'grep -Rn "SNAPSHOT" --include={pom.xml,build.gradle} | ' +
-                    'grep -v -e "0.1.0-SNAPSHOT" -e ">1.0-SNAPSHOT" | ' +
+                    'grep -v -e "1.0-SNAPSHOT" | ' +
                     'cat', returnStdout: true)
         }
     }


### PR DESCRIPTION
Due to https://github.com/kiegroup/optaplanner-quickstarts/commit/3119ded80cd37068b3cad85789e6a0e4a47a0b25

Tested locally with:

```bash
# Optaplanner
git clone https://github.com/kiegroup/optaplanner
git checkout upstream/8.15.x
mvn -fae -N -e versions:set -Dfull -DnewVersion=8.15.0.Final -DallowSnapshots=false -DgenerateBackupPoms=false
mvn -fae -e versions:set-property -Dfull -Dproperty=version.org.kie.kogito -DnewVersion=1.15.0.Final -DallowSnapshots=true -DgenerateBackupPoms=false
mvn -fae -U -pl org.optaplanner:optaplanner-build-parent,org.optaplanner:optaplanner-bom -am clean install -Dfull -DskipTests=true

# Optaplanner Quickstarts
git clone https://github.com/kiegroup/optaplanner-quickstarts
git checkout upstream/8.15.x
mvn -fae -N -e versions:update-parent -Dfull '-DparentVersion=[8.15.0.Final]' -DallowSnapshots=false -DgenerateBackupPoms=false
mvn -fae -N -e versions:update-child-modules -Dfull -DallowSnapshots=false -DgenerateBackupPoms=false
find . -name build.gradle -exec sed -i -E 's/def optaplannerVersion = "[^"\s]+"/def optaplannerVersion = "8.15.0.Final"/' '{}' ';'
mvn -fae -e versions:set-property -Dfull -Dproperty=version.org.optaplanner -DnewVersion=8.15.0.Final -DallowSnapshots=true -DgenerateBackupPoms=false
```

`grep -v -e "1.0-SNAPSHOT"` will give empty result