### PR TITLE
PLANNER-2665: Make BEST_SCORE statistic enabled by default in benchmarker

### DIFF
--- a/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/config/ProblemBenchmarksConfig.java
+++ b/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/config/ProblemBenchmarksConfig.java
@@ -124,7 +124,7 @@ public class ProblemBenchmarksConfig extends AbstractConfig<ProblemBenchmarksCon
         }
 
         if (problemStatisticTypeList == null || problemStatisticTypeList.isEmpty()) {
-            return ProblemStatisticType.defaultMetricList();
+            return ProblemStatisticType.defaultList();
         }
 
         return problemStatisticTypeList;

--- a/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/config/ProblemBenchmarksConfig.java
+++ b/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/config/ProblemBenchmarksConfig.java
@@ -17,7 +17,9 @@
 package org.optaplanner.benchmark.config;
 
 import java.io.File;
+import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import java.util.function.Consumer;
 
 import javax.xml.bind.annotation.XmlElement;
@@ -104,6 +106,37 @@ public class ProblemBenchmarksConfig extends AbstractConfig<ProblemBenchmarksCon
 
     public void setSingleStatisticTypeList(List<SingleStatisticType> singleStatisticTypeList) {
         this.singleStatisticTypeList = singleStatisticTypeList;
+    }
+
+    // ************************************************************************
+    // Complex methods
+    // ************************************************************************
+
+    /**
+     * Return the problem statistic type list, or a list containing default metrics if problemStatisticEnabled
+     * is not false. If problemStatisticEnabled is false, an empty list is returned.
+     *
+     * @return never null
+     */
+    public List<ProblemStatisticType> determineProblemStatisticTypeList() {
+        if (problemStatisticEnabled != null && !problemStatisticEnabled) {
+            return Collections.emptyList();
+        }
+
+        if (problemStatisticTypeList == null || problemStatisticTypeList.isEmpty()) {
+            return ProblemStatisticType.defaultMetricList();
+        }
+
+        return problemStatisticTypeList;
+    }
+
+    /**
+     * Return the single statistic type list, or an empty list if it is null
+     *
+     * @return never null
+     */
+    public List<SingleStatisticType> determineSingleStatisticTypeList() {
+        return Objects.requireNonNullElse(singleStatisticTypeList, Collections.emptyList());
     }
 
     @Override

--- a/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/config/statistic/ProblemStatisticType.java
+++ b/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/config/statistic/ProblemStatisticType.java
@@ -16,6 +16,8 @@
 
 package org.optaplanner.benchmark.config.statistic;
 
+import java.util.List;
+
 import javax.xml.bind.annotation.XmlEnum;
 
 import org.optaplanner.benchmark.impl.result.ProblemBenchmarkResult;
@@ -60,6 +62,10 @@ public enum ProblemStatisticType implements StatisticType {
     public boolean hasScoreLevels() {
         return this == BEST_SCORE
                 || this == STEP_SCORE;
+    }
+
+    public static List<ProblemStatisticType> defaultMetricList() {
+        return List.of(ProblemStatisticType.BEST_SCORE);
     }
 
 }

--- a/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/config/statistic/ProblemStatisticType.java
+++ b/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/config/statistic/ProblemStatisticType.java
@@ -64,7 +64,7 @@ public enum ProblemStatisticType implements StatisticType {
                 || this == STEP_SCORE;
     }
 
