### PR TITLE
PLANNER-2659 Improve internal ProblemChangeDirector API

### DIFF
--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/solver/change/DefaultProblemChangeDirector.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/solver/change/DefaultProblemChangeDirector.java
@@ -20,14 +20,16 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Consumer;
 
-import org.optaplanner.core.api.score.director.ScoreDirector;
+import org.optaplanner.core.api.score.Score;
+import org.optaplanner.core.api.solver.change.ProblemChange;
 import org.optaplanner.core.api.solver.change.ProblemChangeDirector;
+import org.optaplanner.core.impl.score.director.InnerScoreDirector;
 
 public final class DefaultProblemChangeDirector<Solution_> implements ProblemChangeDirector {
 
-    private final ScoreDirector<Solution_> scoreDirector;
+    private final InnerScoreDirector<Solution_, ?> scoreDirector;
 
-    public DefaultProblemChangeDirector(ScoreDirector<Solution_> scoreDirector) {
+    public DefaultProblemChangeDirector(InnerScoreDirector<Solution_, ?> scoreDirector) {
         this.scoreDirector = scoreDirector;
     }
 
@@ -104,5 +106,11 @@ public final class DefaultProblemChangeDirector<Solution_> implements ProblemCha
     public <EntityOrProblemFact> Optional<EntityOrProblemFact>
             lookUpWorkingObject(EntityOrProblemFact externalObject) {
         return Optional.ofNullable(scoreDirector.lookUpWorkingObjectOrReturnNull(externalObject));
+    }
+
+    public Score<?> doProblemChange(ProblemChange<Solution_> problemChange) {
+        problemChange.doChange(scoreDirector.getWorkingSolution(), this);
+        scoreDirector.triggerVariableListeners();
+        return scoreDirector.calculateScore();
     }
 }

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/solver/change/ProblemChangeAdapter.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/solver/change/ProblemChangeAdapter.java
@@ -37,10 +37,6 @@ public interface ProblemChangeAdapter<Solution_> {
     }
 
     static <Solution_> ProblemChangeAdapter<Solution_> create(ProblemChange<Solution_> problemChange) {
-        return solverScope -> {
-            problemChange.doChange(solverScope.getWorkingSolution(), solverScope.getProblemChangeDirector());
-            solverScope.getScoreDirector().triggerVariableListeners();
-            return solverScope.calculateScore();
-        };
+        return solverScope -> solverScope.getProblemChangeDirector().doProblemChange(problemChange);
     }
 }

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/solver/scope/SolverScope.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/solver/scope/SolverScope.java
@@ -28,12 +28,12 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.optaplanner.core.api.domain.solution.PlanningSolution;
 import org.optaplanner.core.api.score.Score;
 import org.optaplanner.core.api.solver.Solver;
-import org.optaplanner.core.api.solver.change.ProblemChangeDirector;
 import org.optaplanner.core.config.solver.monitoring.SolverMetric;
 import org.optaplanner.core.impl.domain.solution.descriptor.SolutionDescriptor;
 import org.optaplanner.core.impl.phase.scope.AbstractPhaseScope;
 import org.optaplanner.core.impl.score.definition.ScoreDefinition;
 import org.optaplanner.core.impl.score.director.InnerScoreDirector;
+import org.optaplanner.core.impl.solver.change.DefaultProblemChangeDirector;
 import org.optaplanner.core.impl.solver.termination.Termination;
 import org.optaplanner.core.impl.solver.thread.ChildThreadType;
 
