### PR TITLE
PLANNER-2672 Return CompletableFuture for a problem change

### DIFF
--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/api/solver/SolverJob.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/api/solver/SolverJob.java
@@ -18,6 +18,7 @@ package org.optaplanner.core.api.solver;
 
 import java.time.Duration;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -55,10 +56,11 @@ public interface SolverJob<Solution_, ProblemId_> {
      * Schedules a {@link ProblemChange} to be processed by the underlying {@link Solver} and returns immediately.
      *
      * @param problemChange never null
+     * @return CompletableFuture<Void> that completes after the best solution containing this change has been consumed.
      * @throws IllegalStateException if the underlying {@link Solver} is not in the {@link SolverStatus#SOLVING_ACTIVE}
      *         state
      */
-    void addProblemChange(ProblemChange<Solution_> problemChange);
+    CompletableFuture<Void> addProblemChange(ProblemChange<Solution_> problemChange);
 
     /**
      * Terminates the solver or cancels the solver job if it hasn't (re)started yet.

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/api/solver/SolverJob.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/api/solver/SolverJob.java
@@ -56,7 +56,7 @@ public interface SolverJob<Solution_, ProblemId_> {
      * Schedules a {@link ProblemChange} to be processed by the underlying {@link Solver} and returns immediately.
      *
      * @param problemChange never null
-     * @return CompletableFuture<Void> that completes after the best solution containing this change has been consumed.
+     * @return completes after the best solution containing this change has been consumed.
      * @throws IllegalStateException if the underlying {@link Solver} is not in the {@link SolverStatus#SOLVING_ACTIVE}
      *         state
      */

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/api/solver/SolverManager.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/api/solver/SolverManager.java
@@ -313,7 +313,7 @@ public interface SolverManager<Solution_, ProblemId_> extends AutoCloseable {
      * @param problemId never null, a value given to {@link #solve(Object, Function, Consumer)}
      *        or {@link #solveAndListen(Object, Function, Consumer)}
      * @param problemChange never null
-     * @return CompletableFuture<Void> that completes after the best solution containing this change has been consumed.
+     * @return completes after the best solution containing this change has been consumed.
      * @throws IllegalStateException if there is no solver actively solving the problem associated with the problemId
      */
     CompletableFuture<Void> addProblemChange(ProblemId_ problemId, ProblemChange<Solution_> problemChange);

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/api/solver/SolverManager.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/api/solver/SolverManager.java
@@ -17,6 +17,7 @@
 package org.optaplanner.core.api.solver;
 
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -312,9 +313,10 @@ public interface SolverManager<Solution_, ProblemId_> extends AutoCloseable {
      * @param problemId never null, a value given to {@link #solve(Object, Function, Consumer)}
      *        or {@link #solveAndListen(Object, Function, Consumer)}
      * @param problemChange never null
+     * @return CompletableFuture<Void> that completes after the best solution containing this change has been consumed.
      * @throws IllegalStateException if there is no solver actively solving the problem associated with the problemId
      */
-    void addProblemChange(ProblemId_ problemId, ProblemChange<Solution_> problemChange);
+    CompletableFuture<Void> addProblemChange(ProblemId_ problemId, ProblemChange<Solution_> problemChange);
 
     /**
      * Terminates the solver or cancels the solver job if it hasn't (re)started yet.

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/solver/BestSolutionContainingProblemChanges.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/solver/BestSolutionContainingProblemChanges.java
@@ -35,4 +35,8 @@ final class BestSolutionContainingProblemChanges<Solution_> {
     public void completeProblemChanges() {
         containedProblemChanges.forEach(futureProblemChange -> futureProblemChange.complete(null));
     }
+
+    public void completeProblemChangesExceptionally(Throwable exception) {
+        containedProblemChanges.forEach(futureProblemChange -> futureProblemChange.completeExceptionally(exception));
+    }
 }

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/solver/BestSolutionContainingProblemChanges.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/solver/BestSolutionContainingProblemChanges.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.core.impl.solver;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+final class BestSolutionContainingProblemChanges<Solution_> {
+    private final Solution_ bestSolution;
+    private final List<CompletableFuture<Void>> containedProblemChanges;
+
+    public BestSolutionContainingProblemChanges(Solution_ bestSolution, List<CompletableFuture<Void>> containedProblemChanges) {
+        this.bestSolution = bestSolution;
+        this.containedProblemChanges = containedProblemChanges;
+    }
+
+    public Solution_ getBestSolution() {
+        return bestSolution;
+    }
+
+    public void completeProblemChanges() {
+        containedProblemChanges.forEach(futureProblemChange -> futureProblemChange.complete(null));
+    }
+}

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/solver/BestSolutionHolder.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/solver/BestSolutionHolder.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.core.impl.solver;
+
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.SortedMap;
+import java.util.TreeMap;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+import org.optaplanner.core.api.solver.Solver;
+import org.optaplanner.core.api.solver.change.ProblemChange;
+
+final class BestSolutionHolder<Solution_> {
+
+    private final Lock problemChangesLock = new ReentrantLock();
+    private final AtomicReference<VersionedBestSolution> versionedBestSolutionRef = new AtomicReference<>();
+    private final SortedMap<BigInteger, List<CompletableFuture<Void>>> problemChangesPerVersion =
+            new TreeMap<>();
+    private BigInteger currentVersion = BigInteger.ZERO;
+
+    boolean isEmpty() {
+        return versionedBestSolutionRef.get() == null;
+    }
+
+    /**
+     * @return the last best solution together with problem changes the solution contains.
+     */
+    BestSolutionContainingProblemChanges<Solution_> take() {
+        VersionedBestSolution versionedBestSolution = versionedBestSolutionRef.getAndSet(null);
+        if (versionedBestSolution == null) {
+            return null;
+        }
+        SortedMap<BigInteger, List<CompletableFuture<Void>>> containedProblemChangesPerVersion =
+                problemChangesPerVersion.headMap(versionedBestSolution.getVersion().add(BigInteger.ONE));
+
+        List<CompletableFuture<Void>> containedProblemChanges = containedProblemChangesPerVersion.values()
+                .stream()
+                .flatMap(Collection::stream)
+                .collect(Collectors.toList());
+
+        containedProblemChangesPerVersion.keySet().forEach(problemChangesPerVersion::remove);
+
+        return new BestSolutionContainingProblemChanges<>(versionedBestSolution.getBestSolution(),
+                containedProblemChanges);
+    }
+
+    /**
+     * Sets the new best solution if all known problem changes have been processed and thus are contained in this
+     * best solution.
+     * 
+     * @param bestSolution the new best solution that replaces the previous one if there is any
+     * @param isEveryProblemChangeProcessed a supplier that tells if all problem changes have been processed
+     */
+    void set(Solution_ bestSolution, Supplier<Boolean> isEveryProblemChangeProcessed) {
+        problemChangesLock.lock();
+        try {
+            /*
+             * The new best solution can be accepted only if there are no pending problem changes nor any additional
+             * changes may come during this operation. Otherwise, a race condition might occur that leads to associating
+             * problem changes with a solution that was created later, but does not contain them yet.
+             * As a result, CompletableFutures representing these changes would be completed too early.
+             */
+            if (isEveryProblemChangeProcessed.get()) {
+                versionedBestSolutionRef.set(new VersionedBestSolution(bestSolution, currentVersion));
+                currentVersion = currentVersion.add(BigInteger.ONE);
+            }
+        } finally {
+            problemChangesLock.unlock();
+        }
+    }
+
+    /**
+     * Adds a new problem change to a solver and registers the problem change to be later retrieved together with
+     * a relevant best solution by the {@link #take()} method.
+     * 
+     * @return CompletableFuture that will be completed after the best solution containing this change is passed to
+     *         a user-defined Consumer.
+     */
+    CompletableFuture<Void> addProblemChange(Solver<Solution_> solver, ProblemChange<Solution_> problemChange) {
+        CompletableFuture<Void> futureProblemChange;
+        problemChangesLock.lock();
+        try {
+            futureProblemChange = new CompletableFuture<>();
+            problemChangesPerVersion.compute(currentVersion, (version, futureProblemChangeList) -> {
+                if (futureProblemChangeList == null) {
+                    futureProblemChangeList = new ArrayList<>();
+                }
+                futureProblemChangeList.add(futureProblemChange);
+                return futureProblemChangeList;
+            });
+            solver.addProblemChange(problemChange);
+        } finally {
+            problemChangesLock.unlock();
+        }
+
+        return futureProblemChange;
+    }
+
+    void cancelPendingChanges() {
+        problemChangesLock.lock();
+        try {
+            problemChangesPerVersion.values()
+                    .stream()
+                    .flatMap(Collection::stream)
+                    .forEach(pendingProblemChange -> pendingProblemChange.cancel(true));
+            problemChangesPerVersion.clear();
+        } finally {
+            problemChangesLock.unlock();
+        }
+    }
+
+    private final class VersionedBestSolution {
+        final Solution_ bestSolution;
+        final BigInteger version;
+
+        public VersionedBestSolution(Solution_ bestSolution, BigInteger version) {
+            this.bestSolution = bestSolution;
+            this.version = version;
+        }
+
+        public Solution_ getBestSolution() {
+            return bestSolution;
+        }
+
+        public BigInteger getVersion() {
+            return version;
+        }
+    }
+}

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/solver/BestSolutionHolder.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/solver/BestSolutionHolder.java
@@ -124,7 +124,7 @@ final class BestSolutionHolder<Solution_> {
             problemChangesPerVersion.values()
                     .stream()
                     .flatMap(Collection::stream)
-                    .forEach(pendingProblemChange -> pendingProblemChange.cancel(true));
+                    .forEach(pendingProblemChange -> pendingProblemChange.cancel(false));
             problemChangesPerVersion.clear();
         } finally {
             problemChangesLock.unlock();

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/solver/BestSolutionHolder.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/solver/BestSolutionHolder.java
@@ -28,6 +28,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.BooleanSupplier;
+
 import org.optaplanner.core.api.solver.Solver;
 import org.optaplanner.core.api.solver.change.ProblemChange;
 

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/solver/ConsumerSupport.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/solver/ConsumerSupport.java
@@ -112,14 +112,13 @@ final class ConsumerSupport<Solution_, ProblemId_> implements AutoCloseable {
             if (bestSolutionContainingProblemChanges != null) {
                 try {
                     bestSolutionConsumer.accept(bestSolutionContainingProblemChanges.getBestSolution());
-                } catch (Throwable throwable) {
-                    exceptionHandler.accept(problemId, throwable);
-                } finally {
-                    /*
-                     * Complete the CompletableFutures associated with ProblemChanges regardless of a possible
-                     * exception in the consumer to avoid a memory leak.
-                     */
                     bestSolutionContainingProblemChanges.completeProblemChanges();
+                } catch (Throwable throwable) {
+                    if (exceptionHandler != null) {
+                        exceptionHandler.accept(problemId, throwable);
+                    }
+                    bestSolutionContainingProblemChanges.completeProblemChangesExceptionally(throwable);
+                } finally {
                     activeConsumption.release();
                 }
             }

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/solver/ConsumerSupport.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/solver/ConsumerSupport.java
@@ -21,8 +21,8 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Semaphore;
 import java.util.function.BiConsumer;
+import java.util.function.BooleanSupplier;
 import java.util.function.Consumer;
-import java.util.function.Supplier;
 
 final class ConsumerSupport<Solution_, ProblemId_> implements AutoCloseable {
 
@@ -47,7 +47,7 @@ final class ConsumerSupport<Solution_, ProblemId_> implements AutoCloseable {
     }
 
     // Called on the Solver thread.
-    void consumeIntermediateBestSolution(Solution_ bestSolution, Supplier<Boolean> isEveryProblemChangeProcessed) {
+    void consumeIntermediateBestSolution(Solution_ bestSolution, BooleanSupplier isEveryProblemChangeProcessed) {
         /*
          * If the bestSolutionConsumer is not provided, the best solution is still set for the purpose of recording
          * problem changes.

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/solver/DefaultSolverJob.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/solver/DefaultSolverJob.java
@@ -153,6 +153,7 @@ public final class DefaultSolverJob<Solution_, ProblemId_> implements SolverJob<
 
     private void solvingTerminated() {
         solverStatus = SolverStatus.NOT_SOLVING;
+        bestSolutionHolder.cancelPendingChanges();
         solverManager.unregisterSolverJob(problemId);
         terminatedLatch.countDown();
     }

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/solver/DefaultSolverJob.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/solver/DefaultSolverJob.java
@@ -21,6 +21,7 @@ import java.util.Objects;
 import java.util.UUID;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
@@ -35,6 +36,7 @@ import org.optaplanner.core.api.solver.Solver;
 import org.optaplanner.core.api.solver.SolverJob;
 import org.optaplanner.core.api.solver.SolverStatus;
 import org.optaplanner.core.api.solver.change.ProblemChange;
+import org.optaplanner.core.api.solver.event.BestSolutionChangedEvent;
 import org.optaplanner.core.impl.phase.event.PhaseLifecycleListenerAdapter;
 import org.optaplanner.core.impl.solver.scope.SolverScope;
 import org.slf4j.Logger;
@@ -62,6 +64,7 @@ public final class DefaultSolverJob<Solution_, ProblemId_> implements SolverJob<
     private Future<Solution_> finalBestSolutionFuture;
     private ConsumerSupport<Solution_, ProblemId_> consumerSupport;
     private final AtomicBoolean terminatedEarly = new AtomicBoolean(false);
+    private final BestSolutionHolder<Solution_> bestSolutionHolder = new BestSolutionHolder<>();
 
     public DefaultSolverJob(
             DefaultSolverManager<Solution_, ProblemId_> solverManager,
@@ -113,13 +116,13 @@ public final class DefaultSolverJob<Solution_, ProblemId_> implements SolverJob<
             solverStatus = SolverStatus.SOLVING_ACTIVE;
             // Create the consumer thread pool only when this solver job is active.
             consumerSupport = new ConsumerSupport<>(getProblemId(), bestSolutionConsumer, finalBestSolutionConsumer,
-                    exceptionHandler);
+                    exceptionHandler, bestSolutionHolder);
 
             Solution_ problem = problemFinder.apply(problemId);
             // add a phase lifecycle listener that unlock the solver status lock when solving started
             solver.addPhaseLifecycleListener(new UnlockLockPhaseLifecycleListener());
             if (bestSolutionConsumer != null) {
-                solver.addEventListener(event -> consumerSupport.consumeIntermediateBestSolution(event.getNewBestSolution()));
+                solver.addEventListener(this::onBestSolutionChangedEvent);
             }
             final Solution_ finalBestSolution = solver.solve(problem);
             if (finalBestSolutionConsumer != null) {
@@ -143,6 +146,11 @@ public final class DefaultSolverJob<Solution_, ProblemId_> implements SolverJob<
         }
     }
 
+    private void onBestSolutionChangedEvent(BestSolutionChangedEvent<Solution_> bestSolutionChangedEvent) {
+        consumerSupport.consumeIntermediateBestSolution(bestSolutionChangedEvent.getNewBestSolution(),
+                () -> bestSolutionChangedEvent.isEveryProblemChangeProcessed());
+    }
+
     private void solvingTerminated() {
         solverStatus = SolverStatus.NOT_SOLVING;
         solverManager.unregisterSolverJob(problemId);
@@ -156,13 +164,14 @@ public final class DefaultSolverJob<Solution_, ProblemId_> implements SolverJob<
     //    }
 
     @Override
-    public void addProblemChange(ProblemChange<Solution_> problemChange) {
+    public CompletableFuture<Void> addProblemChange(ProblemChange<Solution_> problemChange) {
         Objects.requireNonNull(problemChange, () -> "A problem change (" + problemChange + ") must not be null.");
         if (solverStatus == SolverStatus.NOT_SOLVING) {
             throw new IllegalStateException("Cannot add the problem change (" + problemChange
                     + ") because the solver job (" + solverStatus + ") is not solving.");
         }
-        solver.addProblemChange(problemChange);
+
+        return bestSolutionHolder.addProblemChange(solver, problemChange);
     }
 
     @Override

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/solver/DefaultSolverManager.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/solver/DefaultSolverManager.java
@@ -18,6 +18,7 @@ package org.optaplanner.core.impl.solver;
 
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ExecutorService;
@@ -146,7 +147,7 @@ public final class DefaultSolverManager<Solution_, ProblemId_> implements Solver
     //    }
 
     @Override
-    public void addProblemChange(ProblemId_ problemId, ProblemChange<Solution_> problemChange) {
+    public CompletableFuture<Void> addProblemChange(ProblemId_ problemId, ProblemChange<Solution_> problemChange) {
         DefaultSolverJob<Solution_, ProblemId_> solverJob = getSolverJob(problemId);
         if (solverJob == null) {
             // We cannot distinguish between "already terminated" and "never solved" without causing a memory leak.
@@ -154,7 +155,7 @@ public final class DefaultSolverManager<Solution_, ProblemId_> implements Solver
                     "Cannot add the problem change (" + problemChange + ") because there is no solver solving the problemId ("
                             + problemId + ").");
         }
-        solverJob.addProblemChange(problemChange);
+        return solverJob.addProblemChange(problemChange);
     }
 
     @Override

--- a/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/api/solver/SolverManagerTest.java
+++ b/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/api/solver/SolverManagerTest.java
@@ -603,7 +603,6 @@ class SolverManagerTest {
         // The second solver is scheduled and waits for the fist solver to finish.
         final long secondProblemId = 2L;
         final int entityAndValueCount = 4;
-        // CountDownLatch solutionWithProblemChangeReceived = new CountDownLatch(1);
         AtomicReference<TestdataSolution> bestSolution = new AtomicReference<>();
         solverManager.solveAndListen(secondProblemId,
                 id -> PlannerTestUtils.generateTestdataSolution("s2", entityAndValueCount), bestSolution::set);

--- a/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/solver/BestSolutionHolderTest.java
+++ b/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/solver/BestSolutionHolderTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.core.impl.solver;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.util.concurrent.CompletableFuture;
+
+import org.junit.jupiter.api.Test;
+import org.optaplanner.core.api.solver.Solver;
+import org.optaplanner.core.api.solver.change.ProblemChange;
+import org.optaplanner.core.impl.testdata.domain.TestdataSolution;
+
+class BestSolutionHolderTest {
+
+    @Test
+    void setBestSolution() {
+        BestSolutionHolder<TestdataSolution> bestSolutionHolder = new BestSolutionHolder<>();
+        assertThat(bestSolutionHolder.take()).isNull();
+
+        TestdataSolution solution1 = TestdataSolution.generateSolution();
+        TestdataSolution solution2 = TestdataSolution.generateSolution();
+
+        bestSolutionHolder.set(solution1, () -> true);
+        assertThat(bestSolutionHolder.take().getBestSolution()).isSameAs(solution1);
+        assertThat(bestSolutionHolder.take()).isNull();
+
+        bestSolutionHolder.set(solution1, () -> true);
+        bestSolutionHolder.set(solution2, () -> false);
+        assertThat(bestSolutionHolder.take().getBestSolution()).isSameAs(solution1);
+
+        bestSolutionHolder.set(solution1, () -> true);
+        bestSolutionHolder.set(solution2, () -> true);
+        assertThat(bestSolutionHolder.take().getBestSolution()).isSameAs(solution2);
+    }
+
+    @Test
+    void completeProblemChanges() {
+        BestSolutionHolder<TestdataSolution> bestSolutionHolder = new BestSolutionHolder<>();
+
+        CompletableFuture<Void> problemChange1 = addProblemChange(bestSolutionHolder);
+        bestSolutionHolder.set(TestdataSolution.generateSolution(), () -> true);
+        CompletableFuture<Void> problemChange2 = addProblemChange(bestSolutionHolder);
+
+        bestSolutionHolder.take().completeProblemChanges();
+        assertThat(problemChange1).isCompleted();
+        assertThat(problemChange2).isNotCompleted();
+
+        CompletableFuture<Void> problemChange3 = addProblemChange(bestSolutionHolder);
+        bestSolutionHolder.set(TestdataSolution.generateSolution(), () -> true);
+        bestSolutionHolder.set(TestdataSolution.generateSolution(), () -> true);
+        CompletableFuture<Void> problemChange4 = addProblemChange(bestSolutionHolder);
+
+        bestSolutionHolder.take().completeProblemChanges();
+
+        assertThat(problemChange2).isCompleted();
+        assertThat(problemChange3).isCompleted();
+        assertThat(problemChange4).isNotCompleted();
+    }
+
+    @Test
+    void cancelPendingChanges_noChangesRetrieved() {
+        BestSolutionHolder<TestdataSolution> bestSolutionHolder = new BestSolutionHolder<>();
+
+        CompletableFuture<Void> problemChange = addProblemChange(bestSolutionHolder);
+        bestSolutionHolder.set(TestdataSolution.generateSolution(), () -> true);
+
+        bestSolutionHolder.cancelPendingChanges();
+
+        BestSolutionContainingProblemChanges<TestdataSolution> bestSolution = bestSolutionHolder.take();
+        bestSolution.completeProblemChanges();
+
+        assertThat(problemChange).isCancelled();
+    }
+
+    private CompletableFuture<Void> addProblemChange(BestSolutionHolder<TestdataSolution> bestSolutionHolder) {
+        Solver<TestdataSolution> solver = mock(Solver.class);
+        ProblemChange<TestdataSolution> problemChange = mock(ProblemChange.class);
+        CompletableFuture<Void> futureChange = bestSolutionHolder.addProblemChange(solver, problemChange);
+        verify(solver, times(1)).addProblemChange(problemChange);
+        return futureChange;
+    }
+}

--- a/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/solver/ConsumerSupportTest.java
+++ b/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/solver/ConsumerSupportTest.java
@@ -17,17 +17,24 @@
 package org.optaplanner.core.impl.solver;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.fail;
+import static org.mockito.Mockito.*;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
+import org.optaplanner.core.api.solver.Solver;
+import org.optaplanner.core.api.solver.change.ProblemChange;
 import org.optaplanner.core.impl.testdata.domain.TestdataSolution;
 
 class ConsumerSupportTest {
@@ -77,6 +84,49 @@ class ConsumerSupportTest {
         if (error.get() != null) {
             fail("Exception during consumption.", error.get());
         }
+    }
+
+    @Test
+    @Timeout(60)
+    void problemChangesComplete_afterFinalBestSolutionIsConsumed() throws ExecutionException, InterruptedException {
+        BestSolutionHolder<TestdataSolution> bestSolutionHolder = new BestSolutionHolder<>();
+        AtomicReference<TestdataSolution> finalBestSolutionRef = new AtomicReference<>();
+        consumerSupport = new ConsumerSupport<>(1L, null,
+                finalBestSolution -> finalBestSolutionRef.set(finalBestSolution), null, bestSolutionHolder);
+
+        CompletableFuture<Void> futureProblemChange = addProblemChange(bestSolutionHolder);
+
+        consumeIntermediateBestSolution(TestdataSolution.generateSolution());
+        assertThat(futureProblemChange).isNotCompleted();
+        TestdataSolution finalBestSolution = TestdataSolution.generateSolution();
+        consumerSupport.consumeFinalBestSolution(finalBestSolution);
+        futureProblemChange.get();
+        assertThat(finalBestSolutionRef.get()).isSameAs(finalBestSolution);
+        assertThat(futureProblemChange).isCompleted();
+    }
+
+    @Test
+    @Timeout(60)
+    void pendingProblemChangesAreCanceled_afterFinalBestSolutionIsConsumed() throws ExecutionException, InterruptedException {
+        BestSolutionHolder<TestdataSolution> bestSolutionHolder = new BestSolutionHolder<>();
+        consumerSupport = new ConsumerSupport<>(1L, null, null,
+                null, bestSolutionHolder);
+
+        CompletableFuture<Void> futureProblemChange = addProblemChange(bestSolutionHolder);
+
+        consumeIntermediateBestSolution(TestdataSolution.generateSolution());
+        assertThat(futureProblemChange).isNotCompleted();
+
+        CompletableFuture<Void> pendingProblemChange = addProblemChange(bestSolutionHolder);
+        consumerSupport.consumeFinalBestSolution(TestdataSolution.generateSolution());
+        futureProblemChange.get();
+        assertThat(futureProblemChange).isCompleted();
+
+        assertThatExceptionOfType(CancellationException.class).isThrownBy(() -> pendingProblemChange.get());
+    }
+
+    private CompletableFuture<Void> addProblemChange(BestSolutionHolder<TestdataSolution> bestSolutionHolder) {
+        return bestSolutionHolder.addProblemChange(mock(Solver.class), mock(ProblemChange.class));
     }
 
     private void consumeIntermediateBestSolution(TestdataSolution bestSolution) {

--- a/optaplanner-docs/src/modules/ROOT/pages/repeated-planning/repeated-planning.adoc
+++ b/optaplanner-docs/src/modules/ROOT/pages/repeated-planning/repeated-planning.adoc
@@ -348,7 +348,7 @@ public interface SolverManager<Solution_, ProblemId_> {
 
     ...
 
-    void addProblemChange(ProblemId_ problemId, ProblemChange<Solution_> problemChange);
+    CompletableFuture<Void> addProblemChange(ProblemId_ problemId, ProblemChange<Solution_> problemChange);
 
     ...
 
@@ -363,13 +363,15 @@ public interface SolverJob<Solution_, ProblemId_> {
 
     ...
 
-    void addProblemChange(ProblemChange<Solution_> problemChange);
+    CompletableFuture<Void> addProblemChange(ProblemChange<Solution_> problemChange);
 
     ...
 
 }
 ----
 
+Notice the method returns `CompletableFuture<Void>`, which is completed when a user-defined `Consumer` accepts
+the best solution containing this problem change.
 
 [source,java,options="nowrap"]
 ----


### PR DESCRIPTION
<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.
-->
TODO:
- [x] check and update documentation

### JIRA
https://issues.redhat.com/browse/PLANNER-2672

<!-- Add a JIRA ticket link if it exists. -->
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->

### Referenced pull requests
https://github.com/kiegroup/optaplanner-website/pull/485

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
* https://github.com/kiegroup/drools/pull/3000
* https://github.com/kiegroup/optaplanner/pull/899
* etc.
-->

### Checklist
- [ ] Documentation updated if applicable.
- [ ] Upgrade recipe provided if applicable.

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>specific pull request build</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] tests</b>
* for a <b>full downstream build</b> 
  * for <b>jenkins</b> job: please add comment: <b>Jenkins run fdb</b>
  * for <b>github actions</b> job: add the label `run_fdb`
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
* for a <b>Quarkus LTS check</b> please add comment: <b>Jenkins run LTS</b>
* for a <b>specific Quarkus LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] LTS</b>
* for a <b>Native check</b> please add comment: <b>Jenkins run native</b>
* for a <b>specific Native LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] native</b>
</details>
