### PR TITLE
[1.21.x] Bump Quarkus version to 2.9.0.Final

### DIFF
--- a/build/optaplanner-build-parent/pom.xml
+++ b/build/optaplanner-build-parent/pom.xml
@@ -26,7 +26,7 @@
     <version.ch.qos.logback>1.2.9</version.ch.qos.logback>
     <version.org.apache.logging.log4j>2.17.2</version.org.apache.logging.log4j>
     <version.com.thoughtworks.xstream>1.4.19</version.com.thoughtworks.xstream>
-    <version.io.quarkus>2.8.2.Final</version.io.quarkus>
+    <version.io.quarkus>2.9.0.Final</version.io.quarkus>
     <version.org.apache.commons.math3>3.6.1</version.org.apache.commons.math3>
     <version.org.apache.commons.text>1.9</version.org.apache.commons.text>
     <version.org.apache.poi>5.2.2</version.org.apache.poi>


### PR DESCRIPTION
cherry-pick: https://github.com/kiegroup/optaplanner/pull/1961

Related PRs:
- https://github.com/kiegroup/kogito-pipelines/pull/437
- https://github.com/kiegroup/drools/pull/4357
- https://github.com/kiegroup/kogito-runtimes/pull/2188
- https://github.com/kiegroup/optaplanner/pull/1967
- https://github.com/kiegroup/optaplanner-quickstarts/pull/330
- https://github.com/kiegroup/kogito-apps/pull/1331
- https://github.com/kiegroup/kogito-examples/pull/1245