### PR TITLE
Set default phase list for problems with multiple genuine entities

### DIFF
--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/AbstractFromConfigFactory.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/AbstractFromConfigFactory.java
@@ -23,9 +23,13 @@ import java.util.stream.Collectors;
 
 import org.optaplanner.core.api.domain.solution.PlanningSolution;
 import org.optaplanner.core.config.AbstractConfig;
+import org.optaplanner.core.config.heuristic.selector.common.SelectionCacheType;
+import org.optaplanner.core.config.heuristic.selector.common.SelectionOrder;
+import org.optaplanner.core.config.heuristic.selector.entity.EntitySelectorConfig;
 import org.optaplanner.core.impl.domain.entity.descriptor.EntityDescriptor;
 import org.optaplanner.core.impl.domain.solution.descriptor.SolutionDescriptor;
 import org.optaplanner.core.impl.domain.variable.descriptor.GenuineVariableDescriptor;
+import org.optaplanner.core.impl.heuristic.HeuristicConfigPolicy;
 
 public abstract class AbstractFromConfigFactory<Solution_, Config_ extends AbstractConfig<Config_>> {
 
@@ -33,6 +37,20 @@ public abstract class AbstractFromConfigFactory<Solution_, Config_ extends Abstr
 
     public AbstractFromConfigFactory(Config_ config) {
         this.config = config;
+    }
+
+    public static <Solution_> EntitySelectorConfig getDefaultEntitySelectorConfigForEntity(
+            HeuristicConfigPolicy<Solution_> configPolicy, EntityDescriptor<Solution_> entityDescriptor) {
+        EntitySelectorConfig entitySelectorConfig = new EntitySelectorConfig();
+        Class<?> entityClass = entityDescriptor.getEntityClass();
+        entitySelectorConfig.setId(entityClass.getName());
+        entitySelectorConfig.setEntityClass(entityClass);
+        if (EntitySelectorConfig.hasSorter(configPolicy.getEntitySorterManner(), entityDescriptor)) {
+            entitySelectorConfig.setCacheType(SelectionCacheType.PHASE);
+            entitySelectorConfig.setSelectionOrder(SelectionOrder.SORTED);
+            entitySelectorConfig.setSorterManner(configPolicy.getEntitySorterManner());
+        }
+        return entitySelectorConfig;
     }
 
     protected EntityDescriptor<Solution_> deduceEntityDescriptor(SolutionDescriptor<Solution_> solutionDescriptor,

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/constructionheuristic/DefaultConstructionHeuristicPhaseFactory.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/constructionheuristic/DefaultConstructionHeuristicPhaseFactory.java
@@ -157,7 +157,7 @@ public class DefaultConstructionHeuristicPhaseFactory<Solution_>
         }
     }
 
