### PR TITLE
Do not re-run GHA workflows when PR is marked as ready for review

### DIFF
--- a/.github/workflows/full-downstream.yml
+++ b/.github/workflows/full-downstream.yml
@@ -2,7 +2,7 @@ name: Build Chain FDB
 
 on:
   pull_request:
-    types: [labeled]
+    types: [ labeled ]
     branches:
       - main
     paths-ignore:
@@ -21,9 +21,9 @@ jobs:
       cancel-in-progress: true
     strategy:
       matrix:
-        os: [ubuntu-latest]
-        java-version: [11]
-        maven-version: ['3.8.1']
+        os: [ ubuntu-latest ]
+        java-version: [ 11 ]
+        maven-version: [ '3.8.1' ]
       fail-fast: false
     runs-on: ${{ matrix.os }}
     name: ${{ matrix.os }} - Java ${{ matrix.java-version }} - Maven

--- a/.github/workflows/jenkins-tests-PR.yml
+++ b/.github/workflows/jenkins-tests-PR.yml
@@ -5,27 +5,27 @@ name: Jenkins Tests
 
 on:
   pull_request:
-    paths: 
-    - '.ci/jenkins/**'
+    paths:
+      - '.ci/jenkins/**'
 
 jobs:
   dsl-tests:
     strategy:
       matrix:
-        os: [ubuntu-latest]
-        java-version: [11]
-        maven-version: ['3.8.1']
+        os: [ ubuntu-latest ]
+        java-version: [ 11 ]
+        maven-version: [ '3.8.1' ]
       fail-fast: false
     runs-on: ${{ matrix.os }}
     name: ${{ matrix.os }} - Java ${{ matrix.java-version }} - Maven
     steps:
-    - name: Checkout 
-      uses: actions/checkout@v2
-    - name: Java and Maven Setup
-      uses: kiegroup/kogito-pipelines/.ci/actions/maven@main
-      with:
-        java-version: ${{ matrix.java-version }}
-        maven-version: ${{ matrix.maven-version }}
-        cache-key-prefix: ${{ runner.os }}-${{ matrix.java-version }}-maven${{ matrix.maven-version }}
-    - name: Test DSL
-      run: cd .ci/jenkins/dsl && ./test.sh
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Java and Maven Setup
+        uses: kiegroup/kogito-pipelines/.ci/actions/maven@main
+        with:
+          java-version: ${{ matrix.java-version }}
+          maven-version: ${{ matrix.maven-version }}
+          cache-key-prefix: ${{ runner.os }}-${{ matrix.java-version }}-maven${{ matrix.maven-version }}
+      - name: Test DSL
+        run: cd .ci/jenkins/dsl && ./test.sh

--- a/.github/workflows/jpa_integration_ci.yml
+++ b/.github/workflows/jpa_integration_ci.yml
@@ -14,7 +14,7 @@ on:
       - '*.txt'
       - '.ci/**'
   pull_request:
-    types: [ opened, synchronize, reopened, ready_for_review ]
+    types: [ opened, synchronize, reopened ]
     branches:
       - main
     paths-ignore:

--- a/.github/workflows/jpa_integration_ci.yml
+++ b/.github/workflows/jpa_integration_ci.yml
@@ -12,9 +12,9 @@ on:
       - '**.md'
       - '**.adoc'
       - '*.txt'
-      - '.ci/**'      
+      - '.ci/**'
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
+    types: [ opened, synchronize, reopened, ready_for_review ]
     branches:
       - main
     paths-ignore:
@@ -33,9 +33,9 @@ jobs:
   jpa-postgresql-container:
     strategy:
       matrix:
-        os: [ubuntu-latest]
-        java-version: [11]
-        maven-version: ['3.8.1']
+        os: [ ubuntu-latest ]
+        java-version: [ 11 ]
+        maven-version: [ '3.8.1' ]
       fail-fast: false
     runs-on: ${{ matrix.os }}
     services:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -12,9 +12,9 @@ on:
       - '**.md'
       - '**.adoc'
       - '*.txt'
-      - '.ci/**'      
+      - '.ci/**'
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
+    types: [ opened, synchronize, reopened, ready_for_review ]
     branches:
       - main
       - 8.*
@@ -39,7 +39,7 @@ jobs:
       matrix:
         os: [ ubuntu-latest, windows-latest ]
         java-version: [ 11, 17 ]
-        maven-version: ['3.8.1']
+        maven-version: [ '3.8.1' ]
       fail-fast: false
     runs-on: ${{ matrix.os }}
     name: ${{ matrix.os }} - Java ${{ matrix.java-version }} - Maven

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -14,7 +14,7 @@ on:
       - '*.txt'
       - '.ci/**'
   pull_request:
-    types: [ opened, synchronize, reopened, ready_for_review ]
+    types: [ opened, synchronize, reopened ]
     branches:
       - main
       - 8.*

--- a/.github/workflows/quarkus-snapshot.yml
+++ b/.github/workflows/quarkus-snapshot.yml
@@ -1,7 +1,7 @@
 name: "Quarkus ecosystem"
 on:
   watch:
-    types: [started]
+    types: [ started ]
 
   # For this CI to work, ECOSYSTEM_CI_TOKEN needs to contain a GitHub with rights to close the Quarkus issue that the user/bot has opened,
   # while 'ECOSYSTEM_CI_REPO_PATH' needs to be set to the corresponding path in the 'quarkusio/quarkus-ecosystem-ci' repository
@@ -34,9 +34,9 @@ jobs:
       - name: Java and Maven Setup
         uses: kiegroup/kogito-pipelines/.ci/actions/maven@main
         with:
-         java-version: ${{ matrix.java-version }}
-         maven-version: ${{ matrix.maven-version }}
-         cache-key-prefix: ${{ runner.os }}-${{ matrix.java-version }}-maven${{ matrix.maven-version }}
+          java-version: ${{ matrix.java-version }}
+          maven-version: ${{ matrix.maven-version }}
+          cache-key-prefix: ${{ runner.os }}-${{ matrix.java-version }}-maven${{ matrix.maven-version }}
 
       - name: Checkout repo
         uses: actions/checkout@v2

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -11,7 +11,7 @@ on:
       - '**.md'
       - '**.adoc'
       - '*.txt'
-      - '.ci/**'      
+      - '.ci/**'
 
 defaults:
   run:


### PR DESCRIPTION
That makes no sense. I often start with a draft PR. I polish it
incrementally and make sure all checks are green. Then I mark it as
ready for review. At that point I want the review to see a ready PR that
can be merged immediatelly if no issues are found. But unexpectedly,
workflows are restarted without any change in the code. That is a waste
of time (both human and machine).

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>specific pull request build</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] tests</b>
* for a <b>full downstream build</b> 
  * for <b>jenkins</b> job: please add comment: <b>Jenkins run fdb</b>
  * for <b>github actions</b> job: add the label `run_fdb`
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
* for a <b>Quarkus LTS check</b> please add comment: <b>Jenkins run LTS</b>
* for a <b>specific Quarkus LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] LTS</b>
* for a <b>Native check</b> please add comment: <b>Jenkins run native</b>
* for a <b>specific Native LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] native</b>
</details>
