### PR TITLE
Do not check variableDescriptor.isChained() twice

### DIFF
--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/heuristic/selector/entity/pillar/DefaultPillarSelector.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/heuristic/selector/entity/pillar/DefaultPillarSelector.java
@@ -79,13 +79,6 @@ public class DefaultPillarSelector<Solution_> extends AbstractSelector<Solution_
                         + ") which is chained (" + variableDescriptor.isChained() + ").");
             }
         }
-        for (GenuineVariableDescriptor<Solution_> variableDescriptor : variableDescriptors) {
-            if (variableDescriptor.isChained()) {
-                throw new IllegalStateException("The selector (" + this
-                        + ") cannot have a variableDescriptor (" + variableDescriptor
-                        + ") which is chained (" + variableDescriptor.isChained() + ").");
-            }
-        }
         if (entitySelector.isNeverEnding()) {
             throw new IllegalStateException("The selector (" + this
                     + ") has an entitySelector (" + entitySelector


### PR DESCRIPTION
The same check is already done in the loop above.

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>specific pull request build</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] tests</b>
* for a <b>full downstream build</b> 
  * for <b>jenkins</b> job: please add comment: <b>Jenkins run fdb</b>
  * for <b>github actions</b> job: add the label `run_fdb`
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
* for a <b>Quarkus LTS check</b> please add comment: <b>Jenkins run LTS</b>
* for a <b>specific Quarkus LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] LTS</b>
* for a <b>Native check</b> please add comment: <b>Jenkins run native</b>
* for a <b>specific Native LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] native</b>
</details>
