### PR TITLE
PLANNER-2681 - Small improvements to problem changes

### DIFF
--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/api/solver/Solver.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/api/solver/Solver.java
@@ -98,6 +98,8 @@ public interface Solver<Solution_> {
      * This method is thread-safe.
      * Follows specifications of {@link BlockingQueue#add(Object)} with by default
      * a capacity of {@link Integer#MAX_VALUE}.
+     * <p>
+     * To learn more about problem change semantics, please refer to the {@link ProblemChange} Javadoc.
      *
      * @param problemChange never null
      * @see #addProblemChanges(List)
@@ -113,6 +115,8 @@ public interface Solver<Solution_> {
      * This method is thread-safe.
      * Follows specifications of {@link BlockingQueue#add(Object)} with by default
      * a capacity of {@link Integer#MAX_VALUE}.
+     * <p>
+     * To learn more about problem change semantics, please refer to the {@link ProblemChange} Javadoc.
      *
      * @param problemChangeList never null
      * @see #addProblemChange(ProblemChange)

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/api/solver/SolverJob.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/api/solver/SolverJob.java
@@ -54,7 +54,9 @@ public interface SolverJob<Solution_, ProblemId_> {
 
     /**
      * Schedules a {@link ProblemChange} to be processed by the underlying {@link Solver} and returns immediately.
-     *
+     * <p>
+     * To learn more about problem change semantics, please refer to the {@link ProblemChange} Javadoc.
+     * 
      * @param problemChange never null
      * @return completes after the best solution containing this change has been consumed.
      * @throws IllegalStateException if the underlying {@link Solver} is not in the {@link SolverStatus#SOLVING_ACTIVE}

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/api/solver/SolverManager.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/api/solver/SolverManager.java
@@ -43,6 +43,8 @@ import org.optaplanner.core.impl.solver.DefaultSolverManager;
  * <p>
  * Internally a SolverManager manages a thread pool of solver threads (which call {@link Solver#solve(Object)})
  * and consumer threads (to handle the {@link BestSolutionChangedEvent}s).
+ * <p>
+ * To learn more about problem change semantics, please refer to the {@link ProblemChange} Javadoc.
  *
  * @param <Solution_> the solution type, the class with the {@link PlanningSolution} annotation
  * @param <ProblemId_> the ID type of a submitted problem, such as {@link Long} or {@link UUID}.

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/api/solver/change/ProblemChange.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/api/solver/change/ProblemChange.java
@@ -42,7 +42,6 @@ import org.optaplanner.core.api.solver.Solver;
  * <p>
  * Note that the {@link Solver} clones a {@link PlanningSolution} at will.
  * Any change must be done on the problem facts and planning entities referenced by the {@link PlanningSolution}.
- * Any change must be done on the problem facts and planning entities referenced by the {@link PlanningSolution}.
  * <p>
  * An example implementation, based on the Cloud balancing problem, looks as follows:
  *

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/api/solver/change/ProblemChange.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/api/solver/change/ProblemChange.java
@@ -22,14 +22,60 @@ import org.optaplanner.core.api.score.Score;
 import org.optaplanner.core.api.solver.Solver;
 
 /**
- * A ProblemChange represents a change in 1 or more {@link PlanningEntity planning entities} or problem facts
+ * A ProblemChange represents a change in one or more {@link PlanningEntity planning entities} or problem facts
  * of a {@link PlanningSolution}.
- * Problem facts used by a {@link Solver} must not be changed while it is solving,
- * but by scheduling this command to the {@link Solver}, you can change them when the time is right.
+ * <p>
+ * The {@link Solver} checks the presence of waiting problem changes after every
+ * {@link org.optaplanner.core.impl.heuristic.move.Move} evaluation. If there are waiting problem changes,
+ * the {@link Solver}:
+ * <ol>
+ * <li>clones the last {@link PlanningSolution best solution} and sets the clone
+ * as the new {@link PlanningSolution working solution}</li>
+ * <li>applies every problem change keeping the order in which problem changes have been submitted;
+ * after every problem change, {@link org.optaplanner.core.api.domain.variable.VariableListener variable listeners}
+ * are triggered
+ * <li>calculates the score and makes the {@link PlanningSolution updated working solution}
+ * the new {@link PlanningSolution best solution}; note that this {@link PlanningSolution solution} is not published
+ * via the {@link org.optaplanner.core.api.solver.event.BestSolutionChangedEvent}, as it hasn't been initialized yet</li>
+ * <li>restarts solving to fill potential uninitialized {@link PlanningEntity planning entities}</li>
+ * </ol>
  * <p>
  * Note that the {@link Solver} clones a {@link PlanningSolution} at will.
- * Any change must be done on the problem facts and planning entities referenced by the {@link PlanningSolution}
- * of the {@link ProblemChangeDirector}.
+ * Any change must be done on the problem facts and planning entities referenced by the {@link PlanningSolution}.
+ * Any change must be done on the problem facts and planning entities referenced by the {@link PlanningSolution}.
+ * <p>
+ * An example implementation, based on the Cloud balancing problem, looks as follows:
+ *
+ * <pre>
+ * {@code
+ * public class DeleteComputerProblemChange implements ProblemChange<CloudBalance> {
+ *
+ *     private final CloudComputer computer;
+ *
+ *     public DeleteComputerProblemChange(CloudComputer computer) {
+ *         this.computer = computer;
+ *     }
+ *
+ *     {@literal @Override}
+ *     public void doChange(CloudBalance cloudBalance, ProblemChangeDirector problemChangeDirector) {
+ *         CloudComputer workingComputer = problemChangeDirector.lookUpWorkingObjectOrFail(computer);
+ *         // First remove the problem fact from all planning entities that use it
+ *         for (CloudProcess process : cloudBalance.getProcessList()) {
+ *             if (process.getComputer() == workingComputer) {
+ *                 problemChangeDirector.changeVariable(process, "computer",
+ *                         workingProcess -> workingProcess.setComputer(null));
+ *             }
+ *         }
+ *         // A SolutionCloner does not clone problem fact lists (such as computerList), only entity lists.
+ *         // Shallow clone the computerList so only the working solution is affected.
+ *         ArrayList<CloudComputer> computerList = new ArrayList<>(cloudBalance.getComputerList());
+ *         cloudBalance.setComputerList(computerList);
+ *         // Remove the problem fact itself
+ *         problemChangeDirector.removeProblemFact(workingComputer, computerList::remove);
+ *     }
+ * }
+ * }
+ * </pre>
  *
  * @param <Solution_> the solution type, the class with the {@link PlanningSolution} annotation
  */

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/api/solver/change/ProblemChangeDirector.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/api/solver/change/ProblemChangeDirector.java
@@ -26,8 +26,13 @@ import org.optaplanner.core.api.domain.solution.PlanningSolution;
 import org.optaplanner.core.api.domain.variable.PlanningVariable;
 
 /**
- * Allows external changes to the {@link PlanningSolution working solution}.
+ * Allows external changes to the {@link PlanningSolution working solution}. If the changes are not applied through
+ * the ProblemChangeDirector,
+ * {@link org.optaplanner.core.api.domain.variable.VariableListener both internal and custom variable listeners} are
+ * never notified about them, resulting to inconsistencies in the {@link PlanningSolution working solution}.
  * Should be used only from a {@link ProblemChange} implementation.
+ *
+ * To see an example implementation, please refer to the {@link ProblemChange} Javadoc.
  */
 public interface ProblemChangeDirector {
 

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/score/director/AbstractScoreDirector.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/score/director/AbstractScoreDirector.java
@@ -171,6 +171,13 @@ public abstract class AbstractScoreDirector<Solution_, Score_ extends Score<Scor
     // Complex methods
     // ************************************************************************
 
+    /**
+     * Note: resetting the working solution does NOT substitute the calls to before/after methods of
+     * the {@link org.optaplanner.core.api.solver.change.ProblemChangeDirector} during
+     * {@link org.optaplanner.core.api.solver.change.ProblemChange problem changes},
+     * as these calls are propagated to {@link VariableListener variable listeners}, which update shadow variables
+     * in the {@link org.optaplanner.core.api.domain.solution.PlanningSolution working solution} to keep it consistent.
+     */
     @Override
     public void setWorkingSolution(Solution_ workingSolution) {
         this.workingSolution = requireNonNull(workingSolution);

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/solver/DefaultSolver.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/solver/DefaultSolver.java
@@ -292,7 +292,7 @@ public class DefaultSolver<Solution_> extends AbstractSolver<Solution_> {
             // Everything is fine, proceed.
             Score<?> score = scoreDirector.calculateScore();
             basicPlumbingTermination.endProblemFactChangesProcessing();
-            bestSolutionRecaller.updateBestSolutionAndFire(solverScope);
+            bestSolutionRecaller.updateBestSolutionWithoutFiring(solverScope);
             logger.info("Real-time problem fact changes done: step total ({}), new best score ({}).",
                     stepIndex, score);
             return true;

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/solver/DefaultSolver.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/solver/DefaultSolver.java
@@ -278,29 +278,24 @@ public class DefaultSolver<Solution_> extends AbstractSolver<Solution_> {
             BlockingQueue<ProblemChangeAdapter<Solution_>> problemFactChangeQueue = basicPlumbingTermination
                     .startProblemFactChangesProcessing();
             solverScope.setWorkingSolutionFromBestSolution();
-            Score<?> score = null;
+
             int stepIndex = 0;
-            ProblemChangeAdapter<Solution_> problemFactChange = problemFactChangeQueue.poll();
-            while (problemFactChange != null) {
-                score = doProblemChange(problemFactChange, stepIndex);
+            ProblemChangeAdapter<Solution_> problemChangeAdapter = problemFactChangeQueue.poll();
+            while (problemChangeAdapter != null) {
+                problemChangeAdapter.doProblemChange(solverScope);
                 stepIndex++;
-                problemFactChange = problemFactChangeQueue.poll();
+                problemChangeAdapter = problemFactChangeQueue.poll();
             }
             // All PFCs are processed, fail fast if any of the new facts have null planning IDs.
             InnerScoreDirector<Solution_, ?> scoreDirector = solverScope.getScoreDirector();
             scoreDirector.assertNonNullPlanningIds();
             // Everything is fine, proceed.
+            Score<?> score = scoreDirector.calculateScore();
             basicPlumbingTermination.endProblemFactChangesProcessing();
             bestSolutionRecaller.updateBestSolutionAndFire(solverScope);
             logger.info("Real-time problem fact changes done: step total ({}), new best score ({}).",
                     stepIndex, score);
             return true;
         }
-    }
-
-    private Score<?> doProblemChange(ProblemChangeAdapter<Solution_> problemChangeAdapter, int stepIndex) {
-        Score<?> score = problemChangeAdapter.doProblemChange(solverScope);
-        logger.debug("    Step index ({}), new score ({}) for real-time problem change.", stepIndex, score);
-        return score;
     }
 }

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/solver/DefaultSolver.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/solver/DefaultSolver.java
@@ -283,6 +283,7 @@ public class DefaultSolver<Solution_> extends AbstractSolver<Solution_> {
             ProblemChangeAdapter<Solution_> problemChangeAdapter = problemFactChangeQueue.poll();
             while (problemChangeAdapter != null) {
                 problemChangeAdapter.doProblemChange(solverScope);
+                logger.debug("    Real-time problem change applied; step index ({}).", stepIndex);
                 stepIndex++;
                 problemChangeAdapter = problemFactChangeQueue.poll();
             }

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/solver/change/ProblemChangeAdapter.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/solver/change/ProblemChangeAdapter.java
@@ -16,7 +16,6 @@
 
 package org.optaplanner.core.impl.solver.change;
 
-import org.optaplanner.core.api.score.Score;
 import org.optaplanner.core.api.solver.ProblemFactChange;
 import org.optaplanner.core.api.solver.change.ProblemChange;
 import org.optaplanner.core.impl.solver.scope.SolverScope;
@@ -27,16 +26,16 @@ import org.optaplanner.core.impl.solver.scope.SolverScope;
  */
 public interface ProblemChangeAdapter<Solution_> {
 
-    Score<?> doProblemChange(SolverScope<Solution_> solverScope);
+    void doProblemChange(SolverScope<Solution_> solverScope);
 
     static <Solution_> ProblemChangeAdapter<Solution_> create(ProblemFactChange<Solution_> problemFactChange) {
-        return solverScope -> {
-            problemFactChange.doChange(solverScope.getScoreDirector());
-            return solverScope.calculateScore();
-        };
+        return (solverScope) -> problemFactChange.doChange(solverScope.getScoreDirector());
     }
 
     static <Solution_> ProblemChangeAdapter<Solution_> create(ProblemChange<Solution_> problemChange) {
-        return solverScope -> solverScope.getProblemChangeDirector().doProblemChange(problemChange);
+        return (solverScope) -> {
+            problemChange.doChange(solverScope.getWorkingSolution(), solverScope.getProblemChangeDirector());
+            solverScope.getScoreDirector().triggerVariableListeners();
+        };
     }
 }

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/solver/recaller/BestSolutionRecaller.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/solver/recaller/BestSolutionRecaller.java
@@ -126,14 +126,19 @@ public class BestSolutionRecaller<Solution_> extends PhaseLifecycleListenerAdapt
     }
 
     public void updateBestSolutionAndFire(SolverScope<Solution_> solverScope) {
+        updateBestSolutionWithoutFiring(solverScope);
+        solverEventSupport.fireBestSolutionChanged(solverScope, solverScope.getBestSolution());
+    }
+
+    public void updateBestSolutionWithoutFiring(SolverScope<Solution_> solverScope) {
         Solution_ newBestSolution = solverScope.getScoreDirector().cloneWorkingSolution();
         Score newBestScore = solverScope.getSolutionDescriptor().getScore(newBestSolution);
-        updateBestSolutionAndFire(solverScope, newBestScore, newBestSolution);
+        updateBestSolutionWithoutFiring(solverScope, newBestScore, newBestSolution);
     }
 
     private void updateBestSolutionAndFire(SolverScope<Solution_> solverScope, Score bestScore, Solution_ bestSolution) {
         updateBestSolutionWithoutFiring(solverScope, bestScore, bestSolution);
-        solverEventSupport.fireBestSolutionChanged(solverScope, bestSolution);
+        solverEventSupport.fireBestSolutionChanged(solverScope, solverScope.getBestSolution());
     }
 
     private void updateBestSolutionWithoutFiring(SolverScope<Solution_> solverScope, Score bestScore, Solution_ bestSolution) {

--- a/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/solver/termination/BasicPlumbingTerminationTest.java
+++ b/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/solver/termination/BasicPlumbingTerminationTest.java
@@ -18,7 +18,6 @@ package org.optaplanner.core.impl.solver.termination;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 import java.util.Arrays;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -72,9 +71,10 @@ class BasicPlumbingTerminationTest {
     }
 
     private SolverScope<TestdataSolution> mockSolverScope() {
+        SolverScope<TestdataSolution> solverScope = new SolverScope<>();
         InnerScoreDirector<TestdataSolution, ?> scoreDirectorMock = mock(InnerScoreDirector.class);
-        SolverScope<TestdataSolution> solverScopeMock = mock(SolverScope.class);
-        when(solverScopeMock.getProblemChangeDirector()).thenReturn(new DefaultProblemChangeDirector<>(scoreDirectorMock));
-        return solverScopeMock;
+        solverScope.setScoreDirector(scoreDirectorMock);
+        solverScope.setProblemChangeDirector(new DefaultProblemChangeDirector<>(scoreDirectorMock));
+        return solverScope;
     }
 }


### PR DESCRIPTION
<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.
-->
Focuses on various small improvements and enhancing Javadoc after revealing that https://issues.redhat.com/browse/PLANNER-2681 is not doable following the original plan.

### JIRA
https://issues.redhat.com/browse/PLANNER-2681

<!-- Add a JIRA ticket link if it exists. -->
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
* https://github.com/kiegroup/drools/pull/3000
* https://github.com/kiegroup/optaplanner/pull/899
* etc.
-->

### Checklist
- [ ] Documentation updated if applicable.
- [ ] Upgrade recipe provided if applicable.

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>specific pull request build</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] tests</b>
* for a <b>full downstream build</b> 
  * for <b>jenkins</b> job: please add comment: <b>Jenkins run fdb</b>
  * for <b>github actions</b> job: add the label `run_fdb`
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
* for a <b>Quarkus LTS check</b> please add comment: <b>Jenkins run LTS</b>
* for a <b>specific Quarkus LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] LTS</b>
* for a <b>Native check</b> please add comment: <b>Jenkins run native</b>
* for a <b>specific Native LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] native</b>
</details>

### CI Status

 You can check OptaPlanner repositories CI status from [Chain Status webpage](https://kiegroup.github.io/optaplanner/).