### PR TITLE
PLANNER-2303 Fix problem scale for list variable

### DIFF
--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/entity/descriptor/EntityDescriptor.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/entity/descriptor/EntityDescriptor.java
@@ -567,7 +567,16 @@ public class EntityDescriptor<Solution_> {
     public long getProblemScale(Solution_ solution, Object entity) {
         long problemScale = 1L;
         for (GenuineVariableDescriptor<Solution_> variableDescriptor : effectiveGenuineVariableDescriptorList) {
-            problemScale *= variableDescriptor.getValueCount(solution, entity);
+            long valueCount = variableDescriptor.getValueCount(solution, entity);
+            problemScale *= valueCount;
+            if (variableDescriptor.isListVariable()) {
+                // This formula probably makes no sense other than that it results in the same problem scale for both
+                // chained and list variable models.
+                // TODO fix https://issues.redhat.com/browse/PLANNER-2623 to get rid of this.
+                problemScale *= valueCount;
+                problemScale /= getSolutionDescriptor().getEntityCount(solution);
+                problemScale += valueCount;
+            }
         }
         return problemScale;
     }


### PR DESCRIPTION
### JIRA

https://issues.redhat.com/browse/PLANNER-2303

The formula is `v^2 / e + v`. It's designed so that it gives the same problem scale with the list variable as with the chained basic variable. I can't see any good meaning behind it. Nevertheless, I can live with this being merged provided that we replace the "problem size" metric with solution space as proposed in https://issues.redhat.com/browse/PLANNER-2623.