-    public static List<ProblemStatisticType> defaultMetricList() {
+    public static List<ProblemStatisticType> defaultList() {
         return List.of(ProblemStatisticType.BEST_SCORE);
     }
 

--- a/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/impl/ProblemBenchmarksFactory.java
+++ b/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/impl/ProblemBenchmarksFactory.java
@@ -131,13 +131,11 @@ public class ProblemBenchmarksFactory {
             if (!ConfigUtils.isEmptyCollection(config.getProblemStatisticTypeList())) {
                 throw new IllegalArgumentException("The problemStatisticEnabled (" + config.getProblemStatisticEnabled()
                         + ") and problemStatisticTypeList (" + config.getProblemStatisticTypeList()
-                        + ") can be used together.");
+                        + ") cannot be used together.");
             }
             problemStatisticList = Collections.emptyList();
         } else {
-            List<ProblemStatisticType> problemStatisticTypeList_ = (config.getProblemStatisticTypeList() == null)
-                    ? Collections.singletonList(ProblemStatisticType.BEST_SCORE)
-                    : config.getProblemStatisticTypeList();
+            List<ProblemStatisticType> problemStatisticTypeList_ = config.determineProblemStatisticTypeList();
             problemStatisticList = new ArrayList<>(problemStatisticTypeList_.size());
             for (ProblemStatisticType problemStatisticType : problemStatisticTypeList_) {
                 problemStatisticList.add(problemStatisticType.buildProblemStatistic(problemBenchmarkResult));
@@ -152,17 +150,15 @@ public class ProblemBenchmarksFactory {
             ProblemBenchmarkResult problemBenchmarkResult) {
         SingleBenchmarkResult singleBenchmarkResult = new SingleBenchmarkResult(solverBenchmarkResult, problemBenchmarkResult);
         buildSubSingleBenchmarks(singleBenchmarkResult, solverBenchmarkResult.getSubSingleCount());
+        List<SingleStatisticType> singleStatisticTypeList = config.determineSingleStatisticTypeList();
         for (SubSingleBenchmarkResult subSingleBenchmarkResult : singleBenchmarkResult.getSubSingleBenchmarkResultList()) {
-            subSingleBenchmarkResult.setPureSubSingleStatisticList(new ArrayList<>(
-                    config.getSingleStatisticTypeList() == null ? 0 : config.getSingleStatisticTypeList().size()));
+            subSingleBenchmarkResult.setPureSubSingleStatisticList(new ArrayList<>(singleStatisticTypeList.size()));
         }
-        if (config.getSingleStatisticTypeList() != null) {
-            for (SingleStatisticType singleStatisticType : config.getSingleStatisticTypeList()) {
-                for (SubSingleBenchmarkResult subSingleBenchmarkResult : singleBenchmarkResult
-                        .getSubSingleBenchmarkResultList()) {
-                    subSingleBenchmarkResult.getPureSubSingleStatisticList().add(
-                            singleStatisticType.buildPureSubSingleStatistic(subSingleBenchmarkResult));
-                }
+        for (SingleStatisticType singleStatisticType : singleStatisticTypeList) {
+            for (SubSingleBenchmarkResult subSingleBenchmarkResult : singleBenchmarkResult
+                    .getSubSingleBenchmarkResultList()) {
+                subSingleBenchmarkResult.getPureSubSingleStatisticList().add(
+                        singleStatisticType.buildPureSubSingleStatistic(subSingleBenchmarkResult));
             }
         }
         singleBenchmarkResult.initSubSingleStatisticMaps();

--- a/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/impl/SolverBenchmarkFactory.java
+++ b/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/impl/SolverBenchmarkFactory.java
@@ -104,7 +104,7 @@ public class SolverBenchmarkFactory {
         List<SolverMetric> out = new ArrayList<>();
         for (ProblemStatisticType problemStatisticType : Optional.ofNullable(config)
                 .map(ProblemBenchmarksConfig::determineProblemStatisticTypeList)
-                .orElseGet(ProblemStatisticType::defaultMetricList)) {
+                .orElseGet(ProblemStatisticType::defaultList)) {
             if (problemStatisticType == ProblemStatisticType.SCORE_CALCULATION_SPEED) {
                 out.add(SolverMetric.SCORE_CALCULATION_COUNT);
             } else {

--- a/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/impl/SolverBenchmarkFactory.java
+++ b/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/impl/SolverBenchmarkFactory.java
@@ -19,7 +19,7 @@ package org.optaplanner.benchmark.impl;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Objects;
+import java.util.Optional;
 
 import org.optaplanner.benchmark.config.ProblemBenchmarksConfig;
 import org.optaplanner.benchmark.config.SolverBenchmarkConfig;
@@ -102,24 +102,19 @@ public class SolverBenchmarkFactory {
 
     protected List<SolverMetric> getSolverMetrics(ProblemBenchmarksConfig config) {
         List<SolverMetric> out = new ArrayList<>();
-        if (config == null) {
-            return List.of(SolverMetric.BEST_SCORE);
-        }
-        for (ProblemStatisticType problemStatisticType : Objects.requireNonNullElse(config.getProblemStatisticTypeList(),
-                Collections.<ProblemStatisticType> emptyList())) {
+        for (ProblemStatisticType problemStatisticType : Optional.ofNullable(config)
+                .map(ProblemBenchmarksConfig::determineProblemStatisticTypeList)
+                .orElseGet(ProblemStatisticType::defaultMetricList)) {
             if (problemStatisticType == ProblemStatisticType.SCORE_CALCULATION_SPEED) {
                 out.add(SolverMetric.SCORE_CALCULATION_COUNT);
             } else {
                 out.add(SolverMetric.valueOf(problemStatisticType.name()));
             }
         }
-        for (SingleStatisticType singleStatisticType : Objects.requireNonNullElse(config.getSingleStatisticTypeList(),
-                Collections.<SingleStatisticType> emptyList())) {
+        for (SingleStatisticType singleStatisticType : Optional.ofNullable(config)
+                .map(ProblemBenchmarksConfig::determineSingleStatisticTypeList)
+                .orElseGet(Collections::emptyList)) {
             out.add(SolverMetric.valueOf(singleStatisticType.name()));
-        }
-
-        if (out.isEmpty() && (config.getProblemStatisticEnabled() == null || config.getProblemStatisticEnabled())) {
-            return List.of(SolverMetric.BEST_SCORE);
         }
         return out;
     }

--- a/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/impl/SolverBenchmarkFactory.java
+++ b/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/impl/SolverBenchmarkFactory.java
@@ -103,7 +103,7 @@ public class SolverBenchmarkFactory {
     protected List<SolverMetric> getSolverMetrics(ProblemBenchmarksConfig config) {
         List<SolverMetric> out = new ArrayList<>();
         if (config == null) {
-            return out;
+            return List.of(SolverMetric.BEST_SCORE);
         }
         for (ProblemStatisticType problemStatisticType : Objects.requireNonNullElse(config.getProblemStatisticTypeList(),
                 Collections.<ProblemStatisticType> emptyList())) {
@@ -116,6 +116,10 @@ public class SolverBenchmarkFactory {
         for (SingleStatisticType singleStatisticType : Objects.requireNonNullElse(config.getSingleStatisticTypeList(),
                 Collections.<SingleStatisticType> emptyList())) {
             out.add(SolverMetric.valueOf(singleStatisticType.name()));
+        }
+
+        if (out.isEmpty() && (config.getProblemStatisticEnabled() == null || config.getProblemStatisticEnabled())) {
+            return List.of(SolverMetric.BEST_SCORE);
         }
         return out;
     }

--- a/optaplanner-benchmark/src/test/java/org/optaplanner/benchmark/config/ProblemBenchmarksConfigTest.java
+++ b/optaplanner-benchmark/src/test/java/org/optaplanner/benchmark/config/ProblemBenchmarksConfigTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.benchmark.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.optaplanner.benchmark.config.statistic.ProblemStatisticType;
+import org.optaplanner.benchmark.config.statistic.SingleStatisticType;
+
+public class ProblemBenchmarksConfigTest {
+
+    @Test
+    public void testDetermineProblemStatisticTypeList() {
+        ProblemBenchmarksConfig problemBenchmarksConfig = new ProblemBenchmarksConfig();
+        assertThat(problemBenchmarksConfig.determineProblemStatisticTypeList())
+                .isEqualTo(ProblemStatisticType.defaultMetricList());
+        problemBenchmarksConfig.setProblemStatisticTypeList(Collections.emptyList());
+        assertThat(problemBenchmarksConfig.determineProblemStatisticTypeList())
+                .isEqualTo(ProblemStatisticType.defaultMetricList());
+        problemBenchmarksConfig.setProblemStatisticTypeList(List.of(ProblemStatisticType.MEMORY_USE));
+
+        // This assert is to verify the assert below is testing against a different list from the default
+        assertThat(List.of(ProblemStatisticType.MEMORY_USE)).isNotEqualTo(ProblemStatisticType.defaultMetricList());
+
+        assertThat(problemBenchmarksConfig.determineProblemStatisticTypeList())
+                .isEqualTo(List.of(ProblemStatisticType.MEMORY_USE));
+
+        problemBenchmarksConfig.setProblemStatisticEnabled(true);
+        assertThat(problemBenchmarksConfig.determineProblemStatisticTypeList())
+                .isEqualTo(List.of(ProblemStatisticType.MEMORY_USE));
+
+        problemBenchmarksConfig.setProblemStatisticEnabled(false);
+        assertThat(problemBenchmarksConfig.determineProblemStatisticTypeList()).isEqualTo(Collections.emptyList());
+    }
+
+    @Test
+    public void testDetermineSingleStatisticTypeList() {
+        ProblemBenchmarksConfig problemBenchmarksConfig = new ProblemBenchmarksConfig();
+        assertThat(problemBenchmarksConfig.determineSingleStatisticTypeList()).isEqualTo(Collections.emptyList());
+        problemBenchmarksConfig.setSingleStatisticTypeList(Collections.emptyList());
+        assertThat(problemBenchmarksConfig.determineSingleStatisticTypeList()).isEqualTo(Collections.emptyList());
+        problemBenchmarksConfig.setSingleStatisticTypeList(List.of(SingleStatisticType.CONSTRAINT_MATCH_TOTAL_STEP_SCORE));
+        assertThat(problemBenchmarksConfig.determineSingleStatisticTypeList())
+                .isEqualTo(List.of(SingleStatisticType.CONSTRAINT_MATCH_TOTAL_STEP_SCORE));
+    }
+}

--- a/optaplanner-benchmark/src/test/java/org/optaplanner/benchmark/config/ProblemBenchmarksConfigTest.java
+++ b/optaplanner-benchmark/src/test/java/org/optaplanner/benchmark/config/ProblemBenchmarksConfigTest.java
@@ -31,14 +31,14 @@ public class ProblemBenchmarksConfigTest {
     public void testDetermineProblemStatisticTypeList() {
         ProblemBenchmarksConfig problemBenchmarksConfig = new ProblemBenchmarksConfig();
         assertThat(problemBenchmarksConfig.determineProblemStatisticTypeList())
-                .isEqualTo(ProblemStatisticType.defaultMetricList());
+                .isEqualTo(ProblemStatisticType.defaultList());
         problemBenchmarksConfig.setProblemStatisticTypeList(Collections.emptyList());
         assertThat(problemBenchmarksConfig.determineProblemStatisticTypeList())
-                .isEqualTo(ProblemStatisticType.defaultMetricList());
+                .isEqualTo(ProblemStatisticType.defaultList());
         problemBenchmarksConfig.setProblemStatisticTypeList(List.of(ProblemStatisticType.MEMORY_USE));
 
         // This assert is to verify the assert below is testing against a different list from the default
-        assertThat(List.of(ProblemStatisticType.MEMORY_USE)).isNotEqualTo(ProblemStatisticType.defaultMetricList());
+        assertThat(List.of(ProblemStatisticType.MEMORY_USE)).isNotEqualTo(ProblemStatisticType.defaultList());
 
         assertThat(problemBenchmarksConfig.determineProblemStatisticTypeList())
                 .isEqualTo(List.of(ProblemStatisticType.MEMORY_USE));

--- a/optaplanner-benchmark/src/test/java/org/optaplanner/benchmark/impl/SolverBenchmarkFactoryTest.java
+++ b/optaplanner-benchmark/src/test/java/org/optaplanner/benchmark/impl/SolverBenchmarkFactoryTest.java
@@ -16,10 +16,17 @@
 
 package org.optaplanner.benchmark.impl;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
 
+import java.util.List;
+
 import org.junit.jupiter.api.Test;
+import org.optaplanner.benchmark.config.ProblemBenchmarksConfig;
 import org.optaplanner.benchmark.config.SolverBenchmarkConfig;
+import org.optaplanner.benchmark.config.statistic.ProblemStatisticType;
+import org.optaplanner.benchmark.config.statistic.SingleStatisticType;
+import org.optaplanner.core.config.solver.monitoring.SolverMetric;
 
 class SolverBenchmarkFactoryTest {
 
@@ -85,6 +92,30 @@ class SolverBenchmarkFactoryTest {
         config.setName("name");
         config.setSubSingleCount(0);
         assertThatIllegalStateException().isThrownBy(() -> validateConfig(config));
+    }
+
+    @Test
+    void defaultStatisticsAreUsedIfNotPresent() {
+        SolverBenchmarkConfig config = new SolverBenchmarkConfig();
+        config.setName("name");
+        config.setSubSingleCount(0);
+        SolverBenchmarkFactory solverBenchmarkFactory = new SolverBenchmarkFactory(config);
+        ProblemBenchmarksConfig problemBenchmarksConfig = new ProblemBenchmarksConfig();
+        assertThat(solverBenchmarkFactory.getSolverMetrics(problemBenchmarksConfig))
+                .isEqualTo(List.of(SolverMetric.BEST_SCORE));
+    }
+
+    @Test
+    void problemStatisticsAreUsedIfPresent() {
+        SolverBenchmarkConfig config = new SolverBenchmarkConfig();
+        config.setName("name");
+        config.setSubSingleCount(0);
+        SolverBenchmarkFactory solverBenchmarkFactory = new SolverBenchmarkFactory(config);
+        ProblemBenchmarksConfig problemBenchmarksConfig = new ProblemBenchmarksConfig();
+        problemBenchmarksConfig.setProblemStatisticTypeList(List.of(ProblemStatisticType.STEP_SCORE));
+        problemBenchmarksConfig.setSingleStatisticTypeList(List.of(SingleStatisticType.CONSTRAINT_MATCH_TOTAL_BEST_SCORE));
+        assertThat(solverBenchmarkFactory.getSolverMetrics(problemBenchmarksConfig))
+                .isEqualTo(List.of(SolverMetric.STEP_SCORE, SolverMetric.CONSTRAINT_MATCH_TOTAL_BEST_SCORE));
     }
 
     private void validateConfig(SolverBenchmarkConfig config) {


### PR DESCRIPTION
How are defaults handled? If `problemStatisticType` are provided in `problemBenchmarks` config, and `BEST_SCORE` is not included, is it added to the list, or is it presumed not included? (from https://www.optaplanner.org/docs/optaplanner/latest/benchmarking-and-tweaking/benchmarking-and-tweaking.html#enableAProblemStatistic ; to disable all statistics, `problemStatisticEnabled` must be set to false)
<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.
-->

### JIRA

<!-- Add a JIRA ticket link if it exists. -->
https://issues.redhat.com/browse/PLANNER-2665

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
* https://github.com/kiegroup/drools/pull/3000
* https://github.com/kiegroup/optaplanner/pull/899
* etc.
-->

### Checklist
- [ ] Documentation updated if applicable.
- [ ] Upgrade recipe provided if applicable.

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>specific pull request build</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] tests</b>
* for a <b>full downstream build</b> 
  * for <b>jenkins</b> job: please add comment: <b>Jenkins run fdb</b>
  * for <b>github actions</b> job: add the label `run_fdb`
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
* for a <b>Quarkus LTS check</b> please add comment: <b>Jenkins run LTS</b>
* for a <b>specific Quarkus LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] LTS</b>
* for a <b>Native check</b> please add comment: <b>Jenkins run native</b>
* for a <b>specific Native LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] native</b>
</details>
