### PR TITLE
PLANNER-2627: Move step score map to solve-lifetime scope

### DIFF
--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/phase/AbstractPhase.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/phase/AbstractPhase.java
@@ -17,10 +17,6 @@
 package org.optaplanner.core.impl.phase;
 
 import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.atomic.AtomicReference;
 
 import org.optaplanner.core.api.domain.solution.PlanningSolution;
 import org.optaplanner.core.api.score.Score;
@@ -41,8 +37,6 @@ import org.optaplanner.core.impl.solver.termination.Termination;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import io.micrometer.core.instrument.Tags;
-
 /**
  * @param <Solution_> the solution type, the class with the {@link PlanningSolution} annotation
  * @see DefaultLocalSearchPhase
@@ -53,7 +47,6 @@ public abstract class AbstractPhase<Solution_> implements Phase<Solution_> {
 
     protected final int phaseIndex;
     protected final String logIndentation;
-    protected final Map<Tags, List<AtomicReference<Number>>> stepScoreMap = new ConcurrentHashMap<>();
 
     // Called "phaseTermination" to clearly distinguish from "solverTermination" inside AbstractSolver.
     protected final Termination<Solution_> phaseTermination;
@@ -189,7 +182,7 @@ public abstract class AbstractPhase<Solution_> implements Phase<Solution_> {
             SolverMetric.registerScoreMetrics(SolverMetric.STEP_SCORE,
                     stepScope.getPhaseScope().getSolverScope().getMonitoringTags(),
                     scoreDefinition,
-                    stepScoreMap,
+                    stepScope.getPhaseScope().getSolverScope().getStepScoreMap(),
                     stepScope.getScore());
         }
     }

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/solver/scope/SolverScope.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/solver/scope/SolverScope.java
@@ -18,9 +18,12 @@ package org.optaplanner.core.impl.solver.scope;
 
 import java.util.EnumSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Random;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Semaphore;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.optaplanner.core.api.domain.solution.PlanningSolution;
 import org.optaplanner.core.api.score.Score;
@@ -58,6 +61,10 @@ public class SolverScope<Solution_> {
     protected volatile Solution_ bestSolution;
     protected volatile Score bestScore;
     protected Long bestSolutionTimeMillis;
+    /**
+     * Used for tracking step score
+     */
+    protected final Map<Tags, List<AtomicReference<Number>>> stepScoreMap = new ConcurrentHashMap<>();
 
     // ************************************************************************
     // Constructors and simple getters/setters
@@ -69,6 +76,10 @@ public class SolverScope<Solution_> {
 
     public void setMonitoringTags(Tags monitoringTags) {
         this.monitoringTags = monitoringTags;
+    }
+
+    public Map<Tags, List<AtomicReference<Number>>> getStepScoreMap() {
+        return stepScoreMap;
     }
 
     public Set<SolverMetric> getSolverMetricSet() {


### PR DESCRIPTION
Before, the step score map was configured to a phase-lifetime object.
This is fine when there is only one phase, but there is typically
many phases. Thus, when a new phase is started, the step score map
that the gauge tracks is never updated (since it linked to the old,
forgotten, phase). The step score map now lives in SolverScope, so
it should work across the entire solver run.

Maybe should be backported.
<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.
-->

### JIRA

<!-- Add a JIRA ticket link if it exists. -->
https://issues.redhat.com/browse/PLANNER-2627

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
* https://github.com/kiegroup/drools/pull/3000
* https://github.com/kiegroup/optaplanner/pull/899
* etc.
-->

### Checklist
- [ ] Documentation updated if applicable.
- [ ] Upgrade recipe provided if applicable.

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>specific pull request build</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] tests</b>
* for a <b>full downstream build</b> 
  * for <b>jenkins</b> job: please add comment: <b>Jenkins run fdb</b>
  * for <b>github actions</b> job: add the label `run_fdb`
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
* for a <b>Quarkus LTS check</b> please add comment: <b>Jenkins run LTS</b>
* for a <b>specific Quarkus LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] LTS</b>
* for a <b>Native check</b> please add comment: <b>Jenkins run native</b>
* for a <b>specific Native LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] native</b>
</details>
