### PR TITLE
PLANNER-2730 Create a turtle test job with CS-B

### DIFF
--- a/.ci/jenkins/Jenkinsfile.turtle
+++ b/.ci/jenkins/Jenkinsfile.turtle
@@ -42,7 +42,7 @@ pipeline {
                             .withProperty('full')
                             .withProperty('runTurtleTests', true)
                             .withProperty('maven.test.failure.ignore', true)
-                            .withProperty('csType', getCsType())
+                            .withProperty('constraintStreamImplType', getConstraintStreamImplType())
                             .run('clean install')
                 }
             }
@@ -76,8 +76,8 @@ String getGitAuthor() {
     return params.GIT_AUTHOR
 }
 
-String getCsType() {
-    return env.CS_TYPE
+String getConstraintStreamImplType() {
+    return env.CONSTRAINT_STREAM_IMPL_TYPE
 }
 
 void sendEmail() {

--- a/.ci/jenkins/Jenkinsfile.turtle
+++ b/.ci/jenkins/Jenkinsfile.turtle
@@ -42,6 +42,7 @@ pipeline {
                             .withProperty('full')
                             .withProperty('runTurtleTests', true)
                             .withProperty('maven.test.failure.ignore', true)
+                            .withProperty('csType', getCsType())
                             .run('clean install')
                 }
             }
@@ -73,6 +74,10 @@ String getBuildBranch() {
 
 String getGitAuthor() {
     return params.GIT_AUTHOR
+}
+
+String getCsType() {
+    return params.CS_TYPE
 }
 
 void sendEmail() {

--- a/.ci/jenkins/Jenkinsfile.turtle
+++ b/.ci/jenkins/Jenkinsfile.turtle
@@ -77,7 +77,7 @@ String getGitAuthor() {
 }
 
 String getCsType() {
-    return params.CS_TYPE
+    return env.CS_TYPE
 }
 
 void sendEmail() {

--- a/.ci/jenkins/dsl/jobs.groovy
+++ b/.ci/jenkins/dsl/jobs.groovy
@@ -257,12 +257,12 @@ void setupPostReleaseJob() {
 void setupOptaPlannerTurtleTestsJob(String csType) {
     def jobParams = KogitoJobUtils.getBasicJobParams(this, "optaplanner-turtle-tests-${csType}", Folder.OTHER, "${jenkins_path}/Jenkinsfile.turtle",
             "Run OptaPlanner turtle tests with CS-${csType} on a weekly basis.")
+    jobParams.env.put('CS_TYPE' : "${csType}")
     jobParams.triggers = [ cron : 'H H * * 5' ] // Run every Friday.
     KogitoJobTemplate.createPipelineJob(this, jobParams)?.with {
         parameters {
             stringParam('BUILD_BRANCH_NAME', "${GIT_BRANCH}", 'Git branch to checkout')
             stringParam('GIT_AUTHOR', "${GIT_AUTHOR_NAME}", 'Git author or an organization.')
-            stringParam('CS_TYPE', "${csType}", 'CS implementation type.')
         }
     }
 }

--- a/.ci/jenkins/dsl/jobs.groovy
+++ b/.ci/jenkins/dsl/jobs.groovy
@@ -254,10 +254,10 @@ void setupPostReleaseJob() {
     }
 }
 
-void setupOptaPlannerTurtleTestsJob(String csType) {
-    def jobParams = KogitoJobUtils.getBasicJobParams(this, "optaplanner-turtle-tests-${csType}", Folder.OTHER, "${jenkins_path}/Jenkinsfile.turtle",
-            "Run OptaPlanner turtle tests with CS-${csType} on a weekly basis.")
-    jobParams.env.put('CS_TYPE', "${csType}")
+void setupOptaPlannerTurtleTestsJob(String constraintStreamImplType) {
+    def jobParams = KogitoJobUtils.getBasicJobParams(this, "optaplanner-turtle-tests-${constraintStreamImplType}", Folder.OTHER, "${jenkins_path}/Jenkinsfile.turtle",
+            "Run OptaPlanner turtle tests with CS-${constraintStreamImplType} on a weekly basis.")
+    jobParams.env.put('CONSTRAINT_STREAM_IMPL_TYPE', "${constraintStreamImplType}")
     jobParams.triggers = [ cron : 'H H * * 5' ] // Run every Friday.
     KogitoJobTemplate.createPipelineJob(this, jobParams)?.with {
         parameters {

--- a/.ci/jenkins/dsl/jobs.groovy
+++ b/.ci/jenkins/dsl/jobs.groovy
@@ -257,7 +257,7 @@ void setupPostReleaseJob() {
 void setupOptaPlannerTurtleTestsJob(String csType) {
     def jobParams = KogitoJobUtils.getBasicJobParams(this, "optaplanner-turtle-tests-${csType}", Folder.OTHER, "${jenkins_path}/Jenkinsfile.turtle",
             "Run OptaPlanner turtle tests with CS-${csType} on a weekly basis.")
-    jobParams.env.put('CS_TYPE' : "${csType}")
+    jobParams.env.put('CS_TYPE', "${csType}")
     jobParams.triggers = [ cron : 'H H * * 5' ] // Run every Friday.
     KogitoJobTemplate.createPipelineJob(this, jobParams)?.with {
         parameters {

--- a/.ci/jenkins/dsl/jobs.groovy
+++ b/.ci/jenkins/dsl/jobs.groovy
@@ -73,7 +73,8 @@ setupPromoteJob(Folder.RELEASE)
 setupPostReleaseJob()
 
 if (Utils.isMainBranch(this)) {
-    setupOptaPlannerTurtleTestsJob()
+    setupOptaPlannerTurtleTestsJob('drools')
+    setupOptaPlannerTurtleTestsJob('bavet')
 }
 
 // Tools folder
@@ -253,14 +254,15 @@ void setupPostReleaseJob() {
     }
 }
 
-void setupOptaPlannerTurtleTestsJob() {
-    def jobParams = KogitoJobUtils.getBasicJobParams(this, 'optaplanner-turtle-tests', Folder.OTHER, "${jenkins_path}/Jenkinsfile.turtle",
-            'Run OptaPlanner turtle tests on a weekly basis.')
+void setupOptaPlannerTurtleTestsJob(String csType) {
+    def jobParams = KogitoJobUtils.getBasicJobParams(this, "optaplanner-turtle-tests-${csType}", Folder.OTHER, "${jenkins_path}/Jenkinsfile.turtle",
+            "Run OptaPlanner turtle tests with CS-${csType} on a weekly basis.")
     jobParams.triggers = [ cron : 'H H * * 5' ] // Run every Friday.
     KogitoJobTemplate.createPipelineJob(this, jobParams)?.with {
         parameters {
             stringParam('BUILD_BRANCH_NAME', "${GIT_BRANCH}", 'Git branch to checkout')
             stringParam('GIT_AUTHOR', "${GIT_AUTHOR_NAME}", 'Git author or an organization.')
+            stringParam('CS_TYPE', "${csType}", 'CS implementation type.')
         }
     }
 }

--- a/optaplanner-examples/src/test/java/org/optaplanner/examples/cheaptime/app/CheapTimeSolveAllTurtleTest.java
+++ b/optaplanner-examples/src/test/java/org/optaplanner/examples/cheaptime/app/CheapTimeSolveAllTurtleTest.java
@@ -16,8 +16,6 @@
 
 package org.optaplanner.examples.cheaptime.app;
 
-import org.optaplanner.core.api.score.stream.ConstraintStreamImplType;
-import org.optaplanner.core.config.solver.SolverConfig;
 import org.optaplanner.examples.cheaptime.domain.CheapTimeSolution;
 import org.optaplanner.examples.cheaptime.optional.score.CheapTimeEasyScoreCalculator;
 import org.optaplanner.examples.common.app.CommonApp;

--- a/optaplanner-examples/src/test/java/org/optaplanner/examples/cheaptime/app/CheapTimeSolveAllTurtleTest.java
+++ b/optaplanner-examples/src/test/java/org/optaplanner/examples/cheaptime/app/CheapTimeSolveAllTurtleTest.java
@@ -16,6 +16,8 @@
 
 package org.optaplanner.examples.cheaptime.app;
 
+import org.optaplanner.core.api.score.stream.ConstraintStreamImplType;
+import org.optaplanner.core.config.solver.SolverConfig;
 import org.optaplanner.examples.cheaptime.domain.CheapTimeSolution;
 import org.optaplanner.examples.cheaptime.optional.score.CheapTimeEasyScoreCalculator;
 import org.optaplanner.examples.common.app.CommonApp;
@@ -31,5 +33,10 @@ class CheapTimeSolveAllTurtleTest extends UnsolvedDirSolveAllTurtleTest<CheapTim
     @Override
     protected Class<CheapTimeEasyScoreCalculator> overwritingEasyScoreCalculatorClass() {
         return CheapTimeEasyScoreCalculator.class;
+    }
+
+    @Override
+    protected boolean supportsBavet() {
+        return false;
     }
 }

--- a/optaplanner-examples/src/test/java/org/optaplanner/examples/common/TestSystemProperties.java
+++ b/optaplanner-examples/src/test/java/org/optaplanner/examples/common/TestSystemProperties.java
@@ -19,7 +19,7 @@ package org.optaplanner.examples.common;
 public final class TestSystemProperties {
 
     public static final String MOVE_THREAD_COUNTS = "moveThreadCounts";
-    public static final String CONSTRAINT_STREAM_TYPE = "csType";
+    public static final String CONSTRAINT_STREAM_IMPL_TYPE = "constraintStreamImplType";
     public static final String RUN_TURTLE_TESTS = "runTurtleTests";
     public static final String MOVE_THREAD_COUNT = "moveThreadCount";
 

--- a/optaplanner-examples/src/test/java/org/optaplanner/examples/common/TestSystemProperties.java
+++ b/optaplanner-examples/src/test/java/org/optaplanner/examples/common/TestSystemProperties.java
@@ -19,7 +19,7 @@ package org.optaplanner.examples.common;
 public final class TestSystemProperties {
 
     public static final String MOVE_THREAD_COUNTS = "moveThreadCounts";
-
+    public static final String CONSTRAINT_STREAM_TYPE = "csType";
     public static final String RUN_TURTLE_TESTS = "runTurtleTests";
     public static final String MOVE_THREAD_COUNT = "moveThreadCount";
 

--- a/optaplanner-examples/src/test/java/org/optaplanner/examples/common/app/SolveAllTurtleTest.java
+++ b/optaplanner-examples/src/test/java/org/optaplanner/examples/common/app/SolveAllTurtleTest.java
@@ -23,10 +23,12 @@ import java.util.List;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.TestFactory;
 import org.optaplanner.core.api.domain.solution.PlanningSolution;
 import org.optaplanner.core.api.score.calculator.EasyScoreCalculator;
+import org.optaplanner.core.api.score.stream.ConstraintStreamImplType;
 import org.optaplanner.core.api.solver.Solver;
 import org.optaplanner.core.api.solver.SolverFactory;
 import org.optaplanner.core.config.score.director.ScoreDirectorFactoryConfig;
@@ -68,6 +70,8 @@ public abstract class SolveAllTurtleTest<Solution_> extends LoggingTest {
     }
 
     public void runFastAndFullAssert(SolverConfig solverConfig, Solution_ problem) {
+        checkIfSupportsBavet(solverConfig);
+
         // Specifically use NON_INTRUSIVE_FULL_ASSERT instead of FULL_ASSERT to flush out bugs hidden by intrusiveness
         // 1) NON_INTRUSIVE_FULL_ASSERT ASSERT to find CH bugs (but covers little ground)
         problem = buildAndSolve(solverConfig, EnvironmentMode.NON_INTRUSIVE_FULL_ASSERT, problem, 2L);
@@ -77,14 +81,36 @@ public abstract class SolveAllTurtleTest<Solution_> extends LoggingTest {
         problem = buildAndSolve(solverConfig, EnvironmentMode.NON_INTRUSIVE_FULL_ASSERT, problem, 3L);
     }
 
+    protected boolean supportsBavet() {
+        return true;
+    }
+    protected void checkIfSupportsBavet(SolverConfig solverConfig) {
+        ConstraintStreamImplType constraintStreamImplType =
+                solverConfig.getScoreDirectorFactoryConfig().getConstraintStreamImplType();
+        boolean isBavet = solverConfig.getScoreDirectorFactoryConfig().getConstraintProviderClass() != null &&
+                constraintStreamImplType == ConstraintStreamImplType.BAVET;
+        Assumptions.assumeTrue(!isBavet || supportsBavet(),
+                "The test (" + getClass().getSimpleName() + ") does not support the CS-B.");
+    }
+
     private static SolverConfig buildSolverConfig(String solverConfigResource) {
         SolverConfig solverConfig = SolverConfig.createFromXmlResource(solverConfigResource);
+        if (solverConfig.getScoreDirectorFactoryConfig().getConstraintProviderClass() != null) {
+            solverConfig.getScoreDirectorFactoryConfig().setConstraintStreamImplType(resolveConstraintStreamType());
+        }
         // buildAndSolve() fills in minutesSpentLimit
         solverConfig.setTerminationConfig(new TerminationConfig());
         if (MOVE_THREAD_COUNT_OVERRIDE != null) {
             solverConfig.setMoveThreadCount(MOVE_THREAD_COUNT_OVERRIDE);
         }
         return solverConfig;
+    }
+
+    private static ConstraintStreamImplType resolveConstraintStreamType() {
+        String  csImplProperty = System.getProperty(TestSystemProperties.CONSTRAINT_STREAM_TYPE,
+                        ConstraintStreamImplType.DROOLS.name()).trim().toUpperCase();
+        return csImplProperty.equals(ConstraintStreamImplType.DROOLS.name()) ? ConstraintStreamImplType.DROOLS :
+                ConstraintStreamImplType.BAVET;
     }
 
     private Solution_ buildAndSolve(SolverConfig solverConfig, EnvironmentMode environmentMode,

--- a/optaplanner-examples/src/test/java/org/optaplanner/examples/common/app/SolveAllTurtleTest.java
+++ b/optaplanner-examples/src/test/java/org/optaplanner/examples/common/app/SolveAllTurtleTest.java
@@ -107,7 +107,7 @@ public abstract class SolveAllTurtleTest<Solution_> extends LoggingTest {
     }
 
     private static ConstraintStreamImplType resolveConstraintStreamType() {
-        String  csImplProperty = System.getProperty(TestSystemProperties.CONSTRAINT_STREAM_TYPE,
+        String  csImplProperty = System.getProperty(TestSystemProperties.CONSTRAINT_STREAM_IMPL_TYPE,
                         ConstraintStreamImplType.DROOLS.name()).trim().toUpperCase();
         return csImplProperty.equals(ConstraintStreamImplType.DROOLS.name()) ? ConstraintStreamImplType.DROOLS :
                 ConstraintStreamImplType.BAVET;

--- a/optaplanner-examples/src/test/java/org/optaplanner/examples/common/app/SolveAllTurtleTest.java
+++ b/optaplanner-examples/src/test/java/org/optaplanner/examples/common/app/SolveAllTurtleTest.java
@@ -84,6 +84,7 @@ public abstract class SolveAllTurtleTest<Solution_> extends LoggingTest {
     protected boolean supportsBavet() {
         return true;
     }
+
     protected void checkIfSupportsBavet(SolverConfig solverConfig) {
         ConstraintStreamImplType constraintStreamImplType =
                 solverConfig.getScoreDirectorFactoryConfig().getConstraintStreamImplType();
@@ -107,10 +108,10 @@ public abstract class SolveAllTurtleTest<Solution_> extends LoggingTest {
     }
 
     private static ConstraintStreamImplType resolveConstraintStreamType() {
-        String  csImplProperty = System.getProperty(TestSystemProperties.CONSTRAINT_STREAM_IMPL_TYPE,
-                        ConstraintStreamImplType.DROOLS.name()).trim().toUpperCase();
-        return csImplProperty.equals(ConstraintStreamImplType.DROOLS.name()) ? ConstraintStreamImplType.DROOLS :
-                ConstraintStreamImplType.BAVET;
+        String csImplProperty = System.getProperty(TestSystemProperties.CONSTRAINT_STREAM_IMPL_TYPE,
+                ConstraintStreamImplType.DROOLS.name()).trim().toUpperCase();
+        return csImplProperty.equals(ConstraintStreamImplType.DROOLS.name()) ? ConstraintStreamImplType.DROOLS
+                : ConstraintStreamImplType.BAVET;
     }
 
     private Solution_ buildAndSolve(SolverConfig solverConfig, EnvironmentMode environmentMode,

--- a/optaplanner-examples/src/test/java/org/optaplanner/examples/nurserostering/app/NurseRosteringSolveAllTurtleTest.java
+++ b/optaplanner-examples/src/test/java/org/optaplanner/examples/nurserostering/app/NurseRosteringSolveAllTurtleTest.java
@@ -26,4 +26,9 @@ class NurseRosteringSolveAllTurtleTest extends UnsolvedDirSolveAllTurtleTest<Nur
     protected CommonApp<NurseRoster> createCommonApp() {
         return new NurseRosteringApp();
     }
+
+    @Override
+    protected boolean supportsBavet() {
+        return false;
+    }
 }

--- a/optaplanner-examples/src/test/java/org/optaplanner/examples/projectjobscheduling/app/ProjectJobSchedulingSolveAllTurtleTest.java
+++ b/optaplanner-examples/src/test/java/org/optaplanner/examples/projectjobscheduling/app/ProjectJobSchedulingSolveAllTurtleTest.java
@@ -26,4 +26,9 @@ class ProjectJobSchedulingSolveAllTurtleTest extends UnsolvedDirSolveAllTurtleTe
     protected CommonApp<Schedule> createCommonApp() {
         return new ProjectJobSchedulingApp();
     }
+
+    @Override
+    protected boolean supportsBavet() {
+        return false;
+    }
 }


### PR DESCRIPTION
The goal is to have two turtle test jobs: one with ConstraintStreams-Drools and the other one with ConstraintStreams-Bavet.

<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.
-->

### JIRA
https://issues.redhat.com/browse/PLANNER-2730

<!-- Add a JIRA ticket link if it exists. -->
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
- https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
- https://github.com/kiegroup/drools/pull/3000
- https://github.com/kiegroup/optaplanner/pull/899
- etc.
-->

### Checklist
- [ ] Documentation updated if applicable.
- [ ] Upgrade recipe provided if applicable.

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request checks</b>  
  Please add comment: <b>Jenkins retest this</b>

- for a <b>specific pull request check</b>  
  please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] tests</b>
  
- for a <b>full downstream build</b> 
  - for <b>jenkins</b> job: 
    please add comment: <b>Jenkins run fdb</b>
  - for <b>github actions</b> job: 
    add the label `run_fdb`

- for a <b>compile downstream build</b>  
  please add comment: <b>Jenkins run cdb</b>

- for a <b>full production downstream build</b>  
  please add comment: <b>Jenkins execute product fdb</b>

- for an <b>upstream build</b>  
  please add comment: <b>Jenkins run upstream</b>

- for <b>quarkus branch checks</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins run quarkus-branch</b>

- for a <b>quarkus branch specific check</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] quarkus-branch</b>

- for <b>quarkus main checks</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins run quarkus-main</b>

- for a <b>specific quarkus main check</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] quarkus-branch</b>

- for <b>native checks</b>  
  Run native checks  
  Please add comment: <b>Jenkins run native</b>

- for a <b>specific native check</b>  
  Run native checks 
  Please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] native</b>

- for <b>mandrel checks</b>  
  Run native checks against Mandrel image
  Please add comment: <b>Jenkins run mandrel</b>

- for a <b>specific mandrel check</b>  
  Run native checks against Mandrel image  
  Please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] mandrel</b>
</details>

### CI Status

 You can check OptaPlanner repositories CI status from [Chain Status webpage](https://kiegroup.github.io/optaplanner/).