### PR TITLE
CS-B: GroupBy update

### DIFF
--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/bi/AbstractGroupBiNode.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/bi/AbstractGroupBiNode.java
@@ -17,7 +17,6 @@
 package org.optaplanner.constraint.streams.bavet.bi;
 
 import java.util.function.Consumer;
-import java.util.function.Function;
 
 import org.optaplanner.constraint.streams.bavet.common.AbstractGroupNode;
 import org.optaplanner.constraint.streams.bavet.common.Tuple;
@@ -25,19 +24,20 @@ import org.optaplanner.core.api.function.TriFunction;
 import org.optaplanner.core.api.score.stream.bi.BiConstraintCollector;
 
 abstract class AbstractGroupBiNode<OldA, OldB, OutTuple_ extends Tuple, GroupKey_, ResultContainer_, Result_>
-        extends AbstractGroupNode<BiTuple<OldA, OldB>, OutTuple_, GroupKey_, ResultContainer_> {
+        extends AbstractGroupNode<BiTuple<OldA, OldB>, OutTuple_, GroupKey_, ResultContainer_, Result_> {
 
     private final TriFunction<ResultContainer_, OldA, OldB, Runnable> accumulator;
-    protected final Function<ResultContainer_, Result_> finisher;
 
     protected AbstractGroupBiNode(int groupStoreIndex,
             BiConstraintCollector<OldA, OldB, ResultContainer_, Result_> collector,
-            Consumer<OutTuple_> nextNodesInsert, Consumer<OutTuple_> nextNodesRetract) {
+            Consumer<OutTuple_> nextNodesInsert,
+            Consumer<OutTuple_> nextNodesUpdate,
+            Consumer<OutTuple_> nextNodesRetract) {
         super(groupStoreIndex,
                 collector == null ? null : collector.supplier(),
-                nextNodesInsert, nextNodesRetract);
+                collector == null ? null : collector.finisher(),
+                nextNodesInsert, nextNodesUpdate, nextNodesRetract);
         accumulator = collector == null ? null : collector.accumulator();
-        finisher = collector == null ? null : collector.finisher();
     }
 
     @Override

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/bi/BavetAbstractBiConstraintStream.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/bi/BavetAbstractBiConstraintStream.java
@@ -193,9 +193,11 @@ public abstract class BavetAbstractBiConstraintStream<Solution_, A, B> extends B
     public <ResultContainer_, Result_> UniConstraintStream<Result_> groupBy(
             BiConstraintCollector<A, B, ResultContainer_, Result_> collector) {
         BiGroupNodeConstructor<A, B, UniTuple<Result_>> nodeConstructor =
-                (int inputStoreIndex, Consumer<UniTuple<Result_>> insert, Consumer<UniTuple<Result_>> retract,
-                        int outputStoreSize) -> new Group0Mapping1CollectorBiNode<>(inputStoreIndex, collector, insert,
-                                retract, outputStoreSize);
+                (int inputStoreIndex, Consumer<UniTuple<Result_>> insert,
+                        Consumer<UniTuple<Result_>> update,
+                        Consumer<UniTuple<Result_>> retract,
+                        int outputStoreSize) -> new Group0Mapping1CollectorBiNode<>(inputStoreIndex, collector,
+                                insert, update, retract, outputStoreSize);
         return buildUniGroupBy(nodeConstructor);
     }
 
@@ -213,9 +215,10 @@ public abstract class BavetAbstractBiConstraintStream<Solution_, A, B> extends B
             BiConstraintCollector<A, B, ResultContainerB_, ResultB_> collectorB) {
         BiGroupNodeConstructor<A, B, BiTuple<ResultA_, ResultB_>> nodeConstructor =
                 (int inputStoreIndex, Consumer<BiTuple<ResultA_, ResultB_>> insert,
+                        Consumer<BiTuple<ResultA_, ResultB_>> update,
                         Consumer<BiTuple<ResultA_, ResultB_>> retract,
                         int outputStoreSize) -> new Group0Mapping2CollectorBiNode<>(inputStoreIndex, collectorA, collectorB,
-                                insert, retract, outputStoreSize);
+                                insert, update, retract, outputStoreSize);
         return buildBiGroupBy(nodeConstructor);
     }
 
@@ -236,9 +239,10 @@ public abstract class BavetAbstractBiConstraintStream<Solution_, A, B> extends B
                     BiConstraintCollector<A, B, ResultContainerC_, ResultC_> collectorC) {
         BiGroupNodeConstructor<A, B, TriTuple<ResultA_, ResultB_, ResultC_>> nodeConstructor =
                 (int inputStoreIndex, Consumer<TriTuple<ResultA_, ResultB_, ResultC_>> insert,
+                        Consumer<TriTuple<ResultA_, ResultB_, ResultC_>> update,
                         Consumer<TriTuple<ResultA_, ResultB_, ResultC_>> retract,
                         int outputStoreSize) -> new Group0Mapping3CollectorBiNode<>(inputStoreIndex, collectorA, collectorB,
-                                collectorC, insert, retract, outputStoreSize);
+                                collectorC, insert, update, retract, outputStoreSize);
         return buildTriGroupBy(nodeConstructor);
     }
 
@@ -260,9 +264,10 @@ public abstract class BavetAbstractBiConstraintStream<Solution_, A, B> extends B
                     BiConstraintCollector<A, B, ResultContainerD_, ResultD_> collectorD) {
         BiGroupNodeConstructor<A, B, QuadTuple<ResultA_, ResultB_, ResultC_, ResultD_>> nodeConstructor =
                 (int inputStoreIndex, Consumer<QuadTuple<ResultA_, ResultB_, ResultC_, ResultD_>> insert,
+                        Consumer<QuadTuple<ResultA_, ResultB_, ResultC_, ResultD_>> update,
                         Consumer<QuadTuple<ResultA_, ResultB_, ResultC_, ResultD_>> retract,
                         int outputStoreSize) -> new Group0Mapping4CollectorBiNode<>(inputStoreIndex, collectorA, collectorB,
-                                collectorC, collectorD, insert, retract, outputStoreSize);
+                                collectorC, collectorD, insert, update, retract, outputStoreSize);
         return buildQuadGroupBy(nodeConstructor);
     }
 
@@ -278,9 +283,11 @@ public abstract class BavetAbstractBiConstraintStream<Solution_, A, B> extends B
     @Override
     public <GroupKey_> UniConstraintStream<GroupKey_> groupBy(BiFunction<A, B, GroupKey_> groupKeyMapping) {
         BiGroupNodeConstructor<A, B, UniTuple<GroupKey_>> nodeConstructor =
-                (int inputStoreIndex, Consumer<UniTuple<GroupKey_>> insert, Consumer<UniTuple<GroupKey_>> retract,
-                        int outputStoreSize) -> new Group1Mapping0CollectorBiNode<>(groupKeyMapping, inputStoreIndex, insert,
-                                retract, outputStoreSize);
+                (int inputStoreIndex, Consumer<UniTuple<GroupKey_>> insert,
+                        Consumer<UniTuple<GroupKey_>> update,
+                        Consumer<UniTuple<GroupKey_>> retract,
+                        int outputStoreSize) -> new Group1Mapping0CollectorBiNode<>(groupKeyMapping, inputStoreIndex,
+                                insert, update, retract, outputStoreSize);
         return buildUniGroupBy(nodeConstructor);
     }
 
@@ -291,9 +298,10 @@ public abstract class BavetAbstractBiConstraintStream<Solution_, A, B> extends B
                     BiConstraintCollector<A, B, ResultContainerC_, ResultC_> collectorC) {
         BiGroupNodeConstructor<A, B, TriTuple<GroupKey_, ResultB_, ResultC_>> nodeConstructor =
                 (int inputStoreIndex, Consumer<TriTuple<GroupKey_, ResultB_, ResultC_>> insert,
+                        Consumer<TriTuple<GroupKey_, ResultB_, ResultC_>> update,
                         Consumer<TriTuple<GroupKey_, ResultB_, ResultC_>> retract,
                         int outputStoreSize) -> new Group1Mapping2CollectorBiNode<>(groupKeyMapping, inputStoreIndex,
-                                collectorB, collectorC, insert, retract, outputStoreSize);
+                                collectorB, collectorC, insert, update, retract, outputStoreSize);
         return buildTriGroupBy(nodeConstructor);
     }
 
@@ -306,9 +314,10 @@ public abstract class BavetAbstractBiConstraintStream<Solution_, A, B> extends B
                     BiConstraintCollector<A, B, ResultContainerD_, ResultD_> collectorD) {
         BiGroupNodeConstructor<A, B, QuadTuple<GroupKey_, ResultB_, ResultC_, ResultD_>> nodeConstructor =
                 (int inputStoreIndex, Consumer<QuadTuple<GroupKey_, ResultB_, ResultC_, ResultD_>> insert,
+                        Consumer<QuadTuple<GroupKey_, ResultB_, ResultC_, ResultD_>> update,
                         Consumer<QuadTuple<GroupKey_, ResultB_, ResultC_, ResultD_>> retract,
                         int outputStoreSize) -> new Group1Mapping3CollectorBiNode<>(groupKeyMapping, inputStoreIndex,
-                                collectorB, collectorC, collectorD, insert, retract, outputStoreSize);
+                                collectorB, collectorC, collectorD, insert, update, retract, outputStoreSize);
         return buildQuadGroupBy(nodeConstructor);
     }
 
@@ -318,9 +327,10 @@ public abstract class BavetAbstractBiConstraintStream<Solution_, A, B> extends B
             BiConstraintCollector<A, B, ResultContainer_, Result_> collector) {
         BiGroupNodeConstructor<A, B, BiTuple<GroupKey_, Result_>> nodeConstructor =
                 (int inputStoreIndex, Consumer<BiTuple<GroupKey_, Result_>> insert,
+                        Consumer<BiTuple<GroupKey_, Result_>> update,
                         Consumer<BiTuple<GroupKey_, Result_>> retract,
                         int outputStoreSize) -> new Group1Mapping1CollectorBiNode<>(groupKeyMapping, inputStoreIndex, collector,
-                                insert, retract, outputStoreSize);
+                                insert, update, retract, outputStoreSize);
         return buildBiGroupBy(nodeConstructor);
     }
 
@@ -329,10 +339,11 @@ public abstract class BavetAbstractBiConstraintStream<Solution_, A, B> extends B
             BiFunction<A, B, GroupKeyA_> groupKeyAMapping, BiFunction<A, B, GroupKeyB_> groupKeyBMapping) {
         BiGroupNodeConstructor<A, B, BiTuple<GroupKeyA_, GroupKeyB_>> nodeConstructor =
                 (int inputStoreIndex, Consumer<BiTuple<GroupKeyA_, GroupKeyB_>> insert,
+                        Consumer<BiTuple<GroupKeyA_, GroupKeyB_>> update,
                         Consumer<BiTuple<GroupKeyA_, GroupKeyB_>> retract,
                         int outputStoreSize) -> new Group2Mapping0CollectorBiNode<>(groupKeyAMapping, groupKeyBMapping,
                                 inputStoreIndex,
-                                insert, retract, outputStoreSize);
+                                insert, update, retract, outputStoreSize);
         return buildBiGroupBy(nodeConstructor);
     }
 
@@ -342,9 +353,10 @@ public abstract class BavetAbstractBiConstraintStream<Solution_, A, B> extends B
             BiConstraintCollector<A, B, ResultContainer_, Result_> collector) {
         BiGroupNodeConstructor<A, B, TriTuple<GroupKeyA_, GroupKeyB_, Result_>> nodeConstructor =
                 (int inputStoreIndex, Consumer<TriTuple<GroupKeyA_, GroupKeyB_, Result_>> insert,
+                        Consumer<TriTuple<GroupKeyA_, GroupKeyB_, Result_>> update,
                         Consumer<TriTuple<GroupKeyA_, GroupKeyB_, Result_>> retract,
                         int outputStoreSize) -> new Group2Mapping1CollectorBiNode<>(groupKeyAMapping, groupKeyBMapping,
-                                inputStoreIndex, collector, insert, retract, outputStoreSize);
+                                inputStoreIndex, collector, insert, update, retract, outputStoreSize);
         return buildTriGroupBy(nodeConstructor);
     }
 
@@ -356,9 +368,10 @@ public abstract class BavetAbstractBiConstraintStream<Solution_, A, B> extends B
                     BiConstraintCollector<A, B, ResultContainerD_, ResultD_> collectorD) {
         BiGroupNodeConstructor<A, B, QuadTuple<GroupKeyA_, GroupKeyB_, ResultC_, ResultD_>> nodeConstructor =
                 (int inputStoreIndex, Consumer<QuadTuple<GroupKeyA_, GroupKeyB_, ResultC_, ResultD_>> insert,
+                        Consumer<QuadTuple<GroupKeyA_, GroupKeyB_, ResultC_, ResultD_>> update,
                         Consumer<QuadTuple<GroupKeyA_, GroupKeyB_, ResultC_, ResultD_>> retract,
                         int outputStoreSize) -> new Group2Mapping2CollectorBiNode<>(groupKeyAMapping, groupKeyBMapping,
-                                inputStoreIndex, collectorC, collectorD, insert, retract, outputStoreSize);
+                                inputStoreIndex, collectorC, collectorD, insert, update, retract, outputStoreSize);
         return buildQuadGroupBy(nodeConstructor);
     }
 
@@ -368,10 +381,11 @@ public abstract class BavetAbstractBiConstraintStream<Solution_, A, B> extends B
             BiFunction<A, B, GroupKeyC_> groupKeyCMapping) {
         BiGroupNodeConstructor<A, B, TriTuple<GroupKeyA_, GroupKeyB_, GroupKeyC_>> nodeConstructor =
                 (int inputStoreIndex, Consumer<TriTuple<GroupKeyA_, GroupKeyB_, GroupKeyC_>> insert,
+                        Consumer<TriTuple<GroupKeyA_, GroupKeyB_, GroupKeyC_>> update,
                         Consumer<TriTuple<GroupKeyA_, GroupKeyB_, GroupKeyC_>> retract,
                         int outputStoreSize) -> new Group3Mapping0CollectorBiNode<>(groupKeyAMapping, groupKeyBMapping,
                                 groupKeyCMapping,
-                                inputStoreIndex, insert, retract, outputStoreSize);
+                                inputStoreIndex, insert, update, retract, outputStoreSize);
         return buildTriGroupBy(nodeConstructor);
     }
 
@@ -383,9 +397,10 @@ public abstract class BavetAbstractBiConstraintStream<Solution_, A, B> extends B
                     BiConstraintCollector<A, B, ResultContainerD_, ResultD_> collectorD) {
         BiGroupNodeConstructor<A, B, QuadTuple<GroupKeyA_, GroupKeyB_, GroupKeyC_, ResultD_>> nodeConstructor =
                 (int inputStoreIndex, Consumer<QuadTuple<GroupKeyA_, GroupKeyB_, GroupKeyC_, ResultD_>> insert,
+                        Consumer<QuadTuple<GroupKeyA_, GroupKeyB_, GroupKeyC_, ResultD_>> update,
                         Consumer<QuadTuple<GroupKeyA_, GroupKeyB_, GroupKeyC_, ResultD_>> retract,
                         int outputStoreSize) -> new Group3Mapping1CollectorBiNode<>(groupKeyAMapping, groupKeyBMapping,
-                                groupKeyCMapping, inputStoreIndex, collectorD, insert, retract, outputStoreSize);
+                                groupKeyCMapping, inputStoreIndex, collectorD, insert, update, retract, outputStoreSize);
         return buildQuadGroupBy(nodeConstructor);
     }
 
@@ -395,9 +410,10 @@ public abstract class BavetAbstractBiConstraintStream<Solution_, A, B> extends B
                     BiFunction<A, B, GroupKeyC_> groupKeyCMapping, BiFunction<A, B, GroupKeyD_> groupKeyDMapping) {
         BiGroupNodeConstructor<A, B, QuadTuple<GroupKeyA_, GroupKeyB_, GroupKeyC_, GroupKeyD_>> nodeConstructor =
                 (int inputStoreIndex, Consumer<QuadTuple<GroupKeyA_, GroupKeyB_, GroupKeyC_, GroupKeyD_>> insert,
+                        Consumer<QuadTuple<GroupKeyA_, GroupKeyB_, GroupKeyC_, GroupKeyD_>> update,
                         Consumer<QuadTuple<GroupKeyA_, GroupKeyB_, GroupKeyC_, GroupKeyD_>> retract,
                         int outputStoreSize) -> new Group4Mapping0CollectorBiNode<>(groupKeyAMapping, groupKeyBMapping,
-                                groupKeyCMapping, groupKeyDMapping, inputStoreIndex, insert, retract, outputStoreSize);
+                                groupKeyCMapping, groupKeyDMapping, inputStoreIndex, insert, update, retract, outputStoreSize);
         return buildQuadGroupBy(nodeConstructor);
     }
 

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/bi/BavetBiGroupBridgeBiConstraintStream.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/bi/BavetBiGroupBridgeBiConstraintStream.java
@@ -68,10 +68,11 @@ final class BavetBiGroupBridgeBiConstraintStream<Solution_, A, B, NewA, NewB>
         }
         int inputStoreIndex = buildHelper.reserveTupleStoreIndex(parent.getTupleSource());
         Consumer<BiTuple<NewA, NewB>> insert = buildHelper.getAggregatedInsert(groupStream.getChildStreamList());
+        Consumer<BiTuple<NewA, NewB>> update = buildHelper.getAggregatedUpdate(groupStream.getChildStreamList());
         Consumer<BiTuple<NewA, NewB>> retract = buildHelper.getAggregatedRetract(groupStream.getChildStreamList());
         int outputStoreSize = buildHelper.extractTupleStoreSize(groupStream);
-        AbstractGroupNode<BiTuple<A, B>, BiTuple<NewA, NewB>, ?, ?> node =
-                nodeConstructor.apply(inputStoreIndex, insert, retract, outputStoreSize);
+        AbstractGroupNode<BiTuple<A, B>, BiTuple<NewA, NewB>, ?, ?, ?> node =
+                nodeConstructor.apply(inputStoreIndex, insert, update, retract, outputStoreSize);
         buildHelper.addNode(node);
         buildHelper.putInsertUpdateRetract(this, node::insert, node::update, node::retract);
     }

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/bi/BavetQuadGroupBridgeBiConstraintStream.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/bi/BavetQuadGroupBridgeBiConstraintStream.java
@@ -70,11 +70,12 @@ final class BavetQuadGroupBridgeBiConstraintStream<Solution_, A, B, NewA, NewB, 
         }
         int inputStoreIndex = buildHelper.reserveTupleStoreIndex(parent.getTupleSource());
         Consumer<QuadTuple<NewA, NewB, NewC, NewD>> insert = buildHelper.getAggregatedInsert(groupStream.getChildStreamList());
+        Consumer<QuadTuple<NewA, NewB, NewC, NewD>> update = buildHelper.getAggregatedUpdate(groupStream.getChildStreamList());
         Consumer<QuadTuple<NewA, NewB, NewC, NewD>> retract =
                 buildHelper.getAggregatedRetract(groupStream.getChildStreamList());
         int outputStoreSize = buildHelper.extractTupleStoreSize(groupStream);
-        AbstractGroupNode<BiTuple<A, B>, QuadTuple<NewA, NewB, NewC, NewD>, ?, ?> node =
-                nodeConstructor.apply(inputStoreIndex, insert, retract, outputStoreSize);
+        AbstractGroupNode<BiTuple<A, B>, QuadTuple<NewA, NewB, NewC, NewD>, ?, ?, ?> node =
+                nodeConstructor.apply(inputStoreIndex, insert, update, retract, outputStoreSize);
         buildHelper.addNode(node);
         buildHelper.putInsertUpdateRetract(this, node::insert, node::update, node::retract);
     }

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/bi/BavetTriGroupBridgeBiConstraintStream.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/bi/BavetTriGroupBridgeBiConstraintStream.java
@@ -70,10 +70,11 @@ final class BavetTriGroupBridgeBiConstraintStream<Solution_, A, B, NewA, NewB, N
         }
         int inputStoreIndex = buildHelper.reserveTupleStoreIndex(parent.getTupleSource());
         Consumer<TriTuple<NewA, NewB, NewC>> insert = buildHelper.getAggregatedInsert(groupStream.getChildStreamList());
+        Consumer<TriTuple<NewA, NewB, NewC>> update = buildHelper.getAggregatedUpdate(groupStream.getChildStreamList());
         Consumer<TriTuple<NewA, NewB, NewC>> retract = buildHelper.getAggregatedRetract(groupStream.getChildStreamList());
         int outputStoreSize = buildHelper.extractTupleStoreSize(groupStream);
-        AbstractGroupNode<BiTuple<A, B>, TriTuple<NewA, NewB, NewC>, ?, ?> node =
-                nodeConstructor.apply(inputStoreIndex, insert, retract, outputStoreSize);
+        AbstractGroupNode<BiTuple<A, B>, TriTuple<NewA, NewB, NewC>, ?, ?, ?> node =
+                nodeConstructor.apply(inputStoreIndex, insert, update, retract, outputStoreSize);
         buildHelper.addNode(node);
         buildHelper.putInsertUpdateRetract(this, node::insert, node::update, node::retract);
     }

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/bi/BavetUniGroupBridgeBiConstraintStream.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/bi/BavetUniGroupBridgeBiConstraintStream.java
@@ -17,6 +17,7 @@
 package org.optaplanner.constraint.streams.bavet.bi;
 
 import java.util.Set;
+import java.util.function.Consumer;
 
 import org.optaplanner.constraint.streams.bavet.BavetConstraintFactory;
 import org.optaplanner.constraint.streams.bavet.common.AbstractGroupNode;
@@ -68,10 +69,12 @@ final class BavetUniGroupBridgeBiConstraintStream<Solution_, A, B, NewA>
                     + ") has an non-empty childStreamList (" + childStreamList + ") but it's a groupBy bridge.");
         }
         int inputStoreIndex = buildHelper.reserveTupleStoreIndex(parent.getTupleSource());
+        Consumer<UniTuple<NewA>> insert = buildHelper.getAggregatedInsert(groupStream.getChildStreamList());
+        Consumer<UniTuple<NewA>> update = buildHelper.getAggregatedUpdate(groupStream.getChildStreamList());
+        Consumer<UniTuple<NewA>> retract = buildHelper.getAggregatedRetract(groupStream.getChildStreamList());
         int outputStoreSize = buildHelper.extractTupleStoreSize(groupStream);
-        AbstractGroupNode<BiTuple<A, B>, UniTuple<NewA>, ?, ?> node = nodeConstructor.apply(inputStoreIndex,
-                buildHelper.getAggregatedInsert(groupStream.getChildStreamList()),
-                buildHelper.getAggregatedRetract(groupStream.getChildStreamList()), outputStoreSize);
+        AbstractGroupNode<BiTuple<A, B>, UniTuple<NewA>, ?, ?, ?> node = nodeConstructor.apply(inputStoreIndex,
+                insert, update, retract, outputStoreSize);
         buildHelper.addNode(node);
         buildHelper.putInsertUpdateRetract(this, node::insert, node::update, node::retract);
     }

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/bi/BiGroupNodeConstructor.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/bi/BiGroupNodeConstructor.java
@@ -23,7 +23,8 @@ import org.optaplanner.constraint.streams.bavet.common.Tuple;
 @FunctionalInterface
 interface BiGroupNodeConstructor<A, B, Tuple_ extends Tuple> {
 
-    AbstractGroupBiNode<A, B, Tuple_, ?, ?, ?> apply(int inputStoreIndex, Consumer<Tuple_> insert,
-            Consumer<Tuple_> retract, int outputStoreSize);
+    AbstractGroupBiNode<A, B, Tuple_, ?, ?, ?> apply(int inputStoreIndex,
+            Consumer<Tuple_> insert, Consumer<Tuple_> update, Consumer<Tuple_> retract,
+            int outputStoreSize);
 
 }

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/bi/BiTuple.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/bi/BiTuple.java
@@ -21,8 +21,9 @@ import org.optaplanner.constraint.streams.bavet.common.Tuple;
 
 public final class BiTuple<A, B> implements Tuple {
 
-    public final A factA;
-    public final B factB;
+    // Only a tuple's origin node may modify a fact.
+    public A factA;
+    public B factB;
 
     public final Object[] store;
 

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/bi/Group0Mapping1CollectorBiNode.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/bi/Group0Mapping1CollectorBiNode.java
@@ -18,7 +18,6 @@ package org.optaplanner.constraint.streams.bavet.bi;
 
 import java.util.function.Consumer;
 
-import org.optaplanner.constraint.streams.bavet.common.Group;
 import org.optaplanner.constraint.streams.bavet.uni.UniTuple;
 import org.optaplanner.core.api.score.stream.bi.BiConstraintCollector;
 
@@ -31,9 +30,12 @@ final class Group0Mapping1CollectorBiNode<OldA, OldB, A, ResultContainer_>
 
     public Group0Mapping1CollectorBiNode(int groupStoreIndex,
             BiConstraintCollector<OldA, OldB, ResultContainer_, A> collector,
-            Consumer<UniTuple<A>> nextNodesInsert, Consumer<UniTuple<A>> nextNodesRetract,
+            Consumer<UniTuple<A>> nextNodesInsert,
+            Consumer<UniTuple<A>> nextNodesUpdate,
+            Consumer<UniTuple<A>> nextNodesRetract,
             int outputStoreSize) {
-        super(groupStoreIndex, collector, nextNodesInsert, nextNodesRetract);
+        super(groupStoreIndex, collector,
+                nextNodesInsert, nextNodesUpdate, nextNodesRetract);
         this.outputStoreSize = outputStoreSize;
     }
 
@@ -43,10 +45,13 @@ final class Group0Mapping1CollectorBiNode<OldA, OldB, A, ResultContainer_>
     }
 
     @Override
-    protected UniTuple<A> createOutTuple(Group<UniTuple<A>, String, ResultContainer_> group) {
-        ResultContainer_ resultContainer = group.resultContainer;
-        A a = finisher.apply(resultContainer);
-        return new UniTuple<>(a, outputStoreSize);
+    protected UniTuple<A> createOutTuple(String groupKey) {
+        return new UniTuple<>(null, outputStoreSize);
+    }
+
+    @Override
+    protected void updateOutTupleToResult(UniTuple<A> outTuple, A a) {
+        outTuple.factA = a;
     }
 
     @Override

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/bi/Group0Mapping2CollectorBiNode.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/bi/Group0Mapping2CollectorBiNode.java
@@ -18,7 +18,6 @@ package org.optaplanner.constraint.streams.bavet.bi;
 
 import java.util.function.Consumer;
 
-import org.optaplanner.constraint.streams.bavet.common.Group;
 import org.optaplanner.core.api.score.stream.ConstraintCollectors;
 import org.optaplanner.core.api.score.stream.bi.BiConstraintCollector;
 import org.optaplanner.core.impl.util.Pair;
@@ -33,9 +32,12 @@ final class Group0Mapping2CollectorBiNode<OldA, OldB, A, B, ResultContainerA_, R
     public Group0Mapping2CollectorBiNode(int groupStoreIndex,
             BiConstraintCollector<OldA, OldB, ResultContainerA_, A> collectorA,
             BiConstraintCollector<OldA, OldB, ResultContainerB_, B> collectorB,
-            Consumer<BiTuple<A, B>> nextNodesInsert, Consumer<BiTuple<A, B>> nextNodesRetract,
+            Consumer<BiTuple<A, B>> nextNodesInsert,
+            Consumer<BiTuple<A, B>> nextNodesUpdate,
+            Consumer<BiTuple<A, B>> nextNodesRetract,
             int outputStoreSize) {
-        super(groupStoreIndex, mergeCollectors(collectorA, collectorB), nextNodesInsert, nextNodesRetract);
+        super(groupStoreIndex, mergeCollectors(collectorA, collectorB),
+                nextNodesInsert, nextNodesUpdate, nextNodesRetract);
         this.outputStoreSize = outputStoreSize;
     }
 
@@ -53,10 +55,14 @@ final class Group0Mapping2CollectorBiNode<OldA, OldB, A, B, ResultContainerA_, R
     }
 
     @Override
-    protected BiTuple<A, B> createOutTuple(Group<BiTuple<A, B>, String, Object> group) {
-        Object resultContainer = group.resultContainer;
-        Pair<A, B> result = finisher.apply(resultContainer);
-        return new BiTuple<>(result.getKey(), result.getValue(), outputStoreSize);
+    protected BiTuple<A, B> createOutTuple(String groupKey) {
+        return new BiTuple<>(null, null, outputStoreSize);
+    }
+
+    @Override
+    protected void updateOutTupleToResult(BiTuple<A, B> outTuple, Pair<A, B> result) {
+        outTuple.factA = result.getKey();
+        outTuple.factB = result.getValue();
     }
 
     @Override

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/bi/Group0Mapping3CollectorBiNode.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/bi/Group0Mapping3CollectorBiNode.java
@@ -18,7 +18,6 @@ package org.optaplanner.constraint.streams.bavet.bi;
 
 import java.util.function.Consumer;
 
-import org.optaplanner.constraint.streams.bavet.common.Group;
 import org.optaplanner.constraint.streams.bavet.tri.TriTuple;
 import org.optaplanner.core.api.score.stream.ConstraintCollectors;
 import org.optaplanner.core.api.score.stream.bi.BiConstraintCollector;
@@ -35,9 +34,12 @@ final class Group0Mapping3CollectorBiNode<OldA, OldB, A, B, C, ResultContainerA_
             BiConstraintCollector<OldA, OldB, ResultContainerA_, A> collectorA,
             BiConstraintCollector<OldA, OldB, ResultContainerB_, B> collectorB,
             BiConstraintCollector<OldA, OldB, ResultContainerC_, C> collectorC,
-            Consumer<TriTuple<A, B, C>> nextNodesInsert, Consumer<TriTuple<A, B, C>> nextNodesRetract,
+            Consumer<TriTuple<A, B, C>> nextNodesInsert,
+            Consumer<TriTuple<A, B, C>> nextNodesUpdate,
+            Consumer<TriTuple<A, B, C>> nextNodesRetract,
             int outputStoreSize) {
-        super(groupStoreIndex, mergeCollectors(collectorA, collectorB, collectorC), nextNodesInsert, nextNodesRetract);
+        super(groupStoreIndex, mergeCollectors(collectorA, collectorB, collectorC),
+                nextNodesInsert, nextNodesUpdate, nextNodesRetract);
         this.outputStoreSize = outputStoreSize;
     }
 
