### PR TITLE
Fail fast if the inverse shadow variable type is a Collection

### DIFF
--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/variable/inverserelation/InverseRelationShadowVariableDescriptor.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/variable/inverserelation/InverseRelationShadowVariableDescriptor.java
@@ -62,6 +62,22 @@ public class InverseRelationShadowVariableDescriptor<Solution_> extends ShadowVa
         linkShadowSources(descriptorPolicy);
     }
 
+    /**
+     * The following table describes which combinations of source and shadow variable types are supported.
+     * The unsupported combinations are detected and fail fast.
+     *
+     * <pre>
+     * {@code
+     *          | singleton | collection
+     * -----------------------------------
+     *   basic  |     ✕     |     ✓
+     * chained  |     ✓     |     ✕
+     *    list  |     ✓     |     ✕
+     *}
+     * </pre>
+     *
+     * @param descriptorPolicy descriptor policy
+     */
     private void linkShadowSources(DescriptorPolicy descriptorPolicy) {
         InverseRelationShadowVariable shadowVariableAnnotation = variableMemberAccessor
                 .getAnnotation(InverseRelationShadowVariable.class);
@@ -116,13 +132,19 @@ public class InverseRelationShadowVariableDescriptor<Solution_> extends ShadowVa
                         + " Only list and chained variables support a singleton inverse.");
             }
         } else {
-            if (chained) {
+            if (chained || list) {
                 throw new IllegalArgumentException("The entityClass (" + entityDescriptor.getEntityClass()
                         + ") has an @" + InverseRelationShadowVariable.class.getSimpleName()
                         + " annotated property (" + variableMemberAccessor.getName()
                         + ") which returns a " + Collection.class.getSimpleName()
-                        + " with sourceVariableName (" + sourceVariableName
-                        + ") which is chained. A chained variable supports only a singleton inverse.");
+                        + " (" + variablePropertyType
+                        + ") with sourceVariableName (" + sourceVariableName
+                        + ") which is a" + (chained
+                                ? " chained variable @" + PlanningVariable.class.getSimpleName()
+                                        + "(graphType=" + PlanningVariableGraphType.CHAINED
+                                        + "). A chained variable supports only a singleton inverse."
+                                : " list variable @" + PlanningListVariable.class.getSimpleName()
+                                        + ". A list variable supports only a singleton inverse."));
             }
         }
         sourceVariableDescriptor.registerSinkVariableDescriptor(this);


### PR DESCRIPTION
A list variable's inverse shadow variable must a "singleton" inverse because each value can only be assigned to a single entity's list variable. Therefore, a Collection type is not supported and it should fail fast.