### PR TITLE
Turn FULL_ASSERT on and off in one step

### DIFF
--- a/optaplanner-examples/src/main/resources/org/optaplanner/examples/batchscheduling/batchSchedulingSolverConfig.xml
+++ b/optaplanner-examples/src/main/resources/org/optaplanner/examples/batchscheduling/batchSchedulingSolverConfig.xml
@@ -1,63 +1,63 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <solver xmlns="https://www.optaplanner.org/xsd/solver" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="https://www.optaplanner.org/xsd/solver https://www.optaplanner.org/xsd/solver/solver.xsd">
-    <!--<environmentMode>FULL_ASSERT</environmentMode>-->
-	<solutionClass>org.optaplanner.examples.batchscheduling.domain.BatchSchedule</solutionClass>
-	<entityClass>org.optaplanner.examples.batchscheduling.domain.Allocation</entityClass>
-	<entityClass>org.optaplanner.examples.batchscheduling.domain.AllocationPath</entityClass>
-	<scoreDirectorFactory>
-		<!-- <easyScoreCalculatorClass>org.optaplanner.examples.batchscheduling.optional.score.BatchSchedulingEasyScoreCalculator</easyScoreCalculatorClass> -->
-		<incrementalScoreCalculatorClass>org.optaplanner.examples.batchscheduling.score.BatchSchedulingIncrementalScoreCalculator</incrementalScoreCalculatorClass>
-		<!--<initializingScoreTrend>ANY</initializingScoreTrend> -->
-		<!--<assertionScoreDirectorFactory> -->
-		<!--<easyScoreCalculatorClass>org.optaplanner.examples.batchscheduling.optional.score.BatchSchedulingEasyScoreCalculator</easyScoreCalculatorClass> -->
-		<!--</assertionScoreDirectorFactory> -->
-	</scoreDirectorFactory>
-	<termination>
-		<minutesSpentLimit>20</minutesSpentLimit>
-	</termination>
-	<constructionHeuristic>
-		<queuedEntityPlacer>
-			<entitySelector id="placerEntitySelector">
-				<entityClass>org.optaplanner.examples.batchscheduling.domain.AllocationPath</entityClass>
-				<cacheType>PHASE</cacheType>
-				<selectionOrder>ORIGINAL</selectionOrder>
-			</entitySelector>
-			<changeMoveSelector>
-				<entitySelector	mimicSelectorRef="placerEntitySelector"/>
-			</changeMoveSelector>
-		</queuedEntityPlacer>
-	</constructionHeuristic>
-	<constructionHeuristic>
-		<queuedEntityPlacer>
-			<entitySelector id="placerEntitySelector">
-				<entityClass>org.optaplanner.examples.batchscheduling.domain.Allocation</entityClass>
-				<cacheType>PHASE</cacheType>
-				<selectionOrder>ORIGINAL</selectionOrder>
-			</entitySelector>
-			<changeMoveSelector>
-				<entitySelector mimicSelectorRef="placerEntitySelector"/>
-			</changeMoveSelector>
-		</queuedEntityPlacer>
-	</constructionHeuristic>
- 	<localSearch>
-		<unionMoveSelector>
-			<changeMoveSelector>
-				<entitySelector>
-					<entityClass>org.optaplanner.examples.batchscheduling.domain.AllocationPath</entityClass>
-					<cacheType>PHASE</cacheType>
-					<selectionOrder>ORIGINAL</selectionOrder>
-				</entitySelector>
-				<valueSelector variableName="routePath"/>
-			</changeMoveSelector>
-			<changeMoveSelector>
-				<entitySelector>
-					<entityClass>org.optaplanner.examples.batchscheduling.domain.Allocation</entityClass>
-					<cacheType>PHASE</cacheType>
-					<selectionOrder>ORIGINAL</selectionOrder>
-				</entitySelector>
-				<valueSelector variableName="delay"/>
-			</changeMoveSelector>
-		</unionMoveSelector>
-	</localSearch>
+        xsi:schemaLocation="https://www.optaplanner.org/xsd/solver https://www.optaplanner.org/xsd/solver/solver.xsd">
+  <!--<environmentMode>FULL_ASSERT</environmentMode>-->
+  <solutionClass>org.optaplanner.examples.batchscheduling.domain.BatchSchedule</solutionClass>
+  <entityClass>org.optaplanner.examples.batchscheduling.domain.Allocation</entityClass>
+  <entityClass>org.optaplanner.examples.batchscheduling.domain.AllocationPath</entityClass>
+  <scoreDirectorFactory>
+    <!--<easyScoreCalculatorClass>org.optaplanner.examples.batchscheduling.optional.score.BatchSchedulingEasyScoreCalculator</easyScoreCalculatorClass>-->
+    <incrementalScoreCalculatorClass>org.optaplanner.examples.batchscheduling.score.BatchSchedulingIncrementalScoreCalculator</incrementalScoreCalculatorClass>
+    <!--<initializingScoreTrend>ANY</initializingScoreTrend>-->
+    <!--<assertionScoreDirectorFactory>-->
+      <!--<easyScoreCalculatorClass>org.optaplanner.examples.batchscheduling.optional.score.BatchSchedulingEasyScoreCalculator</easyScoreCalculatorClass>-->
+    <!--</assertionScoreDirectorFactory>-->
+  </scoreDirectorFactory>
+  <termination>
+    <minutesSpentLimit>20</minutesSpentLimit>
+  </termination>
+  <constructionHeuristic>
+    <queuedEntityPlacer>
+      <entitySelector id="placerEntitySelector">
+        <entityClass>org.optaplanner.examples.batchscheduling.domain.AllocationPath</entityClass>
+        <cacheType>PHASE</cacheType>
+        <selectionOrder>ORIGINAL</selectionOrder>
+      </entitySelector>
+      <changeMoveSelector>
+        <entitySelector mimicSelectorRef="placerEntitySelector"/>
+      </changeMoveSelector>
+    </queuedEntityPlacer>
+  </constructionHeuristic>
+  <constructionHeuristic>
+    <queuedEntityPlacer>
+      <entitySelector id="placerEntitySelector">
+        <entityClass>org.optaplanner.examples.batchscheduling.domain.Allocation</entityClass>
+        <cacheType>PHASE</cacheType>
+        <selectionOrder>ORIGINAL</selectionOrder>
+      </entitySelector>
+      <changeMoveSelector>
+        <entitySelector mimicSelectorRef="placerEntitySelector"/>
+      </changeMoveSelector>
+    </queuedEntityPlacer>
+  </constructionHeuristic>
+  <localSearch>
+    <unionMoveSelector>
+      <changeMoveSelector>
+        <entitySelector>
+          <entityClass>org.optaplanner.examples.batchscheduling.domain.AllocationPath</entityClass>
+          <cacheType>PHASE</cacheType>
+          <selectionOrder>ORIGINAL</selectionOrder>
+        </entitySelector>
+        <valueSelector variableName="routePath"/>
+      </changeMoveSelector>
+      <changeMoveSelector>
+        <entitySelector>
+          <entityClass>org.optaplanner.examples.batchscheduling.domain.Allocation</entityClass>
+          <cacheType>PHASE</cacheType>
+          <selectionOrder>ORIGINAL</selectionOrder>
+        </entitySelector>
+        <valueSelector variableName="delay"/>
+      </changeMoveSelector>
+    </unionMoveSelector>
+  </localSearch>
 </solver>