@@ -56,10 +58,15 @@ final class Group0Mapping3CollectorBiNode<OldA, OldB, A, B, C, ResultContainerA_
     }
 
     @Override
-    protected TriTuple<A, B, C> createOutTuple(Group<TriTuple<A, B, C>, String, Object> group) {
-        Object resultContainer = group.resultContainer;
-        Triple<A, B, C> result = finisher.apply(resultContainer);
-        return new TriTuple<>(result.getA(), result.getB(), result.getC(), outputStoreSize);
+    protected TriTuple<A, B, C> createOutTuple(String groupKey) {
+        return new TriTuple<>(null, null, null, outputStoreSize);
+    }
+
+    @Override
+    protected void updateOutTupleToResult(TriTuple<A, B, C> outTuple, Triple<A, B, C> result) {
+        outTuple.factA = result.getA();
+        outTuple.factB = result.getB();
+        outTuple.factC = result.getC();
     }
 
     @Override

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/bi/Group0Mapping4CollectorBiNode.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/bi/Group0Mapping4CollectorBiNode.java
@@ -18,7 +18,6 @@ package org.optaplanner.constraint.streams.bavet.bi;
 
 import java.util.function.Consumer;
 
-import org.optaplanner.constraint.streams.bavet.common.Group;
 import org.optaplanner.constraint.streams.bavet.quad.QuadTuple;
 import org.optaplanner.core.api.score.stream.ConstraintCollectors;
 import org.optaplanner.core.api.score.stream.bi.BiConstraintCollector;
@@ -36,10 +35,12 @@ final class Group0Mapping4CollectorBiNode<OldA, OldB, A, B, C, D, ResultContaine
             BiConstraintCollector<OldA, OldB, ResultContainerB_, B> collectorB,
             BiConstraintCollector<OldA, OldB, ResultContainerC_, C> collectorC,
             BiConstraintCollector<OldA, OldB, ResultContainerD_, D> collectorD,
-            Consumer<QuadTuple<A, B, C, D>> nextNodesInsert, Consumer<QuadTuple<A, B, C, D>> nextNodesRetract,
+            Consumer<QuadTuple<A, B, C, D>> nextNodesInsert,
+            Consumer<QuadTuple<A, B, C, D>> nextNodesUpdate,
+            Consumer<QuadTuple<A, B, C, D>> nextNodesRetract,
             int outputStoreSize) {
-        super(groupStoreIndex, mergeCollectors(collectorA, collectorB, collectorC, collectorD), nextNodesInsert,
-                nextNodesRetract);
+        super(groupStoreIndex, mergeCollectors(collectorA, collectorB, collectorC, collectorD),
+                nextNodesInsert, nextNodesUpdate, nextNodesRetract);
         this.outputStoreSize = outputStoreSize;
     }
 
@@ -59,10 +60,16 @@ final class Group0Mapping4CollectorBiNode<OldA, OldB, A, B, C, D, ResultContaine
     }
 
     @Override
-    protected QuadTuple<A, B, C, D> createOutTuple(Group<QuadTuple<A, B, C, D>, String, Object> group) {
-        Object resultContainer = group.resultContainer;
-        Quadruple<A, B, C, D> result = finisher.apply(resultContainer);
-        return new QuadTuple<>(result.getA(), result.getB(), result.getC(), result.getD(), outputStoreSize);
+    protected QuadTuple<A, B, C, D> createOutTuple(String groupKey) {
+        return new QuadTuple<>(null, null, null, null, outputStoreSize);
+    }
+
+    @Override
+    protected void updateOutTupleToResult(QuadTuple<A, B, C, D> outTuple, Quadruple<A, B, C, D> result) {
+        outTuple.factA = result.getA();
+        outTuple.factB = result.getB();
+        outTuple.factC = result.getC();
+        outTuple.factD = result.getD();
     }
 
     @Override

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/bi/Group1Mapping0CollectorBiNode.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/bi/Group1Mapping0CollectorBiNode.java
@@ -19,7 +19,6 @@ package org.optaplanner.constraint.streams.bavet.bi;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
 
-import org.optaplanner.constraint.streams.bavet.common.Group;
 import org.optaplanner.constraint.streams.bavet.uni.UniTuple;
 
 final class Group1Mapping0CollectorBiNode<OldA, OldB, A>
@@ -29,16 +28,12 @@ final class Group1Mapping0CollectorBiNode<OldA, OldB, A>
     private final int outputStoreSize;
 
     public Group1Mapping0CollectorBiNode(BiFunction<OldA, OldB, A> groupKeyMapping, int groupStoreIndex,
-            Consumer<UniTuple<A>> nextNodesInsert, Consumer<UniTuple<A>> nextNodesRetract,
+            Consumer<UniTuple<A>> nextNodesInsert, Consumer<UniTuple<A>> nextNodesUpdate,
+            Consumer<UniTuple<A>> nextNodesRetract,
             int outputStoreSize) {
-        super(groupStoreIndex, null, nextNodesInsert, nextNodesRetract);
+        super(groupStoreIndex, null, nextNodesInsert, nextNodesUpdate, nextNodesRetract);
         this.groupKeyMapping = groupKeyMapping;
         this.outputStoreSize = outputStoreSize;
-    }
-
-    @Override
-    public String toString() {
-        return "GroupBiNode 1+0";
     }
 
     @Override
@@ -47,8 +42,18 @@ final class Group1Mapping0CollectorBiNode<OldA, OldB, A>
     }
 
     @Override
-    protected UniTuple<A> createOutTuple(Group<UniTuple<A>, A, Void> group) {
-        A a = group.groupKey;
+    protected UniTuple<A> createOutTuple(A a) {
         return new UniTuple<>(a, outputStoreSize);
     }
+
+    @Override
+    protected void updateOutTupleToResult(UniTuple<A> aUniTuple, Void unused) {
+        throw new IllegalStateException("Impossible state: collector is null.");
+    }
+
+    @Override
+    public String toString() {
+        return "GroupBiNode 1+0";
+    }
+
 }

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/bi/Group1Mapping1CollectorBiNode.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/bi/Group1Mapping1CollectorBiNode.java
@@ -19,7 +19,6 @@ package org.optaplanner.constraint.streams.bavet.bi;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
 
-import org.optaplanner.constraint.streams.bavet.common.Group;
 import org.optaplanner.core.api.score.stream.bi.BiConstraintCollector;
 
 final class Group1Mapping1CollectorBiNode<OldA, OldB, A, B, ResultContainer_>
@@ -30,9 +29,10 @@ final class Group1Mapping1CollectorBiNode<OldA, OldB, A, B, ResultContainer_>
 
     public Group1Mapping1CollectorBiNode(BiFunction<OldA, OldB, A> groupKeyMapping, int groupStoreIndex,
             BiConstraintCollector<OldA, OldB, ResultContainer_, B> collector,
-            Consumer<BiTuple<A, B>> nextNodesInsert, Consumer<BiTuple<A, B>> nextNodesRetract,
+            Consumer<BiTuple<A, B>> nextNodesInsert, Consumer<BiTuple<A, B>> nextNodesUpdate,
+            Consumer<BiTuple<A, B>> nextNodesRetract,
             int outputStoreSize) {
-        super(groupStoreIndex, collector, nextNodesInsert, nextNodesRetract);
+        super(groupStoreIndex, collector, nextNodesInsert, nextNodesUpdate, nextNodesRetract);
         this.groupKeyMapping = groupKeyMapping;
         this.outputStoreSize = outputStoreSize;
     }
@@ -43,10 +43,13 @@ final class Group1Mapping1CollectorBiNode<OldA, OldB, A, B, ResultContainer_>
     }
 
     @Override
-    protected BiTuple<A, B> createOutTuple(Group<BiTuple<A, B>, A, ResultContainer_> group) {
-        A factA = group.groupKey;
-        B factB = finisher.apply(group.resultContainer);
-        return new BiTuple<>(factA, factB, outputStoreSize);
+    protected BiTuple<A, B> createOutTuple(A a) {
+        return new BiTuple<>(a, null, outputStoreSize);
+    }
+
+    @Override
+    protected void updateOutTupleToResult(BiTuple<A, B> outTuple, B b) {
+        outTuple.factB = b;
     }
 
     @Override

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/bi/Group1Mapping2CollectorBiNode.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/bi/Group1Mapping2CollectorBiNode.java
@@ -19,7 +19,6 @@ package org.optaplanner.constraint.streams.bavet.bi;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
 
-import org.optaplanner.constraint.streams.bavet.common.Group;
 import org.optaplanner.constraint.streams.bavet.tri.TriTuple;
 import org.optaplanner.core.api.score.stream.bi.BiConstraintCollector;
 import org.optaplanner.core.impl.util.Pair;
@@ -33,10 +32,11 @@ final class Group1Mapping2CollectorBiNode<OldA, OldB, A, B, C, ResultContainerB_
     public Group1Mapping2CollectorBiNode(BiFunction<OldA, OldB, A> groupKeyMapping, int groupStoreIndex,
             BiConstraintCollector<OldA, OldB, ResultContainerB_, B> collectorB,
             BiConstraintCollector<OldA, OldB, ResultContainerC_, C> collectorC,
-            Consumer<TriTuple<A, B, C>> nextNodesInsert, Consumer<TriTuple<A, B, C>> nextNodesRetract,
+            Consumer<TriTuple<A, B, C>> nextNodesInsert, Consumer<TriTuple<A, B, C>> nextNodesUpdate,
+            Consumer<TriTuple<A, B, C>> nextNodesRetract,
             int outputStoreSize) {
-        super(groupStoreIndex, Group0Mapping2CollectorBiNode.mergeCollectors(collectorB, collectorC), nextNodesInsert,
-                nextNodesRetract);
+        super(groupStoreIndex, Group0Mapping2CollectorBiNode.mergeCollectors(collectorB, collectorC),
+                nextNodesInsert, nextNodesUpdate, nextNodesRetract);
         this.groupKeyMapping = groupKeyMapping;
         this.outputStoreSize = outputStoreSize;
     }
@@ -49,10 +49,14 @@ final class Group1Mapping2CollectorBiNode<OldA, OldB, A, B, C, ResultContainerB_
     }
 
     @Override
-    protected TriTuple<A, B, C> createOutTuple(Group<TriTuple<A, B, C>, A, Object> group) {
-        A factA = group.groupKey;
-        Pair<B, C> result = finisher.apply(group.resultContainer);
-        return new TriTuple<>(factA, result.getKey(), result.getValue(), outputStoreSize);
+    protected TriTuple<A, B, C> createOutTuple(A a) {
+        return new TriTuple<>(a, null, null, outputStoreSize);
+    }
+
+    @Override
+    protected void updateOutTupleToResult(TriTuple<A, B, C> outTuple, Pair<B, C> result) {
+        outTuple.factB = result.getKey();
+        outTuple.factC = result.getValue();
     }
 
     @Override

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/bi/Group1Mapping3CollectorBiNode.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/bi/Group1Mapping3CollectorBiNode.java
@@ -21,7 +21,6 @@ import static org.optaplanner.constraint.streams.bavet.bi.Group0Mapping3Collecto
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
 
-import org.optaplanner.constraint.streams.bavet.common.Group;
 import org.optaplanner.constraint.streams.bavet.quad.QuadTuple;
 import org.optaplanner.core.api.score.stream.bi.BiConstraintCollector;
 import org.optaplanner.core.impl.util.Triple;
@@ -36,10 +35,11 @@ final class Group1Mapping3CollectorBiNode<OldA, OldB, A, B, C, D, ResultContaine
             BiConstraintCollector<OldA, OldB, ResultContainerB_, B> collectorB,
             BiConstraintCollector<OldA, OldB, ResultContainerC_, C> collectorC,
             BiConstraintCollector<OldA, OldB, ResultContainerD_, D> collectorD,
-            Consumer<QuadTuple<A, B, C, D>> nextNodesInsert, Consumer<QuadTuple<A, B, C, D>> nextNodesRetract,
+            Consumer<QuadTuple<A, B, C, D>> nextNodesInsert, Consumer<QuadTuple<A, B, C, D>> nextNodesUpdate,
+            Consumer<QuadTuple<A, B, C, D>> nextNodesRetract,
             int outputStoreSize) {
         super(groupStoreIndex, mergeCollectors(collectorB, collectorC, collectorD),
-                nextNodesInsert, nextNodesRetract);
+                nextNodesInsert, nextNodesUpdate, nextNodesRetract);
         this.groupKeyMapping = groupKeyMapping;
         this.outputStoreSize = outputStoreSize;
     }
@@ -50,10 +50,15 @@ final class Group1Mapping3CollectorBiNode<OldA, OldB, A, B, C, D, ResultContaine
     }
 
     @Override
-    protected QuadTuple<A, B, C, D> createOutTuple(Group<QuadTuple<A, B, C, D>, A, Object> group) {
-        A a = group.groupKey;
-        Triple<B, C, D> result = finisher.apply(group.resultContainer);
-        return new QuadTuple<>(a, result.getA(), result.getB(), result.getC(), outputStoreSize);
+    protected QuadTuple<A, B, C, D> createOutTuple(A a) {
+        return new QuadTuple<>(a, null, null, null, outputStoreSize);
+    }
+
+    @Override
+    protected void updateOutTupleToResult(QuadTuple<A, B, C, D> outTuple, Triple<B, C, D> result) {
+        outTuple.factB = result.getA();
+        outTuple.factC = result.getB();
+        outTuple.factD = result.getC();
     }
 
     @Override

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/bi/Group2Mapping0CollectorBiNode.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/bi/Group2Mapping0CollectorBiNode.java
@@ -19,7 +19,6 @@ package org.optaplanner.constraint.streams.bavet.bi;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
 
-import org.optaplanner.constraint.streams.bavet.common.Group;
 import org.optaplanner.core.impl.util.Pair;
 
 final class Group2Mapping0CollectorBiNode<OldA, OldB, A, B>
@@ -31,9 +30,10 @@ final class Group2Mapping0CollectorBiNode<OldA, OldB, A, B>
 
     public Group2Mapping0CollectorBiNode(BiFunction<OldA, OldB, A> groupKeyMappingA,
             BiFunction<OldA, OldB, B> groupKeyMappingB, int groupStoreIndex,
-            Consumer<BiTuple<A, B>> nextNodesInsert, Consumer<BiTuple<A, B>> nextNodesRetract,
+            Consumer<BiTuple<A, B>> nextNodesInsert, Consumer<BiTuple<A, B>> nextNodesUpdate,
+            Consumer<BiTuple<A, B>> nextNodesRetract,
             int outputStoreSize) {
-        super(groupStoreIndex, null, nextNodesInsert, nextNodesRetract);
+        super(groupStoreIndex, null, nextNodesInsert, nextNodesUpdate, nextNodesRetract);
         this.groupKeyMappingA = groupKeyMappingA;
         this.groupKeyMappingB = groupKeyMappingB;
         this.outputStoreSize = outputStoreSize;
@@ -49,9 +49,13 @@ final class Group2Mapping0CollectorBiNode<OldA, OldB, A, B>
     }
 
     @Override
-    protected BiTuple<A, B> createOutTuple(Group<BiTuple<A, B>, Pair<A, B>, Void> group) {
-        Pair<A, B> key = group.groupKey;
-        return new BiTuple<>(key.getKey(), key.getValue(), outputStoreSize);
+    protected BiTuple<A, B> createOutTuple(Pair<A, B> groupKey) {
+        return new BiTuple<>(groupKey.getKey(), groupKey.getValue(), outputStoreSize);
+    }
+
+    @Override
+    protected void updateOutTupleToResult(BiTuple<A, B> outTuple, Void unused) {
+        throw new IllegalStateException("Impossible state: collector is null.");
     }
 
     @Override

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/bi/Group2Mapping1CollectorBiNode.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/bi/Group2Mapping1CollectorBiNode.java
@@ -19,7 +19,6 @@ package org.optaplanner.constraint.streams.bavet.bi;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
 
-import org.optaplanner.constraint.streams.bavet.common.Group;
 import org.optaplanner.constraint.streams.bavet.tri.TriTuple;
 import org.optaplanner.core.api.score.stream.bi.BiConstraintCollector;
 import org.optaplanner.core.impl.util.Pair;
@@ -34,9 +33,10 @@ final class Group2Mapping1CollectorBiNode<OldA, OldB, A, B, C, ResultContainer_>
     public Group2Mapping1CollectorBiNode(BiFunction<OldA, OldB, A> groupKeyMappingA, BiFunction<OldA, OldB, B> groupKeyMappingB,
             int groupStoreIndex,
             BiConstraintCollector<OldA, OldB, ResultContainer_, C> collector,
-            Consumer<TriTuple<A, B, C>> nextNodesInsert, Consumer<TriTuple<A, B, C>> nextNodesRetract,
+            Consumer<TriTuple<A, B, C>> nextNodesInsert, Consumer<TriTuple<A, B, C>> nextNodesUpdate,
+            Consumer<TriTuple<A, B, C>> nextNodesRetract,
             int outputStoreSize) {
-        super(groupStoreIndex, collector, nextNodesInsert, nextNodesRetract);
+        super(groupStoreIndex, collector, nextNodesInsert, nextNodesUpdate, nextNodesRetract);
         this.groupKeyMappingA = groupKeyMappingA;
         this.groupKeyMappingB = groupKeyMappingB;
         this.outputStoreSize = outputStoreSize;
@@ -52,10 +52,13 @@ final class Group2Mapping1CollectorBiNode<OldA, OldB, A, B, C, ResultContainer_>
     }
 
     @Override
-    protected TriTuple<A, B, C> createOutTuple(Group<TriTuple<A, B, C>, Pair<A, B>, ResultContainer_> group) {
-        Pair<A, B> groupKey = group.groupKey;
-        C c = finisher.apply(group.resultContainer);
-        return new TriTuple<>(groupKey.getKey(), groupKey.getValue(), c, outputStoreSize);
+    protected TriTuple<A, B, C> createOutTuple(Pair<A, B> groupKey) {
+        return new TriTuple<>(groupKey.getKey(), groupKey.getValue(), null, outputStoreSize);
+    }
+
+    @Override
+    protected void updateOutTupleToResult(TriTuple<A, B, C> outTuple, C c) {
+        outTuple.factC = c;
     }
 
     @Override

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/bi/Group2Mapping2CollectorBiNode.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/bi/Group2Mapping2CollectorBiNode.java
@@ -21,7 +21,6 @@ import static org.optaplanner.constraint.streams.bavet.bi.Group0Mapping2Collecto
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
 
-import org.optaplanner.constraint.streams.bavet.common.Group;
 import org.optaplanner.constraint.streams.bavet.quad.QuadTuple;
 import org.optaplanner.core.api.score.stream.bi.BiConstraintCollector;
 import org.optaplanner.core.impl.util.Pair;
@@ -37,9 +36,10 @@ final class Group2Mapping2CollectorBiNode<OldA, OldB, A, B, C, D, ResultContaine
             int groupStoreIndex,
             BiConstraintCollector<OldA, OldB, ResultContainerC_, C> collectorC,
             BiConstraintCollector<OldA, OldB, ResultContainerD_, D> collectorD,
-            Consumer<QuadTuple<A, B, C, D>> nextNodesInsert, Consumer<QuadTuple<A, B, C, D>> nextNodesRetract,
+            Consumer<QuadTuple<A, B, C, D>> nextNodesInsert, Consumer<QuadTuple<A, B, C, D>> nextNodesUpdate,
+            Consumer<QuadTuple<A, B, C, D>> nextNodesRetract,
             int outputStoreSize) {
-        super(groupStoreIndex, mergeCollectors(collectorC, collectorD), nextNodesInsert, nextNodesRetract);
+        super(groupStoreIndex, mergeCollectors(collectorC, collectorD), nextNodesInsert, nextNodesUpdate, nextNodesRetract);
         this.groupKeyMappingA = groupKeyMappingA;
         this.groupKeyMappingB = groupKeyMappingB;
         this.outputStoreSize = outputStoreSize;
@@ -55,10 +55,14 @@ final class Group2Mapping2CollectorBiNode<OldA, OldB, A, B, C, D, ResultContaine
     }
 
     @Override
-    protected QuadTuple<A, B, C, D> createOutTuple(Group<QuadTuple<A, B, C, D>, Pair<A, B>, Object> group) {
-        Pair<A, B> groupKey = group.groupKey;
-        Pair<C, D> result = finisher.apply(group.resultContainer);
-        return new QuadTuple<>(groupKey.getKey(), groupKey.getValue(), result.getKey(), result.getValue(), outputStoreSize);
+    protected QuadTuple<A, B, C, D> createOutTuple(Pair<A, B> groupKey) {
+        return new QuadTuple<>(groupKey.getKey(), groupKey.getValue(), null, null, outputStoreSize);
+    }
+
+    @Override
+    protected void updateOutTupleToResult(QuadTuple<A, B, C, D> outTuple, Pair<C, D> result) {
+        outTuple.factC = result.getKey();
+        outTuple.factD = result.getValue();
     }
 
     @Override

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/bi/Group3Mapping0CollectorBiNode.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/bi/Group3Mapping0CollectorBiNode.java
@@ -19,7 +19,6 @@ package org.optaplanner.constraint.streams.bavet.bi;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
 
-import org.optaplanner.constraint.streams.bavet.common.Group;
 import org.optaplanner.constraint.streams.bavet.tri.TriTuple;
 import org.optaplanner.core.impl.util.Triple;
 
@@ -33,8 +32,9 @@ final class Group3Mapping0CollectorBiNode<OldA, OldB, A, B, C>
 
     public Group3Mapping0CollectorBiNode(BiFunction<OldA, OldB, A> groupKeyMappingA,
             BiFunction<OldA, OldB, B> groupKeyMappingB, BiFunction<OldA, OldB, C> groupKeyMappingC, int groupStoreIndex,
-            Consumer<TriTuple<A, B, C>> nextNodesInsert, Consumer<TriTuple<A, B, C>> nextNodesRetract, int outputStoreSize) {
-        super(groupStoreIndex, null, nextNodesInsert, nextNodesRetract);
+            Consumer<TriTuple<A, B, C>> nextNodesInsert, Consumer<TriTuple<A, B, C>> nextNodesUpdate,
+            Consumer<TriTuple<A, B, C>> nextNodesRetract, int outputStoreSize) {
+        super(groupStoreIndex, null, nextNodesInsert, nextNodesUpdate, nextNodesRetract);
         this.groupKeyMappingA = groupKeyMappingA;
         this.groupKeyMappingB = groupKeyMappingB;
         this.groupKeyMappingC = groupKeyMappingC;
@@ -52,9 +52,13 @@ final class Group3Mapping0CollectorBiNode<OldA, OldB, A, B, C>
     }
 
     @Override
-    protected TriTuple<A, B, C> createOutTuple(Group<TriTuple<A, B, C>, Triple<A, B, C>, Void> group) {
-        Triple<A, B, C> key = group.groupKey;
-        return new TriTuple<>(key.getA(), key.getB(), key.getC(), outputStoreSize);
+    protected TriTuple<A, B, C> createOutTuple(Triple<A, B, C> groupKey) {
+        return new TriTuple<>(groupKey.getA(), groupKey.getB(), groupKey.getC(), outputStoreSize);
+    }
+
+    @Override
+    protected void updateOutTupleToResult(TriTuple<A, B, C> outTuple, Void unused) {
+        throw new IllegalStateException("Impossible state: collector is null.");
     }
 
     @Override

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/bi/Group3Mapping1CollectorBiNode.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/bi/Group3Mapping1CollectorBiNode.java
@@ -19,7 +19,6 @@ package org.optaplanner.constraint.streams.bavet.bi;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
 
-import org.optaplanner.constraint.streams.bavet.common.Group;
 import org.optaplanner.constraint.streams.bavet.quad.QuadTuple;
 import org.optaplanner.core.api.score.stream.bi.BiConstraintCollector;
 import org.optaplanner.core.impl.util.Triple;
@@ -35,9 +34,10 @@ final class Group3Mapping1CollectorBiNode<OldA, OldB, A, B, C, D, ResultContaine
     public Group3Mapping1CollectorBiNode(BiFunction<OldA, OldB, A> groupKeyMappingA,
             BiFunction<OldA, OldB, B> groupKeyMappingB, BiFunction<OldA, OldB, C> groupKeyMappingC,
             int groupStoreIndex, BiConstraintCollector<OldA, OldB, ResultContainer_, D> collector,
-            Consumer<QuadTuple<A, B, C, D>> nextNodesInsert, Consumer<QuadTuple<A, B, C, D>> nextNodesRetract,
+            Consumer<QuadTuple<A, B, C, D>> nextNodesInsert, Consumer<QuadTuple<A, B, C, D>> nextNodesUpdate,
+            Consumer<QuadTuple<A, B, C, D>> nextNodesRetract,
             int outputStoreSize) {
-        super(groupStoreIndex, collector, nextNodesInsert, nextNodesRetract);
+        super(groupStoreIndex, collector, nextNodesInsert, nextNodesUpdate, nextNodesRetract);
         this.groupKeyMappingA = groupKeyMappingA;
         this.groupKeyMappingB = groupKeyMappingB;
         this.groupKeyMappingC = groupKeyMappingC;
@@ -55,10 +55,13 @@ final class Group3Mapping1CollectorBiNode<OldA, OldB, A, B, C, D, ResultContaine
     }
 
     @Override
-    protected QuadTuple<A, B, C, D> createOutTuple(Group<QuadTuple<A, B, C, D>, Triple<A, B, C>, ResultContainer_> group) {
-        Triple<A, B, C> groupKey = group.groupKey;
-        D d = finisher.apply(group.resultContainer);
-        return new QuadTuple<>(groupKey.getA(), groupKey.getB(), groupKey.getC(), d, outputStoreSize);
+    protected QuadTuple<A, B, C, D> createOutTuple(Triple<A, B, C> groupKey) {
+        return new QuadTuple<>(groupKey.getA(), groupKey.getB(), groupKey.getC(), null, outputStoreSize);
+    }
+
+    @Override
+    protected void updateOutTupleToResult(QuadTuple<A, B, C, D> outTuple, D d) {
+        outTuple.factD = d;
     }
 
     @Override

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/bi/Group4Mapping0CollectorBiNode.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/bi/Group4Mapping0CollectorBiNode.java
@@ -19,7 +19,6 @@ package org.optaplanner.constraint.streams.bavet.bi;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
 
-import org.optaplanner.constraint.streams.bavet.common.Group;
 import org.optaplanner.constraint.streams.bavet.quad.QuadTuple;
 import org.optaplanner.core.impl.util.Quadruple;
 
@@ -34,9 +33,10 @@ final class Group4Mapping0CollectorBiNode<OldA, OldB, A, B, C, D>
 
     public Group4Mapping0CollectorBiNode(BiFunction<OldA, OldB, A> groupKeyMappingA, BiFunction<OldA, OldB, B> groupKeyMappingB,
             BiFunction<OldA, OldB, C> groupKeyMappingC, BiFunction<OldA, OldB, D> groupKeyMappingD, int groupStoreIndex,
-            Consumer<QuadTuple<A, B, C, D>> nextNodesInsert, Consumer<QuadTuple<A, B, C, D>> nextNodesRetract,
+            Consumer<QuadTuple<A, B, C, D>> nextNodesInsert, Consumer<QuadTuple<A, B, C, D>> nextNodesUpdate,
+            Consumer<QuadTuple<A, B, C, D>> nextNodesRetract,
             int outputStoreSize) {
-        super(groupStoreIndex, null, nextNodesInsert, nextNodesRetract);
+        super(groupStoreIndex, null, nextNodesInsert, nextNodesUpdate, nextNodesRetract);
         this.groupKeyMappingA = groupKeyMappingA;
         this.groupKeyMappingB = groupKeyMappingB;
         this.groupKeyMappingC = groupKeyMappingC;
@@ -56,9 +56,13 @@ final class Group4Mapping0CollectorBiNode<OldA, OldB, A, B, C, D>
     }
 
     @Override
-    protected QuadTuple<A, B, C, D> createOutTuple(Group<QuadTuple<A, B, C, D>, Quadruple<A, B, C, D>, Void> group) {
-        Quadruple<A, B, C, D> key = group.groupKey;
-        return new QuadTuple<>(key.getA(), key.getB(), key.getC(), key.getD(), outputStoreSize);
+    protected QuadTuple<A, B, C, D> createOutTuple(Quadruple<A, B, C, D> groupKey) {
+        return new QuadTuple<>(groupKey.getA(), groupKey.getB(), groupKey.getC(), groupKey.getD(), outputStoreSize);
+    }
+
+    @Override
+    protected void updateOutTupleToResult(QuadTuple<A, B, C, D> outTuple, Void unused) {
+        throw new IllegalStateException("Impossible state: collector is null.");
     }
 
     @Override

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/common/AbstractIfExistsNode.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/common/AbstractIfExistsNode.java
@@ -251,6 +251,8 @@ public abstract class AbstractIfExistsNode<LeftTuple_ extends Tuple, Right_> ext
                 case ABORTING:
                     counter.state = BavetTupleState.DEAD;
                     break;
+                case OK:
+                case DEAD:
                 default:
                     throw new IllegalStateException("Impossible state: The dirty counter (" + counter
                             + ") has an non-dirty state (" + counter.state + ").");

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/common/AbstractJoinNode.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/common/AbstractJoinNode.java
@@ -218,6 +218,10 @@ public abstract class AbstractJoinNode<LeftTuple_ extends Tuple, Right_, OutTupl
                 outTuple.setState(BavetTupleState.UPDATING);
                 dirtyTupleQueue.add(outTuple);
                 break;
+            // Impossible because they shouldn't linger in the indexes
+            case DYING:
+            case ABORTING:
+            case DEAD:
             default:
                 throw new IllegalStateException("Impossible state: The tuple (" + outTuple.getState() + ") in node (" +
                         this + ") is in an unexpected state (" + outTuple.getState() + ").");
@@ -240,7 +244,10 @@ public abstract class AbstractJoinNode<LeftTuple_ extends Tuple, Right_, OutTupl
                 // Kill the original propagation
                 outTuple.setState(BavetTupleState.DYING);
                 break;
-            // DYING and ABORTING are impossible because they shouldn't linger in the indexes.
+            // Impossible because they shouldn't linger in the indexes
+            case DYING:
+            case ABORTING:
+            case DEAD:
             default:
                 throw new IllegalStateException("Impossible state: The tuple (" + outTuple.getState() + ") in node (" +
                         this + ") is in an unexpected state (" + outTuple.getState() + ").");
@@ -266,9 +273,8 @@ public abstract class AbstractJoinNode<LeftTuple_ extends Tuple, Right_, OutTupl
                 case ABORTING:
                     tuple.setState(BavetTupleState.DEAD);
                     break;
+                case OK:
                 case DEAD:
-                    throw new IllegalStateException("Impossible state: The tuple (" + tuple + ") in node (" +
-                            this + ") is already in the dead state (" + tuple.getState() + ").");
                 default:
                     throw new IllegalStateException("Impossible state: The tuple (" + tuple + ") in node (" +
                             this + ") is in an unexpected state (" + tuple.getState() + ").");

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/common/Group.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/common/Group.java
@@ -21,9 +21,8 @@ public final class Group<OutTuple_ extends Tuple, GroupKey_, ResultContainer_> {
     public final GroupKey_ groupKey;
     public final ResultContainer_ resultContainer;
     public int parentCount = 0;
-    public boolean dirty = false;
-    public boolean dying = false;
-    public OutTuple_ tuple = null;
+    public BavetTupleState state = null;
+    public OutTuple_ outTuple = null;
 
     public Group(GroupKey_ groupKey, ResultContainer_ resultContainer) {
         this.groupKey = groupKey;

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/common/Group.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/common/Group.java
@@ -20,12 +20,13 @@ public final class Group<OutTuple_ extends Tuple, GroupKey_, ResultContainer_> {
 
     public final GroupKey_ groupKey;
     public final ResultContainer_ resultContainer;
+    public final OutTuple_ outTuple;
     public int parentCount = 0;
-    public BavetTupleState state = null;
-    public OutTuple_ outTuple = null;
 
-    public Group(GroupKey_ groupKey, ResultContainer_ resultContainer) {
+    public Group(GroupKey_ groupKey, ResultContainer_ resultContainer, OutTuple_ outTuple) {
         this.groupKey = groupKey;
         this.resultContainer = resultContainer;
+        this.outTuple = outTuple;
     }
+
 }

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/common/GroupPart.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/common/GroupPart.java
@@ -25,4 +25,5 @@ final class GroupPart<Group_> {
         this.group = group;
         this.undoAccumulator = undoAccumulator;
     }
+
 }

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/quad/AbstractGroupQuadNode.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/quad/AbstractGroupQuadNode.java
@@ -17,7 +17,6 @@
 package org.optaplanner.constraint.streams.bavet.quad;
 
 import java.util.function.Consumer;
-import java.util.function.Function;
 
 import org.optaplanner.constraint.streams.bavet.common.AbstractGroupNode;
 import org.optaplanner.constraint.streams.bavet.common.Tuple;
@@ -25,19 +24,20 @@ import org.optaplanner.core.api.function.PentaFunction;
 import org.optaplanner.core.api.score.stream.quad.QuadConstraintCollector;
 
 abstract class AbstractGroupQuadNode<OldA, OldB, OldC, OldD, OutTuple_ extends Tuple, GroupKey_, ResultContainer_, Result_>
-        extends AbstractGroupNode<QuadTuple<OldA, OldB, OldC, OldD>, OutTuple_, GroupKey_, ResultContainer_> {
+        extends AbstractGroupNode<QuadTuple<OldA, OldB, OldC, OldD>, OutTuple_, GroupKey_, ResultContainer_, Result_> {
 
     private final PentaFunction<ResultContainer_, OldA, OldB, OldC, OldD, Runnable> accumulator;
-    protected final Function<ResultContainer_, Result_> finisher;
 
     protected AbstractGroupQuadNode(int groupStoreIndex,
             QuadConstraintCollector<OldA, OldB, OldC, OldD, ResultContainer_, Result_> collector,
-            Consumer<OutTuple_> nextNodesInsert, Consumer<OutTuple_> nextNodesRetract) {
+            Consumer<OutTuple_> nextNodesInsert,
+            Consumer<OutTuple_> nextNodesUpdate,
+            Consumer<OutTuple_> nextNodesRetract) {
         super(groupStoreIndex,
                 collector == null ? null : collector.supplier(),
-                nextNodesInsert, nextNodesRetract);
+                collector == null ? null : collector.finisher(),
+                nextNodesInsert, nextNodesUpdate, nextNodesRetract);
         accumulator = collector == null ? null : collector.accumulator();
-        finisher = collector == null ? null : collector.finisher();
     }
 
     @Override

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/quad/BavetAbstractQuadConstraintStream.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/quad/BavetAbstractQuadConstraintStream.java
@@ -163,9 +163,11 @@ public abstract class BavetAbstractQuadConstraintStream<Solution_, A, B, C, D>
     public <ResultContainer_, Result_> UniConstraintStream<Result_> groupBy(
             QuadConstraintCollector<A, B, C, D, ResultContainer_, Result_> collector) {
         QuadGroupNodeConstructor<A, B, C, D, UniTuple<Result_>> nodeConstructor =
-                (int inputStoreIndex, Consumer<UniTuple<Result_>> insert, Consumer<UniTuple<Result_>> retract,
-                        int outputStoreSize) -> new Group0Mapping1CollectorQuadNode<>(inputStoreIndex, collector, insert,
-                                retract, outputStoreSize);
+                (int inputStoreIndex, Consumer<UniTuple<Result_>> insert,
+                        Consumer<UniTuple<Result_>> update,
+                        Consumer<UniTuple<Result_>> retract,
+                        int outputStoreSize) -> new Group0Mapping1CollectorQuadNode<>(inputStoreIndex, collector,
+                                insert, update, retract, outputStoreSize);
         return buildUniGroupBy(nodeConstructor);
     }
 
@@ -184,9 +186,10 @@ public abstract class BavetAbstractQuadConstraintStream<Solution_, A, B, C, D>
             QuadConstraintCollector<A, B, C, D, ResultContainerB_, ResultB_> collectorB) {
         QuadGroupNodeConstructor<A, B, C, D, BiTuple<ResultA_, ResultB_>> nodeConstructor =
                 (int inputStoreIndex, Consumer<BiTuple<ResultA_, ResultB_>> insert,
+                        Consumer<BiTuple<ResultA_, ResultB_>> update,
                         Consumer<BiTuple<ResultA_, ResultB_>> retract,
                         int outputStoreSize) -> new Group0Mapping2CollectorQuadNode<>(inputStoreIndex, collectorA, collectorB,
-                                insert, retract, outputStoreSize);
+                                insert, update, retract, outputStoreSize);
         return buildBiGroupBy(nodeConstructor);
     }
 
@@ -207,9 +210,10 @@ public abstract class BavetAbstractQuadConstraintStream<Solution_, A, B, C, D>
                     QuadConstraintCollector<A, B, C, D, ResultContainerC_, ResultC_> collectorC) {
         QuadGroupNodeConstructor<A, B, C, D, TriTuple<ResultA_, ResultB_, ResultC_>> nodeConstructor =
                 (int inputStoreIndex, Consumer<TriTuple<ResultA_, ResultB_, ResultC_>> insert,
+                        Consumer<TriTuple<ResultA_, ResultB_, ResultC_>> update,
                         Consumer<TriTuple<ResultA_, ResultB_, ResultC_>> retract,
                         int outputStoreSize) -> new Group0Mapping3CollectorQuadNode<>(inputStoreIndex, collectorA, collectorB,
-                                collectorC, insert, retract, outputStoreSize);
+                                collectorC, insert, update, retract, outputStoreSize);
         return buildTriGroupBy(nodeConstructor);
     }
 
@@ -231,9 +235,10 @@ public abstract class BavetAbstractQuadConstraintStream<Solution_, A, B, C, D>
                     QuadConstraintCollector<A, B, C, D, ResultContainerD_, ResultD_> collectorD) {
         QuadGroupNodeConstructor<A, B, C, D, QuadTuple<ResultA_, ResultB_, ResultC_, ResultD_>> nodeConstructor =
                 (int inputStoreIndex, Consumer<QuadTuple<ResultA_, ResultB_, ResultC_, ResultD_>> insert,
+                        Consumer<QuadTuple<ResultA_, ResultB_, ResultC_, ResultD_>> update,
                         Consumer<QuadTuple<ResultA_, ResultB_, ResultC_, ResultD_>> retract,
                         int outputStoreSize) -> new Group0Mapping4CollectorQuadNode<>(inputStoreIndex, collectorA, collectorB,
-                                collectorC, collectorD, insert, retract, outputStoreSize);
+                                collectorC, collectorD, insert, update, retract, outputStoreSize);
         return buildQuadGroupBy(nodeConstructor);
     }
 
@@ -249,9 +254,11 @@ public abstract class BavetAbstractQuadConstraintStream<Solution_, A, B, C, D>
     @Override
     public <GroupKey_> UniConstraintStream<GroupKey_> groupBy(QuadFunction<A, B, C, D, GroupKey_> groupKeyMapping) {
         QuadGroupNodeConstructor<A, B, C, D, UniTuple<GroupKey_>> nodeConstructor =
-                (int inputStoreIndex, Consumer<UniTuple<GroupKey_>> insert, Consumer<UniTuple<GroupKey_>> retract,
-                        int outputStoreSize) -> new Group1Mapping0CollectorQuadNode<>(groupKeyMapping, inputStoreIndex, insert,
-                                retract, outputStoreSize);
+                (int inputStoreIndex, Consumer<UniTuple<GroupKey_>> insert,
+                        Consumer<UniTuple<GroupKey_>> update,
+                        Consumer<UniTuple<GroupKey_>> retract,
+                        int outputStoreSize) -> new Group1Mapping0CollectorQuadNode<>(groupKeyMapping, inputStoreIndex,
+                                insert, update, retract, outputStoreSize);
         return buildUniGroupBy(nodeConstructor);
     }
 
@@ -262,9 +269,10 @@ public abstract class BavetAbstractQuadConstraintStream<Solution_, A, B, C, D>
                     QuadConstraintCollector<A, B, C, D, ResultContainerC_, ResultC_> collectorC) {
         QuadGroupNodeConstructor<A, B, C, D, TriTuple<GroupKey_, ResultB_, ResultC_>> nodeConstructor =
                 (int inputStoreIndex, Consumer<TriTuple<GroupKey_, ResultB_, ResultC_>> insert,
+                        Consumer<TriTuple<GroupKey_, ResultB_, ResultC_>> update,
                         Consumer<TriTuple<GroupKey_, ResultB_, ResultC_>> retract,
                         int outputStoreSize) -> new Group1Mapping2CollectorQuadNode<>(groupKeyMapping, inputStoreIndex,
-                                collectorB, collectorC, insert, retract, outputStoreSize);
+                                collectorB, collectorC, insert, update, retract, outputStoreSize);
         return buildTriGroupBy(nodeConstructor);
     }
 
@@ -277,9 +285,10 @@ public abstract class BavetAbstractQuadConstraintStream<Solution_, A, B, C, D>
                     QuadConstraintCollector<A, B, C, D, ResultContainerD_, ResultD_> collectorD) {
         QuadGroupNodeConstructor<A, B, C, D, QuadTuple<GroupKey_, ResultB_, ResultC_, ResultD_>> nodeConstructor =
                 (int inputStoreIndex, Consumer<QuadTuple<GroupKey_, ResultB_, ResultC_, ResultD_>> insert,
+                        Consumer<QuadTuple<GroupKey_, ResultB_, ResultC_, ResultD_>> update,
                         Consumer<QuadTuple<GroupKey_, ResultB_, ResultC_, ResultD_>> retract,
                         int outputStoreSize) -> new Group1Mapping3CollectorQuadNode<>(groupKeyMapping, inputStoreIndex,
-                                collectorB, collectorC, collectorD, insert, retract, outputStoreSize);
+                                collectorB, collectorC, collectorD, insert, update, retract, outputStoreSize);
         return buildQuadGroupBy(nodeConstructor);
     }
 
