### PR TITLE
Improve ChangeMove constructor consistency with other moves

### DIFF
--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/ChangeMove.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/ChangeMove.java
@@ -31,23 +31,23 @@ import org.optaplanner.core.impl.score.director.InnerScoreDirector;
  */
 public class ChangeMove<Solution_> extends AbstractMove<Solution_> {
 
-    protected final Object entity;
     protected final GenuineVariableDescriptor<Solution_> variableDescriptor;
+
+    protected final Object entity;
     protected final Object toPlanningValue;
 
-    public ChangeMove(Object entity, GenuineVariableDescriptor<Solution_> variableDescriptor,
-            Object toPlanningValue) {
-        this.entity = entity;
+    public ChangeMove(GenuineVariableDescriptor<Solution_> variableDescriptor, Object entity, Object toPlanningValue) {
         this.variableDescriptor = variableDescriptor;
+        this.entity = entity;
         this.toPlanningValue = toPlanningValue;
-    }
-
-    public Object getEntity() {
-        return entity;
     }
 
     public String getVariableName() {
         return variableDescriptor.getVariableName();
+    }
+
+    public Object getEntity() {
+        return entity;
     }
 
     public Object getToPlanningValue() {
@@ -67,7 +67,7 @@ public class ChangeMove<Solution_> extends AbstractMove<Solution_> {
     @Override
     public ChangeMove<Solution_> createUndoMove(ScoreDirector<Solution_> scoreDirector) {
         Object oldValue = variableDescriptor.getValue(entity);
-        return new ChangeMove<>(entity, variableDescriptor, oldValue);
+        return new ChangeMove<>(variableDescriptor, entity, oldValue);
     }
 
     @Override
@@ -78,8 +78,7 @@ public class ChangeMove<Solution_> extends AbstractMove<Solution_> {
 
     @Override
     public ChangeMove<Solution_> rebase(ScoreDirector<Solution_> destinationScoreDirector) {
-        return new ChangeMove<>(destinationScoreDirector.lookUpWorkingObject(entity),
-                variableDescriptor,
+        return new ChangeMove<>(variableDescriptor, destinationScoreDirector.lookUpWorkingObject(entity),
                 destinationScoreDirector.lookUpWorkingObject(toPlanningValue));
     }
 
@@ -111,14 +110,14 @@ public class ChangeMove<Solution_> extends AbstractMove<Solution_> {
             return false;
         }
         final ChangeMove<?> other = (ChangeMove<?>) o;
-        return Objects.equals(entity, other.entity) &&
-                Objects.equals(variableDescriptor, other.variableDescriptor) &&
+        return Objects.equals(variableDescriptor, other.variableDescriptor) &&
+                Objects.equals(entity, other.entity) &&
                 Objects.equals(toPlanningValue, other.toPlanningValue);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(entity, variableDescriptor, toPlanningValue);
+        return Objects.hash(variableDescriptor, entity, toPlanningValue);
     }
 
     @Override

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/ChangeMoveSelector.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/ChangeMoveSelector.java
@@ -110,14 +110,14 @@ public class ChangeMoveSelector<Solution_> extends GenericMoveSelector<Solution_
                 return new AbstractOriginalChangeIterator<>(entitySelector, valueSelector) {
                     @Override
                     protected Move<Solution_> newChangeSelection(Object entity, Object toValue) {
-                        return new ChainedChangeMove<>(entity, variableDescriptor, inverseVariableSupply, toValue);
+                        return new ChainedChangeMove<>(variableDescriptor, entity, toValue, inverseVariableSupply);
                     }
                 };
             } else {
                 return new AbstractOriginalChangeIterator<>(entitySelector, valueSelector) {
                     @Override
                     protected Move<Solution_> newChangeSelection(Object entity, Object toValue) {
-                        return new ChangeMove<>(entity, variableDescriptor, toValue);
+                        return new ChangeMove<>(variableDescriptor, entity, toValue);
                     }
                 };
             }
@@ -126,14 +126,14 @@ public class ChangeMoveSelector<Solution_> extends GenericMoveSelector<Solution_
                 return new AbstractRandomChangeIterator<>(entitySelector, valueSelector) {
                     @Override
                     protected Move<Solution_> newChangeSelection(Object entity, Object toValue) {
-                        return new ChainedChangeMove<>(entity, variableDescriptor, inverseVariableSupply, toValue);
+                        return new ChainedChangeMove<>(variableDescriptor, entity, toValue, inverseVariableSupply);
                     }
                 };
             } else {
                 return new AbstractRandomChangeIterator<>(entitySelector, valueSelector) {
                     @Override
                     protected Move<Solution_> newChangeSelection(Object entity, Object toValue) {
-                        return new ChangeMove<>(entity, variableDescriptor, toValue);
+                        return new ChangeMove<>(variableDescriptor, entity, toValue);
                     }
                 };
             }

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/chained/ChainedChangeMove.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/chained/ChainedChangeMove.java
@@ -33,17 +33,17 @@ public class ChainedChangeMove<Solution_> extends ChangeMove<Solution_> {
     protected final Object oldTrailingEntity;
     protected final Object newTrailingEntity;
 
-    public ChainedChangeMove(Object entity, GenuineVariableDescriptor<Solution_> variableDescriptor,
-            SingletonInverseVariableSupply inverseVariableSupply, Object toPlanningValue) {
-        super(entity, variableDescriptor, toPlanningValue);
+    public ChainedChangeMove(GenuineVariableDescriptor<Solution_> variableDescriptor, Object entity, Object toPlanningValue,
+            SingletonInverseVariableSupply inverseVariableSupply) {
+        super(variableDescriptor, entity, toPlanningValue);
         oldTrailingEntity = inverseVariableSupply.getInverseSingleton(entity);
         newTrailingEntity = toPlanningValue == null ? null
                 : inverseVariableSupply.getInverseSingleton(toPlanningValue);
     }
 
-    public ChainedChangeMove(Object entity, GenuineVariableDescriptor<Solution_> variableDescriptor, Object toPlanningValue,
+    public ChainedChangeMove(GenuineVariableDescriptor<Solution_> variableDescriptor, Object entity, Object toPlanningValue,
             Object oldTrailingEntity, Object newTrailingEntity) {
-        super(entity, variableDescriptor, toPlanningValue);
+        super(variableDescriptor, entity, toPlanningValue);
         this.oldTrailingEntity = oldTrailingEntity;
         this.newTrailingEntity = newTrailingEntity;
     }
@@ -61,7 +61,7 @@ public class ChainedChangeMove<Solution_> extends ChangeMove<Solution_> {
     @Override
     public ChainedChangeMove<Solution_> createUndoMove(ScoreDirector<Solution_> scoreDirector) {
         Object oldValue = variableDescriptor.getValue(entity);
-        return new ChainedChangeMove<>(entity, variableDescriptor, oldValue, newTrailingEntity, oldTrailingEntity);
+        return new ChainedChangeMove<>(variableDescriptor, entity, oldValue, newTrailingEntity, oldTrailingEntity);
     }
 
     @Override
@@ -82,8 +82,8 @@ public class ChainedChangeMove<Solution_> extends ChangeMove<Solution_> {
 
     @Override
     public ChainedChangeMove<Solution_> rebase(ScoreDirector<Solution_> destinationScoreDirector) {
-        return new ChainedChangeMove<>(destinationScoreDirector.lookUpWorkingObject(entity),
-                variableDescriptor,
+        return new ChainedChangeMove<>(variableDescriptor,
+                destinationScoreDirector.lookUpWorkingObject(entity),
                 destinationScoreDirector.lookUpWorkingObject(toPlanningValue),
                 destinationScoreDirector.lookUpWorkingObject(oldTrailingEntity),
                 destinationScoreDirector.lookUpWorkingObject(newTrailingEntity));

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/heuristic/move/CompositeMoveTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/heuristic/move/CompositeMoveTest.java
@@ -121,8 +121,8 @@ class CompositeMoveTest {
                         { e3, destinationE3 },
                 });
 
-        ChangeMove<TestdataSolution> a = new ChangeMove<>(e1, variableDescriptor, v2);
-        ChangeMove<TestdataSolution> b = new ChangeMove<>(e2, variableDescriptor, v1);
+        ChangeMove<TestdataSolution> a = new ChangeMove<>(variableDescriptor, e1, v2);
+        ChangeMove<TestdataSolution> b = new ChangeMove<>(variableDescriptor, e2, v1);
         CompositeMove<TestdataSolution> rebaseMove = new CompositeMove<>(a, b).rebase(destinationScoreDirector);
         Move<TestdataSolution>[] rebasedChildMoves = rebaseMove.getMoves();
         assertThat(rebasedChildMoves.length).isEqualTo(2);
@@ -229,7 +229,7 @@ class CompositeMoveTest {
 
         GenuineVariableDescriptor<TestdataSolution> variableDescriptor = TestdataEntity.buildVariableDescriptorForValue();
         SwapMove<TestdataSolution> first = new SwapMove<>(Collections.singletonList(variableDescriptor), e1, e2);
-        ChangeMove<TestdataSolution> second = new ChangeMove<>(e1, variableDescriptor, v3);
+        ChangeMove<TestdataSolution> second = new ChangeMove<>(variableDescriptor, e1, v3);
         Move<TestdataSolution> move = CompositeMove.buildMove(first, second);
 
         assertThat(e1.getValue()).isSameAs(v1);

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/heuristic/selector/move/generic/ChangeMoveTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/heuristic/selector/move/generic/ChangeMoveTest.java
@@ -26,7 +26,6 @@ import java.util.Arrays;
 import org.junit.jupiter.api.Test;
 import org.optaplanner.core.api.score.buildin.simple.SimpleScore;
 import org.optaplanner.core.api.score.director.ScoreDirector;
-import org.optaplanner.core.impl.domain.entity.descriptor.EntityDescriptor;
 import org.optaplanner.core.impl.domain.variable.descriptor.GenuineVariableDescriptor;
 import org.optaplanner.core.impl.score.director.ScoreDirectorFactory;
 import org.optaplanner.core.impl.score.director.easy.EasyScoreDirectorFactory;
@@ -50,11 +49,11 @@ class ChangeMoveTest {
         TestdataEntityProvidingEntity a = new TestdataEntityProvidingEntity("a", Arrays.asList(v1, v2, v3), null);
 
         ScoreDirector<TestdataEntityProvidingSolution> scoreDirector = mock(ScoreDirector.class);
-        EntityDescriptor<TestdataEntityProvidingSolution> entityDescriptor = TestdataEntityProvidingEntity
-                .buildEntityDescriptor();
 
-        ChangeMove<TestdataEntityProvidingSolution> aMove = new ChangeMove<>(a,
-                entityDescriptor.getGenuineVariableDescriptor("value"), v2);
+        GenuineVariableDescriptor<TestdataEntityProvidingSolution> variableDescriptor =
+                TestdataEntityProvidingEntity.buildVariableDescriptorForValue();
+
+        ChangeMove<TestdataEntityProvidingSolution> aMove = new ChangeMove<>(variableDescriptor, a, v2);
         a.setValue(v1);
         assertThat(aMove.isMoveDoable(scoreDirector)).isTrue();
 
@@ -77,11 +76,11 @@ class ChangeMoveTest {
                 new EasyScoreDirectorFactory<>(TestdataEntityProvidingSolution.buildSolutionDescriptor(),
                         solution -> SimpleScore.ZERO);
         ScoreDirector<TestdataEntityProvidingSolution> scoreDirector = scoreDirectorFactory.buildScoreDirector();
-        EntityDescriptor<TestdataEntityProvidingSolution> entityDescriptor = TestdataEntityProvidingEntity
-                .buildEntityDescriptor();
 
-        ChangeMove<TestdataEntityProvidingSolution> aMove = new ChangeMove<>(a,
-                entityDescriptor.getGenuineVariableDescriptor("value"), v2);
+        GenuineVariableDescriptor<TestdataEntityProvidingSolution> variableDescriptor =
+                TestdataEntityProvidingEntity.buildVariableDescriptorForValue();
+
+        ChangeMove<TestdataEntityProvidingSolution> aMove = new ChangeMove<>(variableDescriptor, a, v2);
         a.setValue(v1);
         aMove.doMove(scoreDirector);
         assertThat(a.getValue()).isEqualTo(v2);
@@ -121,13 +120,13 @@ class ChangeMoveTest {
                 });
 
         assertSameProperties(destinationE1, null,
-                new ChangeMove<>(e1, variableDescriptor, null).rebase(destinationScoreDirector));
+                new ChangeMove<>(variableDescriptor, e1, null).rebase(destinationScoreDirector));
         assertSameProperties(destinationE1, destinationV1,
-                new ChangeMove<>(e1, variableDescriptor, v1).rebase(destinationScoreDirector));
+                new ChangeMove<>(variableDescriptor, e1, v1).rebase(destinationScoreDirector));
         assertSameProperties(destinationE2, null,
-                new ChangeMove<>(e2, variableDescriptor, null).rebase(destinationScoreDirector));
+                new ChangeMove<>(variableDescriptor, e2, null).rebase(destinationScoreDirector));
         assertSameProperties(destinationE3, destinationV2,
-                new ChangeMove<>(e3, variableDescriptor, v2).rebase(destinationScoreDirector));
+                new ChangeMove<>(variableDescriptor, e3, v2).rebase(destinationScoreDirector));
     }
 
     public void assertSameProperties(Object entity, Object toPlanningVariable, ChangeMove<?> move) {
@@ -137,17 +136,21 @@ class ChangeMoveTest {
 
     @Test
     void getters() {
-        ChangeMove<TestdataMultiVarSolution> move = new ChangeMove<>(new TestdataMultiVarEntity("a"),
-                TestdataMultiVarEntity.buildVariableDescriptorForPrimaryValue(), null);
-        assertCode("a", move.getEntity());
-        assertThat(move.getVariableName()).isEqualTo("primaryValue");
-        assertCode(null, move.getToPlanningValue());
+        GenuineVariableDescriptor<TestdataMultiVarSolution> primaryVariableDescriptor =
+                TestdataMultiVarEntity.buildVariableDescriptorForPrimaryValue();
+        ChangeMove<TestdataMultiVarSolution> primaryMove =
+                new ChangeMove<>(primaryVariableDescriptor, new TestdataMultiVarEntity("a"), null);
+        assertCode("a", primaryMove.getEntity());
+        assertThat(primaryMove.getVariableName()).isEqualTo("primaryValue");
+        assertCode(null, primaryMove.getToPlanningValue());
 
-        move = new ChangeMove<>(new TestdataMultiVarEntity("b"),
-                TestdataMultiVarEntity.buildVariableDescriptorForSecondaryValue(), new TestdataValue("1"));
-        assertCode("b", move.getEntity());
-        assertThat(move.getVariableName()).isEqualTo("secondaryValue");
-        assertCode("1", move.getToPlanningValue());
+        GenuineVariableDescriptor<TestdataMultiVarSolution> secondaryVariableDescriptor =
+                TestdataMultiVarEntity.buildVariableDescriptorForSecondaryValue();
+        ChangeMove<TestdataMultiVarSolution> secondaryMove =
+                new ChangeMove<>(secondaryVariableDescriptor, new TestdataMultiVarEntity("b"), new TestdataValue("1"));
+        assertCode("b", secondaryMove.getEntity());
+        assertThat(secondaryMove.getVariableName()).isEqualTo("secondaryValue");
+        assertCode("1", secondaryMove.getToPlanningValue());
     }
 
     @Test
@@ -158,12 +161,12 @@ class ChangeMoveTest {
         TestdataEntity b = new TestdataEntity("b", v1);
         GenuineVariableDescriptor<TestdataSolution> variableDescriptor = TestdataEntity.buildVariableDescriptorForValue();
 
-        assertThat(new ChangeMove<>(a, variableDescriptor, null).toString()).isEqualTo("a {null -> null}");
-        assertThat(new ChangeMove<>(a, variableDescriptor, v1).toString()).isEqualTo("a {null -> v1}");
-        assertThat(new ChangeMove<>(a, variableDescriptor, v2).toString()).isEqualTo("a {null -> v2}");
-        assertThat(new ChangeMove<>(b, variableDescriptor, null).toString()).isEqualTo("b {v1 -> null}");
-        assertThat(new ChangeMove<>(b, variableDescriptor, v1).toString()).isEqualTo("b {v1 -> v1}");
-        assertThat(new ChangeMove<>(b, variableDescriptor, v2).toString()).isEqualTo("b {v1 -> v2}");
+        assertThat(new ChangeMove<>(variableDescriptor, a, null).toString()).isEqualTo("a {null -> null}");
+        assertThat(new ChangeMove<>(variableDescriptor, a, v1).toString()).isEqualTo("a {null -> v1}");
+        assertThat(new ChangeMove<>(variableDescriptor, a, v2).toString()).isEqualTo("a {null -> v2}");
+        assertThat(new ChangeMove<>(variableDescriptor, b, null).toString()).isEqualTo("b {v1 -> null}");
+        assertThat(new ChangeMove<>(variableDescriptor, b, v1).toString()).isEqualTo("b {v1 -> v1}");
+        assertThat(new ChangeMove<>(variableDescriptor, b, v2).toString()).isEqualTo("b {v1 -> v2}");
     }
 
     @Test
@@ -177,17 +180,16 @@ class ChangeMoveTest {
         TestdataMultiVarEntity a = new TestdataMultiVarEntity("a", null, null, null);
         TestdataMultiVarEntity b = new TestdataMultiVarEntity("b", v1, v3, w1);
         TestdataMultiVarEntity c = new TestdataMultiVarEntity("c", v2, v4, w2);
-        EntityDescriptor<TestdataMultiVarSolution> entityDescriptor = TestdataMultiVarEntity.buildEntityDescriptor();
-        GenuineVariableDescriptor<TestdataMultiVarSolution> variableDescriptor = entityDescriptor
-                .getGenuineVariableDescriptor("secondaryValue");
+        GenuineVariableDescriptor<TestdataMultiVarSolution> variableDescriptor =
+                TestdataMultiVarEntity.buildVariableDescriptorForSecondaryValue();
 
-        assertThat(new ChangeMove<>(a, variableDescriptor, null).toString()).isEqualTo("a {null -> null}");
-        assertThat(new ChangeMove<>(a, variableDescriptor, v1).toString()).isEqualTo("a {null -> v1}");
-        assertThat(new ChangeMove<>(a, variableDescriptor, v2).toString()).isEqualTo("a {null -> v2}");
-        assertThat(new ChangeMove<>(b, variableDescriptor, null).toString()).isEqualTo("b {v3 -> null}");
-        assertThat(new ChangeMove<>(b, variableDescriptor, v1).toString()).isEqualTo("b {v3 -> v1}");
-        assertThat(new ChangeMove<>(b, variableDescriptor, v2).toString()).isEqualTo("b {v3 -> v2}");
-        assertThat(new ChangeMove<>(c, variableDescriptor, v3).toString()).isEqualTo("c {v4 -> v3}");
+        assertThat(new ChangeMove<>(variableDescriptor, a, null).toString()).isEqualTo("a {null -> null}");
+        assertThat(new ChangeMove<>(variableDescriptor, a, v1).toString()).isEqualTo("a {null -> v1}");
+        assertThat(new ChangeMove<>(variableDescriptor, a, v2).toString()).isEqualTo("a {null -> v2}");
+        assertThat(new ChangeMove<>(variableDescriptor, b, null).toString()).isEqualTo("b {v3 -> null}");
+        assertThat(new ChangeMove<>(variableDescriptor, b, v1).toString()).isEqualTo("b {v3 -> v1}");
+        assertThat(new ChangeMove<>(variableDescriptor, b, v2).toString()).isEqualTo("b {v3 -> v2}");
+        assertThat(new ChangeMove<>(variableDescriptor, c, v3).toString()).isEqualTo("c {v4 -> v3}");
     }
 
 }

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/heuristic/selector/move/generic/chained/ChainedChangeMoveTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/heuristic/selector/move/generic/chained/ChainedChangeMoveTest.java
@@ -54,8 +54,8 @@ class ChainedChangeMoveTest {
         SingletonInverseVariableSupply inverseVariableSupply = SelectorTestUtils.mockSingletonInverseVariableSupply(
                 new TestdataChainedEntity[] { a1, a2, a3, b1 });
 
-        ChainedChangeMove<TestdataChainedSolution> move = new ChainedChangeMove<>(a3, variableDescriptor, inverseVariableSupply,
-                b1);
+        ChainedChangeMove<TestdataChainedSolution> move =
+                new ChainedChangeMove<>(variableDescriptor, a3, b1, inverseVariableSupply);
         assertThat(move.isMoveDoable(scoreDirector)).isTrue();
         ChainedChangeMove<TestdataChainedSolution> undoMove = move.createUndoMove(scoreDirector);
         move.doMove(scoreDirector);
@@ -88,8 +88,8 @@ class ChainedChangeMoveTest {
         SingletonInverseVariableSupply inverseVariableSupply = SelectorTestUtils.mockSingletonInverseVariableSupply(
                 new TestdataChainedEntity[] { a1, a2, a3, b1 });
 
-        ChainedChangeMove<TestdataChainedSolution> move = new ChainedChangeMove<>(a2, variableDescriptor, inverseVariableSupply,
-                b0);
+        ChainedChangeMove<TestdataChainedSolution> move =
+                new ChainedChangeMove<>(variableDescriptor, a2, b0, inverseVariableSupply);
         assertThat(move.isMoveDoable(scoreDirector)).isTrue();
         ChainedChangeMove<TestdataChainedSolution> undoMove = move.createUndoMove(scoreDirector);
         move.doMove(scoreDirector);
@@ -122,8 +122,8 @@ class ChainedChangeMoveTest {
         SingletonInverseVariableSupply inverseVariableSupply = SelectorTestUtils.mockSingletonInverseVariableSupply(
                 new TestdataChainedEntity[] { a1, a2, a3, a4 });
 
-        ChainedChangeMove<TestdataChainedSolution> move = new ChainedChangeMove<>(a2, variableDescriptor, inverseVariableSupply,
-                a3);
+        ChainedChangeMove<TestdataChainedSolution> move =
+                new ChainedChangeMove<>(variableDescriptor, a2, a3, inverseVariableSupply);
         assertThat(move.isMoveDoable(scoreDirector)).isTrue();
         ChainedChangeMove<TestdataChainedSolution> undoMove = move.createUndoMove(scoreDirector);
         move.doMove(scoreDirector);
@@ -154,8 +154,8 @@ class ChainedChangeMoveTest {
         SingletonInverseVariableSupply inverseVariableSupply = SelectorTestUtils.mockSingletonInverseVariableSupply(
                 new TestdataChainedEntity[] { a1, a2, a3, a4 });
 
-        ChainedChangeMove<TestdataChainedSolution> move = new ChainedChangeMove<>(a2, variableDescriptor, inverseVariableSupply,
-                a2);
+        ChainedChangeMove<TestdataChainedSolution> move =
+                new ChainedChangeMove<>(variableDescriptor, a2, a2, inverseVariableSupply);
         assertThat(move.isMoveDoable(scoreDirector)).isFalse();
     }
 
@@ -175,8 +175,8 @@ class ChainedChangeMoveTest {
         SingletonInverseVariableSupply inverseVariableSupply = SelectorTestUtils.mockSingletonInverseVariableSupply(
                 new TestdataChainedEntity[] { a1, a2, a3, a4 });
 
-        ChainedChangeMove<TestdataChainedSolution> move = new ChainedChangeMove<>(a2, variableDescriptor, inverseVariableSupply,
-                a1);
+        ChainedChangeMove<TestdataChainedSolution> move =
+                new ChainedChangeMove<>(variableDescriptor, a2, a1, inverseVariableSupply);
         assertThat(move.isMoveDoable(scoreDirector)).isFalse();
     }
 
@@ -208,14 +208,14 @@ class ChainedChangeMoveTest {
         SingletonInverseVariableSupply inverseVariableSupply = mock(SingletonInverseVariableSupply.class);
 
         assertSameProperties(destinationA1, null,
-                new ChainedChangeMove<>(a1, variableDescriptor, inverseVariableSupply, null).rebase(destinationScoreDirector));
+                new ChainedChangeMove<>(variableDescriptor, a1, null, inverseVariableSupply).rebase(destinationScoreDirector));
         assertSameProperties(destinationA2, destinationB0,
-                new ChainedChangeMove<>(a2, variableDescriptor, inverseVariableSupply, b0).rebase(destinationScoreDirector));
+                new ChainedChangeMove<>(variableDescriptor, a2, b0, inverseVariableSupply).rebase(destinationScoreDirector));
         assertSameProperties(destinationC1, destinationA2,
-                new ChainedChangeMove<>(c1, variableDescriptor, inverseVariableSupply, a2).rebase(destinationScoreDirector));
+                new ChainedChangeMove<>(variableDescriptor, c1, a2, inverseVariableSupply).rebase(destinationScoreDirector));
     }
 
-    public void assertSameProperties(Object entity, Object toPlanningVariable, ChainedChangeMove move) {
+    public void assertSameProperties(Object entity, Object toPlanningVariable, ChainedChangeMove<?> move) {
         assertSoftly(softly -> {
             softly.assertThat(move.getEntity()).isSameAs(entity);
             softly.assertThat(move.getToPlanningValue()).isSameAs(toPlanningVariable);

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/common/business/SolutionBusiness.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/common/business/SolutionBusiness.java
@@ -389,9 +389,9 @@ public class SolutionBusiness<Solution_, Score_ extends Score<Score_>> {
             SupplyManager<Solution_> supplyManager = guiScoreDirector.getSupplyManager();
             SingletonInverseVariableSupply inverseVariableSupply = supplyManager.demand(
                     new SingletonInverseVariableDemand<>(variableDescriptor));
-            return new ChainedChangeMove<>(entity, variableDescriptor, inverseVariableSupply, toPlanningValue);
+            return new ChainedChangeMove<>(variableDescriptor, entity, toPlanningValue, inverseVariableSupply);
         } else {
-            return new ChangeMove<>(entity, variableDescriptor, toPlanningValue);
+            return new ChangeMove<>(variableDescriptor, entity, toPlanningValue);
         }
     }
 


### PR DESCRIPTION
VariableDescriptor always goes first.

I assume that built-in moves are an internal API and so we can afford changing the constructor signature. This would only affect users whose custom move extends `ChangeMove` or `ChainedChangeMove` or create their instances themselves like we do in `SolutionBusiness`:

https://github.com/kiegroup/optaplanner/blob/5a7dd41fc0272be847bc0ff4654fe3f7dee5fa74/optaplanner-examples/src/main/java/org/optaplanner/examples/common/business/SolutionBusiness.java#L385-L395

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>specific pull request build</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] tests</b>
* for a <b>full downstream build</b> 
  * for <b>jenkins</b> job: please add comment: <b>Jenkins run fdb</b>
  * for <b>github actions</b> job: add the label `run_fdb`
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
* for a <b>Quarkus LTS check</b> please add comment: <b>Jenkins run LTS</b>
* for a <b>specific Quarkus LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] LTS</b>
* for a <b>Native check</b> please add comment: <b>Jenkins run native</b>
* for a <b>specific Native LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] native</b>
</details>
