### PR TITLE
Simplify ShadowVariableDescriptor.hasVariableListener()

### DIFF
--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/domain/variable/custom/CustomShadowVariableDescriptor.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/domain/variable/custom/CustomShadowVariableDescriptor.java
@@ -222,7 +222,7 @@ public class CustomShadowVariableDescriptor<Solution_> extends ShadowVariableDes
     }
 
     @Override
-    public boolean hasVariableListener(InnerScoreDirector<Solution_, ?> scoreDirector) {
+    public boolean hasVariableListener() {
         return refVariableDescriptor == null;
     }
 

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/domain/variable/descriptor/ShadowVariableDescriptor.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/domain/variable/descriptor/ShadowVariableDescriptor.java
@@ -74,7 +74,7 @@ public abstract class ShadowVariableDescriptor<Solution_> extends VariableDescri
      */
     public abstract Demand<Solution_, ?> getProvidedDemand();
 
-    public boolean hasVariableListener(InnerScoreDirector<Solution_, ?> scoreDirector) {
+    public boolean hasVariableListener() {
         return true;
     }
 

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/domain/variable/listener/support/VariableListenerSupport.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/domain/variable/listener/support/VariableListenerSupport.java
@@ -64,8 +64,9 @@ public final class VariableListenerSupport<Solution_> implements SupplyManager<S
     public void linkVariableListeners() {
         notificationQueuesAreEmpty = true;
         scoreDirector.getSolutionDescriptor().getEntityDescriptors().stream()
-                .flatMap(entityDescriptor -> entityDescriptor.getDeclaredShadowVariableDescriptors().stream())
-                .filter(descriptor -> descriptor.hasVariableListener(scoreDirector))
+                .map(EntityDescriptor::getDeclaredShadowVariableDescriptors)
+                .flatMap(Collection::stream)
+                .filter(ShadowVariableDescriptor::hasVariableListener)
                 .sorted(Comparator.comparingInt(ShadowVariableDescriptor::getGlobalShadowOrder))
                 .forEach(this::processShadowVariableDescriptor);
     }


### PR DESCRIPTION
Removing the unused `scoreDirector` parameter enables a method reference and makes the stream even more concise.
<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>specific pull request build</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] tests</b>
* for a <b>full downstream build</b> 
  * for <b>jenkins</b> job: please add comment: <b>Jenkins run fdb</b>
  * for <b>github actions</b> job: add the label `run_fdb`
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
* for a <b>Quarkus LTS check</b> please add comment: <b>Jenkins run LTS</b>
* for a <b>specific Quarkus LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] LTS</b>
* for a <b>Native check</b> please add comment: <b>Jenkins run native</b>
* for a <b>specific Native LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] native</b>
</details>

### CI Status

 You can check OptaPlanner repositories CI status from [Chain Status webpage](https://kiegroup.github.io/optaplanner/).