### PR TITLE
PLANNER-2628 Implement consumer threads

### DIFF
--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/solver/ConsumerSupport.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/solver/ConsumerSupport.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.core.impl.solver;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+
+final class ConsumerSupport<Solution_, ProblemId_> {
+
+    private final ProblemId_ problemId;
+    private final Consumer<? super Solution_> bestSolutionConsumer;
+    private final Consumer<? super Solution_> finalBestSolutionConsumer;
+    private final BiConsumer<? super ProblemId_, ? super Throwable> exceptionHandler;
+    private final AtomicReference<Solution_> bestSolutionWaitingForConsumption = new AtomicReference<>();
+    private final Semaphore activeConsumption = new Semaphore(1);
+    private ExecutorService consumerExecutor = Executors.newSingleThreadExecutor();
+
+    public ConsumerSupport(ProblemId_ problemId, Consumer<? super Solution_> bestSolutionConsumer,
+            Consumer<? super Solution_> finalBestSolutionConsumer,
+            BiConsumer<? super ProblemId_, ? super Throwable> exceptionHandler) {
+        this.problemId = problemId;
+        this.bestSolutionConsumer = bestSolutionConsumer;
+        this.finalBestSolutionConsumer = finalBestSolutionConsumer;
+        this.exceptionHandler = exceptionHandler;
+    }
+
+    // Called on the Solver thread.
+    void consumeIntermediateBestSolution(Solution_ bestSolution) {
+        if (bestSolutionConsumer == null) {
+            throw new IllegalStateException("No best solution consumer has been defined.");
+        }
+        bestSolutionWaitingForConsumption.set(bestSolution);
+        tryConsumeWaitingIntermediateBestSolution();
+    }
+
+    // Called on the Solver thread after Solver#solve() returns.
+    void consumeFinalBestSolution(Solution_ finalBestSolution) {
+        if (finalBestSolutionConsumer == null) {
+            throw new IllegalStateException("No final best solution consumer has been defined.");
+        }
+        try {
+            // Wait for the previous consumption to complete.
+            // As the solver has already finished, holding the solver thread is not an issue.
+            activeConsumption.acquire();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException("Interrupted when waiting for the final best solution consumption.");
+        }
+        // Make sure the final best solution is consumed by the intermediate best solution consumer first.
+        // Situation:
+        // The consumer is consuming the last but one best solution. The final best solution is waiting for the consumer.
+        scheduleIntermediateBestSolutionConsumption();
+        consumerExecutor.submit(() -> {
+            try {
+                finalBestSolutionConsumer.accept(finalBestSolution);
+            } catch (Throwable throwable) {
+                exceptionHandler.accept(problemId, throwable);
+            } finally {
+                activeConsumption.release();
+            }
+        });
+    }
+
+    // Called both on the Solver thread and the Consumer thread.
+    private void tryConsumeWaitingIntermediateBestSolution() {
+        if (bestSolutionWaitingForConsumption.get() == null) {
+            return; // There is no best solution to consume.
+        }
+        if (activeConsumption.tryAcquire()) {
+            scheduleIntermediateBestSolutionConsumption().thenRunAsync(this::tryConsumeWaitingIntermediateBestSolution,
+                    consumerExecutor);
+        }
+    }
+
+    /**
+     * Called both on the Solver thread and the Consumer thread.
+     * Don't call without locking, otherwise multiple consumptions may be scheduled.
+     */
+    private CompletableFuture<Void> scheduleIntermediateBestSolutionConsumption() {
+        return CompletableFuture.runAsync(() -> {
+            Solution_ bestSolution = bestSolutionWaitingForConsumption.getAndSet(null);
+            try {
+                if (bestSolution != null) {
+                    bestSolutionConsumer.accept(bestSolution);
+                }
+            } catch (Throwable throwable) {
+                exceptionHandler.accept(problemId, throwable);
+            } finally {
+                activeConsumption.release();
+            }
+        }, consumerExecutor);
+    }
+
+    void close() {
+        if (consumerExecutor != null) {
+            consumerExecutor.shutdownNow();
+            consumerExecutor = null;
+        }
+    }
+}

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/solver/ConsumerSupport.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/solver/ConsumerSupport.java
@@ -24,7 +24,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
-final class ConsumerSupport<Solution_, ProblemId_> {
+final class ConsumerSupport<Solution_, ProblemId_> implements AutoCloseable {
 
     private final ProblemId_ problemId;
     private final Consumer<? super Solution_> bestSolutionConsumer;
@@ -110,7 +110,8 @@ final class ConsumerSupport<Solution_, ProblemId_> {
         }, consumerExecutor);
     }
 