@@ -48,7 +48,7 @@ public class SolverScope<Solution_> {
     protected int startingSolverCount;
     protected Random workingRandom;
     protected InnerScoreDirector<Solution_, ?> scoreDirector;
-    private ProblemChangeDirector problemChangeDirector;
+    private DefaultProblemChangeDirector<Solution_> problemChangeDirector;
     /**
      * Used for capping CPU power usage in multithreaded scenarios.
      */
@@ -72,11 +72,11 @@ public class SolverScope<Solution_> {
     // Constructors and simple getters/setters
     // ************************************************************************
 
-    public ProblemChangeDirector getProblemChangeDirector() {
+    public DefaultProblemChangeDirector<Solution_> getProblemChangeDirector() {
         return problemChangeDirector;
     }
 
-    public void setProblemChangeDirector(ProblemChangeDirector problemChangeDirector) {
+    public void setProblemChangeDirector(DefaultProblemChangeDirector<Solution_> problemChangeDirector) {
         this.problemChangeDirector = problemChangeDirector;
     }
 

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/solver/change/DefaultProblemChangeDirectorTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/solver/change/DefaultProblemChangeDirectorTest.java
@@ -16,12 +16,15 @@
 
 package org.optaplanner.core.impl.solver.change;
 
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import org.junit.jupiter.api.Test;
-import org.optaplanner.core.api.score.director.ScoreDirector;
 import org.optaplanner.core.api.solver.change.ProblemChange;
 import org.optaplanner.core.api.solver.change.ProblemChangeDirector;
+import org.optaplanner.core.impl.score.director.InnerScoreDirector;
 import org.optaplanner.core.impl.testdata.domain.TestdataEntity;
 import org.optaplanner.core.impl.testdata.domain.TestdataSolution;
 import org.optaplanner.core.impl.testdata.domain.score.lavish.TestdataLavishEntity;
@@ -43,7 +46,7 @@ public class DefaultProblemChangeDirectorTest {
         final TestdataLavishEntity changedEntity = new TestdataLavishEntity("changed entity", entityGroupOne);
         final TestdataLavishValue changedEntityValue = new TestdataLavishValue("changed entity value", valueGroupOne);
 
-        ScoreDirector<TestdataSolution> scoreDirectorMock = mock(ScoreDirector.class);
+        InnerScoreDirector<TestdataSolution, ?> scoreDirectorMock = mock(InnerScoreDirector.class);
         when(scoreDirectorMock.lookUpWorkingObject(removedEntity)).thenReturn(removedEntity);
         when(scoreDirectorMock.lookUpWorkingObject(changedEntity)).thenReturn(changedEntity);
         when(scoreDirectorMock.lookUpWorkingObject(removedFact)).thenReturn(removedFact);

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/solver/termination/BasicPlumbingTerminationTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/solver/termination/BasicPlumbingTerminationTest.java
@@ -17,14 +17,15 @@
 package org.optaplanner.core.impl.solver.termination;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.util.Arrays;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.jupiter.api.Test;
 import org.optaplanner.core.impl.score.director.InnerScoreDirector;
+import org.optaplanner.core.impl.solver.change.DefaultProblemChangeDirector;
 import org.optaplanner.core.impl.solver.change.ProblemChangeAdapter;
 import org.optaplanner.core.impl.solver.scope.SolverScope;
 import org.optaplanner.core.impl.testdata.domain.TestdataSolution;
@@ -73,7 +74,7 @@ public class BasicPlumbingTerminationTest {
     private SolverScope<TestdataSolution> mockSolverScope() {
         InnerScoreDirector<TestdataSolution, ?> scoreDirectorMock = mock(InnerScoreDirector.class);
         SolverScope<TestdataSolution> solverScopeMock = mock(SolverScope.class);
-        doReturn(scoreDirectorMock).when(solverScopeMock).getScoreDirector();
+        when(solverScopeMock.getProblemChangeDirector()).thenReturn(new DefaultProblemChangeDirector<>(scoreDirectorMock));
         return solverScopeMock;
     }
 }

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/common/business/SolutionBusiness.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/common/business/SolutionBusiness.java
@@ -39,7 +39,6 @@ import org.optaplanner.core.api.score.constraint.Indictment;
 import org.optaplanner.core.api.solver.Solver;
 import org.optaplanner.core.api.solver.SolverFactory;
 import org.optaplanner.core.api.solver.change.ProblemChange;
-import org.optaplanner.core.api.solver.change.ProblemChangeDirector;
 import org.optaplanner.core.impl.domain.variable.descriptor.GenuineVariableDescriptor;
 import org.optaplanner.core.impl.domain.variable.inverserelation.SingletonInverseVariableDemand;
 import org.optaplanner.core.impl.domain.variable.inverserelation.SingletonInverseVariableSupply;
@@ -97,7 +96,7 @@ public class SolutionBusiness<Solution_, Score_ extends Score<Score_>> {
     private volatile Solver<Solution_> solver;
     private String solutionFileName = null;
     private InnerScoreDirector<Solution_, Score_> guiScoreDirector;
-    private ProblemChangeDirector problemChangeDirector;
+    private DefaultProblemChangeDirector<Solution_> problemChangeDirector;
     private ScoreManager<Solution_, Score_> scoreManager;
 
     private final AtomicReference<Solution_> skipToBestSolutionRef = new AtomicReference<>();
@@ -359,8 +358,7 @@ public class SolutionBusiness<Solution_, Score_ extends Score<Score_>> {
         if (solver.isSolving()) {
             solver.addProblemChange(problemChange);
         } else {
-            problemChange.doChange(guiScoreDirector.getWorkingSolution(), problemChangeDirector);
-            guiScoreDirector.calculateScore();
+            problemChangeDirector.doProblemChange(problemChange);
         }
     }
 


### PR DESCRIPTION
1. Fixes a bug in the examples.
2. Improves the internal problem change API so that a problem fact change can be applied easily without having to explicitly trigger variable listeners.

### JIRA
https://issues.redhat.com/browse/PLANNER-2659

### Referenced pull requests
Could replace https://github.com/kiegroup/optaplanner/pull/1821.

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>specific pull request build</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] tests</b>
* for a <b>full downstream build</b> 
  * for <b>jenkins</b> job: please add comment: <b>Jenkins run fdb</b>
  * for <b>github actions</b> job: add the label `run_fdb`
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
* for a <b>Quarkus LTS check</b> please add comment: <b>Jenkins run LTS</b>
* for a <b>specific Quarkus LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] LTS</b>
* for a <b>Native check</b> please add comment: <b>Jenkins run native</b>
* for a <b>specific Native LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] native</b>
</details>
