### PR TITLE
Find list variable descriptors once and store them

### DIFF
--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/constructionheuristic/DefaultConstructionHeuristicPhaseFactory.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/constructionheuristic/DefaultConstructionHeuristicPhaseFactory.java
@@ -134,7 +134,7 @@ public class DefaultConstructionHeuristicPhaseFactory<Solution_>
 
     private Optional<ListVariableDescriptor<?>> findValidListVariableDescriptor(
             SolutionDescriptor<Solution_> solutionDescriptor) {
-        List<ListVariableDescriptor<Solution_>> listVariableDescriptors = solutionDescriptor.findListVariableDescriptors();
+        List<ListVariableDescriptor<Solution_>> listVariableDescriptors = solutionDescriptor.getListVariableDescriptors();
         if (listVariableDescriptors.isEmpty()) {
             return Optional.empty();
         }

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/domain/solution/descriptor/SolutionDescriptor.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/domain/solution/descriptor/SolutionDescriptor.java
@@ -1042,19 +1042,28 @@ public class SolutionDescriptor<Solution_> {
      * @return {@code >= 0}
      */
     public int countUninitialized(Solution_ solution) {
-        if (!listVariableDescriptors.isEmpty()) {
-            return listVariableDescriptors.stream()
-                    .mapToInt(variableDescriptor -> countUnassignedValues(solution, variableDescriptor))
-                    .sum();
-        }
-        return countUninitializedVariables(solution);
+        return countUninitializedVariables(solution) + countUnassignedValues(solution);
     }
 
+    /**
+     * Counts the number of uninitialized basic planning variables on all entities.
+     */
     private int countUninitializedVariables(Solution_ solution) {
         MutableInt result = new MutableInt();
         visitAllEntities(solution,
                 entity -> result.add(findEntityDescriptorOrFail(entity.getClass()).countUninitializedVariables(entity)));
         return result.intValue();
+    }
+
+    /**
+     * Counts the number of elements from list variable value ranges, that are not assigned to any list variable.
+     */
+    private int countUnassignedValues(Solution_ solution) {
+        int unassignedValueCount = 0;
+        for (ListVariableDescriptor<Solution_> listVariableDescriptor : listVariableDescriptors) {
+            unassignedValueCount += countUnassignedValues(solution, listVariableDescriptor);
+        }
+        return unassignedValueCount;
     }
 
     private int countUnassignedValues(Solution_ solution, ListVariableDescriptor<Solution_> variableDescriptor) {

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/solver/DefaultSolverFactory.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/solver/DefaultSolverFactory.java
@@ -207,7 +207,7 @@ public final class DefaultSolverFactory<Solution_> implements SolverFactory<Solu
                     configPolicy.getSolutionDescriptor().getGenuineEntityDescriptors();
             Map<Class<?>, List<ListVariableDescriptor<Solution_>>> entityClassToListVariableDescriptorListMap =
                     configPolicy.getSolutionDescriptor()
-                            .findListVariableDescriptors()
+                            .getListVariableDescriptors()
                             .stream()
                             .collect(Collectors.groupingBy(
                                     listVariableDescriptor -> listVariableDescriptor.getEntityDescriptor().getEntityClass(),


### PR DESCRIPTION
- The domain model never changes so it's possible and more efficient to find list variable descriptors at the end of the solution descriptor build procedure and store them in a list for future reference.
- With the list of list variable descriptors available, it is now easy to use a `for` loop instead of a stream, which should be more efficient (given that there is typically zero or one list variable).

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>specific pull request build</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] tests</b>
* for a <b>full downstream build</b> 
  * for <b>jenkins</b> job: please add comment: <b>Jenkins run fdb</b>
  * for <b>github actions</b> job: add the label `run_fdb`
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
* for a <b>Quarkus LTS check</b> please add comment: <b>Jenkins run LTS</b>
* for a <b>specific Quarkus LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] LTS</b>
* for a <b>Native check</b> please add comment: <b>Jenkins run native</b>
* for a <b>specific Native LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] native</b>
</details>