--- a/optaplanner-examples/src/main/resources/org/optaplanner/examples/batchscheduling/batchSchedulingSolverConfig.xml
+++ b/optaplanner-examples/src/main/resources/org/optaplanner/examples/batchscheduling/batchSchedulingSolverConfig.xml
@@ -1,7 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <solver xmlns="https://www.optaplanner.org/xsd/solver" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="https://www.optaplanner.org/xsd/solver https://www.optaplanner.org/xsd/solver/solver.xsd">
+  <!-- To slowly prove there are no bugs in this code -->
   <!--<environmentMode>FULL_ASSERT</environmentMode>-->
+  <!-- To solve faster by saturating multiple CPU cores -->
+  <!--<moveThreadCount>AUTO</moveThreadCount>-->
+
   <solutionClass>org.optaplanner.examples.batchscheduling.domain.BatchSchedule</solutionClass>
   <entityClass>org.optaplanner.examples.batchscheduling.domain.Allocation</entityClass>
   <entityClass>org.optaplanner.examples.batchscheduling.domain.AllocationPath</entityClass>

--- a/optaplanner-examples/src/main/resources/org/optaplanner/examples/cheaptime/cheapTimeSolverConfig.xml
+++ b/optaplanner-examples/src/main/resources/org/optaplanner/examples/cheaptime/cheapTimeSolverConfig.xml
@@ -1,8 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <solver xmlns="https://www.optaplanner.org/xsd/solver" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="https://www.optaplanner.org/xsd/solver https://www.optaplanner.org/xsd/solver/solver.xsd">
-  <!--<environmentMode>FULL_ASSERT</environmentMode>--><!-- To slowly prove there are no bugs in this code -->
-  <!--<moveThreadCount>AUTO</moveThreadCount>--><!-- To solve faster by saturating multiple CPU cores -->
+  <!-- To slowly prove there are no bugs in this code -->
+  <!--<environmentMode>FULL_ASSERT</environmentMode>-->
+  <!-- To solve faster by saturating multiple CPU cores -->
+  <!--<moveThreadCount>AUTO</moveThreadCount>-->
 
   <!-- Domain model configuration -->
   <solutionClass>org.optaplanner.examples.cheaptime.domain.CheapTimeSolution</solutionClass>

