### PR TITLE
PLANNER-2625: Do not fail fast if termination is configured per benchmark

### DIFF
--- a/optaplanner-core/src/main/java/org/optaplanner/core/config/solver/termination/TerminationConfig.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/config/solver/termination/TerminationConfig.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.function.Consumer;
 
 import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlTransient;
 import javax.xml.bind.annotation.XmlType;
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 
@@ -509,6 +510,31 @@ public class TerminationConfig extends AbstractConfig<TerminationConfig> {
             unimprovedTimeMillisSpentLimit += unimprovedDaysSpentLimit * 86400000L;
         }
         return unimprovedTimeMillisSpentLimit;
+    }
+
+    /**
+     * Return true if this TerminationConfig configures a termination condition.
+     * Note: this does not mean it will always terminate: ex: bestScoreLimit configured,
+     * but it is impossible to reach the bestScoreLimit.
+     */
+    @XmlTransient
+    public boolean isConfigured() {
+        return terminationClass != null ||
+                spentLimit != null ||
+                millisecondsSpentLimit != null ||
+                secondsSpentLimit != null ||
+                minutesSpentLimit != null ||
+                hoursSpentLimit != null ||
+                daysSpentLimit != null ||
+                bestScoreLimit != null ||
+                unimprovedSpentLimit != null ||
+                unimprovedMillisecondsSpentLimit != null ||
+                unimprovedSecondsSpentLimit != null ||
+                unimprovedMinutesSpentLimit != null ||
+                unimprovedHoursSpentLimit != null ||
+                unimprovedDaysSpentLimit != null ||
+                stepCountLimit != null ||
+                terminationConfigList != null;
     }
 
     @Override

--- a/optaplanner-quarkus-integration/optaplanner-quarkus-benchmark/deployment/src/test/java/org/optaplanner/benchmark/quarkus/OptaPlannerBenchmarkProcessorMissingSpentLimitPerBenchmarkTest.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus-benchmark/deployment/src/test/java/org/optaplanner/benchmark/quarkus/OptaPlannerBenchmarkProcessorMissingSpentLimitPerBenchmarkTest.java
@@ -52,7 +52,7 @@ public class OptaPlannerBenchmarkProcessorMissingSpentLimitPerBenchmarkTest {
         });
         Assertions.assertEquals(
                 "The following " + SolverBenchmarkConfig.class.getSimpleName() + " do not " +
-                        "have termination configured: First Fit and Local Search no Termination. " +
+                        "have termination configured: [First Fit and Local Search without Termination]. " +
                         "At least one of the properties " +
                         "quarkus.optaplanner.benchmark.solver.termination.spent-limit, " +
                         "quarkus.optaplanner.benchmark.solver.termination.best-score-limit, " +

--- a/optaplanner-quarkus-integration/optaplanner-quarkus-benchmark/deployment/src/test/java/org/optaplanner/benchmark/quarkus/OptaPlannerBenchmarkProcessorMissingSpentLimitPerBenchmarkTest.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus-benchmark/deployment/src/test/java/org/optaplanner/benchmark/quarkus/OptaPlannerBenchmarkProcessorMissingSpentLimitPerBenchmarkTest.java
@@ -24,28 +24,41 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.optaplanner.benchmark.config.PlannerBenchmarkConfig;
+import org.optaplanner.benchmark.config.SolverBenchmarkConfig;
 import org.optaplanner.benchmark.quarkus.testdata.normal.constraints.TestdataQuarkusConstraintProvider;
 import org.optaplanner.benchmark.quarkus.testdata.normal.domain.TestdataQuarkusEntity;
 import org.optaplanner.benchmark.quarkus.testdata.normal.domain.TestdataQuarkusSolution;
 
 import io.quarkus.test.QuarkusUnitTest;
 
-public class OptaPlannerBenchmarkProcessorMissingSpentLimitTest {
+public class OptaPlannerBenchmarkProcessorMissingSpentLimitPerBenchmarkTest {
 
     @RegisterExtension
     static final QuarkusUnitTest config = new QuarkusUnitTest()
             .overrideConfigKey("quarkus.test.flat-class-path", "true")
+            .overrideConfigKey("quarkus.optaplanner.benchmark.solver-benchmark-config-xml",
+                    "solverBenchmarkConfigSpentLimitPerBenchmarkNoTermination.xml")
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
                     .addClasses(TestdataQuarkusEntity.class,
-                            TestdataQuarkusSolution.class, TestdataQuarkusConstraintProvider.class));
+                            TestdataQuarkusSolution.class, TestdataQuarkusConstraintProvider.class)
+                    .addAsResource("solverBenchmarkConfigSpentLimitPerBenchmarkNoTermination.xml"));
 
     @Test
     public void benchmark() throws ExecutionException, InterruptedException {
+        PlannerBenchmarkConfig benchmarkConfig =
+                PlannerBenchmarkConfig.createFromXmlResource("solverBenchmarkConfigSpentLimitPerBenchmarkNoTermination.xml");
         IllegalStateException exception = Assertions.assertThrows(IllegalStateException.class, () -> {
-            new OptaPlannerBenchmarkRecorder().benchmarkConfigSupplier(new PlannerBenchmarkConfig()).get();
+            new OptaPlannerBenchmarkRecorder().benchmarkConfigSupplier(benchmarkConfig).get();
         });
         Assertions.assertEquals(
-                "At least one of the properties quarkus.optaplanner.benchmark.solver.termination.spent-limit, quarkus.optaplanner.benchmark.solver.termination.best-score-limit, quarkus.optaplanner.benchmark.solver.termination.unimproved-spent-limit is required if termination is not configured in the inherited solver benchmark config and solverBenchmarkBluePrint is used.",
+                "The following " + SolverBenchmarkConfig.class.getSimpleName() + " do not " +
+                        "have termination configured: First Fit and Local Search no Termination. " +
+                        "At least one of the properties " +
+                        "quarkus.optaplanner.benchmark.solver.termination.spent-limit, " +
+                        "quarkus.optaplanner.benchmark.solver.termination.best-score-limit, " +
+                        "quarkus.optaplanner.benchmark.solver.termination.unimproved-spent-limit " +
+                        "is required if termination is not configured in a solver benchmark and the " +
+                        "inherited solver benchmark config.",
                 exception.getMessage());
     }
 

