### PR TITLE
PLANNER-2639 Improve CS docs

### DIFF
--- a/optaplanner-docs/src/modules/ROOT/pages/constraint-streams/constraint-streams.adoc
+++ b/optaplanner-docs/src/modules/ROOT/pages/constraint-streams/constraint-streams.adoc
@@ -265,6 +265,11 @@ the score.
 The penalty or reward score impact is the constraint weight multiplied by the match weight.
 The default value is `1`.
 
+[NOTE]
+====
+Constraints with zero match weight are automatically disabled and do not impose any performance penalty.
+====
+
 The ConstraintStreams API supports many different types of penalties.
 Browse the API in your IDE for the full list of method overloads.
 Here are some examples:
@@ -283,7 +288,6 @@ every matching `Shift` in the constraint stream.
 
 By replacing the keyword `penalize` by `reward` in the name of these building blocks, you get operations that
 affect score in the opposite direction.
-
 
 [[constraintStreamsFilter]]
 === Filtering
@@ -933,7 +937,6 @@ Alternatively, you can use a `rewardsWith(...)` call to check for rewards instea
 The method to use here depends on whether the constraint stream in question is terminated with a `penalize` or a
 `reward` building block.
 
-
 [[constraintStreamsTestingAllConstraints]]
 === Testing all constraints together
 
@@ -962,6 +965,51 @@ from the given facts.
 
 Using this method, you ensure that the constraint provider does not miss any constraints and that the scoring function
 remains consistent as your code base evolves.
+
+[[constraintStreamsTestingWhatActuallyHappens]]
+==== What actually happens
+
+The purpose of `ConstraintVerifier` is to test constraints in an environment as close as possible to the production deployment.
+Therefore when the `penalizesBy(...)` method (or similar) is called, the following will happen:
+
+* The constraint(s) provided by `verifyThat(...)` method are compiled and the new solver session is created,
+much like if the `Solver` or `SolverManager` APIs were used.
+* All the facts provided by the `given(...)` method are inserted into the solver session.
+* A score will be calculated, executing the constraint(s) on the given facts.
+This will include execution of all variable listeners, should the planning entities have any.
+
+For example, consider the "distanceToPreviousStandstill" constraint in the xref:use-cases-and-examples/vehicle-routing/vehicle-routing.adoc[vehicle routing example]:
+
+[source,java,options="nowrap"]
+----
+    Constraint distanceToPreviousStandstill(ConstraintFactory factory) {
+        return factory.forEach(Customer.class)
+                .penalizeLong("distanceToPreviousStandstill",
+                        HardSoftLongScore.ONE_SOFT,
+                        Customer::getDistanceFromPreviousStandstill);
+    }
+----
+
+Notice how the constraint does not make any `Vehicle` references.
+Yet the `ConstraintVerifier`-based test provides `Vehicle` instances:
+
+[source,java,options="nowrap"]
+----
+    @Test
+    void distanceToPreviousStandstill() {
+        Vehicle vehicleA = ...
+        Customer customer1 = ...
+        Customer customer2 = ...
+
+        constraintVerifier.verifyThat(VehicleRoutingConstraintProvider::distanceToPreviousStandstill)
+                .given(vehicleA, customer1, customer2)
+                .penalizesBy(9000L);
+    }
+----
+
+This is necessary, as the `Customer` class has a shadow variable based on `Vehicle`.
+Had no `Vehicle` instances been provided through the `given(...)` call,
+the constraint would not match anything and the test would have failed.
 
 [[constraintStreamsTestingQuarkus]]
 === Testing in Quarkus

--- a/optaplanner-docs/src/modules/ROOT/pages/quickstart/hello-world/hello-world-quickstart.adoc
+++ b/optaplanner-docs/src/modules/ROOT/pages/quickstart/hello-world/hello-world-quickstart.adoc
@@ -416,7 +416,8 @@ After five seconds, the `main()` method loads the problem, solves it, and prints
         printTimetable(solution);
 ----
 
-The `solve()` method doesn't return instantl. It runs for five seconds before returning the best solution.
+The `solve()` method doesn't return instantly.
+It runs for five seconds before returning the best solution.
 
 OptaPlanner returns _the best solution_ found in the available termination time.
 Due to xref:optimization-algorithms/optimization-algorithms.adoc#doesPlannerFindTheOptimalSolution[the nature of NP-hard problems],
@@ -541,6 +542,8 @@ Notice how `ConstraintVerifier` ignores the constraint weight during testing - e
 if those constraint weights are hard coded in the `ConstraintProvider` - because
 constraints weights change regularly before going into production.
 This way, constraint weight tweaking does not break the unit tests.
+
+For more, see xref:constraint-streams/constraint-streams.adoc#constraintStreamsTesting[Testing Constraint Streams].
 
 === Logging
 


### PR DESCRIPTION
Signed-off-by: Lukáš Petrovický <lpetrovi@redhat.com>

<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.
-->

### JIRA

<!-- Add a JIRA ticket link if it exists. -->
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
* https://github.com/kiegroup/drools/pull/3000
* https://github.com/kiegroup/optaplanner/pull/899
* etc.
-->

### Checklist
- [ ] Documentation updated if applicable.
- [ ] Upgrade recipe provided if applicable.

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>specific pull request build</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] tests</b>
* for a <b>full downstream build</b> 
  * for <b>jenkins</b> job: please add comment: <b>Jenkins run fdb</b>
  * for <b>github actions</b> job: add the label `run_fdb`
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
* for a <b>Quarkus LTS check</b> please add comment: <b>Jenkins run LTS</b>
* for a <b>specific Quarkus LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] LTS</b>
* for a <b>Native check</b> please add comment: <b>Jenkins run native</b>
* for a <b>specific Native LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] native</b>
</details>