--- a/optaplanner-examples/src/main/resources/org/optaplanner/examples/cloudbalancing/cloudBalancingSolverConfig.xml
+++ b/optaplanner-examples/src/main/resources/org/optaplanner/examples/cloudbalancing/cloudBalancingSolverConfig.xml
@@ -1,8 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <solver xmlns="https://www.optaplanner.org/xsd/solver" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="https://www.optaplanner.org/xsd/solver https://www.optaplanner.org/xsd/solver/solver.xsd">
-  <!--<environmentMode>FULL_ASSERT</environmentMode>--><!-- To slowly prove there are no bugs in this code -->
-  <!--<moveThreadCount>AUTO</moveThreadCount>--><!-- To solve faster by saturating multiple CPU cores -->
+  <!-- To slowly prove there are no bugs in this code -->
+  <!--<environmentMode>FULL_ASSERT</environmentMode>-->
+  <!-- To solve faster by saturating multiple CPU cores -->
+  <!--<moveThreadCount>AUTO</moveThreadCount>-->
 
   <!-- Domain model configuration -->
   <solutionClass>org.optaplanner.examples.cloudbalancing.domain.CloudBalance</solutionClass>

--- a/optaplanner-examples/src/main/resources/org/optaplanner/examples/coachshuttlegathering/coachShuttleGatheringSolverConfig.xml
+++ b/optaplanner-examples/src/main/resources/org/optaplanner/examples/coachshuttlegathering/coachShuttleGatheringSolverConfig.xml
@@ -1,8 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <solver xmlns="https://www.optaplanner.org/xsd/solver" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="https://www.optaplanner.org/xsd/solver https://www.optaplanner.org/xsd/solver/solver.xsd">
-  <!--<environmentMode>FULL_ASSERT</environmentMode>--><!-- To slowly prove there are no bugs in this code -->
-  <moveThreadCount>AUTO</moveThreadCount><!-- To solve faster by saturating multiple CPU cores -->
+  <!-- To slowly prove there are no bugs in this code -->
+  <!--<environmentMode>FULL_ASSERT</environmentMode>-->
+  <!-- To solve faster by saturating multiple CPU cores -->
+  <moveThreadCount>AUTO</moveThreadCount>
 
   <solutionClass>org.optaplanner.examples.coachshuttlegathering.domain.CoachShuttleGatheringSolution</solutionClass>
   <entityClass>org.optaplanner.examples.coachshuttlegathering.domain.BusOrStop</entityClass>

--- a/optaplanner-examples/src/main/resources/org/optaplanner/examples/conferencescheduling/conferenceSchedulingSolverConfig.xml
+++ b/optaplanner-examples/src/main/resources/org/optaplanner/examples/conferencescheduling/conferenceSchedulingSolverConfig.xml
@@ -1,8 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <solver xmlns="https://www.optaplanner.org/xsd/solver" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="https://www.optaplanner.org/xsd/solver https://www.optaplanner.org/xsd/solver/solver.xsd">
-  <!--<environmentMode>FULL_ASSERT</environmentMode>--><!-- To slowly prove there are no bugs in this code -->
-  <!--<moveThreadCount>AUTO</moveThreadCount>--><!-- To solve faster by saturating multiple CPU cores -->
+  <!-- To slowly prove there are no bugs in this code -->
+  <!--<environmentMode>FULL_ASSERT</environmentMode>-->
+  <!-- To solve faster by saturating multiple CPU cores -->
+  <!--<moveThreadCount>AUTO</moveThreadCount>-->
 
   <solutionClass>org.optaplanner.examples.conferencescheduling.domain.ConferenceSolution</solutionClass>
   <entityClass>org.optaplanner.examples.conferencescheduling.domain.Talk</entityClass>

