### PR TITLE
PLANNER-2626, PLANNER-2624: Fix inherited benchmark config

### DIFF
--- a/optaplanner-core/src/main/java/org/optaplanner/core/config/solver/termination/TerminationConfig.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/config/solver/termination/TerminationConfig.java
@@ -520,7 +520,6 @@ public class TerminationConfig extends AbstractConfig<TerminationConfig> {
     @XmlTransient
     public boolean isConfigured() {
         return terminationClass != null ||
-                terminationCompositionStyle != null ||
                 spentLimit != null ||
                 millisecondsSpentLimit != null ||
                 secondsSpentLimit != null ||
@@ -533,14 +532,27 @@ public class TerminationConfig extends AbstractConfig<TerminationConfig> {
                 unimprovedMinutesSpentLimit != null ||
                 unimprovedHoursSpentLimit != null ||
                 unimprovedDaysSpentLimit != null ||
-                unimprovedScoreDifferenceThreshold != null ||
                 bestScoreLimit != null ||
                 bestScoreFeasible != null ||
                 stepCountLimit != null ||
                 unimprovedStepCountLimit != null ||
                 scoreCalculationCountLimit != null ||
-                (terminationConfigList != null &&
-                        terminationConfigList.stream().anyMatch(TerminationConfig::isConfigured));
+                isTerminationListConfigured();
+    }
+
+    private boolean isTerminationListConfigured() {
+        if (terminationConfigList == null || terminationCompositionStyle == null) {
+            return false;
+        }
+
+        switch (terminationCompositionStyle) {
+            case AND:
+                return terminationConfigList.stream().allMatch(TerminationConfig::isConfigured);
+            case OR:
+                return terminationConfigList.stream().anyMatch(TerminationConfig::isConfigured);
+            default:
+                throw new IllegalStateException("Unhandled case (" + terminationCompositionStyle + ").");
+        }
     }
 
     @Override

--- a/optaplanner-core/src/main/java/org/optaplanner/core/config/solver/termination/TerminationConfig.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/config/solver/termination/TerminationConfig.java
@@ -520,21 +520,27 @@ public class TerminationConfig extends AbstractConfig<TerminationConfig> {
     @XmlTransient
     public boolean isConfigured() {
         return terminationClass != null ||
+                terminationCompositionStyle != null ||
                 spentLimit != null ||
                 millisecondsSpentLimit != null ||
                 secondsSpentLimit != null ||
                 minutesSpentLimit != null ||
                 hoursSpentLimit != null ||
                 daysSpentLimit != null ||
-                bestScoreLimit != null ||
                 unimprovedSpentLimit != null ||
                 unimprovedMillisecondsSpentLimit != null ||
                 unimprovedSecondsSpentLimit != null ||
                 unimprovedMinutesSpentLimit != null ||
                 unimprovedHoursSpentLimit != null ||
                 unimprovedDaysSpentLimit != null ||
+                unimprovedScoreDifferenceThreshold != null ||
+                bestScoreLimit != null ||
+                bestScoreFeasible != null ||
                 stepCountLimit != null ||
-                terminationConfigList != null;
+                unimprovedStepCountLimit != null ||
+                scoreCalculationCountLimit != null ||
+                (terminationConfigList != null &&
+                        terminationConfigList.stream().anyMatch(TerminationConfig::isConfigured));
     }
 
     @Override

--- a/optaplanner-quarkus-integration/optaplanner-quarkus-benchmark/deployment/src/main/java/org/optaplanner/benchmark/quarkus/deployment/OptaPlannerBenchmarkProcessor.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus-benchmark/deployment/src/main/java/org/optaplanner/benchmark/quarkus/deployment/OptaPlannerBenchmarkProcessor.java
@@ -79,7 +79,7 @@ class OptaPlannerBenchmarkProcessor {
             benchmarkConfig = PlannerBenchmarkConfig.createFromXmlResource(
                     OptaPlannerBenchmarkBuildTimeConfig.DEFAULT_SOLVER_BENCHMARK_CONFIG_URL);
         } else {
-            benchmarkConfig = new PlannerBenchmarkConfig();
+            benchmarkConfig = null;
         }
         syntheticBeans.produce(SyntheticBeanBuildItem.configure(PlannerBenchmarkConfig.class)
                 .supplier(recorder.benchmarkConfigSupplier(benchmarkConfig))

--- a/optaplanner-quarkus-integration/optaplanner-quarkus-benchmark/deployment/src/test/java/org/optaplanner/benchmark/quarkus/OptaPlannerBenchmarkProcessorInheritedSolverBenchmarkTest.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus-benchmark/deployment/src/test/java/org/optaplanner/benchmark/quarkus/OptaPlannerBenchmarkProcessorInheritedSolverBenchmarkTest.java
@@ -26,9 +26,12 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.optaplanner.benchmark.config.PlannerBenchmarkConfig;
+import org.optaplanner.benchmark.config.SolverBenchmarkConfig;
 import org.optaplanner.benchmark.quarkus.testdata.normal.constraints.TestdataQuarkusConstraintProvider;
 import org.optaplanner.benchmark.quarkus.testdata.normal.domain.TestdataQuarkusEntity;
+import org.optaplanner.benchmark.quarkus.testdata.normal.domain.TestdataQuarkusOtherEntity;
 import org.optaplanner.benchmark.quarkus.testdata.normal.domain.TestdataQuarkusSolution;
+import org.optaplanner.core.config.solver.SolverConfig;
 
 import io.quarkus.test.QuarkusUnitTest;
 
@@ -38,23 +41,43 @@ public class OptaPlannerBenchmarkProcessorInheritedSolverBenchmarkTest {
     static final QuarkusUnitTest config = new QuarkusUnitTest()
             .overrideConfigKey("quarkus.optaplanner.benchmark.solver.termination.best-score-limit", "0")
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
-                    .addClasses(TestdataQuarkusEntity.class,
+                    .addClasses(TestdataQuarkusEntity.class, TestdataQuarkusOtherEntity.class,
                             TestdataQuarkusSolution.class, TestdataQuarkusConstraintProvider.class)
                     .addAsResource("solverConfig.xml")
                     .addAsResource("solverBenchmarkConfigWithInheritedSolverBenchmark.xml", "solverBenchmarkConfig.xml"));
+
+    @Inject
+    SolverConfig solverConfig;
 
     @Inject
     PlannerBenchmarkConfig plannerBenchmarkConfig;
 
     @Test
     public void inheritClassesFromSolverConfig() {
-        Assertions.assertEquals(TestdataQuarkusSolution.class,
-                plannerBenchmarkConfig.getInheritedSolverBenchmarkConfig().getSolverConfig().getSolutionClass());
+        Assertions.assertEquals(TestdataQuarkusSolution.class, solverConfig.getSolutionClass());
+        Assertions.assertEquals(2, solverConfig.getEntityClassList().size());
+        Assertions.assertTrue(solverConfig.getEntityClassList().contains(TestdataQuarkusEntity.class));
+        Assertions.assertTrue(solverConfig.getEntityClassList().contains(TestdataQuarkusOtherEntity.class));
+        Assertions.assertEquals(5, plannerBenchmarkConfig.getInheritedSolverBenchmarkConfig()
+                .getSolverConfig().getTerminationConfig().getMillisecondsSpentLimit());
         Assertions.assertEquals(List.of(TestdataQuarkusEntity.class),
                 plannerBenchmarkConfig.getInheritedSolverBenchmarkConfig().getSolverConfig().getEntityClassList());
-        Assertions.assertEquals(5, plannerBenchmarkConfig.getInheritedSolverBenchmarkConfig().getSolverConfig()
-                .getTerminationConfig().getMillisecondsSpentLimit());
-        Assertions.assertNotNull(plannerBenchmarkConfig.getInheritedSolverBenchmarkConfig().getProblemBenchmarksConfig());
+
+        SolverBenchmarkConfig childBenchmarkConfig = plannerBenchmarkConfig.getSolverBenchmarkConfigList().get(0);
+        Assertions.assertEquals(TestdataQuarkusSolution.class,
+                childBenchmarkConfig.getSolverConfig().getSolutionClass());
+        Assertions.assertNull(childBenchmarkConfig.getSolverConfig().getEntityClassList()); // inherited from inherited solver config
+        Assertions.assertEquals(TestdataQuarkusConstraintProvider.class,
+                childBenchmarkConfig.getSolverConfig().getScoreDirectorFactoryConfig()
+                        .getConstraintProviderClass());
+
+        childBenchmarkConfig = plannerBenchmarkConfig.getSolverBenchmarkConfigList().get(1);
+        Assertions.assertEquals(TestdataQuarkusConstraintProvider.class,
+                childBenchmarkConfig.getSolverConfig().getSolutionClass());
+        Assertions.assertNull(childBenchmarkConfig.getSolverConfig().getEntityClassList()); // inherited from inherited solver config
+        Assertions.assertEquals(TestdataQuarkusConstraintProvider.class,
+                childBenchmarkConfig.getSolverConfig().getScoreDirectorFactoryConfig()
+                        .getConstraintProviderClass());
     }
 
 }

--- a/optaplanner-quarkus-integration/optaplanner-quarkus-benchmark/deployment/src/test/java/org/optaplanner/benchmark/quarkus/OptaPlannerBenchmarkProcessorInheritedSolverBenchmarkTest.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus-benchmark/deployment/src/test/java/org/optaplanner/benchmark/quarkus/OptaPlannerBenchmarkProcessorInheritedSolverBenchmarkTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.benchmark.quarkus;
+
+import java.util.List;
+
+import javax.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.optaplanner.benchmark.config.PlannerBenchmarkConfig;
+import org.optaplanner.benchmark.quarkus.testdata.normal.constraints.TestdataQuarkusConstraintProvider;
+import org.optaplanner.benchmark.quarkus.testdata.normal.domain.TestdataQuarkusEntity;
+import org.optaplanner.benchmark.quarkus.testdata.normal.domain.TestdataQuarkusSolution;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class OptaPlannerBenchmarkProcessorInheritedSolverBenchmarkTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .overrideConfigKey("quarkus.optaplanner.benchmark.solver.termination.best-score-limit", "0")
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(TestdataQuarkusEntity.class,
+                            TestdataQuarkusSolution.class, TestdataQuarkusConstraintProvider.class)
+                    .addAsResource("solverConfig.xml")
+                    .addAsResource("solverBenchmarkConfigWithInheritedSolverBenchmark.xml", "solverBenchmarkConfig.xml"));
+
+    @Inject
+    PlannerBenchmarkConfig plannerBenchmarkConfig;
+
+    @Test
+    public void inheritClassesFromSolverConfig() {
+        Assertions.assertEquals(TestdataQuarkusSolution.class,
+                plannerBenchmarkConfig.getInheritedSolverBenchmarkConfig().getSolverConfig().getSolutionClass());
+        Assertions.assertEquals(List.of(TestdataQuarkusEntity.class),
+                plannerBenchmarkConfig.getInheritedSolverBenchmarkConfig().getSolverConfig().getEntityClassList());
+        Assertions.assertEquals(5, plannerBenchmarkConfig.getInheritedSolverBenchmarkConfig().getSolverConfig()
+                .getTerminationConfig().getMillisecondsSpentLimit());
+        Assertions.assertNotNull(plannerBenchmarkConfig.getInheritedSolverBenchmarkConfig().getProblemBenchmarksConfig());
+    }
+
+}

--- a/optaplanner-quarkus-integration/optaplanner-quarkus-benchmark/deployment/src/test/java/org/optaplanner/benchmark/quarkus/OptaPlannerBenchmarkProcessorOnlySolverConfigTest.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus-benchmark/deployment/src/test/java/org/optaplanner/benchmark/quarkus/OptaPlannerBenchmarkProcessorOnlySolverConfigTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.benchmark.quarkus;
+
+import java.util.concurrent.ExecutionException;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import javax.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.optaplanner.benchmark.api.PlannerBenchmarkFactory;
+import org.optaplanner.benchmark.quarkus.testdata.normal.constraints.TestdataQuarkusConstraintProvider;
+import org.optaplanner.benchmark.quarkus.testdata.normal.domain.TestdataQuarkusEntity;
+import org.optaplanner.benchmark.quarkus.testdata.normal.domain.TestdataQuarkusSolution;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class OptaPlannerBenchmarkProcessorOnlySolverConfigTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(TestdataQuarkusEntity.class,
+                            TestdataQuarkusSolution.class, TestdataQuarkusConstraintProvider.class)
+                    .addAsResource("solverConfig.xml"));
+
+    @Inject
+    PlannerBenchmarkFactory benchmarkFactory;
+
+    @Test
+    public void benchmark() throws ExecutionException, InterruptedException {
+        TestdataQuarkusSolution problem = new TestdataQuarkusSolution();
+        problem.setValueList(IntStream.range(1, 3)
+                .mapToObj(i -> "v" + i)
+                .collect(Collectors.toList()));
+        problem.setEntityList(IntStream.range(1, 3)
+                .mapToObj(i -> new TestdataQuarkusEntity())
+                .collect(Collectors.toList()));
+        benchmarkFactory.buildPlannerBenchmark(problem).benchmark();
+    }
+
+}