--- a/optaplanner-quarkus-integration/optaplanner-quarkus-benchmark/deployment/src/test/resources/solverBenchmarkConfigSpentLimitPerBenchmark.xml
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus-benchmark/deployment/src/test/resources/solverBenchmarkConfigSpentLimitPerBenchmark.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plannerBenchmark xmlns="https://www.optaplanner.org/xsd/benchmark" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="https://www.optaplanner.org/xsd/benchmark https://www.optaplanner.org/xsd/benchmark/benchmark.xsd">
+    <solverBenchmark>
+        <name>First Fit and Local Search</name>
+        <solver>
+          <constructionHeuristic>
+            <constructionHeuristicType>FIRST_FIT</constructionHeuristicType>
+          </constructionHeuristic>
+          <localSearch>
+            <termination>
+              <millisecondsSpentLimit>5</millisecondsSpentLimit>
+            </termination>
+          </localSearch>
+        </solver>
+    </solverBenchmark>
+</plannerBenchmark>

--- a/optaplanner-quarkus-integration/optaplanner-quarkus-benchmark/deployment/src/test/resources/solverBenchmarkConfigSpentLimitPerBenchmarkNoTermination.xml
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus-benchmark/deployment/src/test/resources/solverBenchmarkConfigSpentLimitPerBenchmarkNoTermination.xml
@@ -2,7 +2,7 @@
 <plannerBenchmark xmlns="https://www.optaplanner.org/xsd/benchmark" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                   xsi:schemaLocation="https://www.optaplanner.org/xsd/benchmark https://www.optaplanner.org/xsd/benchmark/benchmark.xsd">
   <solverBenchmark>
-      <name>First Fit and Local Search no Termination</name>
+      <name>First Fit and Local Search without Termination</name>
       <solver>
         <constructionHeuristic>
           <constructionHeuristicType>FIRST_FIT</constructionHeuristicType>