--- a/optaplanner-examples/src/main/resources/org/optaplanner/examples/curriculumcourse/curriculumCourseSolverConfig.xml
+++ b/optaplanner-examples/src/main/resources/org/optaplanner/examples/curriculumcourse/curriculumCourseSolverConfig.xml
@@ -1,8 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <solver xmlns="https://www.optaplanner.org/xsd/solver" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="https://www.optaplanner.org/xsd/solver https://www.optaplanner.org/xsd/solver/solver.xsd">
-  <!--<environmentMode>FULL_ASSERT</environmentMode>--><!-- To slowly prove there are no bugs in this code -->
-  <!--<moveThreadCount>AUTO</moveThreadCount>--><!-- To solve faster by saturating multiple CPU cores -->
+  <!-- To slowly prove there are no bugs in this code -->
+  <!--<environmentMode>FULL_ASSERT</environmentMode>-->
+  <!-- To solve faster by saturating multiple CPU cores -->
+  <!--<moveThreadCount>AUTO</moveThreadCount>-->
 
   <solutionClass>org.optaplanner.examples.curriculumcourse.domain.CourseSchedule</solutionClass>
   <entityClass>org.optaplanner.examples.curriculumcourse.domain.Lecture</entityClass>

--- a/optaplanner-examples/src/main/resources/org/optaplanner/examples/examination/examinationSolverConfig.xml
+++ b/optaplanner-examples/src/main/resources/org/optaplanner/examples/examination/examinationSolverConfig.xml
@@ -1,8 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <solver xmlns="https://www.optaplanner.org/xsd/solver" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="https://www.optaplanner.org/xsd/solver https://www.optaplanner.org/xsd/solver/solver.xsd">
-  <!--<environmentMode>FULL_ASSERT</environmentMode>--><!-- To slowly prove there are no bugs in this code -->
-  <!--<moveThreadCount>AUTO</moveThreadCount>--><!-- To solve faster by saturating multiple CPU cores -->
+  <!-- To slowly prove there are no bugs in this code -->
+  <!--<environmentMode>FULL_ASSERT</environmentMode>-->
+  <!-- To solve faster by saturating multiple CPU cores -->
+  <!--<moveThreadCount>AUTO</moveThreadCount>-->
 
   <solutionClass>org.optaplanner.examples.examination.domain.Examination</solutionClass>
   <entityClass>org.optaplanner.examples.examination.domain.Exam</entityClass>

--- a/optaplanner-examples/src/main/resources/org/optaplanner/examples/flightcrewscheduling/flightCrewSchedulingSolverConfig.xml
+++ b/optaplanner-examples/src/main/resources/org/optaplanner/examples/flightcrewscheduling/flightCrewSchedulingSolverConfig.xml
@@ -1,8 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <solver xmlns="https://www.optaplanner.org/xsd/solver" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="https://www.optaplanner.org/xsd/solver https://www.optaplanner.org/xsd/solver/solver.xsd">
-  <!--<environmentMode>FULL_ASSERT</environmentMode>--><!-- To slowly prove there are no bugs in this code -->
-  <!--<moveThreadCount>AUTO</moveThreadCount>--><!-- To solve faster by saturating multiple CPU cores -->
+  <!-- To slowly prove there are no bugs in this code -->
+  <!--<environmentMode>FULL_ASSERT</environmentMode>-->
+  <!-- To solve faster by saturating multiple CPU cores -->
+  <!--<moveThreadCount>AUTO</moveThreadCount>-->
 
   <solutionClass>org.optaplanner.examples.flightcrewscheduling.domain.FlightCrewSolution</solutionClass>
   <entityClass>org.optaplanner.examples.flightcrewscheduling.domain.FlightAssignment</entityClass>

