### PR TITLE
[PLANNER-2727] Optaplanner depends on released version of Drools

### DIFF
--- a/.ci/jenkins/Jenkinsfile.deploy
+++ b/.ci/jenkins/Jenkinsfile.deploy
@@ -34,7 +34,7 @@ pipeline {
     environment {
         // Some generated env is also defined into .jenkins/dsl/jobs.groovy file
 
-        KOGITO_CI_EMAIL_TO = credentials("${JENKINS_EMAIL_CREDS_ID}")
+        OPTAPLANNER_CI_EMAIL_TO = credentials("${JENKINS_EMAIL_CREDS_ID}")
 
         MAVEN_OPTS = '-Xms1024m -Xmx4g'
 
@@ -57,7 +57,6 @@ pipeline {
                     if (isRelease() || isCreatePr()) {
                         // Verify version is set
                         assert getProjectVersion()
-                        assert getDroolsVersion()
 
                         if (isRelease()) {
                             // Verify if on right release branch
@@ -74,7 +73,6 @@ pipeline {
                         setDeployPropertyIfNeeded('git.author', getGitAuthor())
                         setDeployPropertyIfNeeded('project.version', getProjectVersion())
                         setDeployPropertyIfNeeded('release', isRelease())
-                        setDeployPropertyIfNeeded('drools.version', getDroolsVersion())
                     }
                 }
             }
@@ -107,7 +105,6 @@ pipeline {
             }
             steps {
                 script {
-                    maven.mvnSetVersionProperty(getOptaplannerMavenCommand(), 'version.org.drools', getDroolsVersion())
                     maven.mvnVersionsSet(getOptaplannerMavenCommand(), getProjectVersion(), !isRelease())
 
                     mavenCleanInstallOptaPlannerParents()
@@ -294,7 +291,7 @@ pipeline {
 
 void sendNotification() {
     if (params.SEND_NOTIFICATION) {
-        mailer.sendMarkdownTestSummaryNotification('Deploy', "[${getBuildBranch()}] Optaplanner", [env.KOGITO_CI_EMAIL_TO], "cc @*optaplanner-team*")
+        mailer.sendMarkdownTestSummaryNotification('Deploy', "[${getBuildBranch()}] Optaplanner", [env.OPTAPLANNER_CI_EMAIL_TO], "cc @*optaplanner-team*")
     } else {
         echo 'No notification sent per configuration'
     }
@@ -524,10 +521,6 @@ String getGitAuthor() {
 
 String getBuildBranch() {
     return params.BUILD_BRANCH_NAME
-}
-
-String getDroolsVersion() {
-    return params.DROOLS_VERSION
 }
 
 String getProjectVersion() {

--- a/.ci/jenkins/Jenkinsfile.drools
+++ b/.ci/jenkins/Jenkinsfile.drools
@@ -1,0 +1,170 @@
+@Library('jenkins-pipeline-shared-libraries')_
+
+import org.kie.jenkins.MavenCommand
+
+droolsRepo = 'drools'
+optaplannerRepo = 'optaplanner'
+quickstartsRepo = 'optaplanner-quickstarts'
+
+pipeline {
+    agent {
+        label 'kie-rhel7 && kie-mem16g'
+    }
+    environment {
+        // DROOLS_BRANCH should be defined directly into the job environment
+
+        OPTAPLANNER_CI_EMAIL_TO = credentials("${JENKINS_EMAIL_CREDS_ID}")
+
+        MAVEN_OPTS = '-Xms1024m -Xmx4g'
+    }
+    tools {
+        maven 'kie-maven-3.8.1'
+        jdk 'kie-jdk11'
+    }
+    options {
+        timestamps()
+        timeout(time: 360, unit: 'MINUTES')
+        disableConcurrentBuilds(abortPrevious: true)
+    }
+    stages {
+        stage('Initialize') {
+            steps {
+                script {
+                    checkoutDroolsRepo()
+                    checkoutOptaplannerRepo()
+                    checkoutOptaplannerQuickstartsRepo()
+                }
+            }
+        }
+        stage('Build drools') {
+            steps {
+                script {
+                    getMavenCommand(droolsRepo)
+                        .withProperty('quickly')
+                        .run('clean install')
+                }
+            }
+            post {
+                always {
+                    script {
+                        cleanContainers()
+                    }
+                }
+            }
+        }
+
+        stage('Retrieve drools snapshot version') {
+            steps {
+                script {
+                    dir(droolsRepo) {
+                        // query mvn to get the latest version
+                        env.DROOLS_VERSION = """${sh (
+                                script: 'mvn org.apache.maven.plugins:maven-help-plugin:3.2.0:evaluate -Dexpression=project.version -q -DforceStdout',
+                                returnStdout: true
+                            ).trim()}"""
+                        assert env.DROOLS_VERSION != ''
+                        echo "Drools version is: ${env.DROOLS_VERSION}"
+                    }
+                }
+            }
+        }
+
+        stage('Build optaplanner') {
+            steps {
+                script {
+                    getMavenCommand(optaplannerRepo)
+                        .withProperty('maven.test.failure.ignore', true)
+                        .withProperty('version.org.drools', env.DROOLS_VERSION)
+                        .run('clean install')
+                }
+            }
+            post {
+                always {
+                    script {
+                        junit testResults: '**/target/surefire-reports/**/*.xml, **/target/failsafe-reports/**/*.xml', allowEmptyResults: true
+                        util.archiveConsoleLog()
+                        cleanContainers()
+                    }
+                }
+            }
+        }
+
+        stage('Build optaplanner-quickstarts') {
+            steps {
+                script {
+                    getMavenCommand(quickstartsRepo)
+                        .withProperty('maven.test.failure.ignore', true)
+                        .withProperty('version.org.drools', env.DROOLS_VERSION)
+                        .run('clean install')
+                }
+            }
+            post {
+                always {
+                    script {
+                        cleanContainers()
+                    }
+                }
+            }
+        }
+    }
+    post {
+        unsuccessful {
+            sendNotification()
+        }
+        cleanup {
+            script {
+                util.cleanNode('docker')
+            }
+        }
+    }
+}
+
+void sendNotification() {
+    mailer.sendMarkdownTestSummaryNotification("${NOTIFICATION_JOB_NAME}", "[${getBuildBranch()}] Optaplanner", [env.OPTAPLANNER_CI_EMAIL_TO])
+}
+
+void checkoutOptaplannerRepo() {
+    dir(optaplannerRepo) {
+        checkout(githubscm.resolveRepository(optaplannerRepo, params.GIT_AUTHOR, getBuildBranch(), false))
+    }
+}
+
+void checkoutOptaplannerQuickstartsRepo() {
+    // If the PR to OptaPlanner targets the 'main' branch, we assume the branch 'development' for quickstarts.
+    String quickstartsChangeTarget = getBuildBranch() != 'main' ?: 'development'
+
+    dir(quickstartsRepo) {
+        checkout(githubscm.resolveRepository(quickstartsRepo, params.GIT_AUTHOR, quickstartsChangeTarget, false))
+    }
+}
+
+void checkoutDroolsRepo() {
+    dir(droolsRepo) {
+        checkout(githubscm.resolveRepository(droolsRepo, 'kiegroup', getDroolsBranch(), false))
+    }
+}
+
+MavenCommand getMavenCommand(String directory) {
+    def mvnCmd = new MavenCommand(this, ['-fae', '-ntp'])
+                .withSettingsXmlId('kogito_release_settings')
+                // `-Dquarkus.bootstrap.effective-model-builder` is a temporary fix due to quarkus resolver on tests
+                // https://github.com/quarkusio/quarkus/issues/23205
+                .withProperty('quarkus.bootstrap.effective-model-builder', true)
+                .inDirectory(directory)
+    if (env.BUILD_MVN_OPTS) {
+        mvnCmd.withOptions([ env.BUILD_MVN_OPTS ])
+    }
+    return mvnCmd
+}
+
+String getBuildBranch() {
+    return params.BUILD_BRANCH_NAME
+}
+
+String getDroolsBranch() {
+    return env['DROOLS_BRANCH'] ?: 'main'
+}
+
+void cleanContainers() {
+    cloud.cleanContainersAndImages('docker')
+}

--- a/.ci/jenkins/Jenkinsfile.native
+++ b/.ci/jenkins/Jenkinsfile.native
@@ -4,7 +4,6 @@ import org.kie.jenkins.MavenCommand
 
 optaplannerRepo = 'optaplanner'
 quickstartsRepo = 'optaplanner-quickstarts'
-droolsRepo = 'drools'
 
 pipeline {
     agent {
@@ -20,31 +19,14 @@ pipeline {
         disableConcurrentBuilds(abortPrevious: true)
     }
     environment {
-        KOGITO_CI_EMAIL_TO = credentials("${JENKINS_EMAIL_CREDS_ID}")
+        OPTAPLANNER_CI_EMAIL_TO = credentials("${JENKINS_EMAIL_CREDS_ID}")
     }
     stages {
         stage('Initialize') {
             steps {
                 script {
-                    checkoutDroolsRepo()
                     checkoutOptaplannerRepo()
                     checkoutOptaplannerQuickstartsRepo()
-                }
-            }
-        }
-        stage('Build quickly drools') {
-            steps {
-                script {
-                    getMavenCommand(droolsRepo)
-                        .withProperty('quickly')
-                        .run('clean install')
-                }
-            }
-            post {
-                always {
-                    script {
-                        cleanContainers()
-                    }
                 }
             }
         }
@@ -100,50 +82,26 @@ pipeline {
 }
 
 void sendNotification() {
-    mailer.sendMarkdownTestSummaryNotification("${NOTIFICATION_JOB_NAME}", "[${params.BUILD_BRANCH_NAME}] Optaplanner", [env.KOGITO_CI_EMAIL_TO], "cc @*optaplanner-team*")
+    mailer.sendMarkdownTestSummaryNotification("${NOTIFICATION_JOB_NAME}", "[${params.BUILD_BRANCH_NAME}] Optaplanner", [env.OPTAPLANNER_CI_EMAIL_TO], "cc @*optaplanner-team*")
 }
 
 void checkoutOptaplannerRepo() {
     dir(optaplannerRepo) {
-        checkout(githubscm.resolveRepository(optaplannerRepo, params.GIT_AUTHOR, getOptaplannerTargetBranch(), false))
+        checkout(githubscm.resolveRepository(optaplannerRepo, params.GIT_AUTHOR, getBuildBranch(), false))
     }
 }
 
 void checkoutOptaplannerQuickstartsRepo() {
     // If the PR to OptaPlanner targets the 'main' branch, we assume the branch 'development' for quickstarts.
-    String quickstartsChangeTarget = params.BUILD_BRANCH_NAME == 'main' ? 'development' : getOptaplannerTargetBranch()
+    String quickstartsChangeTarget = params.BUILD_BRANCH_NAME == 'main' ? 'development' : getBuildBranch()
 
     dir(quickstartsRepo) {
         checkout(githubscm.resolveRepository(quickstartsRepo, params.GIT_AUTHOR, quickstartsChangeTarget, false))
     }
 }
 
-void checkoutDroolsRepo() {
-    dir(droolsRepo) {
-        checkout(githubscm.resolveRepository(droolsRepo, params.GIT_AUTHOR, getDroolsTargetBranch(), false))
-    }
-}
-
-String getOptaplannerTargetBranch() {
-    return getTargetBranch(0)
-}
-
-String getDroolsTargetBranch() {
-    return getTargetBranch(0)
-}
-
-String getTargetBranch(Integer addToMajor) {
-    String targetBranch = params.BUILD_BRANCH_NAME
-    String [] versionSplit = targetBranch.split("\\.")
-    if (versionSplit.length == 3
-        && versionSplit[0].isNumber()
-        && versionSplit[1].isNumber()
-        && versionSplit[2] == 'x') {
-        targetBranch = "${Integer.parseInt(versionSplit[0]) + addToMajor}.${versionSplit[1]}.x"
-    } else {
-        echo "Cannot parse targetBranch as release branch so going further with current value: ${targetBranch}"
-        }
-    return targetBranch
+String getBuildBranch() {
+    return params.BUILD_BRANCH_NAME
 }
 
 MavenCommand getMavenCommand(String directory) {

--- a/.ci/jenkins/Jenkinsfile.post-release
+++ b/.ci/jenkins/Jenkinsfile.post-release
@@ -31,7 +31,7 @@ pipeline {
     environment {
         // Some generated env is also defined into .jenkins/dsl/jobs.groovy file
 
-        KOGITO_CI_EMAIL_TO = credentials("${JENKINS_EMAIL_CREDS_ID}")
+        OPTAPLANNER_CI_EMAIL_TO = credentials("${JENKINS_EMAIL_CREDS_ID}")
 
         BOT_BRANCH_HASH = "${util.generateHash(10)}"
     }
@@ -131,7 +131,7 @@ pipeline {
 }
 
 void sendNotification() {
-    mailer.sendMarkdownTestSummaryNotification('Post-release', "[${getBuildBranch()}] Optaplanner", [env.KOGITO_CI_EMAIL_TO], 'cc @*optaplanner-team*')
+    mailer.sendMarkdownTestSummaryNotification('Post-release', "[${getBuildBranch()}] Optaplanner", [env.OPTAPLANNER_CI_EMAIL_TO], 'cc @*optaplanner-team*')
 }
 
 //////////////////////////////////////////////////////////////////////////////

--- a/.ci/jenkins/Jenkinsfile.promote
+++ b/.ci/jenkins/Jenkinsfile.promote
@@ -34,7 +34,7 @@ pipeline {
     environment {
         // Some generated env is also defined into .jenkins/dsl/jobs.groovy file
 
-        KOGITO_CI_EMAIL_TO = credentials("${JENKINS_EMAIL_CREDS_ID}")
+        OPTAPLANNER_CI_EMAIL_TO = credentials("${JENKINS_EMAIL_CREDS_ID}")
 
         BOT_BRANCH_HASH = "${util.generateHash(10)}"
     }
@@ -54,7 +54,6 @@ pipeline {
                     if (isRelease()) {
                         // Verify version is set and if on right release branch
                         assert getProjectVersion()
-                        assert getDroolsVersion()
 
                         assert getBuildBranch() == util.getReleaseBranchFromVersion(getProjectVersion())
                     }
@@ -170,7 +169,6 @@ pipeline {
                         prepareForPR(optaplannerRepository)
                         String nextSnapshotVersion = getNextMicroSnapshotVersion(getProjectVersion())
 
-                        maven.mvnSetVersionProperty(getMavenCommand(), 'version.org.drools', getNextMicroSnapshotVersion(getDroolsVersion()))
                         maven.mvnVersionsSet(getMavenCommand(), nextSnapshotVersion, true)
 
                         String prLink = commitAndCreatePR("[${getBuildBranch()}] Update snapshot version to ${nextMicroSnapshotVersion}")
@@ -269,7 +267,7 @@ pipeline {
 
 void sendNotification() {
     if (params.SEND_NOTIFICATION) {
-        mailer.sendMarkdownTestSummaryNotification('Promote', "[${getBuildBranch()}] Optaplanner", [env.KOGITO_CI_EMAIL_TO], "cc @*optaplanner-team*")
+        mailer.sendMarkdownTestSummaryNotification('Promote', "[${getBuildBranch()}] Optaplanner", [env.OPTAPLANNER_CI_EMAIL_TO], "cc @*optaplanner-team*")
     } else {
         echo 'No notification sent per configuration'
     }
@@ -328,10 +326,6 @@ boolean isRelease() {
 
 String getProjectVersion() {
     return getParamOrDeployProperty('PROJECT_VERSION', 'project.version')
-}
-
-String getDroolsVersion() {
-    return getParamOrDeployProperty('DROOLS_VERSION', 'drools.version')
 }
 
 String getNextMicroSnapshotVersion(String currentVersion) {

--- a/.ci/jenkins/Jenkinsfile.quarkus
+++ b/.ci/jenkins/Jenkinsfile.quarkus
@@ -1,0 +1,151 @@
+@Library('jenkins-pipeline-shared-libraries')_
+
+import org.kie.jenkins.MavenCommand
+
+quarkusRepo = 'quarkus'
+optaplannerRepo = 'optaplanner'
+quickstartsRepo = 'optaplanner-quickstarts'
+
+pipeline {
+    agent {
+        label 'kie-rhel7 && kie-mem16g'
+    }
+    environment {
+        // QUARKUS_BRANCH should be defined directly into the job environment
+
+        OPTAPLANNER_CI_EMAIL_TO = credentials("${JENKINS_EMAIL_CREDS_ID}")
+
+        MAVEN_OPTS = '-Xms1024m -Xmx4g'
+    }
+    tools {
+        maven 'kie-maven-3.8.1'
+        jdk 'kie-jdk11'
+    }
+    options {
+        timestamps()
+        timeout(time: 360, unit: 'MINUTES')
+        disableConcurrentBuilds(abortPrevious: true)
+    }
+    stages {
+        stage('Initialize') {
+            steps {
+                script {
+                    checkoutQuarkusRepo()
+                    checkoutOptaplannerRepo()
+                    checkoutOptaplannerQuickstartsRepo()
+                }
+            }
+        }
+        stage('Build quarkus') {
+            steps {
+                script {
+                    getMavenCommand(quarkusRepo, false)
+                        .withProperty('quickly')
+                        .run('clean install')
+                }
+            }
+            post {
+                always {
+                    script {
+                        cleanContainers()
+                    }
+                }
+            }
+        }
+
+        stage('Build optaplanner') {
+            steps {
+                script {
+                    getMavenCommand(optaplannerRepo)
+                        .withProperty('maven.test.failure.ignore', true)
+                        .run('clean install')
+                }
+            }
+            post {
+                always {
+                    script {
+                        junit testResults: '**/target/surefire-reports/**/*.xml, **/target/failsafe-reports/**/*.xml', allowEmptyResults: true
+                        util.archiveConsoleLog()
+                        cleanContainers()
+                    }
+                }
+            }
+        }
+
+        stage('Build optaplanner-quickstarts') {
+            steps {
+                script {
+                    getMavenCommand('optaplanner-quickstarts')
+                        .withProperty('maven.test.failure.ignore', true)
+                        .run('clean install')
+                }
+            }
+            post {
+                always {
+                    script {
+                        cleanContainers()
+                    }
+                }
+            }
+        }
+    }
+    post {
+        unsuccessful {
+            sendNotification()
+        }
+        cleanup {
+            script {
+                util.cleanNode('docker')
+            }
+        }
+    }
+}
+
+void sendNotification() {
+    mailer.sendMarkdownTestSummaryNotification("Quarkus ${getQuarkusBranch()}", "[${params.BUILD_BRANCH_NAME}] Optaplanner", [env.OPTAPLANNER_CI_EMAIL_TO])
+}
+
+void checkoutOptaplannerRepo() {
+    dir(optaplannerRepo) {
+        checkout(githubscm.resolveRepository(optaplannerRepo, params.GIT_AUTHOR, getOptaplannerTargetBranch(), false))
+    }
+}
+
+void checkoutOptaplannerQuickstartsRepo() {
+    // If the PR to OptaPlanner targets the 'main' branch, we assume the branch 'development' for quickstarts.
+    String quickstartsChangeTarget = params.BUILD_BRANCH_NAME == 'main' ? 'development' : getOptaplannerTargetBranch()
+
+    dir(quickstartsRepo) {
+        checkout(githubscm.resolveRepository(quickstartsRepo, params.GIT_AUTHOR, quickstartsChangeTarget, false))
+    }
+}
+
+void checkoutQuarkusRepo() {
+    dir('quarkus') {
+        checkout(githubscm.resolveRepository(quarkusRepo, 'quarkusio', getQuarkusBranch(), false))
+    }
+}
+
+MavenCommand getMavenCommand(String directory, boolean addQuarkusVersion=true) {
+    def mvnCmd = new MavenCommand(this, ['-fae', '-ntp'])
+                .withSettingsXmlId('kogito_release_settings')
+                // `-Dquarkus.bootstrap.effective-model-builder` is a temporary fix due to quarkus resolver on tests
+                // https://github.com/quarkusio/quarkus/issues/23205
+                .withProperty('quarkus.bootstrap.effective-model-builder', true)
+                .inDirectory(directory)
+    if (addQuarkusVersion) {
+        mvnCmd.withProperty('version.io.quarkus', '999-SNAPSHOT')
+    }
+    if (env.BUILD_MVN_OPTS) {
+        mvnCmd.withOptions([ env.BUILD_MVN_OPTS ])
+    }
+    return mvnCmd
+}
+
+String getQuarkusBranch() {
+    return env['QUARKUS_BRANCH'] ?: 'main'
+}
+
+void cleanContainers() {
+    cloud.cleanContainersAndImages('docker')
+}

--- a/.ci/jenkins/Jenkinsfile.quarkus
+++ b/.ci/jenkins/Jenkinsfile.quarkus
@@ -102,18 +102,18 @@ pipeline {
 }
 
 void sendNotification() {
-    mailer.sendMarkdownTestSummaryNotification("Quarkus ${getQuarkusBranch()}", "[${params.BUILD_BRANCH_NAME}] Optaplanner", [env.OPTAPLANNER_CI_EMAIL_TO])
+    mailer.sendMarkdownTestSummaryNotification("Quarkus ${getQuarkusBranch()}", "[${getBuildBranch()}] Optaplanner", [env.OPTAPLANNER_CI_EMAIL_TO])
 }
 
 void checkoutOptaplannerRepo() {
     dir(optaplannerRepo) {
-        checkout(githubscm.resolveRepository(optaplannerRepo, params.GIT_AUTHOR, getOptaplannerTargetBranch(), false))
+        checkout(githubscm.resolveRepository(optaplannerRepo, params.GIT_AUTHOR, getBuildBranch(), false))
     }
 }
 
 void checkoutOptaplannerQuickstartsRepo() {
     // If the PR to OptaPlanner targets the 'main' branch, we assume the branch 'development' for quickstarts.
-    String quickstartsChangeTarget = params.BUILD_BRANCH_NAME == 'main' ? 'development' : getOptaplannerTargetBranch()
+    String quickstartsChangeTarget = getBuildBranch() == 'main' ? 'development' : getBuildBranch()
 
     dir(quickstartsRepo) {
         checkout(githubscm.resolveRepository(quickstartsRepo, params.GIT_AUTHOR, quickstartsChangeTarget, false))
@@ -144,6 +144,10 @@ MavenCommand getMavenCommand(String directory, boolean addQuarkusVersion=true) {
 
 String getQuarkusBranch() {
     return env['QUARKUS_BRANCH'] ?: 'main'
+}
+
+String getBuildBranch() {
+    return params.BUILD_BRANCH_NAME
 }
 
 void cleanContainers() {

--- a/.ci/jenkins/dsl/jobs.groovy
+++ b/.ci/jenkins/dsl/jobs.groovy
@@ -66,6 +66,7 @@ setupPromoteJob(Folder.RELEASE)
 setupPostReleaseJob()
 
 if (Utils.isMainBranch(this)) {
+    setupOptaPlannerTurtleTestsJob('drools')
     setupOptaPlannerTurtleTestsJob('bavet')
 }
 

--- a/.ci/jenkins/dsl/jobs.groovy
+++ b/.ci/jenkins/dsl/jobs.groovy
@@ -30,13 +30,6 @@ Map getMultijobPRConfig(Folder jobFolder) {
                     DISABLE_SONARCLOUD: !Utils.isMainBranch(this),
                 ]
             ], [
-                id: 'kogito-apps',
-                repository: 'kogito-apps',
-                env : [
-                    BUILD_MVN_OPTS_CURRENT: jobFolder.isNative() || jobFolder.isMandrel() ? '-Poptaplanner-downstream,native' : '-Poptaplanner-downstream',
-                    ADDITIONAL_TIMEOUT: jobFolder.isNative() || jobFolder.isMandrel() ? '360' : '210',
-                ]
-            ], [
                 id: 'optaweb-employee-rostering',
                 repository: 'optaweb-employee-rostering'
             ], [
@@ -73,7 +66,6 @@ setupPromoteJob(Folder.RELEASE)
 setupPostReleaseJob()
 
 if (Utils.isMainBranch(this)) {
-    setupOptaPlannerTurtleTestsJob('drools')
     setupOptaPlannerTurtleTestsJob('bavet')
 }
 
@@ -81,6 +73,10 @@ if (Utils.isMainBranch(this)) {
 KogitoJobUtils.createQuarkusUpdateToolsJob(this, 'optaplanner', [
   modules: [ 'optaplanner-build-parent' ],
   properties: [ 'version.io.quarkus' ],
+])
+KogitoJobUtils.createVersionUpdateToolsJob(this, 'optaplanner', 'Drools', [
+  modules: [ 'optaplanner-build-parent' ],
+  properties: [ 'version.org.drools' ],
 ])
 
 /////////////////////////////////////////////////////////////////
@@ -172,7 +168,6 @@ void setupDeployJob(Folder jobFolder) {
 
             booleanParam('CREATE_PR', false, 'Should we create a PR with the changes ?')
             stringParam('PROJECT_VERSION', '', 'Optional if not RELEASE. If RELEASE, cannot be empty.')
-            stringParam('DROOLS_VERSION', '', 'Optional if not RELEASE. If RELEASE, cannot be empty.')
 
             if (jobFolder.isPullRequest()) {
                 stringParam('PR_TARGET_BRANCH', '', 'What is the target branch of the PR?')
@@ -216,7 +211,6 @@ void setupPromoteJob(Folder jobFolder) {
 
             // Release information which can override `deployment.properties`
             stringParam('PROJECT_VERSION', '', 'Override `deployment.properties`. Optional if not RELEASE. If RELEASE, cannot be empty.')
-            stringParam('DROOLS_VERSION', '', 'Optional if not RELEASE. If RELEASE, cannot be empty.')
 
             stringParam('GIT_TAG', '', 'Git tag to set, if different from PROJECT_VERSION')
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -44,7 +44,7 @@ How to retest this PR or trigger a specific build:
   Please add comment: <b>Jenkins retest this</b>
 
 - for a <b>specific pull request check</b>  
-  please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] tests</b>
+  please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] tests</b>
   
 - for a <b>full downstream build</b> 
   - for <b>jenkins</b> job: 
@@ -67,7 +67,7 @@ How to retest this PR or trigger a specific build:
 
 - for a <b>quarkus branch specific check</b>  
   Run checks against Quarkus current used branch  
-  Please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] quarkus-branch</b>
+  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] quarkus-branch</b>
 
 - for <b>quarkus main checks</b>  
   Run checks against Quarkus main branch  
@@ -75,7 +75,7 @@ How to retest this PR or trigger a specific build:
 
 - for a <b>specific quarkus main check</b>  
   Run checks against Quarkus main branch  
-  Please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] quarkus-branch</b>
+  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] quarkus-branch</b>
 
 - for <b>native checks</b>  
   Run native checks  
@@ -83,7 +83,7 @@ How to retest this PR or trigger a specific build:
 
 - for a <b>specific native check</b>  
   Run native checks 
-  Please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] native</b>
+  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] native</b>
 
 - for <b>mandrel checks</b>  
   Run native checks against Mandrel image
@@ -91,7 +91,7 @@ How to retest this PR or trigger a specific build:
 
 - for a <b>specific mandrel check</b>  
   Run native checks against Mandrel image  
-  Please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] mandrel</b>
+  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] mandrel</b>
 </details>
 
 ### CI Status

--- a/build/optaplanner-build-parent/pom.xml
+++ b/build/optaplanner-build-parent/pom.xml
@@ -20,7 +20,7 @@
     <!-- Dependencies -->
     <!-- ************************************************************************ -->
     <!-- SNAPSHOT and KIE dependency versions -->
-    <version.org.drools>8.22.1.Final</version.org.drools>
+    <version.org.drools>8.22.1.Beta</version.org.drools>
 
     <!-- Normal dependency versions -->
     <version.ch.qos.logback>1.2.9</version.ch.qos.logback>

--- a/build/optaplanner-build-parent/pom.xml
+++ b/build/optaplanner-build-parent/pom.xml
@@ -20,7 +20,7 @@
     <!-- Dependencies -->
     <!-- ************************************************************************ -->
     <!-- SNAPSHOT and KIE dependency versions -->
-    <version.org.drools>8.24.0-SNAPSHOT</version.org.drools>
+    <version.org.drools>8.22.1.Final</version.org.drools>
 
     <!-- Normal dependency versions -->
     <version.ch.qos.logback>1.2.9</version.ch.qos.logback>


### PR DESCRIPTION
Related PRs:
- https://github.com/kiegroup/kogito-pipelines/pull/464
- https://github.com/kiegroup/drools/pull/4437
- https://github.com/kiegroup/kogito-runtimes/pull/2243
- https://github.com/kiegroup/optaplanner/pull/2014
- https://github.com/kiegroup/kogito-apps/pull/1366

Jobs to test:
- [x] PR checks
- [x] Deploy job
- [x] Drools nightly job
- [x] Native nightly job
- [x] Post release job
- [x] Promote job
- [x] Quarkus nightly job
- [x] Update Drools version