### PR TITLE
Remove remaining public modifiers from tests

### DIFF
--- a/core/optaplanner-constraint-drl/src/test/java/org/optaplanner/constraint/drl/SolutionDescriptorTest.java
+++ b/core/optaplanner-constraint-drl/src/test/java/org/optaplanner/constraint/drl/SolutionDescriptorTest.java
@@ -27,10 +27,10 @@ import org.optaplanner.core.impl.testdata.domain.TestdataEntity;
 import org.optaplanner.core.impl.testdata.domain.solutionproperties.TestdataNoProblemFactPropertySolution;
 import org.optaplanner.core.impl.testdata.util.PlannerTestUtils;
 
-public class SolutionDescriptorTest {
+class SolutionDescriptorTest {
 
     @Test
-    public void noProblemFactPropertyWithDroolsScoreCalculation() {
+    void noProblemFactPropertyWithDroolsScoreCalculation() {
         assertThatIllegalStateException().isThrownBy(() -> buildSolverFactoryWithDroolsScoreDirector(
                 TestdataNoProblemFactPropertySolution.class, TestdataEntity.class));
     }

--- a/core/optaplanner-constraint-drl/src/test/java/org/optaplanner/constraint/drl/testgen/TestGenTestWriterTest.java
+++ b/core/optaplanner-constraint-drl/src/test/java/org/optaplanner/constraint/drl/testgen/TestGenTestWriterTest.java
@@ -50,7 +50,7 @@ class TestGenTestWriterTest {
 
     @Test
     @Timeout(600)
-    public void fullJournalOutput() throws IOException, URISyntaxException {
+    void fullJournalOutput() throws IOException, URISyntaxException {
         TestGenKieSessionJournal journal = new TestGenKieSessionJournal();
         TestdataEntity entity = new TestdataEntity("E");
         TestdataValue value = new TestdataValue("V");

--- a/core/optaplanner-constraint-drl/src/test/java/org/optaplanner/constraint/drl/testgen/mutation/TestGenHeadCuttingMutatorTest.java
+++ b/core/optaplanner-constraint-drl/src/test/java/org/optaplanner/constraint/drl/testgen/mutation/TestGenHeadCuttingMutatorTest.java
@@ -27,7 +27,7 @@ class TestGenHeadCuttingMutatorTest {
     private ArrayList<Integer> list = new ArrayList<>();
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         for (int i = 0; i < 25; i++) {
             list.add(i);
         }

--- a/core/optaplanner-constraint-drl/src/test/java/org/optaplanner/constraint/drl/testgen/mutation/TestGenRemoveRandomBlockMutatorTest.java
+++ b/core/optaplanner-constraint-drl/src/test/java/org/optaplanner/constraint/drl/testgen/mutation/TestGenRemoveRandomBlockMutatorTest.java
@@ -29,7 +29,7 @@ class TestGenRemoveRandomBlockMutatorTest {
     private ArrayList<Integer> list = new ArrayList<>();
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         for (int i = 0; i < LIST_SIZE; i++) {
             list.add(i);
         }

--- a/core/optaplanner-constraint-streams/src/test/java/org/optaplanner/constraint/streams/ScoreManagerTest.java
+++ b/core/optaplanner-constraint-streams/src/test/java/org/optaplanner/constraint/streams/ScoreManagerTest.java
@@ -37,7 +37,7 @@ class ScoreManagerTest {
 
     @ParameterizedTest
     @EnumSource(ConstraintStreamImplType.class)
-    public void indictmentsPresentOnFreshExplanation(ConstraintStreamImplType constraintStreamImplType) {
+    void indictmentsPresentOnFreshExplanation(ConstraintStreamImplType constraintStreamImplType) {
         // Create the environment.
         ScoreDirectorFactoryConfig scoreDirectorFactoryConfig = new ScoreDirectorFactoryConfig();
         scoreDirectorFactoryConfig.setConstraintProviderClass(TestdataConstraintProvider.class);

--- a/core/optaplanner-constraint-streams/src/test/java/org/optaplanner/constraint/streams/bi/BiConstraintStreamTest.java
+++ b/core/optaplanner-constraint-streams/src/test/java/org/optaplanner/constraint/streams/bi/BiConstraintStreamTest.java
@@ -55,7 +55,7 @@ import org.optaplanner.core.impl.testdata.domain.score.lavish.TestdataLavishSolu
 import org.optaplanner.core.impl.testdata.domain.score.lavish.TestdataLavishValue;
 import org.optaplanner.core.impl.testdata.domain.score.lavish.TestdataLavishValueGroup;
 
-public class BiConstraintStreamTest extends AbstractConstraintStreamTest implements ConstraintStreamFunctionalTest {
+class BiConstraintStreamTest extends AbstractConstraintStreamTest implements ConstraintStreamFunctionalTest {
 
     public BiConstraintStreamTest(boolean constraintMatchEnabled, ConstraintStreamImplType constraintStreamImplType) {
         super(constraintMatchEnabled, constraintStreamImplType);

--- a/core/optaplanner-constraint-streams/src/test/java/org/optaplanner/constraint/streams/quad/QuadConstraintStreamTest.java
+++ b/core/optaplanner-constraint-streams/src/test/java/org/optaplanner/constraint/streams/quad/QuadConstraintStreamTest.java
@@ -59,7 +59,7 @@ import org.optaplanner.core.impl.testdata.domain.score.lavish.TestdataLavishSolu
 import org.optaplanner.core.impl.testdata.domain.score.lavish.TestdataLavishValue;
 import org.optaplanner.core.impl.testdata.domain.score.lavish.TestdataLavishValueGroup;
 
-public class QuadConstraintStreamTest extends AbstractConstraintStreamTest implements ConstraintStreamFunctionalTest {
+class QuadConstraintStreamTest extends AbstractConstraintStreamTest implements ConstraintStreamFunctionalTest {
 
     public QuadConstraintStreamTest(boolean constraintMatchEnabled, ConstraintStreamImplType constraintStreamImplType) {
         super(constraintMatchEnabled, constraintStreamImplType);

--- a/core/optaplanner-constraint-streams/src/test/java/org/optaplanner/constraint/streams/tri/TriConstraintStreamTest.java
+++ b/core/optaplanner-constraint-streams/src/test/java/org/optaplanner/constraint/streams/tri/TriConstraintStreamTest.java
@@ -58,7 +58,7 @@ import org.optaplanner.core.impl.testdata.domain.score.lavish.TestdataLavishSolu
 import org.optaplanner.core.impl.testdata.domain.score.lavish.TestdataLavishValue;
 import org.optaplanner.core.impl.testdata.domain.score.lavish.TestdataLavishValueGroup;
 
-public class TriConstraintStreamTest extends AbstractConstraintStreamTest implements ConstraintStreamFunctionalTest {
+class TriConstraintStreamTest extends AbstractConstraintStreamTest implements ConstraintStreamFunctionalTest {
 
     public TriConstraintStreamTest(boolean constraintMatchEnabled, ConstraintStreamImplType constraintStreamImplType) {
         super(constraintMatchEnabled, constraintStreamImplType);

--- a/core/optaplanner-constraint-streams/src/test/java/org/optaplanner/constraint/streams/uni/UniConstraintStreamTest.java
+++ b/core/optaplanner-constraint-streams/src/test/java/org/optaplanner/constraint/streams/uni/UniConstraintStreamTest.java
@@ -61,7 +61,7 @@ import org.optaplanner.core.impl.testdata.domain.score.lavish.TestdataLavishSolu
 import org.optaplanner.core.impl.testdata.domain.score.lavish.TestdataLavishValue;
 import org.optaplanner.core.impl.testdata.domain.score.lavish.TestdataLavishValueGroup;
 
-public class UniConstraintStreamTest extends AbstractConstraintStreamTest implements ConstraintStreamFunctionalTest {
+class UniConstraintStreamTest extends AbstractConstraintStreamTest implements ConstraintStreamFunctionalTest {
 
     public UniConstraintStreamTest(boolean constraintMatchEnabled, ConstraintStreamImplType constraintStreamImplType) {
         super(constraintMatchEnabled, constraintStreamImplType);

--- a/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/api/score/ScoreManagerTest.java
+++ b/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/api/score/ScoreManagerTest.java
@@ -34,7 +34,7 @@ public class ScoreManagerTest {
 
     @ParameterizedTest
     @EnumSource(ScoreManagerSource.class)
-    public void updateScore(ScoreManagerSource scoreManagerSource) {
+    void updateScore(ScoreManagerSource scoreManagerSource) {
         ScoreManager<TestdataSolution, ?> scoreManager = scoreManagerSource.createScoreManager(SOLVER_FACTORY);
         assertThat(scoreManager).isNotNull();
         TestdataSolution solution = TestdataSolution.generateSolution();
@@ -45,7 +45,7 @@ public class ScoreManagerTest {
 
     @ParameterizedTest
     @EnumSource(ScoreManagerSource.class)
-    public void explainScore(ScoreManagerSource scoreManagerSource) {
+    void explainScore(ScoreManagerSource scoreManagerSource) {
         ScoreManager<TestdataSolution, ?> scoreManager = scoreManagerSource.createScoreManager(SOLVER_FACTORY);
         assertThat(scoreManager).isNotNull();
         TestdataSolution solution = TestdataSolution.generateSolution();

--- a/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/api/score/buildin/bendablebigdecimal/BendableBigDecimalScoreTest.java
+++ b/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/api/score/buildin/bendablebigdecimal/BendableBigDecimalScoreTest.java
@@ -200,7 +200,7 @@ class BendableBigDecimalScoreTest extends AbstractScoreTest {
 
     @Test
     @Disabled("The problem of BigDecimal ^ BigDecimal.")
-    public void powerHSS() {
+    void powerHSS() {
         // .multiply(1.0) is there to get the proper BigDecimal scale
         assertThat(scoreDefinitionHSS.createScore(THREE, MINUS_FOUR, FIVE).power(2.0))
                 .isEqualTo(scoreDefinitionHSS.createScore(NINE, PLUS_16, PLUS_25));
@@ -323,7 +323,7 @@ class BendableBigDecimalScoreTest extends AbstractScoreTest {
 
     @Test
     @Disabled("The problem of BigDecimal ^ BigDecimal.")
-    public void powerHHSSS() {
+    void powerHHSSS() {
         // .multiply(1.0) is there to get the proper BigDecimal scale
         assertThat(scoreDefinitionHHSSS.createScore(THREE, MINUS_FOUR, FIVE, ZERO, ZERO).power(2.0))
                 .isEqualTo(scoreDefinitionHHSSS.createScore(NINE, PLUS_16, PLUS_25, ZERO, ZERO));

--- a/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/api/solver/SolverManagerTest.java
+++ b/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/api/solver/SolverManagerTest.java
@@ -65,7 +65,7 @@ class SolverManagerTest {
     private SolverManager<TestdataSolution, Long> solverManager;
 
     @AfterEach
-    public void closeSolverManager() {
+    void closeSolverManager() {
         if (solverManager != null) {
             solverManager.close();
         }
@@ -84,7 +84,7 @@ class SolverManagerTest {
 
     @Test
     @Timeout(60)
-    public void solveBatch_2InParallel() throws ExecutionException, InterruptedException {
+    void solveBatch_2InParallel() throws ExecutionException, InterruptedException {
         SolverConfig solverConfig = PlannerTestUtils.buildSolverConfig(TestdataSolution.class, TestdataEntity.class)
                 .withPhases(createPhaseWithConcurrentSolvingStart(2), new ConstructionHeuristicPhaseConfig());
         solverManager = SolverManager.create(
@@ -113,7 +113,7 @@ class SolverManagerTest {
 
     @Test
     @Timeout(60)
-    public void getSolverStatus() throws InterruptedException, BrokenBarrierException, ExecutionException {
+    void getSolverStatus() throws InterruptedException, BrokenBarrierException, ExecutionException {
         CyclicBarrier solverThreadReadyBarrier = new CyclicBarrier(2);
         CyclicBarrier mainThreadReadyBarrier = new CyclicBarrier(2);
         SolverConfig solverConfig = PlannerTestUtils.buildSolverConfig(TestdataSolution.class, TestdataEntity.class)
@@ -160,7 +160,7 @@ class SolverManagerTest {
 
     @Test
     @Timeout(60)
-    public void exceptionInSolver() {
+    void exceptionInSolver() {
         SolverConfig solverConfig = PlannerTestUtils.buildSolverConfig(TestdataSolution.class, TestdataEntity.class)
                 .withPhases(new CustomPhaseConfig().withCustomPhaseCommands(
                         scoreDirector -> {
@@ -183,7 +183,7 @@ class SolverManagerTest {
 
     @Test
     @Timeout(60)
-    public void exceptionInConsumer() throws InterruptedException {
+    void exceptionInConsumer() throws InterruptedException {
         SolverConfig solverConfig = PlannerTestUtils.buildSolverConfig(TestdataSolution.class, TestdataEntity.class)
                 .withPhases(new ConstructionHeuristicPhaseConfig());
         solverManager = SolverManager.create(
@@ -210,7 +210,7 @@ class SolverManagerTest {
 
     @Test
     @Timeout(60)
-    public void solveGenerics() throws ExecutionException, InterruptedException {
+    void solveGenerics() throws ExecutionException, InterruptedException {
         SolverConfig solverConfig = PlannerTestUtils
                 .buildSolverConfig(TestdataSolution.class, TestdataEntity.class);
         solverManager = SolverManager
@@ -229,7 +229,7 @@ class SolverManagerTest {
 
     @Test
     @Timeout(60)
-    public void skipAhead() throws ExecutionException, InterruptedException {
+    void skipAhead() throws ExecutionException, InterruptedException {
         CountDownLatch latch = new CountDownLatch(1);
         SolverConfig solverConfig = PlannerTestUtils.buildSolverConfig(TestdataSolution.class,
                 TestdataEntity.class)
@@ -303,7 +303,7 @@ class SolverManagerTest {
 
     @Test
     @Timeout(600)
-    public void terminateEarly() throws InterruptedException, BrokenBarrierException {
+    void terminateEarly() throws InterruptedException, BrokenBarrierException {
         CyclicBarrier startedBarrier = new CyclicBarrier(2);
         SolverConfig solverConfig = PlannerTestUtils.buildSolverConfig(TestdataSolution.class,
                 TestdataEntity.class)
@@ -367,7 +367,7 @@ class SolverManagerTest {
     @Disabled("https://issues.redhat.com/browse/PLANNER-1837")
     @Test
     @Timeout(60)
-    public void solveMultipleThreadedMovesWithSolverManager_allGetSolved() throws ExecutionException, InterruptedException {
+    void solveMultipleThreadedMovesWithSolverManager_allGetSolved() throws ExecutionException, InterruptedException {
         int processCount = Runtime.getRuntime().availableProcessors();
         SolverConfig solverConfig =
                 PlannerTestUtils.buildSolverConfig(TestdataSolution.class, TestdataEntity.class)
@@ -397,7 +397,7 @@ class SolverManagerTest {
 
     @Test
     @Timeout(60)
-    public void submitMoreProblemsThanCpus_allGetSolved() throws InterruptedException, ExecutionException {
+    void submitMoreProblemsThanCpus_allGetSolved() throws InterruptedException, ExecutionException {
         // Use twice the amount of problems than available processors.
         int problemCount = Runtime.getRuntime().availableProcessors() * 2;
 
@@ -521,7 +521,7 @@ class SolverManagerTest {
 
     @Test
     @Timeout(60)
-    public void runSameIdProcesses_throwsIllegalStateException() {
+    void runSameIdProcesses_throwsIllegalStateException() {
         SolverManagerConfig solverManagerConfig = new SolverManagerConfig();
 
         SolverConfig solverConfig = PlannerTestUtils.buildSolverConfig(TestdataSolution.class,

--- a/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/config/solver/EnvironmentModeTest.java
+++ b/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/config/solver/EnvironmentModeTest.java
@@ -66,7 +66,7 @@ class EnvironmentModeTest {
     private static TestdataSolution inputProblem;
 
     @BeforeAll
-    public static void setUpInputProblem() {
+    static void setUpInputProblem() {
         inputProblem = new TestdataSolution("s1");
         inputProblem.setValueList(Arrays.asList(new TestdataValue("v1"), new TestdataValue("v2"),
                 new TestdataValue("v3")));
@@ -92,7 +92,7 @@ class EnvironmentModeTest {
 
     @ParameterizedTest(name = "{0}")
     @EnumSource(EnvironmentMode.class)
-    public void determinism(EnvironmentMode environmentMode) {
+    void determinism(EnvironmentMode environmentMode) {
         SolverConfig solverConfig = buildSolverConfig(environmentMode);
         setSolverConfigCalculatorClass(solverConfig, TestdataDifferentValuesCalculator.class);
 
@@ -116,7 +116,7 @@ class EnvironmentModeTest {
 
     @ParameterizedTest(name = "{0}")
     @EnumSource(EnvironmentMode.class)
-    public void corruptedCustomMoves(EnvironmentMode environmentMode) {
+    void corruptedCustomMoves(EnvironmentMode environmentMode) {
         SolverConfig solverConfig = buildSolverConfig(environmentMode);
         // Intrusive modes should throw exception about corrupted undoMove
         setSolverConfigCalculatorClass(solverConfig, TestdataDifferentValuesCalculator.class);
@@ -146,7 +146,7 @@ class EnvironmentModeTest {
 
     @ParameterizedTest(name = "{0}")
     @EnumSource(EnvironmentMode.class)
-    public void corruptedConstraints(EnvironmentMode environmentMode) {
+    void corruptedConstraints(EnvironmentMode environmentMode) {
         SolverConfig solverConfig = buildSolverConfig(environmentMode);
         // For full assert modes it should throw exception about corrupted score
         setSolverConfigCalculatorClass(solverConfig, TestdataCorruptedDifferentValuesCalculator.class);

--- a/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/config/solver/SolverConfigMultiThreadedTest.java
+++ b/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/config/solver/SolverConfigMultiThreadedTest.java
@@ -35,14 +35,14 @@ class SolverConfigMultiThreadedTest {
 
     @Test
     @Timeout(5)
-    public void solvingWithTooHighThreadCountFinishes() {
+    void solvingWithTooHighThreadCountFinishes() {
         runSolvingAndVerifySolution(10, 20, "256");
     }
 
     @Disabled("PLANNER-1180")
     @Test
     @Timeout(5)
-    public void solvingOfVerySmallProblemFinishes() {
+    void solvingOfVerySmallProblemFinishes() {
         runSolvingAndVerifySolution(1, 1, "2");
     }
 
@@ -75,7 +75,7 @@ class SolverConfigMultiThreadedTest {
 
     @Test
     @Timeout(5)
-    public void customThreadFactoryClassIsUsed() {
+    void customThreadFactoryClassIsUsed() {
         SolverConfig solverConfig = PlannerTestUtils.buildSolverConfig(TestdataSolution.class,
                 TestdataEntity.class);
         solverConfig.setThreadFactoryClass(MockThreadFactory.class);

--- a/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/domain/common/accessor/gizmo/GizmoMemberAccessorFactoryTest.java
+++ b/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/domain/common/accessor/gizmo/GizmoMemberAccessorFactoryTest.java
@@ -19,12 +19,12 @@ class GizmoMemberAccessorFactoryTest {
     static ClassLoader contextClassLoader;
 
     @BeforeAll
-    public static void setContextClassLoader() {
+    static void setContextClassLoader() {
         contextClassLoader = Thread.currentThread().getContextClassLoader();
     }
 
     @BeforeEach
-    public void setup() {
+    void setup() {
         Thread.currentThread().setContextClassLoader(contextClassLoader);
     }
 

--- a/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/domain/entity/descriptor/EntityDescriptorTest.java
+++ b/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/domain/entity/descriptor/EntityDescriptorTest.java
@@ -48,7 +48,7 @@ class EntityDescriptorTest {
 
     @Test
     @Disabled // TODO FIXME PLANNER-849
-    public void extendedMovableEntitySelectionFilterUsedByParentSelector() {
+    void extendedMovableEntitySelectionFilterUsedByParentSelector() {
         ScoreDirector<TestdataExtendedPinnedSolution> scoreDirector = mock(ScoreDirector.class);
         SolutionDescriptor<TestdataExtendedPinnedSolution> solutionDescriptor =
                 TestdataExtendedPinnedSolution.buildSolutionDescriptor();

--- a/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/domain/lookup/LookUpManagerTest.java
+++ b/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/domain/lookup/LookUpManagerTest.java
@@ -30,7 +30,7 @@ class LookUpManagerTest {
     private LookUpManager lookUpManager;
 
     @BeforeEach
-    public void setUpLookUpManager() {
+    void setUpLookUpManager() {
         lookUpManager = new LookUpManager(
                 new LookUpStrategyResolver(DomainAccessType.REFLECTION, LookUpStrategyType.PLANNING_ID_OR_NONE));
     }

--- a/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/domain/lookup/LookUpStrategyEqualityTest.java
+++ b/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/domain/lookup/LookUpStrategyEqualityTest.java
@@ -33,7 +33,7 @@ class LookUpStrategyEqualityTest {
     private LookUpManager lookUpManager;
 
     @BeforeEach
-    public void setUpLookUpManager() {
+    void setUpLookUpManager() {
         lookUpManager = new LookUpManager(new LookUpStrategyResolver(DomainAccessType.REFLECTION, LookUpStrategyType.EQUALITY));
     }
 

--- a/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/domain/lookup/LookUpStrategyIdOrFailTest.java
+++ b/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/domain/lookup/LookUpStrategyIdOrFailTest.java
@@ -35,7 +35,7 @@ class LookUpStrategyIdOrFailTest {
     private LookUpManager lookUpManager;
 
     @BeforeEach
-    public void setUpLookUpManager() {
+    void setUpLookUpManager() {
         lookUpManager = new LookUpManager(
                 new LookUpStrategyResolver(DomainAccessType.REFLECTION, LookUpStrategyType.PLANNING_ID_OR_FAIL_FAST));
     }

--- a/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/domain/lookup/LookUpStrategyIdOrNoneTest.java
+++ b/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/domain/lookup/LookUpStrategyIdOrNoneTest.java
@@ -35,7 +35,7 @@ class LookUpStrategyIdOrNoneTest {
     private LookUpManager lookUpManager;
 
     @BeforeEach
-    public void setUpLookUpManager() {
+    void setUpLookUpManager() {
         lookUpManager = new LookUpManager(
                 new LookUpStrategyResolver(DomainAccessType.REFLECTION, LookUpStrategyType.PLANNING_ID_OR_NONE));
     }

--- a/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/domain/lookup/LookUpStrategyImmutableTest.java
+++ b/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/domain/lookup/LookUpStrategyImmutableTest.java
@@ -49,7 +49,7 @@ class LookUpStrategyImmutableTest {
 
     private LookUpManager lookUpManager;
 
-    public static Stream<Arguments> data() {
+    static Stream<Arguments> data() {
         return Stream.of(
                 arguments(true, true),
                 arguments((byte) 1, (byte) 1),
@@ -83,26 +83,26 @@ class LookUpStrategyImmutableTest {
     }
 
     @BeforeEach
-    public void setUpLookUpManager() {
+    void setUpLookUpManager() {
         lookUpManager = new LookUpManager(
                 new LookUpStrategyResolver(DomainAccessType.REFLECTION, LookUpStrategyType.PLANNING_ID_OR_NONE));
     }
 
     @ParameterizedTest(name = "{index}: {0}")
     @MethodSource("data")
-    public void addImmutable(Object internalObject) {
+    void addImmutable(Object internalObject) {
         lookUpManager.addWorkingObject(internalObject);
     }
 
     @ParameterizedTest(name = "{index}: {0}")
     @MethodSource("data")
-    public void removeImmutable(Object internalObject) {
+    void removeImmutable(Object internalObject) {
         lookUpManager.removeWorkingObject(internalObject);
     }
 
     @ParameterizedTest(name = "{index}: {0}")
     @MethodSource("data")
-    public void lookUpImmutable(Object internalObject, Object externalObject) {
+    void lookUpImmutable(Object internalObject, Object externalObject) {
         assertThat(lookUpManager.lookUpWorkingObject(externalObject)).isEqualTo(internalObject);
     }
 

--- a/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/domain/lookup/LookUpStrategyNoneTest.java
+++ b/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/domain/lookup/LookUpStrategyNoneTest.java
@@ -31,7 +31,7 @@ class LookUpStrategyNoneTest {
     private LookUpManager lookUpManager;
 
     @BeforeEach
-    public void setUpLookUpManager() {
+    void setUpLookUpManager() {
         lookUpManager = new LookUpManager(new LookUpStrategyResolver(DomainAccessType.REFLECTION, LookUpStrategyType.NONE));
     }
 

--- a/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/exhaustivesearch/BlackBoxExhaustiveSearchPhaseTest.java
+++ b/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/exhaustivesearch/BlackBoxExhaustiveSearchPhaseTest.java
@@ -74,7 +74,7 @@ class BlackBoxExhaustiveSearchPhaseTest {
      *
      * @return collection of combination of input parameters
      */
-    public static Collection<Object[]> params() {
+    static Collection<Object[]> params() {
         return Stream.concat(getBranchAndBoundConfigs(), getBruteForceConfigs()).collect(Collectors.toList());
     }
 
@@ -413,7 +413,7 @@ class BlackBoxExhaustiveSearchPhaseTest {
 
     @ParameterizedTest(name = "{0}, NodeExplorationType-{1}, EntitySorterManner-{2}, ValueSorterManner-{3}")
     @MethodSource("params")
-    public void verifyExhaustiveSearchSteps(
+    void verifyExhaustiveSearchSteps(
             ExhaustiveSearchType exhaustiveSearchType,
             NodeExplorationType nodeExplorationType,
             EntitySorterManner entitySorterManner,
@@ -470,8 +470,7 @@ class BlackBoxExhaustiveSearchPhaseTest {
         }
     }
 
-    public static class TestdataSolutionStateRecorder
-            extends PhaseLifecycleListenerAdapter<TestdataDifficultyComparingSolution> {
+    static class TestdataSolutionStateRecorder extends PhaseLifecycleListenerAdapter<TestdataDifficultyComparingSolution> {
 
         private final List<String> workingSolutions = new ArrayList<>();
 
@@ -492,7 +491,7 @@ class BlackBoxExhaustiveSearchPhaseTest {
                     .collect(Collectors.joining()));
         }
 
-        public List<String> getWorkingSolutions() {
+        List<String> getWorkingSolutions() {
             return workingSolutions;
         }
     }

--- a/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/heuristic/selector/move/generic/chained/KOptMoveTest.java
+++ b/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/heuristic/selector/move/generic/chained/KOptMoveTest.java
@@ -191,7 +191,7 @@ class KOptMoveTest {
 
     @Test
     @Disabled("Valid 1 chain moves aren't supported yet") // TODO
-    public void doMove3OptWithOnly1Chain() {
+    void doMove3OptWithOnly1Chain() {
         GenuineVariableDescriptor<TestdataChainedSolution> variableDescriptor = TestdataChainedEntity
                 .buildVariableDescriptorForChainedObject();
         SolutionDescriptor<TestdataChainedSolution> solutionDescriptor = variableDescriptor.getEntityDescriptor()
@@ -258,7 +258,7 @@ class KOptMoveTest {
 
     @Test
     @Disabled("https://issues.redhat.com/browse/PLANNER-1250") // TODO https://issues.redhat.com/browse/PLANNER-1250
-    public void rebase() {
+    void rebase() {
         GenuineVariableDescriptor<TestdataChainedSolution> variableDescriptor = TestdataChainedEntity
                 .buildVariableDescriptorForChainedObject();
 
@@ -299,7 +299,7 @@ class KOptMoveTest {
                         .rebase(destinationScoreDirector));
     }
 
-    public void assertSameProperties(Object leftEntity, Iterable<Object> values, KOptMove<TestdataChainedSolution> move) {
+    void assertSameProperties(Object leftEntity, Iterable<Object> values, KOptMove<TestdataChainedSolution> move) {
         assertThat(move.getEntity()).isSameAs(leftEntity);
         assertThat(move.getValues()).hasSameElementsAs(values);
     }

--- a/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/heuristic/thread/OrderByMoveIndexBlockingQueueTest.java
+++ b/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/heuristic/thread/OrderByMoveIndexBlockingQueueTest.java
@@ -41,7 +41,7 @@ class OrderByMoveIndexBlockingQueueTest {
     private final ExecutorService executorService = Executors.newFixedThreadPool(2);
 
     @AfterEach
-    public void tearDown() throws InterruptedException {
+    void tearDown() throws InterruptedException {
         executorService.shutdownNow();
         if (!executorService.awaitTermination(1, TimeUnit.MILLISECONDS)) {
             LOGGER.warn("Thread pool didn't terminate within the timeout.");

--- a/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/partitionedsearch/DefaultPartitionedSearchPhaseTest.java
+++ b/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/partitionedsearch/DefaultPartitionedSearchPhaseTest.java
@@ -55,17 +55,17 @@ class DefaultPartitionedSearchPhaseTest {
 
     @Test
     @Timeout(5)
-    public void partCount() {
+    void partCount() {
         partCount(SolverConfig.MOVE_THREAD_COUNT_NONE);
     }
 
     @Test
     @Timeout(5)
-    public void partCountAndMoveThreadCount() {
+    void partCountAndMoveThreadCount() {
         partCount("2");
     }
 
-    public void partCount(String moveThreadCount) {
+    void partCount(String moveThreadCount) {
         final int partSize = 3;
         final int partCount = 7;
         SolverFactory<TestdataSolution> solverFactory = createSolverFactory(false, moveThreadCount, partSize);
@@ -114,7 +114,7 @@ class DefaultPartitionedSearchPhaseTest {
 
     @Test
     @Timeout(5)
-    public void exceptionPropagation() {
+    void exceptionPropagation() {
         final int partSize = 7;
         final int partCount = 3;
 
@@ -133,7 +133,7 @@ class DefaultPartitionedSearchPhaseTest {
 
     @Test
     @Timeout(5)
-    public void terminateEarly() throws InterruptedException, ExecutionException {
+    void terminateEarly() throws InterruptedException, ExecutionException {
         final int partSize = 1;
         final int partCount = 2;
 
@@ -167,7 +167,7 @@ class DefaultPartitionedSearchPhaseTest {
     @Disabled("PLANNER-2249")
     @Test
     @Timeout(5)
-    public void shutdownMainThreadAbruptly() throws InterruptedException {
+    void shutdownMainThreadAbruptly() throws InterruptedException {
         final int partSize = 5;
         final int partCount = 3;
 

--- a/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/partitionedsearch/queue/PartitionQueueTest.java
+++ b/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/partitionedsearch/queue/PartitionQueueTest.java
@@ -39,7 +39,7 @@ class PartitionQueueTest {
     private final ExecutorService executorService = Executors.newFixedThreadPool(2);
 
     @AfterEach
-    public void tearDown() throws InterruptedException {
+    void tearDown() throws InterruptedException {
         executorService.shutdownNow();
         if (!executorService.awaitTermination(1, TimeUnit.MILLISECONDS)) {
             LOGGER.warn("Thread pool didn't terminate within the timeout.");
@@ -143,7 +143,7 @@ class PartitionQueueTest {
         assertThatIllegalStateException().isThrownBy(it::hasNext).withCause(exception);
     }
 
-    public PartitionChangeMove<TestdataSolution> buildMove() {
+    PartitionChangeMove<TestdataSolution> buildMove() {
         return new PartitionChangeMove<>(null, -1);
     }
 

--- a/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/score/comparator/FlatteningHardSoftScoreComparatorTest.java
+++ b/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/score/comparator/FlatteningHardSoftScoreComparatorTest.java
@@ -27,7 +27,7 @@ import org.optaplanner.core.impl.score.buildin.HardSoftScoreDefinition;
 
 class FlatteningHardSoftScoreComparatorTest {
 
-    public static Collection parameters() {
+    static Collection parameters() {
         String simpleScore = "10hard/123soft";
         String lowHardScore = "10hard/987654321soft";
         String highHardScore = "987654321hard/123soft";
@@ -55,7 +55,7 @@ class FlatteningHardSoftScoreComparatorTest {
 
     @ParameterizedTest(name = "{index}: {0}")
     @MethodSource("parameters")
-    public void compare(int expectedResult, int modifier, String firstScore, String secondScore) {
+    void compare(int expectedResult, int modifier, String firstScore, String secondScore) {
         assertThat(new FlatteningHardSoftScoreComparator(modifier)
                 .compare(new HardSoftScoreDefinition().parseScore(firstScore),
                         new HardSoftScoreDefinition().parseScore(secondScore))).isEqualTo(expectedResult);

--- a/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/solver/DefaultSolverTest.java
+++ b/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/solver/DefaultSolverTest.java
@@ -88,7 +88,7 @@ import io.micrometer.core.instrument.Tags;
 class DefaultSolverTest {
 
     @BeforeEach
-    public void resetGlobalRegistry() {
+    void resetGlobalRegistry() {
         Metrics.globalRegistry.clear();
     }
 
@@ -487,7 +487,7 @@ class DefaultSolverTest {
                 .isEqualTo(3);
     }
 
-    public static class ErrorThowingEasyScoreCalculator implements EasyScoreCalculator<TestdataSolution, SimpleScore> {
+    public static class ErrorThrowingEasyScoreCalculator implements EasyScoreCalculator<TestdataSolution, SimpleScore> {
 
         @Override
         public SimpleScore calculateScore(TestdataSolution testdataSolution) {
@@ -504,7 +504,7 @@ class DefaultSolverTest {
                 TestdataSolution.class, TestdataEntity.class);
 
         solverConfig.setScoreDirectorFactoryConfig(
-                new ScoreDirectorFactoryConfig().withEasyScoreCalculatorClass(ErrorThowingEasyScoreCalculator.class));
+                new ScoreDirectorFactoryConfig().withEasyScoreCalculatorClass(ErrorThrowingEasyScoreCalculator.class));
         SolverFactory<TestdataSolution> solverFactory = SolverFactory.create(solverConfig);
 
         Solver<TestdataSolution> solver = solverFactory.buildSolver();
@@ -566,7 +566,7 @@ class DefaultSolverTest {
     // TODO https://issues.redhat.com/browse/PLANNER-1738
     @Test
     @Disabled("We currently don't support an empty value list yet if the entity list is not empty.")
-    public void solveEmptyValueList() {
+    void solveEmptyValueList() {
         SolverConfig solverConfig = PlannerTestUtils.buildSolverConfig(TestdataSolution.class, TestdataEntity.class);
         SolverFactory<TestdataSolution> solverFactory = SolverFactory.create(solverConfig);
         Solver<TestdataSolution> solver = solverFactory.buildSolver();
@@ -582,7 +582,7 @@ class DefaultSolverTest {
 
     @Test
     @Disabled("We currently don't support an empty value list yet if the entity list is not empty.")
-    public void solveChainedEmptyValueList() {
+    void solveChainedEmptyValueList() {
         SolverConfig solverConfig = PlannerTestUtils.buildSolverConfig(TestdataChainedSolution.class,
                 TestdataChainedEntity.class);
         SolverFactory<TestdataChainedSolution> solverFactory = SolverFactory.create(solverConfig);
@@ -676,7 +676,7 @@ class DefaultSolverTest {
 
     @Test
     @Timeout(60)
-    public void solveWithProblemChange() throws InterruptedException {
+    void solveWithProblemChange() throws InterruptedException {
         SolverConfig solverConfig = PlannerTestUtils.buildSolverConfig(TestdataSolution.class, TestdataEntity.class);
         solverConfig.setDaemon(true); // Avoid terminating the solver too quickly.
         SolverFactory<TestdataSolution> solverFactory = SolverFactory.create(solverConfig);

--- a/optaplanner-benchmark/src/test/java/org/optaplanner/benchmark/config/ProblemBenchmarksConfigTest.java
+++ b/optaplanner-benchmark/src/test/java/org/optaplanner/benchmark/config/ProblemBenchmarksConfigTest.java
@@ -25,10 +25,10 @@ import org.junit.jupiter.api.Test;
 import org.optaplanner.benchmark.config.statistic.ProblemStatisticType;
 import org.optaplanner.benchmark.config.statistic.SingleStatisticType;
 
-public class ProblemBenchmarksConfigTest {
+class ProblemBenchmarksConfigTest {
 
     @Test
-    public void testDetermineProblemStatisticTypeList() {
+    void testDetermineProblemStatisticTypeList() {
         ProblemBenchmarksConfig problemBenchmarksConfig = new ProblemBenchmarksConfig();
         assertThat(problemBenchmarksConfig.determineProblemStatisticTypeList())
                 .isEqualTo(ProblemStatisticType.defaultList());
@@ -52,7 +52,7 @@ public class ProblemBenchmarksConfigTest {
     }
 
     @Test
-    public void testDetermineSingleStatisticTypeList() {
+    void testDetermineSingleStatisticTypeList() {
         ProblemBenchmarksConfig problemBenchmarksConfig = new ProblemBenchmarksConfig();
         assertThat(problemBenchmarksConfig.determineSingleStatisticTypeList()).isEqualTo(Collections.emptyList());
         problemBenchmarksConfig.setSingleStatisticTypeList(Collections.emptyList());

--- a/optaplanner-benchmark/src/test/java/org/optaplanner/benchmark/impl/ranking/TotalRankSolverRankingWeightFactoryTest.java
+++ b/optaplanner-benchmark/src/test/java/org/optaplanner/benchmark/impl/ranking/TotalRankSolverRankingWeightFactoryTest.java
@@ -43,7 +43,7 @@ class TotalRankSolverRankingWeightFactoryTest extends AbstractSolverRankingCompa
     private List<SingleBenchmarkResult> bSingleBenchmarkResultList;
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         benchmarkReport = mock(BenchmarkReport.class);
         factory = new TotalRankSolverRankingWeightFactory();
         solverBenchmarkResultList = new ArrayList<>();

--- a/optaplanner-benchmark/src/test/java/org/optaplanner/benchmark/impl/ranking/TotalScoreSolverRankingComparatorTest.java
+++ b/optaplanner-benchmark/src/test/java/org/optaplanner/benchmark/impl/ranking/TotalScoreSolverRankingComparatorTest.java
@@ -41,7 +41,7 @@ class TotalScoreSolverRankingComparatorTest extends AbstractSolverRankingCompara
     private List<SingleBenchmarkResult> bSingleBenchmarkResultList;
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         benchmarkReport = mock(BenchmarkReport.class);
         comparator = new TotalScoreSolverRankingComparator();
         a = new SolverBenchmarkResult(null);

--- a/optaplanner-benchmark/src/test/java/org/optaplanner/benchmark/impl/ranking/WorstScoreSolverRankingComparatorTest.java
+++ b/optaplanner-benchmark/src/test/java/org/optaplanner/benchmark/impl/ranking/WorstScoreSolverRankingComparatorTest.java
@@ -41,7 +41,7 @@ class WorstScoreSolverRankingComparatorTest extends AbstractSolverRankingCompara
     private List<SingleBenchmarkResult> bSingleBenchmarkResultList;
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         benchmarkReport = mock(BenchmarkReport.class);
         comparator = new WorstScoreSolverRankingComparator();
         a = new SolverBenchmarkResult(null);

--- a/optaplanner-examples/src/test/java/org/optaplanner/examples/cloudbalancing/app/CloudBalancingDaemonTest.java
+++ b/optaplanner-examples/src/test/java/org/optaplanner/examples/cloudbalancing/app/CloudBalancingDaemonTest.java
@@ -54,7 +54,7 @@ class CloudBalancingDaemonTest extends LoggingTest {
     @Disabled("PLANNER-2249")
     @Test
     @Timeout(600)
-    public void daemon() throws InterruptedException {
+    void daemon() throws InterruptedException {
         // In main thread
         Solver<CloudBalance> solver = buildSolver();
         CloudBalance cloudBalance = buildProblem(4, 12);

--- a/optaplanner-examples/src/test/java/org/optaplanner/examples/conferencescheduling/optional/score/ConferenceSchedulingConstraintsXlsxTest.java
+++ b/optaplanner-examples/src/test/java/org/optaplanner/examples/conferencescheduling/optional/score/ConferenceSchedulingConstraintsXlsxTest.java
@@ -60,7 +60,7 @@ import org.optaplanner.test.impl.score.buildin.hardmediumsoft.HardMediumSoftScor
 
 class ConferenceSchedulingConstraintsXlsxTest {
 
-    public static Collection<Object[]> testSheetParameters() {
+    static Collection<Object[]> testSheetParameters() {
         File testFile = new File(ConferenceSchedulingConstraintsXlsxTest.class.getResource(testFileName).getFile());
         try (InputStream in = new BufferedInputStream(new FileInputStream(testFile))) {
             XSSFWorkbook workbook = new XSSFWorkbook(in);
@@ -93,7 +93,7 @@ class ConferenceSchedulingConstraintsXlsxTest {
 
     @ParameterizedTest(name = "{4}")
     @MethodSource("testSheetParameters")
-    public void constraints(String constraintPackage, String constraintName,
+    void constraints(String constraintPackage, String constraintName,
             HardMediumSoftScore expectedScore, ConferenceSolution solution, String testSheetName) {
         SCORE_VERIFIER.assertHardWeight(constraintPackage, constraintName, expectedScore.getHardScore(), solution);
         SCORE_VERIFIER.assertMediumWeight(constraintPackage, constraintName, expectedScore.getMediumScore(), solution);

--- a/optaplanner-examples/src/test/java/org/optaplanner/examples/nqueens/optional/benchmark/BrokenNQueensBenchmarkTest.java
+++ b/optaplanner-examples/src/test/java/org/optaplanner/examples/nqueens/optional/benchmark/BrokenNQueensBenchmarkTest.java
@@ -33,7 +33,7 @@ import org.optaplanner.persistence.xstream.impl.domain.solution.XStreamSolutionF
 
 class BrokenNQueensBenchmarkTest extends PlannerBenchmarkTest {
 
-    public BrokenNQueensBenchmarkTest() {
+    BrokenNQueensBenchmarkTest() {
         super(NQueensApp.SOLVER_CONFIG);
     }
 
@@ -43,7 +43,7 @@ class BrokenNQueensBenchmarkTest extends PlannerBenchmarkTest {
 
     @Test
     @Timeout(100)
-    public void benchmarkBroken8queens() {
+    void benchmarkBroken8queens() {
         NQueens problem = new XStreamSolutionFileIO<NQueens>(NQueens.class)
                 .read(new File("data/nqueens/unsolved/8queens.xml"));
         PlannerBenchmarkConfig benchmarkConfig = buildPlannerBenchmarkConfig();

--- a/optaplanner-examples/src/test/java/org/optaplanner/examples/nqueens/optional/benchmark/NQueensBenchmarkTest.java
+++ b/optaplanner-examples/src/test/java/org/optaplanner/examples/nqueens/optional/benchmark/NQueensBenchmarkTest.java
@@ -35,7 +35,7 @@ import org.optaplanner.persistence.xstream.impl.domain.solution.XStreamSolutionF
 
 class NQueensBenchmarkTest extends PlannerBenchmarkTest {
 
-    public NQueensBenchmarkTest() {
+    NQueensBenchmarkTest() {
         super(NQueensApp.SOLVER_CONFIG);
     }
 
@@ -44,7 +44,7 @@ class NQueensBenchmarkTest extends PlannerBenchmarkTest {
     // ************************************************************************
 
     @Timeout(600)
-    public void benchmark64queens() {
+    void benchmark64queens() {
         NQueens problem = new XStreamSolutionFileIO<NQueens>(NQueens.class)
                 .read(new File("data/nqueens/unsolved/64queens.xml"));
         PlannerBenchmarkConfig benchmarkConfig = buildPlannerBenchmarkConfig();
@@ -56,7 +56,7 @@ class NQueensBenchmarkTest extends PlannerBenchmarkTest {
 
     @Test
     @Timeout(600)
-    public void benchmark64queensSingleThread() {
+    void benchmark64queensSingleThread() {
         NQueens problem = new XStreamSolutionFileIO<NQueens>(NQueens.class)
                 .read(new File("data/nqueens/unsolved/64queens.xml"));
         PlannerBenchmarkConfig benchmarkConfig = buildPlannerBenchmarkConfig();

--- a/optaplanner-examples/src/test/java/org/optaplanner/examples/nqueens/optional/solver/tracking/NQueensConstructionHeuristicTrackingTest.java
+++ b/optaplanner-examples/src/test/java/org/optaplanner/examples/nqueens/optional/solver/tracking/NQueensConstructionHeuristicTrackingTest.java
@@ -41,7 +41,7 @@ class NQueensConstructionHeuristicTrackingTest extends NQueensAbstractTrackingTe
 
     @ParameterizedTest(name = "ConstructionHeuristicType: {0}, EntitySorterManner: {1}, ValueSorterManner: {2}")
     @MethodSource("parameters")
-    public void trackConstructionHeuristics(ConstructionHeuristicType constructionHeuristicType,
+    void trackConstructionHeuristics(ConstructionHeuristicType constructionHeuristicType,
             EntitySorterManner entitySorterManner, ValueSorterManner valueSorterManner,
             List<NQueensStepTracking> expectedCoordinates) {
         SolverConfig solverConfig = SolverConfig.createFromXmlResource(NQueensApp.SOLVER_CONFIG);
@@ -65,7 +65,7 @@ class NQueensConstructionHeuristicTrackingTest extends NQueensAbstractTrackingTe
         assertTrackingList(expectedCoordinates, listener.getTrackingList());
     }
 
-    public static Collection<Object[]> parameters() {
+    static Collection<Object[]> parameters() {
         Collection<Object[]> params = new ArrayList<>();
 
         params.add(new Object[] { ConstructionHeuristicType.FIRST_FIT, null, null, Arrays.asList(

--- a/optaplanner-examples/src/test/java/org/optaplanner/examples/nqueens/optional/solver/tracking/NQueensLocalSearchTrackingTest.java
+++ b/optaplanner-examples/src/test/java/org/optaplanner/examples/nqueens/optional/solver/tracking/NQueensLocalSearchTrackingTest.java
@@ -45,7 +45,7 @@ class NQueensLocalSearchTrackingTest extends NQueensAbstractTrackingTest {
 
     @ParameterizedTest(name = "AcceptorType: {0}")
     @MethodSource("parameters")
-    public void trackLocalSearch(LocalSearchAcceptorConfig acceptorConfig,
+    void trackLocalSearch(LocalSearchAcceptorConfig acceptorConfig,
             LocalSearchForagerConfig localSearchForagerConfig,
             List<NQueensStepTracking> expectedCoordinates) {
         SolverConfig solverConfig = SolverConfig.createFromXmlResource(NQueensApp.SOLVER_CONFIG);
@@ -72,7 +72,7 @@ class NQueensLocalSearchTrackingTest extends NQueensAbstractTrackingTest {
         assertTrackingList(expectedCoordinates, listener.getTrackingList());
     }
 
-    public static Collection<Object[]> parameters() {
+    static Collection<Object[]> parameters() {
         Collection<Object[]> params = new ArrayList<>();
 
         params.add(new Object[] {

--- a/optaplanner-examples/src/test/java/org/optaplanner/examples/nurserostering/score/NurseRosteringConstraintProviderTest.java
+++ b/optaplanner-examples/src/test/java/org/optaplanner/examples/nurserostering/score/NurseRosteringConstraintProviderTest.java
@@ -64,7 +64,7 @@ class NurseRosteringConstraintProviderTest {
     private final ShiftType nightShiftType = new ShiftType();
 
     @BeforeEach
-    public void setup() {
+    void setup() {
         idSupplier.set(0);
         indexShiftTypePairToShiftMap.clear();
         indexToShiftDateMap.clear();

--- a/optaplanner-examples/src/test/java/org/optaplanner/examples/pas/score/PatientAdmissionScheduleConstraintProviderTest.java
+++ b/optaplanner-examples/src/test/java/org/optaplanner/examples/pas/score/PatientAdmissionScheduleConstraintProviderTest.java
@@ -82,7 +82,7 @@ class PatientAdmissionScheduleConstraintProviderTest {
 
     @ParameterizedTest
     @MethodSource("genderLimitationsProvider")
-    public void genderRoomLimitationConstraintTest(Gender gender, GenderLimitation genderLimitation,
+    void genderRoomLimitationConstraintTest(Gender gender, GenderLimitation genderLimitation,
             BiFunction constraintFunction) {
 
         Room room = new Room();
@@ -120,7 +120,7 @@ class PatientAdmissionScheduleConstraintProviderTest {
 
     @ParameterizedTest
     @MethodSource("departmentAgeLimitationProvider")
-    public void departmentAgeLimitationConstraintTest(Department department, int patientAge, BiFunction constraintFunction) {
+    void departmentAgeLimitationConstraintTest(Department department, int patientAge, BiFunction constraintFunction) {
 
         Room room = new Room();
         room.setDepartment(department);

--- a/optaplanner-examples/src/test/java/org/optaplanner/examples/vehiclerouting/app/VehicleRoutingMultiThreadedReproducibilityTest.java
+++ b/optaplanner-examples/src/test/java/org/optaplanner/examples/vehiclerouting/app/VehicleRoutingMultiThreadedReproducibilityTest.java
@@ -54,7 +54,7 @@ class VehicleRoutingMultiThreadedReproducibilityTest {
     private SolverFactory<VehicleRoutingSolution> solverFactory;
 
     @BeforeEach
-    public void createUninitializedSolutions() {
+    void createUninitializedSolutions() {
         final VehicleRoutingImporter importer = new VehicleRoutingImporter();
         for (int i = 0; i < REPETITION_COUNT; i++) {
             File dataSetFile = new File(CommonApp.determineDataDir(vehicleRoutingApp.getDataDirName()), DATA_SET);
@@ -75,7 +75,7 @@ class VehicleRoutingMultiThreadedReproducibilityTest {
     }
 
     @TurtleTest
-    public void multiThreadedSolvingIsReproducible() {
+    void multiThreadedSolvingIsReproducible() {
         IntStream.range(0, REPETITION_COUNT).forEach(this::solveAndCompareWithPrevious);
     }
 

--- a/optaplanner-persistence/optaplanner-persistence-jackson/src/test/java/org/optaplanner/persistence/jackson/impl/domain/solution/JacksonSolutionFileIOTest.java
+++ b/optaplanner-persistence/optaplanner-persistence-jackson/src/test/java/org/optaplanner/persistence/jackson/impl/domain/solution/JacksonSolutionFileIOTest.java
@@ -35,7 +35,7 @@ class JacksonSolutionFileIOTest {
     private static File solutionTestDir;
 
     @BeforeAll
-    public static void setup() {
+    static void setup() {
         solutionTestDir = new File("target/solutionTest/");
         solutionTestDir.mkdirs();
     }

--- a/optaplanner-persistence/optaplanner-persistence-xstream/src/test/java/org/optaplanner/persistence/xstream/impl/domain/solution/XStreamSolutionFileIOTest.java
+++ b/optaplanner-persistence/optaplanner-persistence-xstream/src/test/java/org/optaplanner/persistence/xstream/impl/domain/solution/XStreamSolutionFileIOTest.java
@@ -37,7 +37,7 @@ class XStreamSolutionFileIOTest {
     private static File solutionTestDir;
 
     @BeforeAll
-    public static void setup() {
+    static void setup() {
         solutionTestDir = new File("target/solutionTest/");
         solutionTestDir.mkdirs();
     }

--- a/optaplanner-quarkus-integration/optaplanner-quarkus-benchmark/integration-test/src/test/java/org/optaplanner/quarkus/benchmark/it/OptaPlannerBenchmarkTestResourceTest.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus-benchmark/integration-test/src/test/java/org/optaplanner/quarkus/benchmark/it/OptaPlannerBenchmarkTestResourceTest.java
@@ -36,7 +36,7 @@ class OptaPlannerBenchmarkTestResourceTest {
 
     @Test
     @Timeout(600)
-    public void benchmark() throws Exception {
+    void benchmark() throws Exception {
         String benchmarkResultDirectory = RestAssured.given()
                 .header("Content-Type", "text/plain;charset=UTF-8")
                 .when()

--- a/optaplanner-quarkus-integration/optaplanner-quarkus-jackson/integration-test/src/test/java/org/optaplanner/quarkus/jackson/it/OptaPlannerTestResourceTest.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus-jackson/integration-test/src/test/java/org/optaplanner/quarkus/jackson/it/OptaPlannerTestResourceTest.java
@@ -33,7 +33,7 @@ class OptaPlannerTestResourceTest {
 
     @Test
     @Timeout(600)
-    public void solveWithSolverFactory() throws Exception {
+    void solveWithSolverFactory() throws Exception {
         RestAssured.given()
                 .header("Content-Type", "application/json")
                 .when()

--- a/optaplanner-quarkus-integration/optaplanner-quarkus-jsonb/integration-test/src/test/java/org/optaplanner/quarkus/jsonb/it/OptaPlannerTestResourceTest.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus-jsonb/integration-test/src/test/java/org/optaplanner/quarkus/jsonb/it/OptaPlannerTestResourceTest.java
@@ -32,7 +32,7 @@ class OptaPlannerTestResourceTest {
 
     @Test
     @Timeout(600)
-    public void solveWithSolverFactory() throws Exception {
+    void solveWithSolverFactory() throws Exception {
         RestAssured.given()
                 .header("Content-Type", "application/json")
                 .when()

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/drl-integration-test/src/test/java/org/optaplanner/quarkus/drl/it/OptaPlannerTestResourceTest.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/drl-integration-test/src/test/java/org/optaplanner/quarkus/drl/it/OptaPlannerTestResourceTest.java
@@ -35,7 +35,7 @@ class OptaPlannerTestResourceTest {
 
     @Test
     @Timeout(600)
-    public void solveWithSolverFactory() throws Exception {
+    void solveWithSolverFactory() throws Exception {
         Properties result = new Properties();
         result.load(new StringReader(RestAssured.given()
                 .header("Content-Type", "application/json")

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/integration-test/src/test/java/org/optaplanner/quarkus/it/OptaPlannerTestResourceTest.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/integration-test/src/test/java/org/optaplanner/quarkus/it/OptaPlannerTestResourceTest.java
@@ -33,7 +33,7 @@ class OptaPlannerTestResourceTest {
 
     @Test
     @Timeout(600)
-    public void solveWithSolverFactory() throws Exception {
+    void solveWithSolverFactory() throws Exception {
         RestAssured.given()
                 .header("Content-Type", "application/json")
                 .when()


### PR DESCRIPTION

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>specific pull request build</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] tests</b>
* for a <b>full downstream build</b> 
  * for <b>jenkins</b> job: please add comment: <b>Jenkins run fdb</b>
  * for <b>github actions</b> job: add the label `run_fdb`
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
* for a <b>Quarkus LTS check</b> please add comment: <b>Jenkins run LTS</b>
* for a <b>specific Quarkus LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] LTS</b>
* for a <b>Native check</b> please add comment: <b>Jenkins run native</b>
* for a <b>specific Native LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] native</b>
</details>
