### PR TITLE
PLANNER-2675  CS-B: Stores instead of maps WITH unified store

### DIFF
--- a/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/bavet/bi/BavetFilterBiConstraintStream.java
+++ b/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/bavet/bi/BavetFilterBiConstraintStream.java
@@ -25,6 +25,7 @@ import org.optaplanner.constraint.streams.bavet.BavetConstraintFactory;
 import org.optaplanner.constraint.streams.bavet.common.BavetAbstractConstraintStream;
 import org.optaplanner.constraint.streams.bavet.common.NodeBuildHelper;
 import org.optaplanner.core.api.score.Score;
+import org.optaplanner.core.api.score.stream.ConstraintStream;
 
 public final class BavetFilterBiConstraintStream<Solution_, A, B> extends BavetAbstractBiConstraintStream<Solution_, A, B> {
 
@@ -55,6 +56,11 @@ public final class BavetFilterBiConstraintStream<Solution_, A, B> extends BavetA
     public void collectActiveConstraintStreams(Set<BavetAbstractConstraintStream<Solution_>> constraintStreamSet) {
         parent.collectActiveConstraintStreams(constraintStreamSet);
         constraintStreamSet.add(this);
+    }
+
+    @Override
+    public ConstraintStream getTupleSource() {
+        return parent.getTupleSource();
     }
 
     @Override

--- a/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/bavet/bi/BavetGroupBiConstraintStream.java
+++ b/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/bavet/bi/BavetGroupBiConstraintStream.java
@@ -22,6 +22,7 @@ import org.optaplanner.constraint.streams.bavet.BavetConstraintFactory;
 import org.optaplanner.constraint.streams.bavet.common.BavetAbstractConstraintStream;
 import org.optaplanner.constraint.streams.bavet.common.NodeBuildHelper;
 import org.optaplanner.core.api.score.Score;
+import org.optaplanner.core.api.score.stream.ConstraintStream;
 
 public final class BavetGroupBiConstraintStream<Solution_, A, B>
         extends BavetAbstractBiConstraintStream<Solution_, A, B> {
@@ -47,6 +48,11 @@ public final class BavetGroupBiConstraintStream<Solution_, A, B>
     public void collectActiveConstraintStreams(Set<BavetAbstractConstraintStream<Solution_>> constraintStreamSet) {
         parent.collectActiveConstraintStreams(constraintStreamSet);
         constraintStreamSet.add(this);
+    }
+
+    @Override
+    public ConstraintStream getTupleSource() {
+        return this;
     }
 
     @Override

--- a/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/bavet/bi/BavetGroupBridgeBiConstraintStream.java
+++ b/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/bavet/bi/BavetGroupBridgeBiConstraintStream.java
@@ -76,9 +76,10 @@ public final class BavetGroupBridgeBiConstraintStream<Solution_, A, B, NewA, Res
         }
         Consumer<BiTuple<NewA, NewB>> insert = buildHelper.getAggregatedInsert(groupStream.getChildStreamList());
         Consumer<BiTuple<NewA, NewB>> retract = buildHelper.getAggregatedRetract(groupStream.getChildStreamList());
+        int joinStoreSize = buildHelper.extractJoinStoreSize(groupStream);
         int scoreStoreSize = buildHelper.extractScoreStoreSize(groupStream);
         GroupBiToBiNode<A, B, NewA, NewB, ResultContainer_> node = new GroupBiToBiNode<>(groupKeyMapping, collector,
-                insert, retract, scoreStoreSize);
+                insert, retract, joinStoreSize, scoreStoreSize);
         buildHelper.addNode(node);
         buildHelper.putInsertRetract(this, node::insertAB, node::retractAB);
     }

--- a/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/bavet/bi/BavetGroupBridgeBiConstraintStream.java
+++ b/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/bavet/bi/BavetGroupBridgeBiConstraintStream.java
@@ -74,12 +74,15 @@ public final class BavetGroupBridgeBiConstraintStream<Solution_, A, B, NewA, Res
             throw new IllegalStateException("Impossible state: the stream (" + this
                     + ") has an non-empty childStreamList (" + childStreamList + ") but it's a groupBy bridge.");
         }
+        int groupStoreIndex = buildHelper.reserveGroupStoreIndex(parent.getTupleSource());
         Consumer<BiTuple<NewA, NewB>> insert = buildHelper.getAggregatedInsert(groupStream.getChildStreamList());
         Consumer<BiTuple<NewA, NewB>> retract = buildHelper.getAggregatedRetract(groupStream.getChildStreamList());
         int joinStoreSize = buildHelper.extractJoinStoreSize(groupStream);
+        int groupStoreSize = buildHelper.extractGroupStoreSize(groupStream);
         int scoreStoreSize = buildHelper.extractScoreStoreSize(groupStream);
-        GroupBiToBiNode<A, B, NewA, NewB, ResultContainer_> node = new GroupBiToBiNode<>(groupKeyMapping, collector,
-                insert, retract, joinStoreSize, scoreStoreSize);
+        GroupBiToBiNode<A, B, NewA, NewB, ResultContainer_> node = new GroupBiToBiNode<>(
+                groupKeyMapping, groupStoreIndex, collector,
+                insert, retract, joinStoreSize, groupStoreSize, scoreStoreSize);
         buildHelper.addNode(node);
         buildHelper.putInsertRetract(this, node::insertAB, node::retractAB);
     }

--- a/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/bavet/bi/BavetGroupBridgeBiConstraintStream.java
+++ b/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/bavet/bi/BavetGroupBridgeBiConstraintStream.java
@@ -24,6 +24,7 @@ import org.optaplanner.constraint.streams.bavet.BavetConstraintFactory;
 import org.optaplanner.constraint.streams.bavet.common.BavetAbstractConstraintStream;
 import org.optaplanner.constraint.streams.bavet.common.NodeBuildHelper;
 import org.optaplanner.core.api.score.Score;
+import org.optaplanner.core.api.score.stream.ConstraintStream;
 import org.optaplanner.core.api.score.stream.bi.BiConstraintCollector;
 
 public final class BavetGroupBridgeBiConstraintStream<Solution_, A, B, NewA, ResultContainer_, NewB>
@@ -63,6 +64,11 @@ public final class BavetGroupBridgeBiConstraintStream<Solution_, A, B, NewA, Res
     }
 
     @Override
+    public ConstraintStream getTupleSource() {
+        return parent.getTupleSource();
+    }
+
+    @Override
     public <Score_ extends Score<Score_>> void buildNode(NodeBuildHelper<Score_> buildHelper) {
         if (!childStreamList.isEmpty()) {
             throw new IllegalStateException("Impossible state: the stream (" + this
@@ -70,8 +76,9 @@ public final class BavetGroupBridgeBiConstraintStream<Solution_, A, B, NewA, Res
         }
         Consumer<BiTuple<NewA, NewB>> insert = buildHelper.getAggregatedInsert(groupStream.getChildStreamList());
         Consumer<BiTuple<NewA, NewB>> retract = buildHelper.getAggregatedRetract(groupStream.getChildStreamList());
+        int scoreStoreSize = buildHelper.extractScoreStoreSize(groupStream);
         GroupBiToBiNode<A, B, NewA, NewB, ResultContainer_> node = new GroupBiToBiNode<>(groupKeyMapping, collector,
-                insert, retract);
+                insert, retract, scoreStoreSize);
         buildHelper.addNode(node);
         buildHelper.putInsertRetract(this, node::insertAB, node::retractAB);
     }

--- a/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/bavet/bi/BavetGroupBridgeBiConstraintStream.java
+++ b/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/bavet/bi/BavetGroupBridgeBiConstraintStream.java
@@ -74,15 +74,13 @@ public final class BavetGroupBridgeBiConstraintStream<Solution_, A, B, NewA, Res
             throw new IllegalStateException("Impossible state: the stream (" + this
                     + ") has an non-empty childStreamList (" + childStreamList + ") but it's a groupBy bridge.");
         }
-        int groupStoreIndex = buildHelper.reserveGroupStoreIndex(parent.getTupleSource());
+        int inputStoreIndex = buildHelper.reserveTupleStoreIndex(parent.getTupleSource());
         Consumer<BiTuple<NewA, NewB>> insert = buildHelper.getAggregatedInsert(groupStream.getChildStreamList());
         Consumer<BiTuple<NewA, NewB>> retract = buildHelper.getAggregatedRetract(groupStream.getChildStreamList());
-        int joinStoreSize = buildHelper.extractJoinStoreSize(groupStream);
-        int groupStoreSize = buildHelper.extractGroupStoreSize(groupStream);
-        int scoreStoreSize = buildHelper.extractScoreStoreSize(groupStream);
+        int outputStoreSize = buildHelper.extractTupleStoreSize(groupStream);
         GroupBiToBiNode<A, B, NewA, NewB, ResultContainer_> node = new GroupBiToBiNode<>(
-                groupKeyMapping, groupStoreIndex, collector,
-                insert, retract, joinStoreSize, groupStoreSize, scoreStoreSize);
+                groupKeyMapping, inputStoreIndex, collector,
+                insert, retract, outputStoreSize);
         buildHelper.addNode(node);
         buildHelper.putInsertRetract(this, node::insertAB, node::retractAB);
     }

--- a/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/bavet/bi/BavetJoinBiConstraintStream.java
+++ b/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/bavet/bi/BavetJoinBiConstraintStream.java
@@ -29,6 +29,7 @@ import org.optaplanner.constraint.streams.bavet.common.index.IndexerFactory;
 import org.optaplanner.constraint.streams.bavet.uni.BavetAbstractUniConstraintStream;
 import org.optaplanner.constraint.streams.bavet.uni.UniTuple;
 import org.optaplanner.core.api.score.Score;
+import org.optaplanner.core.api.score.stream.ConstraintStream;
 
 public final class BavetJoinBiConstraintStream<Solution_, A, B> extends BavetAbstractBiConstraintStream<Solution_, A, B>
         implements BavetJoinConstraintStream<Solution_> {
@@ -70,13 +71,19 @@ public final class BavetJoinBiConstraintStream<Solution_, A, B> extends BavetAbs
     }
 
     @Override
+    public ConstraintStream getTupleSource() {
+        return this;
+    }
+
+    @Override
     public <Score_ extends Score<Score_>> void buildNode(NodeBuildHelper<Score_> buildHelper) {
         Consumer<BiTuple<A, B>> insert = buildHelper.getAggregatedInsert(childStreamList);
         Consumer<BiTuple<A, B>> retract = buildHelper.getAggregatedRetract(childStreamList);
         Indexer<UniTuple<A>, Set<BiTuple<A, B>>> indexerA = indexerFactory.buildIndexer(true);
         Indexer<UniTuple<B>, Set<BiTuple<A, B>>> indexerB = indexerFactory.buildIndexer(false);
+        int scoreStoreSize = buildHelper.extractScoreStoreSize(this);
         JoinBiNode<A, B> node = new JoinBiNode<>(leftMapping, rightMapping,
-                insert, retract,
+                insert, retract, scoreStoreSize,
                 indexerA, indexerB);
         buildHelper.addNode(node);
         buildHelper.putInsertRetract(leftParent, node::insertA, node::retractA);

--- a/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/bavet/bi/BavetJoinBiConstraintStream.java
+++ b/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/bavet/bi/BavetJoinBiConstraintStream.java
@@ -77,17 +77,18 @@ public final class BavetJoinBiConstraintStream<Solution_, A, B> extends BavetAbs
 
     @Override
     public <Score_ extends Score<Score_>> void buildNode(NodeBuildHelper<Score_> buildHelper) {
-        Consumer<BiTuple<A, B>> insert = buildHelper.getAggregatedInsert(childStreamList);
-        Consumer<BiTuple<A, B>> retract = buildHelper.getAggregatedRetract(childStreamList);
-        Indexer<UniTuple<A>, Set<BiTuple<A, B>>> indexerA = indexerFactory.buildIndexer(true);
-        Indexer<UniTuple<B>, Set<BiTuple<A, B>>> indexerB = indexerFactory.buildIndexer(false);
         int joinStoreIndexA = buildHelper.reserveJoinStoreIndex(leftParent.getTupleSource());
         int joinStoreIndexB = buildHelper.reserveJoinStoreIndex(rightParent.getTupleSource());
+        Consumer<BiTuple<A, B>> insert = buildHelper.getAggregatedInsert(childStreamList);
+        Consumer<BiTuple<A, B>> retract = buildHelper.getAggregatedRetract(childStreamList);
         int joinStoreSize = buildHelper.extractJoinStoreSize(this);
+        int groupStoreSize = buildHelper.extractGroupStoreSize(this);
         int scoreStoreSize = buildHelper.extractScoreStoreSize(this);
+        Indexer<UniTuple<A>, Set<BiTuple<A, B>>> indexerA = indexerFactory.buildIndexer(true);
+        Indexer<UniTuple<B>, Set<BiTuple<A, B>>> indexerB = indexerFactory.buildIndexer(false);
         JoinBiNode<A, B> node = new JoinBiNode<>(
                 leftMapping, rightMapping, joinStoreIndexA, joinStoreIndexB,
-                insert, retract, joinStoreSize, scoreStoreSize,
+                insert, retract, joinStoreSize, groupStoreSize, scoreStoreSize,
                 indexerA, indexerB);
         buildHelper.addNode(node);
         buildHelper.putInsertRetract(leftParent, node::insertA, node::retractA);

--- a/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/bavet/bi/BavetJoinBiConstraintStream.java
+++ b/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/bavet/bi/BavetJoinBiConstraintStream.java
@@ -77,18 +77,16 @@ public final class BavetJoinBiConstraintStream<Solution_, A, B> extends BavetAbs
 
     @Override
     public <Score_ extends Score<Score_>> void buildNode(NodeBuildHelper<Score_> buildHelper) {
-        int joinStoreIndexA = buildHelper.reserveJoinStoreIndex(leftParent.getTupleSource());
-        int joinStoreIndexB = buildHelper.reserveJoinStoreIndex(rightParent.getTupleSource());
+        int inputStoreIndexA = buildHelper.reserveTupleStoreIndex(leftParent.getTupleSource());
+        int inputStoreIndexB = buildHelper.reserveTupleStoreIndex(rightParent.getTupleSource());
         Consumer<BiTuple<A, B>> insert = buildHelper.getAggregatedInsert(childStreamList);
         Consumer<BiTuple<A, B>> retract = buildHelper.getAggregatedRetract(childStreamList);
-        int joinStoreSize = buildHelper.extractJoinStoreSize(this);
-        int groupStoreSize = buildHelper.extractGroupStoreSize(this);
-        int scoreStoreSize = buildHelper.extractScoreStoreSize(this);
+        int outputStoreSize = buildHelper.extractTupleStoreSize(this);
         Indexer<UniTuple<A>, Set<BiTuple<A, B>>> indexerA = indexerFactory.buildIndexer(true);
         Indexer<UniTuple<B>, Set<BiTuple<A, B>>> indexerB = indexerFactory.buildIndexer(false);
         JoinBiNode<A, B> node = new JoinBiNode<>(
-                leftMapping, rightMapping, joinStoreIndexA, joinStoreIndexB,
-                insert, retract, joinStoreSize, groupStoreSize, scoreStoreSize,
+                leftMapping, rightMapping, inputStoreIndexA, inputStoreIndexB,
+                insert, retract, outputStoreSize,
                 indexerA, indexerB);
         buildHelper.addNode(node);
         buildHelper.putInsertRetract(leftParent, node::insertA, node::retractA);

--- a/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/bavet/bi/BavetJoinBiConstraintStream.java
+++ b/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/bavet/bi/BavetJoinBiConstraintStream.java
@@ -81,9 +81,13 @@ public final class BavetJoinBiConstraintStream<Solution_, A, B> extends BavetAbs
         Consumer<BiTuple<A, B>> retract = buildHelper.getAggregatedRetract(childStreamList);
         Indexer<UniTuple<A>, Set<BiTuple<A, B>>> indexerA = indexerFactory.buildIndexer(true);
         Indexer<UniTuple<B>, Set<BiTuple<A, B>>> indexerB = indexerFactory.buildIndexer(false);
+        int joinStoreIndexA = buildHelper.reserveJoinStoreIndex(leftParent.getTupleSource());
+        int joinStoreIndexB = buildHelper.reserveJoinStoreIndex(rightParent.getTupleSource());
+        int joinStoreSize = buildHelper.extractJoinStoreSize(this);
         int scoreStoreSize = buildHelper.extractScoreStoreSize(this);
-        JoinBiNode<A, B> node = new JoinBiNode<>(leftMapping, rightMapping,
-                insert, retract, scoreStoreSize,
+        JoinBiNode<A, B> node = new JoinBiNode<>(
+                leftMapping, rightMapping, joinStoreIndexA, joinStoreIndexB,
+                insert, retract, joinStoreSize, scoreStoreSize,
                 indexerA, indexerB);
         buildHelper.addNode(node);
         buildHelper.putInsertRetract(leftParent, node::insertA, node::retractA);

--- a/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/bavet/bi/BavetJoinBridgeBiConstraintStream.java
+++ b/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/bavet/bi/BavetJoinBridgeBiConstraintStream.java
@@ -23,6 +23,7 @@ import org.optaplanner.constraint.streams.bavet.common.BavetAbstractConstraintSt
 import org.optaplanner.constraint.streams.bavet.common.BavetJoinConstraintStream;
 import org.optaplanner.constraint.streams.bavet.common.NodeBuildHelper;
 import org.optaplanner.core.api.score.Score;
+import org.optaplanner.core.api.score.stream.ConstraintStream;
 
 public final class BavetJoinBridgeBiConstraintStream<Solution_, A, B>
         extends BavetAbstractBiConstraintStream<Solution_, A, B> {
@@ -56,6 +57,11 @@ public final class BavetJoinBridgeBiConstraintStream<Solution_, A, B>
     public void collectActiveConstraintStreams(Set<BavetAbstractConstraintStream<Solution_>> constraintStreamSet) {
         parent.collectActiveConstraintStreams(constraintStreamSet);
         constraintStreamSet.add(this);
+    }
+
+    @Override
+    public ConstraintStream getTupleSource() {
+        return parent.getTupleSource();
     }
 
     @Override

--- a/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/bavet/bi/BavetScoringBiConstraintStream.java
+++ b/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/bavet/bi/BavetScoringBiConstraintStream.java
@@ -146,7 +146,7 @@ public final class BavetScoringBiConstraintStream<Solution_, A, B>
             throw new IllegalStateException("Impossible state: neither of the supported match weighers provided.");
         }
         BiScorer<A, B> scorer = new BiScorer<>(constraint.getConstraintPackage(), constraint.getConstraintName(),
-                constraintWeight, scoreImpacter, buildHelper.reserveScoreStoreIndex(parent.getTupleSource()));
+                constraintWeight, scoreImpacter, buildHelper.reserveTupleStoreIndex(parent.getTupleSource()));
         buildHelper.putInsertRetract(this, scorer::insert, scorer::retract);
     }
 

--- a/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/bavet/bi/BavetScoringBiConstraintStream.java
+++ b/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/bavet/bi/BavetScoringBiConstraintStream.java
@@ -33,6 +33,7 @@ import org.optaplanner.constraint.streams.common.inliner.AbstractScoreInliner;
 import org.optaplanner.constraint.streams.common.inliner.UndoScoreImpacter;
 import org.optaplanner.constraint.streams.common.inliner.WeightedScoreImpacter;
 import org.optaplanner.core.api.score.Score;
+import org.optaplanner.core.api.score.stream.ConstraintStream;
 
 public final class BavetScoringBiConstraintStream<Solution_, A, B>
         extends BavetAbstractBiConstraintStream<Solution_, A, B>
@@ -111,6 +112,11 @@ public final class BavetScoringBiConstraintStream<Solution_, A, B>
     }
 
     @Override
+    public ConstraintStream getTupleSource() {
+        return parent.getTupleSource();
+    }
+
+    @Override
     public <Score_ extends Score<Score_>> void buildNode(NodeBuildHelper<Score_> buildHelper) {
         Score_ constraintWeight = buildHelper.getConstraintWeight(constraint);
         AbstractScoreInliner<Score_> scoreInliner = buildHelper.getScoreInliner();
@@ -140,7 +146,7 @@ public final class BavetScoringBiConstraintStream<Solution_, A, B>
             throw new IllegalStateException("Impossible state: neither of the supported match weighers provided.");
         }
         BiScorer<A, B> scorer = new BiScorer<>(constraint.getConstraintPackage(), constraint.getConstraintName(),
-                constraintWeight, scoreImpacter);
+                constraintWeight, scoreImpacter, buildHelper.reserveScoreStoreIndex(parent.getTupleSource()));
         buildHelper.putInsertRetract(this, scorer::insert, scorer::retract);
     }
 