-    void close() {
+    @Override
+    public void close() {
         if (consumerExecutor != null) {
             consumerExecutor.shutdownNow();
             consumerExecutor = null;

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/solver/DefaultSolverJob.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/solver/DefaultSolverJob.java
@@ -218,6 +218,7 @@ public final class DefaultSolverJob<Solution_, ProblemId_> implements SolverJob<
     void close() {
         if (consumerSupport != null) {
             consumerSupport.close();
+            consumerSupport = null;
         }
     }
 

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/solver/DefaultSolverManager.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/solver/DefaultSolverManager.java
@@ -40,7 +40,7 @@ import org.slf4j.LoggerFactory;
 
 /**
  * @param <Solution_> the solution type, the class with the {@link PlanningSolution} annotation
- * @param <ProblemId_> the ID type of a submitted problem, such as {@link Long} or {@link UUID}.
+ * @param <ProblemId_> the ID type of submitted problem, such as {@link Long} or {@link UUID}.
  */
 public final class DefaultSolverManager<Solution_, ProblemId_> implements SolverManager<Solution_, ProblemId_> {
 

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/solver/ConsumerSupportTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/solver/ConsumerSupportTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.core.impl.solver;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.optaplanner.core.impl.testdata.domain.TestdataSolution;
+
+class ConsumerSupportTest {
+
+    private ConsumerSupport<TestdataSolution, Long> consumerSupport;
+
+    @AfterEach
+    void close() {
+        consumerSupport.close();
+    }
+
+    @Test
+    @Timeout(60)
+    void skipAhead() {
+        CountDownLatch consumptionPaused = new CountDownLatch(1);
+        AtomicReference<Throwable> error = new AtomicReference<>();
+        List<TestdataSolution> consumedSolutions = Collections.synchronizedList(new ArrayList<>());
+        consumerSupport = new ConsumerSupport<>(1L, testdataSolution -> {
+            try {
+                consumptionPaused.await();
+                consumedSolutions.add(testdataSolution);
+            } catch (InterruptedException e) {
+                error.set(new IllegalStateException("Interrupted waiting.", e));
+            }
+        }, null, null);
+
+        consumerSupport.consumeIntermediateBestSolution(TestdataSolution.generateSolution(1, 1));
+        // This solution should be skipped.
+        consumerSupport.consumeIntermediateBestSolution(TestdataSolution.generateSolution(2, 2));
+        consumerSupport.consumeIntermediateBestSolution(TestdataSolution.generateSolution(3, 3));
+
+        consumptionPaused.countDown();
+
+        assertThat(consumedSolutions).hasSize(2);
+        assertThat(consumedSolutions.get(0).getEntityList()).hasSize(1);
+        assertThat(consumedSolutions.get(1).getEntityList()).hasSize(3);
+
+        if (error.get() != null) {
+            fail("Exception during consumption.", error.get());
+        }
+    }
+}


### PR DESCRIPTION
<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.
-->

### JIRA
https://issues.redhat.com/browse/PLANNER-2628

<!-- Add a JIRA ticket link if it exists. -->
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
* https://github.com/kiegroup/drools/pull/3000
* https://github.com/kiegroup/optaplanner/pull/899
* etc.
-->

### Checklist
- [ ] Review and improve test coverage.
- [ ] Documentation updated if applicable.
- [ ] Upgrade recipe provided if applicable.

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>specific pull request build</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] tests</b>
* for a <b>full downstream build</b> 
  * for <b>jenkins</b> job: please add comment: <b>Jenkins run fdb</b>
  * for <b>github actions</b> job: add the label `run_fdb`
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
* for a <b>Quarkus LTS check</b> please add comment: <b>Jenkins run LTS</b>
* for a <b>specific Quarkus LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] LTS</b>
* for a <b>Native check</b> please add comment: <b>Jenkins run native</b>
* for a <b>specific Native LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] native</b>
</details>