--- a/optaplanner-quarkus-integration/optaplanner-quarkus-benchmark/deployment/src/test/resources/solverBenchmarkConfigSpentLimitPerBenchmarkNoTermination.xml
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus-benchmark/deployment/src/test/resources/solverBenchmarkConfigSpentLimitPerBenchmarkNoTermination.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plannerBenchmark xmlns="https://www.optaplanner.org/xsd/benchmark" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="https://www.optaplanner.org/xsd/benchmark https://www.optaplanner.org/xsd/benchmark/benchmark.xsd">
+  <solverBenchmark>
+      <name>First Fit and Local Search no Termination</name>
+      <solver>
+        <constructionHeuristic>
+          <constructionHeuristicType>FIRST_FIT</constructionHeuristicType>
+        </constructionHeuristic>
+        <localSearch />
+      </solver>
+  </solverBenchmark>
+  <solverBenchmark>
+    <name>First Fit and Local Search with Termination</name>
+    <solver>
+      <constructionHeuristic>
+        <constructionHeuristicType>FIRST_FIT</constructionHeuristicType>
+      </constructionHeuristic>
+      <localSearch>
+        <termination>
+          <millisecondsSpentLimit>5</millisecondsSpentLimit>
+        </termination>
+      </localSearch>
+    </solver>
+  </solverBenchmark>
+</plannerBenchmark>

--- a/optaplanner-quarkus-integration/optaplanner-quarkus-benchmark/runtime/src/main/java/org/optaplanner/benchmark/quarkus/OptaPlannerBenchmarkRecorder.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus-benchmark/runtime/src/main/java/org/optaplanner/benchmark/quarkus/OptaPlannerBenchmarkRecorder.java
@@ -17,13 +17,17 @@
 package org.optaplanner.benchmark.quarkus;
 
 import java.io.File;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 import java.util.function.Supplier;
 
 import org.optaplanner.benchmark.config.PlannerBenchmarkConfig;
 import org.optaplanner.benchmark.config.ProblemBenchmarksConfig;
 import org.optaplanner.benchmark.config.SolverBenchmarkConfig;
 import org.optaplanner.benchmark.quarkus.config.OptaPlannerBenchmarkRuntimeConfig;
+import org.optaplanner.core.config.constructionheuristic.ConstructionHeuristicPhaseConfig;
+import org.optaplanner.core.config.phase.PhaseConfig;
 import org.optaplanner.core.config.solver.SolverConfig;
 import org.optaplanner.core.config.solver.termination.TerminationConfig;
 
