### PR TITLE
Core split cleanup

### DIFF
--- a/core/.gitignore
+++ b/core/.gitignore
@@ -1,0 +1,9 @@
+/local
+
+# Eclipse, Netbeans and IntelliJ files
+/.*
+!.gitignore
+/nbproject
+/*.ipr
+/*.iws
+/*.iml

--- a/core/optaplanner-constraint-drl/pom.xml
+++ b/core/optaplanner-constraint-drl/pom.xml
@@ -114,20 +114,4 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
-
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-dependency-plugin</artifactId>
-        <configuration>
-          <ignoredUnusedDeclaredDependencies>
-            <!-- Uses PlanningEntity in Javadoc. -->
-            <dependency>org.optaplanner:optaplanner-core-impl:jar</dependency>
-          </ignoredUnusedDeclaredDependencies>
-        </configuration>
-      </plugin>
-    </plugins>
-  </build>
-
 </project>

--- a/core/optaplanner-constraint-drl/src/main/java/org/optaplanner/constraint/drl/testgen/operation/TestGenKieSessionUpdate.java
+++ b/core/optaplanner-constraint-drl/src/main/java/org/optaplanner/constraint/drl/testgen/operation/TestGenKieSessionUpdate.java
@@ -20,6 +20,7 @@ import java.lang.reflect.Method;
 import org.kie.api.runtime.KieSession;
 import org.kie.api.runtime.rule.FactHandle;
 import org.optaplanner.constraint.drl.testgen.fact.TestGenFact;
+import org.optaplanner.constraint.drl.testgen.fact.TestGenNullFact;
 import org.optaplanner.core.impl.domain.common.ReflectionHelper;
 import org.optaplanner.core.impl.domain.common.accessor.ReflectionBeanPropertyMemberAccessor;
 import org.optaplanner.core.impl.domain.variable.descriptor.VariableDescriptor;

--- a/core/optaplanner-constraint-drl/src/main/java/org/optaplanner/constraint/drl/testgen/reproducer/TestGenCorruptedScoreReproducer.java
+++ b/core/optaplanner-constraint-drl/src/main/java/org/optaplanner/constraint/drl/testgen/reproducer/TestGenCorruptedScoreReproducer.java
@@ -32,8 +32,7 @@ import org.slf4j.LoggerFactory;
  * Detects corrupted score for the given journal. It should behave equally to
  * {@link AbstractScoreDirector#assertWorkingScoreFromScratch(Score, Object)}.
  */
-public class TestGenCorruptedScoreReproducer implements TestGenOriginalProblemReproducer,
-        TestGenKieSessionListener {
+public class TestGenCorruptedScoreReproducer implements TestGenOriginalProblemReproducer, TestGenKieSessionListener {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(TestGenCorruptedScoreReproducer.class);
     private final String analysis;


### PR DESCRIPTION

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>specific pull request build</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] tests</b>
* for a <b>full downstream build</b> 
  * for <b>jenkins</b> job: please add comment: <b>Jenkins run fdb</b>
  * for <b>github actions</b> job: add the label `run_fdb`
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
* for a <b>Quarkus LTS check</b> please add comment: <b>Jenkins run LTS</b>
* for a <b>specific Quarkus LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] LTS</b>
* for a <b>Native check</b> please add comment: <b>Jenkins run native</b>
* for a <b>specific Native LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] native</b>
</details>
