### PR TITLE
[DROOLS-6942] remove useless interfaces from spi package

### DIFF
--- a/core/optaplanner-constraint-drl/src/main/java/org/optaplanner/constraint/drl/holder/AbstractScoreHolder.java
+++ b/core/optaplanner-constraint-drl/src/main/java/org/optaplanner/constraint/drl/holder/AbstractScoreHolder.java
@@ -26,7 +26,7 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import org.drools.core.common.AgendaItem;
-import org.drools.core.spi.Activation;
+import org.drools.core.rule.consequence.Activation;
 import org.kie.api.definition.rule.Rule;
 import org.kie.api.runtime.KieSession;
 import org.kie.api.runtime.rule.RuleContext;

--- a/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/drools/common/AbstractAccumulator.java
+++ b/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/drools/common/AbstractAccumulator.java
@@ -22,9 +22,9 @@ import java.util.function.Supplier;
 
 import org.drools.core.common.InternalFactHandle;
 import org.drools.core.common.ReteEvaluator;
+import org.drools.core.reteoo.Tuple;
 import org.drools.core.rule.Declaration;
-import org.drools.core.spi.Accumulator;
-import org.drools.core.spi.Tuple;
+import org.drools.core.rule.accessor.Accumulator;
 
 abstract class AbstractAccumulator<ResultContainer_, Result_> implements Accumulator {
 

--- a/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/drools/common/BiAccumulator.java
+++ b/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/drools/common/BiAccumulator.java
@@ -20,8 +20,8 @@ import java.util.Objects;
 import java.util.function.Function;
 
 import org.drools.core.common.InternalFactHandle;
+import org.drools.core.reteoo.Tuple;
 import org.drools.core.rule.Declaration;
-import org.drools.core.spi.Tuple;
 import org.drools.model.Variable;
 import org.optaplanner.core.api.function.TriFunction;
 import org.optaplanner.core.api.score.stream.bi.BiConstraintCollector;

--- a/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/drools/common/QuadAccumulator.java
+++ b/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/drools/common/QuadAccumulator.java
@@ -20,8 +20,8 @@ import java.util.Objects;
 import java.util.function.Function;
 
 import org.drools.core.common.InternalFactHandle;
+import org.drools.core.reteoo.Tuple;
 import org.drools.core.rule.Declaration;
-import org.drools.core.spi.Tuple;
 import org.drools.model.Variable;
 import org.optaplanner.core.api.function.PentaFunction;
 import org.optaplanner.core.api.score.stream.quad.QuadConstraintCollector;

--- a/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/drools/common/TriAccumulator.java
+++ b/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/drools/common/TriAccumulator.java
@@ -20,8 +20,8 @@ import java.util.Objects;
 import java.util.function.Function;
 
 import org.drools.core.common.InternalFactHandle;
+import org.drools.core.reteoo.Tuple;
 import org.drools.core.rule.Declaration;
-import org.drools.core.spi.Tuple;
 import org.drools.model.Variable;
 import org.optaplanner.core.api.function.QuadFunction;
 import org.optaplanner.core.api.score.stream.tri.TriConstraintCollector;

--- a/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/drools/common/UniAccumulator.java
+++ b/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/drools/common/UniAccumulator.java
@@ -22,8 +22,8 @@ import java.util.function.UnaryOperator;
 
 import org.drools.core.common.InternalFactHandle;
 import org.drools.core.reteoo.SubnetworkTuple;
+import org.drools.core.reteoo.Tuple;
 import org.drools.core.rule.Declaration;
-import org.drools.core.spi.Tuple;
 import org.drools.model.Variable;
 import org.optaplanner.core.api.score.stream.uni.UniConstraintCollector;
 

--- a/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/drools/common/ValueExtractor.java
+++ b/core/optaplanner-constraint-streams/src/main/java/org/optaplanner/constraint/streams/drools/common/ValueExtractor.java
@@ -4,8 +4,8 @@ import java.util.Objects;
 import java.util.function.Function;
 import java.util.function.UnaryOperator;
 
+import org.drools.core.reteoo.Tuple;
 import org.drools.core.rule.Declaration;
-import org.drools.core.spi.Tuple;
 
 final class ValueExtractor<X> implements Function<Tuple, X> {
 


### PR DESCRIPTION
**JIRA**: https://issues.redhat.com/browse/DROOLS-6942

Related PRs:
- https://github.com/kiegroup/drools/pull/4359
- https://github.com/kiegroup/kogito-runtimes/pull/2193
- https://github.com/kiegroup/optaplanner/pull/1970