### PR TITLE
AbstractPhaseScope doesn't need ScoreDefinition

### DIFF
--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/phase/AbstractPhase.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/phase/AbstractPhase.java
@@ -29,7 +29,6 @@ import org.optaplanner.core.impl.phase.event.PhaseLifecycleListener;
 import org.optaplanner.core.impl.phase.event.PhaseLifecycleSupport;
 import org.optaplanner.core.impl.phase.scope.AbstractPhaseScope;
 import org.optaplanner.core.impl.phase.scope.AbstractStepScope;
-import org.optaplanner.core.impl.score.definition.ScoreDefinition;
 import org.optaplanner.core.impl.score.director.InnerScoreDirector;
 import org.optaplanner.core.impl.solver.AbstractSolver;
 import org.optaplanner.core.impl.solver.scope.SolverScope;
@@ -176,13 +175,12 @@ public abstract class AbstractPhase<Solution_> implements Phase<Solution_> {
     }
 
     private void collectMetrics(AbstractStepScope<Solution_> stepScope) {
-        if (stepScope.getPhaseScope().getSolverScope().isMetricEnabled(SolverMetric.STEP_SCORE)
-                && stepScope.getScore().isSolutionInitialized()) {
-            ScoreDefinition<?> scoreDefinition = stepScope.getPhaseScope().getScoreDefinition();
+        SolverScope<Solution_> solverScope = stepScope.getPhaseScope().getSolverScope();
+        if (solverScope.isMetricEnabled(SolverMetric.STEP_SCORE) && stepScope.getScore().isSolutionInitialized()) {
             SolverMetric.registerScoreMetrics(SolverMetric.STEP_SCORE,
-                    stepScope.getPhaseScope().getSolverScope().getMonitoringTags(),
-                    scoreDefinition,
-                    stepScope.getPhaseScope().getSolverScope().getStepScoreMap(),
+                    solverScope.getMonitoringTags(),
+                    solverScope.getScoreDefinition(),
+                    solverScope.getStepScoreMap(),
                     stepScope.getScore());
         }
     }

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/phase/scope/AbstractPhaseScope.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/phase/scope/AbstractPhaseScope.java
@@ -22,7 +22,6 @@ import java.util.Random;
 import org.optaplanner.core.api.domain.solution.PlanningSolution;
 import org.optaplanner.core.api.score.Score;
 import org.optaplanner.core.impl.domain.solution.descriptor.SolutionDescriptor;
-import org.optaplanner.core.impl.score.definition.ScoreDefinition;
 import org.optaplanner.core.impl.score.director.InnerScoreDirector;
 import org.optaplanner.core.impl.solver.scope.SolverScope;
 import org.slf4j.Logger;
@@ -101,10 +100,6 @@ public abstract class AbstractPhaseScope<Solution_> {
 
     public SolutionDescriptor<Solution_> getSolutionDescriptor() {
         return solverScope.getSolutionDescriptor();
-    }
-
-    public <Score_ extends Score<Score_>> ScoreDefinition<Score_> getScoreDefinition() {
-        return solverScope.getScoreDefinition();
     }
 
     public long calculateSolverTimeMillisSpentUpToNow() {

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/solver/termination/BestScoreFeasibleTerminationTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/solver/termination/BestScoreFeasibleTerminationTest.java
@@ -66,7 +66,6 @@ public class BestScoreFeasibleTerminationTest {
         when(scoreDefinition.getFeasibleLevelsSize()).thenReturn(1);
         Termination<TestdataSolution> termination = new BestScoreFeasibleTermination<>(scoreDefinition, new double[] {});
         AbstractPhaseScope<TestdataSolution> phaseScope = mock(AbstractPhaseScope.class);
-        when(phaseScope.getScoreDefinition()).thenReturn((ScoreDefinition) new HardSoftScoreDefinition());
         when(phaseScope.getStartingScore()).thenReturn(HardSoftScore.of(-100, -100));
         when(phaseScope.isBestSolutionInitialized()).thenReturn(true);
 

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/solver/termination/BestScoreTerminationTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/solver/termination/BestScoreTerminationTest.java
@@ -74,7 +74,6 @@ public class BestScoreTerminationTest {
         Termination<TestdataSolution> termination =
                 new BestScoreTermination<>(scoreDefinition, SimpleScore.of(-1000), new double[] {});
         AbstractPhaseScope<TestdataSolution> phaseScope = mock(AbstractPhaseScope.class);
-        when(phaseScope.getScoreDefinition()).thenReturn((ScoreDefinition) new SimpleScoreDefinition());
         when(phaseScope.isBestSolutionInitialized()).thenReturn(true);
         when(phaseScope.getStartingScore()).thenReturn(SimpleScore.of(-1100));
 


### PR DESCRIPTION
Simple internal API cleanup.


<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>specific pull request build</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] tests</b>
* for a <b>full downstream build</b> 
  * for <b>jenkins</b> job: please add comment: <b>Jenkins run fdb</b>
  * for <b>github actions</b> job: add the label `run_fdb`
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
* for a <b>Quarkus LTS check</b> please add comment: <b>Jenkins run LTS</b>
* for a <b>specific Quarkus LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] LTS</b>
* for a <b>Native check</b> please add comment: <b>Jenkins run native</b>
* for a <b>specific Native LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] native</b>
</details>
