### PR TITLE
Upgrade Java Operator SDK

### DIFF
--- a/build/optaplanner-build-parent/pom.xml
+++ b/build/optaplanner-build-parent/pom.xml
@@ -26,8 +26,8 @@
     <version.ch.qos.logback>1.2.9</version.ch.qos.logback>
     <version.org.apache.logging.log4j>2.17.2</version.org.apache.logging.log4j>
     <version.com.thoughtworks.xstream>1.4.19</version.com.thoughtworks.xstream>
-    <version.io.javaoperatorsdk>3.0.0.RC1</version.io.javaoperatorsdk>
-    <version.io.quarkiverse.operatorsdk>3.0.7</version.io.quarkiverse.operatorsdk>
+    <version.io.javaoperatorsdk>3.0.2</version.io.javaoperatorsdk>
+    <version.io.quarkiverse.operatorsdk>4.0.0.RC</version.io.quarkiverse.operatorsdk>
     <version.io.quarkus>2.9.2.Final</version.io.quarkus>
     <version.io.strimzi>0.28.0</version.io.strimzi>
     <version.org.apache.commons.math3>3.6.1</version.org.apache.commons.math3>

--- a/optaplanner-operator/src/main/java/org/optaplanner/operator/impl/solver/OptaPlannerSolverReconciler.java
+++ b/optaplanner-operator/src/main/java/org/optaplanner/operator/impl/solver/OptaPlannerSolverReconciler.java
@@ -37,6 +37,7 @@ import io.javaoperatorsdk.operator.api.reconciler.EventSourceContext;
 import io.javaoperatorsdk.operator.api.reconciler.EventSourceInitializer;
 import io.javaoperatorsdk.operator.api.reconciler.Reconciler;
 import io.javaoperatorsdk.operator.api.reconciler.UpdateControl;
+import io.javaoperatorsdk.operator.processing.dependent.kubernetes.KubernetesDependentResourceConfig;
 import io.javaoperatorsdk.operator.processing.event.source.EventSource;
 import io.strimzi.api.kafka.model.KafkaTopic;
 
@@ -57,6 +58,16 @@ public final class OptaPlannerSolverReconciler implements Reconciler<OptaPlanner
         inputKafkaTopicDependentResource = new KafkaTopicDependentResource(MessageAddress.INPUT, kubernetesClient);
         outputKafkaTopicDependentResource = new KafkaTopicDependentResource(MessageAddress.OUTPUT, kubernetesClient);
         configMapDependentResource = new ConfigMapDependentResource(kubernetesClient);
+
+        // The two dependent resource of the same type need to be differentiated by a label.
+        inputKafkaTopicDependentResource.configureWith(
+                new KubernetesDependentResourceConfig().setLabelSelector(getTopicSelector(MessageAddress.INPUT)));
+        outputKafkaTopicDependentResource.configureWith(
+                new KubernetesDependentResourceConfig().setLabelSelector(getTopicSelector(MessageAddress.OUTPUT)));
+    }
+
+    private String getTopicSelector(MessageAddress messageAddress) {
+        return KafkaTopicDependentResource.MESSAGE_ADDRESS_LABEL + "=" + messageAddress.getName();
     }
 
     @Override

--- a/optaplanner-operator/src/test/java/org/optaplanner/operator/impl/solver/OptaPlannerSolverReconcilerTest.java
+++ b/optaplanner-operator/src/test/java/org/optaplanner/operator/impl/solver/OptaPlannerSolverReconcilerTest.java
@@ -23,6 +23,10 @@ import static org.awaitility.Awaitility.await;
 import java.util.List;
 import java.util.Map;
 
+import javax.inject.Inject;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.optaplanner.operator.impl.solver.model.ConfigMapDependentResource;
 import org.optaplanner.operator.impl.solver.model.OptaPlannerSolver;
@@ -33,6 +37,7 @@ import org.optaplanner.operator.impl.solver.model.messaging.MessageAddress;
 import io.fabric8.kubernetes.api.model.ConfigMap;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.fabric8.kubernetes.client.server.mock.KubernetesServer;
+import io.javaoperatorsdk.operator.Operator;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.kubernetes.client.KubernetesTestServer;
 import io.quarkus.test.kubernetes.client.WithKubernetesTestServer;
@@ -44,8 +49,22 @@ public class OptaPlannerSolverReconcilerTest {
     @KubernetesTestServer
     KubernetesServer mockServer;
 
+    @Inject
+    Operator operator;
+
+    @BeforeEach
+    void startOperator() {
+        operator.start();
+    }
+
+    @AfterEach
+    void stopOperator() {
+        operator.stop();
+    }
+
     @Test
     void canReconcile() {
+
         final OptaPlannerSolver solver = new OptaPlannerSolver();
         final String solverName = "test-solver";
         solver.getMetadata().setName(solverName);

--- a/pom.xml
+++ b/pom.xml
@@ -142,7 +142,7 @@
     </profile>
     <profile>
       <!-- TODO: This profile excludes the optaplanner-operator module from the default build. Remove the profile when
-           the io.javaoperatorsdk:operator-framework-core:3.0.0.Final is released. -->
+           the io.quarkiverse.operatorsdk:quarkus-operator-sdk:4.0.0.Final is released. -->
       <id>operator</id>
       <activation>
         <property>


### PR DESCRIPTION
Upgrading the Java Operator SDK to the latest final version requires upgrading also the `io.quarkiverse.operatorsdk:quarkus-operator-sdk`. Unfortunately, there is no compatible final version yet (hopefully there will be one very soon).

Although we are trading one non-final version for another, it's still a step forward.

<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.
-->

### JIRA

<!-- Add a JIRA ticket link if it exists. -->
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
- https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
- https://github.com/kiegroup/drools/pull/3000
- https://github.com/kiegroup/optaplanner/pull/899
- etc.
-->

### Checklist
- [ ] Documentation updated if applicable.
- [ ] Upgrade recipe provided if applicable.

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request checks</b>  
  Please add comment: <b>Jenkins retest this</b>

- for a <b>specific pull request check</b>  
  please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] tests</b>
  
- for a <b>full downstream build</b> 
  - for <b>jenkins</b> job: 
    please add comment: <b>Jenkins run fdb</b>
  - for <b>github actions</b> job: 
    add the label `run_fdb`

- for a <b>compile downstream build</b>  
  please add comment: <b>Jenkins run cdb</b>

- for a <b>full production downstream build</b>  
  please add comment: <b>Jenkins execute product fdb</b>

- for an <b>upstream build</b>  
  please add comment: <b>Jenkins run upstream</b>

- for <b>quarkus branch checks</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins run quarkus-branch</b>

- for a <b>quarkus branch specific check</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] quarkus-branch</b>

- for <b>quarkus main checks</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins run quarkus-main</b>

- for a <b>specific quarkus main check</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] quarkus-branch</b>

- for <b>native checks</b>  
  Run native checks  
  Please add comment: <b>Jenkins run native</b>

- for a <b>specific native check</b>  
  Run native checks 
  Please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] native</b>

- for <b>mandrel checks</b>  
  Run native checks against Mandrel image
  Please add comment: <b>Jenkins run mandrel</b>

- for a <b>specific mandrel check</b>  
  Run native checks against Mandrel image  
  Please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] mandrel</b>
</details>

### CI Status

 You can check OptaPlanner repositories CI status from [Chain Status webpage](https://kiegroup.github.io/optaplanner/).