### PR TITLE
Reuse code between CS direct and indirect variables

### DIFF
--- a/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/drools/common/AbstractLeftHandSide.java
+++ b/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/drools/common/AbstractLeftHandSide.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/drools/common/AbstractPatternVariable.java
+++ b/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/drools/common/AbstractPatternVariable.java
@@ -1,0 +1,249 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.constraint.streams.drools.common;
+
+import static org.drools.model.PatternDSL.betaIndexedBy;
+
+import java.util.List;
+import java.util.function.BiFunction;
+import java.util.function.BiPredicate;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+import java.util.function.UnaryOperator;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.drools.model.BetaIndex;
+import org.drools.model.BetaIndex2;
+import org.drools.model.BetaIndex3;
+import org.drools.model.PatternDSL;
+import org.drools.model.Variable;
+import org.drools.model.functions.Function1;
+import org.drools.model.functions.Predicate2;
+import org.drools.model.functions.Predicate3;
+import org.drools.model.functions.Predicate4;
+import org.drools.model.view.ViewItem;
+import org.optaplanner.constraint.streams.bi.DefaultBiJoiner;
+import org.optaplanner.constraint.streams.quad.DefaultQuadJoiner;
+import org.optaplanner.constraint.streams.tri.DefaultTriJoiner;
+import org.optaplanner.core.api.function.QuadFunction;
+import org.optaplanner.core.api.function.QuadPredicate;
+import org.optaplanner.core.api.function.TriFunction;
+import org.optaplanner.core.api.function.TriPredicate;
+import org.optaplanner.core.impl.score.stream.JoinerType;
+
+abstract class AbstractPatternVariable<A, PatternVar_, Child_ extends AbstractPatternVariable<A, PatternVar_, Child_>>
+        implements PatternVariable<A, PatternVar_, Child_> {
+
+    private final Variable<A> primaryVariable;
+    private final Supplier<PatternDSL.PatternDef<PatternVar_>> patternSupplier;
+    private final List<ViewItem<?>> prerequisiteExpressions;
+    private final List<ViewItem<?>> dependentExpressions;
+
+    protected AbstractPatternVariable(Variable<A> aVariable, Supplier<PatternDSL.PatternDef<PatternVar_>> patternSupplier,
+            List<ViewItem<?>> prerequisiteExpressions, List<ViewItem<?>> dependentExpressions) {
+        this.primaryVariable = aVariable;
+        this.patternSupplier = patternSupplier;
+        this.prerequisiteExpressions = prerequisiteExpressions;
+        this.dependentExpressions = dependentExpressions;
+    }
+
+    protected AbstractPatternVariable(AbstractPatternVariable<?, PatternVar_, ?> patternCreator,
+            Variable<A> boundVariable) {
+        this.primaryVariable = boundVariable;
+        this.patternSupplier = patternCreator.getPatternSupplier();
+        this.prerequisiteExpressions = patternCreator.getPrerequisiteExpressions();
+        this.dependentExpressions = patternCreator.getDependentExpressions();
+    }
+
+    protected AbstractPatternVariable(AbstractPatternVariable<A, PatternVar_, ?> patternCreator,
+            UnaryOperator<PatternDSL.PatternDef<PatternVar_>> patternMutator) {
+        this.primaryVariable = patternCreator.primaryVariable;
+        this.patternSupplier = () -> patternMutator.apply(patternCreator.patternSupplier.get());
+        this.prerequisiteExpressions = patternCreator.prerequisiteExpressions;
+        this.dependentExpressions = patternCreator.dependentExpressions;
+    }
+
+    protected AbstractPatternVariable(AbstractPatternVariable<A, PatternVar_, ?> patternCreator,
+            ViewItem<?> dependentExpression) {
+        this.primaryVariable = patternCreator.primaryVariable;
+        this.patternSupplier = patternCreator.patternSupplier;
+        this.prerequisiteExpressions = patternCreator.prerequisiteExpressions;
+        this.dependentExpressions = Stream.concat(patternCreator.dependentExpressions.stream(), Stream.of(dependentExpression))
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public Variable<A> getPrimaryVariable() {
+        return primaryVariable;
+    }
+
+    public Supplier<PatternDSL.PatternDef<PatternVar_>> getPatternSupplier() {
+        return patternSupplier;
+    }
+
+    @Override
+    public List<ViewItem<?>> getPrerequisiteExpressions() {
+        return prerequisiteExpressions;
+    }
+
+    @Override
+    public List<ViewItem<?>> getDependentExpressions() {
+        return dependentExpressions;
+    }
+
+    /**
+     * Variable values can be either read directly from the pattern variable (see {@link DirectPatternVariable}
+     * or indirectly by applying a mapping function to it (see {@link IndirectPatternVariable}.
+     * This method abstracts this behavior, so that the surrounding code may be shared between both implementations.
+     *
+     * @param patternVar never null, pattern variable to extract the value from
+     * @return value of the variable
+     */
+    protected abstract A extract(PatternVar_ patternVar);
+
+    protected abstract Child_ create(UnaryOperator<PatternDSL.PatternDef<PatternVar_>> patternMutator);
+
+    protected abstract Child_ create(ViewItem<?> dependentExpression);
+
+    @Override
+    public final Child_ filter(Predicate<A> predicate) {
+        return create(p -> p.expr("Filter using " + predicate, a -> predicate.test(extract(a))));
+    }
+
+    @Override
+    public final <LeftJoinVar_> Child_ filter(BiPredicate<LeftJoinVar_, A> predicate,
+            Variable<LeftJoinVar_> leftJoinVariable) {
+        return create(p -> p.expr("Filter using " + predicate, leftJoinVariable,
+                (a, leftJoinVar) -> predicate.test(leftJoinVar, extract(a))));
+    }
+
+    @Override
+    public final <LeftJoinVarA_, LeftJoinVarB_> Child_ filter(
+            TriPredicate<LeftJoinVarA_, LeftJoinVarB_, A> predicate, Variable<LeftJoinVarA_> leftJoinVariableA,
+            Variable<LeftJoinVarB_> leftJoinVariableB) {
+        return create(p -> p.expr("Filter using " + predicate, leftJoinVariableA, leftJoinVariableB,
+                (a, leftJoinVarA, leftJoinVarB) -> predicate.test(leftJoinVarA, leftJoinVarB, extract(a))));
+    }
+
+    @Override
+    public final <LeftJoinVarA_, LeftJoinVarB_, LeftJoinVarC_> Child_ filter(
+            QuadPredicate<LeftJoinVarA_, LeftJoinVarB_, LeftJoinVarC_, A> predicate,
+            Variable<LeftJoinVarA_> leftJoinVariableA, Variable<LeftJoinVarB_> leftJoinVariableB,
+            Variable<LeftJoinVarC_> leftJoinVariableC) {
+        return create(p -> p.expr("Filter using " + predicate, leftJoinVariableA, leftJoinVariableB, leftJoinVariableC,
+                (a, leftJoinVarA, leftJoinVarB, leftJoinVarC) -> predicate.test(leftJoinVarA, leftJoinVarB,
+                        leftJoinVarC, extract(a))));
+    }
+
+    @Override
+    public final <LeftJoinVar_> Child_ filterForJoin(Variable<LeftJoinVar_> leftJoinVar,
+            DefaultBiJoiner<LeftJoinVar_, A> joiner, JoinerType joinerType, int mappingIndex) {
+        Function<LeftJoinVar_, Object> leftMapping = joiner.getLeftMapping(mappingIndex);
+        Function<A, Object> rightMapping = joiner.getRightMapping(mappingIndex);
+        Function1<PatternVar_, Object> rightExtractor = b -> rightMapping.apply(extract(b));
+        Predicate2<PatternVar_, LeftJoinVar_> predicate =
+                (b, a) -> joinerType.matches(leftMapping.apply(a), rightExtractor.apply(b));
+        return create(p -> {
+            BetaIndex<PatternVar_, LeftJoinVar_, Object> index = betaIndexedBy(Object.class,
+                    AbstractLeftHandSide.getConstraintType(joinerType), mappingIndex, rightExtractor,
+                    leftMapping::apply);
+            return p.expr("Join using joiner #" + mappingIndex + " in " + joiner, leftJoinVar, predicate, index);
+        });
+    }
+
+    @Override
+    public final <LeftJoinVarA_, LeftJoinVarB_> Child_ filterForJoin(Variable<LeftJoinVarA_> leftJoinVarA,
+            Variable<LeftJoinVarB_> leftJoinVarB, DefaultTriJoiner<LeftJoinVarA_, LeftJoinVarB_, A> joiner,
+            JoinerType joinerType, int mappingIndex) {
+        BiFunction<LeftJoinVarA_, LeftJoinVarB_, Object> leftMapping = joiner.getLeftMapping(mappingIndex);
+        Function<A, Object> rightMapping = joiner.getRightMapping(mappingIndex);
+        Function1<PatternVar_, Object> rightExtractor = b -> rightMapping.apply(extract(b));
+        Predicate3<PatternVar_, LeftJoinVarA_, LeftJoinVarB_> predicate =
+                (c, a, b) -> joinerType.matches(leftMapping.apply(a, b), rightExtractor.apply(c));
+        return create(p -> {
+            BetaIndex2<PatternVar_, LeftJoinVarA_, LeftJoinVarB_, Object> index =
+                    betaIndexedBy(Object.class, AbstractLeftHandSide.getConstraintType(joinerType), mappingIndex,
+                            rightExtractor, leftMapping::apply, Object.class);
+            return p.expr("Join using joiner #" + mappingIndex + " in " + joiner, leftJoinVarA, leftJoinVarB, predicate, index);
+        });
+    }
+
+    @Override
+    public final <LeftJoinVarA_, LeftJoinVarB_, LeftJoinVarC_> Child_ filterForJoin(Variable<LeftJoinVarA_> leftJoinVarA,
+            Variable<LeftJoinVarB_> leftJoinVarB, Variable<LeftJoinVarC_> leftJoinVarC,
+            DefaultQuadJoiner<LeftJoinVarA_, LeftJoinVarB_, LeftJoinVarC_, A> joiner, JoinerType joinerType,
+            int mappingIndex) {
+        TriFunction<LeftJoinVarA_, LeftJoinVarB_, LeftJoinVarC_, Object> leftMapping =
+                joiner.getLeftMapping(mappingIndex);
+        Function<A, Object> rightMapping = joiner.getRightMapping(mappingIndex);
+        Function1<PatternVar_, Object> rightExtractor = b -> rightMapping.apply(extract(b));
+        Predicate4<PatternVar_, LeftJoinVarA_, LeftJoinVarB_, LeftJoinVarC_> predicate =
+                (d, a, b, c) -> joinerType.matches(leftMapping.apply(a, b, c), rightExtractor.apply(d));
+        return create(p -> {
+            BetaIndex3<PatternVar_, LeftJoinVarA_, LeftJoinVarB_, LeftJoinVarC_, Object> index =
+                    betaIndexedBy(Object.class, AbstractLeftHandSide.getConstraintType(joinerType), mappingIndex,
+                            rightExtractor, leftMapping::apply, Object.class);
+            return p.expr("Join using joiner #" + mappingIndex + " in " + joiner, leftJoinVarA, leftJoinVarB,
+                    leftJoinVarC, predicate, index);
+        });
+    }
+
+    @Override
+    public final <BoundVar_> Child_ bind(Variable<BoundVar_> boundVariable, Function<A, BoundVar_> bindingFunction) {
+        return create(p -> p.bind(boundVariable, a -> bindingFunction.apply(extract(a))));
+    }
+
+    @Override
+    public final <BoundVar_, LeftJoinVar_> Child_ bind(Variable<BoundVar_> boundVariable,
+            Variable<LeftJoinVar_> leftJoinVariable, BiFunction<A, LeftJoinVar_, BoundVar_> bindingFunction) {
+        return create(p -> p.bind(boundVariable, leftJoinVariable,
+                (a, leftJoinVar) -> bindingFunction.apply(extract(a), leftJoinVar)));
+    }
+
+    @Override
+    public final <BoundVar_, LeftJoinVarA_, LeftJoinVarB_> Child_ bind(Variable<BoundVar_> boundVariable,
+            Variable<LeftJoinVarA_> leftJoinVariableA, Variable<LeftJoinVarB_> leftJoinVariableB,
+            TriFunction<A, LeftJoinVarA_, LeftJoinVarB_, BoundVar_> bindingFunction) {
+        return create(p -> p.bind(boundVariable, leftJoinVariableA, leftJoinVariableB,
+                (a, leftJoinVarA, leftJoinVarB) -> bindingFunction.apply(extract(a), leftJoinVarA, leftJoinVarB)));
+    }
+
+    @Override
+    public final <BoundVar_, LeftJoinVarA_, LeftJoinVarB_, LeftJoinVarC_> Child_ bind(Variable<BoundVar_> boundVariable,
+            Variable<LeftJoinVarA_> leftJoinVariableA, Variable<LeftJoinVarB_> leftJoinVariableB,
+            Variable<LeftJoinVarC_> leftJoinVariableC,
+            QuadFunction<A, LeftJoinVarA_, LeftJoinVarB_, LeftJoinVarC_, BoundVar_> bindingFunction) {
+        return create(p -> p.bind(boundVariable, leftJoinVariableA, leftJoinVariableB, leftJoinVariableC,
+                (a, leftJoinVarA, leftJoinVarB, leftJoinVarC) -> bindingFunction.apply(extract(a), leftJoinVarA,
+                        leftJoinVarB, leftJoinVarC)));
+    }
+
+    @Override
+    public final Child_ addDependentExpression(ViewItem<?> expression) {
+        return create(expression);
+    }
+
+    @Override
+    public final List<ViewItem<?>> build() {
+        Stream<ViewItem<?>> prerequisites = prerequisiteExpressions.stream();
+        Stream<ViewItem<?>> dependents = dependentExpressions.stream();
+        return Stream.concat(Stream.concat(prerequisites, Stream.of(patternSupplier.get())), dependents)
+                .collect(Collectors.toList());
+    }
+}

--- a/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/drools/common/BiLeftHandSide.java
+++ b/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/drools/common/BiLeftHandSide.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -91,11 +91,11 @@ public final class BiLeftHandSide<A, B> extends AbstractLeftHandSide {
     private final PatternVariable<B, ?, ?> patternVariableB;
     private final BiRuleContext<A, B> ruleContext;
 
-    protected BiLeftHandSide(Variable<A> left, PatternVariable<B, ?, ?> right, DroolsVariableFactory variableFactory) {
+    BiLeftHandSide(Variable<A> left, PatternVariable<B, ?, ?> right, DroolsVariableFactory variableFactory) {
         this(new DetachedPatternVariable<>(left), right, variableFactory);
     }
 
-    protected BiLeftHandSide(PatternVariable<A, ?, ?> left, PatternVariable<B, ?, ?> right,
+    BiLeftHandSide(PatternVariable<A, ?, ?> left, PatternVariable<B, ?, ?> right,
             DroolsVariableFactory variableFactory) {
         super(variableFactory);
         this.patternVariableA = Objects.requireNonNull(left);

--- a/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/drools/common/BiTuple.java
+++ b/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/drools/common/BiTuple.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +20,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 
-public final class BiTuple<A, B> implements FactTuple {
+final class BiTuple<A, B> implements FactTuple {
     public final A a;
     public final B b;
     private final int hashCode;

--- a/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/drools/common/DetachedPatternVariable.java
+++ b/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/drools/common/DetachedPatternVariable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/drools/common/IndirectPatternVariable.java
+++ b/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/drools/common/IndirectPatternVariable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,36 +16,12 @@
 
 package org.optaplanner.constraint.streams.drools.common;
 
-import static org.drools.model.PatternDSL.betaIndexedBy;
-
-import java.util.List;
-import java.util.function.BiFunction;
-import java.util.function.BiPredicate;
 import java.util.function.Function;
-import java.util.function.Predicate;
-import java.util.function.Supplier;
 import java.util.function.UnaryOperator;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
-import org.drools.model.BetaIndex;
-import org.drools.model.BetaIndex2;
-import org.drools.model.BetaIndex3;
 import org.drools.model.PatternDSL;
 import org.drools.model.Variable;
-import org.drools.model.functions.Function1;
-import org.drools.model.functions.Predicate2;
-import org.drools.model.functions.Predicate3;
-import org.drools.model.functions.Predicate4;
 import org.drools.model.view.ViewItem;
-import org.optaplanner.constraint.streams.bi.DefaultBiJoiner;
-import org.optaplanner.constraint.streams.quad.DefaultQuadJoiner;
-import org.optaplanner.constraint.streams.tri.DefaultTriJoiner;
-import org.optaplanner.core.api.function.QuadFunction;
-import org.optaplanner.core.api.function.QuadPredicate;
-import org.optaplanner.core.api.function.TriFunction;
-import org.optaplanner.core.api.function.TriPredicate;
-import org.optaplanner.core.impl.score.stream.JoinerType;
 
 /**
  * Represents a single variable with all of its patterns in the left hand side of a Drools rule,
@@ -88,206 +64,50 @@ import org.optaplanner.core.impl.score.stream.JoinerType;
  * @param <PatternVar_>> generic type of the pattern variable
  */
 final class IndirectPatternVariable<A, PatternVar_>
-        implements PatternVariable<A, PatternVar_, IndirectPatternVariable<A, PatternVar_>> {
+        extends AbstractPatternVariable<A, PatternVar_, IndirectPatternVariable<A, PatternVar_>> {
 
-    private final Variable<A> primaryVariable;
-    private final Supplier<PatternDSL.PatternDef<PatternVar_>> patternSupplier;
     private final Function<PatternVar_, A> mappingFunction;
-    private final List<ViewItem<?>> prerequisiteExpressions;
-    private final List<ViewItem<?>> dependentExpressions;
 
     <OldA> IndirectPatternVariable(IndirectPatternVariable<OldA, PatternVar_> patternCreator, Variable<A> boundVariable,
             Function<OldA, A> mappingFunction) {
-        this.primaryVariable = boundVariable;
-        this.patternSupplier = patternCreator.patternSupplier;
+        super(patternCreator, boundVariable);
         this.mappingFunction = patternCreator.mappingFunction.andThen(mappingFunction);
-        this.prerequisiteExpressions = patternCreator.prerequisiteExpressions;
-        this.dependentExpressions = patternCreator.dependentExpressions;
     }
 
     IndirectPatternVariable(DirectPatternVariable<PatternVar_> patternCreator, Variable<A> boundVariable,
             Function<PatternVar_, A> mappingFunction) {
-        this.primaryVariable = boundVariable;
-        this.patternSupplier = patternCreator.getPatternSupplier();
+        super(patternCreator, boundVariable);
         this.mappingFunction = mappingFunction;
-        this.prerequisiteExpressions = patternCreator.getPrerequisiteExpressions();
-        this.dependentExpressions = patternCreator.getDependentExpressions();
     }
 
     private IndirectPatternVariable(IndirectPatternVariable<A, PatternVar_> patternCreator,
             UnaryOperator<PatternDSL.PatternDef<PatternVar_>> patternMutator) {
-        this.primaryVariable = patternCreator.primaryVariable;
-        this.patternSupplier = () -> patternMutator.apply(patternCreator.patternSupplier.get());
+        super(patternCreator, patternMutator);
         this.mappingFunction = patternCreator.mappingFunction;
-        this.prerequisiteExpressions = patternCreator.prerequisiteExpressions;
-        this.dependentExpressions = patternCreator.dependentExpressions;
     }
 
     private IndirectPatternVariable(IndirectPatternVariable<A, PatternVar_> patternCreator,
             ViewItem<?> dependentExpression) {
-        this.primaryVariable = patternCreator.primaryVariable;
-        this.patternSupplier = patternCreator.patternSupplier;
+        super(patternCreator, dependentExpression);
         this.mappingFunction = patternCreator.mappingFunction;
-        this.prerequisiteExpressions = patternCreator.prerequisiteExpressions;
-        this.dependentExpressions = Stream.concat(patternCreator.dependentExpressions.stream(), Stream.of(dependentExpression))
-                .collect(Collectors.toList());
     }
 
     @Override
-    public Variable<A> getPrimaryVariable() {
-        return primaryVariable;
-    }
-
-    @Override
-    public List<ViewItem<?>> getPrerequisiteExpressions() {
-        return prerequisiteExpressions;
-    }
-
-    @Override
-    public List<ViewItem<?>> getDependentExpressions() {
-        return dependentExpressions;
-    }
-
-    private A extract(PatternVar_ patternVar) {
+    protected A extract(PatternVar_ patternVar) {
+        // Value of an indirect variable is a result of applying a mapping on the pattern variable.
         return mappingFunction.apply(patternVar);
     }
 
     @Override
-    public IndirectPatternVariable<A, PatternVar_> filter(Predicate<A> predicate) {
-        return new IndirectPatternVariable<>(this, p -> p.expr("Filter using " + predicate,
-                a -> predicate.test(extract(a))));
+    protected IndirectPatternVariable<A, PatternVar_> create(
+            UnaryOperator<PatternDSL.PatternDef<PatternVar_>> patternMutator) {
+        return new IndirectPatternVariable<>(this, patternMutator);
     }
 
     @Override
-    public <LeftJoinVar_> IndirectPatternVariable<A, PatternVar_> filter(BiPredicate<LeftJoinVar_, A> predicate,
-            Variable<LeftJoinVar_> leftJoinVariable) {
-        return new IndirectPatternVariable<>(this,
-                p -> p.expr("Filter using " + predicate, leftJoinVariable,
-                        (a, leftJoinVar) -> predicate.test(leftJoinVar, extract(a))));
+    protected IndirectPatternVariable<A, PatternVar_> create(
+            ViewItem<?> dependentExpression) {
+        return new IndirectPatternVariable<>(this, dependentExpression);
     }
 
-    @Override
-    public <LeftJoinVarA_, LeftJoinVarB_> IndirectPatternVariable<A, PatternVar_> filter(
-            TriPredicate<LeftJoinVarA_, LeftJoinVarB_, A> predicate, Variable<LeftJoinVarA_> leftJoinVariableA,
-            Variable<LeftJoinVarB_> leftJoinVariableB) {
-        return new IndirectPatternVariable<>(this,
-                p -> p.expr("Filter using " + predicate, leftJoinVariableA, leftJoinVariableB,
-                        (a, leftJoinVarA, leftJoinVarB) -> predicate.test(leftJoinVarA, leftJoinVarB, extract(a))));
-    }
-
-    @Override
-    public <LeftJoinVarA_, LeftJoinVarB_, LeftJoinVarC_> IndirectPatternVariable<A, PatternVar_> filter(
-            QuadPredicate<LeftJoinVarA_, LeftJoinVarB_, LeftJoinVarC_, A> predicate,
-            Variable<LeftJoinVarA_> leftJoinVariableA, Variable<LeftJoinVarB_> leftJoinVariableB,
-            Variable<LeftJoinVarC_> leftJoinVariableC) {
-        return new IndirectPatternVariable<>(this,
-                p -> p.expr("Filter using " + predicate, leftJoinVariableA, leftJoinVariableB, leftJoinVariableC,
-                        (a, leftJoinVarA, leftJoinVarB, leftJoinVarC) -> predicate.test(leftJoinVarA, leftJoinVarB,
-                                leftJoinVarC, extract(a))));
-    }
-
-    @Override
-    public <LeftJoinVar_> PatternVariable<A, PatternVar_, IndirectPatternVariable<A, PatternVar_>> filterForJoin(
-            Variable<LeftJoinVar_> leftJoinVar, DefaultBiJoiner<LeftJoinVar_, A> joiner, JoinerType joinerType,
-            int mappingIndex) {
-        Function<LeftJoinVar_, Object> leftMapping = joiner.getLeftMapping(mappingIndex);
-        Function<A, Object> rightMapping = joiner.getRightMapping(mappingIndex);
-        Function1<PatternVar_, Object> rightExtractor = b -> rightMapping.apply(extract(b));
-        Predicate2<PatternVar_, LeftJoinVar_> predicate =
-                (b, a) -> joinerType.matches(leftMapping.apply(a), rightExtractor.apply(b));
-        return new IndirectPatternVariable<>(this, p -> {
-            BetaIndex<PatternVar_, LeftJoinVar_, Object> index = betaIndexedBy(Object.class,
-                    AbstractLeftHandSide.getConstraintType(joinerType), mappingIndex, rightExtractor,
-                    leftMapping::apply);
-            return p.expr("Join using joiner #" + mappingIndex + " in " + joiner, leftJoinVar, predicate, index);
-        });
-    }
-
-    @Override
-    public <LeftJoinVarA_, LeftJoinVarB_> PatternVariable<A, PatternVar_, IndirectPatternVariable<A, PatternVar_>>
-            filterForJoin(Variable<LeftJoinVarA_> leftJoinVarA, Variable<LeftJoinVarB_> leftJoinVarB,
-                    DefaultTriJoiner<LeftJoinVarA_, LeftJoinVarB_, A> joiner, JoinerType joinerType, int mappingIndex) {
-        BiFunction<LeftJoinVarA_, LeftJoinVarB_, Object> leftMapping = joiner.getLeftMapping(mappingIndex);
-        Function<A, Object> rightMapping = joiner.getRightMapping(mappingIndex);
-        Function1<PatternVar_, Object> rightExtractor = b -> rightMapping.apply(extract(b));
-        Predicate3<PatternVar_, LeftJoinVarA_, LeftJoinVarB_> predicate =
-                (c, a, b) -> joinerType.matches(leftMapping.apply(a, b), rightExtractor.apply(c));
-        return new IndirectPatternVariable<>(this, p -> {
-            BetaIndex2<PatternVar_, LeftJoinVarA_, LeftJoinVarB_, Object> index =
-                    betaIndexedBy(Object.class, AbstractLeftHandSide.getConstraintType(joinerType), mappingIndex,
-                            rightExtractor, leftMapping::apply, Object.class);
-            return p.expr("Join using joiner #" + mappingIndex + " in " + joiner, leftJoinVarA, leftJoinVarB, predicate, index);
-        });
-    }
-
-    @Override
-    public <LeftJoinVarA_, LeftJoinVarB_, LeftJoinVarC_>
-            PatternVariable<A, PatternVar_, IndirectPatternVariable<A, PatternVar_>>
-            filterForJoin(Variable<LeftJoinVarA_> leftJoinVarA, Variable<LeftJoinVarB_> leftJoinVarB,
-                    Variable<LeftJoinVarC_> leftJoinVarC,
-                    DefaultQuadJoiner<LeftJoinVarA_, LeftJoinVarB_, LeftJoinVarC_, A> joiner, JoinerType joinerType,
-                    int mappingIndex) {
-        TriFunction<LeftJoinVarA_, LeftJoinVarB_, LeftJoinVarC_, Object> leftMapping =
-                joiner.getLeftMapping(mappingIndex);
-        Function<A, Object> rightMapping = joiner.getRightMapping(mappingIndex);
-        Function1<PatternVar_, Object> rightExtractor = b -> rightMapping.apply(extract(b));
-        Predicate4<PatternVar_, LeftJoinVarA_, LeftJoinVarB_, LeftJoinVarC_> predicate =
-                (d, a, b, c) -> joinerType.matches(leftMapping.apply(a, b, c), rightExtractor.apply(d));
-        return new IndirectPatternVariable<>(this, p -> {
-            BetaIndex3<PatternVar_, LeftJoinVarA_, LeftJoinVarB_, LeftJoinVarC_, Object> index =
-                    betaIndexedBy(Object.class, AbstractLeftHandSide.getConstraintType(joinerType), mappingIndex,
-                            rightExtractor, leftMapping::apply, Object.class);
-            return p.expr("Join using joiner #" + mappingIndex + " in " + joiner, leftJoinVarA, leftJoinVarB,
-                    leftJoinVarC, predicate, index);
-        });
-    }
-
-    @Override
-    public <BoundVar_> IndirectPatternVariable<A, PatternVar_> bind(Variable<BoundVar_> boundVariable,
-            Function<A, BoundVar_> bindingFunction) {
-        return new IndirectPatternVariable<>(this,
-                p -> p.bind(boundVariable, a -> bindingFunction.apply(extract(a))));
-    }
-
-    @Override
-    public <BoundVar_, LeftJoinVar_> IndirectPatternVariable<A, PatternVar_> bind(Variable<BoundVar_> boundVariable,
-            Variable<LeftJoinVar_> leftJoinVariable, BiFunction<A, LeftJoinVar_, BoundVar_> bindingFunction) {
-        return new IndirectPatternVariable<>(this,
-                p -> p.bind(boundVariable, leftJoinVariable,
-                        (a, leftJoinVar) -> bindingFunction.apply(extract(a), leftJoinVar)));
-    }
-
-    @Override
-    public <BoundVar_, LeftJoinVarA_, LeftJoinVarB_> IndirectPatternVariable<A, PatternVar_> bind(
-            Variable<BoundVar_> boundVariable, Variable<LeftJoinVarA_> leftJoinVariableA,
-            Variable<LeftJoinVarB_> leftJoinVariableB,
-            TriFunction<A, LeftJoinVarA_, LeftJoinVarB_, BoundVar_> bindingFunction) {
-        return new IndirectPatternVariable<>(this,
-                p -> p.bind(boundVariable, leftJoinVariableA, leftJoinVariableB,
-                        (a, leftJoinVarA, leftJoinVarB) -> bindingFunction.apply(extract(a), leftJoinVarA, leftJoinVarB)));
-    }
-
-    @Override
-    public <BoundVar_, LeftJoinVarA_, LeftJoinVarB_, LeftJoinVarC_> IndirectPatternVariable<A, PatternVar_> bind(
-            Variable<BoundVar_> boundVariable, Variable<LeftJoinVarA_> leftJoinVariableA,
-            Variable<LeftJoinVarB_> leftJoinVariableB, Variable<LeftJoinVarC_> leftJoinVariableC,
-            QuadFunction<A, LeftJoinVarA_, LeftJoinVarB_, LeftJoinVarC_, BoundVar_> bindingFunction) {
-        return new IndirectPatternVariable<>(this,
-                p -> p.bind(boundVariable, leftJoinVariableA, leftJoinVariableB, leftJoinVariableC,
-                        (a, leftJoinVarA, leftJoinVarB, leftJoinVarC) -> bindingFunction.apply(extract(a), leftJoinVarA,
-                                leftJoinVarB, leftJoinVarC)));
-    }
-
-    @Override
-    public IndirectPatternVariable<A, PatternVar_> addDependentExpression(ViewItem<?> expression) {
-        return new IndirectPatternVariable<>(this, expression);
-    }
-
-    @Override
-    public List<ViewItem<?>> build() {
-        Stream<ViewItem<?>> prerequisites = prerequisiteExpressions.stream();
-        Stream<ViewItem<?>> dependents = dependentExpressions.stream();
-        return Stream.concat(Stream.concat(prerequisites, Stream.of(patternSupplier.get())), dependents)
-                .collect(Collectors.toList());
-    }
 }

--- a/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/drools/common/QuadLeftHandSide.java
+++ b/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/drools/common/QuadLeftHandSide.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -67,13 +67,13 @@ public final class QuadLeftHandSide<A, B, C, D> extends AbstractLeftHandSide {
     private final PatternVariable<D, ?, ?> patternVariableD;
     private final QuadRuleContext<A, B, C, D> ruleContext;
 
-    protected QuadLeftHandSide(Variable<A> variableA, Variable<B> variableB, Variable<C> variableC,
+    QuadLeftHandSide(Variable<A> variableA, Variable<B> variableB, Variable<C> variableC,
             PatternVariable<D, ?, ?> patternVariableD, DroolsVariableFactory variableFactory) {
         this(new DetachedPatternVariable<>(variableA), new DetachedPatternVariable<>(variableB),
                 new DetachedPatternVariable<>(variableC), patternVariableD, variableFactory);
     }
 
-    protected QuadLeftHandSide(PatternVariable<A, ?, ?> patternVariableA, PatternVariable<B, ?, ?> patternVariableB,
+    QuadLeftHandSide(PatternVariable<A, ?, ?> patternVariableA, PatternVariable<B, ?, ?> patternVariableB,
             PatternVariable<C, ?, ?> patternVariableC, PatternVariable<D, ?, ?> patternVariableD,
             DroolsVariableFactory variableFactory) {
         super(variableFactory);

--- a/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/drools/common/QuadTuple.java
+++ b/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/drools/common/QuadTuple.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +20,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 
-public final class QuadTuple<A, B, C, D> implements FactTuple {
+final class QuadTuple<A, B, C, D> implements FactTuple {
     public final A a;
     public final B b;
     public final C c;

--- a/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/drools/common/TriLeftHandSide.java
+++ b/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/drools/common/TriLeftHandSide.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -65,13 +65,13 @@ public final class TriLeftHandSide<A, B, C> extends AbstractLeftHandSide {
     private final PatternVariable<C, ?, ?> patternVariableC;
     private final TriRuleContext<A, B, C> ruleContext;
 
-    protected TriLeftHandSide(Variable<A> variableA, Variable<B> variableB, PatternVariable<C, ?, ?> patternVariableC,
+    TriLeftHandSide(Variable<A> variableA, Variable<B> variableB, PatternVariable<C, ?, ?> patternVariableC,
             DroolsVariableFactory variableFactory) {
         this(new DetachedPatternVariable<>(variableA), new DetachedPatternVariable<>(variableB), patternVariableC,
                 variableFactory);
     }
 
-    protected TriLeftHandSide(PatternVariable<A, ?, ?> patternVariableA, PatternVariable<B, ?, ?> patternVariableB,
+    TriLeftHandSide(PatternVariable<A, ?, ?> patternVariableA, PatternVariable<B, ?, ?> patternVariableB,
             PatternVariable<C, ?, ?> patternVariableC, DroolsVariableFactory variableFactory) {
         super(variableFactory);
         this.patternVariableA = Objects.requireNonNull(patternVariableA);

--- a/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/drools/common/TriTuple.java
+++ b/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/drools/common/TriTuple.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +20,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 
-public final class TriTuple<A, B, C> implements FactTuple {
+final class TriTuple<A, B, C> implements FactTuple {
     public final A a;
     public final B b;
     public final C c;

--- a/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/drools/common/UniLeftHandSide.java
+++ b/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/drools/common/UniLeftHandSide.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -101,11 +101,11 @@ public final class UniLeftHandSide<A> extends AbstractLeftHandSide {
         this(new DirectPatternVariable<>(variableFactory.createVariable(aClass, "var")), variableFactory);
     }
 
-    protected UniLeftHandSide(Variable<A> variable, List<ViewItem<?>> viewItems, DroolsVariableFactory variableFactory) {
+    UniLeftHandSide(Variable<A> variable, List<ViewItem<?>> viewItems, DroolsVariableFactory variableFactory) {
         this(new DirectPatternVariable<>(variable, viewItems), variableFactory);
     }
 
-    protected UniLeftHandSide(PatternVariable<A, ?, ?> patternVariable, DroolsVariableFactory variableFactory) {
+    UniLeftHandSide(PatternVariable<A, ?, ?> patternVariable, DroolsVariableFactory variableFactory) {
         super(variableFactory);
         this.patternVariable = Objects.requireNonNull(patternVariable);
         this.ruleContext = buildRuleContext();


### PR DESCRIPTION
This is a pure refactor. `DirectPatternVariable` and `IndirectPatternVariable` were nearly carbon copies. I extracted the common logic into `AbstractPatternVariable`, significantly reducing code duplication.