--- a/optaplanner-examples/src/main/resources/org/optaplanner/examples/investment/investmentSolverConfig.xml
+++ b/optaplanner-examples/src/main/resources/org/optaplanner/examples/investment/investmentSolverConfig.xml
@@ -1,8 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <solver xmlns="https://www.optaplanner.org/xsd/solver" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="https://www.optaplanner.org/xsd/solver https://www.optaplanner.org/xsd/solver/solver.xsd">
-  <!--<environmentMode>FULL_ASSERT</environmentMode>--><!-- To slowly prove there are no bugs in this code -->
-  <!--<moveThreadCount>AUTO</moveThreadCount>--><!-- To solve faster by saturating multiple CPU cores -->
+  <!-- To slowly prove there are no bugs in this code -->
+  <!--<environmentMode>FULL_ASSERT</environmentMode>-->
+  <!-- To solve faster by saturating multiple CPU cores -->
+  <!--<moveThreadCount>AUTO</moveThreadCount>-->
 
   <!-- Domain model configuration -->
   <solutionClass>org.optaplanner.examples.investment.domain.InvestmentSolution</solutionClass>

--- a/optaplanner-examples/src/main/resources/org/optaplanner/examples/machinereassignment/machineReassignmentSolverConfig.xml
+++ b/optaplanner-examples/src/main/resources/org/optaplanner/examples/machinereassignment/machineReassignmentSolverConfig.xml
@@ -1,8 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <solver xmlns="https://www.optaplanner.org/xsd/solver" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="https://www.optaplanner.org/xsd/solver https://www.optaplanner.org/xsd/solver/solver.xsd">
-  <!--<environmentMode>FULL_ASSERT</environmentMode>--><!-- To slowly prove there are no bugs in this code -->
-  <!--<moveThreadCount>AUTO</moveThreadCount>--><!-- To solve faster by saturating multiple CPU cores -->
+  <!-- To slowly prove there are no bugs in this code -->
+  <!--<environmentMode>FULL_ASSERT</environmentMode>-->
+  <!-- To solve faster by saturating multiple CPU cores -->
+  <!--<moveThreadCount>AUTO</moveThreadCount>-->
 
   <solutionClass>org.optaplanner.examples.machinereassignment.domain.MachineReassignment</solutionClass>
   <entityClass>org.optaplanner.examples.machinereassignment.domain.MrProcessAssignment</entityClass>
@@ -18,7 +20,7 @@
   <termination>
     <minutesSpentLimit>5</minutesSpentLimit>
   </termination>
-  
+
   <!--<constructionHeuristic>-->
     <!--<constructionHeuristicType>FIRST_FIT</constructionHeuristicType>-->
   <!--</constructionHeuristic>-->

--- a/optaplanner-examples/src/main/resources/org/optaplanner/examples/meetingscheduling/meetingSchedulingSolverConfig.xml
+++ b/optaplanner-examples/src/main/resources/org/optaplanner/examples/meetingscheduling/meetingSchedulingSolverConfig.xml
@@ -1,8 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <solver xmlns="https://www.optaplanner.org/xsd/solver" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="https://www.optaplanner.org/xsd/solver https://www.optaplanner.org/xsd/solver/solver.xsd">
-  <!--<environmentMode>FULL_ASSERT</environmentMode>--><!-- To slowly prove there are no bugs in this code -->
-  <!--<moveThreadCount>AUTO</moveThreadCount>--><!-- To solve faster by saturating multiple CPU cores -->
+  <!-- To slowly prove there are no bugs in this code -->
+  <!--<environmentMode>FULL_ASSERT</environmentMode>-->
+  <!-- To solve faster by saturating multiple CPU cores -->
+  <!--<moveThreadCount>AUTO</moveThreadCount>-->
 
   <solutionClass>org.optaplanner.examples.meetingscheduling.domain.MeetingSchedule</solutionClass>
   <entityClass>org.optaplanner.examples.meetingscheduling.domain.MeetingAssignment</entityClass>

