### PR TITLE
PLANNER-2629 Pause the best solution consumer

### DIFF
--- a/optaplanner-core/src/build/revapi-config.json
+++ b/optaplanner-core/src/build/revapi-config.json
@@ -465,6 +465,24 @@
           "methodName": "addProblemChange",
           "elementKind": "method",
           "justification": "Added method to submit problem change. Users are not supposed to implement the SolverManager interface."
+        },
+        {
+          "code": "java.method.addedToInterface",
+          "new": "method org.optaplanner.core.api.solver.ConsumptionPause org.optaplanner.core.api.solver.SolverJob<Solution_, ProblemId_>::pauseBestSolutionConsumer()",
+          "package": "org.optaplanner.core.api.solver",
+          "classSimpleName": "SolverJob",
+          "methodName": "pauseBestSolutionConsumer",
+          "elementKind": "method",
+          "justification": "Added a method to pause a consumer thread. Users are not supposed to implement the SolverJob interface."
+        },
+        {
+          "code": "java.method.addedToInterface",
+          "new": "method org.optaplanner.core.api.solver.ConsumptionPause org.optaplanner.core.api.solver.SolverManager<Solution_, ProblemId_>::pauseBestSolutionConsumer(ProblemId_)",
+          "package": "org.optaplanner.core.api.solver",
+          "classSimpleName": "SolverManager",
+          "methodName": "pauseBestSolutionConsumer",
+          "elementKind": "method",
+          "justification": "Added a method to pause a consumer thread. Users are not supposed to implement the SolverManager interface."
         }
       ]
     }

--- a/optaplanner-core/src/build/revapi-config.json
+++ b/optaplanner-core/src/build/revapi-config.json
@@ -483,6 +483,15 @@
           "methodName": "pauseBestSolutionConsumer",
           "elementKind": "method",
           "justification": "Added a method to pause a consumer thread. Users are not supposed to implement the SolverManager interface."
+        },
+        {
+          "code": "java.method.addedToInterface",
+          "new": "method void org.optaplanner.core.api.solver.SolverManager<Solution_, ProblemId_>::reloadProblem(ProblemId_, java.util.function.Function<? super ProblemId_, Solution_>)",
+          "package": "org.optaplanner.core.api.solver",
+          "classSimpleName": "SolverManager",
+          "methodName": "reloadProblem",
+          "elementKind": "method",
+          "justification": "Added a method to reload a problem. Users are not supposed to implement the SolverManager interface."
         }
       ]
     }

--- a/optaplanner-core/src/main/java/org/optaplanner/core/api/solver/ConsumptionPause.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/api/solver/ConsumptionPause.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.core.api.solver;
+
+/**
+ * Represents a pause of a solution consumer initiated by calling
+ * {@link SolverManager#pauseBestSolutionConsumer(Object)}.
+ */
+public interface ConsumptionPause extends AutoCloseable {
+
+    @Override
+    void close();
+}

