### PR TITLE
Enable FilteringEntitySelector to support list iterator

### DIFF
--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/common/iterator/UpcomingSelectionListIterator.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/common/iterator/UpcomingSelectionListIterator.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2012 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.core.impl.heuristic.selector.common.iterator;
+
+import java.util.ListIterator;
+import java.util.NoSuchElementException;
+
+public abstract class UpcomingSelectionListIterator<S> extends UpcomingSelectionIterator<S>
+        implements ListIterator<S> {
+
+    private int nextListIteratorIndex = 0;
+
+    protected S previousSelection;
+    protected boolean previousCreated = false;
+    protected boolean hasPreviousSelection = false;
+
+    protected S noPreviousSelection() {
+        hasPreviousSelection = false;
+        return null;
+    }
+
+    protected abstract S createUpcomingSelection();
+
+    protected abstract S createPreviousSelection();
+
+    @Override
+    public boolean hasPrevious() {
+
+        if (!previousCreated) {
+            previousSelection = createPreviousSelection();
+            previousCreated = true;
+        }
+        return hasPreviousSelection;
+    }
+
+    @Override
+    public S next() {
+        S next = super.next();
+        nextListIteratorIndex++;
+        hasPreviousSelection = true;
+        return next;
+    }
+
+    @Override
+    public S previous() {
+        if (!hasPreviousSelection) {
+            throw new NoSuchElementException();
+        }
+        if (!previousCreated) {
+            previousSelection = createPreviousSelection();
+        }
+        previousCreated = false;
+        nextListIteratorIndex--;
+        hasUpcomingSelection = true;
+        return previousSelection;
+    }
+
+    @Override
+    public int nextIndex() {
+        return nextListIteratorIndex;
+    }
+
+    @Override
+    public int previousIndex() {
+        return nextListIteratorIndex - 1;
+    }
+
+    @Override
+    public void remove() {
+        throw new UnsupportedOperationException("The optional operation remove() is not supported.");
+    }
+
+    @Override
+    public void set(S o) {
+        throw new UnsupportedOperationException("The optional operation set(...) is not supported.");
+    }
+
+    @Override
+    public void add(S o) {
+        throw new UnsupportedOperationException("The optional operation add(...) is not supported.");
+    }
+}

--- a/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/testdata/util/PlannerAssert.java
+++ b/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/testdata/util/PlannerAssert.java
@@ -20,7 +20,7 @@ package org.optaplanner.core.impl.testdata.util;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
-import static org.mockito.Mockito.any;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
@@ -28,6 +28,7 @@ import java.util.Collection;
 import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
+import java.util.ListIterator;
 import java.util.NoSuchElementException;
 
 import org.assertj.core.util.Streams;
@@ -35,6 +36,7 @@ import org.optaplanner.core.impl.constructionheuristic.event.ConstructionHeurist
 import org.optaplanner.core.impl.constructionheuristic.scope.ConstructionHeuristicPhaseScope;
 import org.optaplanner.core.impl.constructionheuristic.scope.ConstructionHeuristicStepScope;
 import org.optaplanner.core.impl.heuristic.selector.IterableSelector;
+import org.optaplanner.core.impl.heuristic.selector.ListIterableSelector;
 import org.optaplanner.core.impl.heuristic.selector.entity.EntitySelector;
 import org.optaplanner.core.impl.heuristic.selector.entity.pillar.PillarSelector;
 import org.optaplanner.core.impl.heuristic.selector.move.MoveSelector;
@@ -253,12 +255,35 @@ public final class PlannerAssert {
         assertThat(iterator).isExhausted();
     }
 
