### PR TITLE
PLANNER-2667: Fix consecutive collector getting corrupted on data that depends on planning variables

### DIFF
--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/common/experimental/ExperimentalConstraintCollectors.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/common/experimental/ExperimentalConstraintCollectors.java
@@ -66,7 +66,6 @@ public class ExperimentalConstraintCollectors {
             @Override
             public Supplier<ConsecutiveSetTree<A, Integer, Integer>> supplier() {
                 return () -> new ConsecutiveSetTree<>(
-                        indexMap::applyAsInt,
                         (Integer a, Integer b) -> b - a,
                         Integer::sum,
                         1, 0);
@@ -75,7 +74,8 @@ public class ExperimentalConstraintCollectors {
             @Override
             public BiFunction<ConsecutiveSetTree<A, Integer, Integer>, A, Runnable> accumulator() {
                 return (acc, a) -> {
-                    acc.add(a);
+                    Integer value = indexMap.applyAsInt(a);
+                    acc.add(a, value);
                     return () -> acc.remove(a);
                 };
             }
@@ -104,7 +104,6 @@ public class ExperimentalConstraintCollectors {
             @Override
             public Supplier<ConsecutiveSetTree<Result, Integer, Integer>> supplier() {
                 return () -> new ConsecutiveSetTree<>(
-                        indexMap::applyAsInt,
                         (Integer a, Integer b) -> b - a,
                         Integer::sum, 1, 0);
             }
@@ -113,7 +112,8 @@ public class ExperimentalConstraintCollectors {
             public TriFunction<ConsecutiveSetTree<Result, Integer, Integer>, A, B, Runnable> accumulator() {
                 return (acc, a, b) -> {
                     Result result = resultMap.apply(a, b);
-                    acc.add(result);
+                    Integer value = indexMap.applyAsInt(result);
+                    acc.add(result, value);
                     return () -> acc.remove(result);
                 };
             }
@@ -143,7 +143,6 @@ public class ExperimentalConstraintCollectors {
             @Override
             public Supplier<ConsecutiveSetTree<Result, Integer, Integer>> supplier() {
                 return () -> new ConsecutiveSetTree<>(
-                        indexMap::applyAsInt,
                         (Integer a, Integer b) -> b - a, Integer::sum, 1, 0);
             }
 
@@ -151,7 +150,8 @@ public class ExperimentalConstraintCollectors {
             public QuadFunction<ConsecutiveSetTree<Result, Integer, Integer>, A, B, C, Runnable> accumulator() {
                 return (acc, a, b, c) -> {
                     Result result = resultMap.apply(a, b, c);
-                    acc.add(result);
+                    Integer value = indexMap.applyAsInt(result);
+                    acc.add(result, value);
                     return () -> acc.remove(result);
                 };
             }
@@ -182,7 +182,6 @@ public class ExperimentalConstraintCollectors {
             @Override
             public Supplier<ConsecutiveSetTree<Result, Integer, Integer>> supplier() {
                 return () -> new ConsecutiveSetTree<>(
-                        indexMap::applyAsInt,
                         (Integer a, Integer b) -> b - a, Integer::sum, 1, 0);
             }
 
@@ -190,7 +189,8 @@ public class ExperimentalConstraintCollectors {
             public PentaFunction<ConsecutiveSetTree<Result, Integer, Integer>, A, B, C, D, Runnable> accumulator() {
                 return (acc, a, b, c, d) -> {
                     Result result = resultMap.apply(a, b, c, d);
-                    acc.add(result);
+                    Integer value = indexMap.applyAsInt(result);
+                    acc.add(result, value);
                     return () -> acc.remove(result);
                 };
             }

--- a/optaplanner-examples/src/test/java/org/optaplanner/examples/common/experimental/ExperimentalConstraintCollectorsTest.java
+++ b/optaplanner-examples/src/test/java/org/optaplanner/examples/common/experimental/ExperimentalConstraintCollectorsTest.java
@@ -124,7 +124,7 @@ class ExperimentalConstraintCollectorsTest {
     private ConsecutiveInfo<Integer, Integer> consecutiveData(Integer... data) {
         ConsecutiveSetTree<Integer, Integer, Integer> tree =
                 new ConsecutiveSetTree<>((a, b) -> b - a, Integer::sum, 1, 0);
-        asList(data).forEach(datum -> tree.add(datum, datum)); // datum is the singular form of data
+        asList(data).forEach(datum -> tree.add(datum, datum));
         return tree;
     }
 

--- a/optaplanner-examples/src/test/java/org/optaplanner/examples/common/experimental/ExperimentalConstraintCollectorsTest.java
+++ b/optaplanner-examples/src/test/java/org/optaplanner/examples/common/experimental/ExperimentalConstraintCollectorsTest.java
@@ -123,8 +123,8 @@ class ExperimentalConstraintCollectorsTest {
 
     private ConsecutiveInfo<Integer, Integer> consecutiveData(Integer... data) {
         ConsecutiveSetTree<Integer, Integer, Integer> tree =
-                new ConsecutiveSetTree<>(Integer::intValue, (a, b) -> b - a, Integer::sum, 1, 0);
-        asList(data).forEach(tree::add);
+                new ConsecutiveSetTree<>((a, b) -> b - a, Integer::sum, 1, 0);
+        asList(data).forEach(datum -> tree.add(datum, datum)); // datum is the singular form of data
         return tree;
     }
 


### PR DESCRIPTION
There was a bug where the consecutive collector gets corrupted
if its index function depends on planning variable. This is due
to how score calculation works:

1. A move is performed
2. calculateScore is called
3. The undo move is performed

Since calculateScore is not called for undo, when
the entity is later removed by the next move, its index
would have change, corrupting the consecutive collector.

To fix consecutive, the index of the value is cached on add, and
the cached index is used during remove.

<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.
-->

### JIRA

<!-- Add a JIRA ticket link if it exists. -->
https://issues.redhat.com/browse/PLANNER-2667

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
* https://github.com/kiegroup/drools/pull/3000
* https://github.com/kiegroup/optaplanner/pull/899
* etc.
-->

### Checklist
- [ ] Documentation updated if applicable.
- [ ] Upgrade recipe provided if applicable.

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>specific pull request build</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] tests</b>
* for a <b>full downstream build</b> 
  * for <b>jenkins</b> job: please add comment: <b>Jenkins run fdb</b>
  * for <b>github actions</b> job: add the label `run_fdb`
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
* for a <b>Quarkus LTS check</b> please add comment: <b>Jenkins run LTS</b>
* for a <b>specific Quarkus LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] LTS</b>
* for a <b>Native check</b> please add comment: <b>Jenkins run native</b>
* for a <b>specific Native LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] native</b>
</details>
