### PR TITLE
PLANNER-2716 Ignore empty iterators

### DIFF
--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/composite/UniformRandomUnionMoveIterator.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/composite/UniformRandomUnionMoveIterator.java
@@ -33,6 +33,7 @@ final class UniformRandomUnionMoveIterator<Solution_> extends SelectionIterator<
     public UniformRandomUnionMoveIterator(List<MoveSelector<Solution_>> childMoveSelectorList, Random workingRandom) {
         this.moveIteratorList = childMoveSelectorList.stream()
                 .map(Iterable::iterator)
+                .filter(Iterator::hasNext)
                 .collect(Collectors.toList());
         this.workingRandom = workingRandom;
     }

--- a/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/heuristic/selector/move/composite/UnionMoveSelectorTest.java
+++ b/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/heuristic/selector/move/composite/UnionMoveSelectorTest.java
@@ -165,7 +165,36 @@ class UnionMoveSelectorTest {
     }
 
     @Test
-    void emptyRandomSelection() {
+    void emptyUniformRandomSelection() {
+        ArrayList<MoveSelector<TestdataSolution>> childMoveSelectorList = new ArrayList<>();
+        childMoveSelectorList.add(SelectorTestUtils.mockMoveSelector(DummyMove.class));
+        childMoveSelectorList.add(SelectorTestUtils.mockMoveSelector(DummyMove.class));
+        UnionMoveSelector<TestdataSolution> moveSelector =
+                new UnionMoveSelector<>(childMoveSelectorList, true, null);
+
+        Random workingRandom = new TestRandom(1);
+
+        SolverScope<TestdataSolution> solverScope = mock(SolverScope.class);
+        when(solverScope.getWorkingRandom()).thenReturn(workingRandom);
+        moveSelector.solvingStarted(solverScope);
+        AbstractPhaseScope<TestdataSolution> phaseScopeA = PlannerTestUtils.delegatingPhaseScope(solverScope);
+        moveSelector.phaseStarted(phaseScopeA);
+        AbstractStepScope<TestdataSolution> stepScopeA1 = PlannerTestUtils.delegatingStepScope(phaseScopeA);
+        moveSelector.stepStarted(stepScopeA1);
+
+        // A union of ending MoveSelectors does end, even with randomSelection
+        assertAllCodesOfMoveSelector(moveSelector);
+
+        moveSelector.stepEnded(stepScopeA1);
+        moveSelector.phaseEnded(phaseScopeA);
+        moveSelector.solvingEnded(solverScope);
+
+        verifyPhaseLifecycle(childMoveSelectorList.get(0), 1, 1, 1);
+        verifyPhaseLifecycle(childMoveSelectorList.get(1), 1, 1, 1);
+    }
+
+    @Test
+    void emptyBiasedRandomSelection() {
         ArrayList<MoveSelector<TestdataSolution>> childMoveSelectorList = new ArrayList<>();
         Map<MoveSelector<TestdataSolution>, Double> fixedProbabilityWeightMap = new HashMap<>();
         childMoveSelectorList.add(SelectorTestUtils.mockMoveSelector(DummyMove.class));

--- a/optaplanner-examples/src/test/java/org/optaplanner/examples/vehiclerouting/app/VehicleRoutingPerformanceTest.java
+++ b/optaplanner-examples/src/test/java/org/optaplanner/examples/vehiclerouting/app/VehicleRoutingPerformanceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,7 +36,7 @@ class VehicleRoutingPerformanceTest extends SolverPerformanceTest<VehicleRouting
     @Override
     protected Stream<TestData<HardSoftLongScore>> testData() {
         return Stream.of(
-                testData(CVRP_32_CUSTOMERS_XML, HardSoftLongScore.of(0, -743441), EnvironmentMode.REPRODUCIBLE),
+                testData(CVRP_32_CUSTOMERS_XML, HardSoftLongScore.of(0, -744242), EnvironmentMode.REPRODUCIBLE),
                 testData(CVRP_32_CUSTOMERS_XML, HardSoftLongScore.of(0, -745420), EnvironmentMode.FAST_ASSERT),
                 testData(CVRPTW_100_CUSTOMERS_A_XML, HardSoftLongScore.of(0, -1798722), EnvironmentMode.REPRODUCIBLE),
                 testData(CVRPTW_100_CUSTOMERS_A_XML, HardSoftLongScore.of(0, -1812202), EnvironmentMode.FAST_ASSERT));


### PR DESCRIPTION
Otherwise .next() can produce a null move.
Identified by `kogito-apps` CI.