@@ -289,9 +298,10 @@ public abstract class BavetAbstractQuadConstraintStream<Solution_, A, B, C, D>
             QuadConstraintCollector<A, B, C, D, ResultContainer_, Result_> collector) {
         QuadGroupNodeConstructor<A, B, C, D, BiTuple<GroupKey_, Result_>> nodeConstructor =
                 (int inputStoreIndex, Consumer<BiTuple<GroupKey_, Result_>> insert,
+                        Consumer<BiTuple<GroupKey_, Result_>> update,
                         Consumer<BiTuple<GroupKey_, Result_>> retract,
                         int outputStoreSize) -> new Group1Mapping1CollectorQuadNode<>(groupKeyMapping, inputStoreIndex,
-                                collector, insert, retract, outputStoreSize);
+                                collector, insert, update, retract, outputStoreSize);
         return buildBiGroupBy(nodeConstructor);
     }
 
@@ -301,10 +311,11 @@ public abstract class BavetAbstractQuadConstraintStream<Solution_, A, B, C, D>
             QuadFunction<A, B, C, D, GroupKeyB_> groupKeyBMapping) {
         QuadGroupNodeConstructor<A, B, C, D, BiTuple<GroupKeyA_, GroupKeyB_>> nodeConstructor =
                 (int inputStoreIndex, Consumer<BiTuple<GroupKeyA_, GroupKeyB_>> insert,
+                        Consumer<BiTuple<GroupKeyA_, GroupKeyB_>> update,
                         Consumer<BiTuple<GroupKeyA_, GroupKeyB_>> retract,
                         int outputStoreSize) -> new Group2Mapping0CollectorQuadNode<>(groupKeyAMapping, groupKeyBMapping,
                                 inputStoreIndex,
-                                insert, retract, outputStoreSize);
+                                insert, update, retract, outputStoreSize);
         return buildBiGroupBy(nodeConstructor);
     }
 
@@ -315,9 +326,10 @@ public abstract class BavetAbstractQuadConstraintStream<Solution_, A, B, C, D>
             QuadConstraintCollector<A, B, C, D, ResultContainer_, Result_> collector) {
         QuadGroupNodeConstructor<A, B, C, D, TriTuple<GroupKeyA_, GroupKeyB_, Result_>> nodeConstructor =
                 (int inputStoreIndex, Consumer<TriTuple<GroupKeyA_, GroupKeyB_, Result_>> insert,
+                        Consumer<TriTuple<GroupKeyA_, GroupKeyB_, Result_>> update,
                         Consumer<TriTuple<GroupKeyA_, GroupKeyB_, Result_>> retract,
                         int outputStoreSize) -> new Group2Mapping1CollectorQuadNode<>(groupKeyAMapping, groupKeyBMapping,
-                                inputStoreIndex, collector, insert, retract, outputStoreSize);
+                                inputStoreIndex, collector, insert, update, retract, outputStoreSize);
         return buildTriGroupBy(nodeConstructor);
     }
 
@@ -330,9 +342,10 @@ public abstract class BavetAbstractQuadConstraintStream<Solution_, A, B, C, D>
                     QuadConstraintCollector<A, B, C, D, ResultContainerD_, ResultD_> collectorD) {
         QuadGroupNodeConstructor<A, B, C, D, QuadTuple<GroupKeyA_, GroupKeyB_, ResultC_, ResultD_>> nodeConstructor =
                 (int inputStoreIndex, Consumer<QuadTuple<GroupKeyA_, GroupKeyB_, ResultC_, ResultD_>> insert,
+                        Consumer<QuadTuple<GroupKeyA_, GroupKeyB_, ResultC_, ResultD_>> update,
                         Consumer<QuadTuple<GroupKeyA_, GroupKeyB_, ResultC_, ResultD_>> retract,
                         int outputStoreSize) -> new Group2Mapping2CollectorQuadNode<>(groupKeyAMapping, groupKeyBMapping,
-                                inputStoreIndex, collectorC, collectorD, insert, retract, outputStoreSize);
+                                inputStoreIndex, collectorC, collectorD, insert, update, retract, outputStoreSize);
         return buildQuadGroupBy(nodeConstructor);
     }
 
@@ -342,10 +355,11 @@ public abstract class BavetAbstractQuadConstraintStream<Solution_, A, B, C, D>
             QuadFunction<A, B, C, D, GroupKeyC_> groupKeyCMapping) {
         QuadGroupNodeConstructor<A, B, C, D, TriTuple<GroupKeyA_, GroupKeyB_, GroupKeyC_>> nodeConstructor =
                 (int inputStoreIndex, Consumer<TriTuple<GroupKeyA_, GroupKeyB_, GroupKeyC_>> insert,
+                        Consumer<TriTuple<GroupKeyA_, GroupKeyB_, GroupKeyC_>> update,
                         Consumer<TriTuple<GroupKeyA_, GroupKeyB_, GroupKeyC_>> retract,
                         int outputStoreSize) -> new Group3Mapping0CollectorQuadNode<>(groupKeyAMapping, groupKeyBMapping,
                                 groupKeyCMapping,
-                                inputStoreIndex, insert, retract, outputStoreSize);
+                                inputStoreIndex, insert, update, retract, outputStoreSize);
         return buildTriGroupBy(nodeConstructor);
     }
 
@@ -358,9 +372,10 @@ public abstract class BavetAbstractQuadConstraintStream<Solution_, A, B, C, D>
                     QuadConstraintCollector<A, B, C, D, ResultContainerD_, ResultD_> collectorD) {
         QuadGroupNodeConstructor<A, B, C, D, QuadTuple<GroupKeyA_, GroupKeyB_, GroupKeyC_, ResultD_>> nodeConstructor =
                 (int inputStoreIndex, Consumer<QuadTuple<GroupKeyA_, GroupKeyB_, GroupKeyC_, ResultD_>> insert,
+                        Consumer<QuadTuple<GroupKeyA_, GroupKeyB_, GroupKeyC_, ResultD_>> update,
                         Consumer<QuadTuple<GroupKeyA_, GroupKeyB_, GroupKeyC_, ResultD_>> retract,
                         int outputStoreSize) -> new Group3Mapping1CollectorQuadNode<>(groupKeyAMapping, groupKeyBMapping,
-                                groupKeyCMapping, inputStoreIndex, collectorD, insert, retract, outputStoreSize);
+                                groupKeyCMapping, inputStoreIndex, collectorD, insert, update, retract, outputStoreSize);
         return buildQuadGroupBy(nodeConstructor);
     }
 
@@ -372,9 +387,10 @@ public abstract class BavetAbstractQuadConstraintStream<Solution_, A, B, C, D>
                     QuadFunction<A, B, C, D, GroupKeyD_> groupKeyDMapping) {
         QuadGroupNodeConstructor<A, B, C, D, QuadTuple<GroupKeyA_, GroupKeyB_, GroupKeyC_, GroupKeyD_>> nodeConstructor =
                 (int inputStoreIndex, Consumer<QuadTuple<GroupKeyA_, GroupKeyB_, GroupKeyC_, GroupKeyD_>> insert,
+                        Consumer<QuadTuple<GroupKeyA_, GroupKeyB_, GroupKeyC_, GroupKeyD_>> update,
                         Consumer<QuadTuple<GroupKeyA_, GroupKeyB_, GroupKeyC_, GroupKeyD_>> retract,
                         int outputStoreSize) -> new Group4Mapping0CollectorQuadNode<>(groupKeyAMapping, groupKeyBMapping,
-                                groupKeyCMapping, groupKeyDMapping, inputStoreIndex, insert, retract, outputStoreSize);
+                                groupKeyCMapping, groupKeyDMapping, inputStoreIndex, insert, update, retract, outputStoreSize);
         return buildQuadGroupBy(nodeConstructor);
     }
 

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/quad/BavetBiGroupBridgeQuadConstraintStream.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/quad/BavetBiGroupBridgeQuadConstraintStream.java
@@ -70,10 +70,11 @@ final class BavetBiGroupBridgeQuadConstraintStream<Solution_, A, B, C, D, NewA, 
         }
         int inputStoreIndex = buildHelper.reserveTupleStoreIndex(parent.getTupleSource());
         Consumer<BiTuple<NewA, NewB>> insert = buildHelper.getAggregatedInsert(groupStream.getChildStreamList());
+        Consumer<BiTuple<NewA, NewB>> update = buildHelper.getAggregatedUpdate(groupStream.getChildStreamList());
         Consumer<BiTuple<NewA, NewB>> retract = buildHelper.getAggregatedRetract(groupStream.getChildStreamList());
         int outputStoreSize = buildHelper.extractTupleStoreSize(groupStream);
-        AbstractGroupNode<QuadTuple<A, B, C, D>, BiTuple<NewA, NewB>, ?, ?> node =
-                nodeConstructor.apply(inputStoreIndex, insert, retract, outputStoreSize);
+        AbstractGroupNode<QuadTuple<A, B, C, D>, BiTuple<NewA, NewB>, ?, ?, ?> node =
+                nodeConstructor.apply(inputStoreIndex, insert, update, retract, outputStoreSize);
         buildHelper.addNode(node);
         buildHelper.putInsertUpdateRetract(this, node::insert, node::update, node::retract);
     }

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/quad/BavetQuadGroupBridgeQuadConstraintStream.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/quad/BavetQuadGroupBridgeQuadConstraintStream.java
@@ -68,11 +68,12 @@ final class BavetQuadGroupBridgeQuadConstraintStream<Solution_, A, B, C, D, NewA
         }
         int inputStoreIndex = buildHelper.reserveTupleStoreIndex(parent.getTupleSource());
         Consumer<QuadTuple<NewA, NewB, NewC, NewD>> insert = buildHelper.getAggregatedInsert(groupStream.getChildStreamList());
+        Consumer<QuadTuple<NewA, NewB, NewC, NewD>> update = buildHelper.getAggregatedUpdate(groupStream.getChildStreamList());
         Consumer<QuadTuple<NewA, NewB, NewC, NewD>> retract =
                 buildHelper.getAggregatedRetract(groupStream.getChildStreamList());
         int outputStoreSize = buildHelper.extractTupleStoreSize(groupStream);
-        AbstractGroupNode<QuadTuple<A, B, C, D>, QuadTuple<NewA, NewB, NewC, NewD>, ?, ?> node =
-                nodeConstructor.apply(inputStoreIndex, insert, retract, outputStoreSize);
+        AbstractGroupNode<QuadTuple<A, B, C, D>, QuadTuple<NewA, NewB, NewC, NewD>, ?, ?, ?> node =
+                nodeConstructor.apply(inputStoreIndex, insert, update, retract, outputStoreSize);
         buildHelper.addNode(node);
         buildHelper.putInsertUpdateRetract(this, node::insert, node::update, node::retract);
     }

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/quad/BavetTriGroupBridgeQuadConstraintStream.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/quad/BavetTriGroupBridgeQuadConstraintStream.java
@@ -70,10 +70,11 @@ final class BavetTriGroupBridgeQuadConstraintStream<Solution_, A, B, C, D, NewA,
         }
         int inputStoreIndex = buildHelper.reserveTupleStoreIndex(parent.getTupleSource());
         Consumer<TriTuple<NewA, NewB, NewC>> insert = buildHelper.getAggregatedInsert(groupStream.getChildStreamList());
+        Consumer<TriTuple<NewA, NewB, NewC>> update = buildHelper.getAggregatedUpdate(groupStream.getChildStreamList());
         Consumer<TriTuple<NewA, NewB, NewC>> retract = buildHelper.getAggregatedRetract(groupStream.getChildStreamList());
         int outputStoreSize = buildHelper.extractTupleStoreSize(groupStream);
-        AbstractGroupNode<QuadTuple<A, B, C, D>, TriTuple<NewA, NewB, NewC>, ?, ?> node =
-                nodeConstructor.apply(inputStoreIndex, insert, retract, outputStoreSize);
+        AbstractGroupNode<QuadTuple<A, B, C, D>, TriTuple<NewA, NewB, NewC>, ?, ?, ?> node =
+                nodeConstructor.apply(inputStoreIndex, insert, update, retract, outputStoreSize);
         buildHelper.addNode(node);
         buildHelper.putInsertUpdateRetract(this, node::insert, node::update, node::retract);
     }

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/quad/BavetUniGroupBridgeQuadConstraintStream.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/quad/BavetUniGroupBridgeQuadConstraintStream.java
@@ -17,6 +17,7 @@
 package org.optaplanner.constraint.streams.bavet.quad;
 
 import java.util.Set;
+import java.util.function.Consumer;
 
 import org.optaplanner.constraint.streams.bavet.BavetConstraintFactory;
 import org.optaplanner.constraint.streams.bavet.common.AbstractGroupNode;
@@ -68,10 +69,12 @@ final class BavetUniGroupBridgeQuadConstraintStream<Solution_, A, B, C, D, NewA>
                     + ") has an non-empty childStreamList (" + childStreamList + ") but it's a groupBy bridge.");
         }
         int inputStoreIndex = buildHelper.reserveTupleStoreIndex(parent.getTupleSource());
+        Consumer<UniTuple<NewA>> insert = buildHelper.getAggregatedInsert(groupStream.getChildStreamList());
+        Consumer<UniTuple<NewA>> update = buildHelper.getAggregatedUpdate(groupStream.getChildStreamList());
+        Consumer<UniTuple<NewA>> retract = buildHelper.getAggregatedRetract(groupStream.getChildStreamList());
         int outputStoreSize = buildHelper.extractTupleStoreSize(groupStream);
-        AbstractGroupNode<QuadTuple<A, B, C, D>, UniTuple<NewA>, ?, ?> node = nodeConstructor.apply(inputStoreIndex,
-                buildHelper.getAggregatedInsert(groupStream.getChildStreamList()),
-                buildHelper.getAggregatedRetract(groupStream.getChildStreamList()), outputStoreSize);
+        AbstractGroupNode<QuadTuple<A, B, C, D>, UniTuple<NewA>, ?, ?, ?> node = nodeConstructor.apply(inputStoreIndex,
+                insert, update, retract, outputStoreSize);
         buildHelper.addNode(node);
         buildHelper.putInsertUpdateRetract(this, node::insert, node::update, node::retract);
     }

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/quad/Group0Mapping1CollectorQuadNode.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/quad/Group0Mapping1CollectorQuadNode.java
@@ -18,7 +18,6 @@ package org.optaplanner.constraint.streams.bavet.quad;
 
 import java.util.function.Consumer;
 
-import org.optaplanner.constraint.streams.bavet.common.Group;
 import org.optaplanner.constraint.streams.bavet.uni.UniTuple;
 import org.optaplanner.core.api.score.stream.quad.QuadConstraintCollector;
 
@@ -31,9 +30,10 @@ final class Group0Mapping1CollectorQuadNode<OldA, OldB, OldC, OldD, A, ResultCon
 
     public Group0Mapping1CollectorQuadNode(int groupStoreIndex,
             QuadConstraintCollector<OldA, OldB, OldC, OldD, ResultContainer_, A> collector,
-            Consumer<UniTuple<A>> nextNodesInsert, Consumer<UniTuple<A>> nextNodesRetract,
+            Consumer<UniTuple<A>> nextNodesInsert, Consumer<UniTuple<A>> nextNodesUpdate,
+            Consumer<UniTuple<A>> nextNodesRetract,
             int outputStoreSize) {
-        super(groupStoreIndex, collector, nextNodesInsert, nextNodesRetract);
+        super(groupStoreIndex, collector, nextNodesInsert, nextNodesUpdate, nextNodesRetract);
         this.outputStoreSize = outputStoreSize;
     }
 
@@ -43,10 +43,13 @@ final class Group0Mapping1CollectorQuadNode<OldA, OldB, OldC, OldD, A, ResultCon
     }
 
     @Override
-    protected UniTuple<A> createOutTuple(Group<UniTuple<A>, String, ResultContainer_> group) {
-        ResultContainer_ resultContainer = group.resultContainer;
-        A a = finisher.apply(resultContainer);
-        return new UniTuple<>(a, outputStoreSize);
+    protected UniTuple<A> createOutTuple(String groupKey) {
+        return new UniTuple<>(null, outputStoreSize);
+    }
+
+    @Override
+    protected void updateOutTupleToResult(UniTuple<A> outTuple, A a) {
+        outTuple.factA = a;
     }
 
     @Override

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/quad/Group0Mapping2CollectorQuadNode.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/quad/Group0Mapping2CollectorQuadNode.java
@@ -19,7 +19,6 @@ package org.optaplanner.constraint.streams.bavet.quad;
 import java.util.function.Consumer;
 
 import org.optaplanner.constraint.streams.bavet.bi.BiTuple;
-import org.optaplanner.constraint.streams.bavet.common.Group;
 import org.optaplanner.core.api.score.stream.ConstraintCollectors;
 import org.optaplanner.core.api.score.stream.quad.QuadConstraintCollector;
 import org.optaplanner.core.impl.util.Pair;
@@ -34,9 +33,10 @@ final class Group0Mapping2CollectorQuadNode<OldA, OldB, OldC, OldD, A, B, Result
     public Group0Mapping2CollectorQuadNode(int groupStoreIndex,
             QuadConstraintCollector<OldA, OldB, OldC, OldD, ResultContainerA_, A> collectorA,
             QuadConstraintCollector<OldA, OldB, OldC, OldD, ResultContainerB_, B> collectorB,
-            Consumer<BiTuple<A, B>> nextNodesInsert, Consumer<BiTuple<A, B>> nextNodesRetract,
+            Consumer<BiTuple<A, B>> nextNodesInsert, Consumer<BiTuple<A, B>> nextNodesUpdate,
+            Consumer<BiTuple<A, B>> nextNodesRetract,
             int outputStoreSize) {
-        super(groupStoreIndex, mergeCollectors(collectorA, collectorB), nextNodesInsert, nextNodesRetract);
+        super(groupStoreIndex, mergeCollectors(collectorA, collectorB), nextNodesInsert, nextNodesUpdate, nextNodesRetract);
         this.outputStoreSize = outputStoreSize;
     }
 
@@ -54,10 +54,14 @@ final class Group0Mapping2CollectorQuadNode<OldA, OldB, OldC, OldD, A, B, Result
     }
 
     @Override
