### PR TITLE
bumped up to next 8.20.0-SNAPSHOT

### DIFF
--- a/build/optaplanner-build-parent/pom.xml
+++ b/build/optaplanner-build-parent/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.optaplanner</groupId>
     <artifactId>optaplanner-parent</artifactId>
-    <version>8.19.0-SNAPSHOT</version>
+    <version>8.20.0-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 
@@ -20,7 +20,7 @@
     <!-- Dependencies -->
     <!-- ************************************************************************ -->
     <!-- SNAPSHOT and KIE dependency versions -->
-    <version.org.drools>8.19.0-SNAPSHOT</version.org.drools>
+    <version.org.drools>8.20.0-SNAPSHOT</version.org.drools>
 
     <!-- Normal dependency versions -->
     <version.ch.qos.logback>1.2.9</version.ch.qos.logback>

--- a/build/optaplanner-distribution-internal/pom.xml
+++ b/build/optaplanner-distribution-internal/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.optaplanner</groupId>
     <artifactId>optaplanner-build-parent</artifactId>
-    <version>8.19.0-SNAPSHOT</version>
+    <version>8.20.0-SNAPSHOT</version>
     <relativePath>../optaplanner-build-parent/pom.xml</relativePath>
   </parent>
 

--- a/build/optaplanner-ide-config/pom.xml
+++ b/build/optaplanner-ide-config/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.optaplanner</groupId>
     <artifactId>optaplanner-parent</artifactId>
-    <version>8.19.0-SNAPSHOT</version>
+    <version>8.20.0-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <artifactId>optaplanner-ide-config</artifactId>

--- a/build/optaplanner-javadoc/pom.xml
+++ b/build/optaplanner-javadoc/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.optaplanner</groupId>
     <artifactId>optaplanner-build-parent</artifactId>
-    <version>8.19.0-SNAPSHOT</version>
+    <version>8.20.0-SNAPSHOT</version>
     <relativePath>../optaplanner-build-parent/pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/core/optaplanner-constraint-drl/pom.xml
+++ b/core/optaplanner-constraint-drl/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.optaplanner</groupId>
     <artifactId>optaplanner-core-parent</artifactId>
-    <version>8.19.0-SNAPSHOT</version>
+    <version>8.20.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/core/optaplanner-constraint-streams/pom.xml
+++ b/core/optaplanner-constraint-streams/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.optaplanner</groupId>
     <artifactId>optaplanner-core-parent</artifactId>
-    <version>8.19.0-SNAPSHOT</version>
+    <version>8.20.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/core/optaplanner-core-impl/pom.xml
+++ b/core/optaplanner-core-impl/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.optaplanner</groupId>
     <artifactId>optaplanner-core-parent</artifactId>
-    <version>8.19.0-SNAPSHOT</version>
+    <version>8.20.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>optaplanner-core-impl</artifactId>

--- a/core/optaplanner-core/pom.xml
+++ b/core/optaplanner-core/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.optaplanner</groupId>
     <artifactId>optaplanner-core-parent</artifactId>
-    <version>8.19.0-SNAPSHOT</version>
+    <version>8.20.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.optaplanner</groupId>
     <artifactId>optaplanner-build-parent</artifactId>
-    <version>8.19.0-SNAPSHOT</version>
+    <version>8.20.0-SNAPSHOT</version>
     <relativePath>../build/optaplanner-build-parent/pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/optaplanner-benchmark/pom.xml
+++ b/optaplanner-benchmark/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.optaplanner</groupId>
     <artifactId>optaplanner-build-parent</artifactId>
-    <version>8.19.0-SNAPSHOT</version>
+    <version>8.20.0-SNAPSHOT</version>
     <relativePath>../build/optaplanner-build-parent/pom.xml</relativePath>
   </parent>
 

--- a/optaplanner-bom/pom.xml
+++ b/optaplanner-bom/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.optaplanner</groupId>
     <artifactId>optaplanner-parent</artifactId>
-    <version>8.19.0-SNAPSHOT</version>
+    <version>8.20.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>optaplanner-bom</artifactId>

--- a/optaplanner-docs/pom.xml
+++ b/optaplanner-docs/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.optaplanner</groupId>
     <artifactId>optaplanner-build-parent</artifactId>
-    <version>8.19.0-SNAPSHOT</version>
+    <version>8.20.0-SNAPSHOT</version>
     <relativePath>../build/optaplanner-build-parent/pom.xml</relativePath>
   </parent>
 

