### PR TITLE
Rename the annotation to `@PlanningListVariable`

### DIFF
--- a/optaplanner-core/src/main/java/org/optaplanner/core/api/domain/variable/IndexShadowVariable.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/api/domain/variable/IndexShadowVariable.java
@@ -28,18 +28,18 @@ import org.optaplanner.core.api.solver.Solver;
 
 /**
  * Specifies that a bean property (or a field) is an index of this planning value in another entity's
- * {@link PlanningCollectionVariable}.
+ * {@link PlanningListVariable}.
  * <p>
  * It is specified on a getter of a java bean property (or a field) of a {@link PlanningEntity} class.
  * <p>
- * The source variable must be a {@link PlanningCollectionVariable list variable}.
+ * The source variable must be a {@link PlanningListVariable list variable}.
  */
 @Target({ METHOD, FIELD })
 @Retention(RUNTIME)
 public @interface IndexShadowVariable {
 
     /**
-     * The source variable must be a {@link PlanningCollectionVariable list variable}.
+     * The source variable must be a {@link PlanningListVariable list variable}.
      * <p>
      * When the {@link Solver} changes a genuine variable, it adjusts the shadow variable accordingly.
      * In practice, the {@link Solver} ignores shadow variables (except for consistency housekeeping).

--- a/optaplanner-core/src/main/java/org/optaplanner/core/api/domain/variable/PlanningListVariable.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/api/domain/variable/PlanningListVariable.java
@@ -29,14 +29,14 @@ import org.optaplanner.core.api.domain.entity.PlanningEntity;
 import org.optaplanner.core.impl.heuristic.selector.common.decorator.SelectionSorterWeightFactory;
 
 /**
- * Specifies that a bean property (or a field) of a {@link List} type should be optimized by the optimization
- * algorithms. Unlike {@link PlanningVariable}, the {@link PlanningCollectionVariable} tells solver to change
- * elements inside the list variable instead of changing the list reference.
+ * Specifies that a bean property (or a field) of a {@link List} type should be optimized by the optimization algorithms.
+ * Unlike {@link PlanningVariable}, the {@link PlanningListVariable} tells solver to change elements inside the list variable
+ * instead of changing the list reference.
  * <p>
  * It is specified on a getter of a java bean property (or directly on a field) of a {@link PlanningEntity} class.
  * <h3>Disjoint lists</h3>
  * <p>
- * The type of the {@link PlanningCollectionVariable} annotated bean property (or field) must be {@link List}.
+ * The type of the {@link PlanningListVariable} annotated bean property (or field) must be {@link List}.
  * Furthermore, the current implementation works under the assumption that the list variables of all entity instances
  * are "disjoint lists":
  * <ul>
@@ -56,7 +56,7 @@ import org.optaplanner.core.impl.heuristic.selector.common.decorator.SelectionSo
  */
 @Target({ METHOD, FIELD })
 @Retention(RUNTIME)
-public @interface PlanningCollectionVariable {
+public @interface PlanningListVariable {
     String[] valueRangeProviderRefs() default {};
 
     /**

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/entity/descriptor/EntityDescriptor.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/entity/descriptor/EntityDescriptor.java
@@ -40,7 +40,7 @@ import org.optaplanner.core.api.domain.variable.AnchorShadowVariable;
 import org.optaplanner.core.api.domain.variable.CustomShadowVariable;
 import org.optaplanner.core.api.domain.variable.IndexShadowVariable;
 import org.optaplanner.core.api.domain.variable.InverseRelationShadowVariable;
-import org.optaplanner.core.api.domain.variable.PlanningCollectionVariable;
+import org.optaplanner.core.api.domain.variable.PlanningListVariable;
 import org.optaplanner.core.api.domain.variable.PlanningVariable;
 import org.optaplanner.core.api.score.director.ScoreDirector;
 import org.optaplanner.core.config.heuristic.selector.common.decorator.SelectionSorterOrder;
@@ -76,7 +76,7 @@ public class EntityDescriptor<Solution_> {
 
     private static final Class[] VARIABLE_ANNOTATION_CLASSES = {
             PlanningVariable.class,
-            PlanningCollectionVariable.class,
+            PlanningListVariable.class,
             InverseRelationShadowVariable.class,
             AnchorShadowVariable.class,
             IndexShadowVariable.class,
@@ -263,14 +263,14 @@ public class EntityDescriptor<Solution_> {
             GenuineVariableDescriptor<Solution_> variableDescriptor = new BasicVariableDescriptor<>(
                     this, memberAccessor);
             declaredGenuineVariableDescriptorMap.put(memberName, variableDescriptor);
-        } else if (variableAnnotationClass.equals(PlanningCollectionVariable.class)) {
+        } else if (variableAnnotationClass.equals(PlanningListVariable.class)) {
             if (List.class.isAssignableFrom(memberAccessor.getType())) {
                 GenuineVariableDescriptor<Solution_> variableDescriptor = new ListVariableDescriptor<>(
                         this, memberAccessor);
                 declaredGenuineVariableDescriptorMap.put(memberName, variableDescriptor);
             } else {
                 throw new IllegalStateException("The entityClass (" + entityClass
-                        + ") has a @" + PlanningCollectionVariable.class.getSimpleName()
+                        + ") has a @" + PlanningListVariable.class.getSimpleName()
                         + " annotated member (" + memberAccessor
                         + ") that has an unsupported type (" + memberAccessor.getType() + ").\n"
                         + "Maybe use " + List.class.getCanonicalName() + ".");

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/variable/descriptor/GenuineVariableDescriptor.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/variable/descriptor/GenuineVariableDescriptor.java
@@ -25,7 +25,7 @@ import java.util.List;
 import org.optaplanner.core.api.domain.solution.PlanningSolution;
 import org.optaplanner.core.api.domain.valuerange.CountableValueRange;
 import org.optaplanner.core.api.domain.valuerange.ValueRangeProvider;
-import org.optaplanner.core.api.domain.variable.PlanningCollectionVariable;
+import org.optaplanner.core.api.domain.variable.PlanningListVariable;
 import org.optaplanner.core.api.domain.variable.PlanningVariable;
 import org.optaplanner.core.api.score.director.ScoreDirector;
 import org.optaplanner.core.config.heuristic.selector.common.decorator.SelectionSorterOrder;
@@ -128,7 +128,7 @@ public abstract class GenuineVariableDescriptor<Solution_> extends VariableDescr
             Class<? extends Comparator> strengthComparatorClass,
             Class<? extends SelectionSorterWeightFactory> strengthWeightFactoryClass) {
         if (strengthComparatorClass == PlanningVariable.NullStrengthComparator.class
-                || strengthComparatorClass == PlanningCollectionVariable.NullStrengthComparator.class) {
+                || strengthComparatorClass == PlanningListVariable.NullStrengthComparator.class) {
             strengthComparatorClass = null;
         }
         if (strengthWeightFactoryClass == PlanningVariable.NullStrengthWeightFactory.class) {
@@ -201,7 +201,7 @@ public abstract class GenuineVariableDescriptor<Solution_> extends VariableDescr
     // ************************************************************************
 
     /**
-     * A {@link PlanningVariable#nullable() nullable} planning variable and {@link PlanningCollectionVariable}
+     * A {@link PlanningVariable#nullable() nullable} planning variable and {@link PlanningListVariable}
      * are always considered initialized.
      *
      * @param entity never null

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/variable/descriptor/ListVariableDescriptor.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/variable/descriptor/ListVariableDescriptor.java
@@ -23,7 +23,7 @@ import java.util.stream.Collectors;
 import org.optaplanner.core.api.domain.entity.PlanningEntity;
 import org.optaplanner.core.api.domain.solution.PlanningSolution;
 import org.optaplanner.core.api.domain.valuerange.ValueRangeProvider;
-import org.optaplanner.core.api.domain.variable.PlanningCollectionVariable;
+import org.optaplanner.core.api.domain.variable.PlanningListVariable;
 import org.optaplanner.core.config.util.ConfigUtils;
 import org.optaplanner.core.impl.domain.common.accessor.MemberAccessor;
 import org.optaplanner.core.impl.domain.entity.descriptor.EntityDescriptor;
@@ -37,8 +37,7 @@ public class ListVariableDescriptor<Solution_> extends GenuineVariableDescriptor
 
     @Override
     protected void processPropertyAnnotations(DescriptorPolicy descriptorPolicy) {
-        PlanningCollectionVariable planningVariableAnnotation =
-                variableMemberAccessor.getAnnotation(PlanningCollectionVariable.class);
+        PlanningListVariable planningVariableAnnotation = variableMemberAccessor.getAnnotation(PlanningListVariable.class);
         processValueRangeRefs(descriptorPolicy, planningVariableAnnotation.valueRangeProviderRefs());
         processStrength(descriptorPolicy, planningVariableAnnotation.strengthComparatorClass(),
                 planningVariableAnnotation.strengthWeightFactoryClass());
@@ -80,7 +79,7 @@ public class ListVariableDescriptor<Solution_> extends GenuineVariableDescriptor
         Class<?> variableTypeArgument = ConfigUtils.extractCollectionGenericTypeParameterStrictly(
                 "entityClass", entityDescriptor.getEntityClass(),
                 variableMemberAccessor.getType(), variableMemberAccessor.getGenericType(),
-                PlanningCollectionVariable.class, variableMemberAccessor.getName());
+                PlanningListVariable.class, variableMemberAccessor.getName());
         return variableTypeArgument.isAssignableFrom(valueType);
     }
 

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/variable/index/IndexShadowVariableDescriptor.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/variable/index/IndexShadowVariableDescriptor.java
@@ -21,7 +21,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import org.optaplanner.core.api.domain.variable.IndexShadowVariable;
-import org.optaplanner.core.api.domain.variable.PlanningCollectionVariable;
+import org.optaplanner.core.api.domain.variable.PlanningListVariable;
 import org.optaplanner.core.api.domain.variable.VariableListener;
 import org.optaplanner.core.impl.domain.common.accessor.MemberAccessor;
 import org.optaplanner.core.impl.domain.entity.descriptor.EntityDescriptor;
@@ -97,7 +97,7 @@ public class IndexShadowVariableDescriptor<Solution_> extends ShadowVariableDesc
                     + ") has an @" + IndexShadowVariable.class.getSimpleName()
                     + " annotated property (" + variableMemberAccessor.getName()
                     + ") with sourceVariableName (" + sourceVariableName
-                    + ") which is not a @" + PlanningCollectionVariable.class.getSimpleName() + ".");
+                    + ") which is not a @" + PlanningListVariable.class.getSimpleName() + ".");
         }
         sourceVariableDescriptor = (ListVariableDescriptor<Solution_>) variableDescriptor;
         sourceVariableDescriptor.registerSinkVariableDescriptor(this);

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/variable/index/IndexVariableSupply.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/variable/index/IndexVariableSupply.java
@@ -16,13 +16,13 @@
 
 package org.optaplanner.core.impl.domain.variable.index;
 
-import org.optaplanner.core.api.domain.variable.PlanningCollectionVariable;
+import org.optaplanner.core.api.domain.variable.PlanningListVariable;
 import org.optaplanner.core.impl.domain.variable.supply.Supply;
 
 public interface IndexVariableSupply extends Supply {
 
     /**
-     * Get {@code planningValue}'s index in the {@link PlanningCollectionVariable list variable} it is a member of.
+     * Get {@code planningValue}'s index in the {@link PlanningListVariable list variable} it is a member of.
      *
      * @param planningValue never null
      * @return {@code planningValue}'s index in the list variable it is a member of or {@code null} if the value is unassigned

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/variable/inverserelation/InverseRelationShadowVariableDescriptor.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/variable/inverserelation/InverseRelationShadowVariableDescriptor.java
@@ -23,7 +23,7 @@ import java.util.List;
 
 import org.optaplanner.core.api.domain.solution.PlanningSolution;
 import org.optaplanner.core.api.domain.variable.InverseRelationShadowVariable;
-import org.optaplanner.core.api.domain.variable.PlanningCollectionVariable;
+import org.optaplanner.core.api.domain.variable.PlanningListVariable;
 import org.optaplanner.core.api.domain.variable.PlanningVariable;
 import org.optaplanner.core.api.domain.variable.PlanningVariableGraphType;
 import org.optaplanner.core.api.domain.variable.VariableListener;
@@ -110,7 +110,7 @@ public class InverseRelationShadowVariableDescriptor<Solution_> extends ShadowVa
                         + " annotated property (" + variableMemberAccessor.getName()
                         + ") which does not return a " + Collection.class.getSimpleName()
                         + " with sourceVariableName (" + sourceVariableName
-                        + ") which is neither a list variable @" + PlanningCollectionVariable.class.getSimpleName()
+                        + ") which is neither a list variable @" + PlanningListVariable.class.getSimpleName()
                         + " nor a chained variable @" + PlanningVariable.class.getSimpleName()
                         + "(graphType=" + PlanningVariableGraphType.CHAINED + ")."
                         + " Only list and chained variables support a singleton inverse.");

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/variable/inverserelation/SingletonInverseVariableSupply.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/variable/inverserelation/SingletonInverseVariableSupply.java
@@ -16,12 +16,12 @@
 
 package org.optaplanner.core.impl.domain.variable.inverserelation;
 
-import org.optaplanner.core.api.domain.variable.PlanningCollectionVariable;
+import org.optaplanner.core.api.domain.variable.PlanningListVariable;
 import org.optaplanner.core.impl.domain.variable.supply.Supply;
 import org.optaplanner.core.impl.score.director.InnerScoreDirector;
 
 /**
- * Currently only supported for chained variables and {@link PlanningCollectionVariable list variables},
+ * Currently only supported for chained variables and {@link PlanningListVariable list variables},
  * which guarantee that no 2 entities use the same planningValue.
  * <p>
  * To get an instance, demand a {@link SingletonInverseVariableDemand} (for a chained variable)

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/SwapMoveSelectorFactory.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/SwapMoveSelectorFactory.java
@@ -21,7 +21,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
 
-import org.optaplanner.core.api.domain.variable.PlanningCollectionVariable;
+import org.optaplanner.core.api.domain.variable.PlanningListVariable;
 import org.optaplanner.core.config.heuristic.selector.common.SelectionCacheType;
 import org.optaplanner.core.config.heuristic.selector.common.SelectionOrder;
 import org.optaplanner.core.config.heuristic.selector.entity.EntitySelectorConfig;
@@ -86,7 +86,7 @@ public class SwapMoveSelectorFactory<Solution_>
                     randomSelection);
         }
         throw new IllegalArgumentException("The variableDescriptorList (" + variableDescriptorList
-                + ") has multiple variables and one or more of them is a @" + PlanningCollectionVariable.class.getSimpleName()
+                + ") has multiple variables and one or more of them is a @" + PlanningListVariable.class.getSimpleName()
                 + ", which is currently not supported.");
     }
 

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/ListChangeMove.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/ListChangeMove.java
@@ -23,14 +23,14 @@ import java.util.Objects;
 import java.util.Set;
 
 import org.optaplanner.core.api.domain.solution.PlanningSolution;
-import org.optaplanner.core.api.domain.variable.PlanningCollectionVariable;
+import org.optaplanner.core.api.domain.variable.PlanningListVariable;
 import org.optaplanner.core.api.score.director.ScoreDirector;
 import org.optaplanner.core.impl.domain.variable.descriptor.ListVariableDescriptor;
 import org.optaplanner.core.impl.heuristic.move.AbstractMove;
 import org.optaplanner.core.impl.score.director.InnerScoreDirector;
 
 /**
- * Moves an element of a {@link PlanningCollectionVariable list variable}. The moved element is identified
+ * Moves an element of a {@link PlanningListVariable list variable}. The moved element is identified
  * by an entity instance and a position in that entity's list variable. The element is inserted at the given index
  * in the given destination entity's list variable.
  * <p>

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/ListSwapMove.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/ListSwapMove.java
@@ -23,14 +23,14 @@ import java.util.Objects;
 import java.util.Set;
 
 import org.optaplanner.core.api.domain.solution.PlanningSolution;
-import org.optaplanner.core.api.domain.variable.PlanningCollectionVariable;
+import org.optaplanner.core.api.domain.variable.PlanningListVariable;
 import org.optaplanner.core.api.score.director.ScoreDirector;
 import org.optaplanner.core.impl.domain.variable.descriptor.ListVariableDescriptor;
 import org.optaplanner.core.impl.heuristic.move.AbstractMove;
 import org.optaplanner.core.impl.score.director.InnerScoreDirector;
 
 /**
- * Swaps two elements of a {@link PlanningCollectionVariable list variable}.
+ * Swaps two elements of a {@link PlanningListVariable list variable}.
  * Each element is identified by an entity instance and an index in that entity's list variable.
  * The swap move has two sides called left and right. The element at {@code leftIndex} in {@code leftEntity}'s list variable
  * is replaced by the element at {@code rightIndex} in {@code rightEntity}'s list variable and vice versa.

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/testdata/domain/list/TestdataListEntity.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/testdata/domain/list/TestdataListEntity.java
@@ -21,7 +21,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import org.optaplanner.core.api.domain.entity.PlanningEntity;
-import org.optaplanner.core.api.domain.variable.PlanningCollectionVariable;
+import org.optaplanner.core.api.domain.variable.PlanningListVariable;
 import org.optaplanner.core.impl.domain.entity.descriptor.EntityDescriptor;
 import org.optaplanner.core.impl.domain.variable.descriptor.ListVariableDescriptor;
 import org.optaplanner.core.impl.testdata.domain.TestdataObject;
@@ -50,7 +50,7 @@ public class TestdataListEntity extends TestdataObject {
         return this;
     }
 
-    @PlanningCollectionVariable(valueRangeProviderRefs = "valueRange")
+    @PlanningListVariable(valueRangeProviderRefs = "valueRange")
     private List<TestdataListValue> valueList;
 
     public TestdataListEntity() {

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/testdata/domain/list/externalized/TestdataListEntityExternalized.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/testdata/domain/list/externalized/TestdataListEntityExternalized.java
@@ -21,13 +21,13 @@ import java.util.Arrays;
 import java.util.List;
 
 import org.optaplanner.core.api.domain.entity.PlanningEntity;
-import org.optaplanner.core.api.domain.variable.PlanningCollectionVariable;
+import org.optaplanner.core.api.domain.variable.PlanningListVariable;
 import org.optaplanner.core.impl.testdata.domain.TestdataObject;
 
 @PlanningEntity
 public class TestdataListEntityExternalized extends TestdataObject {
 
-    @PlanningCollectionVariable(valueRangeProviderRefs = "valueRange")
+    @PlanningListVariable(valueRangeProviderRefs = "valueRange")
     private List<TestdataListValueExternalized> valueList;
 
     public TestdataListEntityExternalized() {

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/testdata/domain/list/mixed/TestdataMixedVariablesEntity.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/testdata/domain/list/mixed/TestdataMixedVariablesEntity.java
@@ -19,7 +19,7 @@ package org.optaplanner.core.impl.testdata.domain.list.mixed;
 import java.util.List;
 
 import org.optaplanner.core.api.domain.entity.PlanningEntity;
-import org.optaplanner.core.api.domain.variable.PlanningCollectionVariable;
+import org.optaplanner.core.api.domain.variable.PlanningListVariable;
 import org.optaplanner.core.api.domain.variable.PlanningVariable;
 import org.optaplanner.core.impl.domain.entity.descriptor.EntityDescriptor;
 import org.optaplanner.core.impl.domain.variable.descriptor.ListVariableDescriptor;
@@ -39,7 +39,7 @@ public class TestdataMixedVariablesEntity extends TestdataObject {
                 .getGenuineVariableDescriptor("valueList");
     }
 
-    @PlanningCollectionVariable(valueRangeProviderRefs = "valueRange")
+    @PlanningListVariable(valueRangeProviderRefs = "valueRange")
     private final List<TestdataValue> valueList;
     @PlanningVariable(valueRangeProviderRefs = "valueRange")
     private TestdataValue value;

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/testdata/domain/list/valuerange/TestdataListEntityWithArrayValueRange.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/testdata/domain/list/valuerange/TestdataListEntityWithArrayValueRange.java
@@ -21,7 +21,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import org.optaplanner.core.api.domain.entity.PlanningEntity;
-import org.optaplanner.core.api.domain.variable.PlanningCollectionVariable;
+import org.optaplanner.core.api.domain.variable.PlanningListVariable;
 import org.optaplanner.core.impl.domain.entity.descriptor.EntityDescriptor;
 import org.optaplanner.core.impl.domain.variable.descriptor.GenuineVariableDescriptor;
 import org.optaplanner.core.impl.testdata.domain.TestdataObject;
@@ -39,7 +39,7 @@ public class TestdataListEntityWithArrayValueRange extends TestdataObject {
         return buildEntityDescriptor().getGenuineVariableDescriptor("valueList");
     }
 
-    @PlanningCollectionVariable(valueRangeProviderRefs = "arrayValueRange")
+    @PlanningListVariable(valueRangeProviderRefs = "arrayValueRange")
     private final List<TestdataValue> valueList;
 
     public TestdataListEntityWithArrayValueRange(String code, List<TestdataValue> valueList) {

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/taskassigning_listvariable/domain/Employee.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/taskassigning_listvariable/domain/Employee.java
@@ -24,7 +24,7 @@ import java.util.Map;
 import java.util.Set;
 
 import org.optaplanner.core.api.domain.entity.PlanningEntity;
-import org.optaplanner.core.api.domain.variable.PlanningCollectionVariable;
+import org.optaplanner.core.api.domain.variable.PlanningListVariable;
 import org.optaplanner.examples.common.domain.AbstractPersistable;
 import org.optaplanner.examples.common.swingui.components.Labeled;
 import org.optaplanner.examples.taskassigning_listvariable.domain.solver.TaskDifficultyComparator;
@@ -43,7 +43,7 @@ public class Employee extends AbstractPersistable implements Labeled {
     // TODO maybe needs graphType=DISJOINT_LIST(_ORDERED)
     // - disjoint because otherwise the inverse relation shadow variable would be a collection
     // - ordered because otherwise index shadow variable is not possible
-    @PlanningCollectionVariable(valueRangeProviderRefs = "taskRange", strengthComparatorClass = TaskDifficultyComparator.class)
+    @PlanningListVariable(valueRangeProviderRefs = "taskRange", strengthComparatorClass = TaskDifficultyComparator.class)
     private List<Task> tasks;
 
     // TODO pinning

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/main/java/org/optaplanner/quarkus/deployment/DotNames.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/main/java/org/optaplanner/quarkus/deployment/DotNames.java
@@ -35,7 +35,7 @@ import org.optaplanner.core.api.domain.valuerange.ValueRangeProvider;
 import org.optaplanner.core.api.domain.variable.AnchorShadowVariable;
 import org.optaplanner.core.api.domain.variable.CustomShadowVariable;
 import org.optaplanner.core.api.domain.variable.InverseRelationShadowVariable;
-import org.optaplanner.core.api.domain.variable.PlanningCollectionVariable;
+import org.optaplanner.core.api.domain.variable.PlanningListVariable;
 import org.optaplanner.core.api.domain.variable.PlanningVariable;
 import org.optaplanner.core.api.domain.variable.PlanningVariableReference;
 import org.optaplanner.core.api.score.calculator.EasyScoreCalculator;
@@ -65,7 +65,7 @@ public final class DotNames {
     static final DotName PLANNING_ID = DotName.createSimple(PlanningId.class.getName());
 
     static final DotName PLANNING_VARIABLE = DotName.createSimple(PlanningVariable.class.getName());
-    static final DotName PLANNING_COLLECTION_VARIABLE = DotName.createSimple(PlanningCollectionVariable.class.getName());
+    static final DotName PLANNING_COLLECTION_VARIABLE = DotName.createSimple(PlanningListVariable.class.getName());
     static final DotName VALUE_RANGE_PROVIDER = DotName.createSimple(ValueRangeProvider.class.getName());
     static final DotName PLANNING_VARIABLE_REFERENCE = DotName.createSimple(PlanningVariableReference.class.getName());
 


### PR DESCRIPTION
Changing the annotation name to `@PlanningListVariable` as agreed in the **List variable naming, part 2** discussion on October 14.