### PR TITLE
PLANNER-2670 SolverJob returns best solution after terminateEarly

### DIFF
--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/api/solver/SolverJob.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/api/solver/SolverJob.java
@@ -72,6 +72,12 @@ public interface SolverJob<Solution_, ProblemId_> {
     void terminateEarly();
 
     /**
+     * @return true if {@link SolverJob#terminateEarly} has been called since the underlying {@link Solver}
+     *         started solving.
+     */
+    boolean isTerminatedEarly();
+
+    /**
      * Waits if necessary for the solver to complete and then returns the final best {@link PlanningSolution}.
      *
      * @return never null, but it could be the original uninitialized problem

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/solver/DefaultSolverJob.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/solver/DefaultSolverJob.java
@@ -211,7 +211,7 @@ public final class DefaultSolverJob<Solution_, ProblemId_> implements SolverJob<
             return finalBestSolutionFuture.get();
         } catch (CancellationException cancellationException) {
             LOGGER.debug("The terminateEarly() has been called before the solver job started solving. "
-                    + "Retrieving the input problem.");
+                    + "Retrieving the input problem instead.");
             return problemFinder.apply(problemId);
         }
     }

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/solver/DefaultSolverJob.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/solver/DefaultSolverJob.java
@@ -160,9 +160,7 @@ public final class DefaultSolverJob<Solution_, ProblemId_> implements SolverJob<
         Objects.requireNonNull(problemChange, () -> "A problem change (" + problemChange + ") must not be null.");
         if (solverStatus == SolverStatus.NOT_SOLVING) {
             throw new IllegalStateException("Cannot add the problem change (" + problemChange
-                    + ") because the solver job ("
-                    + solverStatus
-                    + ") is not solving.");
+                    + ") because the solver job (" + solverStatus + ") is not solving.");
         }
         solver.addProblemChange(problemChange);
     }

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/solver/DefaultSolverJob.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/solver/DefaultSolverJob.java
@@ -167,13 +167,14 @@ public final class DefaultSolverJob<Solution_, ProblemId_> implements SolverJob<
     public void terminateEarly() {
         try {
             solverStatusModifyingLock.lock();
-            finalBestSolutionFuture.cancel(false);
             switch (solverStatus) {
                 case SOLVING_SCHEDULED:
+                    finalBestSolutionFuture.cancel(false);
                     solvingTerminated();
                     break;
                 case SOLVING_ACTIVE:
                     // Indirectly triggers solvingTerminated()
+                    // No need to cancel the finalBestSolutionFuture as it will finish normally.
                     solver.terminateEarly();
                     break;
                 case NOT_SOLVING:
@@ -192,6 +193,11 @@ public final class DefaultSolverJob<Solution_, ProblemId_> implements SolverJob<
         } finally {
             solverStatusModifyingLock.unlock();
         }
+    }
+
+    @Override
+    public boolean isTerminatedEarly() {
+        return solver.isTerminateEarly();
     }
 
     @Override

--- a/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/api/solver/SolverManagerTest.java
+++ b/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/api/solver/SolverManagerTest.java
@@ -652,4 +652,34 @@ class SolverManagerTest {
         assertThat(result).isNotNull();
         assertThat(solverJob.isTerminatedEarly()).isTrue();
     }
+
+    @Test
+    @Timeout(60)
+    void terminateScheduledSolverJobEarly_returnsInputProblem() throws ExecutionException, InterruptedException {
+        CountDownLatch solvingPausedLatch = new CountDownLatch(1);
+        PhaseConfig<?> pausedPhaseConfig = new CustomPhaseConfig().withCustomPhaseCommands(
+                scoreDirector -> {
+                    try {
+                        solvingPausedLatch.await();
+                    } catch (InterruptedException e) {
+                        fail("CountDownLatch failed.");
+                    }
+                });
+
+        SolverConfig solverConfig = PlannerTestUtils.buildSolverConfig(TestdataSolution.class, TestdataEntity.class)
+                .withPhases(pausedPhaseConfig, new ConstructionHeuristicPhaseConfig());
+        // Allow only a single active solver.
+        SolverManagerConfig solverManagerConfig = new SolverManagerConfig().withParallelSolverCount("1");
+        solverManager = SolverManager.create(solverConfig, solverManagerConfig);
+
+        // The first solver waits.
+        solverManager.solve(1L, PlannerTestUtils.generateTestdataSolution("s1", 4));
+        TestdataSolution inputProblem = PlannerTestUtils.generateTestdataSolution("s2", 4);
+        SolverJob<TestdataSolution, Long> solverJob = solverManager.solve(2L, inputProblem);
+
+        solverJob.terminateEarly();
+        TestdataSolution result = solverJob.getFinalBestSolution();
+        assertThat(result).isSameAs(inputProblem);
+        assertThat(solverJob.isTerminatedEarly()).isTrue();
+    }
 }


### PR DESCRIPTION
<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.
-->

### JIRA
https://issues.redhat.com/browse/PLANNER-2670

<!-- Add a JIRA ticket link if it exists. -->
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
* https://github.com/kiegroup/drools/pull/3000
* https://github.com/kiegroup/optaplanner/pull/899
* etc.
-->

### Checklist
- [ ] Documentation updated if applicable.
- [ ] Upgrade recipe provided if applicable.

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>specific pull request build</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] tests</b>
* for a <b>full downstream build</b> 
  * for <b>jenkins</b> job: please add comment: <b>Jenkins run fdb</b>
  * for <b>github actions</b> job: add the label `run_fdb`
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
* for a <b>Quarkus LTS check</b> please add comment: <b>Jenkins run LTS</b>
* for a <b>specific Quarkus LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] LTS</b>
* for a <b>Native check</b> please add comment: <b>Jenkins run native</b>
* for a <b>specific Native LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] native</b>
</details>