--- a/optaplanner-docs/src/antora.yml
+++ b/optaplanner-docs/src/antora.yml
@@ -1,7 +1,18 @@
-# This file is a placeholder that is replaced by antora-template.yml during a release.
-# Please note that some AsciiDoc attributes might be missing if you build the docs from this branch.
+# This file is a template for antora.yml, which is created during a release by:
+#   1. running maven that substitutes the properties into this file
+#   2. running build/release/update_antora_yml.sh that copies the result of the previous step to src/antora.yml
+#
+# The goal is to have the antora.yml containing correct attributes available in the release branch before
+# the optaplanner-website is refreshed.
 name: optaplanner
-title: OptaPlanner User Guide
+title: OptaPlanner User Guide 8.20.0-SNAPSHOT
 version: latest
+asciidoc:
+  attributes:
+    optaplanner-version: 8.20.0-SNAPSHOT
+    java-version: 11
+    maven-version: 3.8.1
+    quarkus-version: 2.7.3.Final
+    spring-boot-version: 2.4.5
 nav:
   - modules/ROOT/nav.adoc

--- a/optaplanner-examples/pom.xml
+++ b/optaplanner-examples/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.optaplanner</groupId>
     <artifactId>optaplanner-build-parent</artifactId>
-    <version>8.19.0-SNAPSHOT</version>
+    <version>8.20.0-SNAPSHOT</version>
     <relativePath>../build/optaplanner-build-parent/pom.xml</relativePath>
   </parent>
 

--- a/optaplanner-persistence/optaplanner-persistence-common/pom.xml
+++ b/optaplanner-persistence/optaplanner-persistence-common/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.optaplanner</groupId>
     <artifactId>optaplanner-persistence</artifactId>
-    <version>8.19.0-SNAPSHOT</version>
+    <version>8.20.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>optaplanner-persistence-common</artifactId>

--- a/optaplanner-persistence/optaplanner-persistence-jackson/pom.xml
+++ b/optaplanner-persistence/optaplanner-persistence-jackson/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.optaplanner</groupId>
     <artifactId>optaplanner-persistence</artifactId>
-    <version>8.19.0-SNAPSHOT</version>
+    <version>8.20.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>optaplanner-persistence-jackson</artifactId>

--- a/optaplanner-persistence/optaplanner-persistence-jaxb/pom.xml
+++ b/optaplanner-persistence/optaplanner-persistence-jaxb/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.optaplanner</groupId>
     <artifactId>optaplanner-persistence</artifactId>
-    <version>8.19.0-SNAPSHOT</version>
+    <version>8.20.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>optaplanner-persistence-jaxb</artifactId>

--- a/optaplanner-persistence/optaplanner-persistence-jpa/pom.xml
+++ b/optaplanner-persistence/optaplanner-persistence-jpa/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.optaplanner</groupId>
     <artifactId>optaplanner-persistence</artifactId>
-    <version>8.19.0-SNAPSHOT</version>
+    <version>8.20.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>optaplanner-persistence-jpa</artifactId>

--- a/optaplanner-persistence/optaplanner-persistence-jsonb/pom.xml
+++ b/optaplanner-persistence/optaplanner-persistence-jsonb/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.optaplanner</groupId>
     <artifactId>optaplanner-persistence</artifactId>
-    <version>8.19.0-SNAPSHOT</version>
+    <version>8.20.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>optaplanner-persistence-jsonb</artifactId>

--- a/optaplanner-persistence/optaplanner-persistence-xstream/pom.xml
+++ b/optaplanner-persistence/optaplanner-persistence-xstream/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.optaplanner</groupId>
     <artifactId>optaplanner-persistence</artifactId>
-    <version>8.19.0-SNAPSHOT</version>
+    <version>8.20.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>optaplanner-persistence-xstream</artifactId>

--- a/optaplanner-persistence/pom.xml
+++ b/optaplanner-persistence/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.optaplanner</groupId>
     <artifactId>optaplanner-build-parent</artifactId>
-    <version>8.19.0-SNAPSHOT</version>
+    <version>8.20.0-SNAPSHOT</version>
     <relativePath>../build/optaplanner-build-parent/pom.xml</relativePath>
   </parent>
 

--- a/optaplanner-quarkus-integration/optaplanner-quarkus-benchmark/deployment/pom.xml
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus-benchmark/deployment/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.optaplanner</groupId>
     <artifactId>optaplanner-quarkus-benchmark-parent</artifactId>
-    <version>8.19.0-SNAPSHOT</version>
+    <version>8.20.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>optaplanner-quarkus-benchmark-deployment</artifactId>

--- a/optaplanner-quarkus-integration/optaplanner-quarkus-benchmark/integration-test/pom.xml
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus-benchmark/integration-test/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.optaplanner</groupId>
     <artifactId>optaplanner-quarkus-benchmark-parent</artifactId>
-    <version>8.19.0-SNAPSHOT</version>
+    <version>8.20.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>optaplanner-quarkus-benchmark-integration-test</artifactId>

