### PR TITLE
Make cloud balancing process colors stable

### DIFF
--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/cloudbalancing/swingui/CloudBalancingPanel.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/cloudbalancing/swingui/CloudBalancingPanel.java
@@ -17,6 +17,7 @@
 package org.optaplanner.examples.cloudbalancing.swingui;
 
 import java.awt.BorderLayout;
+import java.awt.Color;
 import java.awt.GridLayout;
 import java.awt.event.ActionEvent;
 import java.util.LinkedHashMap;
@@ -44,11 +45,13 @@ import org.optaplanner.examples.cloudbalancing.swingui.realtime.DeleteProcessPro
 import org.optaplanner.examples.common.swingui.SolutionPanel;
 import org.optaplanner.examples.common.swingui.components.LabeledComboBoxRenderer;
 import org.optaplanner.swing.impl.SwingUtils;
+import org.optaplanner.swing.impl.TangoColorFactory;
 
 public class CloudBalancingPanel extends SolutionPanel<CloudBalance> {
 
     public static final String LOGO_PATH = "/org/optaplanner/examples/cloudbalancing/swingui/cloudBalancingLogo.png";
 
+    private final TangoColorFactory processColorFactory;
     private final ImageIcon cloudComputerIcon;
     private final ImageIcon addCloudComputerIcon;
     private final ImageIcon deleteCloudComputerIcon;
@@ -66,6 +69,7 @@ public class CloudBalancingPanel extends SolutionPanel<CloudBalance> {
     private int maximumComputerNetworkBandwidth;
 
     public CloudBalancingPanel() {
+        processColorFactory = new TangoColorFactory();
         cloudComputerIcon = new ImageIcon(getClass().getResource("cloudComputer.png"));
         addCloudComputerIcon = new ImageIcon(getClass().getResource("addCloudComputer.png"));
         deleteCloudComputerIcon = new ImageIcon(getClass().getResource("deleteCloudComputer.png"));
@@ -83,6 +87,10 @@ public class CloudBalancingPanel extends SolutionPanel<CloudBalance> {
                         GroupLayout.PREFERRED_SIZE)
                 .addComponent(computersPanel, GroupLayout.PREFERRED_SIZE, GroupLayout.PREFERRED_SIZE,
                         GroupLayout.PREFERRED_SIZE));
+    }
+
+    public Color getCloudProcessColor(CloudProcess process) {
+        return processColorFactory.pickColor(process.getLabel());
     }
 
     public ImageIcon getCloudComputerIcon() {

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/cloudbalancing/swingui/CloudComputerPanel.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/cloudbalancing/swingui/CloudComputerPanel.java
@@ -25,6 +25,7 @@ import java.awt.GridLayout;
 import java.awt.event.ActionEvent;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.ToIntFunction;
 
 import javax.swing.AbstractAction;
 import javax.swing.Action;
@@ -136,14 +137,19 @@ public class CloudComputerPanel extends JPanel {
         numberOfProcessesLabel.setEnabled(false);
         numberOfProcessesLabel.setBorder(BorderFactory.createEmptyBorder(0, 37, 0, 0));
         add(numberOfProcessesLabel);
-        cpuPowerBar = new CloudBar(getComputerCpuPower(), cloudBalancingPanel.getMaximumComputerCpuPower());
+        cpuPowerBar = new CloudBar(getComputerCpuPower(),
+                cloudBalancingPanel.getMaximumComputerCpuPower(),
+                CloudProcess::getRequiredCpuPower);
         cpuPowerBar.setEnabled(false);
         add(cpuPowerBar);
-        memoryBar = new CloudBar(getComputerMemory(), cloudBalancingPanel.getMaximumComputerMemory());
+        memoryBar = new CloudBar(getComputerMemory(),
+                cloudBalancingPanel.getMaximumComputerMemory(),
+                CloudProcess::getRequiredMemory);
         memoryBar.setEnabled(false);
         add(memoryBar);
         networkBandwidthBar = new CloudBar(getComputerNetworkBandwidth(),
-                cloudBalancingPanel.getMaximumComputerNetworkBandwidth());
+                cloudBalancingPanel.getMaximumComputerNetworkBandwidth(),
+                CloudProcess::getRequiredNetworkBandwidth);
         networkBandwidthBar.setEnabled(false);
         add(networkBandwidthBar);
         detailsButton = new JButton(new AbstractAction("Details") {
@@ -172,18 +178,18 @@ public class CloudComputerPanel extends JPanel {
 
     public void update() {
         int usedCpuPower = 0;
-        cpuPowerBar.clearProcessValues();
+        cpuPowerBar.clearProcesses();
         int usedMemory = 0;
-        memoryBar.clearProcessValues();
+        memoryBar.clearProcesses();
         int usedNetworkBandwidth = 0;
-        networkBandwidthBar.clearProcessValues();
+        networkBandwidthBar.clearProcesses();
         for (CloudProcess process : processList) {
             usedCpuPower += process.getRequiredCpuPower();
-            cpuPowerBar.addProcessValue(process.getRequiredCpuPower());
+            cpuPowerBar.addProcess(process);
             usedMemory += process.getRequiredMemory();
-            memoryBar.addProcessValue(process.getRequiredMemory());
+            memoryBar.addProcess(process);
             usedNetworkBandwidth += process.getRequiredNetworkBandwidth();
-            networkBandwidthBar.addProcessValue(process.getRequiredNetworkBandwidth());
+            networkBandwidthBar.addProcess(process);
         }
         boolean used = processList.size() > 0;
         updateTotals(usedCpuPower, usedMemory, usedNetworkBandwidth, used);
@@ -218,23 +224,25 @@ public class CloudComputerPanel extends JPanel {
         detailsButton.setEnabled(used);
     }
 
-    private static class CloudBar extends JPanel {
+    private class CloudBar extends JPanel {
 
-        private List<Integer> processValues = new ArrayList<>();
+        private List<CloudProcess> processes = new ArrayList<>();
         private int computerValue;
         private int maximumComputerValue;
+        private ToIntFunction<CloudProcess> processValueExtractor;
 
-        public CloudBar(int computerValue, int maximumComputerValue) {
+        public CloudBar(int computerValue, int maximumComputerValue, ToIntFunction<CloudProcess> processValueExtractor) {
             this.computerValue = computerValue;
             this.maximumComputerValue = maximumComputerValue;
+            this.processValueExtractor = processValueExtractor;
         }
 
-        public void clearProcessValues() {
-            processValues.clear();
+        public void clearProcesses() {
+            processes.clear();
         }
 
-        public void addProcessValue(int processValue) {
-            processValues.add(processValue);
+        public void addProcess(CloudProcess process) {
+            processes.add(process);
         }
 
         @Override
@@ -256,15 +264,14 @@ public class CloudComputerPanel extends JPanel {
                 g.fillRect(0, 0, computerWidth, size.height);
             }
             int offsetValue = 0;
-            int colorIndex = 0;
-            for (int processValue : processValues) {
+            for (CloudProcess process : processes) {
+                int processValue = processValueExtractor.applyAsInt(process);
                 int offset = (int) (offsetValue * pixelsPerValue);
                 int processWidth = (int) (processValue * pixelsPerValue) + 1;
                 processWidth = Math.max(processWidth, 1);
-                g.setColor(TangoColorFactory.SEQUENCE_1.get(colorIndex));
+                g.setColor(cloudBalancingPanel.getCloudProcessColor(process));
                 g.fillRect(offset, 0, processWidth, size.height);
                 offsetValue += processValue;
-                colorIndex = (colorIndex + 1) % TangoColorFactory.SEQUENCE_1.size();
             }
             if (this.computerValue > 0) {
                 g.setColor(isEnabled() ? Color.BLACK : TangoColorFactory.ALUMINIUM_5);
@@ -315,10 +322,8 @@ public class CloudComputerPanel extends JPanel {
 
         private JPanel createAssignmentsPanel() {
             JPanel assignmentsPanel = new JPanel(new GridLayout(0, 1));
-            int colorIndex = 0;
             for (final CloudProcess process : processList) {
-                assignmentsPanel.add(new CloudProcessAssignmentPanel(assignmentsPanel, process, colorIndex));
-                colorIndex = (colorIndex + 1) % TangoColorFactory.SEQUENCE_1.size();
+                assignmentsPanel.add(new CloudProcessAssignmentPanel(assignmentsPanel, process));
             }
             JPanel fillerAssignmentsPanel = new JPanel(new BorderLayout());
             fillerAssignmentsPanel.add(assignmentsPanel, BorderLayout.NORTH);
@@ -327,12 +332,12 @@ public class CloudComputerPanel extends JPanel {
 
         private class CloudProcessAssignmentPanel extends JPanel {
 
-            public CloudProcessAssignmentPanel(JPanel assignmentsPanel, CloudProcess process, int colorIndex) {
+            public CloudProcessAssignmentPanel(JPanel assignmentsPanel, CloudProcess process) {
                 super(new GridLayout(0, 5));
                 JPanel labelAndDeletePanel = new JPanel(new BorderLayout(5, 0));
                 labelAndDeletePanel.add(new JLabel(cloudBalancingPanel.getCloudProcessIcon()), BorderLayout.WEST);
                 JLabel processLabel = new JLabel(process.getLabel());
-                processLabel.setForeground(TangoColorFactory.SEQUENCE_1.get(colorIndex));
+                processLabel.setForeground(cloudBalancingPanel.getCloudProcessColor(process));
                 labelAndDeletePanel.add(processLabel, BorderLayout.CENTER);
                 JPanel deletePanel = new JPanel(new BorderLayout());
                 JButton deleteButton = SwingUtils.makeSmallButton(new JButton(cloudBalancingPanel.getDeleteCloudProcessIcon()));

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/cloudbalancing/swingui/CloudComputerPanel.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/cloudbalancing/swingui/CloudComputerPanel.java
@@ -178,18 +178,12 @@ public class CloudComputerPanel extends JPanel {
 
     public void update() {
         int usedCpuPower = 0;
-        cpuPowerBar.clearProcesses();
         int usedMemory = 0;
-        memoryBar.clearProcesses();
         int usedNetworkBandwidth = 0;
-        networkBandwidthBar.clearProcesses();
         for (CloudProcess process : processList) {
             usedCpuPower += process.getRequiredCpuPower();
-            cpuPowerBar.addProcess(process);
             usedMemory += process.getRequiredMemory();
-            memoryBar.addProcess(process);
             usedNetworkBandwidth += process.getRequiredNetworkBandwidth();
-            networkBandwidthBar.addProcess(process);
         }
         boolean used = processList.size() > 0;
         updateTotals(usedCpuPower, usedMemory, usedNetworkBandwidth, used);
@@ -226,7 +220,6 @@ public class CloudComputerPanel extends JPanel {
 
     private class CloudBar extends JPanel {
 
-        private List<CloudProcess> processes = new ArrayList<>();
         private int computerValue;
         private int maximumComputerValue;
         private ToIntFunction<CloudProcess> processValueExtractor;
@@ -235,14 +228,6 @@ public class CloudComputerPanel extends JPanel {
             this.computerValue = computerValue;
             this.maximumComputerValue = maximumComputerValue;
             this.processValueExtractor = processValueExtractor;
-        }
-
-        public void clearProcesses() {
-            processes.clear();
-        }
-
-        public void addProcess(CloudProcess process) {
-            processes.add(process);
         }
 
         @Override
@@ -264,7 +249,7 @@ public class CloudComputerPanel extends JPanel {
                 g.fillRect(0, 0, computerWidth, size.height);
             }
             int offsetValue = 0;
-            for (CloudProcess process : processes) {
+            for (CloudProcess process : CloudComputerPanel.this.processList) {
                 int processValue = processValueExtractor.applyAsInt(process);
                 int offset = (int) (offsetValue * pixelsPerValue);
                 int processWidth = (int) (processValue * pixelsPerValue) + 1;


### PR DESCRIPTION
Colors are now assigned based on process labels (and cached) by the `TangoColorFactory` instead of their order on a computer. It's now easier to track process movement during solving on small data sets.

Code-wise, using the factory eliminates `colorIndex` calculations.

Potential downside: similar or identical colors might appear next to each other with large data sets. If this is a problem, I can easily restore the original behavior but still use the factory to avoid `colorIndex` calculations.


<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>specific pull request build</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] tests</b>
* for a <b>full downstream build</b> 
  * for <b>jenkins</b> job: please add comment: <b>Jenkins run fdb</b>
  * for <b>github actions</b> job: add the label `run_fdb`
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
* for a <b>Quarkus LTS check</b> please add comment: <b>Jenkins run LTS</b>
* for a <b>specific Quarkus LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] LTS</b>
* for a <b>Native check</b> please add comment: <b>Jenkins run native</b>
* for a <b>specific Native LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] native</b>
</details>