+    public static <O> void assertReverseCodesOfListIterator(ListIterator<O> listIterator, String... codes) {
+        assertThat(listIterator).isNotNull();
+        for (int i = codes.length - 1; i >= 0; i--) {
+            assertCode(codes[i], listIterator.previous());
+        }
+    }
+
+    public static <O> void assertAllReverseCodesOfIterator(ListIterator<O> listIterator, String... codes) {
+        assertReverseCodesOfListIterator(listIterator, codes);
+        assertThat(listIterator.hasPrevious()).isFalse();
+    }
+
     public static void assertAllCodesOfCollection(Collection<?> collection, String... codes) {
         assertAllCodesOfIterator(collection.iterator(), codes);
     }
 
     public static void assertAllCodesOfIterableSelector(IterableSelector<?, ?> selector, long size, String... codes) {
         assertAllCodesOfIterator(selector.iterator(), codes);
+        assertThat(selector.isCountable()).isTrue();
+        assertThat(selector.isNeverEnding()).isFalse();
+        if (size != DO_NOT_ASSERT_SIZE) {
+            assertThat(selector.getSize()).isEqualTo(size);
+        }
+    }
+
+    public static void assertAllCodesOfListIterableSelector(ListIterableSelector<?, ?> selector, long size, String... codes) {
+        ListIterator<?> listIterator = selector.listIterator();
+        assertAllCodesOfIterator(listIterator, codes);
+        assertAllReverseCodesOfIterator(listIterator, codes);
         assertThat(selector.isCountable()).isTrue();
         assertThat(selector.isNeverEnding()).isFalse();
         if (size != DO_NOT_ASSERT_SIZE) {
@@ -324,6 +349,21 @@ public final class PlannerAssert {
 
     public static void assertCodesOfNeverEndingOfEntitySelector(EntitySelector<?> entitySelector, long size, String... codes) {
         assertCodesOfNeverEndingIterableSelector(entitySelector, size, codes);
+    }
+
+    public static void assertAllCodesOfOrderedEntitySelector(EntitySelector<?> entitySelector, String... codes) {
+        assertAllCodesOfOrderedEntitySelector(entitySelector, codes.length, codes);
+    }
+
+    public static void assertAllCodesOfOrderedEntitySelector(EntitySelector<?> entitySelector, long size, String... codes) {
+        ListIterator<?> listIterator = entitySelector.listIterator();
+        assertAllCodesOfIterator(listIterator, codes);
+        assertAllReverseCodesOfIterator(listIterator, codes);
+        assertThat(entitySelector.isCountable()).isTrue();
+        assertThat(entitySelector.isNeverEnding()).isFalse();
+        if (size != DO_NOT_ASSERT_SIZE) {
+            assertThat(entitySelector.getSize()).isEqualTo(size);
+        }
     }
 
     // ---- Pillar

--- a/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/testdata/util/PlannerAssert.java
+++ b/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/testdata/util/PlannerAssert.java
@@ -20,7 +20,7 @@ package org.optaplanner.core.impl.testdata.util;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
-import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 


### PR DESCRIPTION
Hello 👋 

I ran into difficulties benchmarking with a dataset that included pinned entities, and came to learn the cause was I couldn't run `VARIABLE_NEIGHBORHOOD_DESCENT` with pinned entities, because [FilteringEntitySelector#listIterator](https://github.com/kiegroup/optaplanner/blob/32b4fb0ad0ccc13f72ac940a9709c15db1bdd9e0/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/entity/decorator/FilteringEntitySelector.java#L123-L126) had not yet been implemented.

I was interested in the internals so had a stab at doing this by extending the existing [UpcomingSelectionIterator](https://github.com/kiegroup/optaplanner/blob/32b4fb0ad0ccc13f72ac940a9709c15db1bdd9e0/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/common/iterator/UpcomingSelectionIterator.java) into a new class that could also iterate backwards, and using that in the implementation.

Updated unit tests to include this, though wasn't sure if you guys would want a more comprehensive integration test as well? e.g. could add some pinned entities into the tennis example [here for instance](https://github.com/kiegroup/optaplanner/blob/32b4fb0ad0ccc13f72ac940a9709c15db1bdd9e0/optaplanner-examples/data/tennis/unsolved/munich-7teams.xml#L174), and run one of the tennis tests with variable descent to check it all works end-to-end, if that's advisable.

Let me know if there's any questions or feedback, or if there's other reasons I missed for why this can't/shouldn't be supported.

### JIRA

Was not explicitly dealing with a JIRA ticket, though I came across this one that's related: https://issues.redhat.com/browse/PLANNER-196 (status "won't fix")
