### PR TITLE
PLANNER-2614 Remove forward dependency on ClassAndPlanningIdComparator

### DIFF
--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/AbstractScoreDirector.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/AbstractScoreDirector.java
@@ -49,7 +49,6 @@ import org.optaplanner.core.config.util.ConfigUtils;
 import org.optaplanner.core.impl.domain.common.accessor.MemberAccessor;
 import org.optaplanner.core.impl.domain.constraintweight.descriptor.ConstraintConfigurationDescriptor;
 import org.optaplanner.core.impl.domain.entity.descriptor.EntityDescriptor;
-import org.optaplanner.core.impl.domain.lookup.ClassAndPlanningIdComparator;
 import org.optaplanner.core.impl.domain.lookup.LookUpManager;
 import org.optaplanner.core.impl.domain.solution.descriptor.SolutionDescriptor;
 import org.optaplanner.core.impl.domain.variable.descriptor.ShadowVariableDescriptor;
@@ -816,8 +815,7 @@ public abstract class AbstractScoreDirector<Solution_, Score_ extends Score<Scor
     private Map<Object, Set<ConstraintMatch<Score_>>> createConstraintMatchMap(
             Collection<ConstraintMatchTotal<Score_>> constraintMatchTotals) {
         Comparator<Object> comparator = new ClassAndPlanningIdComparator(getSolutionDescriptor().getDomainAccessType(),
-                getSolutionDescriptor().getGeneratedMemberAccessorMap(),
-                false);
+                getSolutionDescriptor().getGeneratedMemberAccessorMap());
         Map<Object, Set<ConstraintMatch<Score_>>> constraintMatchMap =
                 new LinkedHashMap<>(constraintMatchTotals.size() * 16);
         for (ConstraintMatchTotal<Score_> constraintMatchTotal : constraintMatchTotals) {

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/score/director/ClassAndPlanningIdComparatorTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/score/director/ClassAndPlanningIdComparatorTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.optaplanner.core.impl.domain.lookup;
+package org.optaplanner.core.impl.score.director;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertCompareToOrder;
@@ -27,7 +27,7 @@ import org.optaplanner.core.impl.testdata.domain.score.lavish.TestdataLavishEnti
 
 public class ClassAndPlanningIdComparatorTest {
 
-    private final Comparator<Object> comparator = new ClassAndPlanningIdComparator(false);
+    private final Comparator<Object> comparator = new ClassAndPlanningIdComparator();
 
     @Test
     public void comparesDifferentClassesByClassName() {
@@ -50,8 +50,8 @@ public class ClassAndPlanningIdComparatorTest {
 
     @Test
     public void treatesSameUnComparableClassesWithoutPlanningIdAsEqual() {
-        Object firstObject = new ClassAndPlanningIdComparator(false);
-        Object secondObject = new ClassAndPlanningIdComparator(false);
+        Object firstObject = new ClassAndPlanningIdComparator();
+        Object secondObject = new ClassAndPlanningIdComparator();
         int result = comparator.compare(firstObject, secondObject);
         assertThat(result).isEqualTo(0);
     }


### PR DESCRIPTION
Coincidentally also significantly speeds up CM as comparisons no longer require `MemberAccessor`s.