--- a/optaplanner-examples/src/main/resources/org/optaplanner/examples/nqueens/nqueensSolverConfig.xml
+++ b/optaplanner-examples/src/main/resources/org/optaplanner/examples/nqueens/nqueensSolverConfig.xml
@@ -1,8 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <solver xmlns="https://www.optaplanner.org/xsd/solver" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="https://www.optaplanner.org/xsd/solver https://www.optaplanner.org/xsd/solver/solver.xsd">
-  <!--<environmentMode>FULL_ASSERT</environmentMode>--><!-- To slowly prove there are no bugs in this code -->
-  <!--<moveThreadCount>AUTO</moveThreadCount>--><!-- To solve faster by saturating multiple CPU cores -->
+  <!-- To slowly prove there are no bugs in this code -->
+  <!--<environmentMode>FULL_ASSERT</environmentMode>-->
+  <!-- To solve faster by saturating multiple CPU cores -->
+  <!--<moveThreadCount>AUTO</moveThreadCount>-->
 
   <solutionClass>org.optaplanner.examples.nqueens.domain.NQueens</solutionClass>
   <entityClass>org.optaplanner.examples.nqueens.domain.Queen</entityClass>

--- a/optaplanner-examples/src/main/resources/org/optaplanner/examples/nurserostering/nurseRosteringSolverConfig.xml
+++ b/optaplanner-examples/src/main/resources/org/optaplanner/examples/nurserostering/nurseRosteringSolverConfig.xml
@@ -1,8 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <solver xmlns="https://www.optaplanner.org/xsd/solver" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="https://www.optaplanner.org/xsd/solver https://www.optaplanner.org/xsd/solver/solver.xsd">
-  <!--<environmentMode>FULL_ASSERT</environmentMode>--><!-- To slowly prove there are no bugs in this code -->
-  <!--<moveThreadCount>AUTO</moveThreadCount>--><!-- To solve faster by saturating multiple CPU cores -->
+  <!-- To slowly prove there are no bugs in this code -->
+  <!--<environmentMode>FULL_ASSERT</environmentMode>-->
+  <!-- To solve faster by saturating multiple CPU cores -->
+  <!--<moveThreadCount>AUTO</moveThreadCount>-->
 
   <solutionClass>org.optaplanner.examples.nurserostering.domain.NurseRoster</solutionClass>
   <entityClass>org.optaplanner.examples.nurserostering.domain.ShiftAssignment</entityClass>

--- a/optaplanner-examples/src/main/resources/org/optaplanner/examples/pas/patientAdmissionScheduleSolverConfig.xml
+++ b/optaplanner-examples/src/main/resources/org/optaplanner/examples/pas/patientAdmissionScheduleSolverConfig.xml
@@ -1,8 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <solver xmlns="https://www.optaplanner.org/xsd/solver" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="https://www.optaplanner.org/xsd/solver https://www.optaplanner.org/xsd/solver/solver.xsd">
-  <!--<environmentMode>FULL_ASSERT</environmentMode>--><!-- To slowly prove there are no bugs in this code -->
-  <!--<moveThreadCount>AUTO</moveThreadCount>--><!-- To solve faster by saturating multiple CPU cores -->
+  <!-- To slowly prove there are no bugs in this code -->
+  <!--<environmentMode>FULL_ASSERT</environmentMode>-->
+  <!-- To solve faster by saturating multiple CPU cores -->
+  <!--<moveThreadCount>AUTO</moveThreadCount>-->
 
   <solutionClass>org.optaplanner.examples.pas.domain.PatientAdmissionSchedule</solutionClass>
   <entityClass>org.optaplanner.examples.pas.domain.BedDesignation</entityClass>

--- a/optaplanner-examples/src/main/resources/org/optaplanner/examples/projectjobscheduling/projectJobSchedulingSolverConfig.xml
+++ b/optaplanner-examples/src/main/resources/org/optaplanner/examples/projectjobscheduling/projectJobSchedulingSolverConfig.xml
@@ -1,8 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <solver xmlns="https://www.optaplanner.org/xsd/solver" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="https://www.optaplanner.org/xsd/solver https://www.optaplanner.org/xsd/solver/solver.xsd">
-  <!--<environmentMode>FULL_ASSERT</environmentMode>--><!-- To slowly prove there are no bugs in this code -->
-  <!--<moveThreadCount>AUTO</moveThreadCount>--><!-- To solve faster by saturating multiple CPU cores -->
+  <!-- To slowly prove there are no bugs in this code -->
+  <!--<environmentMode>FULL_ASSERT</environmentMode>-->
+  <!-- To solve faster by saturating multiple CPU cores -->
+  <!--<moveThreadCount>AUTO</moveThreadCount>-->
 
   <solutionClass>org.optaplanner.examples.projectjobscheduling.domain.Schedule</solutionClass>
   <entityClass>org.optaplanner.examples.projectjobscheduling.domain.Allocation</entityClass>