--- a/optaplanner-quarkus-integration/optaplanner-quarkus-benchmark/pom.xml
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus-benchmark/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.optaplanner</groupId>
     <artifactId>optaplanner-quarkus-integration</artifactId>
-    <version>8.19.0-SNAPSHOT</version>
+    <version>8.20.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/optaplanner-quarkus-integration/optaplanner-quarkus-benchmark/runtime/pom.xml
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus-benchmark/runtime/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.optaplanner</groupId>
     <artifactId>optaplanner-quarkus-benchmark-parent</artifactId>
-    <version>8.19.0-SNAPSHOT</version>
+    <version>8.20.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>optaplanner-quarkus-benchmark</artifactId>

--- a/optaplanner-quarkus-integration/optaplanner-quarkus-jackson/deployment/pom.xml
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus-jackson/deployment/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.optaplanner</groupId>
     <artifactId>optaplanner-quarkus-jackson-parent</artifactId>
-    <version>8.19.0-SNAPSHOT</version>
+    <version>8.20.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>optaplanner-quarkus-jackson-deployment</artifactId>

--- a/optaplanner-quarkus-integration/optaplanner-quarkus-jackson/integration-test/pom.xml
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus-jackson/integration-test/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.optaplanner</groupId>
     <artifactId>optaplanner-quarkus-jackson-parent</artifactId>
-    <version>8.19.0-SNAPSHOT</version>
+    <version>8.20.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>optaplanner-quarkus-jackson-integration-test</artifactId>

--- a/optaplanner-quarkus-integration/optaplanner-quarkus-jackson/pom.xml
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus-jackson/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.optaplanner</groupId>
     <artifactId>optaplanner-quarkus-integration</artifactId>
-    <version>8.19.0-SNAPSHOT</version>
+    <version>8.20.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>optaplanner-quarkus-jackson-parent</artifactId>

--- a/optaplanner-quarkus-integration/optaplanner-quarkus-jackson/runtime/pom.xml
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus-jackson/runtime/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.optaplanner</groupId>
     <artifactId>optaplanner-quarkus-jackson-parent</artifactId>
-    <version>8.19.0-SNAPSHOT</version>
+    <version>8.20.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>optaplanner-quarkus-jackson</artifactId>

--- a/optaplanner-quarkus-integration/optaplanner-quarkus-jsonb/deployment/pom.xml
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus-jsonb/deployment/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.optaplanner</groupId>
     <artifactId>optaplanner-quarkus-jsonb-parent</artifactId>
-    <version>8.19.0-SNAPSHOT</version>
+    <version>8.20.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>optaplanner-quarkus-jsonb-deployment</artifactId>

--- a/optaplanner-quarkus-integration/optaplanner-quarkus-jsonb/integration-test/pom.xml
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus-jsonb/integration-test/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.optaplanner</groupId>
     <artifactId>optaplanner-quarkus-jsonb-parent</artifactId>
-    <version>8.19.0-SNAPSHOT</version>
+    <version>8.20.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>optaplanner-quarkus-jsonb-integration-test</artifactId>

--- a/optaplanner-quarkus-integration/optaplanner-quarkus-jsonb/pom.xml
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus-jsonb/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.optaplanner</groupId>
     <artifactId>optaplanner-quarkus-integration</artifactId>
-    <version>8.19.0-SNAPSHOT</version>
+    <version>8.20.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>optaplanner-quarkus-jsonb-parent</artifactId>

--- a/optaplanner-quarkus-integration/optaplanner-quarkus-jsonb/runtime/pom.xml
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus-jsonb/runtime/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.optaplanner</groupId>
     <artifactId>optaplanner-quarkus-jsonb-parent</artifactId>
-    <version>8.19.0-SNAPSHOT</version>
+    <version>8.20.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>optaplanner-quarkus-jsonb</artifactId>

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/pom.xml
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.optaplanner</groupId>
     <artifactId>optaplanner-quarkus-parent</artifactId>
-    <version>8.19.0-SNAPSHOT</version>
+    <version>8.20.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>optaplanner-quarkus-deployment</artifactId>

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/devui-integration-test/pom.xml
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/devui-integration-test/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.optaplanner</groupId>
     <artifactId>optaplanner-quarkus-parent</artifactId>
-    <version>8.19.0-SNAPSHOT</version>
+    <version>8.20.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>optaplanner-quarkus-devui-integration-test</artifactId>

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/drl-integration-test/pom.xml
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/drl-integration-test/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.optaplanner</groupId>
     <artifactId>optaplanner-quarkus-parent</artifactId>
-    <version>8.19.0-SNAPSHOT</version>
+    <version>8.20.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>optaplanner-quarkus-drl-integration-test</artifactId>

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/integration-test/pom.xml
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/integration-test/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.optaplanner</groupId>
     <artifactId>optaplanner-quarkus-parent</artifactId>