-    protected BiTuple<A, B> createOutTuple(Group<BiTuple<A, B>, String, Object> group) {
-        Object resultContainer = group.resultContainer;
-        Pair<A, B> result = finisher.apply(resultContainer);
-        return new BiTuple<>(result.getKey(), result.getValue(), outputStoreSize);
+    protected BiTuple<A, B> createOutTuple(String groupKey) {
+        return new BiTuple<>(null, null, outputStoreSize);
+    }
+
+    @Override
+    protected void updateOutTupleToResult(BiTuple<A, B> outTuple, Pair<A, B> result) {
+        outTuple.factA = result.getKey();
+        outTuple.factB = result.getValue();
     }
 
     @Override

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/quad/Group0Mapping3CollectorQuadNode.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/quad/Group0Mapping3CollectorQuadNode.java
@@ -18,7 +18,6 @@ package org.optaplanner.constraint.streams.bavet.quad;
 
 import java.util.function.Consumer;
 
-import org.optaplanner.constraint.streams.bavet.common.Group;
 import org.optaplanner.constraint.streams.bavet.tri.TriTuple;
 import org.optaplanner.core.api.score.stream.ConstraintCollectors;
 import org.optaplanner.core.api.score.stream.quad.QuadConstraintCollector;
@@ -35,9 +34,11 @@ final class Group0Mapping3CollectorQuadNode<OldA, OldB, OldC, OldD, A, B, C, Res
             QuadConstraintCollector<OldA, OldB, OldC, OldD, ResultContainerA_, A> collectorA,
             QuadConstraintCollector<OldA, OldB, OldC, OldD, ResultContainerB_, B> collectorB,
             QuadConstraintCollector<OldA, OldB, OldC, OldD, ResultContainerC_, C> collectorC,
-            Consumer<TriTuple<A, B, C>> nextNodesInsert, Consumer<TriTuple<A, B, C>> nextNodesRetract,
+            Consumer<TriTuple<A, B, C>> nextNodesInsert, Consumer<TriTuple<A, B, C>> nextNodesUpdate,
+            Consumer<TriTuple<A, B, C>> nextNodesRetract,
             int outputStoreSize) {
-        super(groupStoreIndex, mergeCollectors(collectorA, collectorB, collectorC), nextNodesInsert, nextNodesRetract);
+        super(groupStoreIndex, mergeCollectors(collectorA, collectorB, collectorC), nextNodesInsert, nextNodesUpdate,
+                nextNodesRetract);
         this.outputStoreSize = outputStoreSize;
     }
 
@@ -57,10 +58,15 @@ final class Group0Mapping3CollectorQuadNode<OldA, OldB, OldC, OldD, A, B, C, Res
     }
 
     @Override
-    protected TriTuple<A, B, C> createOutTuple(Group<TriTuple<A, B, C>, String, Object> group) {
-        Object resultContainer = group.resultContainer;
-        Triple<A, B, C> result = finisher.apply(resultContainer);
-        return new TriTuple<>(result.getA(), result.getB(), result.getC(), outputStoreSize);
+    protected TriTuple<A, B, C> createOutTuple(String groupKey) {
+        return new TriTuple<>(null, null, null, outputStoreSize);
+    }
+
+    @Override
+    protected void updateOutTupleToResult(TriTuple<A, B, C> outTuple, Triple<A, B, C> result) {
+        outTuple.factA = result.getA();
+        outTuple.factB = result.getB();
+        outTuple.factC = result.getC();
     }
 
     @Override

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/quad/Group0Mapping4CollectorQuadNode.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/quad/Group0Mapping4CollectorQuadNode.java
@@ -18,7 +18,6 @@ package org.optaplanner.constraint.streams.bavet.quad;
 
 import java.util.function.Consumer;
 
-import org.optaplanner.constraint.streams.bavet.common.Group;
 import org.optaplanner.core.api.score.stream.ConstraintCollectors;
 import org.optaplanner.core.api.score.stream.quad.QuadConstraintCollector;
 import org.optaplanner.core.impl.util.Quadruple;
@@ -35,10 +34,11 @@ final class Group0Mapping4CollectorQuadNode<OldA, OldB, OldC, OldD, A, B, C, D, 
             QuadConstraintCollector<OldA, OldB, OldC, OldD, ResultContainerB_, B> collectorB,
             QuadConstraintCollector<OldA, OldB, OldC, OldD, ResultContainerC_, C> collectorC,
             QuadConstraintCollector<OldA, OldB, OldC, OldD, ResultContainerD_, D> collectorD,
-            Consumer<QuadTuple<A, B, C, D>> nextNodesInsert, Consumer<QuadTuple<A, B, C, D>> nextNodesRetract,
+            Consumer<QuadTuple<A, B, C, D>> nextNodesInsert, Consumer<QuadTuple<A, B, C, D>> nextNodesUpdate,
+            Consumer<QuadTuple<A, B, C, D>> nextNodesRetract,
             int outputStoreSize) {
-        super(groupStoreIndex, mergeCollectors(collectorA, collectorB, collectorC, collectorD), nextNodesInsert,
-                nextNodesRetract);
+        super(groupStoreIndex, mergeCollectors(collectorA, collectorB, collectorC, collectorD),
+                nextNodesInsert, nextNodesUpdate, nextNodesRetract);
         this.outputStoreSize = outputStoreSize;
     }
 
@@ -58,10 +58,16 @@ final class Group0Mapping4CollectorQuadNode<OldA, OldB, OldC, OldD, A, B, C, D, 
     }
 
     @Override
-    protected QuadTuple<A, B, C, D> createOutTuple(Group<QuadTuple<A, B, C, D>, String, Object> group) {
-        Object resultContainer = group.resultContainer;
-        Quadruple<A, B, C, D> result = finisher.apply(resultContainer);
-        return new QuadTuple<>(result.getA(), result.getB(), result.getC(), result.getD(), outputStoreSize);
+    protected QuadTuple<A, B, C, D> createOutTuple(String groupKey) {
+        return new QuadTuple<>(null, null, null, null, outputStoreSize);
+    }
+
+    @Override
+    protected void updateOutTupleToResult(QuadTuple<A, B, C, D> outTuple, Quadruple<A, B, C, D> result) {
+        outTuple.factA = result.getA();
+        outTuple.factB = result.getB();
+        outTuple.factC = result.getC();
+        outTuple.factD = result.getD();
     }
 
     @Override

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/quad/Group1Mapping0CollectorQuadNode.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/quad/Group1Mapping0CollectorQuadNode.java
@@ -18,7 +18,6 @@ package org.optaplanner.constraint.streams.bavet.quad;
 
 import java.util.function.Consumer;
 
-import org.optaplanner.constraint.streams.bavet.common.Group;
 import org.optaplanner.constraint.streams.bavet.uni.UniTuple;
 import org.optaplanner.core.api.function.QuadFunction;
 
@@ -29,9 +28,10 @@ final class Group1Mapping0CollectorQuadNode<OldA, OldB, OldC, OldD, A>
     private final int outputStoreSize;
 
     public Group1Mapping0CollectorQuadNode(QuadFunction<OldA, OldB, OldC, OldD, A> groupKeyMapping, int groupStoreIndex,
-            Consumer<UniTuple<A>> nextNodesInsert, Consumer<UniTuple<A>> nextNodesRetract,
+            Consumer<UniTuple<A>> nextNodesInsert, Consumer<UniTuple<A>> nextNodesUpdate,
+            Consumer<UniTuple<A>> nextNodesRetract,
             int outputStoreSize) {
-        super(groupStoreIndex, null, nextNodesInsert, nextNodesRetract);
+        super(groupStoreIndex, null, nextNodesInsert, nextNodesUpdate, nextNodesRetract);
         this.groupKeyMapping = groupKeyMapping;
         this.outputStoreSize = outputStoreSize;
     }
@@ -42,9 +42,13 @@ final class Group1Mapping0CollectorQuadNode<OldA, OldB, OldC, OldD, A>
     }
 
     @Override
-    protected UniTuple<A> createOutTuple(Group<UniTuple<A>, A, Void> group) {
-        A a = group.groupKey;
+    protected UniTuple<A> createOutTuple(A a) {
         return new UniTuple<>(a, outputStoreSize);
+    }
+
+    @Override
+    protected void updateOutTupleToResult(UniTuple<A> aUniTuple, Void unused) {
+        throw new IllegalStateException("Impossible state: collector is null.");
     }
 
     @Override

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/quad/Group1Mapping1CollectorQuadNode.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/quad/Group1Mapping1CollectorQuadNode.java
@@ -19,7 +19,6 @@ package org.optaplanner.constraint.streams.bavet.quad;
 import java.util.function.Consumer;
 
 import org.optaplanner.constraint.streams.bavet.bi.BiTuple;
-import org.optaplanner.constraint.streams.bavet.common.Group;
 import org.optaplanner.core.api.function.QuadFunction;
 import org.optaplanner.core.api.score.stream.quad.QuadConstraintCollector;
 
@@ -31,9 +30,10 @@ final class Group1Mapping1CollectorQuadNode<OldA, OldB, OldC, OldD, A, B, Result
 
     public Group1Mapping1CollectorQuadNode(QuadFunction<OldA, OldB, OldC, OldD, A> groupKeyMapping, int groupStoreIndex,
             QuadConstraintCollector<OldA, OldB, OldC, OldD, ResultContainer_, B> collector,
-            Consumer<BiTuple<A, B>> nextNodesInsert, Consumer<BiTuple<A, B>> nextNodesRetract,
+            Consumer<BiTuple<A, B>> nextNodesInsert, Consumer<BiTuple<A, B>> nextNodesUpdate,
+            Consumer<BiTuple<A, B>> nextNodesRetract,
             int outputStoreSize) {
-        super(groupStoreIndex, collector, nextNodesInsert, nextNodesRetract);
+        super(groupStoreIndex, collector, nextNodesInsert, nextNodesUpdate, nextNodesRetract);
         this.groupKeyMapping = groupKeyMapping;
         this.outputStoreSize = outputStoreSize;
     }
@@ -44,10 +44,13 @@ final class Group1Mapping1CollectorQuadNode<OldA, OldB, OldC, OldD, A, B, Result
     }
 
     @Override
-    protected BiTuple<A, B> createOutTuple(Group<BiTuple<A, B>, A, ResultContainer_> group) {
-        A a = group.groupKey;
-        B b = finisher.apply(group.resultContainer);
-        return new BiTuple<>(a, b, outputStoreSize);
+    protected BiTuple<A, B> createOutTuple(A a) {
+        return new BiTuple<>(a, null, outputStoreSize);
+    }
+
+    @Override
+    protected void updateOutTupleToResult(BiTuple<A, B> outTuple, B b) {
+        outTuple.factB = b;
     }
 
     @Override

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/quad/Group1Mapping2CollectorQuadNode.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/quad/Group1Mapping2CollectorQuadNode.java
@@ -18,7 +18,6 @@ package org.optaplanner.constraint.streams.bavet.quad;
 
 import java.util.function.Consumer;
 
-import org.optaplanner.constraint.streams.bavet.common.Group;
 import org.optaplanner.constraint.streams.bavet.tri.TriTuple;
 import org.optaplanner.core.api.function.QuadFunction;
 import org.optaplanner.core.api.score.stream.quad.QuadConstraintCollector;
@@ -33,10 +32,11 @@ final class Group1Mapping2CollectorQuadNode<OldA, OldB, OldC, OldD, A, B, C, Res
     public Group1Mapping2CollectorQuadNode(QuadFunction<OldA, OldB, OldC, OldD, A> groupKeyMapping, int groupStoreIndex,
             QuadConstraintCollector<OldA, OldB, OldC, OldD, ResultContainerB_, B> collectorB,
             QuadConstraintCollector<OldA, OldB, OldC, OldD, ResultContainerC_, C> collectorC,
-            Consumer<TriTuple<A, B, C>> nextNodesInsert, Consumer<TriTuple<A, B, C>> nextNodesRetract,
+            Consumer<TriTuple<A, B, C>> nextNodesInsert, Consumer<TriTuple<A, B, C>> nextNodesUpdate,
+            Consumer<TriTuple<A, B, C>> nextNodesRetract,
             int outputStoreSize) {
-        super(groupStoreIndex, Group0Mapping2CollectorQuadNode.mergeCollectors(collectorB, collectorC), nextNodesInsert,
-                nextNodesRetract);
+        super(groupStoreIndex, Group0Mapping2CollectorQuadNode.mergeCollectors(collectorB, collectorC),
+                nextNodesInsert, nextNodesUpdate, nextNodesRetract);
         this.groupKeyMapping = groupKeyMapping;
         this.outputStoreSize = outputStoreSize;
     }
@@ -51,10 +51,14 @@ final class Group1Mapping2CollectorQuadNode<OldA, OldB, OldC, OldD, A, B, C, Res
     }
 
     @Override
-    protected TriTuple<A, B, C> createOutTuple(Group<TriTuple<A, B, C>, A, Object> group) {
-        A a = group.groupKey;
-        Pair<B, C> result = finisher.apply(group.resultContainer);
-        return new TriTuple<>(a, result.getKey(), result.getValue(), outputStoreSize);
+    protected TriTuple<A, B, C> createOutTuple(A a) {
+        return new TriTuple<>(a, null, null, outputStoreSize);
+    }
+
+    @Override
+    protected void updateOutTupleToResult(TriTuple<A, B, C> outTuple, Pair<B, C> result) {
+        outTuple.factB = result.getKey();
+        outTuple.factC = result.getValue();
     }
 
     @Override

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/quad/Group1Mapping3CollectorQuadNode.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/quad/Group1Mapping3CollectorQuadNode.java
@@ -20,7 +20,6 @@ import static org.optaplanner.constraint.streams.bavet.quad.Group0Mapping3Collec
 
 import java.util.function.Consumer;
 
-import org.optaplanner.constraint.streams.bavet.common.Group;
 import org.optaplanner.core.api.function.QuadFunction;
 import org.optaplanner.core.api.score.stream.quad.QuadConstraintCollector;
 import org.optaplanner.core.impl.util.Triple;
@@ -35,10 +34,11 @@ final class Group1Mapping3CollectorQuadNode<OldA, OldB, OldC, OldD, A, B, C, D, 
             QuadConstraintCollector<OldA, OldB, OldC, OldD, ResultContainerB_, B> collectorB,
             QuadConstraintCollector<OldA, OldB, OldC, OldD, ResultContainerC_, C> collectorC,
             QuadConstraintCollector<OldA, OldB, OldC, OldD, ResultContainerD_, D> collectorD,
-            Consumer<QuadTuple<A, B, C, D>> nextNodesInsert, Consumer<QuadTuple<A, B, C, D>> nextNodesRetract,
+            Consumer<QuadTuple<A, B, C, D>> nextNodesInsert, Consumer<QuadTuple<A, B, C, D>> nextNodesUpdate,
+            Consumer<QuadTuple<A, B, C, D>> nextNodesRetract,
             int outputStoreSize) {
         super(groupStoreIndex, mergeCollectors(collectorB, collectorC, collectorD),
-                nextNodesInsert, nextNodesRetract);
+                nextNodesInsert, nextNodesUpdate, nextNodesRetract);
         this.groupKeyMapping = groupKeyMapping;
         this.outputStoreSize = outputStoreSize;
     }
@@ -49,10 +49,15 @@ final class Group1Mapping3CollectorQuadNode<OldA, OldB, OldC, OldD, A, B, C, D, 
     }
 
     @Override
-    protected QuadTuple<A, B, C, D> createOutTuple(Group<QuadTuple<A, B, C, D>, A, Object> group) {
-        A a = group.groupKey;
-        Triple<B, C, D> result = finisher.apply(group.resultContainer);
-        return new QuadTuple<>(a, result.getA(), result.getB(), result.getC(), outputStoreSize);
+    protected QuadTuple<A, B, C, D> createOutTuple(A a) {
+        return new QuadTuple<>(a, null, null, null, outputStoreSize);
+    }
+
+    @Override
+    protected void updateOutTupleToResult(QuadTuple<A, B, C, D> outTuple, Triple<B, C, D> result) {
+        outTuple.factB = result.getA();
+        outTuple.factC = result.getB();
+        outTuple.factD = result.getC();
     }
 
     @Override

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/quad/Group2Mapping0CollectorQuadNode.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/quad/Group2Mapping0CollectorQuadNode.java
@@ -19,7 +19,6 @@ package org.optaplanner.constraint.streams.bavet.quad;
 import java.util.function.Consumer;
 
 import org.optaplanner.constraint.streams.bavet.bi.BiTuple;
-import org.optaplanner.constraint.streams.bavet.common.Group;
 import org.optaplanner.core.api.function.QuadFunction;
 import org.optaplanner.core.impl.util.Pair;
 
@@ -32,9 +31,10 @@ final class Group2Mapping0CollectorQuadNode<OldA, OldB, OldC, OldD, A, B>
 
     public Group2Mapping0CollectorQuadNode(QuadFunction<OldA, OldB, OldC, OldD, A> groupKeyMappingA,
             QuadFunction<OldA, OldB, OldC, OldD, B> groupKeyMappingB, int groupStoreIndex,
-            Consumer<BiTuple<A, B>> nextNodesInsert, Consumer<BiTuple<A, B>> nextNodesRetract,
+            Consumer<BiTuple<A, B>> nextNodesInsert, Consumer<BiTuple<A, B>> nextNodesUpdate,
+            Consumer<BiTuple<A, B>> nextNodesRetract,
             int outputStoreSize) {
-        super(groupStoreIndex, null, nextNodesInsert, nextNodesRetract);
+        super(groupStoreIndex, null, nextNodesInsert, nextNodesUpdate, nextNodesRetract);
         this.groupKeyMappingA = groupKeyMappingA;
         this.groupKeyMappingB = groupKeyMappingB;
         this.outputStoreSize = outputStoreSize;
@@ -52,9 +52,13 @@ final class Group2Mapping0CollectorQuadNode<OldA, OldB, OldC, OldD, A, B>
     }
 
     @Override
-    protected BiTuple<A, B> createOutTuple(Group<BiTuple<A, B>, Pair<A, B>, Void> group) {
-        Pair<A, B> key = group.groupKey;
-        return new BiTuple<>(key.getKey(), key.getValue(), outputStoreSize);
+    protected BiTuple<A, B> createOutTuple(Pair<A, B> groupKey) {
+        return new BiTuple<>(groupKey.getKey(), groupKey.getValue(), outputStoreSize);
+    }
+
+    @Override
+    protected void updateOutTupleToResult(BiTuple<A, B> outTuple, Void unused) {
+        throw new IllegalStateException("Impossible state: collector is null.");
     }
 
     @Override

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/quad/Group2Mapping1CollectorQuadNode.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/quad/Group2Mapping1CollectorQuadNode.java
@@ -18,7 +18,6 @@ package org.optaplanner.constraint.streams.bavet.quad;
 
 import java.util.function.Consumer;
 
-import org.optaplanner.constraint.streams.bavet.common.Group;
 import org.optaplanner.constraint.streams.bavet.tri.TriTuple;
 import org.optaplanner.core.api.function.QuadFunction;
 import org.optaplanner.core.api.score.stream.quad.QuadConstraintCollector;
@@ -35,9 +34,10 @@ final class Group2Mapping1CollectorQuadNode<OldA, OldB, OldC, OldD, A, B, C, Res
             QuadFunction<OldA, OldB, OldC, OldD, B> groupKeyMappingB,
             int groupStoreIndex,
             QuadConstraintCollector<OldA, OldB, OldC, OldD, ResultContainer_, C> collector,
-            Consumer<TriTuple<A, B, C>> nextNodesInsert, Consumer<TriTuple<A, B, C>> nextNodesRetract,
+            Consumer<TriTuple<A, B, C>> nextNodesInsert, Consumer<TriTuple<A, B, C>> nextNodesUpdate,
+            Consumer<TriTuple<A, B, C>> nextNodesRetract,
             int outputStoreSize) {
-        super(groupStoreIndex, collector, nextNodesInsert, nextNodesRetract);
+        super(groupStoreIndex, collector, nextNodesInsert, nextNodesUpdate, nextNodesRetract);
         this.groupKeyMappingA = groupKeyMappingA;
         this.groupKeyMappingB = groupKeyMappingB;
         this.outputStoreSize = outputStoreSize;
@@ -55,10 +55,13 @@ final class Group2Mapping1CollectorQuadNode<OldA, OldB, OldC, OldD, A, B, C, Res
     }
 
     @Override
-    protected TriTuple<A, B, C> createOutTuple(Group<TriTuple<A, B, C>, Pair<A, B>, ResultContainer_> group) {
-        Pair<A, B> groupKey = group.groupKey;
-        C c = finisher.apply(group.resultContainer);
-        return new TriTuple<>(groupKey.getKey(), groupKey.getValue(), c, outputStoreSize);
+    protected TriTuple<A, B, C> createOutTuple(Pair<A, B> groupKey) {
+        return new TriTuple<>(groupKey.getKey(), groupKey.getValue(), null, outputStoreSize);
+    }
+
+    @Override
+    protected void updateOutTupleToResult(TriTuple<A, B, C> outTuple, C c) {
+        outTuple.factC = c;
     }
 
     @Override

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/quad/Group2Mapping2CollectorQuadNode.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/quad/Group2Mapping2CollectorQuadNode.java
@@ -20,7 +20,6 @@ import static org.optaplanner.constraint.streams.bavet.quad.Group0Mapping2Collec
 
 import java.util.function.Consumer;
 
-import org.optaplanner.constraint.streams.bavet.common.Group;
 import org.optaplanner.core.api.function.QuadFunction;
 import org.optaplanner.core.api.score.stream.quad.QuadConstraintCollector;
 import org.optaplanner.core.impl.util.Pair;
@@ -36,9 +35,10 @@ final class Group2Mapping2CollectorQuadNode<OldA, OldB, OldC, OldD, A, B, C, D, 
             QuadFunction<OldA, OldB, OldC, OldD, B> groupKeyMappingB, int groupStoreIndex,
             QuadConstraintCollector<OldA, OldB, OldC, OldD, ResultContainerC_, C> collectorC,
             QuadConstraintCollector<OldA, OldB, OldC, OldD, ResultContainerD_, D> collectorD,
-            Consumer<QuadTuple<A, B, C, D>> nextNodesInsert, Consumer<QuadTuple<A, B, C, D>> nextNodesRetract,
+            Consumer<QuadTuple<A, B, C, D>> nextNodesInsert, Consumer<QuadTuple<A, B, C, D>> nextNodesUpdate,
+            Consumer<QuadTuple<A, B, C, D>> nextNodesRetract,
             int outputStoreSize) {
-        super(groupStoreIndex, mergeCollectors(collectorC, collectorD), nextNodesInsert, nextNodesRetract);
+        super(groupStoreIndex, mergeCollectors(collectorC, collectorD), nextNodesInsert, nextNodesUpdate, nextNodesRetract);
         this.groupKeyMappingA = groupKeyMappingA;
         this.groupKeyMappingB = groupKeyMappingB;
         this.outputStoreSize = outputStoreSize;
@@ -56,10 +56,14 @@ final class Group2Mapping2CollectorQuadNode<OldA, OldB, OldC, OldD, A, B, C, D, 
     }
 
     @Override
-    protected QuadTuple<A, B, C, D> createOutTuple(Group<QuadTuple<A, B, C, D>, Pair<A, B>, Object> group) {
-        Pair<A, B> groupKey = group.groupKey;
-        Pair<C, D> result = finisher.apply(group.resultContainer);
-        return new QuadTuple<>(groupKey.getKey(), groupKey.getValue(), result.getKey(), result.getValue(), outputStoreSize);
+    protected QuadTuple<A, B, C, D> createOutTuple(Pair<A, B> groupKey) {
+        return new QuadTuple<>(groupKey.getKey(), groupKey.getValue(), null, null, outputStoreSize);
+    }
+
+    @Override
+    protected void updateOutTupleToResult(QuadTuple<A, B, C, D> outTuple, Pair<C, D> result) {
+        outTuple.factC = result.getKey();
+        outTuple.factD = result.getValue();
     }
 
     @Override

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/quad/Group3Mapping0CollectorQuadNode.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/quad/Group3Mapping0CollectorQuadNode.java
@@ -18,7 +18,6 @@ package org.optaplanner.constraint.streams.bavet.quad;
 
 import java.util.function.Consumer;
 
-import org.optaplanner.constraint.streams.bavet.common.Group;
 import org.optaplanner.constraint.streams.bavet.tri.TriTuple;
 import org.optaplanner.core.api.function.QuadFunction;
 import org.optaplanner.core.impl.util.Triple;
@@ -34,8 +33,9 @@ final class Group3Mapping0CollectorQuadNode<OldA, OldB, OldC, OldD, A, B, C>
     public Group3Mapping0CollectorQuadNode(QuadFunction<OldA, OldB, OldC, OldD, A> groupKeyMappingA,
             QuadFunction<OldA, OldB, OldC, OldD, B> groupKeyMappingB, QuadFunction<OldA, OldB, OldC, OldD, C> groupKeyMappingC,
             int groupStoreIndex,
-            Consumer<TriTuple<A, B, C>> nextNodesInsert, Consumer<TriTuple<A, B, C>> nextNodesRetract, int outputStoreSize) {
-        super(groupStoreIndex, null, nextNodesInsert, nextNodesRetract);
+            Consumer<TriTuple<A, B, C>> nextNodesInsert, Consumer<TriTuple<A, B, C>> nextNodesUpdate,
+            Consumer<TriTuple<A, B, C>> nextNodesRetract, int outputStoreSize) {
+        super(groupStoreIndex, null, nextNodesInsert, nextNodesUpdate, nextNodesRetract);
         this.groupKeyMappingA = groupKeyMappingA;
         this.groupKeyMappingB = groupKeyMappingB;
         this.groupKeyMappingC = groupKeyMappingC;
@@ -55,9 +55,13 @@ final class Group3Mapping0CollectorQuadNode<OldA, OldB, OldC, OldD, A, B, C>
     }
 
     @Override
-    protected TriTuple<A, B, C> createOutTuple(Group<TriTuple<A, B, C>, Triple<A, B, C>, Void> group) {
-        Triple<A, B, C> key = group.groupKey;
-        return new TriTuple<>(key.getA(), key.getB(), key.getC(), outputStoreSize);
+    protected TriTuple<A, B, C> createOutTuple(Triple<A, B, C> groupKey) {
+        return new TriTuple<>(groupKey.getA(), groupKey.getB(), groupKey.getC(), outputStoreSize);
+    }
+
+    @Override
+    protected void updateOutTupleToResult(TriTuple<A, B, C> outTuple, Void unused) {
+        throw new IllegalStateException("Impossible state: collector is null.");
     }
 
     @Override

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/quad/Group3Mapping1CollectorQuadNode.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/quad/Group3Mapping1CollectorQuadNode.java
@@ -18,7 +18,6 @@ package org.optaplanner.constraint.streams.bavet.quad;
 
 import java.util.function.Consumer;
 
-import org.optaplanner.constraint.streams.bavet.common.Group;
 import org.optaplanner.core.api.function.QuadFunction;
 import org.optaplanner.core.api.score.stream.quad.QuadConstraintCollector;
 import org.optaplanner.core.impl.util.Triple;
@@ -34,9 +33,10 @@ final class Group3Mapping1CollectorQuadNode<OldA, OldB, OldC, OldD, A, B, C, D, 
     public Group3Mapping1CollectorQuadNode(QuadFunction<OldA, OldB, OldC, OldD, A> groupKeyMappingA,
             QuadFunction<OldA, OldB, OldC, OldD, B> groupKeyMappingB, QuadFunction<OldA, OldB, OldC, OldD, C> groupKeyMappingC,
             int groupStoreIndex, QuadConstraintCollector<OldA, OldB, OldC, OldD, ResultContainer_, D> collector,
-            Consumer<QuadTuple<A, B, C, D>> nextNodesInsert, Consumer<QuadTuple<A, B, C, D>> nextNodesRetract,
+            Consumer<QuadTuple<A, B, C, D>> nextNodesInsert, Consumer<QuadTuple<A, B, C, D>> nextNodesUpdate,
+            Consumer<QuadTuple<A, B, C, D>> nextNodesRetract,
             int outputStoreSize) {
-        super(groupStoreIndex, collector, nextNodesInsert, nextNodesRetract);
+        super(groupStoreIndex, collector, nextNodesInsert, nextNodesUpdate, nextNodesRetract);
         this.groupKeyMappingA = groupKeyMappingA;
         this.groupKeyMappingB = groupKeyMappingB;
         this.groupKeyMappingC = groupKeyMappingC;
@@ -56,10 +56,13 @@ final class Group3Mapping1CollectorQuadNode<OldA, OldB, OldC, OldD, A, B, C, D, 
     }
 
     @Override
-    protected QuadTuple<A, B, C, D> createOutTuple(Group<QuadTuple<A, B, C, D>, Triple<A, B, C>, ResultContainer_> group) {
-        Triple<A, B, C> groupKey = group.groupKey;
-        D d = finisher.apply(group.resultContainer);
-        return new QuadTuple<>(groupKey.getA(), groupKey.getB(), groupKey.getC(), d, outputStoreSize);
+    protected QuadTuple<A, B, C, D> createOutTuple(Triple<A, B, C> groupKey) {
+        return new QuadTuple<>(groupKey.getA(), groupKey.getB(), groupKey.getC(), null, outputStoreSize);
+    }
+
+    @Override
+    protected void updateOutTupleToResult(QuadTuple<A, B, C, D> outTuple, D d) {
+        outTuple.factD = d;
     }
 
     @Override

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/quad/Group4Mapping0CollectorQuadNode.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/quad/Group4Mapping0CollectorQuadNode.java
@@ -18,7 +18,6 @@ package org.optaplanner.constraint.streams.bavet.quad;
 
 import java.util.function.Consumer;
 
-import org.optaplanner.constraint.streams.bavet.common.Group;
 import org.optaplanner.core.api.function.QuadFunction;
 import org.optaplanner.core.impl.util.Quadruple;
 
@@ -34,9 +33,10 @@ final class Group4Mapping0CollectorQuadNode<OldA, OldB, OldC, OldD, A, B, C, D>
     public Group4Mapping0CollectorQuadNode(QuadFunction<OldA, OldB, OldC, OldD, A> groupKeyMappingA,
             QuadFunction<OldA, OldB, OldC, OldD, B> groupKeyMappingB, QuadFunction<OldA, OldB, OldC, OldD, C> groupKeyMappingC,
             QuadFunction<OldA, OldB, OldC, OldD, D> groupKeyMappingD, int groupStoreIndex,
-            Consumer<QuadTuple<A, B, C, D>> nextNodesInsert, Consumer<QuadTuple<A, B, C, D>> nextNodesRetract,
+            Consumer<QuadTuple<A, B, C, D>> nextNodesInsert, Consumer<QuadTuple<A, B, C, D>> nextNodesUpdate,
+            Consumer<QuadTuple<A, B, C, D>> nextNodesRetract,
             int outputStoreSize) {
-        super(groupStoreIndex, null, nextNodesInsert, nextNodesRetract);
+        super(groupStoreIndex, null, nextNodesInsert, nextNodesUpdate, nextNodesRetract);
         this.groupKeyMappingA = groupKeyMappingA;
         this.groupKeyMappingB = groupKeyMappingB;
         this.groupKeyMappingC = groupKeyMappingC;
@@ -58,9 +58,13 @@ final class Group4Mapping0CollectorQuadNode<OldA, OldB, OldC, OldD, A, B, C, D>
     }
 
     @Override
-    protected QuadTuple<A, B, C, D> createOutTuple(Group<QuadTuple<A, B, C, D>, Quadruple<A, B, C, D>, Void> group) {
-        Quadruple<A, B, C, D> key = group.groupKey;
-        return new QuadTuple<>(key.getA(), key.getB(), key.getC(), key.getD(), outputStoreSize);
+    protected QuadTuple<A, B, C, D> createOutTuple(Quadruple<A, B, C, D> groupKey) {
+        return new QuadTuple<>(groupKey.getA(), groupKey.getB(), groupKey.getC(), groupKey.getD(), outputStoreSize);
+    }
+
+    @Override
+    protected void updateOutTupleToResult(QuadTuple<A, B, C, D> outTuple, Void unused) {
+        throw new IllegalStateException("Impossible state: collector is null.");
     }
 
     @Override

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/quad/QuadGroupNodeConstructor.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/quad/QuadGroupNodeConstructor.java
@@ -23,7 +23,8 @@ import org.optaplanner.constraint.streams.bavet.common.Tuple;
 @FunctionalInterface
 interface QuadGroupNodeConstructor<A, B, C, D, Tuple_ extends Tuple> {
 
-    AbstractGroupQuadNode<A, B, C, D, Tuple_, ?, ?, ?> apply(int inputStoreIndex, Consumer<Tuple_> insert,
-            Consumer<Tuple_> retract, int outputStoreSize);
+    AbstractGroupQuadNode<A, B, C, D, Tuple_, ?, ?, ?> apply(int inputStoreIndex,
+            Consumer<Tuple_> insert, Consumer<Tuple_> update, Consumer<Tuple_> retract,
+            int outputStoreSize);
 
 }

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/quad/QuadTuple.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/quad/QuadTuple.java
@@ -21,10 +21,11 @@ import org.optaplanner.constraint.streams.bavet.common.Tuple;
 
 public final class QuadTuple<A, B, C, D> implements Tuple {
 
-    public final A factA;
-    public final B factB;
-    public final C factC;
-    public final D factD;
+    // Only a tuple's origin node may modify a fact.
+    public A factA;
+    public B factB;
+    public C factC;
+    public D factD;
 
     public final Object[] store;
 

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/tri/AbstractGroupTriNode.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/tri/AbstractGroupTriNode.java
@@ -17,7 +17,6 @@
 package org.optaplanner.constraint.streams.bavet.tri;
 
 import java.util.function.Consumer;
-import java.util.function.Function;
 
 import org.optaplanner.constraint.streams.bavet.common.AbstractGroupNode;
 import org.optaplanner.constraint.streams.bavet.common.Tuple;
@@ -25,19 +24,20 @@ import org.optaplanner.core.api.function.QuadFunction;
 import org.optaplanner.core.api.score.stream.tri.TriConstraintCollector;
 
 abstract class AbstractGroupTriNode<OldA, OldB, OldC, OutTuple_ extends Tuple, GroupKey_, ResultContainer_, Result_>
-        extends AbstractGroupNode<TriTuple<OldA, OldB, OldC>, OutTuple_, GroupKey_, ResultContainer_> {
+        extends AbstractGroupNode<TriTuple<OldA, OldB, OldC>, OutTuple_, GroupKey_, ResultContainer_, Result_> {
 
     private final QuadFunction<ResultContainer_, OldA, OldB, OldC, Runnable> accumulator;
-    protected final Function<ResultContainer_, Result_> finisher;
 
     protected AbstractGroupTriNode(int groupStoreIndex,
             TriConstraintCollector<OldA, OldB, OldC, ResultContainer_, Result_> collector,
-            Consumer<OutTuple_> nextNodesInsert, Consumer<OutTuple_> nextNodesRetract) {
+            Consumer<OutTuple_> nextNodesInsert,
+            Consumer<OutTuple_> nextNodesUpdate,
+            Consumer<OutTuple_> nextNodesRetract) {
         super(groupStoreIndex,
                 collector == null ? null : collector.supplier(),
-                nextNodesInsert, nextNodesRetract);
+                collector == null ? null : collector.finisher(),
+                nextNodesInsert, nextNodesUpdate, nextNodesRetract);
         accumulator = collector == null ? null : collector.accumulator();
-        finisher = collector == null ? null : collector.finisher();
     }
 
     @Override

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/tri/BavetAbstractTriConstraintStream.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/tri/BavetAbstractTriConstraintStream.java
@@ -197,9 +197,11 @@ public abstract class BavetAbstractTriConstraintStream<Solution_, A, B, C> exten
     public <ResultContainer_, Result_> UniConstraintStream<Result_> groupBy(
             TriConstraintCollector<A, B, C, ResultContainer_, Result_> collector) {
         TriGroupNodeConstructor<A, B, C, UniTuple<Result_>> nodeConstructor =
-                (int inputStoreIndex, Consumer<UniTuple<Result_>> insert, Consumer<UniTuple<Result_>> retract,
-                        int outputStoreSize) -> new Group0Mapping1CollectorTriNode<>(inputStoreIndex, collector, insert,
-                                retract, outputStoreSize);
+                (int inputStoreIndex, Consumer<UniTuple<Result_>> insert,
+                        Consumer<UniTuple<Result_>> update,
+                        Consumer<UniTuple<Result_>> retract,
+                        int outputStoreSize) -> new Group0Mapping1CollectorTriNode<>(inputStoreIndex, collector,
+                                insert, update, retract, outputStoreSize);
         return buildUniGroupBy(nodeConstructor);
     }
 
@@ -217,9 +219,10 @@ public abstract class BavetAbstractTriConstraintStream<Solution_, A, B, C> exten
             TriConstraintCollector<A, B, C, ResultContainerB_, ResultB_> collectorB) {
         TriGroupNodeConstructor<A, B, C, BiTuple<ResultA_, ResultB_>> nodeConstructor =
                 (int inputStoreIndex, Consumer<BiTuple<ResultA_, ResultB_>> insert,
+                        Consumer<BiTuple<ResultA_, ResultB_>> update,
                         Consumer<BiTuple<ResultA_, ResultB_>> retract,
                         int outputStoreSize) -> new Group0Mapping2CollectorTriNode<>(inputStoreIndex, collectorA, collectorB,
-                                insert, retract, outputStoreSize);
+                                insert, update, retract, outputStoreSize);
         return buildBiGroupBy(nodeConstructor);
     }
 
@@ -240,9 +243,10 @@ public abstract class BavetAbstractTriConstraintStream<Solution_, A, B, C> exten
                     TriConstraintCollector<A, B, C, ResultContainerC_, ResultC_> collectorC) {
         TriGroupNodeConstructor<A, B, C, TriTuple<ResultA_, ResultB_, ResultC_>> nodeConstructor =
                 (int inputStoreIndex, Consumer<TriTuple<ResultA_, ResultB_, ResultC_>> insert,
+                        Consumer<TriTuple<ResultA_, ResultB_, ResultC_>> update,
                         Consumer<TriTuple<ResultA_, ResultB_, ResultC_>> retract,
                         int outputStoreSize) -> new Group0Mapping3CollectorTriNode<>(inputStoreIndex, collectorA, collectorB,
-                                collectorC, insert, retract, outputStoreSize);
+                                collectorC, insert, update, retract, outputStoreSize);
         return buildTriGroupBy(nodeConstructor);
     }
 
@@ -264,9 +268,10 @@ public abstract class BavetAbstractTriConstraintStream<Solution_, A, B, C> exten
                     TriConstraintCollector<A, B, C, ResultContainerD_, ResultD_> collectorD) {
         TriGroupNodeConstructor<A, B, C, QuadTuple<ResultA_, ResultB_, ResultC_, ResultD_>> nodeConstructor =
                 (int inputStoreIndex, Consumer<QuadTuple<ResultA_, ResultB_, ResultC_, ResultD_>> insert,
+                        Consumer<QuadTuple<ResultA_, ResultB_, ResultC_, ResultD_>> update,
                         Consumer<QuadTuple<ResultA_, ResultB_, ResultC_, ResultD_>> retract,
                         int outputStoreSize) -> new Group0Mapping4CollectorTriNode<>(inputStoreIndex, collectorA, collectorB,
-                                collectorC, collectorD, insert, retract, outputStoreSize);
+                                collectorC, collectorD, insert, update, retract, outputStoreSize);
         return buildQuadGroupBy(nodeConstructor);
     }
 
@@ -282,9 +287,11 @@ public abstract class BavetAbstractTriConstraintStream<Solution_, A, B, C> exten
     @Override
     public <GroupKey_> UniConstraintStream<GroupKey_> groupBy(TriFunction<A, B, C, GroupKey_> groupKeyMapping) {
         TriGroupNodeConstructor<A, B, C, UniTuple<GroupKey_>> nodeConstructor =
-                (int inputStoreIndex, Consumer<UniTuple<GroupKey_>> insert, Consumer<UniTuple<GroupKey_>> retract,
-                        int outputStoreSize) -> new Group1Mapping0CollectorTriNode<>(groupKeyMapping, inputStoreIndex, insert,
-                                retract, outputStoreSize);
+                (int inputStoreIndex, Consumer<UniTuple<GroupKey_>> insert,
+                        Consumer<UniTuple<GroupKey_>> update,
+                        Consumer<UniTuple<GroupKey_>> retract,
+                        int outputStoreSize) -> new Group1Mapping0CollectorTriNode<>(groupKeyMapping, inputStoreIndex,
+                                insert, update, retract, outputStoreSize);
         return buildUniGroupBy(nodeConstructor);
     }
 
@@ -295,9 +302,10 @@ public abstract class BavetAbstractTriConstraintStream<Solution_, A, B, C> exten
                     TriConstraintCollector<A, B, C, ResultContainerC_, ResultC_> collectorC) {
         TriGroupNodeConstructor<A, B, C, TriTuple<GroupKey_, ResultB_, ResultC_>> nodeConstructor =
                 (int inputStoreIndex, Consumer<TriTuple<GroupKey_, ResultB_, ResultC_>> insert,
+                        Consumer<TriTuple<GroupKey_, ResultB_, ResultC_>> update,
                         Consumer<TriTuple<GroupKey_, ResultB_, ResultC_>> retract,
                         int outputStoreSize) -> new Group1Mapping2CollectorTriNode<>(groupKeyMapping, inputStoreIndex,
-                                collectorB, collectorC, insert, retract, outputStoreSize);
+                                collectorB, collectorC, insert, update, retract, outputStoreSize);
         return buildTriGroupBy(nodeConstructor);
     }
 
