### PR TITLE
Remove strengthComparatorClass because the API is not yet stable

### DIFF
--- a/optaplanner-core/src/main/java/org/optaplanner/core/api/domain/variable/PlanningListVariable.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/api/domain/variable/PlanningListVariable.java
@@ -22,11 +22,9 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
-import java.util.Comparator;
 import java.util.List;
 
 import org.optaplanner.core.api.domain.entity.PlanningEntity;
-import org.optaplanner.core.impl.heuristic.selector.common.decorator.SelectionSorterWeightFactory;
 
 /**
  * Specifies that a bean property (or a field) of a {@link List} type should be optimized by the optimization algorithms.
@@ -59,37 +57,5 @@ import org.optaplanner.core.impl.heuristic.selector.common.decorator.SelectionSo
 public @interface PlanningListVariable {
     String[] valueRangeProviderRefs() default {};
 
-    /**
-     * Allows a collection of planning values for this variable to be sorted by strength.
-     * A strengthWeight estimates how strong a planning value is.
-     * Some algorithms benefit from planning on weaker planning values first or from focusing on them.
-     * <p>
-     * The {@link Comparator} should sort in ascending strength.
-     * For example: sorting 3 tasks on strength based on their duration:
-     * Task B (90 minutes), Task A (45 minutes), Task C (10 minutes),
-     * <p>
-     * Do not use together with {@link #strengthWeightFactoryClass()}.
-     *
-     * @return {@link PlanningVariable.NullStrengthComparator} when it is null (workaround for annotation limitation)
-     * @see #strengthWeightFactoryClass()
-     */
-    Class<? extends Comparator> strengthComparatorClass() default PlanningVariable.NullStrengthComparator.class;
-
-    /** Workaround for annotation limitation in {@link #strengthComparatorClass()}. */
-    interface NullStrengthComparator extends Comparator {
-    }
-
-    /**
-     * The {@link SelectionSorterWeightFactory} alternative for {@link #strengthComparatorClass()}.
-     * <p>
-     * Do not use together with {@link #strengthComparatorClass()}.
-     *
-     * @return {@link PlanningVariable.NullStrengthWeightFactory} when it is null (workaround for annotation limitation)
-     * @see #strengthComparatorClass()
-     */
-    Class<? extends SelectionSorterWeightFactory> strengthWeightFactoryClass() default PlanningVariable.NullStrengthWeightFactory.class;
-
-    /** Workaround for annotation limitation in {@link #strengthWeightFactoryClass()}. */
-    interface NullStrengthWeightFactory extends SelectionSorterWeightFactory {
-    }
+    // TODO value comparison: https://issues.redhat.com/browse/PLANNER-2542
 }

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/variable/descriptor/GenuineVariableDescriptor.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/variable/descriptor/GenuineVariableDescriptor.java
@@ -127,8 +127,7 @@ public abstract class GenuineVariableDescriptor<Solution_> extends VariableDescr
             DescriptorPolicy descriptorPolicy,
             Class<? extends Comparator> strengthComparatorClass,
             Class<? extends SelectionSorterWeightFactory> strengthWeightFactoryClass) {
-        if (strengthComparatorClass == PlanningVariable.NullStrengthComparator.class
-                || strengthComparatorClass == PlanningListVariable.NullStrengthComparator.class) {
+        if (strengthComparatorClass == PlanningVariable.NullStrengthComparator.class) {
             strengthComparatorClass = null;
         }
         if (strengthWeightFactoryClass == PlanningVariable.NullStrengthWeightFactory.class) {

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/variable/descriptor/ListVariableDescriptor.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/variable/descriptor/ListVariableDescriptor.java
@@ -47,8 +47,6 @@ public class ListVariableDescriptor<Solution_> extends GenuineVariableDescriptor
     protected void processPropertyAnnotations(DescriptorPolicy descriptorPolicy) {
         PlanningListVariable planningVariableAnnotation = variableMemberAccessor.getAnnotation(PlanningListVariable.class);
         processValueRangeRefs(descriptorPolicy, planningVariableAnnotation.valueRangeProviderRefs());
-        processStrength(descriptorPolicy, planningVariableAnnotation.strengthComparatorClass(),
-                planningVariableAnnotation.strengthWeightFactoryClass());
     }
 
     @Override

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/taskassigning/domain/Employee.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/taskassigning/domain/Employee.java
@@ -27,7 +27,6 @@ import org.optaplanner.core.api.domain.entity.PlanningEntity;
 import org.optaplanner.core.api.domain.variable.PlanningListVariable;
 import org.optaplanner.examples.common.domain.AbstractPersistable;
 import org.optaplanner.examples.common.swingui.components.Labeled;
-import org.optaplanner.examples.taskassigning.domain.solver.TaskDifficultyComparator;
 
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 
@@ -40,7 +39,7 @@ public class Employee extends AbstractPersistable implements Labeled {
     private Set<Skill> skillSet;
     private Map<Customer, Affinity> affinityMap;
 
-    @PlanningListVariable(valueRangeProviderRefs = "taskRange", strengthComparatorClass = TaskDifficultyComparator.class)
+    @PlanningListVariable(valueRangeProviderRefs = "taskRange")
     private List<Task> tasks;
 
     // TODO pinning

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/taskassigning/domain/Task.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/taskassigning/domain/Task.java
@@ -25,12 +25,10 @@ import org.optaplanner.core.api.domain.variable.PlanningVariableReference;
 import org.optaplanner.examples.common.domain.AbstractPersistable;
 import org.optaplanner.examples.common.swingui.components.Labeled;
 import org.optaplanner.examples.taskassigning.domain.solver.StartTimeUpdatingVariableListener;
-import org.optaplanner.examples.taskassigning.domain.solver.TaskDifficultyComparator;
 
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 
-// TODO convert entity difficulty to value strength
-@PlanningEntity(difficultyComparatorClass = TaskDifficultyComparator.class)
+@PlanningEntity
 @XStreamAlias("TaTask")
 public class Task extends AbstractPersistable implements Labeled {
 

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/taskassigning/domain/solver/TaskDifficultyComparator.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/taskassigning/domain/solver/TaskDifficultyComparator.java
@@ -20,15 +20,22 @@ import java.util.Comparator;
 
 import org.optaplanner.examples.taskassigning.domain.Task;
 
+/**
+ * Compares tasks by difficulty.
+ */
 public class TaskDifficultyComparator implements Comparator<Task> {
+    // FIXME This class is currently unused until the @PlanningListVariable(comparator = ???) API is stable.
+    //  See https://issues.redhat.com/browse/PLANNER-2542.
 
-    private static final Comparator<Task> COMPARATOR = Comparator.comparing(Task::getPriority)
+    static final Comparator<Task> INCREASING_DIFFICULTY_COMPARATOR = Comparator.comparing(Task::getPriority)
             .thenComparingInt(task -> task.getTaskType().getRequiredSkillList().size())
             .thenComparingInt(task -> task.getTaskType().getBaseDuration())
             .thenComparingLong(Task::getId);
 
+    static final Comparator<Task> DECREASING_DIFFICULTY_COMPARATOR = INCREASING_DIFFICULTY_COMPARATOR.reversed();
+
     @Override
     public int compare(Task a, Task b) {
-        return -COMPARATOR.compare(a, b);
+        return DECREASING_DIFFICULTY_COMPARATOR.compare(a, b);
     }
 }

--- a/optaplanner-examples/src/test/java/org/optaplanner/examples/taskassigning/domain/solver/TaskDifficultyComparatorTest.java
+++ b/optaplanner-examples/src/test/java/org/optaplanner/examples/taskassigning/domain/solver/TaskDifficultyComparatorTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.examples.taskassigning.domain.solver;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.optaplanner.examples.taskassigning.domain.Priority;
+import org.optaplanner.examples.taskassigning.domain.Skill;
+import org.optaplanner.examples.taskassigning.domain.Task;
+import org.optaplanner.examples.taskassigning.domain.TaskType;
+
+class TaskDifficultyComparatorTest {
+
+    @Test
+    void compareTasks() {
+        Skill skill1 = new Skill(1, "skill1");
+        Skill skill2 = new Skill(2, "skill2");
+        TaskType typeCritical = new TaskType(1, "Critical", "", 1);
+        TaskType typeMajorHard = new TaskType(2, "Major-Skills2", "", 1); // 2 skills
+        TaskType typeMajorMedium = new TaskType(1, "Major-Skills1", "", 1); // 1 skill
+        TaskType typeMajorEasySlow = new TaskType(0, "Major-Skills0-Slow", "", 999); // 0 skills, slow
+        TaskType typeMajorEasyQuick = new TaskType(0, "Major-Skills0-Quick", "", 100); // 0 skills, quick
+        TaskType typeMinor = new TaskType(0, "Minor", "", 200);
+        typeMajorHard.setRequiredSkillList(List.of(skill1, skill2));
+        typeMajorMedium.setRequiredSkillList(List.of(skill1));
+
+        // Priority decides first.
+        Task critical = new Task(0, typeCritical, 1, null, 0, Priority.CRITICAL);
+        // Then the number of required skills decides.
+        Task majorHard = new Task(10, typeMajorHard, 2, null, 0, Priority.MAJOR);
+        Task majorMedium = new Task(11, typeMajorMedium, 3, null, 0, Priority.MAJOR);
+        // Then the base duration decides.
+        Task majorEasySlow = new Task(20, typeMajorEasySlow, 1, null, 0, Priority.MAJOR);
+        Task majorEasyQuick = new Task(21, typeMajorEasyQuick, 2, null, 0, Priority.MAJOR);
+        // ID decides last.
+        Task minor300 = new Task(300, typeMinor, 3, null, 0, Priority.MINOR);
+        Task minor200 = new Task(200, typeMinor, 2, null, 0, Priority.MINOR);
+        Task minor100 = new Task(100, typeMinor, 1, null, 0, Priority.MINOR);
+
+        List<Task> decreasingDifficultyList = List.of(
+                critical,
+                majorHard,
+                majorMedium,
+                majorEasySlow,
+                majorEasyQuick,
+                minor300,
+                minor300,
+                minor200,
+                minor100);
+
+        // Pseudo-random order, minor300 appears twice.
+        List<Task> input = Arrays.asList(
+                majorEasySlow,
+                minor100,
+                majorMedium,
+                minor300,
+                majorHard,
+                majorEasyQuick,
+                minor200,
+                critical,
+                minor300);
+
+        input.sort(TaskDifficultyComparator.DECREASING_DIFFICULTY_COMPARATOR);
+        assertThat(input).containsExactlyElementsOf(decreasingDifficultyList);
+        Collections.reverse(input);
+        assertThat(input).isSortedAccordingTo(TaskDifficultyComparator.INCREASING_DIFFICULTY_COMPARATOR);
+    }
+}


### PR DESCRIPTION
According to **raw meeting notes vrp simplification merging phase 1** (Dec 10)

Goal:
  - merge vrp simplification to main
  - **do not expose non-future-proof API's yet**
  - do expose the ones we're sure off

@PlanningListVariable: naming (will be) OK
  - behaviour: OK to write in stone.
  - **strengthComparatorClass: leave OUT**
      Add "// TODO" for task assignment
  - strengthWeightFactoryClass: leave OUT