### PR TITLE
Improve Flight Crew Scheduling constraints consistency

### DIFF
--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/flightcrewscheduling/score/FlightCrewSchedulingConstraintProvider.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/flightcrewscheduling/score/FlightCrewSchedulingConstraintProvider.java
@@ -38,8 +38,8 @@ public class FlightCrewSchedulingConstraintProvider implements ConstraintProvide
                 flightConflict(constraintFactory),
                 transferBetweenTwoFlights(constraintFactory),
                 employeeUnavailability(constraintFactory),
-                firstAssignmentDepartingFromHome(constraintFactory),
-                lastAssignmentArrivingAtHome(constraintFactory)
+                firstAssignmentNotDepartingFromHome(constraintFactory),
+                lastAssignmentNotArrivingAtHome(constraintFactory)
         };
     }
 
@@ -54,8 +54,8 @@ public class FlightCrewSchedulingConstraintProvider implements ConstraintProvide
 
     private Constraint flightConflict(ConstraintFactory constraintFactory) {
         return constraintFactory.forEachUniquePair(FlightAssignment.class, equal(FlightAssignment::getEmployee),
-                overlapping(fa -> fa.getFlight().getDepartureUTCDateTime(),
-                        fa -> fa.getFlight().getArrivalUTCDateTime()))
+                overlapping(flightAssignment -> flightAssignment.getFlight().getDepartureUTCDateTime(),
+                        flightAssignment -> flightAssignment.getFlight().getArrivalUTCDateTime()))
                 .penalize("Flight conflict", HardSoftLongScore.ofHard(10));
     }
 
@@ -74,16 +74,16 @@ public class FlightCrewSchedulingConstraintProvider implements ConstraintProvide
                 .penalize("Employee unavailable", HardSoftLongScore.ofHard(10));
     }
 
-    private Constraint firstAssignmentDepartingFromHome(ConstraintFactory constraintFactory) {
+    private Constraint firstAssignmentNotDepartingFromHome(ConstraintFactory constraintFactory) {
         return constraintFactory.forEach(Employee.class)
                 .filter(employee -> !employee.isFirstAssignmentDepartingFromHome())
-                .penalize("First assignment departing from home", HardSoftLongScore.ofSoft(1_000_000));
+                .penalize("First assignment not departing from home", HardSoftLongScore.ofSoft(1_000_000));
     }
 
-    private Constraint lastAssignmentArrivingAtHome(ConstraintFactory constraintFactory) {
+    private Constraint lastAssignmentNotArrivingAtHome(ConstraintFactory constraintFactory) {
         return constraintFactory.forEach(Employee.class)
                 .filter(employee -> !employee.isLastAssignmentArrivingAtHome())
-                .penalize("Last assignment arriving at home", HardSoftLongScore.ofSoft(1_000_000));
+                .penalize("Last assignment not arriving at home", HardSoftLongScore.ofSoft(1_000_000));
     }
 
 }

--- a/optaplanner-examples/src/main/resources/org/optaplanner/examples/flightcrewscheduling/optional/score/flightCrewSchedulingConstraints.drl
+++ b/optaplanner-examples/src/main/resources/org/optaplanner/examples/flightcrewscheduling/optional/score/flightCrewSchedulingConstraints.drl
@@ -74,14 +74,14 @@ end
 // ############################################################################
 
 
-rule "First assignment departing from home"
+rule "First assignment not departing from home"
     when
         Employee(!isFirstAssignmentDepartingFromHome())
     then
         scoreHolder.addSoftConstraintMatch(kcontext, -1_000_000);
 end
 
-rule "Last assignment arriving at home"
+rule "Last assignment not arriving at home"
     when
         Employee(!isLastAssignmentArrivingAtHome())
     then


### PR DESCRIPTION
1. Variable names (change `fa` to `flightAssignment`).
2. In my opinion it helps understand the constraints if the constraint name _consistently_ either A) describes the condition it penalizes or B) describes the goal it maximizes by penalizing its negation. When this is used consistently it's easy to guess what the constraint does without looking at the implementation. I choose `A` because in this case it's a natural language description of the filtering condition.



<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request checks</b>  
  Please add comment: <b>Jenkins retest this</b>

- for a <b>specific pull request check</b>  
  please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] tests</b>
  
- for a <b>full downstream build</b> 
  - for <b>jenkins</b> job: 
    please add comment: <b>Jenkins run fdb</b>
  - for <b>github actions</b> job: 
    add the label `run_fdb`

- for a <b>compile downstream build</b>  
  please add comment: <b>Jenkins run cdb</b>

- for a <b>full production downstream build</b>  
  please add comment: <b>Jenkins execute product fdb</b>

- for an <b>upstream build</b>  
  please add comment: <b>Jenkins run upstream</b>

- for <b>quarkus branch checks</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins run quarkus-branch</b>

- for a <b>quarkus branch specific check</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] quarkus-branch</b>

- for <b>quarkus main checks</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins run quarkus-main</b>

- for a <b>specific quarkus main check</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] quarkus-branch</b>

- for <b>native checks</b>  
  Run native checks  
  Please add comment: <b>Jenkins run native</b>

- for a <b>specific native check</b>  
  Run native checks 
  Please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] native</b>

- for <b>mandrel checks</b>  
  Run native checks against Mandrel image
  Please add comment: <b>Jenkins run mandrel</b>

- for a <b>specific mandrel check</b>  
  Run native checks against Mandrel image  
  Please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] mandrel</b>
</details>

### CI Status

 You can check OptaPlanner repositories CI status from [Chain Status webpage](https://kiegroup.github.io/optaplanner/).