@@ -310,9 +318,10 @@ public abstract class BavetAbstractTriConstraintStream<Solution_, A, B, C> exten
                     TriConstraintCollector<A, B, C, ResultContainerD_, ResultD_> collectorD) {
         TriGroupNodeConstructor<A, B, C, QuadTuple<GroupKey_, ResultB_, ResultC_, ResultD_>> nodeConstructor =
                 (int inputStoreIndex, Consumer<QuadTuple<GroupKey_, ResultB_, ResultC_, ResultD_>> insert,
+                        Consumer<QuadTuple<GroupKey_, ResultB_, ResultC_, ResultD_>> update,
                         Consumer<QuadTuple<GroupKey_, ResultB_, ResultC_, ResultD_>> retract,
                         int outputStoreSize) -> new Group1Mapping3CollectorTriNode<>(groupKeyMapping, inputStoreIndex,
-                                collectorB, collectorC, collectorD, insert, retract, outputStoreSize);
+                                collectorB, collectorC, collectorD, insert, update, retract, outputStoreSize);
         return buildQuadGroupBy(nodeConstructor);
     }
 
@@ -322,9 +331,10 @@ public abstract class BavetAbstractTriConstraintStream<Solution_, A, B, C> exten
             TriConstraintCollector<A, B, C, ResultContainer_, Result_> collector) {
         TriGroupNodeConstructor<A, B, C, BiTuple<GroupKey_, Result_>> nodeConstructor =
                 (int inputStoreIndex, Consumer<BiTuple<GroupKey_, Result_>> insert,
+                        Consumer<BiTuple<GroupKey_, Result_>> update,
                         Consumer<BiTuple<GroupKey_, Result_>> retract,
                         int outputStoreSize) -> new Group1Mapping1CollectorTriNode<>(groupKeyMapping, inputStoreIndex,
-                                collector, insert, retract, outputStoreSize);
+                                collector, insert, update, retract, outputStoreSize);
         return buildBiGroupBy(nodeConstructor);
     }
 
@@ -334,10 +344,11 @@ public abstract class BavetAbstractTriConstraintStream<Solution_, A, B, C> exten
             TriFunction<A, B, C, GroupKeyB_> groupKeyBMapping) {
         TriGroupNodeConstructor<A, B, C, BiTuple<GroupKeyA_, GroupKeyB_>> nodeConstructor =
                 (int inputStoreIndex, Consumer<BiTuple<GroupKeyA_, GroupKeyB_>> insert,
+                        Consumer<BiTuple<GroupKeyA_, GroupKeyB_>> update,
                         Consumer<BiTuple<GroupKeyA_, GroupKeyB_>> retract,
                         int outputStoreSize) -> new Group2Mapping0CollectorTriNode<>(groupKeyAMapping, groupKeyBMapping,
                                 inputStoreIndex,
-                                insert, retract, outputStoreSize);
+                                insert, update, retract, outputStoreSize);
         return buildBiGroupBy(nodeConstructor);
     }
 
@@ -348,9 +359,10 @@ public abstract class BavetAbstractTriConstraintStream<Solution_, A, B, C> exten
             TriConstraintCollector<A, B, C, ResultContainer_, Result_> collector) {
         TriGroupNodeConstructor<A, B, C, TriTuple<GroupKeyA_, GroupKeyB_, Result_>> nodeConstructor =
                 (int inputStoreIndex, Consumer<TriTuple<GroupKeyA_, GroupKeyB_, Result_>> insert,
+                        Consumer<TriTuple<GroupKeyA_, GroupKeyB_, Result_>> update,
                         Consumer<TriTuple<GroupKeyA_, GroupKeyB_, Result_>> retract,
                         int outputStoreSize) -> new Group2Mapping1CollectorTriNode<>(groupKeyAMapping, groupKeyBMapping,
-                                inputStoreIndex, collector, insert, retract, outputStoreSize);
+                                inputStoreIndex, collector, insert, update, retract, outputStoreSize);
         return buildTriGroupBy(nodeConstructor);
     }
 
@@ -363,9 +375,10 @@ public abstract class BavetAbstractTriConstraintStream<Solution_, A, B, C> exten
                     TriConstraintCollector<A, B, C, ResultContainerD_, ResultD_> collectorD) {
         TriGroupNodeConstructor<A, B, C, QuadTuple<GroupKeyA_, GroupKeyB_, ResultC_, ResultD_>> nodeConstructor =
                 (int inputStoreIndex, Consumer<QuadTuple<GroupKeyA_, GroupKeyB_, ResultC_, ResultD_>> insert,
+                        Consumer<QuadTuple<GroupKeyA_, GroupKeyB_, ResultC_, ResultD_>> update,
                         Consumer<QuadTuple<GroupKeyA_, GroupKeyB_, ResultC_, ResultD_>> retract,
                         int outputStoreSize) -> new Group2Mapping2CollectorTriNode<>(groupKeyAMapping, groupKeyBMapping,
-                                inputStoreIndex, collectorC, collectorD, insert, retract, outputStoreSize);
+                                inputStoreIndex, collectorC, collectorD, insert, update, retract, outputStoreSize);
         return buildQuadGroupBy(nodeConstructor);
     }
 
@@ -375,10 +388,11 @@ public abstract class BavetAbstractTriConstraintStream<Solution_, A, B, C> exten
             TriFunction<A, B, C, GroupKeyC_> groupKeyCMapping) {
         TriGroupNodeConstructor<A, B, C, TriTuple<GroupKeyA_, GroupKeyB_, GroupKeyC_>> nodeConstructor =
                 (int inputStoreIndex, Consumer<TriTuple<GroupKeyA_, GroupKeyB_, GroupKeyC_>> insert,
+                        Consumer<TriTuple<GroupKeyA_, GroupKeyB_, GroupKeyC_>> update,
                         Consumer<TriTuple<GroupKeyA_, GroupKeyB_, GroupKeyC_>> retract,
                         int outputStoreSize) -> new Group3Mapping0CollectorTriNode<>(groupKeyAMapping, groupKeyBMapping,
                                 groupKeyCMapping,
-                                inputStoreIndex, insert, retract, outputStoreSize);
+                                inputStoreIndex, insert, update, retract, outputStoreSize);
         return buildTriGroupBy(nodeConstructor);
     }
 
@@ -391,9 +405,10 @@ public abstract class BavetAbstractTriConstraintStream<Solution_, A, B, C> exten
                     TriConstraintCollector<A, B, C, ResultContainerD_, ResultD_> collectorD) {
         TriGroupNodeConstructor<A, B, C, QuadTuple<GroupKeyA_, GroupKeyB_, GroupKeyC_, ResultD_>> nodeConstructor =
                 (int inputStoreIndex, Consumer<QuadTuple<GroupKeyA_, GroupKeyB_, GroupKeyC_, ResultD_>> insert,
+                        Consumer<QuadTuple<GroupKeyA_, GroupKeyB_, GroupKeyC_, ResultD_>> update,
                         Consumer<QuadTuple<GroupKeyA_, GroupKeyB_, GroupKeyC_, ResultD_>> retract,
                         int outputStoreSize) -> new Group3Mapping1CollectorTriNode<>(groupKeyAMapping, groupKeyBMapping,
-                                groupKeyCMapping, inputStoreIndex, collectorD, insert, retract, outputStoreSize);
+                                groupKeyCMapping, inputStoreIndex, collectorD, insert, update, retract, outputStoreSize);
         return buildQuadGroupBy(nodeConstructor);
     }
 
@@ -405,9 +420,10 @@ public abstract class BavetAbstractTriConstraintStream<Solution_, A, B, C> exten
                     TriFunction<A, B, C, GroupKeyD_> groupKeyDMapping) {
         TriGroupNodeConstructor<A, B, C, QuadTuple<GroupKeyA_, GroupKeyB_, GroupKeyC_, GroupKeyD_>> nodeConstructor =
                 (int inputStoreIndex, Consumer<QuadTuple<GroupKeyA_, GroupKeyB_, GroupKeyC_, GroupKeyD_>> insert,
+                        Consumer<QuadTuple<GroupKeyA_, GroupKeyB_, GroupKeyC_, GroupKeyD_>> update,
                         Consumer<QuadTuple<GroupKeyA_, GroupKeyB_, GroupKeyC_, GroupKeyD_>> retract,
                         int outputStoreSize) -> new Group4Mapping0CollectorTriNode<>(groupKeyAMapping, groupKeyBMapping,
-                                groupKeyCMapping, groupKeyDMapping, inputStoreIndex, insert, retract, outputStoreSize);
+                                groupKeyCMapping, groupKeyDMapping, inputStoreIndex, insert, update, retract, outputStoreSize);
         return buildQuadGroupBy(nodeConstructor);
     }
 

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/tri/BavetBiGroupBridgeTriConstraintStream.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/tri/BavetBiGroupBridgeTriConstraintStream.java
@@ -70,10 +70,11 @@ final class BavetBiGroupBridgeTriConstraintStream<Solution_, A, B, C, NewA, NewB
         }
         int inputStoreIndex = buildHelper.reserveTupleStoreIndex(parent.getTupleSource());
         Consumer<BiTuple<NewA, NewB>> insert = buildHelper.getAggregatedInsert(groupStream.getChildStreamList());
+        Consumer<BiTuple<NewA, NewB>> update = buildHelper.getAggregatedUpdate(groupStream.getChildStreamList());
         Consumer<BiTuple<NewA, NewB>> retract = buildHelper.getAggregatedRetract(groupStream.getChildStreamList());
         int outputStoreSize = buildHelper.extractTupleStoreSize(groupStream);
-        AbstractGroupNode<TriTuple<A, B, C>, BiTuple<NewA, NewB>, ?, ?> node =
-                nodeConstructor.apply(inputStoreIndex, insert, retract, outputStoreSize);
+        AbstractGroupNode<TriTuple<A, B, C>, BiTuple<NewA, NewB>, ?, ?, ?> node =
+                nodeConstructor.apply(inputStoreIndex, insert, update, retract, outputStoreSize);
         buildHelper.addNode(node);
         buildHelper.putInsertUpdateRetract(this, node::insert, node::update, node::retract);
     }

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/tri/BavetQuadGroupBridgeTriConstraintStream.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/tri/BavetQuadGroupBridgeTriConstraintStream.java
@@ -70,11 +70,12 @@ final class BavetQuadGroupBridgeTriConstraintStream<Solution_, A, B, C, NewA, Ne
         }
         int inputStoreIndex = buildHelper.reserveTupleStoreIndex(parent.getTupleSource());
         Consumer<QuadTuple<NewA, NewB, NewC, NewD>> insert = buildHelper.getAggregatedInsert(groupStream.getChildStreamList());
+        Consumer<QuadTuple<NewA, NewB, NewC, NewD>> update = buildHelper.getAggregatedUpdate(groupStream.getChildStreamList());
         Consumer<QuadTuple<NewA, NewB, NewC, NewD>> retract =
                 buildHelper.getAggregatedRetract(groupStream.getChildStreamList());
         int outputStoreSize = buildHelper.extractTupleStoreSize(groupStream);
-        AbstractGroupNode<TriTuple<A, B, C>, QuadTuple<NewA, NewB, NewC, NewD>, ?, ?> node =
-                nodeConstructor.apply(inputStoreIndex, insert, retract, outputStoreSize);
+        AbstractGroupNode<TriTuple<A, B, C>, QuadTuple<NewA, NewB, NewC, NewD>, ?, ?, ?> node =
+                nodeConstructor.apply(inputStoreIndex, insert, update, retract, outputStoreSize);
         buildHelper.addNode(node);
         buildHelper.putInsertUpdateRetract(this, node::insert, node::update, node::retract);
     }

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/tri/BavetTriGroupBridgeTriConstraintStream.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/tri/BavetTriGroupBridgeTriConstraintStream.java
@@ -68,10 +68,11 @@ final class BavetTriGroupBridgeTriConstraintStream<Solution_, A, B, C, NewA, New
         }
         int inputStoreIndex = buildHelper.reserveTupleStoreIndex(parent.getTupleSource());
         Consumer<TriTuple<NewA, NewB, NewC>> insert = buildHelper.getAggregatedInsert(groupStream.getChildStreamList());
+        Consumer<TriTuple<NewA, NewB, NewC>> update = buildHelper.getAggregatedUpdate(groupStream.getChildStreamList());
         Consumer<TriTuple<NewA, NewB, NewC>> retract = buildHelper.getAggregatedRetract(groupStream.getChildStreamList());
         int outputStoreSize = buildHelper.extractTupleStoreSize(groupStream);
-        AbstractGroupNode<TriTuple<A, B, C>, TriTuple<NewA, NewB, NewC>, ?, ?> node =
-                nodeConstructor.apply(inputStoreIndex, insert, retract, outputStoreSize);
+        AbstractGroupNode<TriTuple<A, B, C>, TriTuple<NewA, NewB, NewC>, ?, ?, ?> node =
+                nodeConstructor.apply(inputStoreIndex, insert, update, retract, outputStoreSize);
         buildHelper.addNode(node);
         buildHelper.putInsertUpdateRetract(this, node::insert, node::update, node::retract);
     }

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/tri/BavetUniGroupBridgeTriConstraintStream.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/tri/BavetUniGroupBridgeTriConstraintStream.java
@@ -17,6 +17,7 @@
 package org.optaplanner.constraint.streams.bavet.tri;
 
 import java.util.Set;
+import java.util.function.Consumer;
 
 import org.optaplanner.constraint.streams.bavet.BavetConstraintFactory;
 import org.optaplanner.constraint.streams.bavet.common.AbstractGroupNode;
@@ -68,10 +69,12 @@ final class BavetUniGroupBridgeTriConstraintStream<Solution_, A, B, C, NewA>
                     + ") has an non-empty childStreamList (" + childStreamList + ") but it's a groupBy bridge.");
         }
         int inputStoreIndex = buildHelper.reserveTupleStoreIndex(parent.getTupleSource());
+        Consumer<UniTuple<NewA>> insert = buildHelper.getAggregatedInsert(groupStream.getChildStreamList());
+        Consumer<UniTuple<NewA>> update = buildHelper.getAggregatedUpdate(groupStream.getChildStreamList());
+        Consumer<UniTuple<NewA>> retract = buildHelper.getAggregatedRetract(groupStream.getChildStreamList());
         int outputStoreSize = buildHelper.extractTupleStoreSize(groupStream);
-        AbstractGroupNode<TriTuple<A, B, C>, UniTuple<NewA>, ?, ?> node = nodeConstructor.apply(inputStoreIndex,
-                buildHelper.getAggregatedInsert(groupStream.getChildStreamList()),
-                buildHelper.getAggregatedRetract(groupStream.getChildStreamList()), outputStoreSize);
+        AbstractGroupNode<TriTuple<A, B, C>, UniTuple<NewA>, ?, ?, ?> node = nodeConstructor.apply(inputStoreIndex,
+                insert, update, retract, outputStoreSize);
         buildHelper.addNode(node);
         buildHelper.putInsertUpdateRetract(this, node::insert, node::update, node::retract);
     }

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/tri/Group0Mapping1CollectorTriNode.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/tri/Group0Mapping1CollectorTriNode.java
@@ -18,7 +18,6 @@ package org.optaplanner.constraint.streams.bavet.tri;
 
 import java.util.function.Consumer;
 
-import org.optaplanner.constraint.streams.bavet.common.Group;
 import org.optaplanner.constraint.streams.bavet.uni.UniTuple;
 import org.optaplanner.core.api.score.stream.tri.TriConstraintCollector;
 
@@ -31,9 +30,10 @@ final class Group0Mapping1CollectorTriNode<OldA, OldB, OldC, A, ResultContainer_
 
     public Group0Mapping1CollectorTriNode(int groupStoreIndex,
             TriConstraintCollector<OldA, OldB, OldC, ResultContainer_, A> collector,
-            Consumer<UniTuple<A>> nextNodesInsert, Consumer<UniTuple<A>> nextNodesRetract,
+            Consumer<UniTuple<A>> nextNodesInsert, Consumer<UniTuple<A>> nextNodesUpdate,
+            Consumer<UniTuple<A>> nextNodesRetract,
             int outputStoreSize) {
-        super(groupStoreIndex, collector, nextNodesInsert, nextNodesRetract);
+        super(groupStoreIndex, collector, nextNodesInsert, nextNodesUpdate, nextNodesRetract);
         this.outputStoreSize = outputStoreSize;
     }
 
@@ -43,10 +43,13 @@ final class Group0Mapping1CollectorTriNode<OldA, OldB, OldC, A, ResultContainer_
     }
 
     @Override
-    protected UniTuple<A> createOutTuple(Group<UniTuple<A>, String, ResultContainer_> group) {
-        ResultContainer_ resultContainer = group.resultContainer;
-        A a = finisher.apply(resultContainer);
-        return new UniTuple<>(a, outputStoreSize);
+    protected UniTuple<A> createOutTuple(String groupKey) {
+        return new UniTuple<>(null, outputStoreSize);
+    }
+
+    @Override
+    protected void updateOutTupleToResult(UniTuple<A> outTuple, A a) {
+        outTuple.factA = a;
     }
 
     @Override

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/tri/Group0Mapping2CollectorTriNode.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/tri/Group0Mapping2CollectorTriNode.java
@@ -19,7 +19,6 @@ package org.optaplanner.constraint.streams.bavet.tri;
 import java.util.function.Consumer;
 
 import org.optaplanner.constraint.streams.bavet.bi.BiTuple;
-import org.optaplanner.constraint.streams.bavet.common.Group;
 import org.optaplanner.core.api.score.stream.ConstraintCollectors;
 import org.optaplanner.core.api.score.stream.tri.TriConstraintCollector;
 import org.optaplanner.core.impl.util.Pair;
@@ -34,9 +33,10 @@ final class Group0Mapping2CollectorTriNode<OldA, OldB, OldC, A, B, ResultContain
     public Group0Mapping2CollectorTriNode(int groupStoreIndex,
             TriConstraintCollector<OldA, OldB, OldC, ResultContainerA_, A> collectorA,
             TriConstraintCollector<OldA, OldB, OldC, ResultContainerB_, B> collectorB,
-            Consumer<BiTuple<A, B>> nextNodesInsert, Consumer<BiTuple<A, B>> nextNodesRetract,
+            Consumer<BiTuple<A, B>> nextNodesInsert, Consumer<BiTuple<A, B>> nextNodesUpdate,
+            Consumer<BiTuple<A, B>> nextNodesRetract,
             int outputStoreSize) {
-        super(groupStoreIndex, mergeCollectors(collectorA, collectorB), nextNodesInsert, nextNodesRetract);
+        super(groupStoreIndex, mergeCollectors(collectorA, collectorB), nextNodesInsert, nextNodesUpdate, nextNodesRetract);
         this.outputStoreSize = outputStoreSize;
     }
 
@@ -55,10 +55,14 @@ final class Group0Mapping2CollectorTriNode<OldA, OldB, OldC, A, B, ResultContain
     }
 
     @Override
