### PR TITLE
Improve externalized supplies' reset

### DIFF
--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/domain/variable/anchor/ExternalizedAnchorVariableSupply.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/domain/variable/anchor/ExternalizedAnchorVariableSupply.java
@@ -20,8 +20,6 @@ import java.util.IdentityHashMap;
 import java.util.Map;
 
 import org.optaplanner.core.api.score.director.ScoreDirector;
-import org.optaplanner.core.impl.domain.entity.descriptor.EntityDescriptor;
-import org.optaplanner.core.impl.domain.solution.descriptor.SolutionDescriptor;
 import org.optaplanner.core.impl.domain.variable.descriptor.VariableDescriptor;
 import org.optaplanner.core.impl.domain.variable.inverserelation.SingletonInverseVariableSupply;
 import org.optaplanner.core.impl.domain.variable.listener.SourcedVariableListener;
@@ -29,8 +27,8 @@ import org.optaplanner.core.impl.domain.variable.listener.SourcedVariableListene
 /**
  * Alternative to {@link AnchorVariableListener}.
  */
-public class ExternalizedAnchorVariableSupply<Solution_> implements SourcedVariableListener<Solution_, Object>,
-        AnchorVariableSupply {
+public class ExternalizedAnchorVariableSupply<Solution_>
+        implements SourcedVariableListener<Solution_, Object>, AnchorVariableSupply {
 
     protected final VariableDescriptor<Solution_> previousVariableDescriptor;
     protected final SingletonInverseVariableSupply nextVariableSupply;
@@ -50,10 +48,9 @@ public class ExternalizedAnchorVariableSupply<Solution_> implements SourcedVaria
 
     @Override
     public void resetWorkingSolution(ScoreDirector<Solution_> scoreDirector) {
-        EntityDescriptor<Solution_> entityDescriptor = previousVariableDescriptor.getEntityDescriptor();
-        SolutionDescriptor<Solution_> solutionDescriptor = entityDescriptor.getSolutionDescriptor();
         anchorMap = new IdentityHashMap<>();
-        solutionDescriptor.visitAllEntities(scoreDirector.getWorkingSolution(), this::insert);
+        previousVariableDescriptor.getEntityDescriptor().getSolutionDescriptor()
+                .visitAllEntities(scoreDirector.getWorkingSolution(), this::insert);
     }
 
     @Override

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/domain/variable/index/ExternalizedIndexVariableSupply.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/domain/variable/index/ExternalizedIndexVariableSupply.java
@@ -22,8 +22,6 @@ import java.util.Map;
 import java.util.Objects;
 
 import org.optaplanner.core.api.score.director.ScoreDirector;
-import org.optaplanner.core.impl.domain.entity.descriptor.EntityDescriptor;
-import org.optaplanner.core.impl.domain.solution.descriptor.SolutionDescriptor;
 import org.optaplanner.core.impl.domain.variable.descriptor.ListVariableDescriptor;
 import org.optaplanner.core.impl.domain.variable.descriptor.VariableDescriptor;
 import org.optaplanner.core.impl.domain.variable.listener.SourcedVariableListener;
@@ -49,10 +47,9 @@ public class ExternalizedIndexVariableSupply<Solution_>
 
     @Override
     public void resetWorkingSolution(ScoreDirector<Solution_> scoreDirector) {
-        EntityDescriptor<Solution_> entityDescriptor = sourceVariableDescriptor.getEntityDescriptor();
-        SolutionDescriptor<Solution_> solutionDescriptor = entityDescriptor.getSolutionDescriptor();
         indexMap = new IdentityHashMap<>();
-        solutionDescriptor.visitAllEntities(scoreDirector.getWorkingSolution(), this::insert);
+        sourceVariableDescriptor.getEntityDescriptor().getSolutionDescriptor()
+                .visitAllEntities(scoreDirector.getWorkingSolution(), this::insert);
     }
 
     @Override

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/domain/variable/inverserelation/ExternalizedCollectionInverseVariableSupply.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/domain/variable/inverserelation/ExternalizedCollectionInverseVariableSupply.java
@@ -23,8 +23,6 @@ import java.util.Map;
 import java.util.Set;
 
 import org.optaplanner.core.api.score.director.ScoreDirector;
-import org.optaplanner.core.impl.domain.entity.descriptor.EntityDescriptor;
-import org.optaplanner.core.impl.domain.solution.descriptor.SolutionDescriptor;
 import org.optaplanner.core.impl.domain.variable.descriptor.VariableDescriptor;
 import org.optaplanner.core.impl.domain.variable.listener.SourcedVariableListener;
 
@@ -49,10 +47,9 @@ public class ExternalizedCollectionInverseVariableSupply<Solution_>
 
     @Override
     public void resetWorkingSolution(ScoreDirector<Solution_> scoreDirector) {
-        EntityDescriptor<Solution_> entityDescriptor = sourceVariableDescriptor.getEntityDescriptor();
-        SolutionDescriptor<Solution_> solutionDescriptor = entityDescriptor.getSolutionDescriptor();
         inverseEntitySetMap = new IdentityHashMap<>();
-        solutionDescriptor.visitAllEntities(scoreDirector.getWorkingSolution(), this::insert);
+        sourceVariableDescriptor.getEntityDescriptor().getSolutionDescriptor()
+                .visitAllEntities(scoreDirector.getWorkingSolution(), this::insert);
     }
 
     @Override

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/domain/variable/inverserelation/ExternalizedSingletonInverseVariableSupply.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/domain/variable/inverserelation/ExternalizedSingletonInverseVariableSupply.java
@@ -20,8 +20,6 @@ import java.util.IdentityHashMap;
 import java.util.Map;
 
 import org.optaplanner.core.api.score.director.ScoreDirector;
-import org.optaplanner.core.impl.domain.entity.descriptor.EntityDescriptor;
-import org.optaplanner.core.impl.domain.solution.descriptor.SolutionDescriptor;
 import org.optaplanner.core.impl.domain.variable.descriptor.VariableDescriptor;
 import org.optaplanner.core.impl.domain.variable.listener.SourcedVariableListener;
 
@@ -46,10 +44,9 @@ public class ExternalizedSingletonInverseVariableSupply<Solution_>
 
     @Override
     public void resetWorkingSolution(ScoreDirector<Solution_> scoreDirector) {
-        EntityDescriptor<Solution_> entityDescriptor = sourceVariableDescriptor.getEntityDescriptor();
-        SolutionDescriptor<Solution_> solutionDescriptor = entityDescriptor.getSolutionDescriptor();
         inverseEntityMap = new IdentityHashMap<>();
-        solutionDescriptor.visitAllEntities(scoreDirector.getWorkingSolution(), this::insert);
+        sourceVariableDescriptor.getEntityDescriptor().getSolutionDescriptor()
+                .visitAllEntities(scoreDirector.getWorkingSolution(), this::insert);
     }
 
     @Override

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/domain/variable/inverserelation/ExternalizedSingletonListInverseVariableSupply.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/domain/variable/inverserelation/ExternalizedSingletonListInverseVariableSupply.java
@@ -21,8 +21,6 @@ import java.util.List;
 import java.util.Map;
 
 import org.optaplanner.core.api.score.director.ScoreDirector;
-import org.optaplanner.core.impl.domain.entity.descriptor.EntityDescriptor;
-import org.optaplanner.core.impl.domain.solution.descriptor.SolutionDescriptor;
 import org.optaplanner.core.impl.domain.variable.descriptor.ListVariableDescriptor;
 import org.optaplanner.core.impl.domain.variable.descriptor.VariableDescriptor;
 import org.optaplanner.core.impl.domain.variable.listener.SourcedVariableListener;
@@ -48,10 +46,9 @@ public class ExternalizedSingletonListInverseVariableSupply<Solution_>
 
     @Override
     public void resetWorkingSolution(ScoreDirector<Solution_> scoreDirector) {
-        EntityDescriptor<Solution_> entityDescriptor = sourceVariableDescriptor.getEntityDescriptor();
-        SolutionDescriptor<Solution_> solutionDescriptor = entityDescriptor.getSolutionDescriptor();
         inverseEntityMap = new IdentityHashMap<>();
-        solutionDescriptor.visitAllEntities(scoreDirector.getWorkingSolution(), this::insert);
+        sourceVariableDescriptor.getEntityDescriptor().getSolutionDescriptor()
+                .visitAllEntities(scoreDirector.getWorkingSolution(), this::insert);
     }
 
     @Override


### PR DESCRIPTION
Nice improvement from the closed #1876.

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>specific pull request build</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] tests</b>
* for a <b>full downstream build</b> 
  * for <b>jenkins</b> job: please add comment: <b>Jenkins run fdb</b>
  * for <b>github actions</b> job: add the label `run_fdb`
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
* for a <b>Quarkus LTS check</b> please add comment: <b>Jenkins run LTS</b>
* for a <b>specific Quarkus LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] LTS</b>
* for a <b>Native check</b> please add comment: <b>Jenkins run native</b>
* for a <b>specific Native LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] native</b>
</details>
