### PR TITLE
CS-B: Remove unnecessary indirection

### DIFF
--- a/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/bavet/common/index/ComparisonIndexer.java
+++ b/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/bavet/common/index/ComparisonIndexer.java
@@ -20,8 +20,8 @@ import java.util.Map;
 import java.util.NavigableMap;
 import java.util.Objects;
 import java.util.TreeMap;
+import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
-import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
@@ -86,7 +86,7 @@ final class ComparisonIndexer<Tuple_ extends Tuple, Value_> implements Indexer<T
     }
 
     @Override
-    public void visit(IndexProperties indexProperties, Consumer<Map<Tuple_, Value_>> tupleValueMapVisitor) {
+    public void visit(IndexProperties indexProperties, BiConsumer<Tuple_, Value_> tupleValueVisitor) {
         Comparable comparisonIndexProperty = comparisonIndexPropertyFunction.apply(indexProperties);
         Map<Object, Indexer<Tuple_, Value_>> selectedComparisonMap =
                 submapFunction.apply(comparisonMap, comparisonIndexProperty);
@@ -94,7 +94,7 @@ final class ComparisonIndexer<Tuple_ extends Tuple, Value_> implements Indexer<T
             return;
         }
         for (Indexer<Tuple_, Value_> indexer : selectedComparisonMap.values()) {
-            indexer.visit(indexProperties, tupleValueMapVisitor);
+            indexer.visit(indexProperties, tupleValueVisitor);
         }
     }
 

--- a/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/bavet/common/index/EqualsIndexer.java
+++ b/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/bavet/common/index/EqualsIndexer.java
@@ -19,7 +19,7 @@ package org.optaplanner.constraint.streams.bavet.common.index;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
-import java.util.function.Consumer;
+import java.util.function.BiConsumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
@@ -63,12 +63,12 @@ final class EqualsIndexer<Tuple_ extends Tuple, Value_> implements Indexer<Tuple
     }
 
     @Override
-    public void visit(IndexProperties indexProperties, Consumer<Map<Tuple_, Value_>> tupleValueMapVisitor) {
+    public void visit(IndexProperties indexProperties, BiConsumer<Tuple_, Value_> tupleValueVisitor) {
         Indexer<Tuple_, Value_> downstreamIndexer = downstreamIndexerMap.get(indexerKeyFunction.apply(indexProperties));
-        if (downstreamIndexer == null) {
+        if (downstreamIndexer == null || downstreamIndexer.isEmpty()) {
             return;
         }
-        downstreamIndexer.visit(indexProperties, tupleValueMapVisitor);
+        downstreamIndexer.visit(indexProperties, tupleValueVisitor);
     }
 
     @Override

--- a/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/bavet/common/index/Indexer.java
+++ b/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/bavet/common/index/Indexer.java
@@ -70,15 +70,7 @@ public interface Indexer<Tuple_ extends Tuple, Value_> {
      * @param indexProperties never null
      * @param tupleValueMapEntryVisitor never null
      */
-    default void visit(IndexProperties indexProperties, BiConsumer<Tuple_, Value_> tupleValueMapEntryVisitor) {
-        visit(indexProperties, map -> map.forEach(tupleValueMapEntryVisitor));
-    }
-
-    /**
-     * @param indexProperties never null
-     * @param tupleValueMapVisitor never null
-     */
-    void visit(IndexProperties indexProperties, Consumer<Map<Tuple_, Value_>> tupleValueMapVisitor);
+    void visit(IndexProperties indexProperties, BiConsumer<Tuple_, Value_> tupleValueMapEntryVisitor);
 
     boolean isEmpty();
 

--- a/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/bavet/common/index/NoneIndexer.java
+++ b/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/bavet/common/index/NoneIndexer.java
@@ -19,11 +19,11 @@ package org.optaplanner.constraint.streams.bavet.common.index;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
-import java.util.function.Consumer;
+import java.util.function.BiConsumer;
 
 import org.optaplanner.constraint.streams.bavet.common.Tuple;
 
-public final class NoneIndexer<Tuple_ extends Tuple, Value_> implements Indexer<Tuple_, Value_> {
+final class NoneIndexer<Tuple_ extends Tuple, Value_> implements Indexer<Tuple_, Value_> {
 
     private final Map<Tuple_, Value_> tupleMap = new LinkedHashMap<>();
 
@@ -50,8 +50,10 @@ public final class NoneIndexer<Tuple_ extends Tuple, Value_> implements Indexer<
     }
 
     @Override
-    public void visit(IndexProperties indexProperties, Consumer<Map<Tuple_, Value_>> tupleValueMapVisitor) {
-        tupleValueMapVisitor.accept(tupleMap);
+    public void visit(IndexProperties indexProperties, BiConsumer<Tuple_, Value_> tupleValueVisitor) {
+        if (!isEmpty()) {
+            tupleMap.forEach(tupleValueVisitor);
+        }
     }
 
     @Override


### PR DESCRIPTION
There was a level of indirection in `visit(...)` that used to be necessary.
With the recent refactoring, it no longer is.