-    protected BiTuple<A, B> createOutTuple(Group<BiTuple<A, B>, String, Object> group) {
-        Object resultContainer = group.resultContainer;
-        Pair<A, B> result = finisher.apply(resultContainer);
-        return new BiTuple<>(result.getKey(), result.getValue(), outputStoreSize);
+    protected BiTuple<A, B> createOutTuple(String groupKey) {
+        return new BiTuple<>(null, null, outputStoreSize);
+    }
+
+    @Override
+    protected void updateOutTupleToResult(BiTuple<A, B> outTuple, Pair<A, B> result) {
+        outTuple.factA = result.getKey();
+        outTuple.factB = result.getValue();
     }
 
     @Override

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/tri/Group0Mapping3CollectorTriNode.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/tri/Group0Mapping3CollectorTriNode.java
@@ -18,7 +18,6 @@ package org.optaplanner.constraint.streams.bavet.tri;
 
 import java.util.function.Consumer;
 
-import org.optaplanner.constraint.streams.bavet.common.Group;
 import org.optaplanner.core.api.score.stream.ConstraintCollectors;
 import org.optaplanner.core.api.score.stream.tri.TriConstraintCollector;
 import org.optaplanner.core.impl.util.Triple;
@@ -34,9 +33,11 @@ final class Group0Mapping3CollectorTriNode<OldA, OldB, OldC, A, B, C, ResultCont
             TriConstraintCollector<OldA, OldB, OldC, ResultContainerA_, A> collectorA,
             TriConstraintCollector<OldA, OldB, OldC, ResultContainerB_, B> collectorB,
             TriConstraintCollector<OldA, OldB, OldC, ResultContainerC_, C> collectorC,
-            Consumer<TriTuple<A, B, C>> nextNodesInsert, Consumer<TriTuple<A, B, C>> nextNodesRetract,
+            Consumer<TriTuple<A, B, C>> nextNodesInsert, Consumer<TriTuple<A, B, C>> nextNodesUpdate,
+            Consumer<TriTuple<A, B, C>> nextNodesRetract,
             int outputStoreSize) {
-        super(groupStoreIndex, mergeCollectors(collectorA, collectorB, collectorC), nextNodesInsert, nextNodesRetract);
+        super(groupStoreIndex, mergeCollectors(collectorA, collectorB, collectorC), nextNodesInsert, nextNodesUpdate,
+                nextNodesRetract);
         this.outputStoreSize = outputStoreSize;
     }
 
@@ -55,10 +56,15 @@ final class Group0Mapping3CollectorTriNode<OldA, OldB, OldC, A, B, C, ResultCont
     }
 
     @Override
-    protected TriTuple<A, B, C> createOutTuple(Group<TriTuple<A, B, C>, String, Object> group) {
-        Object resultContainer = group.resultContainer;
-        Triple<A, B, C> result = finisher.apply(resultContainer);
-        return new TriTuple<>(result.getA(), result.getB(), result.getC(), outputStoreSize);
+    protected TriTuple<A, B, C> createOutTuple(String groupKey) {
+        return new TriTuple<>(null, null, null, outputStoreSize);
+    }
+
+    @Override
+    protected void updateOutTupleToResult(TriTuple<A, B, C> outTuple, Triple<A, B, C> result) {
+        outTuple.factA = result.getA();
+        outTuple.factB = result.getB();
+        outTuple.factC = result.getC();
     }
 
     @Override

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/tri/Group0Mapping4CollectorTriNode.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/tri/Group0Mapping4CollectorTriNode.java
@@ -18,7 +18,6 @@ package org.optaplanner.constraint.streams.bavet.tri;
 
 import java.util.function.Consumer;
 
-import org.optaplanner.constraint.streams.bavet.common.Group;
 import org.optaplanner.constraint.streams.bavet.quad.QuadTuple;
 import org.optaplanner.core.api.score.stream.ConstraintCollectors;
 import org.optaplanner.core.api.score.stream.tri.TriConstraintCollector;
@@ -36,10 +35,11 @@ final class Group0Mapping4CollectorTriNode<OldA, OldB, OldC, A, B, C, D, ResultC
             TriConstraintCollector<OldA, OldB, OldC, ResultContainerB_, B> collectorB,
             TriConstraintCollector<OldA, OldB, OldC, ResultContainerC_, C> collectorC,
             TriConstraintCollector<OldA, OldB, OldC, ResultContainerD_, D> collectorD,
-            Consumer<QuadTuple<A, B, C, D>> nextNodesInsert, Consumer<QuadTuple<A, B, C, D>> nextNodesRetract,
+            Consumer<QuadTuple<A, B, C, D>> nextNodesInsert, Consumer<QuadTuple<A, B, C, D>> nextNodesUpdate,
+            Consumer<QuadTuple<A, B, C, D>> nextNodesRetract,
             int outputStoreSize) {
-        super(groupStoreIndex, mergeCollectors(collectorA, collectorB, collectorC, collectorD), nextNodesInsert,
-                nextNodesRetract);
+        super(groupStoreIndex, mergeCollectors(collectorA, collectorB, collectorC, collectorD),
+                nextNodesInsert, nextNodesUpdate, nextNodesRetract);
         this.outputStoreSize = outputStoreSize;
     }
 
@@ -59,10 +59,16 @@ final class Group0Mapping4CollectorTriNode<OldA, OldB, OldC, A, B, C, D, ResultC
     }
 
     @Override
-    protected QuadTuple<A, B, C, D> createOutTuple(Group<QuadTuple<A, B, C, D>, String, Object> group) {
-        Object resultContainer = group.resultContainer;
-        Quadruple<A, B, C, D> result = finisher.apply(resultContainer);
-        return new QuadTuple<>(result.getA(), result.getB(), result.getC(), result.getD(), outputStoreSize);
+    protected QuadTuple<A, B, C, D> createOutTuple(String groupKey) {
+        return new QuadTuple<>(null, null, null, null, outputStoreSize);
+    }
+
+    @Override
+    protected void updateOutTupleToResult(QuadTuple<A, B, C, D> outTuple, Quadruple<A, B, C, D> result) {
+        outTuple.factA = result.getA();
+        outTuple.factB = result.getB();
+        outTuple.factC = result.getC();
+        outTuple.factD = result.getD();
     }
 
     @Override

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/tri/Group1Mapping0CollectorTriNode.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/tri/Group1Mapping0CollectorTriNode.java
@@ -18,7 +18,6 @@ package org.optaplanner.constraint.streams.bavet.tri;
 
 import java.util.function.Consumer;
 
-import org.optaplanner.constraint.streams.bavet.common.Group;
 import org.optaplanner.constraint.streams.bavet.uni.UniTuple;
 import org.optaplanner.core.api.function.TriFunction;
 
@@ -29,9 +28,10 @@ final class Group1Mapping0CollectorTriNode<OldA, OldB, OldC, A>
     private final int outputStoreSize;
 
     public Group1Mapping0CollectorTriNode(TriFunction<OldA, OldB, OldC, A> groupKeyMapping, int groupStoreIndex,
-            Consumer<UniTuple<A>> nextNodesInsert, Consumer<UniTuple<A>> nextNodesRetract,
+            Consumer<UniTuple<A>> nextNodesInsert, Consumer<UniTuple<A>> nextNodesUpdate,
+            Consumer<UniTuple<A>> nextNodesRetract,
             int outputStoreSize) {
-        super(groupStoreIndex, null, nextNodesInsert, nextNodesRetract);
+        super(groupStoreIndex, null, nextNodesInsert, nextNodesUpdate, nextNodesRetract);
         this.groupKeyMapping = groupKeyMapping;
         this.outputStoreSize = outputStoreSize;
     }
@@ -42,9 +42,13 @@ final class Group1Mapping0CollectorTriNode<OldA, OldB, OldC, A>
     }
 
     @Override
-    protected UniTuple<A> createOutTuple(Group<UniTuple<A>, A, Void> group) {
-        A a = group.groupKey;
+    protected UniTuple<A> createOutTuple(A a) {
         return new UniTuple<>(a, outputStoreSize);
+    }
+
+    @Override
+    protected void updateOutTupleToResult(UniTuple<A> aUniTuple, Void unused) {
+        throw new IllegalStateException("Impossible state: collector is null.");
     }
 
     @Override

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/tri/Group1Mapping1CollectorTriNode.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/tri/Group1Mapping1CollectorTriNode.java
@@ -19,7 +19,6 @@ package org.optaplanner.constraint.streams.bavet.tri;
 import java.util.function.Consumer;
 
 import org.optaplanner.constraint.streams.bavet.bi.BiTuple;
-import org.optaplanner.constraint.streams.bavet.common.Group;
 import org.optaplanner.core.api.function.TriFunction;
 import org.optaplanner.core.api.score.stream.tri.TriConstraintCollector;
 
@@ -31,9 +30,10 @@ final class Group1Mapping1CollectorTriNode<OldA, OldB, OldC, A, B, ResultContain
 
     public Group1Mapping1CollectorTriNode(TriFunction<OldA, OldB, OldC, A> groupKeyMapping, int groupStoreIndex,
             TriConstraintCollector<OldA, OldB, OldC, ResultContainer_, B> collector,
-            Consumer<BiTuple<A, B>> nextNodesInsert, Consumer<BiTuple<A, B>> nextNodesRetract,
+            Consumer<BiTuple<A, B>> nextNodesInsert, Consumer<BiTuple<A, B>> nextNodesUpdate,
+            Consumer<BiTuple<A, B>> nextNodesRetract,
             int outputStoreSize) {
-        super(groupStoreIndex, collector, nextNodesInsert, nextNodesRetract);
+        super(groupStoreIndex, collector, nextNodesInsert, nextNodesUpdate, nextNodesRetract);
         this.groupKeyMapping = groupKeyMapping;
         this.outputStoreSize = outputStoreSize;
     }
@@ -44,10 +44,13 @@ final class Group1Mapping1CollectorTriNode<OldA, OldB, OldC, A, B, ResultContain
     }
 
     @Override
-    protected BiTuple<A, B> createOutTuple(Group<BiTuple<A, B>, A, ResultContainer_> group) {
-        A a = group.groupKey;
-        B b = finisher.apply(group.resultContainer);
-        return new BiTuple<>(a, b, outputStoreSize);
+    protected BiTuple<A, B> createOutTuple(A a) {
+        return new BiTuple<>(a, null, outputStoreSize);
+    }
+
+    @Override
+    protected void updateOutTupleToResult(BiTuple<A, B> outTuple, B b) {
+        outTuple.factB = b;
     }
 
     @Override

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/tri/Group1Mapping2CollectorTriNode.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/tri/Group1Mapping2CollectorTriNode.java
@@ -18,7 +18,6 @@ package org.optaplanner.constraint.streams.bavet.tri;
 
 import java.util.function.Consumer;
 
-import org.optaplanner.constraint.streams.bavet.common.Group;
 import org.optaplanner.core.api.function.TriFunction;
 import org.optaplanner.core.api.score.stream.tri.TriConstraintCollector;
 import org.optaplanner.core.impl.util.Pair;
@@ -32,10 +31,11 @@ final class Group1Mapping2CollectorTriNode<OldA, OldB, OldC, A, B, C, ResultCont
     public Group1Mapping2CollectorTriNode(TriFunction<OldA, OldB, OldC, A> groupKeyMapping, int groupStoreIndex,
             TriConstraintCollector<OldA, OldB, OldC, ResultContainerB_, B> collectorB,
             TriConstraintCollector<OldA, OldB, OldC, ResultContainerC_, C> collectorC,
-            Consumer<TriTuple<A, B, C>> nextNodesInsert, Consumer<TriTuple<A, B, C>> nextNodesRetract,
+            Consumer<TriTuple<A, B, C>> nextNodesInsert, Consumer<TriTuple<A, B, C>> nextNodesUpdate,
+            Consumer<TriTuple<A, B, C>> nextNodesRetract,
             int outputStoreSize) {
-        super(groupStoreIndex, Group0Mapping2CollectorTriNode.mergeCollectors(collectorB, collectorC), nextNodesInsert,
-                nextNodesRetract);
+        super(groupStoreIndex, Group0Mapping2CollectorTriNode.mergeCollectors(collectorB, collectorC),
+                nextNodesInsert, nextNodesUpdate, nextNodesRetract);
         this.groupKeyMapping = groupKeyMapping;
         this.outputStoreSize = outputStoreSize;
     }
@@ -49,10 +49,14 @@ final class Group1Mapping2CollectorTriNode<OldA, OldB, OldC, A, B, C, ResultCont
     }
 
     @Override
-    protected TriTuple<A, B, C> createOutTuple(Group<TriTuple<A, B, C>, A, Object> group) {
-        A a = group.groupKey;
-        Pair<B, C> result = finisher.apply(group.resultContainer);
-        return new TriTuple<>(a, result.getKey(), result.getValue(), outputStoreSize);
+    protected TriTuple<A, B, C> createOutTuple(A a) {
+        return new TriTuple<>(a, null, null, outputStoreSize);
+    }
+
+    @Override
+    protected void updateOutTupleToResult(TriTuple<A, B, C> outTuple, Pair<B, C> result) {
+        outTuple.factB = result.getKey();
+        outTuple.factC = result.getValue();
     }
 
     @Override

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/tri/Group1Mapping3CollectorTriNode.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/tri/Group1Mapping3CollectorTriNode.java
@@ -20,7 +20,6 @@ import static org.optaplanner.constraint.streams.bavet.tri.Group0Mapping3Collect
 
 import java.util.function.Consumer;
 
-import org.optaplanner.constraint.streams.bavet.common.Group;
 import org.optaplanner.constraint.streams.bavet.quad.QuadTuple;
 import org.optaplanner.core.api.function.TriFunction;
 import org.optaplanner.core.api.score.stream.tri.TriConstraintCollector;
@@ -36,10 +35,11 @@ final class Group1Mapping3CollectorTriNode<OldA, OldB, OldC, A, B, C, D, ResultC
             TriConstraintCollector<OldA, OldB, OldC, ResultContainerB_, B> collectorB,
             TriConstraintCollector<OldA, OldB, OldC, ResultContainerC_, C> collectorC,
             TriConstraintCollector<OldA, OldB, OldC, ResultContainerD_, D> collectorD,
-            Consumer<QuadTuple<A, B, C, D>> nextNodesInsert, Consumer<QuadTuple<A, B, C, D>> nextNodesRetract,
+            Consumer<QuadTuple<A, B, C, D>> nextNodesInsert, Consumer<QuadTuple<A, B, C, D>> nextNodesUpdate,
+            Consumer<QuadTuple<A, B, C, D>> nextNodesRetract,
             int outputStoreSize) {
         super(groupStoreIndex, mergeCollectors(collectorB, collectorC, collectorD),
-                nextNodesInsert, nextNodesRetract);
+                nextNodesInsert, nextNodesUpdate, nextNodesRetract);
         this.groupKeyMapping = groupKeyMapping;
         this.outputStoreSize = outputStoreSize;
     }
@@ -50,10 +50,15 @@ final class Group1Mapping3CollectorTriNode<OldA, OldB, OldC, A, B, C, D, ResultC
     }
 
     @Override
-    protected QuadTuple<A, B, C, D> createOutTuple(Group<QuadTuple<A, B, C, D>, A, Object> group) {
-        A a = group.groupKey;
-        Triple<B, C, D> result = finisher.apply(group.resultContainer);
-        return new QuadTuple<>(a, result.getA(), result.getB(), result.getC(), outputStoreSize);
+    protected QuadTuple<A, B, C, D> createOutTuple(A a) {
+        return new QuadTuple<>(a, null, null, null, outputStoreSize);
+    }
+
+    @Override
+    protected void updateOutTupleToResult(QuadTuple<A, B, C, D> outTuple, Triple<B, C, D> result) {
+        outTuple.factB = result.getA();
+        outTuple.factC = result.getB();
+        outTuple.factD = result.getC();
     }
 
     @Override

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/tri/Group2Mapping0CollectorTriNode.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/tri/Group2Mapping0CollectorTriNode.java
@@ -19,7 +19,6 @@ package org.optaplanner.constraint.streams.bavet.tri;
 import java.util.function.Consumer;
 
 import org.optaplanner.constraint.streams.bavet.bi.BiTuple;
-import org.optaplanner.constraint.streams.bavet.common.Group;
 import org.optaplanner.core.api.function.TriFunction;
 import org.optaplanner.core.impl.util.Pair;
 
@@ -32,9 +31,10 @@ final class Group2Mapping0CollectorTriNode<OldA, OldB, OldC, A, B>
 
     public Group2Mapping0CollectorTriNode(TriFunction<OldA, OldB, OldC, A> groupKeyMappingA,
             TriFunction<OldA, OldB, OldC, B> groupKeyMappingB, int groupStoreIndex,
-            Consumer<BiTuple<A, B>> nextNodesInsert, Consumer<BiTuple<A, B>> nextNodesRetract,
+            Consumer<BiTuple<A, B>> nextNodesInsert, Consumer<BiTuple<A, B>> nextNodesUpdate,
+            Consumer<BiTuple<A, B>> nextNodesRetract,
             int outputStoreSize) {
-        super(groupStoreIndex, null, nextNodesInsert, nextNodesRetract);
+        super(groupStoreIndex, null, nextNodesInsert, nextNodesUpdate, nextNodesRetract);
         this.groupKeyMappingA = groupKeyMappingA;
         this.groupKeyMappingB = groupKeyMappingB;
         this.outputStoreSize = outputStoreSize;
@@ -51,9 +51,13 @@ final class Group2Mapping0CollectorTriNode<OldA, OldB, OldC, A, B>
     }
 
     @Override
-    protected BiTuple<A, B> createOutTuple(Group<BiTuple<A, B>, Pair<A, B>, Void> group) {
-        Pair<A, B> key = group.groupKey;
-        return new BiTuple<>(key.getKey(), key.getValue(), outputStoreSize);
+    protected BiTuple<A, B> createOutTuple(Pair<A, B> groupKey) {
+        return new BiTuple<>(groupKey.getKey(), groupKey.getValue(), outputStoreSize);
+    }
+
+    @Override
+    protected void updateOutTupleToResult(BiTuple<A, B> outTuple, Void unused) {
+        throw new IllegalStateException("Impossible state: collector is null.");
     }
 
     @Override

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/tri/Group2Mapping1CollectorTriNode.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/tri/Group2Mapping1CollectorTriNode.java
@@ -18,7 +18,6 @@ package org.optaplanner.constraint.streams.bavet.tri;
 
 import java.util.function.Consumer;
 
-import org.optaplanner.constraint.streams.bavet.common.Group;
 import org.optaplanner.core.api.function.TriFunction;
 import org.optaplanner.core.api.score.stream.tri.TriConstraintCollector;
 import org.optaplanner.core.impl.util.Pair;
@@ -34,9 +33,10 @@ final class Group2Mapping1CollectorTriNode<OldA, OldB, OldC, A, B, C, ResultCont
             TriFunction<OldA, OldB, OldC, B> groupKeyMappingB,
             int groupStoreIndex,
             TriConstraintCollector<OldA, OldB, OldC, ResultContainer_, C> collector,
-            Consumer<TriTuple<A, B, C>> nextNodesInsert, Consumer<TriTuple<A, B, C>> nextNodesRetract,
+            Consumer<TriTuple<A, B, C>> nextNodesInsert, Consumer<TriTuple<A, B, C>> nextNodesUpdate,
+            Consumer<TriTuple<A, B, C>> nextNodesRetract,
             int outputStoreSize) {
-        super(groupStoreIndex, collector, nextNodesInsert, nextNodesRetract);
+        super(groupStoreIndex, collector, nextNodesInsert, nextNodesUpdate, nextNodesRetract);
         this.groupKeyMappingA = groupKeyMappingA;
         this.groupKeyMappingB = groupKeyMappingB;
         this.outputStoreSize = outputStoreSize;
@@ -53,10 +53,13 @@ final class Group2Mapping1CollectorTriNode<OldA, OldB, OldC, A, B, C, ResultCont
     }
 
     @Override
-    protected TriTuple<A, B, C> createOutTuple(Group<TriTuple<A, B, C>, Pair<A, B>, ResultContainer_> group) {
-        Pair<A, B> groupKey = group.groupKey;
-        C c = finisher.apply(group.resultContainer);
-        return new TriTuple<>(groupKey.getKey(), groupKey.getValue(), c, outputStoreSize);
+    protected TriTuple<A, B, C> createOutTuple(Pair<A, B> groupKey) {
+        return new TriTuple<>(groupKey.getKey(), groupKey.getValue(), null, outputStoreSize);
+    }
+
+    @Override
+    protected void updateOutTupleToResult(TriTuple<A, B, C> outTuple, C c) {
+        outTuple.factC = c;
     }
 
     @Override

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/tri/Group2Mapping2CollectorTriNode.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/tri/Group2Mapping2CollectorTriNode.java
@@ -20,7 +20,6 @@ import static org.optaplanner.constraint.streams.bavet.tri.Group0Mapping2Collect
 
 import java.util.function.Consumer;
 
-import org.optaplanner.constraint.streams.bavet.common.Group;
 import org.optaplanner.constraint.streams.bavet.quad.QuadTuple;
 import org.optaplanner.core.api.function.TriFunction;
 import org.optaplanner.core.api.score.stream.tri.TriConstraintCollector;
@@ -37,9 +36,10 @@ final class Group2Mapping2CollectorTriNode<OldA, OldB, OldC, A, B, C, D, ResultC
             TriFunction<OldA, OldB, OldC, B> groupKeyMappingB, int groupStoreIndex,
             TriConstraintCollector<OldA, OldB, OldC, ResultContainerC_, C> collectorC,
             TriConstraintCollector<OldA, OldB, OldC, ResultContainerD_, D> collectorD,
-            Consumer<QuadTuple<A, B, C, D>> nextNodesInsert, Consumer<QuadTuple<A, B, C, D>> nextNodesRetract,
+            Consumer<QuadTuple<A, B, C, D>> nextNodesInsert, Consumer<QuadTuple<A, B, C, D>> nextNodesUpdate,
+            Consumer<QuadTuple<A, B, C, D>> nextNodesRetract,
             int outputStoreSize) {
-        super(groupStoreIndex, mergeCollectors(collectorC, collectorD), nextNodesInsert, nextNodesRetract);
+        super(groupStoreIndex, mergeCollectors(collectorC, collectorD), nextNodesInsert, nextNodesUpdate, nextNodesRetract);
         this.groupKeyMappingA = groupKeyMappingA;
         this.groupKeyMappingB = groupKeyMappingB;
         this.outputStoreSize = outputStoreSize;
@@ -56,10 +56,14 @@ final class Group2Mapping2CollectorTriNode<OldA, OldB, OldC, A, B, C, D, ResultC
     }
 
     @Override
-    protected QuadTuple<A, B, C, D> createOutTuple(Group<QuadTuple<A, B, C, D>, Pair<A, B>, Object> group) {
-        Pair<A, B> groupKey = group.groupKey;
-        Pair<C, D> result = finisher.apply(group.resultContainer);
-        return new QuadTuple<>(groupKey.getKey(), groupKey.getValue(), result.getKey(), result.getValue(), outputStoreSize);
+    protected QuadTuple<A, B, C, D> createOutTuple(Pair<A, B> groupKey) {
+        return new QuadTuple<>(groupKey.getKey(), groupKey.getValue(), null, null, outputStoreSize);
+    }
+
+    @Override
+    protected void updateOutTupleToResult(QuadTuple<A, B, C, D> outTuple, Pair<C, D> result) {
+        outTuple.factC = result.getKey();
+        outTuple.factD = result.getValue();
     }
 
     @Override

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/tri/Group3Mapping0CollectorTriNode.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/tri/Group3Mapping0CollectorTriNode.java
@@ -18,7 +18,6 @@ package org.optaplanner.constraint.streams.bavet.tri;
 
 import java.util.function.Consumer;
 
-import org.optaplanner.constraint.streams.bavet.common.Group;
 import org.optaplanner.core.api.function.TriFunction;
 import org.optaplanner.core.impl.util.Triple;
 
@@ -33,8 +32,9 @@ final class Group3Mapping0CollectorTriNode<OldA, OldB, OldC, A, B, C>
     public Group3Mapping0CollectorTriNode(TriFunction<OldA, OldB, OldC, A> groupKeyMappingA,
             TriFunction<OldA, OldB, OldC, B> groupKeyMappingB, TriFunction<OldA, OldB, OldC, C> groupKeyMappingC,
             int groupStoreIndex,
-            Consumer<TriTuple<A, B, C>> nextNodesInsert, Consumer<TriTuple<A, B, C>> nextNodesRetract, int outputStoreSize) {
-        super(groupStoreIndex, null, nextNodesInsert, nextNodesRetract);
+            Consumer<TriTuple<A, B, C>> nextNodesInsert, Consumer<TriTuple<A, B, C>> nextNodesUpdate,
+            Consumer<TriTuple<A, B, C>> nextNodesRetract, int outputStoreSize) {
+        super(groupStoreIndex, null, nextNodesInsert, nextNodesUpdate, nextNodesRetract);
         this.groupKeyMappingA = groupKeyMappingA;
         this.groupKeyMappingB = groupKeyMappingB;
         this.groupKeyMappingC = groupKeyMappingC;
@@ -53,9 +53,13 @@ final class Group3Mapping0CollectorTriNode<OldA, OldB, OldC, A, B, C>
     }
 
     @Override
-    protected TriTuple<A, B, C> createOutTuple(Group<TriTuple<A, B, C>, Triple<A, B, C>, Void> group) {
-        Triple<A, B, C> key = group.groupKey;
-        return new TriTuple<>(key.getA(), key.getB(), key.getC(), outputStoreSize);
+    protected TriTuple<A, B, C> createOutTuple(Triple<A, B, C> groupKey) {
+        return new TriTuple<>(groupKey.getA(), groupKey.getB(), groupKey.getC(), outputStoreSize);
+    }
+
+    @Override
+    protected void updateOutTupleToResult(TriTuple<A, B, C> outTuple, Void unused) {
+        throw new IllegalStateException("Impossible state: collector is null.");
     }
 
     @Override

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/tri/Group3Mapping1CollectorTriNode.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/tri/Group3Mapping1CollectorTriNode.java
@@ -18,7 +18,6 @@ package org.optaplanner.constraint.streams.bavet.tri;
 
 import java.util.function.Consumer;
 
-import org.optaplanner.constraint.streams.bavet.common.Group;
 import org.optaplanner.constraint.streams.bavet.quad.QuadTuple;
 import org.optaplanner.core.api.function.TriFunction;
 import org.optaplanner.core.api.score.stream.tri.TriConstraintCollector;
@@ -35,9 +34,10 @@ final class Group3Mapping1CollectorTriNode<OldA, OldB, OldC, A, B, C, D, ResultC
     public Group3Mapping1CollectorTriNode(TriFunction<OldA, OldB, OldC, A> groupKeyMappingA,
             TriFunction<OldA, OldB, OldC, B> groupKeyMappingB, TriFunction<OldA, OldB, OldC, C> groupKeyMappingC,
             int groupStoreIndex, TriConstraintCollector<OldA, OldB, OldC, ResultContainer_, D> collector,
-            Consumer<QuadTuple<A, B, C, D>> nextNodesInsert, Consumer<QuadTuple<A, B, C, D>> nextNodesRetract,
+            Consumer<QuadTuple<A, B, C, D>> nextNodesInsert, Consumer<QuadTuple<A, B, C, D>> nextNodesUpdate,
+            Consumer<QuadTuple<A, B, C, D>> nextNodesRetract,
             int outputStoreSize) {
-        super(groupStoreIndex, collector, nextNodesInsert, nextNodesRetract);
+        super(groupStoreIndex, collector, nextNodesInsert, nextNodesUpdate, nextNodesRetract);
         this.groupKeyMappingA = groupKeyMappingA;
         this.groupKeyMappingB = groupKeyMappingB;
         this.groupKeyMappingC = groupKeyMappingC;
@@ -56,10 +56,13 @@ final class Group3Mapping1CollectorTriNode<OldA, OldB, OldC, A, B, C, D, ResultC
     }
 
     @Override
-    protected QuadTuple<A, B, C, D> createOutTuple(Group<QuadTuple<A, B, C, D>, Triple<A, B, C>, ResultContainer_> group) {
-        Triple<A, B, C> groupKey = group.groupKey;
-        D d = finisher.apply(group.resultContainer);
-        return new QuadTuple<>(groupKey.getA(), groupKey.getB(), groupKey.getC(), d, outputStoreSize);
+    protected QuadTuple<A, B, C, D> createOutTuple(Triple<A, B, C> groupKey) {
+        return new QuadTuple<>(groupKey.getA(), groupKey.getB(), groupKey.getC(), null, outputStoreSize);
+    }
+
+    @Override
+    protected void updateOutTupleToResult(QuadTuple<A, B, C, D> outTuple, D d) {
+        outTuple.factD = d;
     }
 
     @Override

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/tri/Group4Mapping0CollectorTriNode.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/tri/Group4Mapping0CollectorTriNode.java
@@ -18,7 +18,6 @@ package org.optaplanner.constraint.streams.bavet.tri;
 
 import java.util.function.Consumer;
 
-import org.optaplanner.constraint.streams.bavet.common.Group;
 import org.optaplanner.constraint.streams.bavet.quad.QuadTuple;
 import org.optaplanner.core.api.function.TriFunction;
 import org.optaplanner.core.impl.util.Quadruple;
@@ -35,9 +34,10 @@ final class Group4Mapping0CollectorTriNode<OldA, OldB, OldC, A, B, C, D>
     public Group4Mapping0CollectorTriNode(TriFunction<OldA, OldB, OldC, A> groupKeyMappingA,
             TriFunction<OldA, OldB, OldC, B> groupKeyMappingB, TriFunction<OldA, OldB, OldC, C> groupKeyMappingC,
             TriFunction<OldA, OldB, OldC, D> groupKeyMappingD, int groupStoreIndex,
-            Consumer<QuadTuple<A, B, C, D>> nextNodesInsert, Consumer<QuadTuple<A, B, C, D>> nextNodesRetract,
+            Consumer<QuadTuple<A, B, C, D>> nextNodesInsert, Consumer<QuadTuple<A, B, C, D>> nextNodesUpdate,
+            Consumer<QuadTuple<A, B, C, D>> nextNodesRetract,
             int outputStoreSize) {
-        super(groupStoreIndex, null, nextNodesInsert, nextNodesRetract);
+        super(groupStoreIndex, null, nextNodesInsert, nextNodesUpdate, nextNodesRetract);
         this.groupKeyMappingA = groupKeyMappingA;
         this.groupKeyMappingB = groupKeyMappingB;
         this.groupKeyMappingC = groupKeyMappingC;
@@ -58,9 +58,13 @@ final class Group4Mapping0CollectorTriNode<OldA, OldB, OldC, A, B, C, D>
     }
 
     @Override
-    protected QuadTuple<A, B, C, D> createOutTuple(Group<QuadTuple<A, B, C, D>, Quadruple<A, B, C, D>, Void> group) {
-        Quadruple<A, B, C, D> key = group.groupKey;
-        return new QuadTuple<>(key.getA(), key.getB(), key.getC(), key.getD(), outputStoreSize);
+    protected QuadTuple<A, B, C, D> createOutTuple(Quadruple<A, B, C, D> groupKey) {
+        return new QuadTuple<>(groupKey.getA(), groupKey.getB(), groupKey.getC(), groupKey.getD(), outputStoreSize);
+    }
+
+    @Override
+    protected void updateOutTupleToResult(QuadTuple<A, B, C, D> outTuple, Void unused) {
+        throw new IllegalStateException("Impossible state: collector is null.");
     }
 
     @Override

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/tri/TriGroupNodeConstructor.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/tri/TriGroupNodeConstructor.java
@@ -23,7 +23,8 @@ import org.optaplanner.constraint.streams.bavet.common.Tuple;
 @FunctionalInterface
 interface TriGroupNodeConstructor<A, B, C, Tuple_ extends Tuple> {
 
-    AbstractGroupTriNode<A, B, C, Tuple_, ?, ?, ?> apply(int inputStoreIndex, Consumer<Tuple_> insert,
-            Consumer<Tuple_> retract, int outputStoreSize);
+    AbstractGroupTriNode<A, B, C, Tuple_, ?, ?, ?> apply(int inputStoreIndex,
+            Consumer<Tuple_> insert, Consumer<Tuple_> update, Consumer<Tuple_> retract,
+            int outputStoreSize);
 
 }

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/tri/TriTuple.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/tri/TriTuple.java
@@ -21,9 +21,10 @@ import org.optaplanner.constraint.streams.bavet.common.Tuple;
 
 public final class TriTuple<A, B, C> implements Tuple {
 
-    public final A factA;
-    public final B factB;
-    public final C factC;
+    // Only a tuple's origin node may modify a fact.
+    public A factA;
+    public B factB;
+    public C factC;
 
     public final Object[] store;
 

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/uni/AbstractGroupUniNode.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/uni/AbstractGroupUniNode.java
@@ -19,26 +19,26 @@ package org.optaplanner.constraint.streams.bavet.uni;
 
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
-import java.util.function.Function;
 
 import org.optaplanner.constraint.streams.bavet.common.AbstractGroupNode;
 import org.optaplanner.constraint.streams.bavet.common.Tuple;
 import org.optaplanner.core.api.score.stream.uni.UniConstraintCollector;
 
 abstract class AbstractGroupUniNode<OldA, OutTuple_ extends Tuple, GroupKey_, ResultContainer_, Result_>
-        extends AbstractGroupNode<UniTuple<OldA>, OutTuple_, GroupKey_, ResultContainer_> {
+        extends AbstractGroupNode<UniTuple<OldA>, OutTuple_, GroupKey_, ResultContainer_, Result_> {
 
     private final BiFunction<ResultContainer_, OldA, Runnable> accumulator;
-    protected final Function<ResultContainer_, Result_> finisher;
 
     protected AbstractGroupUniNode(int groupStoreIndex,
             UniConstraintCollector<OldA, ResultContainer_, Result_> collector,
-            Consumer<OutTuple_> nextNodesInsert, Consumer<OutTuple_> nextNodesRetract) {
+            Consumer<OutTuple_> nextNodesInsert,
+            Consumer<OutTuple_> nextNodesUpdate,
+            Consumer<OutTuple_> nextNodesRetract) {
         super(groupStoreIndex,
                 collector == null ? null : collector.supplier(),
-                nextNodesInsert, nextNodesRetract);
+                collector == null ? null : collector.finisher(),
+                nextNodesInsert, nextNodesUpdate, nextNodesRetract);
         accumulator = collector == null ? null : collector.accumulator();
-        finisher = collector == null ? null : collector.finisher();
     }
 
     @Override

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/uni/BavetAbstractUniConstraintStream.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/uni/BavetAbstractUniConstraintStream.java
@@ -194,9 +194,11 @@ public abstract class BavetAbstractUniConstraintStream<Solution_, A> extends Bav
     public <ResultContainer_, Result_> UniConstraintStream<Result_> groupBy(
             UniConstraintCollector<A, ResultContainer_, Result_> collector) {
         UniGroupNodeConstructor<A, UniTuple<Result_>> nodeConstructor =
-                (int inputStoreIndex, Consumer<UniTuple<Result_>> insert, Consumer<UniTuple<Result_>> retract,
-                        int outputStoreSize) -> new Group0Mapping1CollectorUniNode<>(inputStoreIndex, collector, insert,
-                                retract, outputStoreSize);
+                (int inputStoreIndex, Consumer<UniTuple<Result_>> insert,
+                        Consumer<UniTuple<Result_>> update,
+                        Consumer<UniTuple<Result_>> retract,
+                        int outputStoreSize) -> new Group0Mapping1CollectorUniNode<>(inputStoreIndex, collector,
+                                insert, update, retract, outputStoreSize);
         return buildUniGroupBy(nodeConstructor);
     }
 
@@ -214,9 +216,10 @@ public abstract class BavetAbstractUniConstraintStream<Solution_, A> extends Bav
             UniConstraintCollector<A, ResultContainerB_, ResultB_> collectorB) {
         UniGroupNodeConstructor<A, BiTuple<ResultA_, ResultB_>> nodeConstructor =
                 (int inputStoreIndex, Consumer<BiTuple<ResultA_, ResultB_>> insert,
+                        Consumer<BiTuple<ResultA_, ResultB_>> update,
                         Consumer<BiTuple<ResultA_, ResultB_>> retract,
                         int outputStoreSize) -> new Group0Mapping2CollectorUniNode<>(inputStoreIndex, collectorA, collectorB,
-                                insert, retract, outputStoreSize);
+                                insert, update, retract, outputStoreSize);
         return buildBiGroupBy(nodeConstructor);
     }
 
@@ -237,9 +240,10 @@ public abstract class BavetAbstractUniConstraintStream<Solution_, A> extends Bav
                     UniConstraintCollector<A, ResultContainerC_, ResultC_> collectorC) {
         UniGroupNodeConstructor<A, TriTuple<ResultA_, ResultB_, ResultC_>> nodeConstructor =
                 (int inputStoreIndex, Consumer<TriTuple<ResultA_, ResultB_, ResultC_>> insert,
+                        Consumer<TriTuple<ResultA_, ResultB_, ResultC_>> update,
                         Consumer<TriTuple<ResultA_, ResultB_, ResultC_>> retract,
                         int outputStoreSize) -> new Group0Mapping3CollectorUniNode<>(inputStoreIndex, collectorA, collectorB,
-                                collectorC, insert, retract, outputStoreSize);
+                                collectorC, insert, update, retract, outputStoreSize);
         return buildTriGroupBy(nodeConstructor);
     }
 
@@ -261,9 +265,10 @@ public abstract class BavetAbstractUniConstraintStream<Solution_, A> extends Bav
                     UniConstraintCollector<A, ResultContainerD_, ResultD_> collectorD) {
         UniGroupNodeConstructor<A, QuadTuple<ResultA_, ResultB_, ResultC_, ResultD_>> nodeConstructor =
                 (int inputStoreIndex, Consumer<QuadTuple<ResultA_, ResultB_, ResultC_, ResultD_>> insert,
+                        Consumer<QuadTuple<ResultA_, ResultB_, ResultC_, ResultD_>> update,
                         Consumer<QuadTuple<ResultA_, ResultB_, ResultC_, ResultD_>> retract,
                         int outputStoreSize) -> new Group0Mapping4CollectorUniNode<>(inputStoreIndex, collectorA, collectorB,
-                                collectorC, collectorD, insert, retract, outputStoreSize);
+                                collectorC, collectorD, insert, update, retract, outputStoreSize);
         return buildQuadGroupBy(nodeConstructor);
     }
 
@@ -279,9 +284,11 @@ public abstract class BavetAbstractUniConstraintStream<Solution_, A> extends Bav
     @Override
     public <GroupKey_> UniConstraintStream<GroupKey_> groupBy(Function<A, GroupKey_> groupKeyMapping) {
         UniGroupNodeConstructor<A, UniTuple<GroupKey_>> nodeConstructor =
-                (int inputStoreIndex, Consumer<UniTuple<GroupKey_>> insert, Consumer<UniTuple<GroupKey_>> retract,
-                        int outputStoreSize) -> new Group1Mapping0CollectorUniNode<>(groupKeyMapping, inputStoreIndex, insert,
-                                retract, outputStoreSize);
+                (int inputStoreIndex, Consumer<UniTuple<GroupKey_>> insert,
+                        Consumer<UniTuple<GroupKey_>> update,
+                        Consumer<UniTuple<GroupKey_>> retract,
+                        int outputStoreSize) -> new Group1Mapping0CollectorUniNode<>(groupKeyMapping, inputStoreIndex,
+                                insert, update, retract, outputStoreSize);
         return buildUniGroupBy(nodeConstructor);
     }
 
@@ -292,9 +299,10 @@ public abstract class BavetAbstractUniConstraintStream<Solution_, A> extends Bav
                     UniConstraintCollector<A, ResultContainerC_, ResultC_> collectorC) {
         UniGroupNodeConstructor<A, TriTuple<GroupKey_, ResultB_, ResultC_>> nodeConstructor =
                 (int inputStoreIndex, Consumer<TriTuple<GroupKey_, ResultB_, ResultC_>> insert,
+                        Consumer<TriTuple<GroupKey_, ResultB_, ResultC_>> update,
                         Consumer<TriTuple<GroupKey_, ResultB_, ResultC_>> retract,
                         int outputStoreSize) -> new Group1Mapping2CollectorUniNode<>(groupKeyMapping, inputStoreIndex,
-                                collectorB, collectorC, insert, retract, outputStoreSize);
+                                collectorB, collectorC, insert, update, retract, outputStoreSize);
         return buildTriGroupBy(nodeConstructor);
     }
 