--- a/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/bavet/bi/BiScorer.java
+++ b/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/bavet/bi/BiScorer.java
@@ -28,34 +28,34 @@ public final class BiScorer<A, B> extends AbstractScorer {
     private final String constraintName;
     private final Score<?> constraintWeight;
     private final BiFunction<A, B, UndoScoreImpacter> scoreImpacter;
-    private final int scoreStoreIndex;
+    private final int inputStoreIndex;
 
     public BiScorer(String constraintPackage, String constraintName,
             Score<?> constraintWeight, BiFunction<A, B, UndoScoreImpacter> scoreImpacter,
-            int scoreStoreIndex) {
+            int inputStoreIndex) {
         this.constraintPackage = constraintPackage;
         this.constraintName = constraintName;
         this.constraintWeight = constraintWeight;
         this.scoreImpacter = scoreImpacter;
-        this.scoreStoreIndex = scoreStoreIndex;
+        this.inputStoreIndex = inputStoreIndex;
     }
 
     public void insert(BiTuple<A, B> tupleAB) {
-        if (tupleAB.scorerStore[scoreStoreIndex] != null) {
+        if (tupleAB.store[inputStoreIndex] != null) {
             throw new IllegalStateException("Impossible state: the tuple for the facts ("
                     + tupleAB.factA + ", " + tupleAB.factB
                     + ") was already added in the scorerStore.");
         }
         UndoScoreImpacter undoScoreImpacter = scoreImpacter.apply(tupleAB.factA, tupleAB.factB);
-        tupleAB.scorerStore[scoreStoreIndex] = undoScoreImpacter;
+        tupleAB.store[inputStoreIndex] = undoScoreImpacter;
     }
 
     public void retract(BiTuple<A, B> tupleAB) {
-        UndoScoreImpacter undoScoreImpacter = tupleAB.scorerStore[scoreStoreIndex];
+        UndoScoreImpacter undoScoreImpacter = (UndoScoreImpacter) tupleAB.store[inputStoreIndex];
         // No fail fast if null because we don't track which tuples made it through the filter predicate(s)
         if (undoScoreImpacter != null) {
             undoScoreImpacter.run();
-            tupleAB.scorerStore[scoreStoreIndex] = null;
+            tupleAB.store[inputStoreIndex] = null;
         }
     }
 

--- a/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/bavet/bi/BiScorer.java
+++ b/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/bavet/bi/BiScorer.java
@@ -16,8 +16,6 @@
 
 package org.optaplanner.constraint.streams.bavet.bi;
 
-import java.util.HashMap;
-import java.util.Map;
 import java.util.function.BiFunction;
 
 import org.optaplanner.constraint.streams.bavet.common.AbstractScorer;

--- a/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/bavet/bi/BiTuple.java
+++ b/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/bavet/bi/BiTuple.java
@@ -26,14 +26,16 @@ public final class BiTuple<A, B> implements Tuple {
     public final B factB;
 
     public final Object[][] joinStore;
+    public final Object[] groupStore;
     public final UndoScoreImpacter[] scorerStore;
 
     public BavetTupleState state;
 
-    public BiTuple(A factA, B factB, int joinStoreSize, int scoreStoreSize) {
+    public BiTuple(A factA, B factB, int joinStoreSize, int groupStoreSize, int scoreStoreSize) {
         this.factA = factA;
         this.factB = factB;
         joinStore = (joinStoreSize <= 0) ? null : new Object[joinStoreSize][];
+        groupStore = (groupStoreSize <= 0) ? null : new Object[groupStoreSize];
         scorerStore = (scoreStoreSize <= 0) ? null : new UndoScoreImpacter[scoreStoreSize];
     }
 

--- a/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/bavet/bi/BiTuple.java
+++ b/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/bavet/bi/BiTuple.java
@@ -18,25 +18,20 @@ package org.optaplanner.constraint.streams.bavet.bi;
 
 import org.optaplanner.constraint.streams.bavet.common.BavetTupleState;
 import org.optaplanner.constraint.streams.bavet.common.Tuple;
-import org.optaplanner.constraint.streams.common.inliner.UndoScoreImpacter;
 
 public final class BiTuple<A, B> implements Tuple {
 
     public final A factA;
     public final B factB;
 
-    public final Object[][] joinStore;
-    public final Object[] groupStore;
-    public final UndoScoreImpacter[] scorerStore;
+    public final Object[] store;
 
     public BavetTupleState state;
 
-    public BiTuple(A factA, B factB, int joinStoreSize, int groupStoreSize, int scoreStoreSize) {
+    public BiTuple(A factA, B factB, int storeSize) {
         this.factA = factA;
         this.factB = factB;
-        joinStore = (joinStoreSize <= 0) ? null : new Object[joinStoreSize][];
-        groupStore = (groupStoreSize <= 0) ? null : new Object[groupStoreSize];
-        scorerStore = (scoreStoreSize <= 0) ? null : new UndoScoreImpacter[scoreStoreSize];
+        store = (storeSize <= 0) ? null : new Object[storeSize];
     }
 
     @Override

--- a/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/bavet/bi/BiTuple.java
+++ b/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/bavet/bi/BiTuple.java
@@ -18,18 +18,21 @@ package org.optaplanner.constraint.streams.bavet.bi;
 
 import org.optaplanner.constraint.streams.bavet.common.BavetTupleState;
 import org.optaplanner.constraint.streams.bavet.common.Tuple;
+import org.optaplanner.constraint.streams.common.inliner.UndoScoreImpacter;
 
-// TODO Java 17: refactor to record
 public final class BiTuple<A, B> implements Tuple {
 
     public final A factA;
     public final B factB;
 
+    public final UndoScoreImpacter[] scorerStore;
+
     public BavetTupleState state;
 
-    public BiTuple(A factA, B factB) {
+    public BiTuple(A factA, B factB, int scoreStoreSize) {
         this.factA = factA;
         this.factB = factB;
+        scorerStore = (scoreStoreSize <= 0) ? null : new UndoScoreImpacter[scoreStoreSize];
     }
 
     @Override

--- a/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/bavet/bi/BiTuple.java
+++ b/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/bavet/bi/BiTuple.java
@@ -25,13 +25,15 @@ public final class BiTuple<A, B> implements Tuple {
     public final A factA;
     public final B factB;
 
+    public final Object[][] joinStore;
     public final UndoScoreImpacter[] scorerStore;
 
     public BavetTupleState state;
 
-    public BiTuple(A factA, B factB, int scoreStoreSize) {
+    public BiTuple(A factA, B factB, int joinStoreSize, int scoreStoreSize) {
         this.factA = factA;
         this.factB = factB;
+        joinStore = (joinStoreSize <= 0) ? null : new Object[joinStoreSize][];
         scorerStore = (scoreStoreSize <= 0) ? null : new UndoScoreImpacter[scoreStoreSize];
     }
 

--- a/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/bavet/bi/GroupBiToBiNode.java
+++ b/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/bavet/bi/GroupBiToBiNode.java
@@ -36,6 +36,7 @@ public final class GroupBiToBiNode<OldA, OldB, A, B, ResultContainer_> extends A
     // TODO Most of this code duplicates GroupUniToBiNode.
 
     private final BiFunction<OldA, OldB, A> groupKeyMapping;
+    private final int groupStoreIndex;
     private final Supplier<ResultContainer_> supplier;
     private final TriFunction<ResultContainer_, OldA, OldB, Runnable> accumulator;
     private final Function<ResultContainer_, B> finisher;
@@ -48,26 +49,27 @@ public final class GroupBiToBiNode<OldA, OldB, A, B, ResultContainer_> extends A
      */
     private final Consumer<BiTuple<A, B>> nextNodesRetract;
     private final int joinStoreSize;
+    private final int groupStoreSize;
     private final int scoreStoreSize;
 
-    private final Map<BiTuple<OldA, OldB>, GroupPart> groupPartMap;
     private final Map<A, Group> groupMap;
     private final Queue<Group> dirtyGroupQueue;
 
-    public GroupBiToBiNode(BiFunction<OldA, OldB, A> groupKeyMapping,
+    public GroupBiToBiNode(BiFunction<OldA, OldB, A> groupKeyMapping, int groupStoreIndex,
             BiConstraintCollector<OldA, OldB, ResultContainer_, B> collector,
             Consumer<BiTuple<A, B>> nextNodesInsert, Consumer<BiTuple<A, B>> nextNodesRetract,
-            int joinStoreSize, int scoreStoreSize) {
+            int joinStoreSize, int groupStoreSize, int scoreStoreSize) {
         this.groupKeyMapping = groupKeyMapping;
+        this.groupStoreIndex = groupStoreIndex;
         supplier = collector.supplier();
         accumulator = collector.accumulator();
         finisher = collector.finisher();
         this.nextNodesInsert = nextNodesInsert;
         this.nextNodesRetract = nextNodesRetract;
         this.joinStoreSize = joinStoreSize;
+        this.groupStoreSize = groupStoreSize;
         this.scoreStoreSize = scoreStoreSize;
         groupMap = new HashMap<>(1000);
-        groupPartMap = new HashMap<>(1000);
         dirtyGroupQueue = new ArrayDeque<>(1000);
     }
 
@@ -96,17 +98,17 @@ public final class GroupBiToBiNode<OldA, OldB, A, B, ResultContainer_> extends A
     }
 
     public void insertAB(BiTuple<OldA, OldB> tupleOldAB) {
+        if (tupleOldAB.groupStore[groupStoreIndex] != null) {
+            throw new IllegalStateException("Impossible state: the tuple for the fact ("
+                    + tupleOldAB.factA + ", " + tupleOldAB.factB + ") was already added in the groupStore.");
+        }
         A groupKey = groupKeyMapping.apply(tupleOldAB.factA, tupleOldAB.factB);
         Group group = groupMap.computeIfAbsent(groupKey, k -> new Group(groupKey, supplier.get()));
         group.parentCount++;
 
         Runnable undoAccumulator = accumulator.apply(group.resultContainer, tupleOldAB.factA, tupleOldAB.factB);
         GroupPart groupPart = new GroupPart(group, undoAccumulator);
-        GroupPart old = groupPartMap.put(tupleOldAB, groupPart);
-        if (old != null) {
-            throw new IllegalStateException("Impossible state: the tuple for the fact ("
-                    + tupleOldAB.factA + ", " + tupleOldAB.factB + ") was already added in the groupPartMap.");
-        }
+        tupleOldAB.groupStore[groupStoreIndex] = groupPart;
         if (!group.dirty) {
             group.dirty = true;
             dirtyGroupQueue.add(group);
@@ -114,11 +116,12 @@ public final class GroupBiToBiNode<OldA, OldB, A, B, ResultContainer_> extends A
     }
 
     public void retractAB(BiTuple<OldA, OldB> tupleOldAB) {
-        GroupPart groupPart = groupPartMap.remove(tupleOldAB);
+        GroupPart groupPart = (GroupPart) tupleOldAB.groupStore[groupStoreIndex];
         if (groupPart == null) {
             // No fail fast if null because we don't track which tuples made it through the filter predicate(s)
             return;
         }
+        tupleOldAB.groupStore[groupStoreIndex] = null;
         Group group = groupPart.group;
         group.parentCount--;
         groupPart.undoAccumulator.run();
@@ -152,7 +155,7 @@ public final class GroupBiToBiNode<OldA, OldB, A, B, ResultContainer_> extends A
             if (!group.dying) {
                 // Delay calculating B until it propagates
                 B factB = finisher.apply(group.resultContainer);
-                group.tupleAB = new BiTuple<>(group.groupKey, factB, joinStoreSize, scoreStoreSize);
+                group.tupleAB = new BiTuple<>(group.groupKey, factB, joinStoreSize, groupStoreSize, scoreStoreSize);
                 nextNodesInsert.accept(group.tupleAB);
                 group.tupleAB.state = BavetTupleState.OK;
             }

--- a/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/bavet/bi/GroupBiToBiNode.java
+++ b/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/bavet/bi/GroupBiToBiNode.java
@@ -47,6 +47,7 @@ public final class GroupBiToBiNode<OldA, OldB, A, B, ResultContainer_> extends A
      * Calls for example {@link BiScorer#retract(BiTuple)}, {@link JoinTriNode#insertAB(BiTuple)} and/or ...
      */
     private final Consumer<BiTuple<A, B>> nextNodesRetract;
+    private final int joinStoreSize;
     private final int scoreStoreSize;
 
     private final Map<BiTuple<OldA, OldB>, GroupPart> groupPartMap;
@@ -56,13 +57,14 @@ public final class GroupBiToBiNode<OldA, OldB, A, B, ResultContainer_> extends A
     public GroupBiToBiNode(BiFunction<OldA, OldB, A> groupKeyMapping,
             BiConstraintCollector<OldA, OldB, ResultContainer_, B> collector,
             Consumer<BiTuple<A, B>> nextNodesInsert, Consumer<BiTuple<A, B>> nextNodesRetract,
-            int scoreStoreSize) {
+            int joinStoreSize, int scoreStoreSize) {
         this.groupKeyMapping = groupKeyMapping;
         supplier = collector.supplier();
         accumulator = collector.accumulator();
         finisher = collector.finisher();
         this.nextNodesInsert = nextNodesInsert;
         this.nextNodesRetract = nextNodesRetract;
+        this.joinStoreSize = joinStoreSize;
         this.scoreStoreSize = scoreStoreSize;
         groupMap = new HashMap<>(1000);
         groupPartMap = new HashMap<>(1000);
@@ -150,7 +152,7 @@ public final class GroupBiToBiNode<OldA, OldB, A, B, ResultContainer_> extends A
             if (!group.dying) {
                 // Delay calculating B until it propagates
                 B factB = finisher.apply(group.resultContainer);
-                group.tupleAB = new BiTuple<>(group.groupKey, factB, scoreStoreSize);
+                group.tupleAB = new BiTuple<>(group.groupKey, factB, joinStoreSize, scoreStoreSize);
                 nextNodesInsert.accept(group.tupleAB);
                 group.tupleAB.state = BavetTupleState.OK;
             }

--- a/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/bavet/bi/GroupBiToBiNode.java
+++ b/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/bavet/bi/GroupBiToBiNode.java
@@ -42,11 +42,12 @@ public final class GroupBiToBiNode<OldA, OldB, A, B, ResultContainer_> extends A
     /**
      * Calls for example {@link BiScorer#insert(BiTuple)}, {@link JoinTriNode#insertAB(BiTuple)} and/or ...
      */
-    public final Consumer<BiTuple<A, B>> nextNodesInsert;
+    private final Consumer<BiTuple<A, B>> nextNodesInsert;
     /**
      * Calls for example {@link BiScorer#retract(BiTuple)}, {@link JoinTriNode#insertAB(BiTuple)} and/or ...
      */
-    public final Consumer<BiTuple<A, B>> nextNodesRetract;
+    private final Consumer<BiTuple<A, B>> nextNodesRetract;
+    private final int scoreStoreSize;
 
     private final Map<BiTuple<OldA, OldB>, GroupPart> groupPartMap;
     private final Map<A, Group> groupMap;
@@ -54,13 +55,15 @@ public final class GroupBiToBiNode<OldA, OldB, A, B, ResultContainer_> extends A
 
     public GroupBiToBiNode(BiFunction<OldA, OldB, A> groupKeyMapping,
             BiConstraintCollector<OldA, OldB, ResultContainer_, B> collector,
-            Consumer<BiTuple<A, B>> nextNodesInsert, Consumer<BiTuple<A, B>> nextNodesRetract) {
+            Consumer<BiTuple<A, B>> nextNodesInsert, Consumer<BiTuple<A, B>> nextNodesRetract,
+            int scoreStoreSize) {
         this.groupKeyMapping = groupKeyMapping;
         supplier = collector.supplier();
         accumulator = collector.accumulator();
         finisher = collector.finisher();
         this.nextNodesInsert = nextNodesInsert;
         this.nextNodesRetract = nextNodesRetract;
+        this.scoreStoreSize = scoreStoreSize;
         groupMap = new HashMap<>(1000);
         groupPartMap = new HashMap<>(1000);
         dirtyGroupQueue = new ArrayDeque<>(1000);
@@ -147,7 +150,7 @@ public final class GroupBiToBiNode<OldA, OldB, A, B, ResultContainer_> extends A
             if (!group.dying) {
                 // Delay calculating B until it propagates
                 B factB = finisher.apply(group.resultContainer);
-                group.tupleAB = new BiTuple<>(group.groupKey, factB);
+                group.tupleAB = new BiTuple<>(group.groupKey, factB, scoreStoreSize);
                 nextNodesInsert.accept(group.tupleAB);
                 group.tupleAB.state = BavetTupleState.OK;
             }

--- a/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/bavet/bi/GroupUniToBiNode.java
+++ b/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/bavet/bi/GroupUniToBiNode.java
@@ -45,6 +45,7 @@ public final class GroupUniToBiNode<OldA, A, B, ResultContainer_> extends Abstra
      * Calls for example {@link BiScorer#retract(BiTuple)}, {@link JoinTriNode#insertAB(BiTuple)} and/or ...
      */
     private final Consumer<BiTuple<A, B>> nextNodesRetract;
+    private final int joinStoreSize;
     private final int scoreStoreSize;
 
     private final Map<UniTuple<OldA>, GroupPart> groupPartMap;
@@ -54,13 +55,14 @@ public final class GroupUniToBiNode<OldA, A, B, ResultContainer_> extends Abstra
     public GroupUniToBiNode(Function<OldA, A> groupKeyMapping,
             UniConstraintCollector<OldA, ResultContainer_, B> collector,
             Consumer<BiTuple<A, B>> nextNodesInsert, Consumer<BiTuple<A, B>> nextNodesRetract,
-            int scoreStoreSize) {
+            int joinStoreSize, int scoreStoreSize) {
         this.groupKeyMapping = groupKeyMapping;
         supplier = collector.supplier();
         accumulator = collector.accumulator();
         finisher = collector.finisher();
         this.nextNodesInsert = nextNodesInsert;
         this.nextNodesRetract = nextNodesRetract;
+        this.joinStoreSize = joinStoreSize;
         this.scoreStoreSize = scoreStoreSize;
         groupMap = new HashMap<>(1000);
         groupPartMap = new HashMap<>(1000);
@@ -148,7 +150,7 @@ public final class GroupUniToBiNode<OldA, A, B, ResultContainer_> extends Abstra
             if (!group.dying) {
                 // Delay calculating B until it propagates
                 B factB = finisher.apply(group.resultContainer);
-                group.tupleAB = new BiTuple<>(group.groupKey, factB, scoreStoreSize);
+                group.tupleAB = new BiTuple<>(group.groupKey, factB, joinStoreSize, scoreStoreSize);
                 nextNodesInsert.accept(group.tupleAB);
                 group.tupleAB.state = BavetTupleState.OK;
             }

--- a/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/bavet/bi/JoinBiNode.java
+++ b/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/bavet/bi/JoinBiNode.java
@@ -18,7 +18,6 @@ package org.optaplanner.constraint.streams.bavet.bi;
 
 import java.util.ArrayDeque;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Queue;

--- a/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/bavet/bi/JoinBiNode.java
+++ b/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/bavet/bi/JoinBiNode.java
@@ -39,11 +39,12 @@ public final class JoinBiNode<A, B> extends AbstractNode {
     /**
      * Calls for example {@link BiScorer#insert(BiTuple)}, {@link JoinTriNode#insertAB(BiTuple)} and/or ...
      */
-    public final Consumer<BiTuple<A, B>> nextNodesInsert;
+    private final Consumer<BiTuple<A, B>> nextNodesInsert;
     /**
      * Calls for example {@link BiScorer#retract(BiTuple)}, {@link JoinTriNode#insertAB(BiTuple)} and/or ...
      */
-    public final Consumer<BiTuple<A, B>> nextNodesRetract;
+    private final Consumer<BiTuple<A, B>> nextNodesRetract;
+    private final int scoreStoreSize;
 
     private final Indexer<UniTuple<A>, Set<BiTuple<A, B>>> indexerA;
     private final Map<UniTuple<A>, Object[]> indexPropertiesMapA = new HashMap<>();
@@ -53,11 +54,13 @@ public final class JoinBiNode<A, B> extends AbstractNode {
 
     public JoinBiNode(Function<A, Object[]> mappingA, Function<B, Object[]> mappingB,
             Consumer<BiTuple<A, B>> nextNodesInsert, Consumer<BiTuple<A, B>> nextNodesRetract,
+            int scoreStoreSize,
             Indexer<UniTuple<A>, Set<BiTuple<A, B>>> indexerA, Indexer<UniTuple<B>, Set<BiTuple<A, B>>> indexerB) {
         this.mappingA = mappingA;
         this.mappingB = mappingB;
         this.nextNodesInsert = nextNodesInsert;
         this.nextNodesRetract = nextNodesRetract;
+        this.scoreStoreSize = scoreStoreSize;
         this.indexerA = indexerA;
         this.indexerB = indexerB;
         dirtyTupleQueue = new ArrayDeque<>(1000);
@@ -77,7 +80,7 @@ public final class JoinBiNode<A, B> extends AbstractNode {
         indexerA.put(indexProperties, tupleA, tupleABSetA);
 
         tupleABSetMapB.forEach((tupleB, tupleABSetB) -> {
-            BiTuple<A, B> tupleAB = new BiTuple<>(tupleA.factA, tupleB.factA);
+            BiTuple<A, B> tupleAB = new BiTuple<>(tupleA.factA, tupleB.factA, scoreStoreSize);
             tupleAB.state = BavetTupleState.CREATING;
             tupleABSetA.add(tupleAB);
             tupleABSetB.add(tupleAB);
@@ -124,7 +127,7 @@ public final class JoinBiNode<A, B> extends AbstractNode {
         indexerB.put(indexProperties, tupleB, tupleABSetB);
 
         tupleABSetMapB.forEach((tupleA, tupleABSetA) -> {
-            BiTuple<A, B> tupleAB = new BiTuple<>(tupleA.factA, tupleB.factA);
+            BiTuple<A, B> tupleAB = new BiTuple<>(tupleA.factA, tupleB.factA, scoreStoreSize);
             tupleAB.state = BavetTupleState.CREATING;
             tupleABSetB.add(tupleAB);
             tupleABSetA.add(tupleAB);

--- a/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/bavet/bi/JoinBiNode.java
+++ b/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/bavet/bi/JoinBiNode.java
@@ -47,6 +47,7 @@ public final class JoinBiNode<A, B> extends AbstractNode {
      */
     private final Consumer<BiTuple<A, B>> nextNodesRetract;
     private final int joinStoreSize;
+    private final int groupStoreSize;
     private final int scoreStoreSize;
 
     private final Indexer<UniTuple<A>, Set<BiTuple<A, B>>> indexerA;
@@ -56,7 +57,7 @@ public final class JoinBiNode<A, B> extends AbstractNode {
     public JoinBiNode(Function<A, Object[]> mappingA, Function<B, Object[]> mappingB,
             int joinStoreIndexA, int joinStoreIndexB,
             Consumer<BiTuple<A, B>> nextNodesInsert, Consumer<BiTuple<A, B>> nextNodesRetract,
-            int joinStoreSize, int scoreStoreSize,
+            int joinStoreSize, int groupStoreSize, int scoreStoreSize,
             Indexer<UniTuple<A>, Set<BiTuple<A, B>>> indexerA, Indexer<UniTuple<B>, Set<BiTuple<A, B>>> indexerB) {
         this.mappingA = mappingA;
         this.mappingB = mappingB;
@@ -65,6 +66,7 @@ public final class JoinBiNode<A, B> extends AbstractNode {
         this.nextNodesInsert = nextNodesInsert;
         this.nextNodesRetract = nextNodesRetract;
         this.joinStoreSize = joinStoreSize;
+        this.groupStoreSize = groupStoreSize;
         this.scoreStoreSize = scoreStoreSize;
         this.indexerA = indexerA;
         this.indexerB = indexerB;
@@ -85,7 +87,8 @@ public final class JoinBiNode<A, B> extends AbstractNode {
         indexerA.put(indexProperties, tupleA, tupleABSetA);
 
         tupleABSetMapB.forEach((tupleB, tupleABSetB) -> {
-            BiTuple<A, B> tupleAB = new BiTuple<>(tupleA.factA, tupleB.factA, joinStoreSize, scoreStoreSize);
+            BiTuple<A, B> tupleAB = new BiTuple<>(tupleA.factA, tupleB.factA,
+                    joinStoreSize, groupStoreSize, scoreStoreSize);
             tupleAB.state = BavetTupleState.CREATING;
             tupleABSetA.add(tupleAB);
             tupleABSetB.add(tupleAB);
@@ -133,7 +136,8 @@ public final class JoinBiNode<A, B> extends AbstractNode {
         indexerB.put(indexProperties, tupleB, tupleABSetB);
 
         tupleABSetMapB.forEach((tupleA, tupleABSetA) -> {
-            BiTuple<A, B> tupleAB = new BiTuple<>(tupleA.factA, tupleB.factA, joinStoreSize, scoreStoreSize);
+            BiTuple<A, B> tupleAB = new BiTuple<>(tupleA.factA, tupleB.factA,
+                    joinStoreSize, groupStoreSize, scoreStoreSize);
             tupleAB.state = BavetTupleState.CREATING;
             tupleABSetB.add(tupleAB);
             tupleABSetA.add(tupleAB);

--- a/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/bavet/common/BavetAbstractConstraintStream.java
+++ b/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/bavet/common/BavetAbstractConstraintStream.java
@@ -25,6 +25,7 @@ import org.optaplanner.constraint.streams.common.AbstractConstraintStream;
 import org.optaplanner.constraint.streams.common.RetrievalSemantics;
 import org.optaplanner.constraint.streams.common.ScoreImpactType;
 import org.optaplanner.core.api.score.Score;
+import org.optaplanner.core.api.score.stream.ConstraintStream;
 
 public abstract class BavetAbstractConstraintStream<Solution_> extends AbstractConstraintStream<Solution_> {
 
@@ -69,6 +70,8 @@ public abstract class BavetAbstractConstraintStream<Solution_> extends AbstractC
     // ************************************************************************
 
     public abstract void collectActiveConstraintStreams(Set<BavetAbstractConstraintStream<Solution_>> constraintStreamSet);
+
+    public abstract ConstraintStream getTupleSource();
 
     public abstract <Score_ extends Score<Score_>> void buildNode(NodeBuildHelper<Score_> buildHelper);
 

--- a/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/bavet/common/NodeBuildHelper.java
+++ b/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/bavet/common/NodeBuildHelper.java
@@ -39,6 +39,7 @@ public class NodeBuildHelper<Score_ extends Score<Score_>> {
     private final Map<ConstraintStream, Consumer<? extends Tuple>> retractMap;
 
     private final Map<ConstraintStream, Integer> joinStoreIndexMap;
+    private final Map<ConstraintStream, Integer> groupStoreIndexMap;
     private final Map<ConstraintStream, Integer> scoreStoreIndexMap;
 
     private List<AbstractNode> reversedNodeList;
@@ -50,6 +51,7 @@ public class NodeBuildHelper<Score_ extends Score<Score_>> {
         insertMap = new HashMap<>(Math.max(16, activeStreamSet.size()));
         retractMap = new HashMap<>(Math.max(16, activeStreamSet.size()));
         joinStoreIndexMap = new HashMap<>(Math.max(16, activeStreamSet.size() / 2));
+        groupStoreIndexMap = new HashMap<>(Math.max(16, activeStreamSet.size() / 2));
         scoreStoreIndexMap = new HashMap<>(Math.max(16, activeStreamSet.size() / 2));
         reversedNodeList = new ArrayList<>(activeStreamSet.size());
         this.constraintWeightMap = constraintWeightMap;
@@ -141,6 +143,24 @@ public class NodeBuildHelper<Score_ extends Score<Score_>> {
 
     public int extractJoinStoreSize(ConstraintStream tupleSourceStream) {
         Integer lastIndex = joinStoreIndexMap.put(tupleSourceStream, Integer.MIN_VALUE);
+        return (lastIndex == null) ? 0 : lastIndex + 1;
+    }
+
+    public int reserveGroupStoreIndex(ConstraintStream tupleSourceStream) {
+        return groupStoreIndexMap.compute(tupleSourceStream, (k, index) -> {
+            if (index == null) {
+                return 0;
+            } else if (index < 0) {
+                throw new IllegalStateException("Impossible state: the tupleSourceStream (" + tupleSourceStream
+                        + ") is reserving a store after it has been extracted.");
+            } else {
+                return index + 1;
+            }
+        });
+    }
+
+    public int extractGroupStoreSize(ConstraintStream tupleSourceStream) {
+        Integer lastIndex = groupStoreIndexMap.put(tupleSourceStream, Integer.MIN_VALUE);
         return (lastIndex == null) ? 0 : lastIndex + 1;
     }
 

--- a/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/bavet/common/NodeBuildHelper.java
+++ b/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/bavet/common/NodeBuildHelper.java
@@ -38,9 +38,7 @@ public class NodeBuildHelper<Score_ extends Score<Score_>> {
     private final Map<ConstraintStream, Consumer<? extends Tuple>> insertMap;
     private final Map<ConstraintStream, Consumer<? extends Tuple>> retractMap;
 
-    private final Map<ConstraintStream, Integer> joinStoreIndexMap;
-    private final Map<ConstraintStream, Integer> groupStoreIndexMap;
-    private final Map<ConstraintStream, Integer> scoreStoreIndexMap;
+    private final Map<ConstraintStream, Integer> storeIndexMap;
 
     private List<AbstractNode> reversedNodeList;
 
@@ -50,9 +48,7 @@ public class NodeBuildHelper<Score_ extends Score<Score_>> {
         this.activeStreamSet = activeStreamSet;
         insertMap = new HashMap<>(Math.max(16, activeStreamSet.size()));
         retractMap = new HashMap<>(Math.max(16, activeStreamSet.size()));
-        joinStoreIndexMap = new HashMap<>(Math.max(16, activeStreamSet.size() / 2));
-        groupStoreIndexMap = new HashMap<>(Math.max(16, activeStreamSet.size() / 2));
-        scoreStoreIndexMap = new HashMap<>(Math.max(16, activeStreamSet.size() / 2));
+        storeIndexMap = new HashMap<>(Math.max(16, activeStreamSet.size() / 2));
         reversedNodeList = new ArrayList<>(activeStreamSet.size());
         this.constraintWeightMap = constraintWeightMap;
         this.scoreInliner = scoreInliner;
@@ -128,8 +124,8 @@ public class NodeBuildHelper<Score_ extends Score<Score_>> {
         return aggregatedRetract;
     }
 
-    public int reserveJoinStoreIndex(ConstraintStream tupleSourceStream) {
-        return joinStoreIndexMap.compute(tupleSourceStream, (k, index) -> {
+    public int reserveTupleStoreIndex(ConstraintStream tupleSourceStream) {
+        return storeIndexMap.compute(tupleSourceStream, (k, index) -> {
             if (index == null) {
                 return 0;
             } else if (index < 0) {
@@ -141,44 +137,8 @@ public class NodeBuildHelper<Score_ extends Score<Score_>> {
         });
     }
 
-    public int extractJoinStoreSize(ConstraintStream tupleSourceStream) {
-        Integer lastIndex = joinStoreIndexMap.put(tupleSourceStream, Integer.MIN_VALUE);
-        return (lastIndex == null) ? 0 : lastIndex + 1;
-    }
-
-    public int reserveGroupStoreIndex(ConstraintStream tupleSourceStream) {
-        return groupStoreIndexMap.compute(tupleSourceStream, (k, index) -> {
-            if (index == null) {
-                return 0;
-            } else if (index < 0) {
-                throw new IllegalStateException("Impossible state: the tupleSourceStream (" + tupleSourceStream
-                        + ") is reserving a store after it has been extracted.");
-            } else {
-                return index + 1;
-            }
-        });
-    }
-
-    public int extractGroupStoreSize(ConstraintStream tupleSourceStream) {
-        Integer lastIndex = groupStoreIndexMap.put(tupleSourceStream, Integer.MIN_VALUE);
-        return (lastIndex == null) ? 0 : lastIndex + 1;
-    }
-
-    public int reserveScoreStoreIndex(ConstraintStream tupleSourceStream) {
-        return scoreStoreIndexMap.compute(tupleSourceStream, (k, index) -> {
-            if (index == null) {
-                return 0;
-            } else if (index < 0) {
-                throw new IllegalStateException("Impossible state: the tupleSourceStream (" + tupleSourceStream
-                        + ") is reserving a store after it has been extracted.");
-            } else {
-                return index + 1;
-            }
-        });
-    }
-
-    public int extractScoreStoreSize(ConstraintStream tupleSourceStream) {
-        Integer lastIndex = scoreStoreIndexMap.put(tupleSourceStream, Integer.MIN_VALUE);
+    public int extractTupleStoreSize(ConstraintStream tupleSourceStream) {
+        Integer lastIndex = storeIndexMap.put(tupleSourceStream, Integer.MIN_VALUE);
         return (lastIndex == null) ? 0 : lastIndex + 1;
     }
 

--- a/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/bavet/tri/BavetFilterTriConstraintStream.java
+++ b/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/bavet/tri/BavetFilterTriConstraintStream.java
@@ -25,6 +25,7 @@ import org.optaplanner.constraint.streams.bavet.common.BavetAbstractConstraintSt
 import org.optaplanner.constraint.streams.bavet.common.NodeBuildHelper;
 import org.optaplanner.core.api.function.TriPredicate;
 import org.optaplanner.core.api.score.Score;
+import org.optaplanner.core.api.score.stream.ConstraintStream;
 
 public final class BavetFilterTriConstraintStream<Solution_, A, B, C>
         extends BavetAbstractTriConstraintStream<Solution_, A, B, C> {
@@ -56,6 +57,11 @@ public final class BavetFilterTriConstraintStream<Solution_, A, B, C>
     public void collectActiveConstraintStreams(Set<BavetAbstractConstraintStream<Solution_>> constraintStreamSet) {
         parent.collectActiveConstraintStreams(constraintStreamSet);
         constraintStreamSet.add(this);
+    }
+
+    @Override
+    public ConstraintStream getTupleSource() {
+        return parent.getTupleSource();
     }
 
     @Override

--- a/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/bavet/tri/BavetJoinTriConstraintStream.java
+++ b/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/bavet/tri/BavetJoinTriConstraintStream.java
@@ -32,6 +32,7 @@ import org.optaplanner.constraint.streams.bavet.common.index.IndexerFactory;
 import org.optaplanner.constraint.streams.bavet.uni.BavetAbstractUniConstraintStream;
 import org.optaplanner.constraint.streams.bavet.uni.UniTuple;
 import org.optaplanner.core.api.score.Score;
+import org.optaplanner.core.api.score.stream.ConstraintStream;
 
 public final class BavetJoinTriConstraintStream<Solution_, A, B, C>
         extends BavetAbstractTriConstraintStream<Solution_, A, B, C>
@@ -74,13 +75,19 @@ public final class BavetJoinTriConstraintStream<Solution_, A, B, C>
     }
 
     @Override
+    public ConstraintStream getTupleSource() {
+        return this;
+    }
+
+    @Override
     public <Score_ extends Score<Score_>> void buildNode(NodeBuildHelper<Score_> buildHelper) {
         Consumer<TriTuple<A, B, C>> insert = buildHelper.getAggregatedInsert(childStreamList);
         Consumer<TriTuple<A, B, C>> retract = buildHelper.getAggregatedRetract(childStreamList);
         Indexer<BiTuple<A, B>, Set<TriTuple<A, B, C>>> indexerAB = indexerFactory.buildIndexer(true);
         Indexer<UniTuple<C>, Set<TriTuple<A, B, C>>> indexerC = indexerFactory.buildIndexer(false);
+        int scoreStoreSize = buildHelper.extractScoreStoreSize(this);
         JoinTriNode<A, B, C> node = new JoinTriNode<>(leftMapping, rightMapping,
-                insert, retract,
+                insert, retract, scoreStoreSize,
                 indexerAB, indexerC);
         buildHelper.addNode(node);
         buildHelper.putInsertRetract(leftParent, node::insertAB, node::retractAB);

--- a/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/bavet/tri/BavetJoinTriConstraintStream.java
+++ b/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/bavet/tri/BavetJoinTriConstraintStream.java
@@ -85,9 +85,13 @@ public final class BavetJoinTriConstraintStream<Solution_, A, B, C>
         Consumer<TriTuple<A, B, C>> retract = buildHelper.getAggregatedRetract(childStreamList);
         Indexer<BiTuple<A, B>, Set<TriTuple<A, B, C>>> indexerAB = indexerFactory.buildIndexer(true);
         Indexer<UniTuple<C>, Set<TriTuple<A, B, C>>> indexerC = indexerFactory.buildIndexer(false);
+        int joinStoreIndexAB = buildHelper.reserveJoinStoreIndex(leftParent.getTupleSource());
+        int joinStoreIndexC = buildHelper.reserveJoinStoreIndex(rightParent.getTupleSource());
+        int joinStoreSize = buildHelper.extractJoinStoreSize(this);
         int scoreStoreSize = buildHelper.extractScoreStoreSize(this);
-        JoinTriNode<A, B, C> node = new JoinTriNode<>(leftMapping, rightMapping,
-                insert, retract, scoreStoreSize,
+        JoinTriNode<A, B, C> node = new JoinTriNode<>(
+                leftMapping, rightMapping, joinStoreIndexAB, joinStoreIndexC,
+                insert, retract, joinStoreSize, scoreStoreSize,
                 indexerAB, indexerC);
         buildHelper.addNode(node);
         buildHelper.putInsertRetract(leftParent, node::insertAB, node::retractAB);

--- a/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/bavet/tri/BavetJoinTriConstraintStream.java
+++ b/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/bavet/tri/BavetJoinTriConstraintStream.java
@@ -81,17 +81,18 @@ public final class BavetJoinTriConstraintStream<Solution_, A, B, C>
 
     @Override
     public <Score_ extends Score<Score_>> void buildNode(NodeBuildHelper<Score_> buildHelper) {
-        Consumer<TriTuple<A, B, C>> insert = buildHelper.getAggregatedInsert(childStreamList);
-        Consumer<TriTuple<A, B, C>> retract = buildHelper.getAggregatedRetract(childStreamList);
-        Indexer<BiTuple<A, B>, Set<TriTuple<A, B, C>>> indexerAB = indexerFactory.buildIndexer(true);
-        Indexer<UniTuple<C>, Set<TriTuple<A, B, C>>> indexerC = indexerFactory.buildIndexer(false);
         int joinStoreIndexAB = buildHelper.reserveJoinStoreIndex(leftParent.getTupleSource());
         int joinStoreIndexC = buildHelper.reserveJoinStoreIndex(rightParent.getTupleSource());
+        Consumer<TriTuple<A, B, C>> insert = buildHelper.getAggregatedInsert(childStreamList);
+        Consumer<TriTuple<A, B, C>> retract = buildHelper.getAggregatedRetract(childStreamList);
         int joinStoreSize = buildHelper.extractJoinStoreSize(this);
+        int groupStoreSize = buildHelper.extractGroupStoreSize(this);
         int scoreStoreSize = buildHelper.extractScoreStoreSize(this);
+        Indexer<BiTuple<A, B>, Set<TriTuple<A, B, C>>> indexerAB = indexerFactory.buildIndexer(true);
+        Indexer<UniTuple<C>, Set<TriTuple<A, B, C>>> indexerC = indexerFactory.buildIndexer(false);
         JoinTriNode<A, B, C> node = new JoinTriNode<>(
                 leftMapping, rightMapping, joinStoreIndexAB, joinStoreIndexC,
-                insert, retract, joinStoreSize, scoreStoreSize,
+                insert, retract, joinStoreSize, groupStoreSize, scoreStoreSize,
                 indexerAB, indexerC);
         buildHelper.addNode(node);
         buildHelper.putInsertRetract(leftParent, node::insertAB, node::retractAB);

--- a/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/bavet/tri/BavetJoinTriConstraintStream.java
+++ b/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/bavet/tri/BavetJoinTriConstraintStream.java
@@ -81,18 +81,16 @@ public final class BavetJoinTriConstraintStream<Solution_, A, B, C>
 
     @Override
     public <Score_ extends Score<Score_>> void buildNode(NodeBuildHelper<Score_> buildHelper) {
-        int joinStoreIndexAB = buildHelper.reserveJoinStoreIndex(leftParent.getTupleSource());
-        int joinStoreIndexC = buildHelper.reserveJoinStoreIndex(rightParent.getTupleSource());
+        int inputStoreIndexAB = buildHelper.reserveTupleStoreIndex(leftParent.getTupleSource());
+        int inputStoreIndexC = buildHelper.reserveTupleStoreIndex(rightParent.getTupleSource());
         Consumer<TriTuple<A, B, C>> insert = buildHelper.getAggregatedInsert(childStreamList);
         Consumer<TriTuple<A, B, C>> retract = buildHelper.getAggregatedRetract(childStreamList);
-        int joinStoreSize = buildHelper.extractJoinStoreSize(this);
-        int groupStoreSize = buildHelper.extractGroupStoreSize(this);
-        int scoreStoreSize = buildHelper.extractScoreStoreSize(this);
+        int outputStoreSize = buildHelper.extractTupleStoreSize(this);
         Indexer<BiTuple<A, B>, Set<TriTuple<A, B, C>>> indexerAB = indexerFactory.buildIndexer(true);
         Indexer<UniTuple<C>, Set<TriTuple<A, B, C>>> indexerC = indexerFactory.buildIndexer(false);
         JoinTriNode<A, B, C> node = new JoinTriNode<>(
-                leftMapping, rightMapping, joinStoreIndexAB, joinStoreIndexC,
-                insert, retract, joinStoreSize, groupStoreSize, scoreStoreSize,
+                leftMapping, rightMapping, inputStoreIndexAB, inputStoreIndexC,
+                insert, retract, outputStoreSize,
                 indexerAB, indexerC);
         buildHelper.addNode(node);
         buildHelper.putInsertRetract(leftParent, node::insertAB, node::retractAB);

--- a/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/bavet/tri/BavetScoringTriConstraintStream.java
+++ b/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/bavet/tri/BavetScoringTriConstraintStream.java
@@ -33,6 +33,7 @@ import org.optaplanner.core.api.function.ToIntTriFunction;
 import org.optaplanner.core.api.function.ToLongTriFunction;
 import org.optaplanner.core.api.function.TriFunction;
 import org.optaplanner.core.api.score.Score;
+import org.optaplanner.core.api.score.stream.ConstraintStream;
 
 public final class BavetScoringTriConstraintStream<Solution_, A, B, C>
         extends BavetAbstractTriConstraintStream<Solution_, A, B, C>
@@ -111,6 +112,11 @@ public final class BavetScoringTriConstraintStream<Solution_, A, B, C>
     }
 
     @Override
+    public ConstraintStream getTupleSource() {
+        return parent.getTupleSource();
+    }
+
+    @Override
     public <Score_ extends Score<Score_>> void buildNode(NodeBuildHelper<Score_> buildHelper) {
         Score_ constraintWeight = buildHelper.getConstraintWeight(constraint);
         AbstractScoreInliner<Score_> scoreInliner = buildHelper.getScoreInliner();
@@ -140,7 +146,7 @@ public final class BavetScoringTriConstraintStream<Solution_, A, B, C>
             throw new IllegalStateException("Impossible state: neither of the supported match weighers provided.");
         }
         TriScorer<A, B, C> scorer = new TriScorer<>(constraint.getConstraintPackage(), constraint.getConstraintName(),
-                constraintWeight, scoreImpacter);
+                constraintWeight, scoreImpacter, buildHelper.reserveScoreStoreIndex(parent.getTupleSource()));
         buildHelper.putInsertRetract(this, scorer::insert, scorer::retract);
     }
 

--- a/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/bavet/tri/BavetScoringTriConstraintStream.java
+++ b/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/bavet/tri/BavetScoringTriConstraintStream.java
@@ -146,7 +146,7 @@ public final class BavetScoringTriConstraintStream<Solution_, A, B, C>
             throw new IllegalStateException("Impossible state: neither of the supported match weighers provided.");
         }
         TriScorer<A, B, C> scorer = new TriScorer<>(constraint.getConstraintPackage(), constraint.getConstraintName(),
-                constraintWeight, scoreImpacter, buildHelper.reserveScoreStoreIndex(parent.getTupleSource()));
+                constraintWeight, scoreImpacter, buildHelper.reserveTupleStoreIndex(parent.getTupleSource()));
         buildHelper.putInsertRetract(this, scorer::insert, scorer::retract);
     }
 

--- a/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/bavet/tri/JoinTriNode.java
+++ b/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/bavet/tri/JoinTriNode.java
@@ -48,6 +48,7 @@ public final class JoinTriNode<A, B, C> extends AbstractNode {
      */
     private final Consumer<TriTuple<A, B, C>> nextNodesRetract;
     private final int joinStoreSize;
+    private final int groupStoreSize;
     private final int scoreStoreSize;
 
     private final Indexer<BiTuple<A, B>, Set<TriTuple<A, B, C>>> indexerAB;
@@ -57,7 +58,7 @@ public final class JoinTriNode<A, B, C> extends AbstractNode {
     public JoinTriNode(BiFunction<A, B, Object[]> mappingAB, Function<C, Object[]> mappingC,
             int joinStoreIndexAB, int joinStoreIndexC,
             Consumer<TriTuple<A, B, C>> nextNodesInsert, Consumer<TriTuple<A, B, C>> nextNodesRetract,
-            int joinStoreSize, int scoreStoreSize,
+            int joinStoreSize, int groupStoreSize, int scoreStoreSize,
             Indexer<BiTuple<A, B>, Set<TriTuple<A, B, C>>> indexerAB, Indexer<UniTuple<C>, Set<TriTuple<A, B, C>>> indexerC) {
         this.mappingAB = mappingAB;
         this.mappingC = mappingC;
@@ -66,6 +67,7 @@ public final class JoinTriNode<A, B, C> extends AbstractNode {
         this.nextNodesInsert = nextNodesInsert;
         this.nextNodesRetract = nextNodesRetract;
         this.joinStoreSize = joinStoreSize;
+        this.groupStoreSize = groupStoreSize;
         this.scoreStoreSize = scoreStoreSize;
         this.indexerAB = indexerAB;
         this.indexerC = indexerC;
@@ -87,7 +89,7 @@ public final class JoinTriNode<A, B, C> extends AbstractNode {
 
         tupleABCSetMapC.forEach((tupleC, tupleABCSetC) -> {
             TriTuple<A, B, C> tupleABC = new TriTuple<>(tupleAB.factA, tupleAB.factB, tupleC.factA,
-                    joinStoreSize, scoreStoreSize);
+                    joinStoreSize, groupStoreSize, scoreStoreSize);
             tupleABC.state = BavetTupleState.CREATING;
             tupleABCSetAB.add(tupleABC);
             tupleABCSetC.add(tupleABC);
@@ -136,7 +138,7 @@ public final class JoinTriNode<A, B, C> extends AbstractNode {
 
         tupleABCSetMapAB.forEach((tupleAB, tupleABCSetAB) -> {
             TriTuple<A, B, C> tupleABC = new TriTuple<>(tupleAB.factA, tupleAB.factB, tupleC.factA,
-                    joinStoreSize, scoreStoreSize);
+                    joinStoreSize, groupStoreSize, scoreStoreSize);
             tupleABC.state = BavetTupleState.CREATING;
             tupleABCSetC.add(tupleABC);
             tupleABCSetAB.add(tupleABC);

--- a/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/bavet/tri/JoinTriNode.java
+++ b/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/bavet/tri/JoinTriNode.java
@@ -18,7 +18,6 @@ package org.optaplanner.constraint.streams.bavet.tri;
 
 import java.util.ArrayDeque;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Queue;

--- a/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/bavet/tri/JoinTriNode.java
+++ b/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/bavet/tri/JoinTriNode.java
@@ -40,11 +40,12 @@ public final class JoinTriNode<A, B, C> extends AbstractNode {
     /**
      * Calls for example {@link TriScorer#insert(TriTuple)} and/or ...
      */
-    public final Consumer<TriTuple<A, B, C>> nextNodesInsert;
+    private final Consumer<TriTuple<A, B, C>> nextNodesInsert;
     /**
      * Calls for example {@link TriScorer#retract(TriTuple)} and/or ...
      */
-    public final Consumer<TriTuple<A, B, C>> nextNodesRetract;
+    private final Consumer<TriTuple<A, B, C>> nextNodesRetract;
+    private final int scoreStoreSize;
 
     private final Indexer<BiTuple<A, B>, Set<TriTuple<A, B, C>>> indexerAB;
     private final Map<BiTuple<A, B>, Object[]> indexPropertiesMapAB = new HashMap<>();
@@ -54,11 +55,13 @@ public final class JoinTriNode<A, B, C> extends AbstractNode {
 
     public JoinTriNode(BiFunction<A, B, Object[]> mappingAB, Function<C, Object[]> mappingC,
             Consumer<TriTuple<A, B, C>> nextNodesInsert, Consumer<TriTuple<A, B, C>> nextNodesRetract,
+            int scoreStoreSize,
             Indexer<BiTuple<A, B>, Set<TriTuple<A, B, C>>> indexerAB, Indexer<UniTuple<C>, Set<TriTuple<A, B, C>>> indexerC) {
         this.mappingAB = mappingAB;
         this.mappingC = mappingC;
         this.nextNodesInsert = nextNodesInsert;
         this.nextNodesRetract = nextNodesRetract;
+        this.scoreStoreSize = scoreStoreSize;
         this.indexerAB = indexerAB;
         this.indexerC = indexerC;
         dirtyTupleQueue = new ArrayDeque<>(1000);
@@ -78,7 +81,7 @@ public final class JoinTriNode<A, B, C> extends AbstractNode {
         indexerAB.put(indexProperties, tupleAB, tupleABCSetAB);
 
         tupleABCSetMapC.forEach((tupleC, tupleABCSetC) -> {
-            TriTuple<A, B, C> tupleABC = new TriTuple<>(tupleAB.factA, tupleAB.factB, tupleC.factA);
+            TriTuple<A, B, C> tupleABC = new TriTuple<>(tupleAB.factA, tupleAB.factB, tupleC.factA, scoreStoreSize);
             tupleABC.state = BavetTupleState.CREATING;
             tupleABCSetAB.add(tupleABC);
             tupleABCSetC.add(tupleABC);
@@ -125,7 +128,7 @@ public final class JoinTriNode<A, B, C> extends AbstractNode {
         indexerC.put(indexProperties, tupleC, tupleABCSetC);
 
         tupleABCSetMapAB.forEach((tupleAB, tupleABCSetAB) -> {
-            TriTuple<A, B, C> tupleABC = new TriTuple<>(tupleAB.factA, tupleAB.factB, tupleC.factA);
+            TriTuple<A, B, C> tupleABC = new TriTuple<>(tupleAB.factA, tupleAB.factB, tupleC.factA, scoreStoreSize);
             tupleABC.state = BavetTupleState.CREATING;
             tupleABCSetC.add(tupleABC);
             tupleABCSetAB.add(tupleABC);

--- a/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/bavet/tri/TriScorer.java
+++ b/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/bavet/tri/TriScorer.java
@@ -16,9 +16,6 @@
 
 package org.optaplanner.constraint.streams.bavet.tri;
 
-import java.util.HashMap;
-import java.util.Map;
-
 import org.optaplanner.constraint.streams.bavet.common.AbstractScorer;
 import org.optaplanner.constraint.streams.common.inliner.UndoScoreImpacter;
 import org.optaplanner.core.api.function.TriFunction;

--- a/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/bavet/tri/TriScorer.java
+++ b/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/bavet/tri/TriScorer.java
@@ -27,34 +27,34 @@ public final class TriScorer<A, B, C> extends AbstractScorer {
     private final String constraintName;
     private final Score<?> constraintWeight;
     private final TriFunction<A, B, C, UndoScoreImpacter> scoreImpacter;
-    private final int scoreStoreIndex;
+    private final int inputStoreIndex;
 
     public TriScorer(String constraintPackage, String constraintName,
             Score<?> constraintWeight, TriFunction<A, B, C, UndoScoreImpacter> scoreImpacter,
-            int scoreStoreIndex) {
+            int inputStoreIndex) {
         this.constraintPackage = constraintPackage;
         this.constraintName = constraintName;
         this.constraintWeight = constraintWeight;
         this.scoreImpacter = scoreImpacter;
-        this.scoreStoreIndex = scoreStoreIndex;
+        this.inputStoreIndex = inputStoreIndex;
     }
 
     public void insert(TriTuple<A, B, C> tupleABC) {
-        if (tupleABC.scorerStore[scoreStoreIndex] != null) {
+        if (tupleABC.store[inputStoreIndex] != null) {
             throw new IllegalStateException("Impossible state: the tuple for the facts ("
                     + tupleABC.factA + ", " + tupleABC.factB + ", " + tupleABC.factC
                     + ") was already added in the scorerStore.");
         }
         UndoScoreImpacter undoScoreImpacter = scoreImpacter.apply(tupleABC.factA, tupleABC.factB, tupleABC.factC);
-        tupleABC.scorerStore[scoreStoreIndex] = undoScoreImpacter;
+        tupleABC.store[inputStoreIndex] = undoScoreImpacter;
     }
 
     public void retract(TriTuple<A, B, C> tupleABC) {
-        UndoScoreImpacter undoScoreImpacter = tupleABC.scorerStore[scoreStoreIndex];
+        UndoScoreImpacter undoScoreImpacter = (UndoScoreImpacter) tupleABC.store[inputStoreIndex];
         // No fail fast if null because we don't track which tuples made it through the filter predicate(s)
         if (undoScoreImpacter != null) {
             undoScoreImpacter.run();
-            tupleABC.scorerStore[scoreStoreIndex] = null;
+            tupleABC.store[inputStoreIndex] = null;
         }
     }
 

--- a/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/bavet/tri/TriTuple.java
+++ b/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/bavet/tri/TriTuple.java
@@ -27,15 +27,17 @@ public final class TriTuple<A, B, C> implements Tuple {
     public final C factC;
 
     public final Object[][] joinStore;
+    public final Object[] groupStore;
     public final UndoScoreImpacter[] scorerStore;
 
     public BavetTupleState state;
 
-    public TriTuple(A factA, B factB, C factC, int joinStoreSize, int scoreStoreSize) {
+    public TriTuple(A factA, B factB, C factC, int joinStoreSize, int groupStoreSize, int scoreStoreSize) {
         this.factA = factA;
         this.factB = factB;
         this.factC = factC;
         joinStore = (joinStoreSize <= 0) ? null : new Object[joinStoreSize][];
+        groupStore = (groupStoreSize <= 0) ? null : new Object[groupStoreSize];
         scorerStore = (scoreStoreSize <= 0) ? null : new UndoScoreImpacter[scoreStoreSize];
     }
 

--- a/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/bavet/tri/TriTuple.java
+++ b/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/bavet/tri/TriTuple.java
@@ -26,14 +26,16 @@ public final class TriTuple<A, B, C> implements Tuple {
     public final B factB;
     public final C factC;
 
+    public final Object[][] joinStore;
     public final UndoScoreImpacter[] scorerStore;
 
     public BavetTupleState state;
 
-    public TriTuple(A factA, B factB, C factC, int scoreStoreSize) {
+    public TriTuple(A factA, B factB, C factC, int joinStoreSize, int scoreStoreSize) {
         this.factA = factA;
         this.factB = factB;
         this.factC = factC;
+        joinStore = (joinStoreSize <= 0) ? null : new Object[joinStoreSize][];
         scorerStore = (scoreStoreSize <= 0) ? null : new UndoScoreImpacter[scoreStoreSize];
     }
 

--- a/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/bavet/tri/TriTuple.java
+++ b/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/bavet/tri/TriTuple.java
@@ -18,7 +18,6 @@ package org.optaplanner.constraint.streams.bavet.tri;
 
 import org.optaplanner.constraint.streams.bavet.common.BavetTupleState;
 import org.optaplanner.constraint.streams.bavet.common.Tuple;
-import org.optaplanner.constraint.streams.common.inliner.UndoScoreImpacter;
 
 public final class TriTuple<A, B, C> implements Tuple {
 
@@ -26,19 +25,15 @@ public final class TriTuple<A, B, C> implements Tuple {
     public final B factB;
     public final C factC;
 
-    public final Object[][] joinStore;
-    public final Object[] groupStore;
-    public final UndoScoreImpacter[] scorerStore;
+    public final Object[] store;
 
     public BavetTupleState state;
 
-    public TriTuple(A factA, B factB, C factC, int joinStoreSize, int groupStoreSize, int scoreStoreSize) {
+    public TriTuple(A factA, B factB, C factC, int storeSize) {
         this.factA = factA;
         this.factB = factB;
         this.factC = factC;
-        joinStore = (joinStoreSize <= 0) ? null : new Object[joinStoreSize][];
-        groupStore = (groupStoreSize <= 0) ? null : new Object[groupStoreSize];
-        scorerStore = (scoreStoreSize <= 0) ? null : new UndoScoreImpacter[scoreStoreSize];
+        store = (storeSize <= 0) ? null : new Object[storeSize];
     }
 
     @Override

--- a/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/bavet/tri/TriTuple.java
+++ b/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/bavet/tri/TriTuple.java
@@ -18,20 +18,23 @@ package org.optaplanner.constraint.streams.bavet.tri;
 
 import org.optaplanner.constraint.streams.bavet.common.BavetTupleState;
 import org.optaplanner.constraint.streams.bavet.common.Tuple;
+import org.optaplanner.constraint.streams.common.inliner.UndoScoreImpacter;
 
-// TODO Java 17: refactor to record
 public final class TriTuple<A, B, C> implements Tuple {
 
     public final A factA;
     public final B factB;
     public final C factC;
 
+    public final UndoScoreImpacter[] scorerStore;
+
     public BavetTupleState state;
 
-    public TriTuple(A factA, B factB, C factC) {
+    public TriTuple(A factA, B factB, C factC, int scoreStoreSize) {
         this.factA = factA;
         this.factB = factB;
         this.factC = factC;
+        scorerStore = (scoreStoreSize <= 0) ? null : new UndoScoreImpacter[scoreStoreSize];
     }
 
     @Override

--- a/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/bavet/uni/BavetFilterUniConstraintStream.java
+++ b/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/bavet/uni/BavetFilterUniConstraintStream.java
@@ -25,6 +25,7 @@ import org.optaplanner.constraint.streams.bavet.BavetConstraintFactory;
 import org.optaplanner.constraint.streams.bavet.common.BavetAbstractConstraintStream;
 import org.optaplanner.constraint.streams.bavet.common.NodeBuildHelper;
 import org.optaplanner.core.api.score.Score;
+import org.optaplanner.core.api.score.stream.ConstraintStream;
 
 public final class BavetFilterUniConstraintStream<Solution_, A> extends BavetAbstractUniConstraintStream<Solution_, A> {
 
@@ -54,6 +55,11 @@ public final class BavetFilterUniConstraintStream<Solution_, A> extends BavetAbs
     public void collectActiveConstraintStreams(Set<BavetAbstractConstraintStream<Solution_>> constraintStreamSet) {
         parent.collectActiveConstraintStreams(constraintStreamSet);
         constraintStreamSet.add(this);
+    }
+
+    @Override
+    public ConstraintStream getTupleSource() {
+        return parent.getTupleSource();
     }
 
     @Override

--- a/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/bavet/uni/BavetForEachUniConstraintStream.java
+++ b/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/bavet/uni/BavetForEachUniConstraintStream.java
@@ -24,6 +24,7 @@ import org.optaplanner.constraint.streams.bavet.common.BavetAbstractConstraintSt
 import org.optaplanner.constraint.streams.bavet.common.NodeBuildHelper;
 import org.optaplanner.constraint.streams.common.RetrievalSemantics;
 import org.optaplanner.core.api.score.Score;
+import org.optaplanner.core.api.score.stream.ConstraintStream;
 
 public final class BavetForEachUniConstraintStream<Solution_, A> extends BavetAbstractUniConstraintStream<Solution_, A> {
 
@@ -53,10 +54,16 @@ public final class BavetForEachUniConstraintStream<Solution_, A> extends BavetAb
     }
 
     @Override
+    public ConstraintStream getTupleSource() {
+        return this;
+    }
+
+    @Override
     public <Score_ extends Score<Score_>> void buildNode(NodeBuildHelper<Score_> buildHelper) {
         Consumer<UniTuple<A>> insert = buildHelper.getAggregatedInsert(childStreamList);
         Consumer<UniTuple<A>> retract = buildHelper.getAggregatedRetract(childStreamList);
-        buildHelper.addNode(new ForEachUniNode<>(forEachClass, insert, retract));
+        int scoreStoreSize = buildHelper.extractScoreStoreSize(this);
+        buildHelper.addNode(new ForEachUniNode<>(forEachClass, insert, retract, scoreStoreSize));
     }
 
     // ************************************************************************

--- a/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/bavet/uni/BavetForEachUniConstraintStream.java
+++ b/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/bavet/uni/BavetForEachUniConstraintStream.java
@@ -63,8 +63,9 @@ public final class BavetForEachUniConstraintStream<Solution_, A> extends BavetAb
         Consumer<UniTuple<A>> insert = buildHelper.getAggregatedInsert(childStreamList);
         Consumer<UniTuple<A>> retract = buildHelper.getAggregatedRetract(childStreamList);
         int joinStoreSize = buildHelper.extractJoinStoreSize(this);
+        int groupStoreSize = buildHelper.extractGroupStoreSize(this);
         int scoreStoreSize = buildHelper.extractScoreStoreSize(this);
-        buildHelper.addNode(new ForEachUniNode<>(forEachClass, insert, retract, joinStoreSize, scoreStoreSize));
+        buildHelper.addNode(new ForEachUniNode<>(forEachClass, insert, retract, joinStoreSize, groupStoreSize, scoreStoreSize));
     }
 
     // ************************************************************************

--- a/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/bavet/uni/BavetForEachUniConstraintStream.java
+++ b/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/bavet/uni/BavetForEachUniConstraintStream.java
@@ -62,8 +62,9 @@ public final class BavetForEachUniConstraintStream<Solution_, A> extends BavetAb
     public <Score_ extends Score<Score_>> void buildNode(NodeBuildHelper<Score_> buildHelper) {
         Consumer<UniTuple<A>> insert = buildHelper.getAggregatedInsert(childStreamList);
         Consumer<UniTuple<A>> retract = buildHelper.getAggregatedRetract(childStreamList);
+        int joinStoreSize = buildHelper.extractJoinStoreSize(this);
         int scoreStoreSize = buildHelper.extractScoreStoreSize(this);
-        buildHelper.addNode(new ForEachUniNode<>(forEachClass, insert, retract, scoreStoreSize));
+        buildHelper.addNode(new ForEachUniNode<>(forEachClass, insert, retract, joinStoreSize, scoreStoreSize));
     }
 
     // ************************************************************************

--- a/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/bavet/uni/BavetForEachUniConstraintStream.java
+++ b/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/bavet/uni/BavetForEachUniConstraintStream.java
@@ -62,10 +62,8 @@ public final class BavetForEachUniConstraintStream<Solution_, A> extends BavetAb
     public <Score_ extends Score<Score_>> void buildNode(NodeBuildHelper<Score_> buildHelper) {
         Consumer<UniTuple<A>> insert = buildHelper.getAggregatedInsert(childStreamList);
         Consumer<UniTuple<A>> retract = buildHelper.getAggregatedRetract(childStreamList);
-        int joinStoreSize = buildHelper.extractJoinStoreSize(this);
-        int groupStoreSize = buildHelper.extractGroupStoreSize(this);
-        int scoreStoreSize = buildHelper.extractScoreStoreSize(this);
-        buildHelper.addNode(new ForEachUniNode<>(forEachClass, insert, retract, joinStoreSize, groupStoreSize, scoreStoreSize));
+        int outputStoreSize = buildHelper.extractTupleStoreSize(this);
+        buildHelper.addNode(new ForEachUniNode<>(forEachClass, insert, retract, outputStoreSize));
     }
 
     // ************************************************************************

--- a/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/bavet/uni/BavetGroupBridgeUniConstraintStream.java
+++ b/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/bavet/uni/BavetGroupBridgeUniConstraintStream.java
@@ -77,12 +77,15 @@ public final class BavetGroupBridgeUniConstraintStream<Solution_, A, NewA, Resul
             throw new IllegalStateException("Impossible state: the stream (" + this
                     + ") has an non-empty childStreamList (" + childStreamList + ") but it's a groupBy bridge.");
         }
+        int groupStoreIndex = buildHelper.reserveGroupStoreIndex(parent.getTupleSource());
         Consumer<BiTuple<NewA, NewB>> insert = buildHelper.getAggregatedInsert(groupStream.getChildStreamList());
         Consumer<BiTuple<NewA, NewB>> retract = buildHelper.getAggregatedRetract(groupStream.getChildStreamList());
         int joinStoreSize = buildHelper.extractJoinStoreSize(groupStream);
+        int groupStoreSize = buildHelper.extractGroupStoreSize(groupStream);
         int scoreStoreSize = buildHelper.extractScoreStoreSize(groupStream);
-        GroupUniToBiNode<A, NewA, NewB, ResultContainer_> node = new GroupUniToBiNode<>(groupKeyMapping, collector,
-                insert, retract, joinStoreSize, scoreStoreSize);
+        GroupUniToBiNode<A, NewA, NewB, ResultContainer_> node = new GroupUniToBiNode<>(
+                groupKeyMapping, groupStoreIndex, collector,
+                insert, retract, joinStoreSize, groupStoreSize, scoreStoreSize);
         buildHelper.addNode(node);
         buildHelper.putInsertRetract(this, node::insertA, node::retractA);
     }

--- a/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/bavet/uni/BavetGroupBridgeUniConstraintStream.java
+++ b/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/bavet/uni/BavetGroupBridgeUniConstraintStream.java
@@ -77,15 +77,13 @@ public final class BavetGroupBridgeUniConstraintStream<Solution_, A, NewA, Resul
             throw new IllegalStateException("Impossible state: the stream (" + this
                     + ") has an non-empty childStreamList (" + childStreamList + ") but it's a groupBy bridge.");
         }
-        int groupStoreIndex = buildHelper.reserveGroupStoreIndex(parent.getTupleSource());
+        int inputStoreIndex = buildHelper.reserveTupleStoreIndex(parent.getTupleSource());
         Consumer<BiTuple<NewA, NewB>> insert = buildHelper.getAggregatedInsert(groupStream.getChildStreamList());
         Consumer<BiTuple<NewA, NewB>> retract = buildHelper.getAggregatedRetract(groupStream.getChildStreamList());
-        int joinStoreSize = buildHelper.extractJoinStoreSize(groupStream);
-        int groupStoreSize = buildHelper.extractGroupStoreSize(groupStream);
-        int scoreStoreSize = buildHelper.extractScoreStoreSize(groupStream);
+        int outputStoreSize = buildHelper.extractTupleStoreSize(groupStream);
         GroupUniToBiNode<A, NewA, NewB, ResultContainer_> node = new GroupUniToBiNode<>(
-                groupKeyMapping, groupStoreIndex, collector,
-                insert, retract, joinStoreSize, groupStoreSize, scoreStoreSize);
+                groupKeyMapping, inputStoreIndex, collector,
+                insert, retract, outputStoreSize);
         buildHelper.addNode(node);
         buildHelper.putInsertRetract(this, node::insertA, node::retractA);
     }

--- a/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/bavet/uni/BavetGroupBridgeUniConstraintStream.java
+++ b/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/bavet/uni/BavetGroupBridgeUniConstraintStream.java
@@ -79,9 +79,10 @@ public final class BavetGroupBridgeUniConstraintStream<Solution_, A, NewA, Resul
         }
         Consumer<BiTuple<NewA, NewB>> insert = buildHelper.getAggregatedInsert(groupStream.getChildStreamList());
         Consumer<BiTuple<NewA, NewB>> retract = buildHelper.getAggregatedRetract(groupStream.getChildStreamList());
+        int joinStoreSize = buildHelper.extractJoinStoreSize(groupStream);
         int scoreStoreSize = buildHelper.extractScoreStoreSize(groupStream);
         GroupUniToBiNode<A, NewA, NewB, ResultContainer_> node = new GroupUniToBiNode<>(groupKeyMapping, collector,
-                insert, retract, scoreStoreSize);
+                insert, retract, joinStoreSize, scoreStoreSize);
         buildHelper.addNode(node);
         buildHelper.putInsertRetract(this, node::insertA, node::retractA);
     }

--- a/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/bavet/uni/BavetGroupBridgeUniConstraintStream.java
+++ b/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/bavet/uni/BavetGroupBridgeUniConstraintStream.java
@@ -27,6 +27,7 @@ import org.optaplanner.constraint.streams.bavet.bi.GroupUniToBiNode;
 import org.optaplanner.constraint.streams.bavet.common.BavetAbstractConstraintStream;
 import org.optaplanner.constraint.streams.bavet.common.NodeBuildHelper;
 import org.optaplanner.core.api.score.Score;
+import org.optaplanner.core.api.score.stream.ConstraintStream;
 import org.optaplanner.core.api.score.stream.uni.UniConstraintCollector;
 
 public final class BavetGroupBridgeUniConstraintStream<Solution_, A, NewA, ResultContainer_, NewB>
@@ -66,6 +67,11 @@ public final class BavetGroupBridgeUniConstraintStream<Solution_, A, NewA, Resul
     }
 
     @Override
+    public ConstraintStream getTupleSource() {
+        return parent.getTupleSource();
+    }
+
+    @Override
     public <Score_ extends Score<Score_>> void buildNode(NodeBuildHelper<Score_> buildHelper) {
         if (!childStreamList.isEmpty()) {
             throw new IllegalStateException("Impossible state: the stream (" + this
@@ -73,8 +79,9 @@ public final class BavetGroupBridgeUniConstraintStream<Solution_, A, NewA, Resul
         }
         Consumer<BiTuple<NewA, NewB>> insert = buildHelper.getAggregatedInsert(groupStream.getChildStreamList());
         Consumer<BiTuple<NewA, NewB>> retract = buildHelper.getAggregatedRetract(groupStream.getChildStreamList());
+        int scoreStoreSize = buildHelper.extractScoreStoreSize(groupStream);
         GroupUniToBiNode<A, NewA, NewB, ResultContainer_> node = new GroupUniToBiNode<>(groupKeyMapping, collector,
-                insert, retract);
+                insert, retract, scoreStoreSize);
         buildHelper.addNode(node);
         buildHelper.putInsertRetract(this, node::insertA, node::retractA);
     }

--- a/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/bavet/uni/BavetJoinBridgeUniConstraintStream.java
+++ b/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/bavet/uni/BavetJoinBridgeUniConstraintStream.java
@@ -23,6 +23,7 @@ import org.optaplanner.constraint.streams.bavet.common.BavetAbstractConstraintSt
 import org.optaplanner.constraint.streams.bavet.common.BavetJoinConstraintStream;
 import org.optaplanner.constraint.streams.bavet.common.NodeBuildHelper;
 import org.optaplanner.core.api.score.Score;
+import org.optaplanner.core.api.score.stream.ConstraintStream;
 
 public final class BavetJoinBridgeUniConstraintStream<Solution_, A>
         extends BavetAbstractUniConstraintStream<Solution_, A> {
@@ -56,6 +57,11 @@ public final class BavetJoinBridgeUniConstraintStream<Solution_, A>
     public void collectActiveConstraintStreams(Set<BavetAbstractConstraintStream<Solution_>> constraintStreamSet) {
         parent.collectActiveConstraintStreams(constraintStreamSet);
         constraintStreamSet.add(this);
+    }
+
+    @Override
+    public ConstraintStream getTupleSource() {
+        return parent.getTupleSource();
     }
 
     @Override

--- a/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/bavet/uni/BavetScoringUniConstraintStream.java
+++ b/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/bavet/uni/BavetScoringUniConstraintStream.java
@@ -33,6 +33,7 @@ import org.optaplanner.constraint.streams.common.inliner.AbstractScoreInliner;
 import org.optaplanner.constraint.streams.common.inliner.UndoScoreImpacter;
 import org.optaplanner.constraint.streams.common.inliner.WeightedScoreImpacter;
 import org.optaplanner.core.api.score.Score;
+import org.optaplanner.core.api.score.stream.ConstraintStream;
 
 public final class BavetScoringUniConstraintStream<Solution_, A>
         extends BavetAbstractUniConstraintStream<Solution_, A>
@@ -110,6 +111,11 @@ public final class BavetScoringUniConstraintStream<Solution_, A>
     }
 
     @Override
+    public ConstraintStream getTupleSource() {
+        return parent.getTupleSource();
+    }
+
+    @Override
     public <Score_ extends Score<Score_>> void buildNode(NodeBuildHelper<Score_> buildHelper) {
         Score_ constraintWeight = buildHelper.getConstraintWeight(constraint);
         AbstractScoreInliner<Score_> scoreInliner = buildHelper.getScoreInliner();
@@ -143,7 +149,7 @@ public final class BavetScoringUniConstraintStream<Solution_, A>
             throw new IllegalStateException("Impossible state: neither of the supported match weighers provided.");
         }
         UniScorer<A> scorer = new UniScorer<>(constraint.getConstraintPackage(), constraint.getConstraintName(),
-                constraintWeight, scoreImpacter);
+                constraintWeight, scoreImpacter, buildHelper.reserveScoreStoreIndex(parent.getTupleSource()));
         buildHelper.putInsertRetract(this, scorer::insert, scorer::retract);
     }
 

--- a/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/bavet/uni/BavetScoringUniConstraintStream.java
+++ b/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/bavet/uni/BavetScoringUniConstraintStream.java
@@ -149,7 +149,7 @@ public final class BavetScoringUniConstraintStream<Solution_, A>
             throw new IllegalStateException("Impossible state: neither of the supported match weighers provided.");
         }
         UniScorer<A> scorer = new UniScorer<>(constraint.getConstraintPackage(), constraint.getConstraintName(),
-                constraintWeight, scoreImpacter, buildHelper.reserveScoreStoreIndex(parent.getTupleSource()));
+                constraintWeight, scoreImpacter, buildHelper.reserveTupleStoreIndex(parent.getTupleSource()));
         buildHelper.putInsertRetract(this, scorer::insert, scorer::retract);
     }
 

--- a/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/bavet/uni/ForEachUniNode.java
+++ b/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/bavet/uni/ForEachUniNode.java
@@ -33,26 +33,29 @@ public final class ForEachUniNode<A> extends AbstractNode {
      * Calls for example {@link UniScorer#insert(UniTuple)}, {@link JoinBiNode#insertA(UniTuple)},
      * {@link JoinBiNode#insertB(UniTuple)} and/or ...
      */
-    public final Consumer<UniTuple<A>> nextNodesInsert;
+    private final Consumer<UniTuple<A>> nextNodesInsert;
     /**
      * Calls for example {@link UniScorer#retract(UniTuple)}, {@link JoinBiNode#retractA(UniTuple)},
      * {@link JoinBiNode#retractB(UniTuple)} and/or ...
      */
-    public final Consumer<UniTuple<A>> nextNodesRetract;
+    private final Consumer<UniTuple<A>> nextNodesRetract;
+    private final int scoreStoreSize;
 
     private final Map<A, UniTuple<A>> tupleMap = new IdentityHashMap<>(1000);
     private final Queue<UniTuple<A>> dirtyTupleQueue;
 
     public ForEachUniNode(Class<A> forEachClass,
-            Consumer<UniTuple<A>> nextNodesInsert, Consumer<UniTuple<A>> nextNodesRetract) {
+            Consumer<UniTuple<A>> nextNodesInsert, Consumer<UniTuple<A>> nextNodesRetract,
+            int scoreStoreSize) {
         this.forEachClass = forEachClass;
         this.nextNodesInsert = nextNodesInsert;
         this.nextNodesRetract = nextNodesRetract;
+        this.scoreStoreSize = scoreStoreSize;
         dirtyTupleQueue = new ArrayDeque<>(1000);
     }
 
     public void insert(A a) {
-        UniTuple<A> tuple = new UniTuple<>(a);
+        UniTuple<A> tuple = new UniTuple<>(a, scoreStoreSize);
         tuple.state = BavetTupleState.CREATING;
         UniTuple<A> old = tupleMap.put(a, tuple);
         if (old != null) {

--- a/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/bavet/uni/ForEachUniNode.java
+++ b/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/bavet/uni/ForEachUniNode.java
@@ -39,6 +39,7 @@ public final class ForEachUniNode<A> extends AbstractNode {
      * {@link JoinBiNode#retractB(UniTuple)} and/or ...
      */
     private final Consumer<UniTuple<A>> nextNodesRetract;
+    private final int joinStoreSize;
     private final int scoreStoreSize;
 
     private final Map<A, UniTuple<A>> tupleMap = new IdentityHashMap<>(1000);
@@ -46,16 +47,17 @@ public final class ForEachUniNode<A> extends AbstractNode {
 
     public ForEachUniNode(Class<A> forEachClass,
             Consumer<UniTuple<A>> nextNodesInsert, Consumer<UniTuple<A>> nextNodesRetract,
-            int scoreStoreSize) {
+            int joinStoreSize, int scoreStoreSize) {
         this.forEachClass = forEachClass;
         this.nextNodesInsert = nextNodesInsert;
         this.nextNodesRetract = nextNodesRetract;
+        this.joinStoreSize = joinStoreSize;
         this.scoreStoreSize = scoreStoreSize;
         dirtyTupleQueue = new ArrayDeque<>(1000);
     }
 
     public void insert(A a) {
-        UniTuple<A> tuple = new UniTuple<>(a, scoreStoreSize);
+        UniTuple<A> tuple = new UniTuple<>(a, joinStoreSize, scoreStoreSize);
         tuple.state = BavetTupleState.CREATING;
         UniTuple<A> old = tupleMap.put(a, tuple);
         if (old != null) {

--- a/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/bavet/uni/ForEachUniNode.java
+++ b/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/bavet/uni/ForEachUniNode.java
@@ -39,27 +39,23 @@ public final class ForEachUniNode<A> extends AbstractNode {
      * {@link JoinBiNode#retractB(UniTuple)} and/or ...
      */
     private final Consumer<UniTuple<A>> nextNodesRetract;
-    private final int joinStoreSize;
-    private final int groupStoreSize;
-    private final int scoreStoreSize;
+    private final int outputStoreSize;
 
     private final Map<A, UniTuple<A>> tupleMap = new IdentityHashMap<>(1000);
     private final Queue<UniTuple<A>> dirtyTupleQueue;
 
     public ForEachUniNode(Class<A> forEachClass,
             Consumer<UniTuple<A>> nextNodesInsert, Consumer<UniTuple<A>> nextNodesRetract,
-            int joinStoreSize, int groupStoreSize, int scoreStoreSize) {
+            int outputStoreSize) {
         this.forEachClass = forEachClass;
         this.nextNodesInsert = nextNodesInsert;
         this.nextNodesRetract = nextNodesRetract;
-        this.joinStoreSize = joinStoreSize;
-        this.groupStoreSize = groupStoreSize;
-        this.scoreStoreSize = scoreStoreSize;
+        this.outputStoreSize = outputStoreSize;
         dirtyTupleQueue = new ArrayDeque<>(1000);
     }
 
     public void insert(A a) {
-        UniTuple<A> tuple = new UniTuple<>(a, joinStoreSize, groupStoreSize, scoreStoreSize);
+        UniTuple<A> tuple = new UniTuple<>(a, outputStoreSize);
         tuple.state = BavetTupleState.CREATING;
         UniTuple<A> old = tupleMap.put(a, tuple);
         if (old != null) {

--- a/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/bavet/uni/ForEachUniNode.java
+++ b/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/bavet/uni/ForEachUniNode.java
@@ -40,6 +40,7 @@ public final class ForEachUniNode<A> extends AbstractNode {
      */
     private final Consumer<UniTuple<A>> nextNodesRetract;
     private final int joinStoreSize;
+    private final int groupStoreSize;
     private final int scoreStoreSize;
 
     private final Map<A, UniTuple<A>> tupleMap = new IdentityHashMap<>(1000);
@@ -47,17 +48,18 @@ public final class ForEachUniNode<A> extends AbstractNode {
 
     public ForEachUniNode(Class<A> forEachClass,
             Consumer<UniTuple<A>> nextNodesInsert, Consumer<UniTuple<A>> nextNodesRetract,
-            int joinStoreSize, int scoreStoreSize) {
+            int joinStoreSize, int groupStoreSize, int scoreStoreSize) {
         this.forEachClass = forEachClass;
         this.nextNodesInsert = nextNodesInsert;
         this.nextNodesRetract = nextNodesRetract;
         this.joinStoreSize = joinStoreSize;
+        this.groupStoreSize = groupStoreSize;
         this.scoreStoreSize = scoreStoreSize;
         dirtyTupleQueue = new ArrayDeque<>(1000);
     }
 
     public void insert(A a) {
-        UniTuple<A> tuple = new UniTuple<>(a, joinStoreSize, scoreStoreSize);
+        UniTuple<A> tuple = new UniTuple<>(a, joinStoreSize, groupStoreSize, scoreStoreSize);
         tuple.state = BavetTupleState.CREATING;
         UniTuple<A> old = tupleMap.put(a, tuple);
         if (old != null) {

--- a/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/bavet/uni/UniScorer.java
+++ b/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/bavet/uni/UniScorer.java
@@ -16,8 +16,6 @@
 
 package org.optaplanner.constraint.streams.bavet.uni;
 
-import java.util.HashMap;
-import java.util.Map;
 import java.util.function.Function;
 
 import org.optaplanner.constraint.streams.bavet.common.AbstractScorer;

--- a/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/bavet/uni/UniScorer.java
+++ b/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/bavet/uni/UniScorer.java
@@ -28,34 +28,34 @@ public final class UniScorer<A> extends AbstractScorer {
     private final String constraintName;
     private final Score<?> constraintWeight;
     private final Function<A, UndoScoreImpacter> scoreImpacter;
-    private final int scoreStoreIndex;
+    private final int inputStoreIndex;
 
     public UniScorer(String constraintPackage, String constraintName,
             Score<?> constraintWeight, Function<A, UndoScoreImpacter> scoreImpacter,
-            int scoreStoreIndex) {
+            int inputStoreIndex) {
         this.constraintPackage = constraintPackage;
         this.constraintName = constraintName;
         this.constraintWeight = constraintWeight;
         this.scoreImpacter = scoreImpacter;
-        this.scoreStoreIndex = scoreStoreIndex;
+        this.inputStoreIndex = inputStoreIndex;
     }
 
     public void insert(UniTuple<A> tupleA) {
-        if (tupleA.scorerStore[scoreStoreIndex] != null) {
+        if (tupleA.store[inputStoreIndex] != null) {
             throw new IllegalStateException("Impossible state: the tuple for the fact ("
                     + tupleA.factA
                     + ") was already added in the scorerStore.");
         }
         UndoScoreImpacter undoScoreImpacter = scoreImpacter.apply(tupleA.factA);
-        tupleA.scorerStore[scoreStoreIndex] = undoScoreImpacter;
+        tupleA.store[inputStoreIndex] = undoScoreImpacter;
     }
 
     public void retract(UniTuple<A> tupleA) {
-        UndoScoreImpacter undoScoreImpacter = tupleA.scorerStore[scoreStoreIndex];
+        UndoScoreImpacter undoScoreImpacter = (UndoScoreImpacter) tupleA.store[inputStoreIndex];
         // No fail fast if null because we don't track which tuples made it through the filter predicate(s)
         if (undoScoreImpacter != null) {
             undoScoreImpacter.run();
-            tupleA.scorerStore[scoreStoreIndex] = null;
+            tupleA.store[inputStoreIndex] = null;
         }
     }
 

--- a/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/bavet/uni/UniTuple.java
+++ b/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/bavet/uni/UniTuple.java
@@ -24,12 +24,14 @@ public final class UniTuple<A> implements Tuple {
 
     public final A factA;
 
+    public final Object[][] joinStore;
     public final UndoScoreImpacter[] scorerStore;
 
     public BavetTupleState state;
 
-    public UniTuple(A factA, int scoreStoreSize) {
+    public UniTuple(A factA, int joinStoreSize, int scoreStoreSize) {
         this.factA = factA;
+        joinStore = (joinStoreSize <= 0) ? null : new Object[joinStoreSize][];
         scorerStore = (scoreStoreSize <= 0) ? null : new UndoScoreImpacter[scoreStoreSize];
     }
 

--- a/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/bavet/uni/UniTuple.java
+++ b/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/bavet/uni/UniTuple.java
@@ -18,16 +18,19 @@ package org.optaplanner.constraint.streams.bavet.uni;
 
 import org.optaplanner.constraint.streams.bavet.common.BavetTupleState;
 import org.optaplanner.constraint.streams.bavet.common.Tuple;
+import org.optaplanner.constraint.streams.common.inliner.UndoScoreImpacter;
 
-// TODO Java 17: refactor to record
 public final class UniTuple<A> implements Tuple {
 
     public final A factA;
 
+    public final UndoScoreImpacter[] scorerStore;
+
     public BavetTupleState state;
 
-    public UniTuple(A factA) {
+    public UniTuple(A factA, int scoreStoreSize) {
         this.factA = factA;
+        scorerStore = (scoreStoreSize <= 0) ? null : new UndoScoreImpacter[scoreStoreSize];
     }
 
     @Override

--- a/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/bavet/uni/UniTuple.java
+++ b/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/bavet/uni/UniTuple.java
@@ -18,23 +18,18 @@ package org.optaplanner.constraint.streams.bavet.uni;
 
 import org.optaplanner.constraint.streams.bavet.common.BavetTupleState;
 import org.optaplanner.constraint.streams.bavet.common.Tuple;
-import org.optaplanner.constraint.streams.common.inliner.UndoScoreImpacter;
 
 public final class UniTuple<A> implements Tuple {
 
     public final A factA;
 
-    public final Object[][] joinStore;
-    public final Object[] groupStore;
-    public final UndoScoreImpacter[] scorerStore;
+    public final Object[] store;
 
     public BavetTupleState state;
 
-    public UniTuple(A factA, int joinStoreSize, int groupStoreSize, int scoreStoreSize) {
+    public UniTuple(A factA, int storeSize) {
         this.factA = factA;
-        joinStore = (joinStoreSize <= 0) ? null : new Object[joinStoreSize][];
-        groupStore = (groupStoreSize <= 0) ? null : new Object[groupStoreSize];
-        scorerStore = (scoreStoreSize <= 0) ? null : new UndoScoreImpacter[scoreStoreSize];
+        store = (storeSize <= 0) ? null : new Object[storeSize];
     }
 
     @Override

--- a/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/bavet/uni/UniTuple.java
+++ b/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/bavet/uni/UniTuple.java
@@ -25,13 +25,15 @@ public final class UniTuple<A> implements Tuple {
     public final A factA;
 
     public final Object[][] joinStore;
+    public final Object[] groupStore;
     public final UndoScoreImpacter[] scorerStore;
 
     public BavetTupleState state;
 
-    public UniTuple(A factA, int joinStoreSize, int scoreStoreSize) {
+    public UniTuple(A factA, int joinStoreSize, int groupStoreSize, int scoreStoreSize) {
         this.factA = factA;
         joinStore = (joinStoreSize <= 0) ? null : new Object[joinStoreSize][];
+        groupStore = (groupStoreSize <= 0) ? null : new Object[groupStoreSize];
         scorerStore = (scoreStoreSize <= 0) ? null : new UndoScoreImpacter[scoreStoreSize];
     }
 

--- a/core/optaplanner-constraint-streams/src/test/java/org/optaplanner/constraint/streams/bavet/common/index/EqualsAndComparisonIndexerTest.java
+++ b/core/optaplanner-constraint-streams/src/test/java/org/optaplanner/constraint/streams/bavet/common/index/EqualsAndComparisonIndexerTest.java
@@ -85,7 +85,7 @@ class EqualsAndComparisonIndexerTest {
     }
 
     private static UniTuple<String> newTuple(String factA) {
-        return new UniTuple<>(factA, 0, 0, 0);
+        return new UniTuple<>(factA, 0);
     }
 
 }

--- a/core/optaplanner-constraint-streams/src/test/java/org/optaplanner/constraint/streams/bavet/common/index/EqualsAndComparisonIndexerTest.java
+++ b/core/optaplanner-constraint-streams/src/test/java/org/optaplanner/constraint/streams/bavet/common/index/EqualsAndComparisonIndexerTest.java
@@ -85,7 +85,7 @@ class EqualsAndComparisonIndexerTest {
     }
 
     private static UniTuple<String> newTuple(String factA) {
-        return new UniTuple<>(factA, 0, 0);
+        return new UniTuple<>(factA, 0, 0, 0);
     }
 
 }

--- a/core/optaplanner-constraint-streams/src/test/java/org/optaplanner/constraint/streams/bavet/common/index/EqualsAndComparisonIndexerTest.java
+++ b/core/optaplanner-constraint-streams/src/test/java/org/optaplanner/constraint/streams/bavet/common/index/EqualsAndComparisonIndexerTest.java
@@ -85,7 +85,7 @@ class EqualsAndComparisonIndexerTest {
     }
 
     private static UniTuple<String> newTuple(String factA) {
-        return new UniTuple<>(factA, 0);
+        return new UniTuple<>(factA, 0, 0);
     }
 
 }

--- a/core/optaplanner-constraint-streams/src/test/java/org/optaplanner/constraint/streams/bavet/common/index/EqualsAndComparisonIndexerTest.java
+++ b/core/optaplanner-constraint-streams/src/test/java/org/optaplanner/constraint/streams/bavet/common/index/EqualsAndComparisonIndexerTest.java
@@ -36,7 +36,7 @@ class EqualsAndComparisonIndexerTest {
     @Test
     void putTwice() {
         Indexer<UniTuple<String>, String> indexer = new EqualsAndComparisonIndexer<>(JoinerType.LESS_THAN_OR_EQUAL);
-        UniTuple<String> annTuple = new UniTuple<>("Ann-F-40");
+        UniTuple<String> annTuple = newTuple("Ann-F-40");
         indexer.put(new Object[] { "F", Integer.valueOf(40) }, annTuple, "Ann value");
         assertThatThrownBy(() -> indexer.put(new Object[] { "F", Integer.valueOf(40) }, annTuple, "Ann value"))
                 .isInstanceOf(IllegalStateException.class);
@@ -45,10 +45,10 @@ class EqualsAndComparisonIndexerTest {
     @Test
     void removeTwice() {
         Indexer<UniTuple<String>, String> indexer = new EqualsAndComparisonIndexer<>(JoinerType.LESS_THAN_OR_EQUAL);
-        UniTuple<String> annTuple = new UniTuple<>("Ann-F-40");
+        UniTuple<String> annTuple = newTuple("Ann-F-40");
         indexer.put(new Object[] { "F", Integer.valueOf(40) }, annTuple, "Ann value");
 
-        UniTuple<String> ednaTuple = new UniTuple<>("Edna-F-40");
+        UniTuple<String> ednaTuple = newTuple("Edna-F-40");
         assertThatThrownBy(() -> indexer.remove(new Object[] { "F", Integer.valueOf(40) }, ednaTuple))
                 .isInstanceOf(IllegalStateException.class);
         assertThat(indexer.remove(new Object[] { "F", Integer.valueOf(40) }, annTuple))
@@ -61,13 +61,13 @@ class EqualsAndComparisonIndexerTest {
     void get() {
         Indexer<UniTuple<String>, String> indexer = new EqualsAndComparisonIndexer<>(JoinerType.LESS_THAN_OR_EQUAL);
 
-        UniTuple<String> annTuple = new UniTuple<>("Ann-F-40");
+        UniTuple<String> annTuple = newTuple("Ann-F-40");
         indexer.put(new Object[] { "F", Integer.valueOf(40) }, annTuple, "Ann value");
-        UniTuple<String> bethTuple = new UniTuple<>("Beth-F-30");
+        UniTuple<String> bethTuple = newTuple("Beth-F-30");
         indexer.put(new Object[] { "F", Integer.valueOf(30) }, bethTuple, "Beth value");
-        indexer.put(new Object[] { "M", Integer.valueOf(40) }, new UniTuple<>("Carl-M-40"), "Carl value");
-        indexer.put(new Object[] { "M", Integer.valueOf(30) }, new UniTuple<>("Dan-M-30"), "Dan value");
-        UniTuple<String> ednaTuple = new UniTuple<>("Edna-F-40");
+        indexer.put(new Object[] { "M", Integer.valueOf(40) }, newTuple("Carl-M-40"), "Carl value");
+        indexer.put(new Object[] { "M", Integer.valueOf(30) }, newTuple("Dan-M-30"), "Dan value");
+        UniTuple<String> ednaTuple = newTuple("Edna-F-40");
         indexer.put(new Object[] { "F", Integer.valueOf(40) }, ednaTuple, "Edna value");
 
         assertThat(indexer.get(new Object[] { "F", Integer.valueOf(40) }))
@@ -82,6 +82,10 @@ class EqualsAndComparisonIndexerTest {
         assertThat(indexer.get(new Object[] { "F", Integer.valueOf(20) }))
                 .isNotNull()
                 .isEmpty();
+    }
+
+    private static UniTuple<String> newTuple(String factA) {
+        return new UniTuple<>(factA, 0);
     }
 
 }

--- a/core/optaplanner-constraint-streams/src/test/java/org/optaplanner/constraint/streams/bavet/common/index/EqualsIndexerTest.java
+++ b/core/optaplanner-constraint-streams/src/test/java/org/optaplanner/constraint/streams/bavet/common/index/EqualsIndexerTest.java
@@ -81,7 +81,7 @@ class EqualsIndexerTest {
     }
 
     private static UniTuple<String> newTuple(String factA) {
-        return new UniTuple<>(factA, 0, 0);
+        return new UniTuple<>(factA, 0, 0, 0);
     }
 
 }

--- a/core/optaplanner-constraint-streams/src/test/java/org/optaplanner/constraint/streams/bavet/common/index/EqualsIndexerTest.java
+++ b/core/optaplanner-constraint-streams/src/test/java/org/optaplanner/constraint/streams/bavet/common/index/EqualsIndexerTest.java
@@ -35,7 +35,7 @@ class EqualsIndexerTest {
     @Test
     void putTwice() {
         Indexer<UniTuple<String>, String> indexer = new EqualsIndexer<>();
-        UniTuple<String> annTuple = new UniTuple<>("Ann-F-40");
+        UniTuple<String> annTuple = newTuple("Ann-F-40");
         indexer.put(new Object[] { "F", Integer.valueOf(40) }, annTuple, "Ann value");
         assertThatThrownBy(() -> indexer.put(new Object[] { "F", Integer.valueOf(40) }, annTuple, "Ann value"))
                 .isInstanceOf(IllegalStateException.class);
@@ -44,10 +44,10 @@ class EqualsIndexerTest {
     @Test
     void removeTwice() {
         Indexer<UniTuple<String>, String> indexer = new EqualsIndexer<>();
-        UniTuple<String> annTuple = new UniTuple<>("Ann-F-40");
+        UniTuple<String> annTuple = newTuple("Ann-F-40");
         indexer.put(new Object[] { "F", Integer.valueOf(40) }, annTuple, "Ann value");
 
-        UniTuple<String> ednaTuple = new UniTuple<>("Edna-F-40");
+        UniTuple<String> ednaTuple = newTuple("Edna-F-40");
         assertThatThrownBy(() -> indexer.remove(new Object[] { "F", Integer.valueOf(40) }, ednaTuple))
                 .isInstanceOf(IllegalStateException.class);
         assertThat(indexer.remove(new Object[] { "F", Integer.valueOf(40) }, annTuple))
@@ -60,13 +60,13 @@ class EqualsIndexerTest {
     void get() {
         Indexer<UniTuple<String>, String> indexer = new EqualsIndexer<>();
 
-        UniTuple<String> annTuple = new UniTuple<>("Ann-F-40");
+        UniTuple<String> annTuple = newTuple("Ann-F-40");
         indexer.put(new Object[] { "F", Integer.valueOf(40) }, annTuple, "Ann value");
-        UniTuple<String> bethTuple = new UniTuple<>("Beth-F-30");
+        UniTuple<String> bethTuple = newTuple("Beth-F-30");
         indexer.put(new Object[] { "F", Integer.valueOf(30) }, bethTuple, "Beth value");
-        indexer.put(new Object[] { "M", Integer.valueOf(40) }, new UniTuple<>("Carl-M-40"), "Carl value");
-        indexer.put(new Object[] { "M", Integer.valueOf(30) }, new UniTuple<>("Dan-M-30"), "Dan value");
-        UniTuple<String> ednaTuple = new UniTuple<>("Edna-F-40");
+        indexer.put(new Object[] { "M", Integer.valueOf(40) }, newTuple("Carl-M-40"), "Carl value");
+        indexer.put(new Object[] { "M", Integer.valueOf(30) }, newTuple("Dan-M-30"), "Dan value");
+        UniTuple<String> ednaTuple = newTuple("Edna-F-40");
         indexer.put(new Object[] { "F", Integer.valueOf(40) }, ednaTuple, "Edna value");
 
         assertThat(indexer.get(new Object[] { "F", Integer.valueOf(40) }))
@@ -78,6 +78,10 @@ class EqualsIndexerTest {
         assertThat(indexer.get(new Object[] { "F", Integer.valueOf(20) }))
                 .isNotNull()
                 .isEmpty();
+    }
+
+    private static UniTuple<String> newTuple(String factA) {
+        return new UniTuple<>(factA, 0);
     }
 
 }

--- a/core/optaplanner-constraint-streams/src/test/java/org/optaplanner/constraint/streams/bavet/common/index/EqualsIndexerTest.java
+++ b/core/optaplanner-constraint-streams/src/test/java/org/optaplanner/constraint/streams/bavet/common/index/EqualsIndexerTest.java
@@ -81,7 +81,7 @@ class EqualsIndexerTest {
     }
 
     private static UniTuple<String> newTuple(String factA) {
-        return new UniTuple<>(factA, 0, 0, 0);
+        return new UniTuple<>(factA, 0);
     }
 
 }

--- a/core/optaplanner-constraint-streams/src/test/java/org/optaplanner/constraint/streams/bavet/common/index/EqualsIndexerTest.java
+++ b/core/optaplanner-constraint-streams/src/test/java/org/optaplanner/constraint/streams/bavet/common/index/EqualsIndexerTest.java
@@ -81,7 +81,7 @@ class EqualsIndexerTest {
     }
 
     private static UniTuple<String> newTuple(String factA) {
-        return new UniTuple<>(factA, 0);
+        return new UniTuple<>(factA, 0, 0);
     }
 
 }

--- a/core/optaplanner-constraint-streams/src/test/java/org/optaplanner/constraint/streams/bavet/common/index/NoneIndexerTest.java
+++ b/core/optaplanner-constraint-streams/src/test/java/org/optaplanner/constraint/streams/bavet/common/index/NoneIndexerTest.java
@@ -72,7 +72,7 @@ class NoneIndexerTest {
     }
     
     private static UniTuple<String> newTuple(String factA) {
-        return new UniTuple<>(factA, 0, 0);
+        return new UniTuple<>(factA, 0, 0, 0);
     }
     
 }

--- a/core/optaplanner-constraint-streams/src/test/java/org/optaplanner/constraint/streams/bavet/common/index/NoneIndexerTest.java
+++ b/core/optaplanner-constraint-streams/src/test/java/org/optaplanner/constraint/streams/bavet/common/index/NoneIndexerTest.java
@@ -71,7 +71,7 @@ class NoneIndexerTest {
     }
 
     private static UniTuple<String> newTuple(String factA) {
-        return new UniTuple<>(factA, 0, 0, 0);
+        return new UniTuple<>(factA, 0);
     }
 
 }

--- a/core/optaplanner-constraint-streams/src/test/java/org/optaplanner/constraint/streams/bavet/common/index/NoneIndexerTest.java
+++ b/core/optaplanner-constraint-streams/src/test/java/org/optaplanner/constraint/streams/bavet/common/index/NoneIndexerTest.java
@@ -18,7 +18,6 @@ package org.optaplanner.constraint.streams.bavet.common.index;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.*;
 
 import org.junit.jupiter.api.Test;
 import org.optaplanner.constraint.streams.bavet.uni.UniTuple;
@@ -70,9 +69,9 @@ class NoneIndexerTest {
                 .isNotNull()
                 .containsOnlyKeys(annTuple, bethTuple);
     }
-    
+
     private static UniTuple<String> newTuple(String factA) {
         return new UniTuple<>(factA, 0, 0, 0);
     }
-    
+
 }

--- a/core/optaplanner-constraint-streams/src/test/java/org/optaplanner/constraint/streams/bavet/common/index/NoneIndexerTest.java
+++ b/core/optaplanner-constraint-streams/src/test/java/org/optaplanner/constraint/streams/bavet/common/index/NoneIndexerTest.java
@@ -72,7 +72,7 @@ class NoneIndexerTest {
     }
     
     private static UniTuple<String> newTuple(String factA) {
-        return new UniTuple<>(factA, 0);
+        return new UniTuple<>(factA, 0, 0);
     }
     
 }

--- a/core/optaplanner-constraint-streams/src/test/java/org/optaplanner/constraint/streams/bavet/common/index/NoneIndexerTest.java
+++ b/core/optaplanner-constraint-streams/src/test/java/org/optaplanner/constraint/streams/bavet/common/index/NoneIndexerTest.java
@@ -36,7 +36,7 @@ class NoneIndexerTest {
     @Test
     void putTwice() {
         Indexer<UniTuple<String>, String> indexer = new NoneIndexer<>();
-        UniTuple<String> annTuple = new UniTuple<>("Ann-F-40");
+        UniTuple<String> annTuple = newTuple("Ann-F-40");
         indexer.put(new Object[] {}, annTuple, "Ann value");
         assertThatThrownBy(() -> indexer.put(new Object[] {}, annTuple, "Ann value"))
                 .isInstanceOf(IllegalStateException.class);
@@ -45,10 +45,10 @@ class NoneIndexerTest {
     @Test
     void removeTwice() {
         Indexer<UniTuple<String>, String> indexer = new NoneIndexer<>();
-        UniTuple<String> annTuple = new UniTuple<>("Ann-F-40");
+        UniTuple<String> annTuple = newTuple("Ann-F-40");
         indexer.put(new Object[] {}, annTuple, "Ann value");
 
-        UniTuple<String> ednaTuple = new UniTuple<>("Edna-F-40");
+        UniTuple<String> ednaTuple = newTuple("Edna-F-40");
         assertThatThrownBy(() -> indexer.remove(new Object[] {}, ednaTuple))
                 .isInstanceOf(IllegalStateException.class);
         assertThat(indexer.remove(new Object[] {}, annTuple))
@@ -61,13 +61,18 @@ class NoneIndexerTest {
     void get() {
         Indexer<UniTuple<String>, String> indexer = new NoneIndexer<>();
 
-        UniTuple<String> annTuple = new UniTuple<>("Ann-F-40");
+        UniTuple<String> annTuple = newTuple("Ann-F-40");
         indexer.put(new Object[] {}, annTuple, "Ann value");
-        UniTuple<String> bethTuple = new UniTuple<>("Beth-F-30");
+        UniTuple<String> bethTuple = newTuple("Beth-F-30");
         indexer.put(new Object[] {}, bethTuple, "Beth value");
 
         assertThat(indexer.get(new Object[] {}))
                 .isNotNull()
                 .containsOnlyKeys(annTuple, bethTuple);
     }
+    
+    private static UniTuple<String> newTuple(String factA) {
+        return new UniTuple<>(factA, 0);
+    }
+    
 }


### PR DESCRIPTION
Trade off alternative advancement of https://github.com/kiegroup/optaplanner/pull/1895

Negative:
- More casting
- 
Positive:
- Less arrays created, so at least least 2 less instances per tuple (lower memory consumption)
- Maybe more CPU cache friendly
- Closer to what "burn" will do.