### PR TITLE
Fail fast if a custom shadow variable listener is sourced on a list variable

### DIFF
--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/variable/custom/CustomShadowVariableDescriptor.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/variable/custom/CustomShadowVariableDescriptor.java
@@ -182,6 +182,14 @@ public class CustomShadowVariableDescriptor<Solution_> extends ShadowVariableDes
                             + sourceEntityDescriptor.getEntityClass() + ").\n"
                             + sourceEntityDescriptor.buildInvalidVariableNameExceptionMessage(sourceVariableName));
                 }
+                if (sourceVariableDescriptor.isGenuineListVariable()) {
+                    throw new IllegalArgumentException("The entityClass (" + entityDescriptor.getEntityClass()
+                            + ") has a @" + CustomShadowVariable.class.getSimpleName()
+                            + " annotated property (" + variableMemberAccessor.getName()
+                            + ") with sourceVariableName (" + sourceVariableName
+                            + ") which is a list variable.\n"
+                            + "Custom shadow variables sourced on list variables are not yet supported.");
+                }
                 sourceVariableDescriptor.registerSinkVariableDescriptor(this);
                 sourceVariableDescriptorList.add(sourceVariableDescriptor);
             }

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/ListChangeMove.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/ListChangeMove.java
@@ -154,12 +154,13 @@ public class ListChangeMove<Solution_> extends AbstractMove<Solution_> {
     @Override
     protected void doMoveOnGenuineVariables(ScoreDirector<Solution_> scoreDirector) {
         InnerScoreDirector<Solution_, ?> innerScoreDirector = (InnerScoreDirector<Solution_, ?>) scoreDirector;
-        // Remove element from the source entity.
+
         innerScoreDirector.beforeVariableChanged(variableDescriptor, sourceEntity);
         Object element = variableDescriptor.removeElement(sourceEntity, sourceIndex);
-        innerScoreDirector.afterVariableChanged(variableDescriptor, sourceEntity);
-        // Add element to the destination entity.
-        innerScoreDirector.beforeVariableChanged(variableDescriptor, destinationEntity);
+        if (sourceEntity != destinationEntity) {
+            innerScoreDirector.afterVariableChanged(variableDescriptor, sourceEntity);
+            innerScoreDirector.beforeVariableChanged(variableDescriptor, destinationEntity);
+        }
         variableDescriptor.addElement(destinationEntity, destinationIndex, element);
         innerScoreDirector.afterVariableChanged(variableDescriptor, destinationEntity);
     }

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/ListSwapMove.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/ListSwapMove.java
@@ -149,9 +149,10 @@ public class ListSwapMove<Solution_> extends AbstractMove<Solution_> {
 
         innerScoreDirector.beforeVariableChanged(variableDescriptor, leftEntity);
         variableDescriptor.setElement(leftEntity, leftIndex, rightElement);
-        innerScoreDirector.afterVariableChanged(variableDescriptor, leftEntity);
-
-        innerScoreDirector.beforeVariableChanged(variableDescriptor, rightEntity);
+        if (leftEntity != rightEntity) {
+            innerScoreDirector.afterVariableChanged(variableDescriptor, leftEntity);
+            innerScoreDirector.beforeVariableChanged(variableDescriptor, rightEntity);
+        }
         variableDescriptor.setElement(rightEntity, rightIndex, leftElement);
         innerScoreDirector.afterVariableChanged(variableDescriptor, rightEntity);
     }

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/taskassigning/domain/Task.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/taskassigning/domain/Task.java
@@ -42,9 +42,12 @@ public class Task extends AbstractPersistable implements Labeled {
     private Employee employee;
     @IndexShadowVariable(sourceVariableName = "tasks")
     private Integer index;
-    // This API will change in https://issues.redhat.com/browse/PLANNER-2542.
+    // This API will change in https://issues.redhat.com/browse/PLANNER-2582.
     @CustomShadowVariable(variableListenerClass = StartTimeUpdatingVariableListener.class,
-            sources = { @PlanningVariableReference(entityClass = Employee.class, variableName = "tasks") })
+            sources = {
+                    @PlanningVariableReference(variableName = "employee"),
+                    @PlanningVariableReference(variableName = "index")
+            })
     private Integer startTime; // In minutes
 
     public Task() {

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/taskassigning/domain/solver/StartTimeUpdatingVariableListener.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/taskassigning/domain/solver/StartTimeUpdatingVariableListener.java
@@ -24,52 +24,58 @@ import org.optaplanner.examples.taskassigning.domain.Employee;
 import org.optaplanner.examples.taskassigning.domain.Task;
 import org.optaplanner.examples.taskassigning.domain.TaskAssigningSolution;
 
-public class StartTimeUpdatingVariableListener implements VariableListener<TaskAssigningSolution, Employee> {
+public class StartTimeUpdatingVariableListener implements VariableListener<TaskAssigningSolution, Task> {
 
     @Override
-    public void beforeEntityAdded(ScoreDirector<TaskAssigningSolution> scoreDirector, Employee employee) {
+    public void beforeEntityAdded(ScoreDirector<TaskAssigningSolution> scoreDirector, Task task) {
         // Do nothing
     }
 
     @Override
-    public void afterEntityAdded(ScoreDirector<TaskAssigningSolution> scoreDirector, Employee employee) {
-        updateStartTime(scoreDirector, employee);
+    public void afterEntityAdded(ScoreDirector<TaskAssigningSolution> scoreDirector, Task task) {
+        updateStartTime(scoreDirector, task);
     }
 
     @Override
-    public void beforeVariableChanged(ScoreDirector<TaskAssigningSolution> scoreDirector, Employee employee) {
+    public void beforeVariableChanged(ScoreDirector<TaskAssigningSolution> scoreDirector, Task task) {
         // Do nothing
     }
 
     @Override
-    public void afterVariableChanged(ScoreDirector<TaskAssigningSolution> scoreDirector, Employee employee) {
-        updateStartTime(scoreDirector, employee);
+    public void afterVariableChanged(ScoreDirector<TaskAssigningSolution> scoreDirector, Task task) {
+        updateStartTime(scoreDirector, task);
     }
 
     @Override
-    public void beforeEntityRemoved(ScoreDirector<TaskAssigningSolution> scoreDirector, Employee employee) {
+    public void beforeEntityRemoved(ScoreDirector<TaskAssigningSolution> scoreDirector, Task task) {
         // Do nothing
     }
 
     @Override
-    public void afterEntityRemoved(ScoreDirector<TaskAssigningSolution> scoreDirector, Employee employee) {
+    public void afterEntityRemoved(ScoreDirector<TaskAssigningSolution> scoreDirector, Task task) {
         // Do nothing
     }
 
-    protected void updateStartTime(ScoreDirector<TaskAssigningSolution> scoreDirector, Employee sourceEmployee) {
-        if (sourceEmployee.getTasks() == null) {
-            return;
+    protected void updateStartTime(ScoreDirector<TaskAssigningSolution> scoreDirector, Task task) {
+        Integer startTime = calculateStartTime(task);
+        if (!Objects.equals(task.getStartTime(), startTime)) {
+            scoreDirector.beforeVariableChanged(task, "startTime");
+            task.setStartTime(startTime);
+            scoreDirector.afterVariableChanged(task, "startTime");
         }
-        int previousStartTime = 0;
-        for (Task task : sourceEmployee.getTasks()) {
-            int startTime = Math.max(task.getReadyTime(), previousStartTime);
-            if (!Objects.equals(task.getStartTime(), startTime)) {
-                scoreDirector.beforeVariableChanged(task, "startTime");
-                task.setStartTime(startTime);
-                scoreDirector.afterVariableChanged(task, "startTime");
-            }
-            previousStartTime = task.getEndTime();
+    }
+
+    private Integer calculateStartTime(Task task) {
+        Employee employee = task.getEmployee();
+        if (employee == null) {
+            return null;
         }
+        Integer index = task.getIndex();
+        Integer previousEndTime = index == 0 ? Integer.valueOf(0) : employee.getTasks().get(index - 1).getEndTime();
+        if (previousEndTime == null) {
+            return null;
+        }
+        return Math.max(task.getReadyTime(), previousEndTime);
     }
 
 }


### PR DESCRIPTION
As agreed previously, let's fail fast if a custom shadow variable is sourced on a `@PlanningListVariable`. In the near future this will be possible but the variable listener class will have to implement `ListVariableListener`, which is a new API that we currently don't have. Will be designed in the next phase, see https://issues.redhat.com/browse/PLANNER-2582.