--- a/optaplanner-quarkus-integration/optaplanner-quarkus-benchmark/deployment/src/test/java/org/optaplanner/benchmark/quarkus/OptaPlannerBenchmarkProcessorPhasesTest.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus-benchmark/deployment/src/test/java/org/optaplanner/benchmark/quarkus/OptaPlannerBenchmarkProcessorPhasesTest.java
@@ -46,8 +46,6 @@ public class OptaPlannerBenchmarkProcessorPhasesTest {
 
     @Test
     public void doesNotInheritPhasesFromSolverConfig() {
-        Assertions
-                .assertNull(plannerBenchmarkConfig.getInheritedSolverBenchmarkConfig().getSolverConfig().getPhaseConfigList());
         Assertions.assertEquals(2, plannerBenchmarkConfig.getSolverBenchmarkConfigList().get(0).getSolverConfig()
                 .getPhaseConfigList().size());
         Assertions.assertEquals(3, plannerBenchmarkConfig.getSolverBenchmarkConfigList().get(1).getSolverConfig()

--- a/optaplanner-quarkus-integration/optaplanner-quarkus-benchmark/deployment/src/test/java/org/optaplanner/benchmark/quarkus/OptaPlannerBenchmarkProcessorPhasesTest.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus-benchmark/deployment/src/test/java/org/optaplanner/benchmark/quarkus/OptaPlannerBenchmarkProcessorPhasesTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.benchmark.quarkus;
+
+import javax.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.optaplanner.benchmark.config.PlannerBenchmarkConfig;
+import org.optaplanner.benchmark.quarkus.testdata.normal.constraints.TestdataQuarkusConstraintProvider;
+import org.optaplanner.benchmark.quarkus.testdata.normal.domain.TestdataQuarkusEntity;
+import org.optaplanner.benchmark.quarkus.testdata.normal.domain.TestdataQuarkusSolution;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class OptaPlannerBenchmarkProcessorPhasesTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .overrideConfigKey("quarkus.optaplanner.benchmark.solver.termination.best-score-limit", "0")
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(TestdataQuarkusEntity.class,
+                            TestdataQuarkusSolution.class, TestdataQuarkusConstraintProvider.class)
+                    .addAsResource("solverConfigWithPhases.xml", "solverConfig.xml")
+                    .addAsResource("solverBenchmarkConfigWithPhases.xml", "solverBenchmarkConfig.xml"));
+
+    @Inject
+    PlannerBenchmarkConfig plannerBenchmarkConfig;
+
+    @Test
+    public void doesNotInheritPhasesFromSolverConfig() {
+        Assertions
+                .assertNull(plannerBenchmarkConfig.getInheritedSolverBenchmarkConfig().getSolverConfig().getPhaseConfigList());
+        Assertions.assertEquals(2, plannerBenchmarkConfig.getSolverBenchmarkConfigList().get(0).getSolverConfig()
+                .getPhaseConfigList().size());
+        Assertions.assertEquals(3, plannerBenchmarkConfig.getSolverBenchmarkConfigList().get(1).getSolverConfig()
+                .getPhaseConfigList().size());
+    }
+
+}

--- a/optaplanner-quarkus-integration/optaplanner-quarkus-benchmark/deployment/src/test/java/org/optaplanner/benchmark/quarkus/testdata/normal/domain/TestdataQuarkusOtherEntity.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus-benchmark/deployment/src/test/java/org/optaplanner/benchmark/quarkus/testdata/normal/domain/TestdataQuarkusOtherEntity.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.benchmark.quarkus.testdata.normal.domain;
+
+import org.optaplanner.core.api.domain.entity.PlanningEntity;
+import org.optaplanner.core.api.domain.variable.PlanningVariable;
+
+@PlanningEntity
+public class TestdataQuarkusOtherEntity {
+
+    private String value;
+
+    @PlanningVariable(valueRangeProviderRefs = "valueRange")
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+
+}

--- a/optaplanner-quarkus-integration/optaplanner-quarkus-benchmark/deployment/src/test/resources/solverBenchmarkConfigWithInheritedSolverBenchmark.xml
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus-benchmark/deployment/src/test/resources/solverBenchmarkConfigWithInheritedSolverBenchmark.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plannerBenchmark xmlns="https://www.optaplanner.org/xsd/benchmark" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="https://www.optaplanner.org/xsd/benchmark https://www.optaplanner.org/xsd/benchmark/benchmark.xsd">
+    <inheritedSolverBenchmark>
+        <solver>
+            <termination>
+                <millisecondsSpentLimit>5</millisecondsSpentLimit>
+            </termination>
+        </solver>
+    </inheritedSolverBenchmark>
+
+    <solverBenchmark>
+        <name>First Fit and Local Search</name>
+        <solver>
+            <constructionHeuristic>
+                <constructionHeuristicType>FIRST_FIT</constructionHeuristicType>
+            </constructionHeuristic>
+            <localSearch />
+        </solver>
+    </solverBenchmark>
+</plannerBenchmark>

--- a/optaplanner-quarkus-integration/optaplanner-quarkus-benchmark/deployment/src/test/resources/solverBenchmarkConfigWithInheritedSolverBenchmark.xml
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus-benchmark/deployment/src/test/resources/solverBenchmarkConfigWithInheritedSolverBenchmark.xml
@@ -3,6 +3,7 @@
                   xsi:schemaLocation="https://www.optaplanner.org/xsd/benchmark https://www.optaplanner.org/xsd/benchmark/benchmark.xsd">
     <inheritedSolverBenchmark>
         <solver>
+            <entityClass>org.optaplanner.benchmark.quarkus.testdata.normal.domain.TestdataQuarkusEntity</entityClass>
             <termination>
                 <millisecondsSpentLimit>5</millisecondsSpentLimit>
             </termination>
@@ -10,8 +11,20 @@
     </inheritedSolverBenchmark>
 
     <solverBenchmark>
-        <name>First Fit and Local Search</name>
+        <name>Inherits Solution Class</name>
         <solver>
+            <constructionHeuristic>
+                <constructionHeuristicType>FIRST_FIT</constructionHeuristicType>
+            </constructionHeuristic>
+            <localSearch />
+        </solver>
+    </solverBenchmark>
+
+    <solverBenchmark>
+        <name>Does Not Inherit Solution Class</name>
+        <solver>
+            <!-- Using a Constraint Provider class since if there was two planning solution class, autocomplete cannot be used -->
+            <solutionClass>org.optaplanner.benchmark.quarkus.testdata.normal.constraints.TestdataQuarkusConstraintProvider</solutionClass>
             <constructionHeuristic>
                 <constructionHeuristicType>FIRST_FIT</constructionHeuristicType>
             </constructionHeuristic>

--- a/optaplanner-quarkus-integration/optaplanner-quarkus-benchmark/deployment/src/test/resources/solverBenchmarkConfigWithPhases.xml
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus-benchmark/deployment/src/test/resources/solverBenchmarkConfigWithPhases.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plannerBenchmark xmlns="https://www.optaplanner.org/xsd/benchmark" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="https://www.optaplanner.org/xsd/benchmark https://www.optaplanner.org/xsd/benchmark/benchmark.xsd">
+    <solverBenchmark>
+        <name>First Fit and Local Search</name>
+        <solver>
+            <constructionHeuristic>
+                <constructionHeuristicType>FIRST_FIT</constructionHeuristicType>
+            </constructionHeuristic>
+            <localSearch>
+                <termination>
+                    <millisecondsSpentLimit>5</millisecondsSpentLimit>
+                </termination>
+            </localSearch>
+        </solver>
+    </solverBenchmark>
+    <solverBenchmark>
+        <name>First Fit and Two Local Search</name>
+        <solver>
+            <constructionHeuristic>
+                <constructionHeuristicType>FIRST_FIT</constructionHeuristicType>
+            </constructionHeuristic>
+            <localSearch>
+                <termination>
+                    <millisecondsSpentLimit>5</millisecondsSpentLimit>
+                </termination>
+            </localSearch>
+            <localSearch>
+                <termination>
+                    <millisecondsSpentLimit>5</millisecondsSpentLimit>
+                </termination>
+            </localSearch>
+        </solver>
+    </solverBenchmark>
+</plannerBenchmark>

--- a/optaplanner-quarkus-integration/optaplanner-quarkus-benchmark/deployment/src/test/resources/solverConfigWithPhases.xml
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus-benchmark/deployment/src/test/resources/solverConfigWithPhases.xml
@@ -1,0 +1,7 @@
+<solver xmlns="https://www.optaplanner.org/xsd/solver" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="https://www.optaplanner.org/xsd/solver https://www.optaplanner.org/xsd/solver/solver.xsd">
+  <constructionHeuristic>
+    <constructionHeuristicType>FIRST_FIT</constructionHeuristicType>
+  </constructionHeuristic>
+  <localSearch />
+</solver>

--- a/optaplanner-quarkus-integration/optaplanner-quarkus-benchmark/runtime/src/main/java/org/optaplanner/benchmark/quarkus/OptaPlannerBenchmarkRecorder.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus-benchmark/runtime/src/main/java/org/optaplanner/benchmark/quarkus/OptaPlannerBenchmarkRecorder.java
@@ -56,12 +56,25 @@ public class OptaPlannerBenchmarkRecorder {
             SolverBenchmarkConfig solverBenchmarkConfig = new SolverBenchmarkConfig();
             SolverConfig benchmarkSolverConfig = new SolverConfig();
             benchmarkSolverConfig.inherit(solverConfig);
+            benchmarkSolverConfig.setPhaseConfigList(null);
 
             solverBenchmarkConfig.setSolverConfig(benchmarkSolverConfig);
             solverBenchmarkConfig.setProblemBenchmarksConfig(problemBenchmarksConfig);
 
             plannerBenchmarkConfig.setBenchmarkDirectory(new File(benchmarkRuntimeConfig.resultDirectory));
             plannerBenchmarkConfig.setInheritedSolverBenchmarkConfig(solverBenchmarkConfig);
+        } else {
+            SolverBenchmarkConfig inheritedSolverBenchmarkConfig = plannerBenchmarkConfig.getInheritedSolverBenchmarkConfig();
+            SolverConfig inheritedSolverConfig = inheritedSolverBenchmarkConfig.getSolverConfig();
+            if (inheritedSolverConfig.getSolutionClass() == null) {
+                inheritedSolverConfig.setSolutionClass(solverConfig.getSolutionClass());
+            }
+            if (inheritedSolverConfig.getEntityClassList() == null) {
+                inheritedSolverConfig.setEntityClassList(solverConfig.getEntityClassList());
+            }
+            if (inheritedSolverBenchmarkConfig.getProblemBenchmarksConfig() == null) {
+                inheritedSolverBenchmarkConfig.setProblemBenchmarksConfig(new ProblemBenchmarksConfig());
+            }
         }
 
         TerminationConfig terminationConfig = plannerBenchmarkConfig.getInheritedSolverBenchmarkConfig()

--- a/optaplanner-quarkus-integration/optaplanner-quarkus-benchmark/runtime/src/main/java/org/optaplanner/benchmark/quarkus/OptaPlannerBenchmarkRecorder.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus-benchmark/runtime/src/main/java/org/optaplanner/benchmark/quarkus/OptaPlannerBenchmarkRecorder.java
@@ -115,14 +115,18 @@ public class OptaPlannerBenchmarkRecorder {
                 benchmarkRuntimeConfig.termination.bestScoreLimit.ifPresent(terminationConfig::setBestScoreLimit);
 
                 if (!terminationConfig.isConfigured()) {
-                    boolean isTerminationConfiguredForAllLocalSearchPhases = !solverBenchmarkConfig
-                            .getSolverConfig().getPhaseConfigList().isEmpty();
-                    for (PhaseConfig<?> phaseConfig : solverBenchmarkConfig.getSolverConfig().getPhaseConfigList()) {
-                        if (phaseConfig instanceof LocalSearchPhaseConfig) {
-                            if (phaseConfig.getTerminationConfig() == null
-                                    || !phaseConfig.getTerminationConfig().isConfigured()) {
-                                isTerminationConfiguredForAllLocalSearchPhases = false;
-                                break;
+                    List<PhaseConfig> phaseConfigList = solverBenchmarkConfig.getSolverConfig().getPhaseConfigList();
+                    boolean isTerminationConfiguredForAllLocalSearchPhases =
+                            phaseConfigList != null && !phaseConfigList.isEmpty();
+
+                    if (isTerminationConfiguredForAllLocalSearchPhases) {
+                        for (PhaseConfig<?> phaseConfig : phaseConfigList) {
+                            if (phaseConfig instanceof LocalSearchPhaseConfig) {
+                                if (phaseConfig.getTerminationConfig() == null
+                                        || !phaseConfig.getTerminationConfig().isConfigured()) {
+                                    isTerminationConfiguredForAllLocalSearchPhases = false;
+                                    break;
+                                }
                             }
                         }
                     }
@@ -152,6 +156,9 @@ public class OptaPlannerBenchmarkRecorder {
 
         if (plannerBenchmarkConfig.getSolverBenchmarkConfigList() != null) {
             for (SolverBenchmarkConfig childBenchmarkConfig : plannerBenchmarkConfig.getSolverBenchmarkConfigList()) {
+                if (childBenchmarkConfig.getSolverConfig() == null) {
+                    childBenchmarkConfig.setSolverConfig(new SolverConfig());
+                }
                 inheritPropertiesFromSolverConfig(childBenchmarkConfig, inheritedBenchmarkConfig, solverConfig);
             }
         }

--- a/optaplanner-quarkus-integration/optaplanner-quarkus-benchmark/runtime/src/main/java/org/optaplanner/benchmark/quarkus/OptaPlannerBenchmarkRecorder.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus-benchmark/runtime/src/main/java/org/optaplanner/benchmark/quarkus/OptaPlannerBenchmarkRecorder.java
@@ -20,15 +20,17 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.function.BiConsumer;
+import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import org.optaplanner.benchmark.config.PlannerBenchmarkConfig;
-import org.optaplanner.benchmark.config.ProblemBenchmarksConfig;
 import org.optaplanner.benchmark.config.SolverBenchmarkConfig;
 import org.optaplanner.benchmark.quarkus.config.OptaPlannerBenchmarkRuntimeConfig;
-import org.optaplanner.core.config.constructionheuristic.ConstructionHeuristicPhaseConfig;
+import org.optaplanner.core.config.localsearch.LocalSearchPhaseConfig;
 import org.optaplanner.core.config.phase.PhaseConfig;
+import org.optaplanner.core.config.score.director.ScoreDirectorFactoryConfig;
 import org.optaplanner.core.config.solver.SolverConfig;
 import org.optaplanner.core.config.solver.termination.TerminationConfig;
 
@@ -43,48 +45,47 @@ public class OptaPlannerBenchmarkRecorder {
                     Arc.container().instance(OptaPlannerBenchmarkRuntimeConfig.class).get();
             SolverConfig solverConfig =
                     Arc.container().instance(SolverConfig.class).get();
-            updateBenchmarkConfigWithRuntimeProperties(benchmarkConfig, optaPlannerRuntimeConfig, solverConfig);
-            return benchmarkConfig;
+            return updateBenchmarkConfigWithRuntimeProperties(benchmarkConfig, optaPlannerRuntimeConfig, solverConfig);
         };
     }
 
-    private void updateBenchmarkConfigWithRuntimeProperties(PlannerBenchmarkConfig plannerBenchmarkConfig,
+    private PlannerBenchmarkConfig updateBenchmarkConfigWithRuntimeProperties(PlannerBenchmarkConfig plannerBenchmarkConfig,
             OptaPlannerBenchmarkRuntimeConfig benchmarkRuntimeConfig,
             SolverConfig solverConfig) {
-        if (plannerBenchmarkConfig.getInheritedSolverBenchmarkConfig() == null) {
-            ProblemBenchmarksConfig problemBenchmarksConfig = new ProblemBenchmarksConfig();
-            SolverBenchmarkConfig solverBenchmarkConfig = new SolverBenchmarkConfig();
-            SolverConfig benchmarkSolverConfig = new SolverConfig();
-            benchmarkSolverConfig.inherit(solverConfig);
-            benchmarkSolverConfig.setPhaseConfigList(null);
-
-            solverBenchmarkConfig.setSolverConfig(benchmarkSolverConfig);
-            solverBenchmarkConfig.setProblemBenchmarksConfig(problemBenchmarksConfig);
-
-            plannerBenchmarkConfig.setBenchmarkDirectory(new File(benchmarkRuntimeConfig.resultDirectory));
-            plannerBenchmarkConfig.setInheritedSolverBenchmarkConfig(solverBenchmarkConfig);
-        } else {
-            SolverBenchmarkConfig inheritedSolverBenchmarkConfig = plannerBenchmarkConfig.getInheritedSolverBenchmarkConfig();
-            SolverConfig inheritedSolverConfig = inheritedSolverBenchmarkConfig.getSolverConfig();
-            if (inheritedSolverConfig.getSolutionClass() == null) {
-                inheritedSolverConfig.setSolutionClass(solverConfig.getSolutionClass());
-            }
-            if (inheritedSolverConfig.getEntityClassList() == null) {
-                inheritedSolverConfig.setEntityClassList(solverConfig.getEntityClassList());
-            }
-            if (inheritedSolverBenchmarkConfig.getProblemBenchmarksConfig() == null) {
-                inheritedSolverBenchmarkConfig.setProblemBenchmarksConfig(new ProblemBenchmarksConfig());
-            }
+        if (plannerBenchmarkConfig == null) { // no benchmarkConfig.xml provided
+            // Can't do this in processor; SolverConfig is not completed yet (has some runtime properties)
+            plannerBenchmarkConfig = PlannerBenchmarkConfig.createFromSolverConfig(solverConfig);
         }
 
-        TerminationConfig terminationConfig = plannerBenchmarkConfig.getInheritedSolverBenchmarkConfig()
-                .getSolverConfig().getTerminationConfig();
-        benchmarkRuntimeConfig.termination.spentLimit.ifPresent(terminationConfig::setSpentLimit);
-        benchmarkRuntimeConfig.termination.unimprovedSpentLimit
-                .ifPresent(terminationConfig::setUnimprovedSpentLimit);
-        benchmarkRuntimeConfig.termination.bestScoreLimit.ifPresent(terminationConfig::setBestScoreLimit);
+        plannerBenchmarkConfig.setBenchmarkDirectory(new File(benchmarkRuntimeConfig.resultDirectory));
+        SolverBenchmarkConfig inheritedBenchmarkConfig = plannerBenchmarkConfig.getInheritedSolverBenchmarkConfig();
 
-        if (terminationConfig == null || !terminationConfig.isConfigured()) {
+        if (plannerBenchmarkConfig.getSolverBenchmarkBluePrintConfigList() != null) {
+            if (inheritedBenchmarkConfig == null) {
+                inheritedBenchmarkConfig = new SolverBenchmarkConfig();
+                plannerBenchmarkConfig.setInheritedSolverBenchmarkConfig(inheritedBenchmarkConfig);
+                inheritedBenchmarkConfig.setSolverConfig(solverConfig.copyConfig());
+            }
+            TerminationConfig inheritedTerminationConfig;
+            if (inheritedBenchmarkConfig.getSolverConfig().getTerminationConfig() != null) {
+                inheritedTerminationConfig = inheritedBenchmarkConfig.getSolverConfig().getTerminationConfig();
+            } else {
+                inheritedTerminationConfig = new TerminationConfig();
+                inheritedBenchmarkConfig.getSolverConfig().setTerminationConfig(inheritedTerminationConfig);
+            }
+            benchmarkRuntimeConfig.termination.spentLimit.ifPresent(inheritedTerminationConfig::setSpentLimit);
+            benchmarkRuntimeConfig.termination.unimprovedSpentLimit
+                    .ifPresent(inheritedTerminationConfig::setUnimprovedSpentLimit);
+            benchmarkRuntimeConfig.termination.bestScoreLimit.ifPresent(inheritedTerminationConfig::setBestScoreLimit);
+        }
+
+        TerminationConfig inheritedTerminationConfig = null;
+        if (inheritedBenchmarkConfig != null && inheritedBenchmarkConfig.getSolverConfig() != null &&
+                inheritedBenchmarkConfig.getSolverConfig().getTerminationConfig() != null) {
+            inheritedTerminationConfig = inheritedBenchmarkConfig.getSolverConfig().getTerminationConfig();
+        }
+
+        if (inheritedTerminationConfig == null || !inheritedTerminationConfig.isConfigured()) {
             List<SolverBenchmarkConfig> solverBenchmarkConfigList = plannerBenchmarkConfig.getSolverBenchmarkConfigList();
             List<String> unconfiguredTerminationSolverBenchmarkList = new ArrayList<>();
             if (solverBenchmarkConfigList == null) {
@@ -97,20 +98,35 @@ public class OptaPlannerBenchmarkRecorder {
             }
             for (int i = 0; i < solverBenchmarkConfigList.size(); i++) {
                 SolverBenchmarkConfig solverBenchmarkConfig = solverBenchmarkConfigList.get(i);
-                terminationConfig = solverBenchmarkConfig.getSolverConfig().getTerminationConfig();
-                if (terminationConfig == null || !terminationConfig.isConfigured()) {
-                    boolean isTerminationConfiguredForAllNonConstructionHeuristicPhases = !solverBenchmarkConfig
+                if (solverBenchmarkConfig.getSolverConfig() == null) {
+                    solverBenchmarkConfig.setSolverConfig(new SolverConfig());
+                }
+                TerminationConfig terminationConfig = solverBenchmarkConfig.getSolverConfig().getTerminationConfig();
+                if (terminationConfig == null) {
+                    terminationConfig = new TerminationConfig();
+                    solverBenchmarkConfig.getSolverConfig().setTerminationConfig(terminationConfig);
+                } else if (terminationConfig.isConfigured()) {
+                    continue;
+                }
+
+                benchmarkRuntimeConfig.termination.spentLimit.ifPresent(terminationConfig::setSpentLimit);
+                benchmarkRuntimeConfig.termination.unimprovedSpentLimit
+                        .ifPresent(terminationConfig::setUnimprovedSpentLimit);
+                benchmarkRuntimeConfig.termination.bestScoreLimit.ifPresent(terminationConfig::setBestScoreLimit);
+
+                if (!terminationConfig.isConfigured()) {
+                    boolean isTerminationConfiguredForAllLocalSearchPhases = !solverBenchmarkConfig
                             .getSolverConfig().getPhaseConfigList().isEmpty();
                     for (PhaseConfig<?> phaseConfig : solverBenchmarkConfig.getSolverConfig().getPhaseConfigList()) {
-                        if (!(phaseConfig instanceof ConstructionHeuristicPhaseConfig)) {
+                        if (phaseConfig instanceof LocalSearchPhaseConfig) {
                             if (phaseConfig.getTerminationConfig() == null
                                     || !phaseConfig.getTerminationConfig().isConfigured()) {
-                                isTerminationConfiguredForAllNonConstructionHeuristicPhases = false;
+                                isTerminationConfiguredForAllLocalSearchPhases = false;
                                 break;
                             }
                         }
                     }
-                    if (!isTerminationConfiguredForAllNonConstructionHeuristicPhases) {
+                    if (!isTerminationConfiguredForAllLocalSearchPhases) {
                         String benchmarkConfigName = solverBenchmarkConfig.getName();
                         if (benchmarkConfigName == null) {
                             benchmarkConfigName = "SolverBenchmarkConfig " + i;
@@ -134,9 +150,77 @@ public class OptaPlannerBenchmarkRecorder {
             }
         }
 
+        if (plannerBenchmarkConfig.getSolverBenchmarkConfigList() != null) {
+            for (SolverBenchmarkConfig childBenchmarkConfig : plannerBenchmarkConfig.getSolverBenchmarkConfigList()) {
+                inheritPropertiesFromSolverConfig(childBenchmarkConfig, inheritedBenchmarkConfig, solverConfig);
+            }
+        }
+
         if (plannerBenchmarkConfig.getSolverBenchmarkConfigList() == null
                 && plannerBenchmarkConfig.getSolverBenchmarkBluePrintConfigList() == null) {
             plannerBenchmarkConfig.setSolverBenchmarkConfigList(Collections.singletonList(new SolverBenchmarkConfig()));
         }
+        return plannerBenchmarkConfig;
+    }
+
+    private void inheritPropertiesFromSolverConfig(SolverBenchmarkConfig childBenchmarkConfig,
+            SolverBenchmarkConfig inheritedBenchmarkConfig,
+            SolverConfig solverConfig) {
+        inheritProperty(childBenchmarkConfig, inheritedBenchmarkConfig, solverConfig,
+                SolverConfig::getSolutionClass, SolverConfig::setSolutionClass);
+        inheritProperty(childBenchmarkConfig, inheritedBenchmarkConfig, solverConfig,
+                SolverConfig::getEntityClassList, SolverConfig::setEntityClassList);
+        inheritScoreCalculation(childBenchmarkConfig, inheritedBenchmarkConfig, solverConfig);
+    }
+
+    private <T> void inheritProperty(SolverBenchmarkConfig childBenchmarkConfig,
+            SolverBenchmarkConfig inheritedBenchmarkConfig,
+            SolverConfig solverConfig,
+            Function<SolverConfig, T> getter,
+            BiConsumer<SolverConfig, T> setter) {
+        if (getter.apply(childBenchmarkConfig.getSolverConfig()) != null) {
+            return;
+        }
+        if (inheritedBenchmarkConfig != null && inheritedBenchmarkConfig.getSolverConfig() != null &&
+                getter.apply(inheritedBenchmarkConfig.getSolverConfig()) != null) {
+            return;
+        }
+        setter.accept(childBenchmarkConfig.getSolverConfig(), getter.apply(solverConfig));
+    }
+
+    private void inheritScoreCalculation(SolverBenchmarkConfig childBenchmarkConfig,
+            SolverBenchmarkConfig inheritedBenchmarkConfig,
+            SolverConfig solverConfig) {
+
+        if (isScoreCalculationDefined(childBenchmarkConfig.getSolverConfig())) {
+            return;
+        }
+        if (inheritedBenchmarkConfig != null && inheritedBenchmarkConfig.getSolverConfig() != null &&
+                isScoreCalculationDefined(inheritedBenchmarkConfig.getSolverConfig())) {
+            return;
+        }
+        ScoreDirectorFactoryConfig childScoreDirectorFactoryConfig = childBenchmarkConfig.getSolverConfig()
+                .getScoreDirectorFactoryConfig();
+        ScoreDirectorFactoryConfig inheritedScoreDirectorFactoryConfig = solverConfig.getScoreDirectorFactoryConfig();
+        if (childScoreDirectorFactoryConfig == null) {
+            childScoreDirectorFactoryConfig = new ScoreDirectorFactoryConfig();
+            childBenchmarkConfig.getSolverConfig().setScoreDirectorFactoryConfig(childScoreDirectorFactoryConfig);
+        }
+        childScoreDirectorFactoryConfig.inherit(inheritedScoreDirectorFactoryConfig);
+    }
+
+    private boolean isScoreCalculationDefined(SolverConfig solverConfig) {
+        if (solverConfig == null) {
+            return false;
+        }
+        ScoreDirectorFactoryConfig scoreDirectorFactoryConfig = solverConfig.getScoreDirectorFactoryConfig();
+        if (scoreDirectorFactoryConfig == null) {
+            return false;
+        }
+        return scoreDirectorFactoryConfig.getEasyScoreCalculatorClass() != null ||
+                scoreDirectorFactoryConfig.getIncrementalScoreCalculatorClass() != null ||
+                scoreDirectorFactoryConfig.getScoreDrlList() != null ||
+                scoreDirectorFactoryConfig.getScoreDrlFileList() != null ||
+                scoreDirectorFactoryConfig.getConstraintProviderClass() != null;
     }
 }

--- a/optaplanner-spring-integration/optaplanner-spring-boot-autoconfigure/src/main/java/org/optaplanner/spring/boot/autoconfigure/OptaPlannerBenchmarkAutoConfiguration.java
+++ b/optaplanner-spring-integration/optaplanner-spring-boot-autoconfigure/src/main/java/org/optaplanner/spring/boot/autoconfigure/OptaPlannerBenchmarkAutoConfiguration.java
@@ -72,7 +72,7 @@ public class OptaPlannerBenchmarkAutoConfiguration
                     .createFromXmlResource(optaPlannerProperties.getBenchmark().getSolverBenchmarkConfigXml(), beanClassLoader);
         } else if (beanClassLoader.getResource(BenchmarkProperties.DEFAULT_SOLVER_BENCHMARK_CONFIG_URL) != null) {
             benchmarkConfig = PlannerBenchmarkConfig.createFromXmlResource(
-                    OptaPlannerProperties.DEFAULT_SOLVER_CONFIG_URL, beanClassLoader);
+                    OptaPlannerProperties.DEFAULT_SOLVER_BENCHMARK_CONFIG_URL, beanClassLoader);
         } else {
             benchmarkConfig = PlannerBenchmarkConfig.createFromSolverConfig(solverConfig);
             benchmarkConfig.setBenchmarkDirectory(new File(BenchmarkProperties.DEFAULT_BENCHMARK_RESULT_DIRECTORY));

--- a/optaplanner-spring-integration/optaplanner-spring-boot-autoconfigure/src/main/java/org/optaplanner/spring/boot/autoconfigure/config/OptaPlannerProperties.java
+++ b/optaplanner-spring-integration/optaplanner-spring-boot-autoconfigure/src/main/java/org/optaplanner/spring/boot/autoconfigure/config/OptaPlannerProperties.java
@@ -26,6 +26,7 @@ import org.springframework.boot.context.properties.NestedConfigurationProperty;
 public class OptaPlannerProperties {
 
     public static final String DEFAULT_SOLVER_CONFIG_URL = "solverConfig.xml";
+    public static final String DEFAULT_SOLVER_BENCHMARK_CONFIG_URL = "solverBenchmarkConfig.xml";
     public static final String DEFAULT_CONSTRAINTS_DRL_URL = "constraints.drl";
     public static final String SCORE_DRL_PROPERTY = "optaplanner.score-drl";
 


### PR DESCRIPTION
<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.
-->

### JIRA

<!-- Add a JIRA ticket link if it exists. -->
https://issues.redhat.com/browse/PLANNER-2624
https://issues.redhat.com/browse/PLANNER-2626

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
* https://github.com/kiegroup/drools/pull/3000
* https://github.com/kiegroup/optaplanner/pull/899
* etc.
-->

### Checklist
- [ ] Documentation updated if applicable.
- [ ] Upgrade recipe provided if applicable.

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>specific pull request build</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] tests</b>
* for a <b>full downstream build</b> 
  * for <b>jenkins</b> job: please add comment: <b>Jenkins run fdb</b>
  * for <b>github actions</b> job: add the label `run_fdb`
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
* for a <b>Quarkus LTS check</b> please add comment: <b>Jenkins run LTS</b>
* for a <b>specific Quarkus LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] LTS</b>
* for a <b>Native check</b> please add comment: <b>Jenkins run native</b>
* for a <b>specific Native LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] native</b>
</details>
