### PR TITLE
[8.16.x] KOGITO-5531 Update Jenkins CI to 3.8.1

### DIFF
--- a/.ci/jenkins/Jenkinsfile.deploy
+++ b/.ci/jenkins/Jenkinsfile.deploy
@@ -17,7 +17,7 @@ pipeline {
     }
 
     tools {
-        maven 'kie-maven-3.6.3'
+        maven 'kie-maven-3.8.1'
         jdk 'kie-jdk11'
     }
 

--- a/.ci/jenkins/Jenkinsfile.native
+++ b/.ci/jenkins/Jenkinsfile.native
@@ -12,7 +12,7 @@ pipeline {
         label 'kie-rhel7 && kie-mem16g'
     }
     tools {
-        maven 'kie-maven-3.6.3'
+        maven 'kie-maven-3.8.1'
         jdk 'kie-jdk11'
     }
     options {

--- a/.ci/jenkins/Jenkinsfile.post-release
+++ b/.ci/jenkins/Jenkinsfile.post-release
@@ -14,7 +14,7 @@ pipeline {
     }
 
     tools {
-        maven 'kie-maven-3.6.3'
+        maven 'kie-maven-3.8.1'
         jdk 'kie-jdk11'
     }
 

--- a/.ci/jenkins/Jenkinsfile.promote
+++ b/.ci/jenkins/Jenkinsfile.promote
@@ -17,7 +17,7 @@ pipeline {
     }
 
     tools {
-        maven 'kie-maven-3.6.3'
+        maven 'kie-maven-3.8.1'
         jdk 'kie-jdk11'
     }
 

--- a/.ci/jenkins/Jenkinsfile.turtle
+++ b/.ci/jenkins/Jenkinsfile.turtle
@@ -9,7 +9,7 @@ pipeline {
         label 'kie-rhel7 && kie-mem16g'
     }
     tools {
-        maven 'kie-maven-3.6.3'
+        maven 'kie-maven-3.8.1'
         jdk 'kie-jdk11'
     }
     options {


### PR DESCRIPTION
https://issues.redhat.com/browse/KOGITO-5531

This is to harmonize all Jenkins CIs.
PR checks are already using the Maven 3.8.x

Related PRs:
- https://github.com/kiegroup/kogito-pipelines/pull/375
- https://github.com/kiegroup/drools/pull/4169
- https://github.com/kiegroup/kogito-runtimes/pull/1954
- https://github.com/kiegroup/optaplanner/pull/1814
- https://github.com/kiegroup/kogito-apps/pull/1220
- https://github.com/kiegroup/kogito-examples/pull/1105
- https://github.com/kiegroup/kogito-apps/pull/1220
- https://github.com/kiegroup/kogito-examples/pull/1105