@@ -307,9 +315,10 @@ public abstract class BavetAbstractUniConstraintStream<Solution_, A> extends Bav
                     UniConstraintCollector<A, ResultContainerD_, ResultD_> collectorD) {
         UniGroupNodeConstructor<A, QuadTuple<GroupKey_, ResultB_, ResultC_, ResultD_>> nodeConstructor =
                 (int inputStoreIndex, Consumer<QuadTuple<GroupKey_, ResultB_, ResultC_, ResultD_>> insert,
+                        Consumer<QuadTuple<GroupKey_, ResultB_, ResultC_, ResultD_>> update,
                         Consumer<QuadTuple<GroupKey_, ResultB_, ResultC_, ResultD_>> retract,
                         int outputStoreSize) -> new Group1Mapping3CollectorUniNode<>(groupKeyMapping, inputStoreIndex,
-                                collectorB, collectorC, collectorD, insert, retract, outputStoreSize);
+                                collectorB, collectorC, collectorD, insert, update, retract, outputStoreSize);
         return buildQuadGroupBy(nodeConstructor);
     }
 
@@ -319,10 +328,11 @@ public abstract class BavetAbstractUniConstraintStream<Solution_, A> extends Bav
             UniConstraintCollector<A, ResultContainer_, Result_> collector) {
         UniGroupNodeConstructor<A, BiTuple<GroupKey_, Result_>> nodeConstructor =
                 (int inputStoreIndex, Consumer<BiTuple<GroupKey_, Result_>> insert,
+                        Consumer<BiTuple<GroupKey_, Result_>> update,
                         Consumer<BiTuple<GroupKey_, Result_>> retract,
                         int outputStoreSize) -> new Group1Mapping1CollectorUniNode<>(groupKeyMapping, inputStoreIndex,
                                 collector,
-                                insert, retract, outputStoreSize);
+                                insert, update, retract, outputStoreSize);
         return buildBiGroupBy(nodeConstructor);
     }
 
@@ -331,10 +341,11 @@ public abstract class BavetAbstractUniConstraintStream<Solution_, A> extends Bav
             Function<A, GroupKeyA_> groupKeyAMapping, Function<A, GroupKeyB_> groupKeyBMapping) {
         UniGroupNodeConstructor<A, BiTuple<GroupKeyA_, GroupKeyB_>> nodeConstructor =
                 (int inputStoreIndex, Consumer<BiTuple<GroupKeyA_, GroupKeyB_>> insert,
+                        Consumer<BiTuple<GroupKeyA_, GroupKeyB_>> update,
                         Consumer<BiTuple<GroupKeyA_, GroupKeyB_>> retract,
                         int outputStoreSize) -> new Group2Mapping0CollectorUniNode<>(groupKeyAMapping, groupKeyBMapping,
                                 inputStoreIndex,
-                                insert, retract, outputStoreSize);
+                                insert, update, retract, outputStoreSize);
         return buildBiGroupBy(nodeConstructor);
     }
 
@@ -344,9 +355,10 @@ public abstract class BavetAbstractUniConstraintStream<Solution_, A> extends Bav
             UniConstraintCollector<A, ResultContainer_, Result_> collector) {
         UniGroupNodeConstructor<A, TriTuple<GroupKeyA_, GroupKeyB_, Result_>> nodeConstructor =
                 (int inputStoreIndex, Consumer<TriTuple<GroupKeyA_, GroupKeyB_, Result_>> insert,
+                        Consumer<TriTuple<GroupKeyA_, GroupKeyB_, Result_>> update,
                         Consumer<TriTuple<GroupKeyA_, GroupKeyB_, Result_>> retract,
                         int outputStoreSize) -> new Group2Mapping1CollectorUniNode<>(groupKeyAMapping, groupKeyBMapping,
-                                inputStoreIndex, collector, insert, retract, outputStoreSize);
+                                inputStoreIndex, collector, insert, update, retract, outputStoreSize);
         return buildTriGroupBy(nodeConstructor);
     }
 
@@ -358,9 +370,10 @@ public abstract class BavetAbstractUniConstraintStream<Solution_, A> extends Bav
                     UniConstraintCollector<A, ResultContainerD_, ResultD_> collectorD) {
         UniGroupNodeConstructor<A, QuadTuple<GroupKeyA_, GroupKeyB_, ResultC_, ResultD_>> nodeConstructor =
                 (int inputStoreIndex, Consumer<QuadTuple<GroupKeyA_, GroupKeyB_, ResultC_, ResultD_>> insert,
+                        Consumer<QuadTuple<GroupKeyA_, GroupKeyB_, ResultC_, ResultD_>> update,
                         Consumer<QuadTuple<GroupKeyA_, GroupKeyB_, ResultC_, ResultD_>> retract,
                         int outputStoreSize) -> new Group2Mapping2CollectorUniNode<>(groupKeyAMapping, groupKeyBMapping,
-                                inputStoreIndex, collectorC, collectorD, insert, retract, outputStoreSize);
+                                inputStoreIndex, collectorC, collectorD, insert, update, retract, outputStoreSize);
         return buildQuadGroupBy(nodeConstructor);
     }
 
@@ -370,10 +383,11 @@ public abstract class BavetAbstractUniConstraintStream<Solution_, A> extends Bav
             Function<A, GroupKeyC_> groupKeyCMapping) {
         UniGroupNodeConstructor<A, TriTuple<GroupKeyA_, GroupKeyB_, GroupKeyC_>> nodeConstructor =
                 (int inputStoreIndex, Consumer<TriTuple<GroupKeyA_, GroupKeyB_, GroupKeyC_>> insert,
+                        Consumer<TriTuple<GroupKeyA_, GroupKeyB_, GroupKeyC_>> update,
                         Consumer<TriTuple<GroupKeyA_, GroupKeyB_, GroupKeyC_>> retract,
                         int outputStoreSize) -> new Group3Mapping0CollectorUniNode<>(groupKeyAMapping, groupKeyBMapping,
                                 groupKeyCMapping,
-                                inputStoreIndex, insert, retract, outputStoreSize);
+                                inputStoreIndex, insert, update, retract, outputStoreSize);
         return buildTriGroupBy(nodeConstructor);
     }
 
@@ -385,9 +399,10 @@ public abstract class BavetAbstractUniConstraintStream<Solution_, A> extends Bav
                     UniConstraintCollector<A, ResultContainerD_, ResultD_> collectorD) {
         UniGroupNodeConstructor<A, QuadTuple<GroupKeyA_, GroupKeyB_, GroupKeyC_, ResultD_>> nodeConstructor =
                 (int inputStoreIndex, Consumer<QuadTuple<GroupKeyA_, GroupKeyB_, GroupKeyC_, ResultD_>> insert,
+                        Consumer<QuadTuple<GroupKeyA_, GroupKeyB_, GroupKeyC_, ResultD_>> update,
                         Consumer<QuadTuple<GroupKeyA_, GroupKeyB_, GroupKeyC_, ResultD_>> retract,
                         int outputStoreSize) -> new Group3Mapping1CollectorUniNode<>(groupKeyAMapping, groupKeyBMapping,
-                                groupKeyCMapping, inputStoreIndex, collectorD, insert, retract, outputStoreSize);
+                                groupKeyCMapping, inputStoreIndex, collectorD, insert, update, retract, outputStoreSize);
         return buildQuadGroupBy(nodeConstructor);
     }
 
@@ -397,9 +412,10 @@ public abstract class BavetAbstractUniConstraintStream<Solution_, A> extends Bav
                     Function<A, GroupKeyC_> groupKeyCMapping, Function<A, GroupKeyD_> groupKeyDMapping) {
         UniGroupNodeConstructor<A, QuadTuple<GroupKeyA_, GroupKeyB_, GroupKeyC_, GroupKeyD_>> nodeConstructor =
                 (int inputStoreIndex, Consumer<QuadTuple<GroupKeyA_, GroupKeyB_, GroupKeyC_, GroupKeyD_>> insert,
+                        Consumer<QuadTuple<GroupKeyA_, GroupKeyB_, GroupKeyC_, GroupKeyD_>> update,
                         Consumer<QuadTuple<GroupKeyA_, GroupKeyB_, GroupKeyC_, GroupKeyD_>> retract,
                         int outputStoreSize) -> new Group4Mapping0CollectorUniNode<>(groupKeyAMapping, groupKeyBMapping,
-                                groupKeyCMapping, groupKeyDMapping, inputStoreIndex, insert, retract, outputStoreSize);
+                                groupKeyCMapping, groupKeyDMapping, inputStoreIndex, insert, update, retract, outputStoreSize);
         return buildQuadGroupBy(nodeConstructor);
     }
 

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/uni/BavetBiGroupBridgeUniConstraintStream.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/uni/BavetBiGroupBridgeUniConstraintStream.java
@@ -70,10 +70,11 @@ final class BavetBiGroupBridgeUniConstraintStream<Solution_, A, NewA, NewB>
         }
         int inputStoreIndex = buildHelper.reserveTupleStoreIndex(parent.getTupleSource());
         Consumer<BiTuple<NewA, NewB>> insert = buildHelper.getAggregatedInsert(groupStream.getChildStreamList());
+        Consumer<BiTuple<NewA, NewB>> update = buildHelper.getAggregatedUpdate(groupStream.getChildStreamList());
         Consumer<BiTuple<NewA, NewB>> retract = buildHelper.getAggregatedRetract(groupStream.getChildStreamList());
         int outputStoreSize = buildHelper.extractTupleStoreSize(groupStream);
-        AbstractGroupNode<UniTuple<A>, BiTuple<NewA, NewB>, ?, ?> node =
-                nodeConstructor.apply(inputStoreIndex, insert, retract, outputStoreSize);
+        AbstractGroupNode<UniTuple<A>, BiTuple<NewA, NewB>, ?, ?, ?> node =
+                nodeConstructor.apply(inputStoreIndex, insert, update, retract, outputStoreSize);
         buildHelper.addNode(node);
         buildHelper.putInsertUpdateRetract(this, node::insert, node::update, node::retract);
     }

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/uni/BavetQuadGroupBridgeUniConstraintStream.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/uni/BavetQuadGroupBridgeUniConstraintStream.java
@@ -70,11 +70,12 @@ final class BavetQuadGroupBridgeUniConstraintStream<Solution_, A, NewA, NewB, Ne
         }
         int inputStoreIndex = buildHelper.reserveTupleStoreIndex(parent.getTupleSource());
         Consumer<QuadTuple<NewA, NewB, NewC, NewD>> insert = buildHelper.getAggregatedInsert(groupStream.getChildStreamList());
+        Consumer<QuadTuple<NewA, NewB, NewC, NewD>> update = buildHelper.getAggregatedUpdate(groupStream.getChildStreamList());
         Consumer<QuadTuple<NewA, NewB, NewC, NewD>> retract =
                 buildHelper.getAggregatedRetract(groupStream.getChildStreamList());
         int outputStoreSize = buildHelper.extractTupleStoreSize(groupStream);
-        AbstractGroupNode<UniTuple<A>, QuadTuple<NewA, NewB, NewC, NewD>, ?, ?> node =
-                nodeConstructor.apply(inputStoreIndex, insert, retract, outputStoreSize);
+        AbstractGroupNode<UniTuple<A>, QuadTuple<NewA, NewB, NewC, NewD>, ?, ?, ?> node =
+                nodeConstructor.apply(inputStoreIndex, insert, update, retract, outputStoreSize);
         buildHelper.addNode(node);
         buildHelper.putInsertUpdateRetract(this, node::insert, node::update, node::retract);
     }

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/uni/BavetTriGroupBridgeUniConstraintStream.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/uni/BavetTriGroupBridgeUniConstraintStream.java
@@ -70,10 +70,11 @@ final class BavetTriGroupBridgeUniConstraintStream<Solution_, A, NewA, NewB, New
         }
         int inputStoreIndex = buildHelper.reserveTupleStoreIndex(parent.getTupleSource());
         Consumer<TriTuple<NewA, NewB, NewC>> insert = buildHelper.getAggregatedInsert(groupStream.getChildStreamList());
+        Consumer<TriTuple<NewA, NewB, NewC>> update = buildHelper.getAggregatedUpdate(groupStream.getChildStreamList());
         Consumer<TriTuple<NewA, NewB, NewC>> retract = buildHelper.getAggregatedRetract(groupStream.getChildStreamList());
         int outputStoreSize = buildHelper.extractTupleStoreSize(groupStream);
-        AbstractGroupNode<UniTuple<A>, TriTuple<NewA, NewB, NewC>, ?, ?> node =
-                nodeConstructor.apply(inputStoreIndex, insert, retract, outputStoreSize);
+        AbstractGroupNode<UniTuple<A>, TriTuple<NewA, NewB, NewC>, ?, ?, ?> node =
+                nodeConstructor.apply(inputStoreIndex, insert, update, retract, outputStoreSize);
         buildHelper.addNode(node);
         buildHelper.putInsertUpdateRetract(this, node::insert, node::update, node::retract);
     }

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/uni/BavetUniGroupBridgeUniConstraintStream.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/uni/BavetUniGroupBridgeUniConstraintStream.java
@@ -17,6 +17,7 @@
 package org.optaplanner.constraint.streams.bavet.uni;
 
 import java.util.Set;
+import java.util.function.Consumer;
 
 import org.optaplanner.constraint.streams.bavet.BavetConstraintFactory;
 import org.optaplanner.constraint.streams.bavet.common.AbstractGroupNode;
@@ -66,10 +67,12 @@ final class BavetUniGroupBridgeUniConstraintStream<Solution_, A, NewA>
                     + ") has an non-empty childStreamList (" + childStreamList + ") but it's a groupBy bridge.");
         }
         int inputStoreIndex = buildHelper.reserveTupleStoreIndex(parent.getTupleSource());
+        Consumer<UniTuple<NewA>> insert = buildHelper.getAggregatedInsert(groupStream.getChildStreamList());
+        Consumer<UniTuple<NewA>> update = buildHelper.getAggregatedUpdate(groupStream.getChildStreamList());
+        Consumer<UniTuple<NewA>> retract = buildHelper.getAggregatedRetract(groupStream.getChildStreamList());
         int outputStoreSize = buildHelper.extractTupleStoreSize(groupStream);
-        AbstractGroupNode<UniTuple<A>, UniTuple<NewA>, ?, ?> node = nodeConstructor.apply(inputStoreIndex,
-                buildHelper.getAggregatedInsert(groupStream.getChildStreamList()),
-                buildHelper.getAggregatedRetract(groupStream.getChildStreamList()), outputStoreSize);
+        AbstractGroupNode<UniTuple<A>, UniTuple<NewA>, ?, ?, ?> node = nodeConstructor.apply(inputStoreIndex,
+                insert, update, retract, outputStoreSize);
         buildHelper.addNode(node);
         buildHelper.putInsertUpdateRetract(this, node::insert, node::update, node::retract);
     }

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/uni/ForEachUniNode.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/uni/ForEachUniNode.java
@@ -118,9 +118,8 @@ public final class ForEachUniNode<A> extends AbstractNode {
                 case ABORTING:
                     tuple.state = BavetTupleState.DEAD;
                     break;
+                case OK:
                 case DEAD:
-                    throw new IllegalStateException("Impossible state: The tuple (" + tuple + ") in node (" +
-                            this + ") is already in the dead state (" + tuple.state + ").");
                 default:
                     throw new IllegalStateException("Impossible state: The tuple (" + tuple + ") in node (" +
                             this + ") is in an unexpected state (" + tuple.state + ").");

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/uni/Group0Mapping1CollectorUniNode.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/uni/Group0Mapping1CollectorUniNode.java
@@ -18,7 +18,6 @@ package org.optaplanner.constraint.streams.bavet.uni;
 
 import java.util.function.Consumer;
 
-import org.optaplanner.constraint.streams.bavet.common.Group;
 import org.optaplanner.core.api.score.stream.uni.UniConstraintCollector;
 
 final class Group0Mapping1CollectorUniNode<OldA, A, ResultContainer_>
@@ -30,9 +29,11 @@ final class Group0Mapping1CollectorUniNode<OldA, A, ResultContainer_>
 
     public Group0Mapping1CollectorUniNode(int groupStoreIndex,
             UniConstraintCollector<OldA, ResultContainer_, A> collector,
-            Consumer<UniTuple<A>> nextNodesInsert, Consumer<UniTuple<A>> nextNodesRetract,
+            Consumer<UniTuple<A>> nextNodesInsert, Consumer<UniTuple<A>> nextNodesUpdate,
+            Consumer<UniTuple<A>> nextNodesRetract,
             int outputStoreSize) {
-        super(groupStoreIndex, collector, nextNodesInsert, nextNodesRetract);
+        super(groupStoreIndex, collector,
+                nextNodesInsert, nextNodesUpdate, nextNodesRetract);
         this.outputStoreSize = outputStoreSize;
     }
 
@@ -42,10 +43,13 @@ final class Group0Mapping1CollectorUniNode<OldA, A, ResultContainer_>
     }
 
     @Override
-    protected UniTuple<A> createOutTuple(Group<UniTuple<A>, String, ResultContainer_> group) {
-        ResultContainer_ resultContainer = group.resultContainer;
-        A a = finisher.apply(resultContainer);
-        return new UniTuple<>(a, outputStoreSize);
+    protected UniTuple<A> createOutTuple(String groupKey) {
+        return new UniTuple<>(null, outputStoreSize);
+    }
+
+    @Override
+    protected void updateOutTupleToResult(UniTuple<A> outTuple, A a) {
+        outTuple.factA = a;
     }
 
     @Override

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/uni/Group0Mapping2CollectorUniNode.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/uni/Group0Mapping2CollectorUniNode.java
@@ -19,7 +19,6 @@ package org.optaplanner.constraint.streams.bavet.uni;
 import java.util.function.Consumer;
 
 import org.optaplanner.constraint.streams.bavet.bi.BiTuple;
-import org.optaplanner.constraint.streams.bavet.common.Group;
 import org.optaplanner.core.api.score.stream.ConstraintCollectors;
 import org.optaplanner.core.api.score.stream.uni.UniConstraintCollector;
 import org.optaplanner.core.impl.util.Pair;
@@ -34,9 +33,11 @@ final class Group0Mapping2CollectorUniNode<OldA, A, B, ResultContainerA_, Result
     public Group0Mapping2CollectorUniNode(int groupStoreIndex,
             UniConstraintCollector<OldA, ResultContainerA_, A> collectorA,
             UniConstraintCollector<OldA, ResultContainerB_, B> collectorB,
-            Consumer<BiTuple<A, B>> nextNodesInsert, Consumer<BiTuple<A, B>> nextNodesRetract,
+            Consumer<BiTuple<A, B>> nextNodesInsert, Consumer<BiTuple<A, B>> nextNodesUpdate,
+            Consumer<BiTuple<A, B>> nextNodesRetract,
             int outputStoreSize) {
-        super(groupStoreIndex, mergeCollectors(collectorA, collectorB), nextNodesInsert, nextNodesRetract);
+        super(groupStoreIndex, mergeCollectors(collectorA, collectorB),
+                nextNodesInsert, nextNodesUpdate, nextNodesRetract);
         this.outputStoreSize = outputStoreSize;
     }
 
@@ -54,10 +55,14 @@ final class Group0Mapping2CollectorUniNode<OldA, A, B, ResultContainerA_, Result
     }
 
     @Override
-    protected BiTuple<A, B> createOutTuple(Group<BiTuple<A, B>, String, Object> group) {
-        Object resultContainer = group.resultContainer;
-        Pair<A, B> result = finisher.apply(resultContainer);
-        return new BiTuple<>(result.getKey(), result.getValue(), outputStoreSize);
+    protected BiTuple<A, B> createOutTuple(String groupKey) {
+        return new BiTuple<>(null, null, outputStoreSize);
+    }
+
+    @Override
+    protected void updateOutTupleToResult(BiTuple<A, B> outTuple, Pair<A, B> result) {
+        outTuple.factA = result.getKey();
+        outTuple.factB = result.getValue();
     }
 
     @Override

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/uni/Group0Mapping3CollectorUniNode.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/uni/Group0Mapping3CollectorUniNode.java
@@ -18,7 +18,6 @@ package org.optaplanner.constraint.streams.bavet.uni;
 
 import java.util.function.Consumer;
 
-import org.optaplanner.constraint.streams.bavet.common.Group;
 import org.optaplanner.constraint.streams.bavet.tri.TriTuple;
 import org.optaplanner.core.api.score.stream.ConstraintCollectors;
 import org.optaplanner.core.api.score.stream.uni.UniConstraintCollector;
@@ -35,9 +34,11 @@ final class Group0Mapping3CollectorUniNode<OldA, A, B, C, ResultContainerA_, Res
             UniConstraintCollector<OldA, ResultContainerA_, A> collectorA,
             UniConstraintCollector<OldA, ResultContainerB_, B> collectorB,
             UniConstraintCollector<OldA, ResultContainerC_, C> collectorC,
-            Consumer<TriTuple<A, B, C>> nextNodesInsert, Consumer<TriTuple<A, B, C>> nextNodesRetract,
+            Consumer<TriTuple<A, B, C>> nextNodesInsert, Consumer<TriTuple<A, B, C>> nextNodesUpdate,
+            Consumer<TriTuple<A, B, C>> nextNodesRetract,
             int outputStoreSize) {
-        super(groupStoreIndex, mergeCollectors(collectorA, collectorB, collectorC), nextNodesInsert, nextNodesRetract);
+        super(groupStoreIndex, mergeCollectors(collectorA, collectorB, collectorC),
+                nextNodesInsert, nextNodesUpdate, nextNodesRetract);
         this.outputStoreSize = outputStoreSize;
     }
 
