### PR TITLE
[8.21.x] Bump Quarkus version to 2.8.2.Final (#1941)

### DIFF
--- a/build/optaplanner-build-parent/pom.xml
+++ b/build/optaplanner-build-parent/pom.xml
@@ -26,7 +26,7 @@
     <version.ch.qos.logback>1.2.9</version.ch.qos.logback>
     <version.org.apache.logging.log4j>2.17.2</version.org.apache.logging.log4j>
     <version.com.thoughtworks.xstream>1.4.19</version.com.thoughtworks.xstream>
-    <version.io.quarkus>2.8.0.Final</version.io.quarkus>
+    <version.io.quarkus>2.8.2.Final</version.io.quarkus>
     <version.org.apache.commons.math3>3.6.1</version.org.apache.commons.math3>
     <version.org.apache.commons.text>1.9</version.org.apache.commons.text>
     <version.org.apache.poi>5.2.2</version.org.apache.poi>


### PR DESCRIPTION
cherry-pick: https://github.com/kiegroup/optaplanner/pull/1941

Related PRs:
- https://github.com/kiegroup/drools/pull/4342
- https://github.com/kiegroup/optaplanner/pull/1958
- https://github.com/kiegroup/optaplanner-quickstarts/pull/327
- https://github.com/kiegroup/kogito-runtimes/pull/2174
- https://github.com/kiegroup/kogito-apps/pull/1315
- https://github.com/kiegroup/kogito-examples/pull/1238