### PR TITLE
CS-B: More code sharing

### DIFF
--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/bi/AbstractGroupBiNode.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/bi/AbstractGroupBiNode.java
@@ -1,5 +1,7 @@
 package org.optaplanner.constraint.streams.bavet.bi;
 
+import java.util.function.Function;
+
 import org.optaplanner.constraint.streams.bavet.common.AbstractGroupNode;
 import org.optaplanner.constraint.streams.bavet.common.Tuple;
 import org.optaplanner.constraint.streams.bavet.common.TupleLifecycle;
@@ -12,9 +14,10 @@ abstract class AbstractGroupBiNode<OldA, OldB, OutTuple_ extends Tuple, GroupKey
     private final TriFunction<ResultContainer_, OldA, OldB, Runnable> accumulator;
 
     protected AbstractGroupBiNode(int groupStoreIndex,
+            Function<BiTuple<OldA, OldB>, GroupKey_> groupKeyFunction,
             BiConstraintCollector<OldA, OldB, ResultContainer_, Result_> collector,
             TupleLifecycle<OutTuple_> nextNodesTupleLifecycle) {
-        super(groupStoreIndex,
+        super(groupStoreIndex, groupKeyFunction,
                 collector == null ? null : collector.supplier(),
                 collector == null ? null : collector.finisher(),
                 nextNodesTupleLifecycle);

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/bi/Group0Mapping1CollectorBiNode.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/bi/Group0Mapping1CollectorBiNode.java
@@ -5,26 +5,19 @@ import org.optaplanner.constraint.streams.bavet.uni.UniTuple;
 import org.optaplanner.core.api.score.stream.bi.BiConstraintCollector;
 
 final class Group0Mapping1CollectorBiNode<OldA, OldB, A, ResultContainer_>
-        extends AbstractGroupBiNode<OldA, OldB, UniTuple<A>, String, ResultContainer_, A> {
-
-    private static final String NO_GROUP_KEY = "NO_GROUP";
+        extends AbstractGroupBiNode<OldA, OldB, UniTuple<A>, Void, ResultContainer_, A> {
 
     private final int outputStoreSize;
 
     public Group0Mapping1CollectorBiNode(int groupStoreIndex,
             BiConstraintCollector<OldA, OldB, ResultContainer_, A> collector,
             TupleLifecycle<UniTuple<A>> nextNodesTupleLifecycle, int outputStoreSize) {
-        super(groupStoreIndex, collector, nextNodesTupleLifecycle);
+        super(groupStoreIndex, null, collector, nextNodesTupleLifecycle);
         this.outputStoreSize = outputStoreSize;
     }
 
     @Override
-    protected String createGroupKey(BiTuple<OldA, OldB> tuple) {
-        return NO_GROUP_KEY;
-    }
-
-    @Override
-    protected UniTuple<A> createOutTuple(String groupKey) {
+    protected UniTuple<A> createOutTuple(Void groupKey) {
         return new UniTuple<>(null, outputStoreSize);
     }
 

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/bi/Group0Mapping2CollectorBiNode.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/bi/Group0Mapping2CollectorBiNode.java
@@ -6,9 +6,7 @@ import org.optaplanner.core.api.score.stream.bi.BiConstraintCollector;
 import org.optaplanner.core.impl.util.Pair;
 
 final class Group0Mapping2CollectorBiNode<OldA, OldB, A, B, ResultContainerA_, ResultContainerB_>
-        extends AbstractGroupBiNode<OldA, OldB, BiTuple<A, B>, String, Object, Pair<A, B>> {
-
-    private static final String NO_GROUP_KEY = "NO_GROUP";
+        extends AbstractGroupBiNode<OldA, OldB, BiTuple<A, B>, Void, Object, Pair<A, B>> {
 
     private final int outputStoreSize;
 
@@ -16,7 +14,7 @@ final class Group0Mapping2CollectorBiNode<OldA, OldB, A, B, ResultContainerA_, R
             BiConstraintCollector<OldA, OldB, ResultContainerA_, A> collectorA,
             BiConstraintCollector<OldA, OldB, ResultContainerB_, B> collectorB,
             TupleLifecycle<BiTuple<A, B>> nextNodesTupleLifecycle, int outputStoreSize) {
-        super(groupStoreIndex, mergeCollectors(collectorA, collectorB), nextNodesTupleLifecycle);
+        super(groupStoreIndex, null, mergeCollectors(collectorA, collectorB), nextNodesTupleLifecycle);
         this.outputStoreSize = outputStoreSize;
     }
 
@@ -29,12 +27,7 @@ final class Group0Mapping2CollectorBiNode<OldA, OldB, A, B, ResultContainerA_, R
     }
 
     @Override
-    protected String createGroupKey(BiTuple<OldA, OldB> tuple) {
-        return NO_GROUP_KEY;
-    }
-
-    @Override
-    protected BiTuple<A, B> createOutTuple(String groupKey) {
+    protected BiTuple<A, B> createOutTuple(Void groupKey) {
         return new BiTuple<>(null, null, outputStoreSize);
     }
 

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/bi/Group0Mapping3CollectorBiNode.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/bi/Group0Mapping3CollectorBiNode.java
@@ -7,9 +7,7 @@ import org.optaplanner.core.api.score.stream.bi.BiConstraintCollector;
 import org.optaplanner.core.impl.util.Triple;
 
 final class Group0Mapping3CollectorBiNode<OldA, OldB, A, B, C, ResultContainerA_, ResultContainerB_, ResultContainerC_>
-        extends AbstractGroupBiNode<OldA, OldB, TriTuple<A, B, C>, String, Object, Triple<A, B, C>> {
-
-    private static final String NO_GROUP_KEY = "NO_GROUP";
+        extends AbstractGroupBiNode<OldA, OldB, TriTuple<A, B, C>, Void, Object, Triple<A, B, C>> {
 
     private final int outputStoreSize;
 
@@ -18,7 +16,7 @@ final class Group0Mapping3CollectorBiNode<OldA, OldB, A, B, C, ResultContainerA_
             BiConstraintCollector<OldA, OldB, ResultContainerB_, B> collectorB,
             BiConstraintCollector<OldA, OldB, ResultContainerC_, C> collectorC,
             TupleLifecycle<TriTuple<A, B, C>> nextNodesTupleLifecycle, int outputStoreSize) {
-        super(groupStoreIndex, mergeCollectors(collectorA, collectorB, collectorC), nextNodesTupleLifecycle);
+        super(groupStoreIndex, null, mergeCollectors(collectorA, collectorB, collectorC), nextNodesTupleLifecycle);
         this.outputStoreSize = outputStoreSize;
     }
 
@@ -32,12 +30,7 @@ final class Group0Mapping3CollectorBiNode<OldA, OldB, A, B, C, ResultContainerA_
     }
 
     @Override
-    protected String createGroupKey(BiTuple<OldA, OldB> tuple) {
-        return NO_GROUP_KEY;
-    }
-
-    @Override
-    protected TriTuple<A, B, C> createOutTuple(String groupKey) {
+    protected TriTuple<A, B, C> createOutTuple(Void groupKey) {
         return new TriTuple<>(null, null, null, outputStoreSize);
     }
 

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/bi/Group0Mapping4CollectorBiNode.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/bi/Group0Mapping4CollectorBiNode.java
@@ -7,9 +7,7 @@ import org.optaplanner.core.api.score.stream.bi.BiConstraintCollector;
 import org.optaplanner.core.impl.util.Quadruple;
 
 final class Group0Mapping4CollectorBiNode<OldA, OldB, A, B, C, D, ResultContainerA_, ResultContainerB_, ResultContainerC_, ResultContainerD_>
-        extends AbstractGroupBiNode<OldA, OldB, QuadTuple<A, B, C, D>, String, Object, Quadruple<A, B, C, D>> {
-
-    private static final String NO_GROUP_KEY = "NO_GROUP";
+        extends AbstractGroupBiNode<OldA, OldB, QuadTuple<A, B, C, D>, Void, Object, Quadruple<A, B, C, D>> {
 
     private final int outputStoreSize;
 
@@ -19,7 +17,7 @@ final class Group0Mapping4CollectorBiNode<OldA, OldB, A, B, C, D, ResultContaine
             BiConstraintCollector<OldA, OldB, ResultContainerC_, C> collectorC,
             BiConstraintCollector<OldA, OldB, ResultContainerD_, D> collectorD,
             TupleLifecycle<QuadTuple<A, B, C, D>> nextNodesTupleLifecycle, int outputStoreSize) {
-        super(groupStoreIndex, mergeCollectors(collectorA, collectorB, collectorC, collectorD), nextNodesTupleLifecycle);
+        super(groupStoreIndex, null, mergeCollectors(collectorA, collectorB, collectorC, collectorD), nextNodesTupleLifecycle);
         this.outputStoreSize = outputStoreSize;
     }
 
@@ -34,12 +32,7 @@ final class Group0Mapping4CollectorBiNode<OldA, OldB, A, B, C, D, ResultContaine
     }
 
     @Override
-    protected String createGroupKey(BiTuple<OldA, OldB> tuple) {
-        return NO_GROUP_KEY;
-    }
-
-    @Override
-    protected QuadTuple<A, B, C, D> createOutTuple(String groupKey) {
+    protected QuadTuple<A, B, C, D> createOutTuple(Void groupKey) {
         return new QuadTuple<>(null, null, null, null, outputStoreSize);
     }
 

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/bi/Group1Mapping0CollectorBiNode.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/bi/Group1Mapping0CollectorBiNode.java
@@ -8,18 +8,15 @@ import org.optaplanner.constraint.streams.bavet.uni.UniTuple;
 final class Group1Mapping0CollectorBiNode<OldA, OldB, A>
         extends AbstractGroupBiNode<OldA, OldB, UniTuple<A>, A, Void, Void> {
 
-    private final BiFunction<OldA, OldB, A> groupKeyMapping;
     private final int outputStoreSize;
 
     public Group1Mapping0CollectorBiNode(BiFunction<OldA, OldB, A> groupKeyMapping, int groupStoreIndex,
             TupleLifecycle<UniTuple<A>> nextNodesTupleLifecycle, int outputStoreSize) {
-        super(groupStoreIndex, null, nextNodesTupleLifecycle);
-        this.groupKeyMapping = groupKeyMapping;
+        super(groupStoreIndex, tuple -> createGroupKey(groupKeyMapping, tuple), null, nextNodesTupleLifecycle);
         this.outputStoreSize = outputStoreSize;
     }
 
-    @Override
-    protected A createGroupKey(BiTuple<OldA, OldB> tuple) {
+    static <A, OldA, OldB> A createGroupKey(BiFunction<OldA, OldB, A> groupKeyMapping, BiTuple<OldA, OldB> tuple) {
         return groupKeyMapping.apply(tuple.factA, tuple.factB);
     }
 

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/bi/Group1Mapping1CollectorBiNode.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/bi/Group1Mapping1CollectorBiNode.java
@@ -1,5 +1,7 @@
 package org.optaplanner.constraint.streams.bavet.bi;
 
+import static org.optaplanner.constraint.streams.bavet.bi.Group1Mapping0CollectorBiNode.createGroupKey;
+
 import java.util.function.BiFunction;
 
 import org.optaplanner.constraint.streams.bavet.common.TupleLifecycle;
@@ -8,20 +10,13 @@ import org.optaplanner.core.api.score.stream.bi.BiConstraintCollector;
 final class Group1Mapping1CollectorBiNode<OldA, OldB, A, B, ResultContainer_>
         extends AbstractGroupBiNode<OldA, OldB, BiTuple<A, B>, A, ResultContainer_, B> {
 
-    private final BiFunction<OldA, OldB, A> groupKeyMapping;
     private final int outputStoreSize;
 
     public Group1Mapping1CollectorBiNode(BiFunction<OldA, OldB, A> groupKeyMapping, int groupStoreIndex,
             BiConstraintCollector<OldA, OldB, ResultContainer_, B> collector,
             TupleLifecycle<BiTuple<A, B>> nextNodesTupleLifecycle, int outputStoreSize) {
-        super(groupStoreIndex, collector, nextNodesTupleLifecycle);
-        this.groupKeyMapping = groupKeyMapping;
+        super(groupStoreIndex, tuple -> createGroupKey(groupKeyMapping, tuple), collector, nextNodesTupleLifecycle);
         this.outputStoreSize = outputStoreSize;
-    }
-
-    @Override
-    protected A createGroupKey(BiTuple<OldA, OldB> tuple) {
-        return groupKeyMapping.apply(tuple.factA, tuple.factB);
     }
 
     @Override

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/bi/Group1Mapping2CollectorBiNode.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/bi/Group1Mapping2CollectorBiNode.java
@@ -1,5 +1,7 @@
 package org.optaplanner.constraint.streams.bavet.bi;
 
+import static org.optaplanner.constraint.streams.bavet.bi.Group1Mapping0CollectorBiNode.createGroupKey;
+
 import java.util.function.BiFunction;
 
 import org.optaplanner.constraint.streams.bavet.common.TupleLifecycle;
@@ -10,23 +12,15 @@ import org.optaplanner.core.impl.util.Pair;
 final class Group1Mapping2CollectorBiNode<OldA, OldB, A, B, C, ResultContainerB_, ResultContainerC_>
         extends AbstractGroupBiNode<OldA, OldB, TriTuple<A, B, C>, A, Object, Pair<B, C>> {
 
-    private final BiFunction<OldA, OldB, A> groupKeyMapping;
     private final int outputStoreSize;
 
     public Group1Mapping2CollectorBiNode(BiFunction<OldA, OldB, A> groupKeyMapping, int groupStoreIndex,
             BiConstraintCollector<OldA, OldB, ResultContainerB_, B> collectorB,
             BiConstraintCollector<OldA, OldB, ResultContainerC_, C> collectorC,
             TupleLifecycle<TriTuple<A, B, C>> nextNodesTupleLifecycle, int outputStoreSize) {
-        super(groupStoreIndex, Group0Mapping2CollectorBiNode.mergeCollectors(collectorB, collectorC), nextNodesTupleLifecycle);
-        this.groupKeyMapping = groupKeyMapping;
+        super(groupStoreIndex, tuple -> createGroupKey(groupKeyMapping, tuple),
+                Group0Mapping2CollectorBiNode.mergeCollectors(collectorB, collectorC), nextNodesTupleLifecycle);
         this.outputStoreSize = outputStoreSize;
-    }
-
-    @Override
-    protected A createGroupKey(BiTuple<OldA, OldB> tuple) {
-        OldA oldA = tuple.factA;
-        OldB oldB = tuple.factB;
-        return groupKeyMapping.apply(oldA, oldB);
     }
 
     @Override

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/bi/Group1Mapping3CollectorBiNode.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/bi/Group1Mapping3CollectorBiNode.java
@@ -1,6 +1,7 @@
 package org.optaplanner.constraint.streams.bavet.bi;
 
 import static org.optaplanner.constraint.streams.bavet.bi.Group0Mapping3CollectorBiNode.mergeCollectors;
+import static org.optaplanner.constraint.streams.bavet.bi.Group1Mapping0CollectorBiNode.createGroupKey;
 
 import java.util.function.BiFunction;
 
@@ -12,7 +13,6 @@ import org.optaplanner.core.impl.util.Triple;
 final class Group1Mapping3CollectorBiNode<OldA, OldB, A, B, C, D, ResultContainerB_, ResultContainerC_, ResultContainerD_>
         extends AbstractGroupBiNode<OldA, OldB, QuadTuple<A, B, C, D>, A, Object, Triple<B, C, D>> {
 
-    private final BiFunction<OldA, OldB, A> groupKeyMapping;
     private final int outputStoreSize;
 
     public Group1Mapping3CollectorBiNode(BiFunction<OldA, OldB, A> groupKeyMapping, int groupStoreIndex,
@@ -20,14 +20,9 @@ final class Group1Mapping3CollectorBiNode<OldA, OldB, A, B, C, D, ResultContaine
             BiConstraintCollector<OldA, OldB, ResultContainerC_, C> collectorC,
             BiConstraintCollector<OldA, OldB, ResultContainerD_, D> collectorD,
             TupleLifecycle<QuadTuple<A, B, C, D>> nextNodesTupleLifecycle, int outputStoreSize) {
-        super(groupStoreIndex, mergeCollectors(collectorB, collectorC, collectorD), nextNodesTupleLifecycle);
-        this.groupKeyMapping = groupKeyMapping;
+        super(groupStoreIndex, tuple -> createGroupKey(groupKeyMapping, tuple),
+                mergeCollectors(collectorB, collectorC, collectorD), nextNodesTupleLifecycle);
         this.outputStoreSize = outputStoreSize;
-    }
-
-    @Override
-    protected A createGroupKey(BiTuple<OldA, OldB> tuple) {
-        return groupKeyMapping.apply(tuple.factA, tuple.factB);
     }
 
     @Override

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/bi/Group2Mapping0CollectorBiNode.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/bi/Group2Mapping0CollectorBiNode.java
@@ -8,21 +8,18 @@ import org.optaplanner.core.impl.util.Pair;
 final class Group2Mapping0CollectorBiNode<OldA, OldB, A, B>
         extends AbstractGroupBiNode<OldA, OldB, BiTuple<A, B>, Pair<A, B>, Void, Void> {
 
-    private final BiFunction<OldA, OldB, A> groupKeyMappingA;
-    private final BiFunction<OldA, OldB, B> groupKeyMappingB;
     private final int outputStoreSize;
 
     public Group2Mapping0CollectorBiNode(BiFunction<OldA, OldB, A> groupKeyMappingA,
             BiFunction<OldA, OldB, B> groupKeyMappingB, int groupStoreIndex,
             TupleLifecycle<BiTuple<A, B>> nextNodesTupleLifecycle, int outputStoreSize) {
-        super(groupStoreIndex, null, nextNodesTupleLifecycle);
-        this.groupKeyMappingA = groupKeyMappingA;
-        this.groupKeyMappingB = groupKeyMappingB;
+        super(groupStoreIndex, tuple -> createGroupKey(groupKeyMappingA, groupKeyMappingB, tuple),
+                null, nextNodesTupleLifecycle);
         this.outputStoreSize = outputStoreSize;
     }
 
-    @Override
-    protected Pair<A, B> createGroupKey(BiTuple<OldA, OldB> tuple) {
+    static <A, B, OldA, OldB> Pair<A, B> createGroupKey(BiFunction<OldA, OldB, A> groupKeyMappingA,
+            BiFunction<OldA, OldB, B> groupKeyMappingB, BiTuple<OldA, OldB> tuple) {
         OldA oldA = tuple.factA;
         OldB oldB = tuple.factB;
         A a = groupKeyMappingA.apply(oldA, oldB);

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/bi/Group2Mapping1CollectorBiNode.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/bi/Group2Mapping1CollectorBiNode.java
@@ -1,5 +1,7 @@
 package org.optaplanner.constraint.streams.bavet.bi;
 
+import static org.optaplanner.constraint.streams.bavet.bi.Group2Mapping0CollectorBiNode.createGroupKey;
+
 import java.util.function.BiFunction;
 
 import org.optaplanner.constraint.streams.bavet.common.TupleLifecycle;
@@ -10,27 +12,15 @@ import org.optaplanner.core.impl.util.Pair;
 final class Group2Mapping1CollectorBiNode<OldA, OldB, A, B, C, ResultContainer_>
         extends AbstractGroupBiNode<OldA, OldB, TriTuple<A, B, C>, Pair<A, B>, ResultContainer_, C> {
 
-    private final BiFunction<OldA, OldB, A> groupKeyMappingA;
-    private final BiFunction<OldA, OldB, B> groupKeyMappingB;
     private final int outputStoreSize;
 
     public Group2Mapping1CollectorBiNode(BiFunction<OldA, OldB, A> groupKeyMappingA, BiFunction<OldA, OldB, B> groupKeyMappingB,
             int groupStoreIndex,
             BiConstraintCollector<OldA, OldB, ResultContainer_, C> collector,
             TupleLifecycle<TriTuple<A, B, C>> nextNodesTupleLifecycle, int outputStoreSize) {
-        super(groupStoreIndex, collector, nextNodesTupleLifecycle);
-        this.groupKeyMappingA = groupKeyMappingA;
-        this.groupKeyMappingB = groupKeyMappingB;
+        super(groupStoreIndex, tuple -> createGroupKey(groupKeyMappingA, groupKeyMappingB, tuple),
+                collector, nextNodesTupleLifecycle);
         this.outputStoreSize = outputStoreSize;
-    }
-
-    @Override
-    protected Pair<A, B> createGroupKey(BiTuple<OldA, OldB> tuple) {
-        OldA oldA = tuple.factA;
-        OldB oldB = tuple.factB;
-        A a = groupKeyMappingA.apply(oldA, oldB);
-        B b = groupKeyMappingB.apply(oldA, oldB);
-        return Pair.of(a, b);
     }
 
     @Override

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/bi/Group2Mapping2CollectorBiNode.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/bi/Group2Mapping2CollectorBiNode.java
@@ -1,6 +1,7 @@
 package org.optaplanner.constraint.streams.bavet.bi;
 
 import static org.optaplanner.constraint.streams.bavet.bi.Group0Mapping2CollectorBiNode.mergeCollectors;
+import static org.optaplanner.constraint.streams.bavet.bi.Group2Mapping0CollectorBiNode.createGroupKey;
 
 import java.util.function.BiFunction;
 
@@ -12,8 +13,6 @@ import org.optaplanner.core.impl.util.Pair;
 final class Group2Mapping2CollectorBiNode<OldA, OldB, A, B, C, D, ResultContainerC_, ResultContainerD_>
         extends AbstractGroupBiNode<OldA, OldB, QuadTuple<A, B, C, D>, Pair<A, B>, Object, Pair<C, D>> {
 
-    private final BiFunction<OldA, OldB, A> groupKeyMappingA;
-    private final BiFunction<OldA, OldB, B> groupKeyMappingB;
     private final int outputStoreSize;
 
     public Group2Mapping2CollectorBiNode(BiFunction<OldA, OldB, A> groupKeyMappingA, BiFunction<OldA, OldB, B> groupKeyMappingB,
@@ -21,19 +20,9 @@ final class Group2Mapping2CollectorBiNode<OldA, OldB, A, B, C, D, ResultContaine
             BiConstraintCollector<OldA, OldB, ResultContainerC_, C> collectorC,
             BiConstraintCollector<OldA, OldB, ResultContainerD_, D> collectorD,
             TupleLifecycle<QuadTuple<A, B, C, D>> nextNodesTupleLifecycle, int outputStoreSize) {
-        super(groupStoreIndex, mergeCollectors(collectorC, collectorD), nextNodesTupleLifecycle);
-        this.groupKeyMappingA = groupKeyMappingA;
-        this.groupKeyMappingB = groupKeyMappingB;
+        super(groupStoreIndex, tuple -> createGroupKey(groupKeyMappingA, groupKeyMappingB, tuple),
+                mergeCollectors(collectorC, collectorD), nextNodesTupleLifecycle);
         this.outputStoreSize = outputStoreSize;
-    }
-
-    @Override
-    protected Pair<A, B> createGroupKey(BiTuple<OldA, OldB> tuple) {
-        OldA oldA = tuple.factA;
-        OldB oldB = tuple.factB;
-        A a = groupKeyMappingA.apply(oldA, oldB);
-        B b = groupKeyMappingB.apply(oldA, oldB);
-        return Pair.of(a, b);
     }
 
     @Override

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/bi/Group3Mapping0CollectorBiNode.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/bi/Group3Mapping0CollectorBiNode.java
@@ -9,23 +9,19 @@ import org.optaplanner.core.impl.util.Triple;
 final class Group3Mapping0CollectorBiNode<OldA, OldB, A, B, C>
         extends AbstractGroupBiNode<OldA, OldB, TriTuple<A, B, C>, Triple<A, B, C>, Void, Void> {
 
-    private final BiFunction<OldA, OldB, A> groupKeyMappingA;
-    private final BiFunction<OldA, OldB, B> groupKeyMappingB;
-    private final BiFunction<OldA, OldB, C> groupKeyMappingC;
     private final int outputStoreSize;
 
     public Group3Mapping0CollectorBiNode(BiFunction<OldA, OldB, A> groupKeyMappingA,
             BiFunction<OldA, OldB, B> groupKeyMappingB, BiFunction<OldA, OldB, C> groupKeyMappingC, int groupStoreIndex,
             TupleLifecycle<TriTuple<A, B, C>> nextNodesTupleLifecycle, int outputStoreSize) {
-        super(groupStoreIndex, null, nextNodesTupleLifecycle);
-        this.groupKeyMappingA = groupKeyMappingA;
-        this.groupKeyMappingB = groupKeyMappingB;
-        this.groupKeyMappingC = groupKeyMappingC;
+        super(groupStoreIndex, tuple -> createGroupKey(groupKeyMappingA, groupKeyMappingB, groupKeyMappingC, tuple),
+                null, nextNodesTupleLifecycle);
         this.outputStoreSize = outputStoreSize;
     }
 
-    @Override
-    protected Triple<A, B, C> createGroupKey(BiTuple<OldA, OldB> tuple) {
+    static <A, B, C, OldA, OldB> Triple<A, B, C> createGroupKey(BiFunction<OldA, OldB, A> groupKeyMappingA,
+            BiFunction<OldA, OldB, B> groupKeyMappingB, BiFunction<OldA, OldB, C> groupKeyMappingC,
+            BiTuple<OldA, OldB> tuple) {
         OldA oldA = tuple.factA;
         OldB oldB = tuple.factB;
         A a = groupKeyMappingA.apply(oldA, oldB);

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/bi/Group3Mapping1CollectorBiNode.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/bi/Group3Mapping1CollectorBiNode.java
@@ -1,5 +1,7 @@
 package org.optaplanner.constraint.streams.bavet.bi;
 
+import static org.optaplanner.constraint.streams.bavet.bi.Group3Mapping0CollectorBiNode.createGroupKey;
+
 import java.util.function.BiFunction;
 
 import org.optaplanner.constraint.streams.bavet.common.TupleLifecycle;
@@ -10,30 +12,15 @@ import org.optaplanner.core.impl.util.Triple;
 final class Group3Mapping1CollectorBiNode<OldA, OldB, A, B, C, D, ResultContainer_>
         extends AbstractGroupBiNode<OldA, OldB, QuadTuple<A, B, C, D>, Triple<A, B, C>, ResultContainer_, D> {
 
-    private final BiFunction<OldA, OldB, A> groupKeyMappingA;
-    private final BiFunction<OldA, OldB, B> groupKeyMappingB;
-    private final BiFunction<OldA, OldB, C> groupKeyMappingC;
     private final int outputStoreSize;
 
     public Group3Mapping1CollectorBiNode(BiFunction<OldA, OldB, A> groupKeyMappingA,
             BiFunction<OldA, OldB, B> groupKeyMappingB, BiFunction<OldA, OldB, C> groupKeyMappingC,
             int groupStoreIndex, BiConstraintCollector<OldA, OldB, ResultContainer_, D> collector,
             TupleLifecycle<QuadTuple<A, B, C, D>> nextNodesTupleLifecycle, int outputStoreSize) {
-        super(groupStoreIndex, collector, nextNodesTupleLifecycle);
-        this.groupKeyMappingA = groupKeyMappingA;
-        this.groupKeyMappingB = groupKeyMappingB;
-        this.groupKeyMappingC = groupKeyMappingC;
+        super(groupStoreIndex, tuple -> createGroupKey(groupKeyMappingA, groupKeyMappingB, groupKeyMappingC, tuple),
+                collector, nextNodesTupleLifecycle);
         this.outputStoreSize = outputStoreSize;
-    }
-
-    @Override
-    protected Triple<A, B, C> createGroupKey(BiTuple<OldA, OldB> tuple) {
-        OldA oldA = tuple.factA;
-        OldB oldB = tuple.factB;
-        A a = groupKeyMappingA.apply(oldA, oldB);
-        B b = groupKeyMappingB.apply(oldA, oldB);
-        C c = groupKeyMappingC.apply(oldA, oldB);
-        return Triple.of(a, b, c);
     }
 
     @Override

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/bi/Group4Mapping0CollectorBiNode.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/bi/Group4Mapping0CollectorBiNode.java
@@ -9,25 +9,21 @@ import org.optaplanner.core.impl.util.Quadruple;
 final class Group4Mapping0CollectorBiNode<OldA, OldB, A, B, C, D>
         extends AbstractGroupBiNode<OldA, OldB, QuadTuple<A, B, C, D>, Quadruple<A, B, C, D>, Void, Void> {
 
-    private final BiFunction<OldA, OldB, A> groupKeyMappingA;
-    private final BiFunction<OldA, OldB, B> groupKeyMappingB;
-    private final BiFunction<OldA, OldB, C> groupKeyMappingC;
-    private final BiFunction<OldA, OldB, D> groupKeyMappingD;
     private final int outputStoreSize;
 
     public Group4Mapping0CollectorBiNode(BiFunction<OldA, OldB, A> groupKeyMappingA, BiFunction<OldA, OldB, B> groupKeyMappingB,
             BiFunction<OldA, OldB, C> groupKeyMappingC, BiFunction<OldA, OldB, D> groupKeyMappingD, int groupStoreIndex,
             TupleLifecycle<QuadTuple<A, B, C, D>> nextNodesTupleLifecycle, int outputStoreSize) {
-        super(groupStoreIndex, null, nextNodesTupleLifecycle);
-        this.groupKeyMappingA = groupKeyMappingA;
-        this.groupKeyMappingB = groupKeyMappingB;
-        this.groupKeyMappingC = groupKeyMappingC;
-        this.groupKeyMappingD = groupKeyMappingD;
+        super(groupStoreIndex,
+                tuple -> createGroupKey(groupKeyMappingA, groupKeyMappingB, groupKeyMappingC, groupKeyMappingD, tuple),
+                null, nextNodesTupleLifecycle);
         this.outputStoreSize = outputStoreSize;
     }
 
-    @Override
-    protected Quadruple<A, B, C, D> createGroupKey(BiTuple<OldA, OldB> tuple) {
+    private static <A, B, C, D, OldA, OldB> Quadruple<A, B, C, D> createGroupKey(
+            BiFunction<OldA, OldB, A> groupKeyMappingA, BiFunction<OldA, OldB, B> groupKeyMappingB,
+            BiFunction<OldA, OldB, C> groupKeyMappingC, BiFunction<OldA, OldB, D> groupKeyMappingD,
+            BiTuple<OldA, OldB> tuple) {
         OldA oldA = tuple.factA;
         OldB oldB = tuple.factB;
         A a = groupKeyMappingA.apply(oldA, oldB);

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/common/AbstractGroupNode.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/common/AbstractGroupNode.java
@@ -36,6 +36,9 @@ public abstract class AbstractGroupNode<InTuple_ extends Tuple, OutTuple_ extend
     private final Map<GroupKey_, Group<OutTuple_, GroupKey_, ResultContainer_>> groupMap;
     /**
      * Used when {@link #hasMultipleGroups} is false, otherwise {@link #groupMap} is used.
+     *
+     * The field is lazy initialized in order to maintain the same semantics as with the groupMap above.
+     * When all tuples are removed, the field will be set to null, as if the group never existed.
      */
     private Group<OutTuple_, GroupKey_, ResultContainer_> singletonGroup;
     private final Queue<Group<OutTuple_, GroupKey_, ResultContainer_>> dirtyGroupQueue;
@@ -52,6 +55,9 @@ public abstract class AbstractGroupNode<InTuple_ extends Tuple, OutTuple_ extend
         this.hasMultipleGroups = groupKeyFunction != null;
         this.hasCollector = supplier != null;
         this.nextNodesTupleLifecycle = nextNodesTupleLifecycle;
+        // Not using the default sizing to 1000.
+        // The number of groups can be very small, and that situation is not unlikely.
+        // Therefore, the size of these collections is kept default.
         this.groupMap = hasMultipleGroups ? new HashMap<>() : null;
         this.dirtyGroupQueue = new ArrayDeque<>();
     }

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/common/GroupPart.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/common/GroupPart.java
@@ -3,11 +3,17 @@ package org.optaplanner.constraint.streams.bavet.common;
 final class GroupPart<Group_> {
 
     public final Group_ group;
-    public final Runnable undoAccumulator;
+    private final Runnable undoAccumulator;
 
     public GroupPart(Group_ group, Runnable undoAccumulator) {
         this.group = group;
         this.undoAccumulator = undoAccumulator;
+    }
+
+    void undoAccumulate() {
+        if (undoAccumulator != null) {
+            undoAccumulator.run();
+        }
     }
 
 }

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/common/index/ComparisonIndexer.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/common/index/ComparisonIndexer.java
@@ -6,7 +6,6 @@ import java.util.NavigableMap;
 import java.util.Objects;
 import java.util.TreeMap;
 import java.util.function.BiConsumer;
-import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
@@ -16,79 +15,102 @@ import org.optaplanner.core.impl.score.stream.JoinerType;
 final class ComparisonIndexer<Tuple_ extends Tuple, Value_, Key_ extends Comparable<Key_>>
         implements Indexer<Tuple_, Value_> {
 
-    private final SubmapBiFunction<Tuple_, Value_, Key_> submapExtractor;
-    private final Function<IndexProperties, Key_> comparisonIndexPropertyFunction;
+    private final int indexKeyPosition;
+    private final Function<Key_, Map<Key_, Indexer<Tuple_, Value_>>> submapExtractor;
     private final Supplier<Indexer<Tuple_, Value_>> downstreamIndexerSupplier;
     private final NavigableMap<Key_, Indexer<Tuple_, Value_>> comparisonMap = new TreeMap<>(new KeyComparator<>());
 
-    public ComparisonIndexer(JoinerType comparisonJoinerType,
-            Function<IndexProperties, Key_> comparisonIndexPropertyFunction,
+    public ComparisonIndexer(JoinerType comparisonJoinerType, Supplier<Indexer<Tuple_, Value_>> downstreamIndexerSupplier) {
+        this(comparisonJoinerType, 0, downstreamIndexerSupplier);
+    }
+
+    public ComparisonIndexer(JoinerType comparisonJoinerType, int indexKeyPosition,
             Supplier<Indexer<Tuple_, Value_>> downstreamIndexerSupplier) {
+        this.indexKeyPosition = indexKeyPosition;
         this.submapExtractor = getSubmapExtractor(comparisonJoinerType);
-        this.comparisonIndexPropertyFunction = Objects.requireNonNull(comparisonIndexPropertyFunction);
         this.downstreamIndexerSupplier = Objects.requireNonNull(downstreamIndexerSupplier);
     }
 
-    private SubmapBiFunction<Tuple_, Value_, Key_> getSubmapExtractor(JoinerType comparisonJoinerType) {
+    private Function<Key_, Map<Key_, Indexer<Tuple_, Value_>>> getSubmapExtractor(JoinerType comparisonJoinerType) {
         switch (comparisonJoinerType) {
             case LESS_THAN:
-                return (comparisonMap, comparisonIndexProperty) -> comparisonMap.headMap(comparisonIndexProperty, false);
+                return this::getLessThanSubmapExtractor;
             case LESS_THAN_OR_EQUAL:
-                return (comparisonMap, comparisonIndexProperty) -> comparisonMap.headMap(comparisonIndexProperty, true);
+                return this::getLessThanOrEqualSubmapExtractor;
             case GREATER_THAN:
-                return (comparisonMap, comparisonIndexProperty) -> comparisonMap.tailMap(comparisonIndexProperty, false);
+                return this::getGreaterThanSubmapExtractor;
             case GREATER_THAN_OR_EQUAL:
-                return (comparisonMap, comparisonIndexProperty) -> comparisonMap.tailMap(comparisonIndexProperty, true);
+                return this::getGreaterThanOrEqualSubmapExtractor;
             default:
                 throw new IllegalStateException("Impossible state: the comparisonJoinerType (" + comparisonJoinerType
                         + ") is not one of the 4 comparison types.");
         }
     }
 
+    private Map<Key_, Indexer<Tuple_, Value_>> getLessThanSubmapExtractor(Key_ comparisonIndexProperty) {
+        return comparisonMap.headMap(comparisonIndexProperty, false);
+    }
+
+    private Map<Key_, Indexer<Tuple_, Value_>> getLessThanOrEqualSubmapExtractor(Key_ comparisonIndexProperty) {
+        return comparisonMap.headMap(comparisonIndexProperty, true);
+    }
+
+    private Map<Key_, Indexer<Tuple_, Value_>> getGreaterThanSubmapExtractor(Key_ comparisonIndexProperty) {
+        return comparisonMap.tailMap(comparisonIndexProperty, false);
+    }
+
+    private Map<Key_, Indexer<Tuple_, Value_>> getGreaterThanOrEqualSubmapExtractor(Key_ comparisonIndexProperty) {
+        return comparisonMap.tailMap(comparisonIndexProperty, true);
+    }
+
+    @Override
+    public void visit(IndexProperties indexProperties, BiConsumer<Tuple_, Value_> tupleValueVisitor) {
+        Key_ comparisonIndexProperty = getIndexerKey(indexProperties);
+        Map<Key_, Indexer<Tuple_, Value_>> selectedComparisonMap =
+                submapExtractor.apply(comparisonIndexProperty);
+        for (Indexer<Tuple_, Value_> indexer : selectedComparisonMap.values()) {
+            indexer.visit(indexProperties, tupleValueVisitor);
+        }
+    }
+
+    private Key_ getIndexerKey(IndexProperties indexProperties) {
+        return indexProperties.getProperty(indexKeyPosition);
+    }
+
+    @Override
+    public Value_ get(IndexProperties indexProperties, Tuple_ tuple) {
+        Key_ indexerKey = getIndexerKey(indexProperties);
+        Indexer<Tuple_, Value_> downstreamIndexer = getDownstreamIndexer(indexProperties, indexerKey, tuple);
+        return downstreamIndexer.get(indexProperties, tuple);
+    }
+
     @Override
     public void put(IndexProperties indexProperties, Tuple_ tuple, Value_ value) {
-        Key_ comparisonIndexProperty = comparisonIndexPropertyFunction.apply(indexProperties);
+        Key_ indexerKey = getIndexerKey(indexProperties);
         Indexer<Tuple_, Value_> downstreamIndexer =
-                comparisonMap.computeIfAbsent(comparisonIndexProperty, k -> downstreamIndexerSupplier.get());
+                comparisonMap.computeIfAbsent(indexerKey, k -> downstreamIndexerSupplier.get());
         downstreamIndexer.put(indexProperties, tuple, value);
     }
 
     @Override
     public Value_ remove(IndexProperties indexProperties, Tuple_ tuple) {
-        Key_ comparisonIndexProperty = comparisonIndexPropertyFunction.apply(indexProperties);
-        Indexer<Tuple_, Value_> downstreamIndexer = comparisonMap.get(comparisonIndexProperty);
-        if (downstreamIndexer == null) {
-            throw new IllegalStateException("Impossible state: the tuple (" + tuple
-                    + ") with indexProperties (" + indexProperties
-                    + ") doesn't exist in the indexer.");
-        }
+        Key_ oldIndexerKey = getIndexerKey(indexProperties);
+        Indexer<Tuple_, Value_> downstreamIndexer = getDownstreamIndexer(indexProperties, oldIndexerKey, tuple);
         Value_ value = downstreamIndexer.remove(indexProperties, tuple);
         if (downstreamIndexer.isEmpty()) {
-            comparisonMap.remove(comparisonIndexProperty);
+            comparisonMap.remove(oldIndexerKey);
         }
         return value;
     }
 
-    @Override
-    public Value_ get(IndexProperties indexProperties, Tuple_ tuple) {
-        Key_ comparisonIndexProperty = comparisonIndexPropertyFunction.apply(indexProperties);
-        Indexer<Tuple_, Value_> downstreamIndexer = comparisonMap.get(comparisonIndexProperty);
+    private Indexer<Tuple_, Value_> getDownstreamIndexer(IndexProperties indexProperties, Key_ indexerKey, Tuple_ tuple) {
+        Indexer<Tuple_, Value_> downstreamIndexer = comparisonMap.get(indexerKey);
         if (downstreamIndexer == null) {
             throw new IllegalStateException("Impossible state: the tuple (" + tuple
                     + ") with indexProperties (" + indexProperties
-                    + ") doesn't exist in the indexer.");
+                    + ") doesn't exist in the indexer" + this + ".");
         }
-        return downstreamIndexer.get(indexProperties, tuple);
-    }
-
-    @Override
-    public void visit(IndexProperties indexProperties, BiConsumer<Tuple_, Value_> tupleValueVisitor) {
-        Key_ comparisonIndexProperty = comparisonIndexPropertyFunction.apply(indexProperties);
-        Map<Key_, Indexer<Tuple_, Value_>> selectedComparisonMap =
-                submapExtractor.apply(comparisonMap, comparisonIndexProperty);
-        for (Indexer<Tuple_, Value_> indexer : selectedComparisonMap.values()) {
-            indexer.visit(indexProperties, tupleValueVisitor);
-        }
+        return downstreamIndexer;
     }
 
     @Override
@@ -103,11 +125,6 @@ final class ComparisonIndexer<Tuple_ extends Tuple, Value_, Key_ extends Compara
             return o1.compareTo(o2);
         }
 
-    }
-
-    private interface SubmapBiFunction<Tuple_ extends Tuple, Value_, Key_ extends Comparable<Key_>>
-            extends BiFunction<NavigableMap<Key_, Indexer<Tuple_, Value_>>, Key_, Map<Key_, Indexer<Tuple_, Value_>>> {
-        // Exists so that the heavily generic code above may be easier to read and less repetitious.
     }
 
 }

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/common/index/EqualsIndexer.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/common/index/EqualsIndexer.java
@@ -4,71 +4,81 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.function.BiConsumer;
-import java.util.function.Function;
 import java.util.function.Supplier;
 
 import org.optaplanner.constraint.streams.bavet.common.Tuple;
 
-final class EqualsIndexer<Tuple_ extends Tuple, Value_, Key_> implements Indexer<Tuple_, Value_> {
+final class EqualsIndexer<Tuple_ extends Tuple, Value_, Key_>
+        implements Indexer<Tuple_, Value_> {
 
-    private final Function<IndexProperties, Key_> indexerKeyFunction;
+    private final int indexKeyFromInclusive;
+    private final int indexKeyToExclusive;
     private final Supplier<Indexer<Tuple_, Value_>> downstreamIndexerSupplier;
     private final Map<Key_, Indexer<Tuple_, Value_>> downstreamIndexerMap = new HashMap<>();
 
-    public EqualsIndexer(Function<IndexProperties, Key_> indexerKeyFunction,
+    public EqualsIndexer(Supplier<Indexer<Tuple_, Value_>> downstreamIndexerSupplier) {
+        this(0, 1, downstreamIndexerSupplier);
+    }
+
+    public EqualsIndexer(int indexKeyFromInclusive, int indexKeyToExclusive,
             Supplier<Indexer<Tuple_, Value_>> downstreamIndexerSupplier) {
+        this.indexKeyFromInclusive = indexKeyFromInclusive;
+        this.indexKeyToExclusive = indexKeyToExclusive;
         this.downstreamIndexerSupplier = Objects.requireNonNull(downstreamIndexerSupplier);
-        this.indexerKeyFunction = Objects.requireNonNull(indexerKeyFunction);
-    }
-
-    @Override
-    public void put(IndexProperties indexProperties, Tuple_ tuple, Value_ value) {
-        Indexer<Tuple_, Value_> downstreamIndexer =
-                downstreamIndexerMap.computeIfAbsent(indexerKeyFunction.apply(indexProperties),
-                        k -> downstreamIndexerSupplier.get());
-        downstreamIndexer.put(indexProperties, tuple, value);
-    }
-
-    @Override
-    public Value_ remove(IndexProperties indexProperties, Tuple_ tuple) {
-        Key_ oldIndexKey = indexerKeyFunction.apply(indexProperties);
-        Indexer<Tuple_, Value_> downstreamIndexer = downstreamIndexerMap.get(oldIndexKey);
-        if (downstreamIndexer == null) {
-            throw new IllegalStateException("Impossible state: the tuple (" + tuple
-                    + ") with indexProperties (" + indexProperties
-                    + ") doesn't exist in the indexer" + this + ".");
-        }
-        Value_ value = downstreamIndexer.remove(indexProperties, tuple);
-        if (downstreamIndexer.isEmpty()) {
-            downstreamIndexerMap.remove(oldIndexKey);
-        }
-        return value;
-    }
-
-    @Override
-    public Value_ get(IndexProperties indexProperties, Tuple_ tuple) {
-        Key_ oldIndexKey = indexerKeyFunction.apply(indexProperties);
-        Indexer<Tuple_, Value_> downstreamIndexer = downstreamIndexerMap.get(oldIndexKey);
-        if (downstreamIndexer == null) {
-            throw new IllegalStateException("Impossible state: the tuple (" + tuple
-                    + ") with indexProperties (" + indexProperties
-                    + ") doesn't exist in the indexer" + this + ".");
-        }
-        return downstreamIndexer.get(indexProperties, tuple);
     }
 
     @Override
     public void visit(IndexProperties indexProperties, BiConsumer<Tuple_, Value_> tupleValueVisitor) {
-        Indexer<Tuple_, Value_> downstreamIndexer = downstreamIndexerMap.get(indexerKeyFunction.apply(indexProperties));
+        Key_ indexKey = getIndexerKey(indexProperties);
+        Indexer<Tuple_, Value_> downstreamIndexer = downstreamIndexerMap.get(indexKey);
         if (downstreamIndexer == null || downstreamIndexer.isEmpty()) {
             return;
         }
         downstreamIndexer.visit(indexProperties, tupleValueVisitor);
     }
 
+    private Key_ getIndexerKey(IndexProperties indexProperties) {
+        return indexProperties.getIndexerKey(indexKeyFromInclusive, indexKeyToExclusive);
+    }
+
+    @Override
+    public Value_ get(IndexProperties indexProperties, Tuple_ tuple) {
+        Key_ indexerKey = getIndexerKey(indexProperties);
+        Indexer<Tuple_, Value_> downstreamIndexer = getDownstreamIndexer(indexProperties, indexerKey, tuple);
+        return downstreamIndexer.get(indexProperties, tuple);
+    }
+
+    @Override
+    public void put(IndexProperties indexProperties, Tuple_ tuple, Value_ value) {
+        Key_ indexerKey = getIndexerKey(indexProperties);
+        Indexer<Tuple_, Value_> downstreamIndexer =
+                downstreamIndexerMap.computeIfAbsent(indexerKey, k -> downstreamIndexerSupplier.get());
+        downstreamIndexer.put(indexProperties, tuple, value);
+    }
+
+    @Override
+    public Value_ remove(IndexProperties indexProperties, Tuple_ tuple) {
+        Key_ oldIndexerKey = getIndexerKey(indexProperties);
+        Indexer<Tuple_, Value_> downstreamIndexer = getDownstreamIndexer(indexProperties, oldIndexerKey, tuple);
+        Value_ value = downstreamIndexer.remove(indexProperties, tuple);
+        if (downstreamIndexer.isEmpty()) {
+            downstreamIndexerMap.remove(oldIndexerKey);
+        }
+        return value;
+    }
+
+    private Indexer<Tuple_, Value_> getDownstreamIndexer(IndexProperties indexProperties, Key_ indexerKey, Tuple_ tuple) {
+        Indexer<Tuple_, Value_> downstreamIndexer = downstreamIndexerMap.get(indexerKey);
+        if (downstreamIndexer == null) {
+            throw new IllegalStateException("Impossible state: the tuple (" + tuple
+                    + ") with indexProperties (" + indexProperties
+                    + ") doesn't exist in the indexer" + this + ".");
+        }
+        return downstreamIndexer;
+    }
+
     @Override
     public boolean isEmpty() {
         return downstreamIndexerMap.isEmpty();
     }
-
 }

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/common/index/IndexProperties.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/common/index/IndexProperties.java
@@ -31,12 +31,6 @@ public interface IndexProperties {
      */
     default <Type_> Type_ getIndexerKey(int fromInclusive, int toExclusive) {
         int length = toExclusive - fromInclusive;
-        if (length < 1 || length > maxLength()) {
-            throw new IllegalArgumentException("Impossible state: key length (" + length + ").");
-        } else if (fromInclusive >= toExclusive) {
-            throw new IllegalArgumentException("Impossible state: key from (" + fromInclusive + ") >= key to (" +
-                    toExclusive + ").");
-        }
         switch (length) {
             case 1:
                 return getProperty(fromInclusive);

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/common/index/IndexerKey.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/common/index/IndexerKey.java
@@ -17,11 +17,6 @@ final class IndexerKey {
     private final int toExclusive;
 
     public IndexerKey(IndexProperties indexProperties, int fromInclusive, int toExclusive) {
-        if (fromInclusive < 0) {
-            throw new IllegalStateException("Impossible state: starting index (" + fromInclusive + ") is invalid.");
-        } else if (toExclusive <= fromInclusive) {
-            throw new IllegalStateException("Impossible state: final index (" + toExclusive + ") is invalid.");
-        }
         this.indexProperties = indexProperties;
         this.fromInclusive = fromInclusive;
         this.toExclusive = toExclusive;

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/common/index/NoneIndexer.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/common/index/NoneIndexer.java
@@ -13,8 +13,7 @@ final class NoneIndexer<Tuple_ extends Tuple, Value_> implements Indexer<Tuple_,
 
     @Override
     public void put(IndexProperties indexProperties, Tuple_ tuple, Value_ value) {
-        Objects.requireNonNull(value);
-        Value_ old = tupleMap.put(tuple, value);
+        Value_ old = tupleMap.put(tuple, Objects.requireNonNull(value));
         if (old != null) {
             throw new IllegalStateException("Impossible state: the tuple (" + tuple
                     + ") with indexProperties (" + indexProperties
@@ -46,9 +45,7 @@ final class NoneIndexer<Tuple_ extends Tuple, Value_> implements Indexer<Tuple_,
 
     @Override
     public void visit(IndexProperties indexProperties, BiConsumer<Tuple_, Value_> tupleValueVisitor) {
-        if (!isEmpty()) {
-            tupleMap.forEach(tupleValueVisitor);
-        }
+        tupleMap.forEach(tupleValueVisitor);
     }
 
     @Override

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/quad/AbstractGroupQuadNode.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/quad/AbstractGroupQuadNode.java
@@ -1,5 +1,7 @@
 package org.optaplanner.constraint.streams.bavet.quad;
 
+import java.util.function.Function;
+
 import org.optaplanner.constraint.streams.bavet.common.AbstractGroupNode;
 import org.optaplanner.constraint.streams.bavet.common.Tuple;
 import org.optaplanner.constraint.streams.bavet.common.TupleLifecycle;
@@ -12,9 +14,10 @@ abstract class AbstractGroupQuadNode<OldA, OldB, OldC, OldD, OutTuple_ extends T
     private final PentaFunction<ResultContainer_, OldA, OldB, OldC, OldD, Runnable> accumulator;
 
     protected AbstractGroupQuadNode(int groupStoreIndex,
+            Function<QuadTuple<OldA, OldB, OldC, OldD>, GroupKey_> groupKeyFunction,
             QuadConstraintCollector<OldA, OldB, OldC, OldD, ResultContainer_, Result_> collector,
             TupleLifecycle<OutTuple_> nextNodesTupleLifecycle) {
-        super(groupStoreIndex,
+        super(groupStoreIndex, groupKeyFunction,
                 collector == null ? null : collector.supplier(),
                 collector == null ? null : collector.finisher(),
                 nextNodesTupleLifecycle);

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/quad/Group0Mapping1CollectorQuadNode.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/quad/Group0Mapping1CollectorQuadNode.java
@@ -5,26 +5,19 @@ import org.optaplanner.constraint.streams.bavet.uni.UniTuple;
 import org.optaplanner.core.api.score.stream.quad.QuadConstraintCollector;
 
 final class Group0Mapping1CollectorQuadNode<OldA, OldB, OldC, OldD, A, ResultContainer_>
-        extends AbstractGroupQuadNode<OldA, OldB, OldC, OldD, UniTuple<A>, String, ResultContainer_, A> {
-
-    private static final String NO_GROUP_KEY = "NO_GROUP";
+        extends AbstractGroupQuadNode<OldA, OldB, OldC, OldD, UniTuple<A>, Void, ResultContainer_, A> {
 
     private final int outputStoreSize;
 
     public Group0Mapping1CollectorQuadNode(int groupStoreIndex,
             QuadConstraintCollector<OldA, OldB, OldC, OldD, ResultContainer_, A> collector,
             TupleLifecycle<UniTuple<A>> nextNodesTupleLifecycle, int outputStoreSize) {
-        super(groupStoreIndex, collector, nextNodesTupleLifecycle);
+        super(groupStoreIndex, null, collector, nextNodesTupleLifecycle);
         this.outputStoreSize = outputStoreSize;
     }
 
     @Override
-    protected String createGroupKey(QuadTuple<OldA, OldB, OldC, OldD> tuple) {
-        return NO_GROUP_KEY;
-    }
-
-    @Override
-    protected UniTuple<A> createOutTuple(String groupKey) {
+    protected UniTuple<A> createOutTuple(Void groupKey) {
         return new UniTuple<>(null, outputStoreSize);
     }
 

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/quad/Group0Mapping2CollectorQuadNode.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/quad/Group0Mapping2CollectorQuadNode.java
@@ -7,9 +7,7 @@ import org.optaplanner.core.api.score.stream.quad.QuadConstraintCollector;
 import org.optaplanner.core.impl.util.Pair;
 
 final class Group0Mapping2CollectorQuadNode<OldA, OldB, OldC, OldD, A, B, ResultContainerA_, ResultContainerB_>
-        extends AbstractGroupQuadNode<OldA, OldB, OldC, OldD, BiTuple<A, B>, String, Object, Pair<A, B>> {
-
-    private static final String NO_GROUP_KEY = "NO_GROUP";
+        extends AbstractGroupQuadNode<OldA, OldB, OldC, OldD, BiTuple<A, B>, Void, Object, Pair<A, B>> {
 
     private final int outputStoreSize;
 
@@ -17,7 +15,7 @@ final class Group0Mapping2CollectorQuadNode<OldA, OldB, OldC, OldD, A, B, Result
             QuadConstraintCollector<OldA, OldB, OldC, OldD, ResultContainerA_, A> collectorA,
             QuadConstraintCollector<OldA, OldB, OldC, OldD, ResultContainerB_, B> collectorB,
             TupleLifecycle<BiTuple<A, B>> nextNodesTupleLifecycle, int outputStoreSize) {
-        super(groupStoreIndex, mergeCollectors(collectorA, collectorB), nextNodesTupleLifecycle);
+        super(groupStoreIndex, null, mergeCollectors(collectorA, collectorB), nextNodesTupleLifecycle);
         this.outputStoreSize = outputStoreSize;
     }
 
@@ -30,12 +28,7 @@ final class Group0Mapping2CollectorQuadNode<OldA, OldB, OldC, OldD, A, B, Result
     }
 
     @Override
-    protected String createGroupKey(QuadTuple<OldA, OldB, OldC, OldD> tuple) {
-        return NO_GROUP_KEY;
-    }
-
-    @Override
-    protected BiTuple<A, B> createOutTuple(String groupKey) {
+    protected BiTuple<A, B> createOutTuple(Void groupKey) {
         return new BiTuple<>(null, null, outputStoreSize);
     }
 

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/quad/Group0Mapping3CollectorQuadNode.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/quad/Group0Mapping3CollectorQuadNode.java
@@ -7,9 +7,7 @@ import org.optaplanner.core.api.score.stream.quad.QuadConstraintCollector;
 import org.optaplanner.core.impl.util.Triple;
 
 final class Group0Mapping3CollectorQuadNode<OldA, OldB, OldC, OldD, A, B, C, ResultContainerA_, ResultContainerB_, ResultContainerC_>
-        extends AbstractGroupQuadNode<OldA, OldB, OldC, OldD, TriTuple<A, B, C>, String, Object, Triple<A, B, C>> {
-
-    private static final String NO_GROUP_KEY = "NO_GROUP";
+        extends AbstractGroupQuadNode<OldA, OldB, OldC, OldD, TriTuple<A, B, C>, Void, Object, Triple<A, B, C>> {
 
     private final int outputStoreSize;
 
@@ -18,7 +16,7 @@ final class Group0Mapping3CollectorQuadNode<OldA, OldB, OldC, OldD, A, B, C, Res
             QuadConstraintCollector<OldA, OldB, OldC, OldD, ResultContainerB_, B> collectorB,
             QuadConstraintCollector<OldA, OldB, OldC, OldD, ResultContainerC_, C> collectorC,
             TupleLifecycle<TriTuple<A, B, C>> nextNodesTupleLifecycle, int outputStoreSize) {
-        super(groupStoreIndex, mergeCollectors(collectorA, collectorB, collectorC), nextNodesTupleLifecycle);
+        super(groupStoreIndex, null, mergeCollectors(collectorA, collectorB, collectorC), nextNodesTupleLifecycle);
         this.outputStoreSize = outputStoreSize;
     }
 
@@ -33,12 +31,7 @@ final class Group0Mapping3CollectorQuadNode<OldA, OldB, OldC, OldD, A, B, C, Res
     }
 
     @Override
-    protected String createGroupKey(QuadTuple<OldA, OldB, OldC, OldD> tuple) {
-        return NO_GROUP_KEY;
-    }
-
-    @Override
-    protected TriTuple<A, B, C> createOutTuple(String groupKey) {
+    protected TriTuple<A, B, C> createOutTuple(Void groupKey) {
         return new TriTuple<>(null, null, null, outputStoreSize);
     }
 

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/quad/Group0Mapping4CollectorQuadNode.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/quad/Group0Mapping4CollectorQuadNode.java
@@ -6,9 +6,7 @@ import org.optaplanner.core.api.score.stream.quad.QuadConstraintCollector;
 import org.optaplanner.core.impl.util.Quadruple;
 
 final class Group0Mapping4CollectorQuadNode<OldA, OldB, OldC, OldD, A, B, C, D, ResultContainerA_, ResultContainerB_, ResultContainerC_, ResultContainerD_>
-        extends AbstractGroupQuadNode<OldA, OldB, OldC, OldD, QuadTuple<A, B, C, D>, String, Object, Quadruple<A, B, C, D>> {
-
-    private static final String NO_GROUP_KEY = "NO_GROUP";
+        extends AbstractGroupQuadNode<OldA, OldB, OldC, OldD, QuadTuple<A, B, C, D>, Void, Object, Quadruple<A, B, C, D>> {
 
     private final int outputStoreSize;
 
@@ -18,7 +16,7 @@ final class Group0Mapping4CollectorQuadNode<OldA, OldB, OldC, OldD, A, B, C, D, 
             QuadConstraintCollector<OldA, OldB, OldC, OldD, ResultContainerC_, C> collectorC,
             QuadConstraintCollector<OldA, OldB, OldC, OldD, ResultContainerD_, D> collectorD,
             TupleLifecycle<QuadTuple<A, B, C, D>> nextNodesTupleLifecycle, int outputStoreSize) {
-        super(groupStoreIndex, mergeCollectors(collectorA, collectorB, collectorC, collectorD), nextNodesTupleLifecycle);
+        super(groupStoreIndex, null, mergeCollectors(collectorA, collectorB, collectorC, collectorD), nextNodesTupleLifecycle);
         this.outputStoreSize = outputStoreSize;
     }
 
@@ -33,12 +31,7 @@ final class Group0Mapping4CollectorQuadNode<OldA, OldB, OldC, OldD, A, B, C, D, 
     }
 
     @Override
-    protected String createGroupKey(QuadTuple<OldA, OldB, OldC, OldD> tuple) {
-        return NO_GROUP_KEY;
-    }
-
-    @Override
-    protected QuadTuple<A, B, C, D> createOutTuple(String groupKey) {
+    protected QuadTuple<A, B, C, D> createOutTuple(Void groupKey) {
         return new QuadTuple<>(null, null, null, null, outputStoreSize);
     }
 

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/quad/Group1Mapping0CollectorQuadNode.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/quad/Group1Mapping0CollectorQuadNode.java
@@ -7,18 +7,16 @@ import org.optaplanner.core.api.function.QuadFunction;
 final class Group1Mapping0CollectorQuadNode<OldA, OldB, OldC, OldD, A>
         extends AbstractGroupQuadNode<OldA, OldB, OldC, OldD, UniTuple<A>, A, Void, Void> {
 
-    private final QuadFunction<OldA, OldB, OldC, OldD, A> groupKeyMapping;
     private final int outputStoreSize;
 
     public Group1Mapping0CollectorQuadNode(QuadFunction<OldA, OldB, OldC, OldD, A> groupKeyMapping, int groupStoreIndex,
             TupleLifecycle<UniTuple<A>> nextNodesTupleLifecycle, int outputStoreSize) {
-        super(groupStoreIndex, null, nextNodesTupleLifecycle);
-        this.groupKeyMapping = groupKeyMapping;
+        super(groupStoreIndex, tuple -> createGroupKey(groupKeyMapping, tuple), null, nextNodesTupleLifecycle);
         this.outputStoreSize = outputStoreSize;
     }
 
-    @Override
-    protected A createGroupKey(QuadTuple<OldA, OldB, OldC, OldD> tuple) {
+    static <A, OldA, OldB, OldC, OldD> A createGroupKey(QuadFunction<OldA, OldB, OldC, OldD, A> groupKeyMapping,
+            QuadTuple<OldA, OldB, OldC, OldD> tuple) {
         return groupKeyMapping.apply(tuple.factA, tuple.factB, tuple.factC, tuple.factD);
     }
 

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/quad/Group1Mapping1CollectorQuadNode.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/quad/Group1Mapping1CollectorQuadNode.java
@@ -1,5 +1,7 @@
 package org.optaplanner.constraint.streams.bavet.quad;
 
+import static org.optaplanner.constraint.streams.bavet.quad.Group1Mapping0CollectorQuadNode.*;
+
 import org.optaplanner.constraint.streams.bavet.bi.BiTuple;
 import org.optaplanner.constraint.streams.bavet.common.TupleLifecycle;
 import org.optaplanner.core.api.function.QuadFunction;
@@ -8,20 +10,13 @@ import org.optaplanner.core.api.score.stream.quad.QuadConstraintCollector;
 final class Group1Mapping1CollectorQuadNode<OldA, OldB, OldC, OldD, A, B, ResultContainer_>
         extends AbstractGroupQuadNode<OldA, OldB, OldC, OldD, BiTuple<A, B>, A, ResultContainer_, B> {
 
-    private final QuadFunction<OldA, OldB, OldC, OldD, A> groupKeyMapping;
     private final int outputStoreSize;
 
     public Group1Mapping1CollectorQuadNode(QuadFunction<OldA, OldB, OldC, OldD, A> groupKeyMapping, int groupStoreIndex,
             QuadConstraintCollector<OldA, OldB, OldC, OldD, ResultContainer_, B> collector,
             TupleLifecycle<BiTuple<A, B>> nextNodesTupleLifecycle, int outputStoreSize) {
-        super(groupStoreIndex, collector, nextNodesTupleLifecycle);
-        this.groupKeyMapping = groupKeyMapping;
+        super(groupStoreIndex, tuple -> createGroupKey(groupKeyMapping, tuple), collector, nextNodesTupleLifecycle);
         this.outputStoreSize = outputStoreSize;
-    }
-
-    @Override
-    protected A createGroupKey(QuadTuple<OldA, OldB, OldC, OldD> tuple) {
-        return groupKeyMapping.apply(tuple.factA, tuple.factB, tuple.factC, tuple.factD);
     }
 
     @Override

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/quad/Group1Mapping2CollectorQuadNode.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/quad/Group1Mapping2CollectorQuadNode.java
@@ -1,5 +1,7 @@
 package org.optaplanner.constraint.streams.bavet.quad;
 
+import static org.optaplanner.constraint.streams.bavet.quad.Group1Mapping0CollectorQuadNode.*;
+
 import org.optaplanner.constraint.streams.bavet.common.TupleLifecycle;
 import org.optaplanner.constraint.streams.bavet.tri.TriTuple;
 import org.optaplanner.core.api.function.QuadFunction;
@@ -9,26 +11,16 @@ import org.optaplanner.core.impl.util.Pair;
 final class Group1Mapping2CollectorQuadNode<OldA, OldB, OldC, OldD, A, B, C, ResultContainerB_, ResultContainerC_>
         extends AbstractGroupQuadNode<OldA, OldB, OldC, OldD, TriTuple<A, B, C>, A, Object, Pair<B, C>> {
 
-    private final QuadFunction<OldA, OldB, OldC, OldD, A> groupKeyMapping;
     private final int outputStoreSize;
 
     public Group1Mapping2CollectorQuadNode(QuadFunction<OldA, OldB, OldC, OldD, A> groupKeyMapping, int groupStoreIndex,
             QuadConstraintCollector<OldA, OldB, OldC, OldD, ResultContainerB_, B> collectorB,
             QuadConstraintCollector<OldA, OldB, OldC, OldD, ResultContainerC_, C> collectorC,
             TupleLifecycle<TriTuple<A, B, C>> nextNodesTupleLifecycle, int outputStoreSize) {
-        super(groupStoreIndex, Group0Mapping2CollectorQuadNode.mergeCollectors(collectorB, collectorC),
+        super(groupStoreIndex, tuple -> createGroupKey(groupKeyMapping, tuple),
+                Group0Mapping2CollectorQuadNode.mergeCollectors(collectorB, collectorC),
                 nextNodesTupleLifecycle);
-        this.groupKeyMapping = groupKeyMapping;
         this.outputStoreSize = outputStoreSize;
-    }
-
-    @Override
-    protected A createGroupKey(QuadTuple<OldA, OldB, OldC, OldD> tuple) {
-        OldA oldA = tuple.factA;
-        OldB oldB = tuple.factB;
-        OldC oldC = tuple.factC;
-        OldD oldD = tuple.factD;
-        return groupKeyMapping.apply(oldA, oldB, oldC, oldD);
     }
 
     @Override

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/quad/Group1Mapping3CollectorQuadNode.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/quad/Group1Mapping3CollectorQuadNode.java
@@ -1,6 +1,7 @@
 package org.optaplanner.constraint.streams.bavet.quad;
 
 import static org.optaplanner.constraint.streams.bavet.quad.Group0Mapping3CollectorQuadNode.mergeCollectors;
+import static org.optaplanner.constraint.streams.bavet.quad.Group1Mapping0CollectorQuadNode.createGroupKey;
 
 import org.optaplanner.constraint.streams.bavet.common.TupleLifecycle;
 import org.optaplanner.core.api.function.QuadFunction;
@@ -10,7 +11,6 @@ import org.optaplanner.core.impl.util.Triple;
 final class Group1Mapping3CollectorQuadNode<OldA, OldB, OldC, OldD, A, B, C, D, ResultContainerB_, ResultContainerC_, ResultContainerD_>
         extends AbstractGroupQuadNode<OldA, OldB, OldC, OldD, QuadTuple<A, B, C, D>, A, Object, Triple<B, C, D>> {
 
-    private final QuadFunction<OldA, OldB, OldC, OldD, A> groupKeyMapping;
     private final int outputStoreSize;
 
     public Group1Mapping3CollectorQuadNode(QuadFunction<OldA, OldB, OldC, OldD, A> groupKeyMapping, int groupStoreIndex,
@@ -18,14 +18,9 @@ final class Group1Mapping3CollectorQuadNode<OldA, OldB, OldC, OldD, A, B, C, D, 
             QuadConstraintCollector<OldA, OldB, OldC, OldD, ResultContainerC_, C> collectorC,
             QuadConstraintCollector<OldA, OldB, OldC, OldD, ResultContainerD_, D> collectorD,
             TupleLifecycle<QuadTuple<A, B, C, D>> nextNodesTupleLifecycle, int outputStoreSize) {
-        super(groupStoreIndex, mergeCollectors(collectorB, collectorC, collectorD), nextNodesTupleLifecycle);
-        this.groupKeyMapping = groupKeyMapping;
+        super(groupStoreIndex, tuple -> createGroupKey(groupKeyMapping, tuple),
+                mergeCollectors(collectorB, collectorC, collectorD), nextNodesTupleLifecycle);
         this.outputStoreSize = outputStoreSize;
-    }
-
-    @Override
-    protected A createGroupKey(QuadTuple<OldA, OldB, OldC, OldD> tuple) {
-        return groupKeyMapping.apply(tuple.factA, tuple.factB, tuple.factC, tuple.factD);
     }
 
     @Override

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/quad/Group2Mapping0CollectorQuadNode.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/quad/Group2Mapping0CollectorQuadNode.java
@@ -8,21 +8,18 @@ import org.optaplanner.core.impl.util.Pair;
 final class Group2Mapping0CollectorQuadNode<OldA, OldB, OldC, OldD, A, B>
         extends AbstractGroupQuadNode<OldA, OldB, OldC, OldD, BiTuple<A, B>, Pair<A, B>, Void, Void> {
 
-    private final QuadFunction<OldA, OldB, OldC, OldD, A> groupKeyMappingA;
-    private final QuadFunction<OldA, OldB, OldC, OldD, B> groupKeyMappingB;
     private final int outputStoreSize;
 
     public Group2Mapping0CollectorQuadNode(QuadFunction<OldA, OldB, OldC, OldD, A> groupKeyMappingA,
             QuadFunction<OldA, OldB, OldC, OldD, B> groupKeyMappingB, int groupStoreIndex,
             TupleLifecycle<BiTuple<A, B>> nextNodesTupleLifecycle, int outputStoreSize) {
-        super(groupStoreIndex, null, nextNodesTupleLifecycle);
-        this.groupKeyMappingA = groupKeyMappingA;
-        this.groupKeyMappingB = groupKeyMappingB;
+        super(groupStoreIndex, tuple -> createGroupKey(groupKeyMappingA, groupKeyMappingB, tuple), null,
+                nextNodesTupleLifecycle);
         this.outputStoreSize = outputStoreSize;
     }
 
-    @Override
-    protected Pair<A, B> createGroupKey(QuadTuple<OldA, OldB, OldC, OldD> tuple) {
+    static <A, B, OldA, OldB, OldC, OldD> Pair<A, B> createGroupKey(QuadFunction<OldA, OldB, OldC, OldD, A> groupKeyMappingA,
+            QuadFunction<OldA, OldB, OldC, OldD, B> groupKeyMappingB, QuadTuple<OldA, OldB, OldC, OldD> tuple) {
         OldA oldA = tuple.factA;
         OldB oldB = tuple.factB;
         OldC oldC = tuple.factC;

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/quad/Group2Mapping1CollectorQuadNode.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/quad/Group2Mapping1CollectorQuadNode.java
@@ -1,5 +1,7 @@
 package org.optaplanner.constraint.streams.bavet.quad;
 
+import static org.optaplanner.constraint.streams.bavet.quad.Group2Mapping0CollectorQuadNode.*;
+
 import org.optaplanner.constraint.streams.bavet.common.TupleLifecycle;
 import org.optaplanner.constraint.streams.bavet.tri.TriTuple;
 import org.optaplanner.core.api.function.QuadFunction;
@@ -9,8 +11,6 @@ import org.optaplanner.core.impl.util.Pair;
 final class Group2Mapping1CollectorQuadNode<OldA, OldB, OldC, OldD, A, B, C, ResultContainer_>
         extends AbstractGroupQuadNode<OldA, OldB, OldC, OldD, TriTuple<A, B, C>, Pair<A, B>, ResultContainer_, C> {
 
-    private final QuadFunction<OldA, OldB, OldC, OldD, A> groupKeyMappingA;
-    private final QuadFunction<OldA, OldB, OldC, OldD, B> groupKeyMappingB;
     private final int outputStoreSize;
 
     public Group2Mapping1CollectorQuadNode(QuadFunction<OldA, OldB, OldC, OldD, A> groupKeyMappingA,
@@ -18,21 +18,9 @@ final class Group2Mapping1CollectorQuadNode<OldA, OldB, OldC, OldD, A, B, C, Res
             int groupStoreIndex,
             QuadConstraintCollector<OldA, OldB, OldC, OldD, ResultContainer_, C> collector,
             TupleLifecycle<TriTuple<A, B, C>> nextNodesTupleLifecycle, int outputStoreSize) {
-        super(groupStoreIndex, collector, nextNodesTupleLifecycle);
-        this.groupKeyMappingA = groupKeyMappingA;
-        this.groupKeyMappingB = groupKeyMappingB;
+        super(groupStoreIndex, tuple -> createGroupKey(groupKeyMappingA, groupKeyMappingB, tuple), collector,
+                nextNodesTupleLifecycle);
         this.outputStoreSize = outputStoreSize;
-    }
-
-    @Override
-    protected Pair<A, B> createGroupKey(QuadTuple<OldA, OldB, OldC, OldD> tuple) {
-        OldA oldA = tuple.factA;
-        OldB oldB = tuple.factB;
-        OldC oldC = tuple.factC;
-        OldD oldD = tuple.factD;
-        A a = groupKeyMappingA.apply(oldA, oldB, oldC, oldD);
-        B b = groupKeyMappingB.apply(oldA, oldB, oldC, oldD);
-        return Pair.of(a, b);
     }
 
     @Override

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/quad/Group2Mapping2CollectorQuadNode.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/quad/Group2Mapping2CollectorQuadNode.java
@@ -1,6 +1,7 @@
 package org.optaplanner.constraint.streams.bavet.quad;
 
 import static org.optaplanner.constraint.streams.bavet.quad.Group0Mapping2CollectorQuadNode.mergeCollectors;
+import static org.optaplanner.constraint.streams.bavet.quad.Group2Mapping0CollectorQuadNode.createGroupKey;
 
 import org.optaplanner.constraint.streams.bavet.common.TupleLifecycle;
 import org.optaplanner.core.api.function.QuadFunction;
@@ -10,8 +11,6 @@ import org.optaplanner.core.impl.util.Pair;
 final class Group2Mapping2CollectorQuadNode<OldA, OldB, OldC, OldD, A, B, C, D, ResultContainerC_, ResultContainerD_>
         extends AbstractGroupQuadNode<OldA, OldB, OldC, OldD, QuadTuple<A, B, C, D>, Pair<A, B>, Object, Pair<C, D>> {
 
-    private final QuadFunction<OldA, OldB, OldC, OldD, A> groupKeyMappingA;
-    private final QuadFunction<OldA, OldB, OldC, OldD, B> groupKeyMappingB;
     private final int outputStoreSize;
 
     public Group2Mapping2CollectorQuadNode(QuadFunction<OldA, OldB, OldC, OldD, A> groupKeyMappingA,
@@ -19,21 +18,9 @@ final class Group2Mapping2CollectorQuadNode<OldA, OldB, OldC, OldD, A, B, C, D, 
             QuadConstraintCollector<OldA, OldB, OldC, OldD, ResultContainerC_, C> collectorC,
             QuadConstraintCollector<OldA, OldB, OldC, OldD, ResultContainerD_, D> collectorD,
             TupleLifecycle<QuadTuple<A, B, C, D>> nextNodesTupleLifecycle, int outputStoreSize) {
-        super(groupStoreIndex, mergeCollectors(collectorC, collectorD), nextNodesTupleLifecycle);
-        this.groupKeyMappingA = groupKeyMappingA;
-        this.groupKeyMappingB = groupKeyMappingB;
+        super(groupStoreIndex, tuple -> createGroupKey(groupKeyMappingA, groupKeyMappingB, tuple),
+                mergeCollectors(collectorC, collectorD), nextNodesTupleLifecycle);
         this.outputStoreSize = outputStoreSize;
-    }
-
-    @Override
-    protected Pair<A, B> createGroupKey(QuadTuple<OldA, OldB, OldC, OldD> tuple) {
-        OldA oldA = tuple.factA;
-        OldB oldB = tuple.factB;
-        OldC oldC = tuple.factC;
-        OldD oldD = tuple.factD;
-        A a = groupKeyMappingA.apply(oldA, oldB, oldC, oldD);
-        B b = groupKeyMappingB.apply(oldA, oldB, oldC, oldD);
-        return Pair.of(a, b);
     }
 
     @Override

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/quad/Group3Mapping0CollectorQuadNode.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/quad/Group3Mapping0CollectorQuadNode.java
@@ -8,24 +8,22 @@ import org.optaplanner.core.impl.util.Triple;
 final class Group3Mapping0CollectorQuadNode<OldA, OldB, OldC, OldD, A, B, C>
         extends AbstractGroupQuadNode<OldA, OldB, OldC, OldD, TriTuple<A, B, C>, Triple<A, B, C>, Void, Void> {
 
-    private final QuadFunction<OldA, OldB, OldC, OldD, A> groupKeyMappingA;
-    private final QuadFunction<OldA, OldB, OldC, OldD, B> groupKeyMappingB;
-    private final QuadFunction<OldA, OldB, OldC, OldD, C> groupKeyMappingC;
     private final int outputStoreSize;
 
     public Group3Mapping0CollectorQuadNode(QuadFunction<OldA, OldB, OldC, OldD, A> groupKeyMappingA,
             QuadFunction<OldA, OldB, OldC, OldD, B> groupKeyMappingB, QuadFunction<OldA, OldB, OldC, OldD, C> groupKeyMappingC,
             int groupStoreIndex,
             TupleLifecycle<TriTuple<A, B, C>> nextNodesTupleLifecycle, int outputStoreSize) {
-        super(groupStoreIndex, null, nextNodesTupleLifecycle);
-        this.groupKeyMappingA = groupKeyMappingA;
-        this.groupKeyMappingB = groupKeyMappingB;
-        this.groupKeyMappingC = groupKeyMappingC;
+        super(groupStoreIndex, tuple -> createGroupKey(groupKeyMappingA, groupKeyMappingB, groupKeyMappingC, tuple), null,
+                nextNodesTupleLifecycle);
         this.outputStoreSize = outputStoreSize;
     }
 
-    @Override
-    protected Triple<A, B, C> createGroupKey(QuadTuple<OldA, OldB, OldC, OldD> tuple) {
+    static <A, B, C, OldA, OldB, OldC, OldD> Triple<A, B, C> createGroupKey(
+            QuadFunction<OldA, OldB, OldC, OldD, A> groupKeyMappingA,
+            QuadFunction<OldA, OldB, OldC, OldD, B> groupKeyMappingB,
+            QuadFunction<OldA, OldB, OldC, OldD, C> groupKeyMappingC,
+            QuadTuple<OldA, OldB, OldC, OldD> tuple) {
         OldA oldA = tuple.factA;
         OldB oldB = tuple.factB;
         OldC oldC = tuple.factC;

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/quad/Group3Mapping1CollectorQuadNode.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/quad/Group3Mapping1CollectorQuadNode.java
@@ -1,5 +1,7 @@
 package org.optaplanner.constraint.streams.bavet.quad;
 
+import static org.optaplanner.constraint.streams.bavet.quad.Group3Mapping0CollectorQuadNode.*;
+
 import org.optaplanner.constraint.streams.bavet.common.TupleLifecycle;
 import org.optaplanner.core.api.function.QuadFunction;
 import org.optaplanner.core.api.score.stream.quad.QuadConstraintCollector;
@@ -8,32 +10,15 @@ import org.optaplanner.core.impl.util.Triple;
 final class Group3Mapping1CollectorQuadNode<OldA, OldB, OldC, OldD, A, B, C, D, ResultContainer_>
         extends AbstractGroupQuadNode<OldA, OldB, OldC, OldD, QuadTuple<A, B, C, D>, Triple<A, B, C>, ResultContainer_, D> {
 
-    private final QuadFunction<OldA, OldB, OldC, OldD, A> groupKeyMappingA;
-    private final QuadFunction<OldA, OldB, OldC, OldD, B> groupKeyMappingB;
-    private final QuadFunction<OldA, OldB, OldC, OldD, C> groupKeyMappingC;
     private final int outputStoreSize;
 
     public Group3Mapping1CollectorQuadNode(QuadFunction<OldA, OldB, OldC, OldD, A> groupKeyMappingA,
             QuadFunction<OldA, OldB, OldC, OldD, B> groupKeyMappingB, QuadFunction<OldA, OldB, OldC, OldD, C> groupKeyMappingC,
             int groupStoreIndex, QuadConstraintCollector<OldA, OldB, OldC, OldD, ResultContainer_, D> collector,
             TupleLifecycle<QuadTuple<A, B, C, D>> nextNodesTupleLifecycle, int outputStoreSize) {
-        super(groupStoreIndex, collector, nextNodesTupleLifecycle);
-        this.groupKeyMappingA = groupKeyMappingA;
-        this.groupKeyMappingB = groupKeyMappingB;
-        this.groupKeyMappingC = groupKeyMappingC;
+        super(groupStoreIndex, tuple -> createGroupKey(groupKeyMappingA, groupKeyMappingB, groupKeyMappingC, tuple),
+                collector, nextNodesTupleLifecycle);
         this.outputStoreSize = outputStoreSize;
-    }
-
-    @Override
-    protected Triple<A, B, C> createGroupKey(QuadTuple<OldA, OldB, OldC, OldD> tuple) {
-        OldA oldA = tuple.factA;
-        OldB oldB = tuple.factB;
-        OldC oldC = tuple.factC;
-        OldD oldD = tuple.factD;
-        A a = groupKeyMappingA.apply(oldA, oldB, oldC, oldD);
-        B b = groupKeyMappingB.apply(oldA, oldB, oldC, oldD);
-        C c = groupKeyMappingC.apply(oldA, oldB, oldC, oldD);
-        return Triple.of(a, b, c);
     }
 
     @Override

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/quad/Group4Mapping0CollectorQuadNode.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/quad/Group4Mapping0CollectorQuadNode.java
@@ -7,26 +7,24 @@ import org.optaplanner.core.impl.util.Quadruple;
 final class Group4Mapping0CollectorQuadNode<OldA, OldB, OldC, OldD, A, B, C, D>
         extends AbstractGroupQuadNode<OldA, OldB, OldC, OldD, QuadTuple<A, B, C, D>, Quadruple<A, B, C, D>, Void, Void> {
 
-    private final QuadFunction<OldA, OldB, OldC, OldD, A> groupKeyMappingA;
-    private final QuadFunction<OldA, OldB, OldC, OldD, B> groupKeyMappingB;
-    private final QuadFunction<OldA, OldB, OldC, OldD, C> groupKeyMappingC;
-    private final QuadFunction<OldA, OldB, OldC, OldD, D> groupKeyMappingD;
     private final int outputStoreSize;
 
     public Group4Mapping0CollectorQuadNode(QuadFunction<OldA, OldB, OldC, OldD, A> groupKeyMappingA,
             QuadFunction<OldA, OldB, OldC, OldD, B> groupKeyMappingB, QuadFunction<OldA, OldB, OldC, OldD, C> groupKeyMappingC,
             QuadFunction<OldA, OldB, OldC, OldD, D> groupKeyMappingD, int groupStoreIndex,
             TupleLifecycle<QuadTuple<A, B, C, D>> nextNodesTupleLifecycle, int outputStoreSize) {
-        super(groupStoreIndex, null, nextNodesTupleLifecycle);
-        this.groupKeyMappingA = groupKeyMappingA;
-        this.groupKeyMappingB = groupKeyMappingB;
-        this.groupKeyMappingC = groupKeyMappingC;
-        this.groupKeyMappingD = groupKeyMappingD;
+        super(groupStoreIndex,
+                tuple -> createGroupKey(groupKeyMappingA, groupKeyMappingB, groupKeyMappingC, groupKeyMappingD, tuple),
+                null, nextNodesTupleLifecycle);
         this.outputStoreSize = outputStoreSize;
     }
 
-    @Override
-    protected Quadruple<A, B, C, D> createGroupKey(QuadTuple<OldA, OldB, OldC, OldD> tuple) {
+    private static <A, B, C, D, OldA, OldB, OldC, OldD> Quadruple<A, B, C, D> createGroupKey(
+            QuadFunction<OldA, OldB, OldC, OldD, A> groupKeyMappingA,
+            QuadFunction<OldA, OldB, OldC, OldD, B> groupKeyMappingB,
+            QuadFunction<OldA, OldB, OldC, OldD, C> groupKeyMappingC,
+            QuadFunction<OldA, OldB, OldC, OldD, D> groupKeyMappingD,
+            QuadTuple<OldA, OldB, OldC, OldD> tuple) {
         OldA oldA = tuple.factA;
         OldB oldB = tuple.factB;
         OldC oldC = tuple.factC;

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/tri/AbstractGroupTriNode.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/tri/AbstractGroupTriNode.java
@@ -1,5 +1,7 @@
 package org.optaplanner.constraint.streams.bavet.tri;
 
+import java.util.function.Function;
+
 import org.optaplanner.constraint.streams.bavet.common.AbstractGroupNode;
 import org.optaplanner.constraint.streams.bavet.common.Tuple;
 import org.optaplanner.constraint.streams.bavet.common.TupleLifecycle;
@@ -12,9 +14,10 @@ abstract class AbstractGroupTriNode<OldA, OldB, OldC, OutTuple_ extends Tuple, G
     private final QuadFunction<ResultContainer_, OldA, OldB, OldC, Runnable> accumulator;
 
     protected AbstractGroupTriNode(int groupStoreIndex,
+            Function<TriTuple<OldA, OldB, OldC>, GroupKey_> groupKeyFunction,
             TriConstraintCollector<OldA, OldB, OldC, ResultContainer_, Result_> collector,
             TupleLifecycle<OutTuple_> nextNodesTupleLifecycle) {
-        super(groupStoreIndex,
+        super(groupStoreIndex, groupKeyFunction,
                 collector == null ? null : collector.supplier(),
                 collector == null ? null : collector.finisher(),
                 nextNodesTupleLifecycle);

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/tri/Group0Mapping1CollectorTriNode.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/tri/Group0Mapping1CollectorTriNode.java
@@ -5,26 +5,19 @@ import org.optaplanner.constraint.streams.bavet.uni.UniTuple;
 import org.optaplanner.core.api.score.stream.tri.TriConstraintCollector;
 
 final class Group0Mapping1CollectorTriNode<OldA, OldB, OldC, A, ResultContainer_>
-        extends AbstractGroupTriNode<OldA, OldB, OldC, UniTuple<A>, String, ResultContainer_, A> {
-
-    private static final String NO_GROUP_KEY = "NO_GROUP";
+        extends AbstractGroupTriNode<OldA, OldB, OldC, UniTuple<A>, Void, ResultContainer_, A> {
 
     private final int outputStoreSize;
 
     public Group0Mapping1CollectorTriNode(int groupStoreIndex,
             TriConstraintCollector<OldA, OldB, OldC, ResultContainer_, A> collector,
             TupleLifecycle<UniTuple<A>> nextNodesTupleLifecycle, int outputStoreSize) {
-        super(groupStoreIndex, collector, nextNodesTupleLifecycle);
+        super(groupStoreIndex, null, collector, nextNodesTupleLifecycle);
         this.outputStoreSize = outputStoreSize;
     }
 
     @Override
-    protected String createGroupKey(TriTuple<OldA, OldB, OldC> tuple) {
-        return NO_GROUP_KEY;
-    }
-
-    @Override
-    protected UniTuple<A> createOutTuple(String groupKey) {
+    protected UniTuple<A> createOutTuple(Void groupKey) {
         return new UniTuple<>(null, outputStoreSize);
     }
 

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/tri/Group0Mapping2CollectorTriNode.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/tri/Group0Mapping2CollectorTriNode.java
@@ -7,9 +7,7 @@ import org.optaplanner.core.api.score.stream.tri.TriConstraintCollector;
 import org.optaplanner.core.impl.util.Pair;
 
 final class Group0Mapping2CollectorTriNode<OldA, OldB, OldC, A, B, ResultContainerA_, ResultContainerB_>
-        extends AbstractGroupTriNode<OldA, OldB, OldC, BiTuple<A, B>, String, Object, Pair<A, B>> {
-
-    private static final String NO_GROUP_KEY = "NO_GROUP";
+        extends AbstractGroupTriNode<OldA, OldB, OldC, BiTuple<A, B>, Void, Object, Pair<A, B>> {
 
     private final int outputStoreSize;
 
@@ -17,7 +15,7 @@ final class Group0Mapping2CollectorTriNode<OldA, OldB, OldC, A, B, ResultContain
             TriConstraintCollector<OldA, OldB, OldC, ResultContainerA_, A> collectorA,
             TriConstraintCollector<OldA, OldB, OldC, ResultContainerB_, B> collectorB,
             TupleLifecycle<BiTuple<A, B>> nextNodesTupleLifecycle, int outputStoreSize) {
-        super(groupStoreIndex, mergeCollectors(collectorA, collectorB), nextNodesTupleLifecycle);
+        super(groupStoreIndex, null, mergeCollectors(collectorA, collectorB), nextNodesTupleLifecycle);
         this.outputStoreSize = outputStoreSize;
     }
 
@@ -31,12 +29,7 @@ final class Group0Mapping2CollectorTriNode<OldA, OldB, OldC, A, B, ResultContain
     }
 
     @Override
-    protected String createGroupKey(TriTuple<OldA, OldB, OldC> tuple) {
-        return NO_GROUP_KEY;
-    }
-
-    @Override
-    protected BiTuple<A, B> createOutTuple(String groupKey) {
+    protected BiTuple<A, B> createOutTuple(Void groupKey) {
         return new BiTuple<>(null, null, outputStoreSize);
     }
 

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/tri/Group0Mapping3CollectorTriNode.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/tri/Group0Mapping3CollectorTriNode.java
@@ -6,9 +6,7 @@ import org.optaplanner.core.api.score.stream.tri.TriConstraintCollector;
 import org.optaplanner.core.impl.util.Triple;
 
 final class Group0Mapping3CollectorTriNode<OldA, OldB, OldC, A, B, C, ResultContainerA_, ResultContainerB_, ResultContainerC_>
-        extends AbstractGroupTriNode<OldA, OldB, OldC, TriTuple<A, B, C>, String, Object, Triple<A, B, C>> {
-
-    private static final String NO_GROUP_KEY = "NO_GROUP";
+        extends AbstractGroupTriNode<OldA, OldB, OldC, TriTuple<A, B, C>, Void, Object, Triple<A, B, C>> {
 
     private final int outputStoreSize;
 
@@ -17,7 +15,7 @@ final class Group0Mapping3CollectorTriNode<OldA, OldB, OldC, A, B, C, ResultCont
             TriConstraintCollector<OldA, OldB, OldC, ResultContainerB_, B> collectorB,
             TriConstraintCollector<OldA, OldB, OldC, ResultContainerC_, C> collectorC,
             TupleLifecycle<TriTuple<A, B, C>> nextNodesTupleLifecycle, int outputStoreSize) {
-        super(groupStoreIndex, mergeCollectors(collectorA, collectorB, collectorC), nextNodesTupleLifecycle);
+        super(groupStoreIndex, null, mergeCollectors(collectorA, collectorB, collectorC), nextNodesTupleLifecycle);
         this.outputStoreSize = outputStoreSize;
     }
 
@@ -31,12 +29,7 @@ final class Group0Mapping3CollectorTriNode<OldA, OldB, OldC, A, B, C, ResultCont
     }
 
     @Override
-    protected String createGroupKey(TriTuple<OldA, OldB, OldC> tuple) {
-        return NO_GROUP_KEY;
-    }
-
-    @Override
-    protected TriTuple<A, B, C> createOutTuple(String groupKey) {
+    protected TriTuple<A, B, C> createOutTuple(Void groupKey) {
         return new TriTuple<>(null, null, null, outputStoreSize);
     }
 

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/tri/Group0Mapping4CollectorTriNode.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/tri/Group0Mapping4CollectorTriNode.java
@@ -7,9 +7,7 @@ import org.optaplanner.core.api.score.stream.tri.TriConstraintCollector;
 import org.optaplanner.core.impl.util.Quadruple;
 
 final class Group0Mapping4CollectorTriNode<OldA, OldB, OldC, A, B, C, D, ResultContainerA_, ResultContainerB_, ResultContainerC_, ResultContainerD_>
-        extends AbstractGroupTriNode<OldA, OldB, OldC, QuadTuple<A, B, C, D>, String, Object, Quadruple<A, B, C, D>> {
-
-    private static final String NO_GROUP_KEY = "NO_GROUP";
+        extends AbstractGroupTriNode<OldA, OldB, OldC, QuadTuple<A, B, C, D>, Void, Object, Quadruple<A, B, C, D>> {
 
     private final int outputStoreSize;
 
@@ -19,7 +17,7 @@ final class Group0Mapping4CollectorTriNode<OldA, OldB, OldC, A, B, C, D, ResultC
             TriConstraintCollector<OldA, OldB, OldC, ResultContainerC_, C> collectorC,
             TriConstraintCollector<OldA, OldB, OldC, ResultContainerD_, D> collectorD,
             TupleLifecycle<QuadTuple<A, B, C, D>> nextNodesTupleLifecycle, int outputStoreSize) {
-        super(groupStoreIndex, mergeCollectors(collectorA, collectorB, collectorC, collectorD), nextNodesTupleLifecycle);
+        super(groupStoreIndex, null, mergeCollectors(collectorA, collectorB, collectorC, collectorD), nextNodesTupleLifecycle);
         this.outputStoreSize = outputStoreSize;
     }
 
@@ -34,12 +32,7 @@ final class Group0Mapping4CollectorTriNode<OldA, OldB, OldC, A, B, C, D, ResultC
     }
 
     @Override
-    protected String createGroupKey(TriTuple<OldA, OldB, OldC> tuple) {
-        return NO_GROUP_KEY;
-    }
-
-    @Override
-    protected QuadTuple<A, B, C, D> createOutTuple(String groupKey) {
+    protected QuadTuple<A, B, C, D> createOutTuple(Void groupKey) {
         return new QuadTuple<>(null, null, null, null, outputStoreSize);
     }
 

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/tri/Group1Mapping0CollectorTriNode.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/tri/Group1Mapping0CollectorTriNode.java
@@ -7,18 +7,16 @@ import org.optaplanner.core.api.function.TriFunction;
 final class Group1Mapping0CollectorTriNode<OldA, OldB, OldC, A>
         extends AbstractGroupTriNode<OldA, OldB, OldC, UniTuple<A>, A, Void, Void> {
 
-    private final TriFunction<OldA, OldB, OldC, A> groupKeyMapping;
     private final int outputStoreSize;
 
     public Group1Mapping0CollectorTriNode(TriFunction<OldA, OldB, OldC, A> groupKeyMapping, int groupStoreIndex,
             TupleLifecycle<UniTuple<A>> nextNodesTupleLifecycle, int outputStoreSize) {
-        super(groupStoreIndex, null, nextNodesTupleLifecycle);
-        this.groupKeyMapping = groupKeyMapping;
+        super(groupStoreIndex, tuple -> createGroupKey(groupKeyMapping, tuple), null, nextNodesTupleLifecycle);
         this.outputStoreSize = outputStoreSize;
     }
 
-    @Override
-    protected A createGroupKey(TriTuple<OldA, OldB, OldC> tuple) {
+    static <A, OldA, OldB, OldC> A createGroupKey(TriFunction<OldA, OldB, OldC, A> groupKeyMapping,
+            TriTuple<OldA, OldB, OldC> tuple) {
         return groupKeyMapping.apply(tuple.factA, tuple.factB, tuple.factC);
     }
 

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/tri/Group1Mapping1CollectorTriNode.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/tri/Group1Mapping1CollectorTriNode.java
@@ -1,5 +1,7 @@
 package org.optaplanner.constraint.streams.bavet.tri;
 
+import static org.optaplanner.constraint.streams.bavet.tri.Group1Mapping0CollectorTriNode.*;
+
 import org.optaplanner.constraint.streams.bavet.bi.BiTuple;
 import org.optaplanner.constraint.streams.bavet.common.TupleLifecycle;
 import org.optaplanner.core.api.function.TriFunction;
@@ -8,20 +10,13 @@ import org.optaplanner.core.api.score.stream.tri.TriConstraintCollector;
 final class Group1Mapping1CollectorTriNode<OldA, OldB, OldC, A, B, ResultContainer_>
         extends AbstractGroupTriNode<OldA, OldB, OldC, BiTuple<A, B>, A, ResultContainer_, B> {
 
-    private final TriFunction<OldA, OldB, OldC, A> groupKeyMapping;
     private final int outputStoreSize;
 
     public Group1Mapping1CollectorTriNode(TriFunction<OldA, OldB, OldC, A> groupKeyMapping, int groupStoreIndex,
             TriConstraintCollector<OldA, OldB, OldC, ResultContainer_, B> collector,
             TupleLifecycle<BiTuple<A, B>> nextNodesTupleLifecycle, int outputStoreSize) {
-        super(groupStoreIndex, collector, nextNodesTupleLifecycle);
-        this.groupKeyMapping = groupKeyMapping;
+        super(groupStoreIndex, tuple -> createGroupKey(groupKeyMapping, tuple), collector, nextNodesTupleLifecycle);
         this.outputStoreSize = outputStoreSize;
-    }
-
-    @Override
-    protected A createGroupKey(TriTuple<OldA, OldB, OldC> tuple) {
-        return groupKeyMapping.apply(tuple.factA, tuple.factB, tuple.factC);
     }
 
     @Override

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/tri/Group1Mapping2CollectorTriNode.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/tri/Group1Mapping2CollectorTriNode.java
@@ -1,5 +1,7 @@
 package org.optaplanner.constraint.streams.bavet.tri;
 
+import static org.optaplanner.constraint.streams.bavet.tri.Group1Mapping0CollectorTriNode.*;
+
 import org.optaplanner.constraint.streams.bavet.common.TupleLifecycle;
 import org.optaplanner.core.api.function.TriFunction;
 import org.optaplanner.core.api.score.stream.tri.TriConstraintCollector;
@@ -8,24 +10,15 @@ import org.optaplanner.core.impl.util.Pair;
 final class Group1Mapping2CollectorTriNode<OldA, OldB, OldC, A, B, C, ResultContainerB_, ResultContainerC_>
         extends AbstractGroupTriNode<OldA, OldB, OldC, TriTuple<A, B, C>, A, Object, Pair<B, C>> {
 
-    private final TriFunction<OldA, OldB, OldC, A> groupKeyMapping;
     private final int outputStoreSize;
 
     public Group1Mapping2CollectorTriNode(TriFunction<OldA, OldB, OldC, A> groupKeyMapping, int groupStoreIndex,
             TriConstraintCollector<OldA, OldB, OldC, ResultContainerB_, B> collectorB,
             TriConstraintCollector<OldA, OldB, OldC, ResultContainerC_, C> collectorC,
             TupleLifecycle<TriTuple<A, B, C>> nextNodesTupleLifecycle, int outputStoreSize) {
-        super(groupStoreIndex, Group0Mapping2CollectorTriNode.mergeCollectors(collectorB, collectorC), nextNodesTupleLifecycle);
-        this.groupKeyMapping = groupKeyMapping;
+        super(groupStoreIndex, tuple -> createGroupKey(groupKeyMapping, tuple),
+                Group0Mapping2CollectorTriNode.mergeCollectors(collectorB, collectorC), nextNodesTupleLifecycle);
         this.outputStoreSize = outputStoreSize;
-    }
-
-    @Override
-    protected A createGroupKey(TriTuple<OldA, OldB, OldC> tuple) {
-        OldA oldA = tuple.factA;
-        OldB oldB = tuple.factB;
-        OldC oldC = tuple.factC;
-        return groupKeyMapping.apply(oldA, oldB, oldC);
     }
 
     @Override

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/tri/Group1Mapping3CollectorTriNode.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/tri/Group1Mapping3CollectorTriNode.java
@@ -1,6 +1,7 @@
 package org.optaplanner.constraint.streams.bavet.tri;
 
 import static org.optaplanner.constraint.streams.bavet.tri.Group0Mapping3CollectorTriNode.mergeCollectors;
+import static org.optaplanner.constraint.streams.bavet.tri.Group1Mapping0CollectorTriNode.createGroupKey;
 
 import org.optaplanner.constraint.streams.bavet.common.TupleLifecycle;
 import org.optaplanner.constraint.streams.bavet.quad.QuadTuple;
@@ -11,7 +12,6 @@ import org.optaplanner.core.impl.util.Triple;
 final class Group1Mapping3CollectorTriNode<OldA, OldB, OldC, A, B, C, D, ResultContainerB_, ResultContainerC_, ResultContainerD_>
         extends AbstractGroupTriNode<OldA, OldB, OldC, QuadTuple<A, B, C, D>, A, Object, Triple<B, C, D>> {
 
-    private final TriFunction<OldA, OldB, OldC, A> groupKeyMapping;
     private final int outputStoreSize;
 
     public Group1Mapping3CollectorTriNode(TriFunction<OldA, OldB, OldC, A> groupKeyMapping, int groupStoreIndex,
@@ -19,15 +19,9 @@ final class Group1Mapping3CollectorTriNode<OldA, OldB, OldC, A, B, C, D, ResultC
             TriConstraintCollector<OldA, OldB, OldC, ResultContainerC_, C> collectorC,
             TriConstraintCollector<OldA, OldB, OldC, ResultContainerD_, D> collectorD,
             TupleLifecycle<QuadTuple<A, B, C, D>> nextNodesTupleLifecycle, int outputStoreSize) {
-        super(groupStoreIndex, mergeCollectors(collectorB, collectorC, collectorD),
-                nextNodesTupleLifecycle);
-        this.groupKeyMapping = groupKeyMapping;
+        super(groupStoreIndex, tuple -> createGroupKey(groupKeyMapping, tuple),
+                mergeCollectors(collectorB, collectorC, collectorD), nextNodesTupleLifecycle);
         this.outputStoreSize = outputStoreSize;
-    }
-
-    @Override
-    protected A createGroupKey(TriTuple<OldA, OldB, OldC> tuple) {
-        return groupKeyMapping.apply(tuple.factA, tuple.factB, tuple.factC);
     }
 
     @Override

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/tri/Group2Mapping0CollectorTriNode.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/tri/Group2Mapping0CollectorTriNode.java
@@ -8,21 +8,18 @@ import org.optaplanner.core.impl.util.Pair;
 final class Group2Mapping0CollectorTriNode<OldA, OldB, OldC, A, B>
         extends AbstractGroupTriNode<OldA, OldB, OldC, BiTuple<A, B>, Pair<A, B>, Void, Void> {
 
-    private final TriFunction<OldA, OldB, OldC, A> groupKeyMappingA;
-    private final TriFunction<OldA, OldB, OldC, B> groupKeyMappingB;
     private final int outputStoreSize;
 
     public Group2Mapping0CollectorTriNode(TriFunction<OldA, OldB, OldC, A> groupKeyMappingA,
             TriFunction<OldA, OldB, OldC, B> groupKeyMappingB, int groupStoreIndex,
             TupleLifecycle<BiTuple<A, B>> nextNodesTupleLifecycle, int outputStoreSize) {
-        super(groupStoreIndex, null, nextNodesTupleLifecycle);
-        this.groupKeyMappingA = groupKeyMappingA;
-        this.groupKeyMappingB = groupKeyMappingB;
+        super(groupStoreIndex, tuple -> createGroupKey(groupKeyMappingA, groupKeyMappingB, tuple),
+                null, nextNodesTupleLifecycle);
         this.outputStoreSize = outputStoreSize;
     }
 
-    @Override
-    protected Pair<A, B> createGroupKey(TriTuple<OldA, OldB, OldC> tuple) {
+    static <A, B, OldA, OldB, OldC> Pair<A, B> createGroupKey(TriFunction<OldA, OldB, OldC, A> groupKeyMappingA,
+            TriFunction<OldA, OldB, OldC, B> groupKeyMappingB, TriTuple<OldA, OldB, OldC> tuple) {
         OldA oldA = tuple.factA;
         OldB oldB = tuple.factB;
         OldC oldC = tuple.factC;

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/tri/Group2Mapping1CollectorTriNode.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/tri/Group2Mapping1CollectorTriNode.java
@@ -1,5 +1,7 @@
 package org.optaplanner.constraint.streams.bavet.tri;
 
+import static org.optaplanner.constraint.streams.bavet.tri.Group2Mapping0CollectorTriNode.*;
+
 import org.optaplanner.constraint.streams.bavet.common.TupleLifecycle;
 import org.optaplanner.core.api.function.TriFunction;
 import org.optaplanner.core.api.score.stream.tri.TriConstraintCollector;
@@ -8,8 +10,6 @@ import org.optaplanner.core.impl.util.Pair;
 final class Group2Mapping1CollectorTriNode<OldA, OldB, OldC, A, B, C, ResultContainer_>
         extends AbstractGroupTriNode<OldA, OldB, OldC, TriTuple<A, B, C>, Pair<A, B>, ResultContainer_, C> {
 
-    private final TriFunction<OldA, OldB, OldC, A> groupKeyMappingA;
-    private final TriFunction<OldA, OldB, OldC, B> groupKeyMappingB;
     private final int outputStoreSize;
 
     public Group2Mapping1CollectorTriNode(TriFunction<OldA, OldB, OldC, A> groupKeyMappingA,
@@ -17,20 +17,9 @@ final class Group2Mapping1CollectorTriNode<OldA, OldB, OldC, A, B, C, ResultCont
             int groupStoreIndex,
             TriConstraintCollector<OldA, OldB, OldC, ResultContainer_, C> collector,
             TupleLifecycle<TriTuple<A, B, C>> nextNodesTupleLifecycle, int outputStoreSize) {
-        super(groupStoreIndex, collector, nextNodesTupleLifecycle);
-        this.groupKeyMappingA = groupKeyMappingA;
-        this.groupKeyMappingB = groupKeyMappingB;
+        super(groupStoreIndex, tuple -> createGroupKey(groupKeyMappingA, groupKeyMappingB, tuple),
+                collector, nextNodesTupleLifecycle);
         this.outputStoreSize = outputStoreSize;
-    }
-
-    @Override
-    protected Pair<A, B> createGroupKey(TriTuple<OldA, OldB, OldC> tuple) {
-        OldA oldA = tuple.factA;
-        OldB oldB = tuple.factB;
-        OldC oldC = tuple.factC;
-        A a = groupKeyMappingA.apply(oldA, oldB, oldC);
-        B b = groupKeyMappingB.apply(oldA, oldB, oldC);
-        return Pair.of(a, b);
     }
 
     @Override

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/tri/Group2Mapping2CollectorTriNode.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/tri/Group2Mapping2CollectorTriNode.java
@@ -1,6 +1,7 @@
 package org.optaplanner.constraint.streams.bavet.tri;
 
 import static org.optaplanner.constraint.streams.bavet.tri.Group0Mapping2CollectorTriNode.mergeCollectors;
+import static org.optaplanner.constraint.streams.bavet.tri.Group2Mapping0CollectorTriNode.createGroupKey;
 
 import org.optaplanner.constraint.streams.bavet.common.TupleLifecycle;
 import org.optaplanner.constraint.streams.bavet.quad.QuadTuple;
@@ -11,8 +12,6 @@ import org.optaplanner.core.impl.util.Pair;
 final class Group2Mapping2CollectorTriNode<OldA, OldB, OldC, A, B, C, D, ResultContainerC_, ResultContainerD_>
         extends AbstractGroupTriNode<OldA, OldB, OldC, QuadTuple<A, B, C, D>, Pair<A, B>, Object, Pair<C, D>> {
 
-    private final TriFunction<OldA, OldB, OldC, A> groupKeyMappingA;
-    private final TriFunction<OldA, OldB, OldC, B> groupKeyMappingB;
     private final int outputStoreSize;
 
     public Group2Mapping2CollectorTriNode(TriFunction<OldA, OldB, OldC, A> groupKeyMappingA,
@@ -20,20 +19,9 @@ final class Group2Mapping2CollectorTriNode<OldA, OldB, OldC, A, B, C, D, ResultC
             TriConstraintCollector<OldA, OldB, OldC, ResultContainerC_, C> collectorC,
             TriConstraintCollector<OldA, OldB, OldC, ResultContainerD_, D> collectorD,
             TupleLifecycle<QuadTuple<A, B, C, D>> nextNodesTupleLifecycle, int outputStoreSize) {
-        super(groupStoreIndex, mergeCollectors(collectorC, collectorD), nextNodesTupleLifecycle);
-        this.groupKeyMappingA = groupKeyMappingA;
-        this.groupKeyMappingB = groupKeyMappingB;
+        super(groupStoreIndex, tuple -> createGroupKey(groupKeyMappingA, groupKeyMappingB, tuple),
+                mergeCollectors(collectorC, collectorD), nextNodesTupleLifecycle);
         this.outputStoreSize = outputStoreSize;
-    }
-
-    @Override
-    protected Pair<A, B> createGroupKey(TriTuple<OldA, OldB, OldC> tuple) {
-        OldA oldA = tuple.factA;
-        OldB oldB = tuple.factB;
-        OldC oldC = tuple.factC;
-        A a = groupKeyMappingA.apply(oldA, oldB, oldC);
-        B b = groupKeyMappingB.apply(oldA, oldB, oldC);
-        return Pair.of(a, b);
     }
 
     @Override

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/tri/Group3Mapping0CollectorTriNode.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/tri/Group3Mapping0CollectorTriNode.java
@@ -7,24 +7,20 @@ import org.optaplanner.core.impl.util.Triple;
 final class Group3Mapping0CollectorTriNode<OldA, OldB, OldC, A, B, C>
         extends AbstractGroupTriNode<OldA, OldB, OldC, TriTuple<A, B, C>, Triple<A, B, C>, Void, Void> {
 
-    private final TriFunction<OldA, OldB, OldC, A> groupKeyMappingA;
-    private final TriFunction<OldA, OldB, OldC, B> groupKeyMappingB;
-    private final TriFunction<OldA, OldB, OldC, C> groupKeyMappingC;
     private final int outputStoreSize;
 
     public Group3Mapping0CollectorTriNode(TriFunction<OldA, OldB, OldC, A> groupKeyMappingA,
             TriFunction<OldA, OldB, OldC, B> groupKeyMappingB, TriFunction<OldA, OldB, OldC, C> groupKeyMappingC,
             int groupStoreIndex,
             TupleLifecycle<TriTuple<A, B, C>> nextNodesTupleLifecycle, int outputStoreSize) {
-        super(groupStoreIndex, null, nextNodesTupleLifecycle);
-        this.groupKeyMappingA = groupKeyMappingA;
-        this.groupKeyMappingB = groupKeyMappingB;
-        this.groupKeyMappingC = groupKeyMappingC;
+        super(groupStoreIndex, tuple -> createGroupKey(groupKeyMappingA, groupKeyMappingB, groupKeyMappingC, tuple),
+                null, nextNodesTupleLifecycle);
         this.outputStoreSize = outputStoreSize;
     }
 
-    @Override
-    protected Triple<A, B, C> createGroupKey(TriTuple<OldA, OldB, OldC> tuple) {
+    static <A, B, C, OldA, OldB, OldC> Triple<A, B, C> createGroupKey(TriFunction<OldA, OldB, OldC, A> groupKeyMappingA,
+            TriFunction<OldA, OldB, OldC, B> groupKeyMappingB, TriFunction<OldA, OldB, OldC, C> groupKeyMappingC,
+            TriTuple<OldA, OldB, OldC> tuple) {
         OldA oldA = tuple.factA;
         OldB oldB = tuple.factB;
         OldC oldC = tuple.factC;

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/tri/Group3Mapping1CollectorTriNode.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/tri/Group3Mapping1CollectorTriNode.java
@@ -1,5 +1,7 @@
 package org.optaplanner.constraint.streams.bavet.tri;
 
+import static org.optaplanner.constraint.streams.bavet.tri.Group3Mapping0CollectorTriNode.*;
+
 import org.optaplanner.constraint.streams.bavet.common.TupleLifecycle;
 import org.optaplanner.constraint.streams.bavet.quad.QuadTuple;
 import org.optaplanner.core.api.function.TriFunction;
@@ -9,31 +11,15 @@ import org.optaplanner.core.impl.util.Triple;
 final class Group3Mapping1CollectorTriNode<OldA, OldB, OldC, A, B, C, D, ResultContainer_>
         extends AbstractGroupTriNode<OldA, OldB, OldC, QuadTuple<A, B, C, D>, Triple<A, B, C>, ResultContainer_, D> {
 
-    private final TriFunction<OldA, OldB, OldC, A> groupKeyMappingA;
-    private final TriFunction<OldA, OldB, OldC, B> groupKeyMappingB;
-    private final TriFunction<OldA, OldB, OldC, C> groupKeyMappingC;
     private final int outputStoreSize;
 
     public Group3Mapping1CollectorTriNode(TriFunction<OldA, OldB, OldC, A> groupKeyMappingA,
             TriFunction<OldA, OldB, OldC, B> groupKeyMappingB, TriFunction<OldA, OldB, OldC, C> groupKeyMappingC,
             int groupStoreIndex, TriConstraintCollector<OldA, OldB, OldC, ResultContainer_, D> collector,
             TupleLifecycle<QuadTuple<A, B, C, D>> nextNodesTupleLifecycle, int outputStoreSize) {
-        super(groupStoreIndex, collector, nextNodesTupleLifecycle);
-        this.groupKeyMappingA = groupKeyMappingA;
-        this.groupKeyMappingB = groupKeyMappingB;
-        this.groupKeyMappingC = groupKeyMappingC;
+        super(groupStoreIndex, tuple -> createGroupKey(groupKeyMappingA, groupKeyMappingB, groupKeyMappingC, tuple),
+                collector, nextNodesTupleLifecycle);
         this.outputStoreSize = outputStoreSize;
-    }
-
-    @Override
-    protected Triple<A, B, C> createGroupKey(TriTuple<OldA, OldB, OldC> tuple) {
-        OldA oldA = tuple.factA;
-        OldB oldB = tuple.factB;
-        OldC oldC = tuple.factC;
-        A a = groupKeyMappingA.apply(oldA, oldB, oldC);
-        B b = groupKeyMappingB.apply(oldA, oldB, oldC);
-        C c = groupKeyMappingC.apply(oldA, oldB, oldC);
-        return Triple.of(a, b, c);
     }
 
     @Override

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/tri/Group4Mapping0CollectorTriNode.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/tri/Group4Mapping0CollectorTriNode.java
@@ -8,26 +8,24 @@ import org.optaplanner.core.impl.util.Quadruple;
 final class Group4Mapping0CollectorTriNode<OldA, OldB, OldC, A, B, C, D>
         extends AbstractGroupTriNode<OldA, OldB, OldC, QuadTuple<A, B, C, D>, Quadruple<A, B, C, D>, Void, Void> {
 
-    private final TriFunction<OldA, OldB, OldC, A> groupKeyMappingA;
-    private final TriFunction<OldA, OldB, OldC, B> groupKeyMappingB;
-    private final TriFunction<OldA, OldB, OldC, C> groupKeyMappingC;
-    private final TriFunction<OldA, OldB, OldC, D> groupKeyMappingD;
     private final int outputStoreSize;
 
     public Group4Mapping0CollectorTriNode(TriFunction<OldA, OldB, OldC, A> groupKeyMappingA,
             TriFunction<OldA, OldB, OldC, B> groupKeyMappingB, TriFunction<OldA, OldB, OldC, C> groupKeyMappingC,
             TriFunction<OldA, OldB, OldC, D> groupKeyMappingD, int groupStoreIndex,
             TupleLifecycle<QuadTuple<A, B, C, D>> nextNodesTupleLifecycle, int outputStoreSize) {
-        super(groupStoreIndex, null, nextNodesTupleLifecycle);
-        this.groupKeyMappingA = groupKeyMappingA;
-        this.groupKeyMappingB = groupKeyMappingB;
-        this.groupKeyMappingC = groupKeyMappingC;
-        this.groupKeyMappingD = groupKeyMappingD;
+        super(groupStoreIndex,
+                tuple -> createGroupKey(groupKeyMappingA, groupKeyMappingB, groupKeyMappingC, groupKeyMappingD, tuple),
+                null, nextNodesTupleLifecycle);
         this.outputStoreSize = outputStoreSize;
     }
 
-    @Override
-    protected Quadruple<A, B, C, D> createGroupKey(TriTuple<OldA, OldB, OldC> tuple) {
+    private static <A, B, C, D, OldA, OldB, OldC> Quadruple<A, B, C, D> createGroupKey(
+            TriFunction<OldA, OldB, OldC, A> groupKeyMappingA,
+            TriFunction<OldA, OldB, OldC, B> groupKeyMappingB,
+            TriFunction<OldA, OldB, OldC, C> groupKeyMappingC,
+            TriFunction<OldA, OldB, OldC, D> groupKeyMappingD,
+            TriTuple<OldA, OldB, OldC> tuple) {
         OldA oldA = tuple.factA;
         OldB oldB = tuple.factB;
         OldC oldC = tuple.factC;

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/uni/AbstractGroupUniNode.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/uni/AbstractGroupUniNode.java
@@ -1,6 +1,7 @@
 package org.optaplanner.constraint.streams.bavet.uni;
 
 import java.util.function.BiFunction;
+import java.util.function.Function;
 
 import org.optaplanner.constraint.streams.bavet.common.AbstractGroupNode;
 import org.optaplanner.constraint.streams.bavet.common.Tuple;
@@ -13,9 +14,10 @@ abstract class AbstractGroupUniNode<OldA, OutTuple_ extends Tuple, GroupKey_, Re
     private final BiFunction<ResultContainer_, OldA, Runnable> accumulator;
 
     protected AbstractGroupUniNode(int groupStoreIndex,
+            Function<UniTuple<OldA>, GroupKey_> groupKeyFunction,
             UniConstraintCollector<OldA, ResultContainer_, Result_> collector,
             TupleLifecycle<OutTuple_> nextNodesTupleLifecycle) {
-        super(groupStoreIndex,
+        super(groupStoreIndex, groupKeyFunction,
                 collector == null ? null : collector.supplier(),
                 collector == null ? null : collector.finisher(),
                 nextNodesTupleLifecycle);

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/uni/Group0Mapping1CollectorUniNode.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/uni/Group0Mapping1CollectorUniNode.java
@@ -4,26 +4,19 @@ import org.optaplanner.constraint.streams.bavet.common.TupleLifecycle;
 import org.optaplanner.core.api.score.stream.uni.UniConstraintCollector;
 
 final class Group0Mapping1CollectorUniNode<OldA, A, ResultContainer_>
-        extends AbstractGroupUniNode<OldA, UniTuple<A>, String, ResultContainer_, A> {
-
-    private static final String NO_GROUP_KEY = "NO_GROUP";
+        extends AbstractGroupUniNode<OldA, UniTuple<A>, Void, ResultContainer_, A> {
 
     private final int outputStoreSize;
 
     public Group0Mapping1CollectorUniNode(int groupStoreIndex,
             UniConstraintCollector<OldA, ResultContainer_, A> collector,
             TupleLifecycle<UniTuple<A>> nextNodesTupleLifecycle, int outputStoreSize) {
-        super(groupStoreIndex, collector, nextNodesTupleLifecycle);
+        super(groupStoreIndex, null, collector, nextNodesTupleLifecycle);
         this.outputStoreSize = outputStoreSize;
     }
 
     @Override
-    protected String createGroupKey(UniTuple<OldA> tuple) {
-        return NO_GROUP_KEY;
-    }
-
-    @Override
-    protected UniTuple<A> createOutTuple(String groupKey) {
+    protected UniTuple<A> createOutTuple(Void groupKey) {
         return new UniTuple<>(null, outputStoreSize);
     }
 

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/uni/Group0Mapping2CollectorUniNode.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/uni/Group0Mapping2CollectorUniNode.java
@@ -7,7 +7,7 @@ import org.optaplanner.core.api.score.stream.uni.UniConstraintCollector;
 import org.optaplanner.core.impl.util.Pair;
 
 final class Group0Mapping2CollectorUniNode<OldA, A, B, ResultContainerA_, ResultContainerB_>
-        extends AbstractGroupUniNode<OldA, BiTuple<A, B>, String, Object, Pair<A, B>> {
+        extends AbstractGroupUniNode<OldA, BiTuple<A, B>, Void, Object, Pair<A, B>> {
 
     private static final String NO_GROUP_KEY = "NO_GROUP";
 
@@ -17,7 +17,7 @@ final class Group0Mapping2CollectorUniNode<OldA, A, B, ResultContainerA_, Result
             UniConstraintCollector<OldA, ResultContainerA_, A> collectorA,
             UniConstraintCollector<OldA, ResultContainerB_, B> collectorB,
             TupleLifecycle<BiTuple<A, B>> nextNodesTupleLifecycle, int outputStoreSize) {
-        super(groupStoreIndex, mergeCollectors(collectorA, collectorB), nextNodesTupleLifecycle);
+        super(groupStoreIndex, null, mergeCollectors(collectorA, collectorB), nextNodesTupleLifecycle);
         this.outputStoreSize = outputStoreSize;
     }
 
@@ -30,12 +30,7 @@ final class Group0Mapping2CollectorUniNode<OldA, A, B, ResultContainerA_, Result
     }
 
     @Override
-    protected String createGroupKey(UniTuple<OldA> tuple) {
-        return NO_GROUP_KEY;
-    }
-
-    @Override
-    protected BiTuple<A, B> createOutTuple(String groupKey) {
+    protected BiTuple<A, B> createOutTuple(Void groupKey) {
         return new BiTuple<>(null, null, outputStoreSize);
     }
 

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/uni/Group0Mapping3CollectorUniNode.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/uni/Group0Mapping3CollectorUniNode.java
@@ -7,9 +7,7 @@ import org.optaplanner.core.api.score.stream.uni.UniConstraintCollector;
 import org.optaplanner.core.impl.util.Triple;
 
 final class Group0Mapping3CollectorUniNode<OldA, A, B, C, ResultContainerA_, ResultContainerB_, ResultContainerC_>
-        extends AbstractGroupUniNode<OldA, TriTuple<A, B, C>, String, Object, Triple<A, B, C>> {
-
-    private static final String NO_GROUP_KEY = "NO_GROUP";
+        extends AbstractGroupUniNode<OldA, TriTuple<A, B, C>, Void, Object, Triple<A, B, C>> {
 
     private final int outputStoreSize;
 
@@ -18,7 +16,7 @@ final class Group0Mapping3CollectorUniNode<OldA, A, B, C, ResultContainerA_, Res
             UniConstraintCollector<OldA, ResultContainerB_, B> collectorB,
             UniConstraintCollector<OldA, ResultContainerC_, C> collectorC,
             TupleLifecycle<TriTuple<A, B, C>> nextNodesTupleLifecycle, int outputStoreSize) {
-        super(groupStoreIndex, mergeCollectors(collectorA, collectorB, collectorC), nextNodesTupleLifecycle);
+        super(groupStoreIndex, null, mergeCollectors(collectorA, collectorB, collectorC), nextNodesTupleLifecycle);
         this.outputStoreSize = outputStoreSize;
     }
 
@@ -32,12 +30,7 @@ final class Group0Mapping3CollectorUniNode<OldA, A, B, C, ResultContainerA_, Res
     }
 
     @Override
-    protected String createGroupKey(UniTuple<OldA> tuple) {
-        return NO_GROUP_KEY;
-    }
-
-    @Override
-    protected TriTuple<A, B, C> createOutTuple(String groupKey) {
+    protected TriTuple<A, B, C> createOutTuple(Void groupKey) {
         return new TriTuple<>(null, null, null, outputStoreSize);
     }
 

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/uni/Group0Mapping4CollectorUniNode.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/uni/Group0Mapping4CollectorUniNode.java
@@ -7,9 +7,7 @@ import org.optaplanner.core.api.score.stream.uni.UniConstraintCollector;
 import org.optaplanner.core.impl.util.Quadruple;
 
 final class Group0Mapping4CollectorUniNode<OldA, A, B, C, D, ResultContainerA_, ResultContainerB_, ResultContainerC_, ResultContainerD_>
-        extends AbstractGroupUniNode<OldA, QuadTuple<A, B, C, D>, String, Object, Quadruple<A, B, C, D>> {
-
-    private static final String NO_GROUP_KEY = "NO_GROUP";
+        extends AbstractGroupUniNode<OldA, QuadTuple<A, B, C, D>, Void, Object, Quadruple<A, B, C, D>> {
 
     private final int outputStoreSize;
 
@@ -19,7 +17,7 @@ final class Group0Mapping4CollectorUniNode<OldA, A, B, C, D, ResultContainerA_, 
             UniConstraintCollector<OldA, ResultContainerC_, C> collectorC,
             UniConstraintCollector<OldA, ResultContainerD_, D> collectorD,
             TupleLifecycle<QuadTuple<A, B, C, D>> nextNodesTupleLifecycle, int outputStoreSize) {
-        super(groupStoreIndex, mergeCollectors(collectorA, collectorB, collectorC, collectorD), nextNodesTupleLifecycle);
+        super(groupStoreIndex, null, mergeCollectors(collectorA, collectorB, collectorC, collectorD), nextNodesTupleLifecycle);
         this.outputStoreSize = outputStoreSize;
     }
 
@@ -34,12 +32,7 @@ final class Group0Mapping4CollectorUniNode<OldA, A, B, C, D, ResultContainerA_, 
     }
 
     @Override
-    protected String createGroupKey(UniTuple<OldA> tuple) {
-        return NO_GROUP_KEY;
-    }
-
-    @Override
-    protected QuadTuple<A, B, C, D> createOutTuple(String groupKey) {
+    protected QuadTuple<A, B, C, D> createOutTuple(Void groupKey) {
         return new QuadTuple<>(null, null, null, null, outputStoreSize);
     }
 

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/uni/Group1Mapping0CollectorUniNode.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/uni/Group1Mapping0CollectorUniNode.java
@@ -7,18 +7,15 @@ import org.optaplanner.constraint.streams.bavet.common.TupleLifecycle;
 final class Group1Mapping0CollectorUniNode<OldA, A>
         extends AbstractGroupUniNode<OldA, UniTuple<A>, A, Void, Void> {
 
-    private final Function<OldA, A> groupKeyMapping;
     private final int outputStoreSize;
 
     public Group1Mapping0CollectorUniNode(Function<OldA, A> groupKeyMapping, int groupStoreIndex,
             TupleLifecycle<UniTuple<A>> nextNodesTupleLifecycle, int outputStoreSize) {
-        super(groupStoreIndex, null, nextNodesTupleLifecycle);
-        this.groupKeyMapping = groupKeyMapping;
+        super(groupStoreIndex, tuple -> createGroupKey(groupKeyMapping, tuple), null, nextNodesTupleLifecycle);
         this.outputStoreSize = outputStoreSize;
     }
 
-    @Override
-    protected A createGroupKey(UniTuple<OldA> tuple) {
+    static <A, OldA> A createGroupKey(Function<OldA, A> groupKeyMapping, UniTuple<OldA> tuple) {
         return groupKeyMapping.apply(tuple.factA);
     }
 

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/uni/Group1Mapping1CollectorUniNode.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/uni/Group1Mapping1CollectorUniNode.java
@@ -1,5 +1,7 @@
 package org.optaplanner.constraint.streams.bavet.uni;
 
+import static org.optaplanner.constraint.streams.bavet.uni.Group1Mapping0CollectorUniNode.createGroupKey;
+
 import java.util.function.Function;
 
 import org.optaplanner.constraint.streams.bavet.bi.BiTuple;
@@ -9,20 +11,13 @@ import org.optaplanner.core.api.score.stream.uni.UniConstraintCollector;
 final class Group1Mapping1CollectorUniNode<OldA, A, B, ResultContainer_>
         extends AbstractGroupUniNode<OldA, BiTuple<A, B>, A, ResultContainer_, B> {
 
-    private final Function<OldA, A> groupKeyMapping;
     private final int outputStoreSize;
 
     public Group1Mapping1CollectorUniNode(Function<OldA, A> groupKeyMapping, int groupStoreIndex,
             UniConstraintCollector<OldA, ResultContainer_, B> collector,
             TupleLifecycle<BiTuple<A, B>> nextNodesTupleLifecycle, int outputStoreSize) {
-        super(groupStoreIndex, collector, nextNodesTupleLifecycle);
-        this.groupKeyMapping = groupKeyMapping;
+        super(groupStoreIndex, tuple -> createGroupKey(groupKeyMapping, tuple), collector, nextNodesTupleLifecycle);
         this.outputStoreSize = outputStoreSize;
-    }
-
-    @Override
-    protected A createGroupKey(UniTuple<OldA> tuple) {
-        return groupKeyMapping.apply(tuple.factA);
     }
 
     @Override

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/uni/Group1Mapping2CollectorUniNode.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/uni/Group1Mapping2CollectorUniNode.java
@@ -1,5 +1,7 @@
 package org.optaplanner.constraint.streams.bavet.uni;
 
+import static org.optaplanner.constraint.streams.bavet.uni.Group1Mapping0CollectorUniNode.createGroupKey;
+
 import java.util.function.Function;
 
 import org.optaplanner.constraint.streams.bavet.common.TupleLifecycle;
@@ -10,21 +12,15 @@ import org.optaplanner.core.impl.util.Pair;
 final class Group1Mapping2CollectorUniNode<OldA, A, B, C, ResultContainerB_, ResultContainerC_>
         extends AbstractGroupUniNode<OldA, TriTuple<A, B, C>, A, Object, Pair<B, C>> {
 
-    private final Function<OldA, A> groupKeyMapping;
     private final int outputStoreSize;
 
     public Group1Mapping2CollectorUniNode(Function<OldA, A> groupKeyMapping, int groupStoreIndex,
             UniConstraintCollector<OldA, ResultContainerB_, B> collectorB,
             UniConstraintCollector<OldA, ResultContainerC_, C> collectorC,
             TupleLifecycle<TriTuple<A, B, C>> nextNodesTupleLifecycle, int outputStoreSize) {
-        super(groupStoreIndex, Group0Mapping2CollectorUniNode.mergeCollectors(collectorB, collectorC), nextNodesTupleLifecycle);
-        this.groupKeyMapping = groupKeyMapping;
+        super(groupStoreIndex, tuple -> createGroupKey(groupKeyMapping, tuple),
+                Group0Mapping2CollectorUniNode.mergeCollectors(collectorB, collectorC), nextNodesTupleLifecycle);
         this.outputStoreSize = outputStoreSize;
-    }
-
-    @Override
-    protected A createGroupKey(UniTuple<OldA> tuple) {
-        return groupKeyMapping.apply(tuple.factA);
     }
 
     @Override

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/uni/Group1Mapping3CollectorUniNode.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/uni/Group1Mapping3CollectorUniNode.java
@@ -1,5 +1,7 @@
 package org.optaplanner.constraint.streams.bavet.uni;
 
+import static org.optaplanner.constraint.streams.bavet.uni.Group1Mapping0CollectorUniNode.createGroupKey;
+
 import java.util.function.Function;
 
 import org.optaplanner.constraint.streams.bavet.common.TupleLifecycle;
@@ -10,7 +12,6 @@ import org.optaplanner.core.impl.util.Triple;
 final class Group1Mapping3CollectorUniNode<OldA, A, B, C, D, ResultContainerB_, ResultContainerC_, ResultContainerD_>
         extends AbstractGroupUniNode<OldA, QuadTuple<A, B, C, D>, A, Object, Triple<B, C, D>> {
 
-    private final Function<OldA, A> groupKeyMapping;
     private final int outputStoreSize;
 
     public Group1Mapping3CollectorUniNode(Function<OldA, A> groupKeyMapping, int groupStoreIndex,
@@ -18,15 +19,10 @@ final class Group1Mapping3CollectorUniNode<OldA, A, B, C, D, ResultContainerB_, 
             UniConstraintCollector<OldA, ResultContainerC_, C> collectorC,
             UniConstraintCollector<OldA, ResultContainerD_, D> collectorD,
             TupleLifecycle<QuadTuple<A, B, C, D>> nextNodesTupleLifecycle, int outputStoreSize) {
-        super(groupStoreIndex, Group0Mapping3CollectorUniNode.mergeCollectors(collectorB, collectorC, collectorD),
+        super(groupStoreIndex, tuple -> createGroupKey(groupKeyMapping, tuple),
+                Group0Mapping3CollectorUniNode.mergeCollectors(collectorB, collectorC, collectorD),
                 nextNodesTupleLifecycle);
-        this.groupKeyMapping = groupKeyMapping;
         this.outputStoreSize = outputStoreSize;
-    }
-
-    @Override
-    protected A createGroupKey(UniTuple<OldA> tuple) {
-        return groupKeyMapping.apply(tuple.factA);
     }
 
     @Override

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/uni/Group2Mapping0CollectorUniNode.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/uni/Group2Mapping0CollectorUniNode.java
@@ -9,20 +9,17 @@ import org.optaplanner.core.impl.util.Pair;
 final class Group2Mapping0CollectorUniNode<OldA, A, B>
         extends AbstractGroupUniNode<OldA, BiTuple<A, B>, Pair<A, B>, Void, Void> {
 
-    private final Function<OldA, A> groupKeyMappingA;
-    private final Function<OldA, B> groupKeyMappingB;
     private final int outputStoreSize;
 
     public Group2Mapping0CollectorUniNode(Function<OldA, A> groupKeyMappingA, Function<OldA, B> groupKeyMappingB,
             int groupStoreIndex, TupleLifecycle<BiTuple<A, B>> nextNodesTupleLifecycle, int outputStoreSize) {
-        super(groupStoreIndex, null, nextNodesTupleLifecycle);
-        this.groupKeyMappingA = groupKeyMappingA;
-        this.groupKeyMappingB = groupKeyMappingB;
+        super(groupStoreIndex, tuple -> createGroupKey(groupKeyMappingA, groupKeyMappingB, tuple),
+                null, nextNodesTupleLifecycle);
         this.outputStoreSize = outputStoreSize;
     }
 
-    @Override
-    protected Pair<A, B> createGroupKey(UniTuple<OldA> tuple) {
+    static <A, B, OldA> Pair<A, B> createGroupKey(Function<OldA, A> groupKeyMappingA, Function<OldA, B> groupKeyMappingB,
+            UniTuple<OldA> tuple) {
         OldA oldA = tuple.factA;
         A a = groupKeyMappingA.apply(oldA);
         B b = groupKeyMappingB.apply(oldA);

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/uni/Group2Mapping1CollectorUniNode.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/uni/Group2Mapping1CollectorUniNode.java
@@ -1,5 +1,7 @@
 package org.optaplanner.constraint.streams.bavet.uni;
 
+import static org.optaplanner.constraint.streams.bavet.uni.Group2Mapping0CollectorUniNode.createGroupKey;
+
 import java.util.function.Function;
 
 import org.optaplanner.constraint.streams.bavet.common.TupleLifecycle;
@@ -10,25 +12,14 @@ import org.optaplanner.core.impl.util.Pair;
 final class Group2Mapping1CollectorUniNode<OldA, A, B, C, ResultContainer_>
         extends AbstractGroupUniNode<OldA, TriTuple<A, B, C>, Pair<A, B>, ResultContainer_, C> {
 
-    private final Function<OldA, A> groupKeyMappingA;
-    private final Function<OldA, B> groupKeyMappingB;
     private final int outputStoreSize;
 
     public Group2Mapping1CollectorUniNode(Function<OldA, A> groupKeyMappingA, Function<OldA, B> groupKeyMappingB,
             int groupStoreIndex, UniConstraintCollector<OldA, ResultContainer_, C> collector,
             TupleLifecycle<TriTuple<A, B, C>> nextNodesTupleLifecycle, int outputStoreSize) {
-        super(groupStoreIndex, collector, nextNodesTupleLifecycle);
-        this.groupKeyMappingA = groupKeyMappingA;
-        this.groupKeyMappingB = groupKeyMappingB;
+        super(groupStoreIndex, tuple -> createGroupKey(groupKeyMappingA, groupKeyMappingB, tuple),
+                collector, nextNodesTupleLifecycle);
         this.outputStoreSize = outputStoreSize;
-    }
-
-    @Override
-    protected Pair<A, B> createGroupKey(UniTuple<OldA> tuple) {
-        OldA oldA = tuple.factA;
-        A a = groupKeyMappingA.apply(oldA);
-        B b = groupKeyMappingB.apply(oldA);
-        return Pair.of(a, b);
     }
 
     @Override

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/uni/Group2Mapping2CollectorUniNode.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/uni/Group2Mapping2CollectorUniNode.java
@@ -1,6 +1,7 @@
 package org.optaplanner.constraint.streams.bavet.uni;
 
 import static org.optaplanner.constraint.streams.bavet.uni.Group0Mapping2CollectorUniNode.mergeCollectors;
+import static org.optaplanner.constraint.streams.bavet.uni.Group2Mapping0CollectorUniNode.createGroupKey;
 
 import java.util.function.Function;
 
@@ -12,8 +13,6 @@ import org.optaplanner.core.impl.util.Pair;
 final class Group2Mapping2CollectorUniNode<OldA, A, B, C, D, ResultContainerC_, ResultContainerD_>
         extends AbstractGroupUniNode<OldA, QuadTuple<A, B, C, D>, Pair<A, B>, Object, Pair<C, D>> {
 
-    private final Function<OldA, A> groupKeyMappingA;
-    private final Function<OldA, B> groupKeyMappingB;
     private final int outputStoreSize;
 
     public Group2Mapping2CollectorUniNode(Function<OldA, A> groupKeyMappingA, Function<OldA, B> groupKeyMappingB,
@@ -21,18 +20,9 @@ final class Group2Mapping2CollectorUniNode<OldA, A, B, C, D, ResultContainerC_, 
             UniConstraintCollector<OldA, ResultContainerC_, C> collectorC,
             UniConstraintCollector<OldA, ResultContainerD_, D> collectorD,
             TupleLifecycle<QuadTuple<A, B, C, D>> nextNodesTupleLifecycle, int outputStoreSize) {
-        super(groupStoreIndex, mergeCollectors(collectorC, collectorD), nextNodesTupleLifecycle);
-        this.groupKeyMappingA = groupKeyMappingA;
-        this.groupKeyMappingB = groupKeyMappingB;
+        super(groupStoreIndex, tuple -> createGroupKey(groupKeyMappingA, groupKeyMappingB, tuple),
+                mergeCollectors(collectorC, collectorD), nextNodesTupleLifecycle);
         this.outputStoreSize = outputStoreSize;
-    }
-
-    @Override
-    protected Pair<A, B> createGroupKey(UniTuple<OldA> tuple) {
-        OldA oldA = tuple.factA;
-        A a = groupKeyMappingA.apply(oldA);
-        B b = groupKeyMappingB.apply(oldA);
-        return Pair.of(a, b);
     }
 
     @Override

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/uni/Group3Mapping0CollectorUniNode.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/uni/Group3Mapping0CollectorUniNode.java
@@ -9,23 +9,18 @@ import org.optaplanner.core.impl.util.Triple;
 final class Group3Mapping0CollectorUniNode<OldA, A, B, C>
         extends AbstractGroupUniNode<OldA, TriTuple<A, B, C>, Triple<A, B, C>, Void, Void> {
 
-    private final Function<OldA, A> groupKeyMappingA;
-    private final Function<OldA, B> groupKeyMappingB;
-    private final Function<OldA, C> groupKeyMappingC;
     private final int outputStoreSize;
 
     public Group3Mapping0CollectorUniNode(Function<OldA, A> groupKeyMappingA, Function<OldA, B> groupKeyMappingB,
             Function<OldA, C> groupKeyMappingC, int groupStoreIndex,
             TupleLifecycle<TriTuple<A, B, C>> nextNodesTupleLifecycle, int outputStoreSize) {
-        super(groupStoreIndex, null, nextNodesTupleLifecycle);
-        this.groupKeyMappingA = groupKeyMappingA;
-        this.groupKeyMappingB = groupKeyMappingB;
-        this.groupKeyMappingC = groupKeyMappingC;
+        super(groupStoreIndex, tuple -> createGroupKey(groupKeyMappingA, groupKeyMappingB, groupKeyMappingC, tuple),
+                null, nextNodesTupleLifecycle);
         this.outputStoreSize = outputStoreSize;
     }
 
-    @Override
-    protected Triple<A, B, C> createGroupKey(UniTuple<OldA> tuple) {
+    static <A, B, C, OldA> Triple<A, B, C> createGroupKey(Function<OldA, A> groupKeyMappingA,
+            Function<OldA, B> groupKeyMappingB, Function<OldA, C> groupKeyMappingC, UniTuple<OldA> tuple) {
         OldA oldA = tuple.factA;
         A a = groupKeyMappingA.apply(oldA);
         B b = groupKeyMappingB.apply(oldA);

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/uni/Group3Mapping1CollectorUniNode.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/uni/Group3Mapping1CollectorUniNode.java
@@ -1,5 +1,7 @@
 package org.optaplanner.constraint.streams.bavet.uni;
 
+import static org.optaplanner.constraint.streams.bavet.uni.Group3Mapping0CollectorUniNode.createGroupKey;
+
 import java.util.function.Function;
 
 import org.optaplanner.constraint.streams.bavet.common.TupleLifecycle;
@@ -10,29 +12,15 @@ import org.optaplanner.core.impl.util.Triple;
 final class Group3Mapping1CollectorUniNode<OldA, A, B, C, D, ResultContainer_>
         extends AbstractGroupUniNode<OldA, QuadTuple<A, B, C, D>, Triple<A, B, C>, ResultContainer_, D> {
 
-    private final Function<OldA, A> groupKeyMappingA;
-    private final Function<OldA, B> groupKeyMappingB;
-    private final Function<OldA, C> groupKeyMappingC;
     private final int outputStoreSize;
 
     public Group3Mapping1CollectorUniNode(Function<OldA, A> groupKeyMappingA, Function<OldA, B> groupKeyMappingB,
             Function<OldA, C> groupKeyMappingC,
             int groupStoreIndex, UniConstraintCollector<OldA, ResultContainer_, D> collector,
             TupleLifecycle<QuadTuple<A, B, C, D>> nextNodesTupleLifecycle, int outputStoreSize) {
-        super(groupStoreIndex, collector, nextNodesTupleLifecycle);
-        this.groupKeyMappingA = groupKeyMappingA;
-        this.groupKeyMappingB = groupKeyMappingB;
-        this.groupKeyMappingC = groupKeyMappingC;
+        super(groupStoreIndex, tuple -> createGroupKey(groupKeyMappingA, groupKeyMappingB, groupKeyMappingC, tuple),
+                collector, nextNodesTupleLifecycle);
         this.outputStoreSize = outputStoreSize;
-    }
-
-    @Override
-    protected Triple<A, B, C> createGroupKey(UniTuple<OldA> tuple) {
-        OldA oldA = tuple.factA;
-        A a = groupKeyMappingA.apply(oldA);
-        B b = groupKeyMappingB.apply(oldA);
-        C c = groupKeyMappingC.apply(oldA);
-        return Triple.of(a, b, c);
     }
 
     @Override

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/uni/Group4Mapping0CollectorUniNode.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/uni/Group4Mapping0CollectorUniNode.java
@@ -9,25 +9,20 @@ import org.optaplanner.core.impl.util.Quadruple;
 final class Group4Mapping0CollectorUniNode<OldA, A, B, C, D>
         extends AbstractGroupUniNode<OldA, QuadTuple<A, B, C, D>, Quadruple<A, B, C, D>, Void, Void> {
 
-    private final Function<OldA, A> groupKeyMappingA;
-    private final Function<OldA, B> groupKeyMappingB;
-    private final Function<OldA, C> groupKeyMappingC;
-    private final Function<OldA, D> groupKeyMappingD;
     private final int outputStoreSize;
 
     public Group4Mapping0CollectorUniNode(Function<OldA, A> groupKeyMappingA, Function<OldA, B> groupKeyMappingB,
             Function<OldA, C> groupKeyMappingC, Function<OldA, D> groupKeyMappingD, int groupStoreIndex,
             TupleLifecycle<QuadTuple<A, B, C, D>> nextNodesTupleLifecycle, int outputStoreSize) {
-        super(groupStoreIndex, null, nextNodesTupleLifecycle);
-        this.groupKeyMappingA = groupKeyMappingA;
-        this.groupKeyMappingB = groupKeyMappingB;
-        this.groupKeyMappingC = groupKeyMappingC;
-        this.groupKeyMappingD = groupKeyMappingD;
+        super(groupStoreIndex,
+                tuple -> createGroupKey(groupKeyMappingA, groupKeyMappingB, groupKeyMappingC, groupKeyMappingD, tuple),
+                null, nextNodesTupleLifecycle);
         this.outputStoreSize = outputStoreSize;
     }
 
-    @Override
-    protected Quadruple<A, B, C, D> createGroupKey(UniTuple<OldA> tuple) {
+    private static <A, B, C, D, OldA> Quadruple<A, B, C, D> createGroupKey(Function<OldA, A> groupKeyMappingA,
+            Function<OldA, B> groupKeyMappingB, Function<OldA, C> groupKeyMappingC, Function<OldA, D> groupKeyMappingD,
+            UniTuple<OldA> tuple) {
         OldA oldA = tuple.factA;
         A a = groupKeyMappingA.apply(oldA);
         B b = groupKeyMappingB.apply(oldA);

--- a/core/optaplanner-constraint-streams-drools/src/test/java/org/optaplanner/constraint/streams/drools/bi/DroolsBiConstraintStreamTest.java
+++ b/core/optaplanner-constraint-streams-drools/src/test/java/org/optaplanner/constraint/streams/drools/bi/DroolsBiConstraintStreamTest.java
@@ -1,0 +1,12 @@
+package org.optaplanner.constraint.streams.drools.bi;
+
+import org.optaplanner.constraint.streams.common.bi.AbstractBiConstraintStreamTest;
+import org.optaplanner.constraint.streams.drools.DroolsConstraintStreamImplSupport;
+
+final class DroolsBiConstraintStreamTest extends AbstractBiConstraintStreamTest {
+
+    public DroolsBiConstraintStreamTest(boolean constraintMatchEnabled) {
+        super(new DroolsConstraintStreamImplSupport(constraintMatchEnabled));
+    }
+
+}

--- a/core/optaplanner-constraint-streams-drools/src/test/java/org/optaplanner/constraint/streams/drools/quad/DroolsQuadConstraintStreamTest.java
+++ b/core/optaplanner-constraint-streams-drools/src/test/java/org/optaplanner/constraint/streams/drools/quad/DroolsQuadConstraintStreamTest.java
@@ -1,0 +1,12 @@
+package org.optaplanner.constraint.streams.drools.quad;
+
+import org.optaplanner.constraint.streams.common.quad.AbstractQuadConstraintStreamTest;
+import org.optaplanner.constraint.streams.drools.DroolsConstraintStreamImplSupport;
+
+final class DroolsQuadConstraintStreamTest extends AbstractQuadConstraintStreamTest {
+
+    public DroolsQuadConstraintStreamTest(boolean constraintMatchEnabled) {
+        super(new DroolsConstraintStreamImplSupport(constraintMatchEnabled));
+    }
+
+}

--- a/core/optaplanner-constraint-streams-drools/src/test/java/org/optaplanner/constraint/streams/drools/tri/DroolsTriConstraintStreamTest.java
+++ b/core/optaplanner-constraint-streams-drools/src/test/java/org/optaplanner/constraint/streams/drools/tri/DroolsTriConstraintStreamTest.java
@@ -1,0 +1,12 @@
+package org.optaplanner.constraint.streams.drools.tri;
+
+import org.optaplanner.constraint.streams.common.tri.AbstractTriConstraintStreamTest;
+import org.optaplanner.constraint.streams.drools.DroolsConstraintStreamImplSupport;
+
+final class DroolsTriConstraintStreamTest extends AbstractTriConstraintStreamTest {
+
+    public DroolsTriConstraintStreamTest(boolean constraintMatchEnabled) {
+        super(new DroolsConstraintStreamImplSupport(constraintMatchEnabled));
+    }
+
+}

--- a/core/optaplanner-constraint-streams-drools/src/test/java/org/optaplanner/constraint/streams/drools/uni/DroolsUniConstraintStreamTest.java
+++ b/core/optaplanner-constraint-streams-drools/src/test/java/org/optaplanner/constraint/streams/drools/uni/DroolsUniConstraintStreamTest.java
@@ -1,0 +1,12 @@
+package org.optaplanner.constraint.streams.drools.uni;
+
+import org.optaplanner.constraint.streams.common.uni.AbstractUniConstraintStreamTest;
+import org.optaplanner.constraint.streams.drools.DroolsConstraintStreamImplSupport;
+
+final class DroolsUniConstraintStreamTest extends AbstractUniConstraintStreamTest {
+
+    public DroolsUniConstraintStreamTest(boolean constraintMatchEnabled) {
+        super(new DroolsConstraintStreamImplSupport(constraintMatchEnabled));
+    }
+
+}


### PR DESCRIPTION
This is done purely to make the code - and flame graphs - read better. There is a minor improvement in groupBy performance.

The meat of this PR is in `AbstractGroupNode` and the indexers. The rest is required updates to the CS boilerplate.