### PR TITLE
PLANNER-2680 Update initScore when a problem change affects list variable

### DIFF
--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/constructionheuristic/DefaultConstructionHeuristicPhaseFactory.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/constructionheuristic/DefaultConstructionHeuristicPhaseFactory.java
@@ -134,7 +134,7 @@ public class DefaultConstructionHeuristicPhaseFactory<Solution_>
 
     private Optional<ListVariableDescriptor<?>> findValidListVariableDescriptor(
             SolutionDescriptor<Solution_> solutionDescriptor) {
-        List<ListVariableDescriptor<Solution_>> listVariableDescriptors = solutionDescriptor.findListVariableDescriptors();
+        List<ListVariableDescriptor<Solution_>> listVariableDescriptors = solutionDescriptor.getListVariableDescriptors();
         if (listVariableDescriptors.isEmpty()) {
             return Optional.empty();
         }

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/domain/solution/descriptor/SolutionDescriptor.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/domain/solution/descriptor/SolutionDescriptor.java
@@ -1034,17 +1034,24 @@ public class SolutionDescriptor<Solution_> {
     }
 
     /**
-     * Calculates the number of elements that need to be processed in the Construction Heuristics phase.
-     * The negative value of this is the {@code initScore}. It represents how many Construction Heuristics steps need to
-     * be taken before the solution is fully initialized.
+     * Counts the number of uninitialized basic planning variables on all entities.
      *
      * @param solution never null
      * @return {@code >= 0}
      */
-    public int countUninitialized(Solution_ solution) {
-        return countUnassignedValues(solution) + countUninitializedVariables(solution);
+    public int countUninitializedVariables(Solution_ solution) {
+        MutableInt result = new MutableInt();
+        visitAllEntities(solution,
+                entity -> result.add(findEntityDescriptorOrFail(entity.getClass()).countUninitializedVariables(entity)));
+        return result.intValue();
     }
 
+    /**
+     * Counts the number of elements from list variable value ranges, that are not assigned to any list variable.
+     *
+     * @param solution never null
+     * @return {@code >= 0}
+     */
     public int countUnassignedValues(Solution_ solution) {
         int unassignedValueCount = 0;
         for (ListVariableDescriptor<Solution_> listVariableDescriptor : listVariableDescriptors) {
@@ -1060,13 +1067,6 @@ public class SolutionDescriptor<Solution_> {
                 entity -> assignedValuesCount.add(variableDescriptor.getListSize(entity)));
         // TODO maybe detect duplicates and elements that are outside the value range
         return Math.toIntExact(totalValueCount - assignedValuesCount.intValue());
-    }
-
-    private int countUninitializedVariables(Solution_ solution) {
-        MutableInt result = new MutableInt();
-        visitAllEntities(solution,
-                entity -> result.add(findEntityDescriptorOrFail(entity.getClass()).countUninitializedVariables(entity)));
-        return result.intValue();
     }
 
     private Stream<Object> extractAllEntitiesStream(Solution_ solution) {

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/domain/solution/descriptor/SolutionDescriptor.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/domain/solution/descriptor/SolutionDescriptor.java
@@ -1026,6 +1026,13 @@ public class SolutionDescriptor<Solution_> {
         return result.longValue();
     }
 
+    public int countListValues(Solution_ solution) {
+        long valueCount = streamListVariableDescriptors()
+                .mapToLong(variableDescriptor -> variableDescriptor.getValueCount(solution, null))
+                .sum();
+        return Math.toIntExact(valueCount);
+    }
+
     /**
      * Calculates the number of elements that need to be processed in the Construction Heuristics phase.
      * The negative value of this is the {@code initScore}. It represents how many Construction Heuristics steps need to

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/domain/solution/descriptor/SolutionDescriptor.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/domain/solution/descriptor/SolutionDescriptor.java
@@ -502,6 +502,25 @@ public class SolutionDescriptor<Solution_> {
             entityDescriptor.linkVariableDescriptors(descriptorPolicy);
         }
         determineGlobalShadowOrder();
+        collectEntityAndProblemFactClasses();
+        // And finally log the successful completion of processing.
+        if (LOGGER.isTraceEnabled()) {
+            LOGGER.trace("    Model annotations parsed for solution {}:", solutionClass.getSimpleName());
+            for (Map.Entry<Class<?>, EntityDescriptor<Solution_>> entry : entityDescriptorMap.entrySet()) {
+                EntityDescriptor<Solution_> entityDescriptor = entry.getValue();
+                LOGGER.trace("        Entity {}:", entityDescriptor.getEntityClass().getSimpleName());
+                for (VariableDescriptor<Solution_> variableDescriptor : entityDescriptor.getDeclaredVariableDescriptors()) {
+                    LOGGER.trace("            {} variable {} ({})",
+                            variableDescriptor instanceof GenuineVariableDescriptor ? "Genuine" : "Shadow",
+                            variableDescriptor.getVariableName(),
+                            variableDescriptor.getMemberAccessorSpeedNote());
+                }
+            }
+        }
+        initSolutionCloner(descriptorPolicy);
+    }
+
+    private void collectEntityAndProblemFactClasses() {
         // Figure out all problem fact or entity types that are used within this solution,
         // using the knowledge we've already gained by processing all the annotations.
         Stream<Class<?>> entityClassStream = entityDescriptorMap.keySet()
@@ -524,21 +543,6 @@ public class SolutionDescriptor<Solution_> {
                     Stream.of(constraintConfigurationDescriptor.getConstraintConfigurationClass()));
         }
         problemFactOrEntityClassSet = problemFactOrEntityClassStream.collect(Collectors.toSet());
-        // And finally log the successful completion of processing.
-        if (LOGGER.isTraceEnabled()) {
-            LOGGER.trace("    Model annotations parsed for solution {}:", solutionClass.getSimpleName());
-            for (Map.Entry<Class<?>, EntityDescriptor<Solution_>> entry : entityDescriptorMap.entrySet()) {
-                EntityDescriptor<Solution_> entityDescriptor = entry.getValue();
-                LOGGER.trace("        Entity {}:", entityDescriptor.getEntityClass().getSimpleName());
-                for (VariableDescriptor<Solution_> variableDescriptor : entityDescriptor.getDeclaredVariableDescriptors()) {
-                    LOGGER.trace("            {} variable {} ({})",
-                            variableDescriptor instanceof GenuineVariableDescriptor ? "Genuine" : "Shadow",
-                            variableDescriptor.getVariableName(),
-                            variableDescriptor.getMemberAccessorSpeedNote());
-                }
-            }
-        }
-        initSolutionCloner(descriptorPolicy);
     }
 
     private void determineGlobalShadowOrder() {

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/score/director/AbstractScoreDirector.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/score/director/AbstractScoreDirector.java
@@ -375,10 +375,12 @@ public abstract class AbstractScoreDirector<Solution_, Score_ extends Score<Scor
     }
 
     public void beforeEntityAdded(EntityDescriptor<Solution_> entityDescriptor, Object entity) {
+        workingInitScore += getSolutionDescriptor().countListValues(workingSolution);
         variableListenerSupport.beforeEntityAdded(entityDescriptor, entity);
     }
 
     public void afterEntityAdded(EntityDescriptor<Solution_> entityDescriptor, Object entity) {
+        workingInitScore -= getSolutionDescriptor().countListValues(workingSolution);
         workingInitScore -= entityDescriptor.countUninitializedVariables(entity);
         if (lookUpEnabled) {
             lookUpManager.addWorkingObject(entity);
@@ -417,11 +419,13 @@ public abstract class AbstractScoreDirector<Solution_, Score_ extends Score<Scor
     }
 
     public void beforeEntityRemoved(EntityDescriptor<Solution_> entityDescriptor, Object entity) {
+        workingInitScore += getSolutionDescriptor().countListValues(workingSolution);
         workingInitScore += entityDescriptor.countUninitializedVariables(entity);
         variableListenerSupport.beforeEntityRemoved(entityDescriptor, entity);
     }
 
     public void afterEntityRemoved(EntityDescriptor<Solution_> entityDescriptor, Object entity) {
+        workingInitScore -= getSolutionDescriptor().countListValues(workingSolution);
         if (lookUpEnabled) {
             lookUpManager.removeWorkingObject(entity);
         }
@@ -437,11 +441,12 @@ public abstract class AbstractScoreDirector<Solution_, Score_ extends Score<Scor
 
     @Override
     public void beforeProblemFactAdded(Object problemFact) {
-        // Do nothing
+        workingInitScore += getSolutionDescriptor().countListValues(workingSolution);
     }
 
     @Override
     public void afterProblemFactAdded(Object problemFact) {
+        workingInitScore -= getSolutionDescriptor().countListValues(workingSolution);
         if (lookUpEnabled) {
             lookUpManager.addWorkingObject(problemFact);
         }
@@ -464,6 +469,7 @@ public abstract class AbstractScoreDirector<Solution_, Score_ extends Score<Scor
 
     @Override
     public void beforeProblemFactRemoved(Object problemFact) {
+        workingInitScore += getSolutionDescriptor().countListValues(workingSolution);
         if (isConstraintConfiguration(problemFact)) {
             throw new IllegalStateException("Attempted to remove constraint configuration (" + problemFact +
                     ") from solution (" + workingSolution + ").\n" +
@@ -473,6 +479,7 @@ public abstract class AbstractScoreDirector<Solution_, Score_ extends Score<Scor
 
     @Override
     public void afterProblemFactRemoved(Object problemFact) {
+        workingInitScore -= getSolutionDescriptor().countListValues(workingSolution);
         if (lookUpEnabled) {
             lookUpManager.removeWorkingObject(problemFact);
         }

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/solver/DefaultSolverFactory.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/solver/DefaultSolverFactory.java
@@ -207,7 +207,7 @@ public final class DefaultSolverFactory<Solution_> implements SolverFactory<Solu
                     configPolicy.getSolutionDescriptor().getGenuineEntityDescriptors();
             Map<Class<?>, List<ListVariableDescriptor<Solution_>>> entityClassToListVariableDescriptorListMap =
                     configPolicy.getSolutionDescriptor()
-                            .findListVariableDescriptors()
+                            .getListVariableDescriptors()
                             .stream()
                             .collect(Collectors.groupingBy(
                                     listVariableDescriptor -> listVariableDescriptor.getEntityDescriptor().getEntityClass(),

--- a/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/domain/solution/descriptor/SolutionDescriptorTest.java
+++ b/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/domain/solution/descriptor/SolutionDescriptorTest.java
@@ -350,13 +350,13 @@ class SolutionDescriptorTest {
         TestdataSolution solution = TestdataSolution.generateSolution(valueCount, entityCount);
         SolutionDescriptor<TestdataSolution> solutionDescriptor = TestdataSolution.buildSolutionDescriptor();
 
-        assertThat(solutionDescriptor.countUninitialized(solution)).isZero();
+        assertThat(solutionDescriptor.countUninitializedVariables(solution)).isZero();
 
         solution.getEntityList().get(0).setValue(null);
-        assertThat(solutionDescriptor.countUninitialized(solution)).isOne();
+        assertThat(solutionDescriptor.countUninitializedVariables(solution)).isOne();
 
         solution.getEntityList().forEach(entity -> entity.setValue(null));
-        assertThat(solutionDescriptor.countUninitialized(solution)).isEqualTo(entityCount);
+        assertThat(solutionDescriptor.countUninitializedVariables(solution)).isEqualTo(entityCount);
     }
 
     @Test
@@ -366,7 +366,7 @@ class SolutionDescriptorTest {
         TestdataListSolution solution = TestdataListSolution.generateInitializedSolution(valueCount, entityCount);
         SolutionDescriptor<TestdataListSolution> solutionDescriptor = TestdataListSolution.buildSolutionDescriptor();
 
-        assertThat(solutionDescriptor.countUninitialized(solution)).isZero();
+        assertThat(solutionDescriptor.countUnassignedValues(solution)).isZero();
 
         List<TestdataListValue> valueList = solution.getEntityList().get(0).getValueList();
         int unassignedValueCount = valueList.size();
@@ -376,7 +376,7 @@ class SolutionDescriptorTest {
             value.setIndex(null);
         });
         valueList.clear();
-        assertThat(solutionDescriptor.countUninitialized(solution)).isEqualTo(unassignedValueCount);
+        assertThat(solutionDescriptor.countUnassignedValues(solution)).isEqualTo(unassignedValueCount);
     }
 
     @Test

--- a/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/testdata/domain/list/TestdataListSolution.java
+++ b/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/testdata/domain/list/TestdataListSolution.java
@@ -98,4 +98,12 @@ public class TestdataListSolution {
     public void setScore(SimpleScore score) {
         this.score = score;
     }
+
+    public void addValue(TestdataListValue value) {
+        valueList.add(value);
+    }
+
+    public void removeValue(TestdataListValue value) {
+        valueList.remove(value);
+    }
 }

--- a/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/testdata/domain/list/externalized/TestdataListSolutionExternalized.java
+++ b/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/testdata/domain/list/externalized/TestdataListSolutionExternalized.java
@@ -26,9 +26,16 @@ import org.optaplanner.core.api.domain.solution.PlanningSolution;
 import org.optaplanner.core.api.domain.solution.ProblemFactCollectionProperty;
 import org.optaplanner.core.api.domain.valuerange.ValueRangeProvider;
 import org.optaplanner.core.api.score.buildin.simple.SimpleScore;
+import org.optaplanner.core.impl.domain.solution.descriptor.SolutionDescriptor;
 
 @PlanningSolution
 public class TestdataListSolutionExternalized {
+
+    public static SolutionDescriptor<TestdataListSolutionExternalized> buildSolutionDescriptor() {
+        return SolutionDescriptor.buildSolutionDescriptor(
+                TestdataListSolutionExternalized.class,
+                TestdataListEntityExternalized.class);
+    }
 
     public static TestdataListSolutionExternalized generateUninitializedSolution(int valueCount, int entityCount) {
         List<TestdataListEntityExternalized> entityList = IntStream.range(0, entityCount)
@@ -73,5 +80,13 @@ public class TestdataListSolutionExternalized {
 
     public void setScore(SimpleScore score) {
         this.score = score;
+    }
+
+    public void addValue(TestdataListValueExternalized value) {
+        valueList.add(value);
+    }
+
+    public void removeValue(TestdataListValueExternalized value) {
+        valueList.remove(value);
     }
 }

--- a/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/testdata/domain/list/externalized/TestdataListSolutionExternalized.java
+++ b/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/testdata/domain/list/externalized/TestdataListSolutionExternalized.java
@@ -37,7 +37,15 @@ public class TestdataListSolutionExternalized {
                 TestdataListEntityExternalized.class);
     }
 
+    public static TestdataListSolutionExternalized generateInitializedSolution(int valueCount, int entityCount) {
+        return generateSolution(valueCount, entityCount).initialize();
+    }
+
     public static TestdataListSolutionExternalized generateUninitializedSolution(int valueCount, int entityCount) {
+        return generateSolution(valueCount, entityCount);
+    }
+
+    private static TestdataListSolutionExternalized generateSolution(int valueCount, int entityCount) {
         List<TestdataListEntityExternalized> entityList = IntStream.range(0, entityCount)
                 .mapToObj(i -> new TestdataListEntityExternalized("Generated Entity " + i))
                 .collect(Collectors.toList());
@@ -53,6 +61,13 @@ public class TestdataListSolutionExternalized {
     private List<TestdataListValueExternalized> valueList;
     private List<TestdataListEntityExternalized> entityList;
     private SimpleScore score;
+
+    private TestdataListSolutionExternalized initialize() {
+        for (int i = 0; i < valueList.size(); i++) {
+            entityList.get(i % entityList.size()).getValueList().add(valueList.get(i));
+        }
+        return this;
+    }
 
     @ValueRangeProvider(id = "valueRange")
     @ProblemFactCollectionProperty

--- a/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/testdata/util/PlannerTestUtils.java
+++ b/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/testdata/util/PlannerTestUtils.java
@@ -123,12 +123,23 @@ public class PlannerTestUtils {
 
     public static <Solution_> InnerScoreDirector<Solution_, SimpleScore> mockScoreDirector(
             SolutionDescriptor<Solution_> solutionDescriptor) {
+        return mock(InnerScoreDirector.class, AdditionalAnswers
+                .delegatesTo(buildEasyScoreDirectorFactory(solutionDescriptor).buildScoreDirector(false, false)));
+    }
+
+    public static <Solution_> InnerScoreDirector<Solution_, SimpleScore> mockScoreDirectorWithLookupEnabled(
+            SolutionDescriptor<Solution_> solutionDescriptor) {
+        return mock(InnerScoreDirector.class, AdditionalAnswers
+                .delegatesTo(buildEasyScoreDirectorFactory(solutionDescriptor).buildScoreDirector(true, false)));
+    }
+
+    private static <Solution_> EasyScoreDirectorFactory<Solution_, SimpleScore> buildEasyScoreDirectorFactory(
+            SolutionDescriptor<Solution_> solutionDescriptor) {
         EasyScoreDirectorFactory<Solution_, SimpleScore> scoreDirectorFactory =
                 new EasyScoreDirectorFactory<>(solutionDescriptor, (solution_) -> SimpleScore.of(0));
         scoreDirectorFactory.setInitializingScoreTrend(
                 InitializingScoreTrend.buildUniformTrend(InitializingScoreTrendLevel.ONLY_DOWN, 1));
-        return mock(InnerScoreDirector.class,
-                AdditionalAnswers.delegatesTo(scoreDirectorFactory.buildScoreDirector(false, false)));
+        return scoreDirectorFactory;
     }
 
     public static <Solution_, Score_ extends Score<Score_>> InnerScoreDirector<Solution_, Score_>


### PR DESCRIPTION
### Summary

Prevents score corruption on #1876.

#### Context
From a list variable perspective, a solution is initialized when all value range elements are assigned to some entity's list variable. The initScore says how many CH steps it takes to initialize the solution. With a list planning variable, it equals the number of unassigned values.

#### Problem
Currently, before/after entity/fact added/removed methods do not account for a situation when the entity/fact is added to/removed from a list variable's value range. This is a hidden bug and it will manifest when problem changes become incremental and stop re-setting working solution in #1876.

#### ~Solution 1~
> When an element is added to a list variable's value range, we assume it's unassigned and we should `workingInitScore--`. Value range modification cannot be detected directly, so we compare the total size of all value ranges before and after the change. The difference is applied to the working init score when the change is done.

#### Solution 2

Adding/removing element to/from a value range doesn't always affect the init score. Therefore, Solution 1 that only looks at value range sizes doesn't work. For example, removing an assigned value reduces value range size but it doesn't improve the init score.

The new solution does the full-blown `countUnassignedValues(solution)` which is already used for initial init score calculation during `setWorkingSolution()`.

#### Caveats
Q: What if a PC adds a value which is already assigned or assigns it? Should the init score remain unchanged?
A: That's a bad idea. Let the CH figure out what's the best entity for the value.
Q: Should this fail fast or should it be supported?

Q: What if a PC removes a value that is ~not~ assigned? That shouldn't affect the init score as in the example above.
~A: In an initialized solution (during LS) all values are assigned, so that's impossible.~
A: Yes, removing an assigned value does not worsen the init score and is supported by Solution 2.
Q: But can a PC happen on an uninitialized solution (during CH)?
A: Yes, it can. Solution 2 doesn't care about the extent of initialization. Removing an assigned value doesn't affect the init score, removing an unassigned value improves the init score.

#### Additional changes
ListVariableDescriptor caching. Once annotations are processed, list variable descriptors are collected and stored.


### JIRA
https://issues.redhat.com/browse/PLANNER-2680

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>specific pull request build</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] tests</b>
* for a <b>full downstream build</b> 
  * for <b>jenkins</b> job: please add comment: <b>Jenkins run fdb</b>
  * for <b>github actions</b> job: add the label `run_fdb`
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
* for a <b>Quarkus LTS check</b> please add comment: <b>Jenkins run LTS</b>
* for a <b>specific Quarkus LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] LTS</b>
* for a <b>Native check</b> please add comment: <b>Jenkins run native</b>
* for a <b>specific Native LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] native</b>
</details>