@@ -56,10 +57,15 @@ final class Group0Mapping3CollectorUniNode<OldA, A, B, C, ResultContainerA_, Res
     }
 
     @Override
-    protected TriTuple<A, B, C> createOutTuple(Group<TriTuple<A, B, C>, String, Object> group) {
-        Object resultContainer = group.resultContainer;
-        Triple<A, B, C> result = finisher.apply(resultContainer);
-        return new TriTuple<>(result.getA(), result.getB(), result.getC(), outputStoreSize);
+    protected TriTuple<A, B, C> createOutTuple(String groupKey) {
+        return new TriTuple<>(null, null, null, outputStoreSize);
+    }
+
+    @Override
+    protected void updateOutTupleToResult(TriTuple<A, B, C> outTuple, Triple<A, B, C> result) {
+        outTuple.factA = result.getA();
+        outTuple.factB = result.getB();
+        outTuple.factC = result.getC();
     }
 
     @Override

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/uni/Group0Mapping4CollectorUniNode.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/uni/Group0Mapping4CollectorUniNode.java
@@ -18,7 +18,6 @@ package org.optaplanner.constraint.streams.bavet.uni;
 
 import java.util.function.Consumer;
 
-import org.optaplanner.constraint.streams.bavet.common.Group;
 import org.optaplanner.constraint.streams.bavet.quad.QuadTuple;
 import org.optaplanner.core.api.score.stream.ConstraintCollectors;
 import org.optaplanner.core.api.score.stream.uni.UniConstraintCollector;
@@ -36,10 +35,11 @@ final class Group0Mapping4CollectorUniNode<OldA, A, B, C, D, ResultContainerA_, 
             UniConstraintCollector<OldA, ResultContainerB_, B> collectorB,
             UniConstraintCollector<OldA, ResultContainerC_, C> collectorC,
             UniConstraintCollector<OldA, ResultContainerD_, D> collectorD,
-            Consumer<QuadTuple<A, B, C, D>> nextNodesInsert, Consumer<QuadTuple<A, B, C, D>> nextNodesRetract,
+            Consumer<QuadTuple<A, B, C, D>> nextNodesInsert, Consumer<QuadTuple<A, B, C, D>> nextNodesUpdate,
+            Consumer<QuadTuple<A, B, C, D>> nextNodesRetract,
             int outputStoreSize) {
-        super(groupStoreIndex, mergeCollectors(collectorA, collectorB, collectorC, collectorD), nextNodesInsert,
-                nextNodesRetract);
+        super(groupStoreIndex, mergeCollectors(collectorA, collectorB, collectorC, collectorD),
+                nextNodesInsert, nextNodesUpdate, nextNodesRetract);
         this.outputStoreSize = outputStoreSize;
     }
 
@@ -59,10 +59,16 @@ final class Group0Mapping4CollectorUniNode<OldA, A, B, C, D, ResultContainerA_, 
     }
 
     @Override
-    protected QuadTuple<A, B, C, D> createOutTuple(Group<QuadTuple<A, B, C, D>, String, Object> group) {
-        Object resultContainer = group.resultContainer;
-        Quadruple<A, B, C, D> result = finisher.apply(resultContainer);
-        return new QuadTuple<>(result.getA(), result.getB(), result.getC(), result.getD(), outputStoreSize);
+    protected QuadTuple<A, B, C, D> createOutTuple(String groupKey) {
+        return new QuadTuple<>(null, null, null, null, outputStoreSize);
+    }
+
+    @Override
+    protected void updateOutTupleToResult(QuadTuple<A, B, C, D> outTuple, Quadruple<A, B, C, D> result) {
+        outTuple.factA = result.getA();
+        outTuple.factB = result.getB();
+        outTuple.factC = result.getC();
+        outTuple.factD = result.getD();
     }
 
     @Override

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/uni/Group1Mapping0CollectorUniNode.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/uni/Group1Mapping0CollectorUniNode.java
@@ -19,8 +19,6 @@ package org.optaplanner.constraint.streams.bavet.uni;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
-import org.optaplanner.constraint.streams.bavet.common.Group;
-
 final class Group1Mapping0CollectorUniNode<OldA, A>
         extends AbstractGroupUniNode<OldA, UniTuple<A>, A, Void, Void> {
 
@@ -28,9 +26,10 @@ final class Group1Mapping0CollectorUniNode<OldA, A>
     private final int outputStoreSize;
 
     public Group1Mapping0CollectorUniNode(Function<OldA, A> groupKeyMapping, int groupStoreIndex,
-            Consumer<UniTuple<A>> nextNodesInsert, Consumer<UniTuple<A>> nextNodesRetract,
+            Consumer<UniTuple<A>> nextNodesInsert, Consumer<UniTuple<A>> nextNodesUpdate,
+            Consumer<UniTuple<A>> nextNodesRetract,
             int outputStoreSize) {
-        super(groupStoreIndex, null, nextNodesInsert, nextNodesRetract);
+        super(groupStoreIndex, null, nextNodesInsert, nextNodesUpdate, nextNodesRetract);
         this.groupKeyMapping = groupKeyMapping;
         this.outputStoreSize = outputStoreSize;
     }
@@ -41,9 +40,13 @@ final class Group1Mapping0CollectorUniNode<OldA, A>
     }
 
     @Override
-    protected UniTuple<A> createOutTuple(Group<UniTuple<A>, A, Void> group) {
-        A a = group.groupKey;
+    protected UniTuple<A> createOutTuple(A a) {
         return new UniTuple<>(a, outputStoreSize);
+    }
+
+    @Override
+    protected void updateOutTupleToResult(UniTuple<A> aUniTuple, Void unused) {
+        throw new IllegalStateException("Impossible state: collector is null.");
     }
 
     @Override

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/uni/Group1Mapping1CollectorUniNode.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/uni/Group1Mapping1CollectorUniNode.java
@@ -20,7 +20,6 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 
 import org.optaplanner.constraint.streams.bavet.bi.BiTuple;
-import org.optaplanner.constraint.streams.bavet.common.Group;
 import org.optaplanner.core.api.score.stream.uni.UniConstraintCollector;
 
 final class Group1Mapping1CollectorUniNode<OldA, A, B, ResultContainer_>
@@ -31,9 +30,10 @@ final class Group1Mapping1CollectorUniNode<OldA, A, B, ResultContainer_>
 
     public Group1Mapping1CollectorUniNode(Function<OldA, A> groupKeyMapping, int groupStoreIndex,
             UniConstraintCollector<OldA, ResultContainer_, B> collector,
-            Consumer<BiTuple<A, B>> nextNodesInsert, Consumer<BiTuple<A, B>> nextNodesRetract,
+            Consumer<BiTuple<A, B>> nextNodesInsert, Consumer<BiTuple<A, B>> nextNodesUpdate,
+            Consumer<BiTuple<A, B>> nextNodesRetract,
             int outputStoreSize) {
-        super(groupStoreIndex, collector, nextNodesInsert, nextNodesRetract);
+        super(groupStoreIndex, collector, nextNodesInsert, nextNodesUpdate, nextNodesRetract);
         this.groupKeyMapping = groupKeyMapping;
         this.outputStoreSize = outputStoreSize;
     }
@@ -44,10 +44,13 @@ final class Group1Mapping1CollectorUniNode<OldA, A, B, ResultContainer_>
     }
 
     @Override
-    protected BiTuple<A, B> createOutTuple(Group<BiTuple<A, B>, A, ResultContainer_> group) {
-        A a = group.groupKey;
-        B b = finisher.apply(group.resultContainer);
-        return new BiTuple<>(a, b, outputStoreSize);
+    protected BiTuple<A, B> createOutTuple(A a) {
+        return new BiTuple<>(a, null, outputStoreSize);
+    }
+
+    @Override
+    protected void updateOutTupleToResult(BiTuple<A, B> outTuple, B b) {
+        outTuple.factB = b;
     }
 
     @Override

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/uni/Group1Mapping2CollectorUniNode.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/uni/Group1Mapping2CollectorUniNode.java
@@ -19,7 +19,6 @@ package org.optaplanner.constraint.streams.bavet.uni;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
-import org.optaplanner.constraint.streams.bavet.common.Group;
 import org.optaplanner.constraint.streams.bavet.tri.TriTuple;
 import org.optaplanner.core.api.score.stream.uni.UniConstraintCollector;
 import org.optaplanner.core.impl.util.Pair;
@@ -33,10 +32,11 @@ final class Group1Mapping2CollectorUniNode<OldA, A, B, C, ResultContainerB_, Res
     public Group1Mapping2CollectorUniNode(Function<OldA, A> groupKeyMapping, int groupStoreIndex,
             UniConstraintCollector<OldA, ResultContainerB_, B> collectorB,
             UniConstraintCollector<OldA, ResultContainerC_, C> collectorC,
-            Consumer<TriTuple<A, B, C>> nextNodesInsert, Consumer<TriTuple<A, B, C>> nextNodesRetract,
+            Consumer<TriTuple<A, B, C>> nextNodesInsert, Consumer<TriTuple<A, B, C>> nextNodesUpdate,
+            Consumer<TriTuple<A, B, C>> nextNodesRetract,
             int outputStoreSize) {
-        super(groupStoreIndex, Group0Mapping2CollectorUniNode.mergeCollectors(collectorB, collectorC), nextNodesInsert,
-                nextNodesRetract);
+        super(groupStoreIndex, Group0Mapping2CollectorUniNode.mergeCollectors(collectorB, collectorC),
+                nextNodesInsert, nextNodesUpdate, nextNodesRetract);
         this.groupKeyMapping = groupKeyMapping;
         this.outputStoreSize = outputStoreSize;
     }
@@ -47,10 +47,14 @@ final class Group1Mapping2CollectorUniNode<OldA, A, B, C, ResultContainerB_, Res
     }
 
     @Override
-    protected TriTuple<A, B, C> createOutTuple(Group<TriTuple<A, B, C>, A, Object> group) {
-        A factA = group.groupKey;
-        Pair<B, C> result = finisher.apply(group.resultContainer);
-        return new TriTuple<>(factA, result.getKey(), result.getValue(), outputStoreSize);
+    protected TriTuple<A, B, C> createOutTuple(A a) {
+        return new TriTuple<>(a, null, null, outputStoreSize);
+    }
+
+    @Override
+    protected void updateOutTupleToResult(TriTuple<A, B, C> outTuple, Pair<B, C> result) {
+        outTuple.factB = result.getKey();
+        outTuple.factC = result.getValue();
     }
 
     @Override

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/uni/Group1Mapping3CollectorUniNode.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/uni/Group1Mapping3CollectorUniNode.java
@@ -19,7 +19,6 @@ package org.optaplanner.constraint.streams.bavet.uni;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
-import org.optaplanner.constraint.streams.bavet.common.Group;
 import org.optaplanner.constraint.streams.bavet.quad.QuadTuple;
 import org.optaplanner.core.api.score.stream.uni.UniConstraintCollector;
 import org.optaplanner.core.impl.util.Triple;
@@ -34,10 +33,11 @@ final class Group1Mapping3CollectorUniNode<OldA, A, B, C, D, ResultContainerB_, 
             UniConstraintCollector<OldA, ResultContainerB_, B> collectorB,
             UniConstraintCollector<OldA, ResultContainerC_, C> collectorC,
             UniConstraintCollector<OldA, ResultContainerD_, D> collectorD,
-            Consumer<QuadTuple<A, B, C, D>> nextNodesInsert, Consumer<QuadTuple<A, B, C, D>> nextNodesRetract,
+            Consumer<QuadTuple<A, B, C, D>> nextNodesInsert, Consumer<QuadTuple<A, B, C, D>> nextNodesUpdate,
+            Consumer<QuadTuple<A, B, C, D>> nextNodesRetract,
             int outputStoreSize) {
         super(groupStoreIndex, Group0Mapping3CollectorUniNode.mergeCollectors(collectorB, collectorC, collectorD),
-                nextNodesInsert, nextNodesRetract);
+                nextNodesInsert, nextNodesUpdate, nextNodesRetract);
         this.groupKeyMapping = groupKeyMapping;
         this.outputStoreSize = outputStoreSize;
     }
@@ -48,10 +48,15 @@ final class Group1Mapping3CollectorUniNode<OldA, A, B, C, D, ResultContainerB_, 
     }
 
     @Override
-    protected QuadTuple<A, B, C, D> createOutTuple(Group<QuadTuple<A, B, C, D>, A, Object> group) {
-        A a = group.groupKey;
-        Triple<B, C, D> result = finisher.apply(group.resultContainer);
-        return new QuadTuple<>(a, result.getA(), result.getB(), result.getC(), outputStoreSize);
+    protected QuadTuple<A, B, C, D> createOutTuple(A a) {
+        return new QuadTuple<>(a, null, null, null, outputStoreSize);
+    }
+
+    @Override
+    protected void updateOutTupleToResult(QuadTuple<A, B, C, D> outTuple, Triple<B, C, D> result) {
+        outTuple.factB = result.getA();
+        outTuple.factC = result.getB();
+        outTuple.factD = result.getC();
     }
 
     @Override

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/uni/Group2Mapping0CollectorUniNode.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/uni/Group2Mapping0CollectorUniNode.java
@@ -20,7 +20,6 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 
 import org.optaplanner.constraint.streams.bavet.bi.BiTuple;
-import org.optaplanner.constraint.streams.bavet.common.Group;
 import org.optaplanner.core.impl.util.Pair;
 
 final class Group2Mapping0CollectorUniNode<OldA, A, B>
@@ -31,9 +30,10 @@ final class Group2Mapping0CollectorUniNode<OldA, A, B>
     private final int outputStoreSize;
 
     public Group2Mapping0CollectorUniNode(Function<OldA, A> groupKeyMappingA, Function<OldA, B> groupKeyMappingB,
-            int groupStoreIndex, Consumer<BiTuple<A, B>> nextNodesInsert, Consumer<BiTuple<A, B>> nextNodesRetract,
+            int groupStoreIndex, Consumer<BiTuple<A, B>> nextNodesInsert, Consumer<BiTuple<A, B>> nextNodesUpdate,
+            Consumer<BiTuple<A, B>> nextNodesRetract,
             int outputStoreSize) {
-        super(groupStoreIndex, null, nextNodesInsert, nextNodesRetract);
+        super(groupStoreIndex, null, nextNodesInsert, nextNodesUpdate, nextNodesRetract);
         this.groupKeyMappingA = groupKeyMappingA;
         this.groupKeyMappingB = groupKeyMappingB;
         this.outputStoreSize = outputStoreSize;
@@ -48,9 +48,13 @@ final class Group2Mapping0CollectorUniNode<OldA, A, B>
     }
 
     @Override
-    protected BiTuple<A, B> createOutTuple(Group<BiTuple<A, B>, Pair<A, B>, Void> group) {
-        Pair<A, B> key = group.groupKey;
-        return new BiTuple<>(key.getKey(), key.getValue(), outputStoreSize);
+    protected BiTuple<A, B> createOutTuple(Pair<A, B> groupKey) {
+        return new BiTuple<>(groupKey.getKey(), groupKey.getValue(), outputStoreSize);
+    }
+
+    @Override
+    protected void updateOutTupleToResult(BiTuple<A, B> outTuple, Void unused) {
+        throw new IllegalStateException("Impossible state: collector is null.");
     }
 
     @Override

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/uni/Group2Mapping1CollectorUniNode.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/uni/Group2Mapping1CollectorUniNode.java
@@ -19,7 +19,6 @@ package org.optaplanner.constraint.streams.bavet.uni;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
-import org.optaplanner.constraint.streams.bavet.common.Group;
 import org.optaplanner.constraint.streams.bavet.tri.TriTuple;
 import org.optaplanner.core.api.score.stream.uni.UniConstraintCollector;
 import org.optaplanner.core.impl.util.Pair;
@@ -33,9 +32,10 @@ final class Group2Mapping1CollectorUniNode<OldA, A, B, C, ResultContainer_>
 
     public Group2Mapping1CollectorUniNode(Function<OldA, A> groupKeyMappingA, Function<OldA, B> groupKeyMappingB,
             int groupStoreIndex, UniConstraintCollector<OldA, ResultContainer_, C> collector,
-            Consumer<TriTuple<A, B, C>> nextNodesInsert, Consumer<TriTuple<A, B, C>> nextNodesRetract,
+            Consumer<TriTuple<A, B, C>> nextNodesInsert, Consumer<TriTuple<A, B, C>> nextNodesUpdate,
+            Consumer<TriTuple<A, B, C>> nextNodesRetract,
             int outputStoreSize) {
-        super(groupStoreIndex, collector, nextNodesInsert, nextNodesRetract);
+        super(groupStoreIndex, collector, nextNodesInsert, nextNodesUpdate, nextNodesRetract);
         this.groupKeyMappingA = groupKeyMappingA;
         this.groupKeyMappingB = groupKeyMappingB;
         this.outputStoreSize = outputStoreSize;
@@ -50,10 +50,13 @@ final class Group2Mapping1CollectorUniNode<OldA, A, B, C, ResultContainer_>
     }
 
     @Override
-    protected TriTuple<A, B, C> createOutTuple(Group<TriTuple<A, B, C>, Pair<A, B>, ResultContainer_> group) {
-        Pair<A, B> groupKey = group.groupKey;
-        C c = finisher.apply(group.resultContainer);
-        return new TriTuple<>(groupKey.getKey(), groupKey.getValue(), c, outputStoreSize);
+    protected TriTuple<A, B, C> createOutTuple(Pair<A, B> groupKey) {
+        return new TriTuple<>(groupKey.getKey(), groupKey.getValue(), null, outputStoreSize);
+    }
+
+    @Override
+    protected void updateOutTupleToResult(TriTuple<A, B, C> outTuple, C c) {
+        outTuple.factC = c;
     }
 
     @Override

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/uni/Group2Mapping2CollectorUniNode.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/uni/Group2Mapping2CollectorUniNode.java
@@ -21,7 +21,6 @@ import static org.optaplanner.constraint.streams.bavet.uni.Group0Mapping2Collect
 import java.util.function.Consumer;
 import java.util.function.Function;
 
-import org.optaplanner.constraint.streams.bavet.common.Group;
 import org.optaplanner.constraint.streams.bavet.quad.QuadTuple;
 import org.optaplanner.core.api.score.stream.uni.UniConstraintCollector;
 import org.optaplanner.core.impl.util.Pair;
@@ -37,9 +36,10 @@ final class Group2Mapping2CollectorUniNode<OldA, A, B, C, D, ResultContainerC_, 
             int groupStoreIndex,
             UniConstraintCollector<OldA, ResultContainerC_, C> collectorC,
             UniConstraintCollector<OldA, ResultContainerD_, D> collectorD,
-            Consumer<QuadTuple<A, B, C, D>> nextNodesInsert, Consumer<QuadTuple<A, B, C, D>> nextNodesRetract,
+            Consumer<QuadTuple<A, B, C, D>> nextNodesInsert, Consumer<QuadTuple<A, B, C, D>> nextNodesUpdate,
+            Consumer<QuadTuple<A, B, C, D>> nextNodesRetract,
             int outputStoreSize) {
-        super(groupStoreIndex, mergeCollectors(collectorC, collectorD), nextNodesInsert, nextNodesRetract);
+        super(groupStoreIndex, mergeCollectors(collectorC, collectorD), nextNodesInsert, nextNodesUpdate, nextNodesRetract);
         this.groupKeyMappingA = groupKeyMappingA;
         this.groupKeyMappingB = groupKeyMappingB;
         this.outputStoreSize = outputStoreSize;
@@ -54,10 +54,14 @@ final class Group2Mapping2CollectorUniNode<OldA, A, B, C, D, ResultContainerC_, 
     }
 
     @Override
-    protected QuadTuple<A, B, C, D> createOutTuple(Group<QuadTuple<A, B, C, D>, Pair<A, B>, Object> group) {
-        Pair<A, B> groupKey = group.groupKey;
-        Pair<C, D> result = finisher.apply(group.resultContainer);
-        return new QuadTuple<>(groupKey.getKey(), groupKey.getValue(), result.getKey(), result.getValue(), outputStoreSize);
+    protected QuadTuple<A, B, C, D> createOutTuple(Pair<A, B> groupKey) {
+        return new QuadTuple<>(groupKey.getKey(), groupKey.getValue(), null, null, outputStoreSize);
+    }
+
+    @Override
+    protected void updateOutTupleToResult(QuadTuple<A, B, C, D> outTuple, Pair<C, D> result) {
+        outTuple.factC = result.getKey();
+        outTuple.factD = result.getValue();
     }
 
     @Override

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/uni/Group3Mapping0CollectorUniNode.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/uni/Group3Mapping0CollectorUniNode.java
@@ -19,7 +19,6 @@ package org.optaplanner.constraint.streams.bavet.uni;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
-import org.optaplanner.constraint.streams.bavet.common.Group;
 import org.optaplanner.constraint.streams.bavet.tri.TriTuple;
 import org.optaplanner.core.impl.util.Triple;
 
@@ -33,8 +32,9 @@ final class Group3Mapping0CollectorUniNode<OldA, A, B, C>
 
     public Group3Mapping0CollectorUniNode(Function<OldA, A> groupKeyMappingA, Function<OldA, B> groupKeyMappingB,
             Function<OldA, C> groupKeyMappingC, int groupStoreIndex,
-            Consumer<TriTuple<A, B, C>> nextNodesInsert, Consumer<TriTuple<A, B, C>> nextNodesRetract, int outputStoreSize) {
-        super(groupStoreIndex, null, nextNodesInsert, nextNodesRetract);
+            Consumer<TriTuple<A, B, C>> nextNodesInsert, Consumer<TriTuple<A, B, C>> nextNodesUpdate,
+            Consumer<TriTuple<A, B, C>> nextNodesRetract, int outputStoreSize) {
+        super(groupStoreIndex, null, nextNodesInsert, nextNodesUpdate, nextNodesRetract);
         this.groupKeyMappingA = groupKeyMappingA;
         this.groupKeyMappingB = groupKeyMappingB;
         this.groupKeyMappingC = groupKeyMappingC;
@@ -51,9 +51,13 @@ final class Group3Mapping0CollectorUniNode<OldA, A, B, C>
     }
 
     @Override
-    protected TriTuple<A, B, C> createOutTuple(Group<TriTuple<A, B, C>, Triple<A, B, C>, Void> group) {
-        Triple<A, B, C> key = group.groupKey;
-        return new TriTuple<>(key.getA(), key.getB(), key.getC(), outputStoreSize);
+    protected TriTuple<A, B, C> createOutTuple(Triple<A, B, C> groupKey) {
+        return new TriTuple<>(groupKey.getA(), groupKey.getB(), groupKey.getC(), outputStoreSize);
+    }
+
+    @Override
+    protected void updateOutTupleToResult(TriTuple<A, B, C> outTuple, Void unused) {
+        throw new IllegalStateException("Impossible state: collector is null.");
     }
 
     @Override

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/uni/Group3Mapping1CollectorUniNode.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/uni/Group3Mapping1CollectorUniNode.java
@@ -19,7 +19,6 @@ package org.optaplanner.constraint.streams.bavet.uni;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
-import org.optaplanner.constraint.streams.bavet.common.Group;
 import org.optaplanner.constraint.streams.bavet.quad.QuadTuple;
 import org.optaplanner.core.api.score.stream.uni.UniConstraintCollector;
 import org.optaplanner.core.impl.util.Triple;
@@ -35,9 +34,10 @@ final class Group3Mapping1CollectorUniNode<OldA, A, B, C, D, ResultContainer_>
     public Group3Mapping1CollectorUniNode(Function<OldA, A> groupKeyMappingA, Function<OldA, B> groupKeyMappingB,
             Function<OldA, C> groupKeyMappingC,
             int groupStoreIndex, UniConstraintCollector<OldA, ResultContainer_, D> collector,
-            Consumer<QuadTuple<A, B, C, D>> nextNodesInsert, Consumer<QuadTuple<A, B, C, D>> nextNodesRetract,
+            Consumer<QuadTuple<A, B, C, D>> nextNodesInsert, Consumer<QuadTuple<A, B, C, D>> nextNodesUpdate,
+            Consumer<QuadTuple<A, B, C, D>> nextNodesRetract,
             int outputStoreSize) {
-        super(groupStoreIndex, collector, nextNodesInsert, nextNodesRetract);
+        super(groupStoreIndex, collector, nextNodesInsert, nextNodesUpdate, nextNodesRetract);
         this.groupKeyMappingA = groupKeyMappingA;
         this.groupKeyMappingB = groupKeyMappingB;
         this.groupKeyMappingC = groupKeyMappingC;
@@ -54,10 +54,13 @@ final class Group3Mapping1CollectorUniNode<OldA, A, B, C, D, ResultContainer_>
     }
 
     @Override
-    protected QuadTuple<A, B, C, D> createOutTuple(Group<QuadTuple<A, B, C, D>, Triple<A, B, C>, ResultContainer_> group) {
-        Triple<A, B, C> groupKey = group.groupKey;
-        D d = finisher.apply(group.resultContainer);
-        return new QuadTuple<>(groupKey.getA(), groupKey.getB(), groupKey.getC(), d, outputStoreSize);
+    protected QuadTuple<A, B, C, D> createOutTuple(Triple<A, B, C> groupKey) {
+        return new QuadTuple<>(groupKey.getA(), groupKey.getB(), groupKey.getC(), null, outputStoreSize);
+    }
+
+    @Override
+    protected void updateOutTupleToResult(QuadTuple<A, B, C, D> outTuple, D d) {
+        outTuple.factD = d;
     }
 
     @Override

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/uni/Group4Mapping0CollectorUniNode.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/uni/Group4Mapping0CollectorUniNode.java
@@ -19,7 +19,6 @@ package org.optaplanner.constraint.streams.bavet.uni;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
-import org.optaplanner.constraint.streams.bavet.common.Group;
 import org.optaplanner.constraint.streams.bavet.quad.QuadTuple;
 import org.optaplanner.core.impl.util.Quadruple;
 
@@ -34,9 +33,10 @@ final class Group4Mapping0CollectorUniNode<OldA, A, B, C, D>
 
     public Group4Mapping0CollectorUniNode(Function<OldA, A> groupKeyMappingA, Function<OldA, B> groupKeyMappingB,
             Function<OldA, C> groupKeyMappingC, Function<OldA, D> groupKeyMappingD, int groupStoreIndex,
-            Consumer<QuadTuple<A, B, C, D>> nextNodesInsert, Consumer<QuadTuple<A, B, C, D>> nextNodesRetract,
+            Consumer<QuadTuple<A, B, C, D>> nextNodesInsert, Consumer<QuadTuple<A, B, C, D>> nextNodesUpdate,
+            Consumer<QuadTuple<A, B, C, D>> nextNodesRetract,
             int outputStoreSize) {
-        super(groupStoreIndex, null, nextNodesInsert, nextNodesRetract);
+        super(groupStoreIndex, null, nextNodesInsert, nextNodesUpdate, nextNodesRetract);
         this.groupKeyMappingA = groupKeyMappingA;
         this.groupKeyMappingB = groupKeyMappingB;
         this.groupKeyMappingC = groupKeyMappingC;
@@ -55,9 +55,13 @@ final class Group4Mapping0CollectorUniNode<OldA, A, B, C, D>
     }
 
     @Override
-    protected QuadTuple<A, B, C, D> createOutTuple(Group<QuadTuple<A, B, C, D>, Quadruple<A, B, C, D>, Void> group) {
-        Quadruple<A, B, C, D> key = group.groupKey;
-        return new QuadTuple<>(key.getA(), key.getB(), key.getC(), key.getD(), outputStoreSize);
+    protected QuadTuple<A, B, C, D> createOutTuple(Quadruple<A, B, C, D> groupKey) {
+        return new QuadTuple<>(groupKey.getA(), groupKey.getB(), groupKey.getC(), groupKey.getD(), outputStoreSize);
+    }
+
+    @Override
+    protected void updateOutTupleToResult(QuadTuple<A, B, C, D> outTuple, Void unused) {
+        throw new IllegalStateException("Impossible state: collector is null.");
     }
 
     @Override

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/uni/UniGroupNodeConstructor.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/uni/UniGroupNodeConstructor.java
@@ -23,7 +23,8 @@ import org.optaplanner.constraint.streams.bavet.common.Tuple;
 @FunctionalInterface
 interface UniGroupNodeConstructor<A, Tuple_ extends Tuple> {
 
-    AbstractGroupUniNode<A, Tuple_, ?, ?, ?> apply(int inputStoreIndex, Consumer<Tuple_> insert, Consumer<Tuple_> retract,
+    AbstractGroupUniNode<A, Tuple_, ?, ?, ?> apply(int inputStoreIndex,
+            Consumer<Tuple_> insert, Consumer<Tuple_> update, Consumer<Tuple_> retract,
             int outputStoreSize);
 
 }

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/uni/UniTuple.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/uni/UniTuple.java
@@ -21,7 +21,8 @@ import org.optaplanner.constraint.streams.bavet.common.Tuple;
 
 public final class UniTuple<A> implements Tuple {
 
-    public final A factA;
+    // Only a tuple's origin node may modify a fact.
+    public A factA;
 
     public final Object[] store;
 


### PR DESCRIPTION
I need to clean AbstractGroupNode up a bit further. This might already be faster because inserts and retracts use update on the out tuple if possible. That is more important than implementing the input update() method, which I'll do now.