-    private static EntityPlacerConfig buildListVariableQueuedValuePlacerConfig(
+    public static EntityPlacerConfig buildListVariableQueuedValuePlacerConfig(
             HeuristicConfigPolicy<?> configPolicy,
             ListVariableDescriptor<?> variableDescriptor) {
         String mimicSelectorId = variableDescriptor.getVariableName();

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/constructionheuristic/placer/PooledEntityPlacerFactory.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/constructionheuristic/placer/PooledEntityPlacerFactory.java
@@ -26,6 +26,7 @@ import org.optaplanner.core.config.heuristic.selector.entity.EntitySelectorConfi
 import org.optaplanner.core.config.heuristic.selector.move.MoveSelectorConfig;
 import org.optaplanner.core.config.heuristic.selector.move.composite.CartesianProductMoveSelectorConfig;
 import org.optaplanner.core.config.heuristic.selector.move.generic.ChangeMoveSelectorConfig;
+import org.optaplanner.core.impl.AbstractFromConfigFactory;
 import org.optaplanner.core.impl.domain.entity.descriptor.EntityDescriptor;
 import org.optaplanner.core.impl.domain.variable.descriptor.GenuineVariableDescriptor;
 import org.optaplanner.core.impl.heuristic.HeuristicConfigPolicy;
@@ -63,27 +64,14 @@ public class PooledEntityPlacerFactory<Solution_>
             if (entitySelectorConfig == null) {
                 EntityDescriptor<Solution_> entityDescriptor = new PooledEntityPlacerFactory<Solution_>(config)
                         .deduceEntityDescriptor(configPolicy.getSolutionDescriptor());
-                entitySelectorConfig = buildEntitySelectorConfig(configPolicy, entityDescriptor);
+                entitySelectorConfig =
+                        AbstractFromConfigFactory.getDefaultEntitySelectorConfigForEntity(configPolicy, entityDescriptor);
                 changeMoveSelectorConfig.setEntitySelectorConfig(entitySelectorConfig);
             }
             changeMoveSelectorConfig.setEntitySelectorConfig(
                     EntitySelectorConfig.newMimicSelectorConfig(entitySelectorConfig.getId()));
         }
         return config;
-    }
-
-    private static <Solution_> EntitySelectorConfig buildEntitySelectorConfig(
-            HeuristicConfigPolicy<Solution_> configPolicy, EntityDescriptor<Solution_> entityDescriptor) {
-        EntitySelectorConfig entitySelectorConfig = new EntitySelectorConfig();
-        Class<?> entityClass = entityDescriptor.getEntityClass();
-        entitySelectorConfig.setId(entityClass.getName());
-        entitySelectorConfig.setEntityClass(entityClass);
-        if (EntitySelectorConfig.hasSorter(configPolicy.getEntitySorterManner(), entityDescriptor)) {
-            entitySelectorConfig.setCacheType(SelectionCacheType.PHASE);
-            entitySelectorConfig.setSelectionOrder(SelectionOrder.SORTED);
-            entitySelectorConfig.setSorterManner(configPolicy.getEntitySorterManner());
-        }
-        return entitySelectorConfig;
     }
 
     public PooledEntityPlacerFactory(PooledEntityPlacerConfig placerConfig) {
@@ -102,7 +90,8 @@ public class PooledEntityPlacerFactory<Solution_>
 
     private MoveSelectorConfig buildMoveSelectorConfig(HeuristicConfigPolicy<Solution_> configPolicy) {
         EntityDescriptor<Solution_> entityDescriptor = deduceEntityDescriptor(configPolicy.getSolutionDescriptor());
-        EntitySelectorConfig entitySelectorConfig = buildEntitySelectorConfig(configPolicy, entityDescriptor);
+        EntitySelectorConfig entitySelectorConfig =
+                AbstractFromConfigFactory.getDefaultEntitySelectorConfigForEntity(configPolicy, entityDescriptor);
 
         List<GenuineVariableDescriptor<Solution_>> variableDescriptors = entityDescriptor.getGenuineVariableDescriptorList();
         List<MoveSelectorConfig> subMoveSelectorConfigList = new ArrayList<>(variableDescriptors.size());

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/constructionheuristic/placer/QueuedEntityPlacerFactory.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/constructionheuristic/placer/QueuedEntityPlacerFactory.java
@@ -115,16 +115,8 @@ public class QueuedEntityPlacerFactory<Solution_>
     public EntitySelectorConfig buildEntitySelectorConfig(HeuristicConfigPolicy<Solution_> configPolicy) {
         EntitySelectorConfig entitySelectorConfig_;
         if (config.getEntitySelectorConfig() == null) {
-            entitySelectorConfig_ = new EntitySelectorConfig();
             EntityDescriptor<Solution_> entityDescriptor = deduceEntityDescriptor(configPolicy.getSolutionDescriptor());
-            Class<?> entityClass = entityDescriptor.getEntityClass();
-            entitySelectorConfig_.setId(entityClass.getName());
-            entitySelectorConfig_.setEntityClass(entityClass);
-            if (EntitySelectorConfig.hasSorter(configPolicy.getEntitySorterManner(), entityDescriptor)) {
-                entitySelectorConfig_.setCacheType(SelectionCacheType.PHASE);
-                entitySelectorConfig_.setSelectionOrder(SelectionOrder.SORTED);
-                entitySelectorConfig_.setSorterManner(configPolicy.getEntitySorterManner());
-            }
+            entitySelectorConfig_ = getDefaultEntitySelectorConfigForEntity(configPolicy, entityDescriptor);
         } else {
             entitySelectorConfig_ = config.getEntitySelectorConfig();
         }

--- a/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/solver/DefaultSolverTest.java
+++ b/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/solver/DefaultSolverTest.java
@@ -65,6 +65,7 @@ import org.optaplanner.core.impl.phase.custom.CustomPhaseCommand;
 import org.optaplanner.core.impl.phase.custom.NoChangeCustomPhaseCommand;
 import org.optaplanner.core.impl.phase.event.PhaseLifecycleListenerAdapter;
 import org.optaplanner.core.impl.phase.scope.AbstractStepScope;
+import org.optaplanner.core.impl.score.DummySimpleScoreEasyScoreCalculator;
 import org.optaplanner.core.impl.testdata.domain.TestdataEntity;
 import org.optaplanner.core.impl.testdata.domain.TestdataSolution;
 import org.optaplanner.core.impl.testdata.domain.TestdataValue;
@@ -74,6 +75,9 @@ import org.optaplanner.core.impl.testdata.domain.chained.TestdataChainedSolution
 import org.optaplanner.core.impl.testdata.domain.list.TestdataListEntity;
 import org.optaplanner.core.impl.testdata.domain.list.TestdataListSolution;
 import org.optaplanner.core.impl.testdata.domain.list.TestdataListValue;
+import org.optaplanner.core.impl.testdata.domain.multientity.TestdataHerdEntity;
+import org.optaplanner.core.impl.testdata.domain.multientity.TestdataLeadEntity;
+import org.optaplanner.core.impl.testdata.domain.multientity.TestdataMultiEntitySolution;
 import org.optaplanner.core.impl.testdata.domain.pinned.TestdataPinnedEntity;
 import org.optaplanner.core.impl.testdata.domain.pinned.TestdataPinnedSolution;
 import org.optaplanner.core.impl.testdata.domain.score.TestdataHardSoftScoreSolution;
@@ -793,6 +797,27 @@ class DefaultSolverTest {
         TestdataSolution solution = new TestdataSolution("s1");
         solution.setValueList(Arrays.asList(new TestdataValue("v1"), new TestdataValue("v2")));
         solution.setEntityList(Arrays.asList(new TestdataEntity("e1")));
+
+        solution = solver.solve(solution);
+        assertThat(solution).isNotNull();
+        assertThat(solution.getScore().isSolutionInitialized()).isTrue();
+    }
+
+    @Test
+    void defaultSolveWithMultipleGenuinePlanningEntities() {
+        SolverConfig solverConfig = new SolverConfig()
+                .withSolutionClass(TestdataMultiEntitySolution.class)
+                .withEntityClasses(TestdataLeadEntity.class, TestdataHerdEntity.class)
+                .withEasyScoreCalculatorClass(DummySimpleScoreEasyScoreCalculator.class)
+                .withTerminationConfig(new TerminationConfig()
+                        .withBestScoreLimit("0"));
+        SolverFactory<TestdataMultiEntitySolution> solverFactory = SolverFactory.create(solverConfig);
+        Solver<TestdataMultiEntitySolution> solver = solverFactory.buildSolver();
+
+        TestdataMultiEntitySolution solution = new TestdataMultiEntitySolution("s1");
+        solution.setValueList(Arrays.asList(new TestdataValue("v1"), new TestdataValue("v2")));
+        solution.setLeadEntityList(Arrays.asList(new TestdataLeadEntity("lead1"), new TestdataLeadEntity("lead2")));
+        solution.setHerdEntityList(Arrays.asList(new TestdataHerdEntity("herd1"), new TestdataHerdEntity("herd2")));
 
         solution = solver.solve(solution);
         assertThat(solution).isNotNull();

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/meetingscheduling/score/MeetingSchedulingConstraintProvider.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/meetingscheduling/score/MeetingSchedulingConstraintProvider.java
@@ -57,8 +57,7 @@ public class MeetingSchedulingConstraintProvider implements ConstraintProvider {
     // ************************************************************************
 
     protected Constraint roomConflict(ConstraintFactory constraintFactory) {
-        return constraintFactory.forEachIncludingNullVars(MeetingAssignment.class)
-                .filter(leftAssignment -> leftAssignment.getRoom() != null)
+        return constraintFactory.forEach(MeetingAssignment.class)
                 .join(MeetingAssignment.class,
                         equal(MeetingAssignment::getRoom),
                         lessThan(MeetingAssignment::getId),


### PR DESCRIPTION
Before, all problems get the phase list [ConstructionHeuristic, LocalSearch] if
the phase list was not configured in the SolverConfig. This poses an issue for
problems with multiple genuine entities:
AbstractFromConfigFactory.deduceEntityDescriptor (which is used for
ConstructionHeuristic with a null entity placer config) throws an
exception if there are multiple genuine planning entities. As a result,
if you had a problem with multiple genuine planning entities, you are
forced to specify the phase list manually.

Now, all problems get the phase list
[
    ConstructionHeuristic(defaultEntityPlacer(genuineEntity1)),
    ConstructionHeuristic(defaultEntityPlacer(genuineEntity2)),
    ...
    ConstructionHeuristic(defaultEntityPlacer(genuineEntityN)),
    LocalSearch
]
if the phase list was not configured in the SolverConfig. Since
the EntityPlacer is configured with a specific genuine entity,
no exception is thrown.  Thus, phases no longer are required to
be configured for problems with multiple genuine entities.

Additionally, deduplicated code used to generate the default
entity placer (was duplicated between QueuedEntityPlacer and
PooledEntityPlacer).

Finally, fixed a bug in the MeetingSchedulingConstraintProvider,
where it used forEachIncludingNullVars but has a join that
depended on all variables (causing a rare NPE in construction
heuristic).

<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.
-->

### JIRA

<!-- Add a JIRA ticket link if it exists. -->
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
* https://github.com/kiegroup/drools/pull/3000
* https://github.com/kiegroup/optaplanner/pull/899
* etc.
-->

### Checklist
- [ ] Documentation updated if applicable.
- [ ] Upgrade recipe provided if applicable.

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>specific pull request build</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] tests</b>
* for a <b>full downstream build</b> 
  * for <b>jenkins</b> job: please add comment: <b>Jenkins run fdb</b>
  * for <b>github actions</b> job: add the label `run_fdb`
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
* for a <b>Quarkus LTS check</b> please add comment: <b>Jenkins run LTS</b>
* for a <b>specific Quarkus LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] LTS</b>
* for a <b>Native check</b> please add comment: <b>Jenkins run native</b>
* for a <b>specific Native LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] native</b>
</details>
