### PR TITLE
PLANNER-2734: Make Solution Cloner clone implementations of entity interfaces

### DIFF
--- a/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/main/java/org/optaplanner/quarkus/deployment/GizmoMemberAccessorEntityEnhancer.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/main/java/org/optaplanner/quarkus/deployment/GizmoMemberAccessorEntityEnhancer.java
@@ -321,6 +321,8 @@ public class GizmoMemberAccessorEntityEnhancer {
                 Class<?> entityClass = (Class<?>) entityClassObject;
                 Collection<ClassInfo> classInfoCollection;
 
+                // getAllKnownSubclasses returns an empty collection for interfaces (silent failure); thus:
+                // for interfaces, we use getAllKnownImplementors; otherwise we use getAllKnownSubclasses
                 if (entityClass.isInterface()) {
                     classInfoCollection = indexView.getAllKnownImplementors(DotName.createSimple(entityClass.getName()));
                 } else {

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/main/java/org/optaplanner/quarkus/deployment/GizmoMemberAccessorEntityEnhancer.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/main/java/org/optaplanner/quarkus/deployment/GizmoMemberAccessorEntityEnhancer.java
@@ -319,8 +319,14 @@ public class GizmoMemberAccessorEntityEnhancer {
             Set<Class<?>> solutionAndEntitySubclassSet = new HashSet<>(solutionSubclassesList);
             for (Object entityClassObject : solutionDescriptor.getEntityClassSet()) {
                 Class<?> entityClass = (Class<?>) entityClassObject;
-                Collection<ClassInfo> classInfoCollection =
-                        indexView.getAllKnownSubclasses(DotName.createSimple(entityClass.getName()));
+                Collection<ClassInfo> classInfoCollection;
+
+                if (entityClass.isInterface()) {
+                    classInfoCollection = indexView.getAllKnownImplementors(DotName.createSimple(entityClass.getName()));
+                } else {
+                    classInfoCollection = indexView.getAllKnownSubclasses(DotName.createSimple(entityClass.getName()));
+                }
+
                 classInfoCollection.stream().map(classInfo -> {
                     try {
                         return Class.forName(classInfo.name().toString(), false,

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/test/java/org/optaplanner/quarkus/OptaPlannerProcessorInterfaceEntityTest.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/test/java/org/optaplanner/quarkus/OptaPlannerProcessorInterfaceEntityTest.java
@@ -1,0 +1,55 @@
+package org.optaplanner.quarkus;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import javax.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.optaplanner.core.api.solver.SolverFactory;
+import org.optaplanner.quarkus.testdata.interfaceentity.domain.TestdataInterfaceEntity;
+import org.optaplanner.quarkus.testdata.interfaceentity.domain.TestdataInterfaceEntityImplementation;
+import org.optaplanner.quarkus.testdata.interfaceentity.domain.TestdataInterfaceEntitySolution;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+class OptaPlannerProcessorInterfaceEntityTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .overrideConfigKey("quarkus.optaplanner.solver.termination.best-score-limit", "0")
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addPackages(true, "org.optaplanner.quarkus.testdata.interfaceentity"));
+
+    @Inject
+    SolverFactory<TestdataInterfaceEntitySolution> solverFactory;
+
+    @Test
+    void buildSolver() {
+        TestdataInterfaceEntitySolution problem = new TestdataInterfaceEntitySolution();
+        List<TestdataInterfaceEntity> entityList = IntStream.range(1, 3)
+                .mapToObj(i -> new TestdataInterfaceEntityImplementation())
+                .collect(Collectors.toList());
+
+        problem.setValueList(IntStream.range(0, 3)
+                .boxed()
+                .collect(Collectors.toList()));
+        problem.setEntityList(entityList);
+
+        TestdataInterfaceEntitySolution solution = solverFactory.buildSolver().solve(problem);
+        assertNotNull(solution);
+
+        assertEquals(entityList.size(), solution.getEntityList().size());
+        for (int i = 0; i < entityList.size(); i++) {
+            assertNotSame(entityList.get(i), solution.getEntityList().get(i));
+        }
+    }
+}

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/test/java/org/optaplanner/quarkus/testdata/interfaceentity/constraints/TestdataInterfaceEntityConstraintProvider.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/test/java/org/optaplanner/quarkus/testdata/interfaceentity/constraints/TestdataInterfaceEntityConstraintProvider.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.quarkus.testdata.interfaceentity.constraints;
+
+import org.optaplanner.core.api.score.buildin.simple.SimpleScore;
+import org.optaplanner.core.api.score.stream.Constraint;
+import org.optaplanner.core.api.score.stream.ConstraintFactory;
+import org.optaplanner.core.api.score.stream.ConstraintProvider;
+import org.optaplanner.quarkus.testdata.interfaceentity.domain.TestdataInterfaceEntity;
+
+public class TestdataInterfaceEntityConstraintProvider implements ConstraintProvider {
+
+    @Override
+    public Constraint[] defineConstraints(ConstraintFactory constraintFactory) {
+        return new Constraint[] {
+                constraintFactory.forEach(TestdataInterfaceEntity.class)
+                        .penalize("Minimize value", SimpleScore.ONE, TestdataInterfaceEntity::getValue)
+        };
+    }
+}

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/test/java/org/optaplanner/quarkus/testdata/interfaceentity/domain/TestdataInterfaceEntity.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/test/java/org/optaplanner/quarkus/testdata/interfaceentity/domain/TestdataInterfaceEntity.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.quarkus.testdata.interfaceentity.domain;
+
+import org.optaplanner.core.api.domain.entity.PlanningEntity;
+import org.optaplanner.core.api.domain.variable.PlanningVariable;
+
+@PlanningEntity
+public interface TestdataInterfaceEntity {
+
+    @PlanningVariable(valueRangeProviderRefs = "valueRange")
+    Integer getValue();
+
+    void setValue(Integer value);
+}

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/test/java/org/optaplanner/quarkus/testdata/interfaceentity/domain/TestdataInterfaceEntityImplementation.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/test/java/org/optaplanner/quarkus/testdata/interfaceentity/domain/TestdataInterfaceEntityImplementation.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.quarkus.testdata.interfaceentity.domain;
+
+public class TestdataInterfaceEntityImplementation implements TestdataInterfaceEntity {
+
+    Integer value;
+
+    public TestdataInterfaceEntityImplementation() {
+    }
+
+    public TestdataInterfaceEntityImplementation(Integer value) {
+        this.value = value;
+    }
+
+    @Override
+    public Integer getValue() {
+        return value;
+    }
+
+    @Override
+    public void setValue(Integer value) {
+        this.value = value;
+    }
+}

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/test/java/org/optaplanner/quarkus/testdata/interfaceentity/domain/TestdataInterfaceEntitySolution.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/test/java/org/optaplanner/quarkus/testdata/interfaceentity/domain/TestdataInterfaceEntitySolution.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.quarkus.testdata.interfaceentity.domain;
+
+import java.util.List;
+
+import org.optaplanner.core.api.domain.solution.PlanningEntityCollectionProperty;
+import org.optaplanner.core.api.domain.solution.PlanningScore;
+import org.optaplanner.core.api.domain.solution.PlanningSolution;
+import org.optaplanner.core.api.domain.valuerange.ValueRangeProvider;
+import org.optaplanner.core.api.score.buildin.simple.SimpleScore;
+
+@PlanningSolution
+public class TestdataInterfaceEntitySolution {
+
+    @PlanningEntityCollectionProperty
+    List<TestdataInterfaceEntity> entityList;
+
+    @ValueRangeProvider(id = "valueRange")
+    List<Integer> valueList;
+
+    @PlanningScore
+    SimpleScore score;
+
+    public TestdataInterfaceEntitySolution() {
+    }
+
+    public TestdataInterfaceEntitySolution(List<TestdataInterfaceEntity> entityList, List<Integer> valueList) {
+        this.entityList = entityList;
+        this.valueList = valueList;
+    }
+
+    public List<TestdataInterfaceEntity> getEntityList() {
+        return entityList;
+    }
+
+    public void setEntityList(List<TestdataInterfaceEntity> entityList) {
+        this.entityList = entityList;
+    }
+
+    public List<Integer> getValueList() {
+        return valueList;
+    }
+
+    public void setValueList(List<Integer> valueList) {
+        this.valueList = valueList;
+    }
+
+    public SimpleScore getScore() {
+        return score;
+    }
+
+    public void setScore(SimpleScore score) {
+        this.score = score;
+    }
+}


### PR DESCRIPTION
IndexView.getAllKnownSubclasses() does not get implementations for
interfaces, causing a bug in the generated SolutionCloner where implementations
of an interface PlanningEntity were not cloned. To fix it,
IndexView.getAllKnownImplementors() need to be used instead for
interfaces.

<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.
-->

### JIRA

<!-- Add a JIRA ticket link if it exists. -->
https://issues.redhat.com/browse/PLANNER-2734

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
- https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
- https://github.com/kiegroup/drools/pull/3000
- https://github.com/kiegroup/optaplanner/pull/899
- etc.
-->

### Checklist
- [ ] Documentation updated if applicable.
- [ ] Upgrade recipe provided if applicable.

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request checks</b>  
  Please add comment: <b>Jenkins retest this</b>

- for a <b>specific pull request check</b>  
  please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] tests</b>
  
- for a <b>full downstream build</b> 
  - for <b>jenkins</b> job: 
    please add comment: <b>Jenkins run fdb</b>
  - for <b>github actions</b> job: 
    add the label `run_fdb`

- for a <b>compile downstream build</b>  
  please add comment: <b>Jenkins run cdb</b>

- for a <b>full production downstream build</b>  
  please add comment: <b>Jenkins execute product fdb</b>

- for an <b>upstream build</b>  
  please add comment: <b>Jenkins run upstream</b>

- for <b>quarkus branch checks</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins run quarkus-branch</b>

- for a <b>quarkus branch specific check</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] quarkus-branch</b>

- for <b>quarkus main checks</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins run quarkus-main</b>

- for a <b>specific quarkus main check</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] quarkus-branch</b>

- for <b>native checks</b>  
  Run native checks  
  Please add comment: <b>Jenkins run native</b>

- for a <b>specific native check</b>  
  Run native checks 
  Please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] native</b>

- for <b>mandrel checks</b>  
  Run native checks against Mandrel image
  Please add comment: <b>Jenkins run mandrel</b>

- for a <b>specific mandrel check</b>  
  Run native checks against Mandrel image  
  Please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] mandrel</b>
</details>

### CI Status

 You can check OptaPlanner repositories CI status from [Chain Status webpage](https://kiegroup.github.io/optaplanner/).