--- a/optaplanner-examples/src/main/resources/org/optaplanner/examples/rocktour/rockTourSolverConfig.xml
+++ b/optaplanner-examples/src/main/resources/org/optaplanner/examples/rocktour/rockTourSolverConfig.xml
@@ -1,8 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <solver xmlns="https://www.optaplanner.org/xsd/solver" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="https://www.optaplanner.org/xsd/solver https://www.optaplanner.org/xsd/solver/solver.xsd">
-  <!--<environmentMode>FULL_ASSERT</environmentMode>--><!-- To slowly prove there are no bugs in this code -->
-  <!--<moveThreadCount>AUTO</moveThreadCount>--><!-- To solve faster by saturating multiple CPU cores -->
+  <!-- To slowly prove there are no bugs in this code -->
+  <!--<environmentMode>FULL_ASSERT</environmentMode>-->
+  <!-- To solve faster by saturating multiple CPU cores -->
+  <!--<moveThreadCount>AUTO</moveThreadCount>-->
 
   <solutionClass>org.optaplanner.examples.rocktour.domain.RockTourSolution</solutionClass>
   <entityClass>org.optaplanner.examples.rocktour.domain.RockShow</entityClass>

--- a/optaplanner-examples/src/main/resources/org/optaplanner/examples/taskassigning/taskAssigningSolverConfig.xml
+++ b/optaplanner-examples/src/main/resources/org/optaplanner/examples/taskassigning/taskAssigningSolverConfig.xml
@@ -1,8 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <solver xmlns="https://www.optaplanner.org/xsd/solver" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="https://www.optaplanner.org/xsd/solver https://www.optaplanner.org/xsd/solver/solver.xsd">
-  <!--<environmentMode>FULL_ASSERT</environmentMode>--><!-- To slowly prove there are no bugs in this code -->
-  <!--<moveThreadCount>AUTO</moveThreadCount>--><!-- To solve faster by saturating multiple CPU cores -->
+  <!-- To slowly prove there are no bugs in this code -->
+  <!--<environmentMode>FULL_ASSERT</environmentMode>-->
+  <!-- To solve faster by saturating multiple CPU cores -->
+  <!--<moveThreadCount>AUTO</moveThreadCount>-->
 
   <solutionClass>org.optaplanner.examples.taskassigning.domain.TaskAssigningSolution</solutionClass>
   <entityClass>org.optaplanner.examples.taskassigning.domain.Employee</entityClass>

--- a/optaplanner-examples/src/main/resources/org/optaplanner/examples/tennis/tennisSolverConfig.xml
+++ b/optaplanner-examples/src/main/resources/org/optaplanner/examples/tennis/tennisSolverConfig.xml
@@ -1,8 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <solver xmlns="https://www.optaplanner.org/xsd/solver" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="https://www.optaplanner.org/xsd/solver https://www.optaplanner.org/xsd/solver/solver.xsd">
-  <!--<environmentMode>FULL_ASSERT</environmentMode>--><!-- To slowly prove there are no bugs in this code -->
-  <!--<moveThreadCount>AUTO</moveThreadCount>--><!-- To solve faster by saturating multiple CPU cores -->
+  <!-- To slowly prove there are no bugs in this code -->
+  <!--<environmentMode>FULL_ASSERT</environmentMode>-->
+  <!-- To solve faster by saturating multiple CPU cores -->
+  <!--<moveThreadCount>AUTO</moveThreadCount>-->
 
   <!-- Domain model configuration -->
   <solutionClass>org.optaplanner.examples.tennis.domain.TennisSolution</solutionClass>