-    <version>8.19.0-SNAPSHOT</version>
+    <version>8.20.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>optaplanner-quarkus-integration-test</artifactId>

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/pom.xml
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.optaplanner</groupId>
     <artifactId>optaplanner-quarkus-integration</artifactId>
-    <version>8.19.0-SNAPSHOT</version>
+    <version>8.20.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>optaplanner-quarkus-parent</artifactId>

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/runtime/pom.xml
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/runtime/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.optaplanner</groupId>
     <artifactId>optaplanner-quarkus-parent</artifactId>
-    <version>8.19.0-SNAPSHOT</version>
+    <version>8.20.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>optaplanner-quarkus</artifactId>

--- a/optaplanner-quarkus-integration/pom.xml
+++ b/optaplanner-quarkus-integration/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.optaplanner</groupId>
     <artifactId>optaplanner-build-parent</artifactId>
-    <version>8.19.0-SNAPSHOT</version>
+    <version>8.20.0-SNAPSHOT</version>
     <relativePath>../build/optaplanner-build-parent/pom.xml</relativePath>
   </parent>
 

--- a/optaplanner-spring-integration/optaplanner-spring-boot-autoconfigure/pom.xml
+++ b/optaplanner-spring-integration/optaplanner-spring-boot-autoconfigure/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.optaplanner</groupId>
     <artifactId>optaplanner-spring-integration</artifactId>
-    <version>8.19.0-SNAPSHOT</version>
+    <version>8.20.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>optaplanner-spring-boot-autoconfigure</artifactId>

--- a/optaplanner-spring-integration/optaplanner-spring-boot-starter/pom.xml
+++ b/optaplanner-spring-integration/optaplanner-spring-boot-starter/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.optaplanner</groupId>
     <artifactId>optaplanner-spring-integration</artifactId>
-    <version>8.19.0-SNAPSHOT</version>
+    <version>8.20.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>optaplanner-spring-boot-starter</artifactId>

--- a/optaplanner-spring-integration/pom.xml
+++ b/optaplanner-spring-integration/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.optaplanner</groupId>
     <artifactId>optaplanner-build-parent</artifactId>
-    <version>8.19.0-SNAPSHOT</version>
+    <version>8.20.0-SNAPSHOT</version>
     <relativePath>../build/optaplanner-build-parent/pom.xml</relativePath>
   </parent>
 

--- a/optaplanner-test/pom.xml
+++ b/optaplanner-test/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.optaplanner</groupId>
     <artifactId>optaplanner-build-parent</artifactId>
-    <version>8.19.0-SNAPSHOT</version>
+    <version>8.20.0-SNAPSHOT</version>
     <relativePath>../build/optaplanner-build-parent/pom.xml</relativePath>
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
   <groupId>org.optaplanner</groupId>
   <artifactId>optaplanner-parent</artifactId>
   <packaging>pom</packaging>
-  <version>8.19.0-SNAPSHOT</version>
+  <version>8.20.0-SNAPSHOT</version>
 
   <name>OptaPlanner multiproject parent</name>
   <description>


### PR DESCRIPTION
<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.
-->

due to kogito pipeline failures the versions of optaplanner and drools main branches weren't upgraded

### JIRA

<!-- Add a JIRA ticket link if it exists. -->
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->

### Referenced pull requests

- https://github.com/kiegroup/drools/pull/4286
- https://github.com/kiegroup/optaplanner/pull/1907
- https://github.com/kiegroup/optaplanner-quickstarts/pull/316
- https://github.com/kiegroup/optaweb-employee-rostering/pull/784
- https://github.com/kiegroup/optaweb-vehicle-routing/pull/674
- https://github.com/kiegroup/kogito-apps/pull/1291
- https://github.com/kiegroup/kogito-examples/pull/1205
- https://github.com/kiegroup/kogito-runtimes/pull/2121

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
* https://github.com/kiegroup/drools/pull/3000
* https://github.com/kiegroup/optaplanner/pull/899
* etc.
-->

### Checklist
- [ ] Documentation updated if applicable.
- [ ] Upgrade recipe provided if applicable.

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>specific pull request build</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] tests</b>
* for a <b>full downstream build</b> 
  * for <b>jenkins</b> job: please add comment: <b>Jenkins run fdb</b>
  * for <b>github actions</b> job: add the label `run_fdb`
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
* for a <b>Quarkus LTS check</b> please add comment: <b>Jenkins run LTS</b>
* for a <b>specific Quarkus LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] LTS</b>
* for a <b>Native check</b> please add comment: <b>Jenkins run native</b>
* for a <b>specific Native LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] native</b>
</details>

### CI Status

 You can check OptaPlanner repositories CI status from [Chain Status webpage](https://kiegroup.github.io/optaplanner/).