@@ -67,11 +71,51 @@ public class OptaPlannerBenchmarkRecorder {
         benchmarkRuntimeConfig.termination.bestScoreLimit.ifPresent(terminationConfig::setBestScoreLimit);
 
         if (!isTerminationConfigured(terminationConfig)) {
-            throw new IllegalStateException("At least one of the properties " +
-                    "quarkus.optaplanner.benchmark.solver.termination.spent-limit, " +
-                    "quarkus.optaplanner.benchmark.solver.termination.best-score-limit, " +
-                    "quarkus.optaplanner.benchmark.solver.termination.unimproved-spent-limit " +
-                    "is required if the inherited solver config does not have termination configured.");
+            List<SolverBenchmarkConfig> solverBenchmarkConfigList = plannerBenchmarkConfig.getSolverBenchmarkConfigList();
+            List<String> unconfiguredTerminationSolverBenchmarkList = new ArrayList<>();
+            if (solverBenchmarkConfigList == null) {
+                throw new IllegalStateException("At least one of the properties " +
+                        "quarkus.optaplanner.benchmark.solver.termination.spent-limit, " +
+                        "quarkus.optaplanner.benchmark.solver.termination.best-score-limit, " +
+                        "quarkus.optaplanner.benchmark.solver.termination.unimproved-spent-limit " +
+                        "is required if termination is not configured in the " +
+                        "inherited solver benchmark config and solverBenchmarkBluePrint is used.");
+            }
+            for (int i = 0; i < solverBenchmarkConfigList.size(); i++) {
+                SolverBenchmarkConfig solverBenchmarkConfig = solverBenchmarkConfigList.get(i);
+                terminationConfig = solverBenchmarkConfig.getSolverConfig().getTerminationConfig();
+                if (!isTerminationConfigured(terminationConfig)) {
+                    boolean isTerminationConfiguredForAllNonConstructionHeuristicPhases = !solverBenchmarkConfig
+                            .getSolverConfig().getPhaseConfigList().isEmpty();
+                    for (PhaseConfig<?> phaseConfig : solverBenchmarkConfig.getSolverConfig().getPhaseConfigList()) {
+                        if (!(phaseConfig instanceof ConstructionHeuristicPhaseConfig)) {
+                            if (!isTerminationConfigured(phaseConfig.getTerminationConfig())) {
+                                System.out.println("The phase " + phaseConfig + " is not configured.");
+                                isTerminationConfiguredForAllNonConstructionHeuristicPhases = false;
+                                break;
+                            }
+                        }
+                    }
+                    if (!isTerminationConfiguredForAllNonConstructionHeuristicPhases) {
+                        String benchmarkConfigName = solverBenchmarkConfig.getName();
+                        if (benchmarkConfigName == null) {
+                            benchmarkConfigName = "SolverBenchmarkConfig " + i;
+                        }
+                        unconfiguredTerminationSolverBenchmarkList.add(benchmarkConfigName);
+                    }
+                }
+            }
+            if (!unconfiguredTerminationSolverBenchmarkList.isEmpty()) {
+                throw new IllegalStateException("The following " + SolverBenchmarkConfig.class.getSimpleName() + " do not " +
+                        "have termination configured: " +
+                        String.join(", ", unconfiguredTerminationSolverBenchmarkList) + ". " +
+                        "At least one of the properties " +
+                        "quarkus.optaplanner.benchmark.solver.termination.spent-limit, " +
+                        "quarkus.optaplanner.benchmark.solver.termination.best-score-limit, " +
+                        "quarkus.optaplanner.benchmark.solver.termination.unimproved-spent-limit " +
+                        "is required if termination is not configured in a solver benchmark and the " +
+                        "inherited solver benchmark config.");
+            }
         }
 
         if (plannerBenchmarkConfig.getSolverBenchmarkConfigList() == null
@@ -81,10 +125,23 @@ public class OptaPlannerBenchmarkRecorder {
     }
 
     private boolean isTerminationConfigured(TerminationConfig terminationConfig) {
+        if (terminationConfig == null) {
+            return false;
+        }
         return terminationConfig.getTerminationClass() != null ||
                 terminationConfig.getSpentLimit() != null ||
+                terminationConfig.getMillisecondsSpentLimit() != null ||
+                terminationConfig.getSecondsSpentLimit() != null ||
+                terminationConfig.getMinutesSpentLimit() != null ||
+                terminationConfig.getHoursSpentLimit() != null ||
+                terminationConfig.getDaysSpentLimit() != null ||
                 terminationConfig.getBestScoreLimit() != null ||
                 terminationConfig.getUnimprovedSpentLimit() != null ||
+                terminationConfig.getUnimprovedMillisecondsSpentLimit() != null ||
+                terminationConfig.getUnimprovedSecondsSpentLimit() != null ||
+                terminationConfig.getUnimprovedMinutesSpentLimit() != null ||
+                terminationConfig.getUnimprovedHoursSpentLimit() != null ||
+                terminationConfig.getUnimprovedDaysSpentLimit() != null ||
                 terminationConfig.getStepCountLimit() != null ||
                 terminationConfig.getTerminationConfigList() != null;
     }


### PR DESCRIPTION
<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.
-->

### JIRA

<!-- Add a JIRA ticket link if it exists. -->
https://issues.redhat.com/browse/PLANNER-2625

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
* https://github.com/kiegroup/drools/pull/3000
* https://github.com/kiegroup/optaplanner/pull/899
* etc.
-->

### Checklist
- [ ] Documentation updated if applicable.
- [ ] Upgrade recipe provided if applicable.

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>specific pull request build</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] tests</b>
* for a <b>full downstream build</b> 
  * for <b>jenkins</b> job: please add comment: <b>Jenkins run fdb</b>
  * for <b>github actions</b> job: add the label `run_fdb`
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
* for a <b>Quarkus LTS check</b> please add comment: <b>Jenkins run LTS</b>
* for a <b>specific Quarkus LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] LTS</b>
* for a <b>Native check</b> please add comment: <b>Jenkins run native</b>
* for a <b>specific Native LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] native</b>
</details>