--- a/optaplanner-examples/src/main/resources/org/optaplanner/examples/travelingtournament/travelingTournamentSolverConfig.xml
+++ b/optaplanner-examples/src/main/resources/org/optaplanner/examples/travelingtournament/travelingTournamentSolverConfig.xml
@@ -1,8 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <solver xmlns="https://www.optaplanner.org/xsd/solver" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="https://www.optaplanner.org/xsd/solver https://www.optaplanner.org/xsd/solver/solver.xsd">
-  <!--<environmentMode>FULL_ASSERT</environmentMode>--><!-- To slowly prove there are no bugs in this code -->
-  <!--<moveThreadCount>AUTO</moveThreadCount>--><!-- To solve faster by saturating multiple CPU cores -->
+  <!-- To slowly prove there are no bugs in this code -->
+  <!--<environmentMode>FULL_ASSERT</environmentMode>-->
+  <!-- To solve faster by saturating multiple CPU cores -->
+  <!--<moveThreadCount>AUTO</moveThreadCount>-->
 
   <solutionClass>org.optaplanner.examples.travelingtournament.domain.TravelingTournament</solutionClass>
   <entityClass>org.optaplanner.examples.travelingtournament.domain.Match</entityClass>

--- a/optaplanner-examples/src/main/resources/org/optaplanner/examples/tsp/tspSolverConfig.xml
+++ b/optaplanner-examples/src/main/resources/org/optaplanner/examples/tsp/tspSolverConfig.xml
@@ -1,8 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <solver xmlns="https://www.optaplanner.org/xsd/solver" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="https://www.optaplanner.org/xsd/solver https://www.optaplanner.org/xsd/solver/solver.xsd">
-  <!--<environmentMode>FULL_ASSERT</environmentMode>--><!-- To slowly prove there are no bugs in this code -->
-  <!--<moveThreadCount>AUTO</moveThreadCount>--><!-- To solve faster by saturating multiple CPU cores -->
+  <!-- To slowly prove there are no bugs in this code -->
+  <!--<environmentMode>FULL_ASSERT</environmentMode>-->
+  <!-- To solve faster by saturating multiple CPU cores -->
+  <!--<moveThreadCount>AUTO</moveThreadCount>-->
 
   <solutionClass>org.optaplanner.examples.tsp.domain.TspSolution</solutionClass>
   <entityClass>org.optaplanner.examples.tsp.domain.Visit</entityClass>

--- a/optaplanner-examples/src/main/resources/org/optaplanner/examples/vehiclerouting/vehicleRoutingSolverConfig.xml
+++ b/optaplanner-examples/src/main/resources/org/optaplanner/examples/vehiclerouting/vehicleRoutingSolverConfig.xml
@@ -1,8 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <solver xmlns="https://www.optaplanner.org/xsd/solver" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="https://www.optaplanner.org/xsd/solver https://www.optaplanner.org/xsd/solver/solver.xsd">
-  <!--<environmentMode>FULL_ASSERT</environmentMode>--><!-- To slowly prove there are no bugs in this code -->
-  <!--<moveThreadCount>AUTO</moveThreadCount>--><!-- To solve faster by saturating multiple CPU cores -->
+  <!-- To slowly prove there are no bugs in this code -->
+  <!--<environmentMode>FULL_ASSERT</environmentMode>-->
+  <!-- To solve faster by saturating multiple CPU cores -->
+  <!--<moveThreadCount>AUTO</moveThreadCount>-->
 
   <solutionClass>org.optaplanner.examples.vehiclerouting.domain.VehicleRoutingSolution</solutionClass>
   <entityClass>org.optaplanner.examples.vehiclerouting.domain.Standstill</entityClass>


### PR DESCRIPTION
This PR makes it possible to turn on full assert mode in one step. Just hit the keyboard shortcut for _Comment with Line Comment_ on the line with `<!--<environmentMode>FULL_ASSERT</environmentMode>-->`.

Before this PR, it took 3 steps because it was necessary to first move `<!-- To slowly prove there are no bugs in this code -->` on a separate line to prevent it from being uncommented as well. That would make the solver config XML invalid.

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>specific pull request build</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] tests</b>
* for a <b>full downstream build</b> 
  * for <b>jenkins</b> job: please add comment: <b>Jenkins run fdb</b>
  * for <b>github actions</b> job: add the label `run_fdb`
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
* for a <b>Quarkus LTS check</b> please add comment: <b>Jenkins run LTS</b>
* for a <b>specific Quarkus LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] LTS</b>
* for a <b>Native check</b> please add comment: <b>Jenkins run native</b>
* for a <b>specific Native LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] native</b>
</details>
