### PR TITLE
KOGITO-6682 Force maven version to 3.8.1+

### DIFF
--- a/build/optaplanner-build-parent/pom.xml
+++ b/build/optaplanner-build-parent/pom.xml
@@ -40,7 +40,7 @@
     <!-- Plugins -->
     <!-- ************************************************************************ -->
 
-    <maven.min.version>3.6.3</maven.min.version>
+    <maven.min.version>3.8.1</maven.min.version>
     <maven.compiler.release>11</maven.compiler.release>
     <!-- A workaround for https://youtrack.jetbrains.com/issue/IDEA-276403. -->
     <maven.compiler.target>11</maven.compiler.target>


### PR DESCRIPTION
https://issues.redhat.com/browse/KOGITO-6682

Related PRs:
- https://github.com/kiegroup/drools/pull/4174
- https://github.com/kiegroup/kogito-runtimes/pull/1962
- https://github.com/kiegroup/optaplanner/pull/1820
- https://github.com/kiegroup/optaweb-vehicle-routing/pull/647
- https://github.com/kiegroup/optaplanner-quickstarts/pull/277
- https://github.com/kiegroup/kogito-apps/pull/1227
- https://github.com/kiegroup/kogito-examples/pull/1109