--- a/optaplanner-core/src/main/java/org/optaplanner/core/api/solver/SolverJob.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/api/solver/SolverJob.java
@@ -58,15 +58,11 @@ public interface SolverJob<Solution_, ProblemId_> {
     void addProblemChange(ProblemChange<Solution_> problemChange);
 
     /**
-     * Pauses the best solution consumer to avoid race conditions between consumption and {@link ProblemChange}s.
-     *
-     * If an incoming {@link ProblemChange} is first applied to a persistent store (e.g. a relational database)
-     * to avoid losing it in case of a failure, the best solution consumer may overwrite it by a solution that does
-     * not contain this {@link ProblemChange} yet.
-     * Normally, it's a temporary inconsistency that will be resolved by saving the next best solution that already
-     * contains the {@link ProblemChange}. However, if the program exits before that, the incoming change will be lost.
-     *
-     * This method pauses the consumer before
+     * Pauses the best solution consumer thread until the {@link ConsumptionPause} is not closed. When an external
+     * change is persisted to the same persistent storage (e.g. a relational database) as the best solutions,
+     * an early best solution that does not contain the external change yet might override the state
+     * in the persistent storage.
+     * See {@link SolverManager#pauseBestSolutionConsumer(Object)}.
      */
     ConsumptionPause pauseBestSolutionConsumer();
 

--- a/optaplanner-core/src/main/java/org/optaplanner/core/api/solver/SolverJob.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/api/solver/SolverJob.java
@@ -58,7 +58,7 @@ public interface SolverJob<Solution_, ProblemId_> {
     void addProblemChange(ProblemChange<Solution_> problemChange);
 
     /**
-     * Pauses the best solution consumer thread until the {@link ConsumptionPause} is not closed. When an external
+     * Pauses the best solution consumer thread until the {@link ConsumptionPause} is closed. When an external
      * change is persisted to the same persistent storage (e.g. a relational database) as the best solutions,
      * an early best solution that does not contain the external change yet might override the state
      * in the persistent storage.

--- a/optaplanner-core/src/main/java/org/optaplanner/core/api/solver/SolverJob.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/api/solver/SolverJob.java
@@ -48,9 +48,6 @@ public interface SolverJob<Solution_, ProblemId_> {
      */
     SolverStatus getSolverStatus();
 
-    // TODO Future features
-    //    void reloadProblem(Function<? super ProblemId_, Solution_> problemFinder);
-
     /**
      * Schedules a {@link ProblemChange} to be processed by the underlying {@link Solver} and returns immediately.
      *

--- a/optaplanner-core/src/main/java/org/optaplanner/core/api/solver/SolverJob.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/api/solver/SolverJob.java
@@ -61,6 +61,19 @@ public interface SolverJob<Solution_, ProblemId_> {
     void addProblemChange(ProblemChange<Solution_> problemChange);
 
     /**
+     * Pauses the best solution consumer to avoid race conditions between consumption and {@link ProblemChange}s.
+     *
+     * If an incoming {@link ProblemChange} is first applied to a persistent store (e.g. a relational database)
+     * to avoid losing it in case of a failure, the best solution consumer may overwrite it by a solution that does
+     * not contain this {@link ProblemChange} yet.
+     * Normally, it's a temporary inconsistency that will be resolved by saving the next best solution that already
+     * contains the {@link ProblemChange}. However, if the program exits before that, the incoming change will be lost.
+     *
+     * This method pauses the consumer before
+     */
+    ConsumptionPause pauseBestSolutionConsumer();
+
+    /**
      * Terminates the solver or cancels the solver job if it hasn't (re)started yet.
      * <p>
      * Does nothing if the solver already terminated.

--- a/optaplanner-core/src/main/java/org/optaplanner/core/api/solver/SolverManager.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/api/solver/SolverManager.java
@@ -316,6 +316,8 @@ public interface SolverManager<Solution_, ProblemId_> extends AutoCloseable {
      */
     void addProblemChange(ProblemId_ problemId, ProblemChange<Solution_> problemChange);
 
+    ConsumptionPause pauseBestSolutionConsumer(ProblemId_ problemId);
+
     /**
      * Terminates the solver or cancels the solver job if it hasn't (re)started yet.
      * <p>

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/solver/DefaultSolverJob.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/solver/DefaultSolverJob.java
@@ -125,7 +125,7 @@ public final class DefaultSolverJob<Solution_, ProblemId_> implements SolverJob<
                 solver.addEventListener(event -> consumerSupport.consumeIntermediateBestSolution(event.getNewBestSolution()));
             }
             final Solution_ finalBestSolution = solver.solve(problem);
-            if (finalBestSolutionConsumer != null && consumerSupport != null) {
+            if (finalBestSolutionConsumer != null) {
                 consumerSupport.consumeFinalBestSolution(finalBestSolution);
             }
             return finalBestSolution;
@@ -248,8 +248,8 @@ public final class DefaultSolverJob<Solution_, ProblemId_> implements SolverJob<
     void reset(Function<? super ProblemId_, ? extends Solution_> problemFinder) {
         startReloading();
         this.problemFinder = problemFinder;
-        close();
         terminateEarly();
+        close();
         terminatedLatch = new CountDownLatch(1);
     }
 

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/solver/DefaultSolverManager.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/solver/DefaultSolverManager.java
@@ -28,6 +28,7 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 
 import org.optaplanner.core.api.domain.solution.PlanningSolution;
+import org.optaplanner.core.api.solver.ConsumptionPause;
 import org.optaplanner.core.api.solver.Solver;
 import org.optaplanner.core.api.solver.SolverFactory;
 import org.optaplanner.core.api.solver.SolverJob;
@@ -155,6 +156,18 @@ public final class DefaultSolverManager<Solution_, ProblemId_> implements Solver
                             + problemId + ").");
         }
         solverJob.addProblemChange(problemChange);
+    }
+
+    @Override
+    public ConsumptionPause pauseBestSolutionConsumer(ProblemId_ problemId) {
+        DefaultSolverJob<Solution_, ProblemId_> solverJob = getSolverJob(problemId);
+        if (solverJob == null) {
+            // We cannot distinguish between "already terminated" and "never solved" without causing a memory leak.
+            throw new IllegalStateException(
+                    "Cannot pause a best solution consumer because there is no solver solving the problemId ("
+                            + problemId + ").");
+        }
+        return solverJob.pauseBestSolutionConsumer();
     }
 
     @Override

--- a/optaplanner-core/src/test/java/org/optaplanner/core/api/solver/SolverManagerTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/api/solver/SolverManagerTest.java
@@ -537,7 +537,7 @@ class SolverManagerTest {
 
     @Test
     @Timeout(60)
-    void submitProblemChange() throws InterruptedException {
+    void addProblemChange() throws InterruptedException {
         SolverConfig solverConfig = PlannerTestUtils.buildSolverConfig(TestdataSolution.class, TestdataEntity.class);
         solverConfig.setDaemon(true);
         solverManager = SolverManager.create(solverConfig);

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/solver/ConsumerSupportTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/solver/ConsumerSupportTest.java
@@ -24,6 +24,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.locks.ReentrantLock;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
@@ -56,7 +57,7 @@ class ConsumerSupportTest {
             } catch (InterruptedException e) {
                 error.set(new IllegalStateException("Interrupted waiting.", e));
             }
-        }, null, null);
+        }, null, null, new ReentrantLock(), () -> true);
 
         // This solution may be skipped.
         consumerSupport.consumeIntermediateBestSolution(TestdataSolution.generateSolution(1, 1));


### PR DESCRIPTION
<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.
-->

### JIRA
https://issues.redhat.com/browse/PLANNER-2629
https://issues.redhat.com/browse/PLANNER-2650

<!-- Add a JIRA ticket link if it exists. -->
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->

### Referenced pull requests
https://github.com/kiegroup/optaplanner/pull/1832
https://github.com/kiegroup/optaplanner-quickstarts/pull/286

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
* https://github.com/kiegroup/drools/pull/3000
* https://github.com/kiegroup/optaplanner/pull/899
* etc.
-->

### Checklist
- [ ] Documentation updated if applicable.
- [ ] Upgrade recipe provided if applicable.

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>specific pull request build</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] tests</b>
* for a <b>full downstream build</b> 
  * for <b>jenkins</b> job: please add comment: <b>Jenkins run fdb</b>
  * for <b>github actions</b> job: add the label `run_fdb`
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
* for a <b>Quarkus LTS check</b> please add comment: <b>Jenkins run LTS</b>
* for a <b>specific Quarkus LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] LTS</b>
* for a <b>Native check</b> please add comment: <b>Jenkins run native</b>
* for a <b>specific Native LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] native</b>
</details>
