### PR TITLE
[PLANNER-2728] Extract optaplanner release from Kogito

### DIFF
--- a/.ci/jenkins/Jenkinsfile.nightly
+++ b/.ci/jenkins/Jenkinsfile.nightly
@@ -1,0 +1,167 @@
+import org.jenkinsci.plugins.workflow.libs.Library
+@Library('jenkins-pipeline-shared-libraries')_
+
+// Deploy jobs
+OPTAPLANNER_DEPLOY = 'optaplanner-deploy'
+
+// Map of executed jobs
+// See https://javadoc.jenkins.io/plugin/workflow-support/org/jenkinsci/plugins/workflow/support/steps/build/RunWrapper.html
+// for more options on built job entity
+JOBS = [:]
+
+FAILED_STAGES = [:]
+UNSTABLE_STAGES = [:]
+
+// Should be multibranch pipeline
+pipeline {
+    agent {
+        label 'kie-rhel7 && !master'
+    }
+
+    options {
+        timeout(time: 1380, unit: 'MINUTES')
+    }
+
+    // parameters {
+    // For parameters, check into ./dsl/jobs.groovy file
+    // }
+
+    environment {
+        // Some generated env is also defined into ./dsl/jobs.groovy file
+
+        OPTAPLANNER_CI_EMAIL_TO = credentials("${JENKINS_EMAIL_CREDS_ID}")
+
+        // Use branch name in nightly tag as we may have parallel main and release branch builds
+        NIGHTLY_TAG = """${getBuildBranch()}-${sh(
+                returnStdout: true,
+                script: 'date -u "+%Y-%m-%d"'
+            ).trim()}"""
+    }
+
+    stages {
+        stage('Initialize') {
+            steps {
+                script {
+                    echo "nightly tag is ${env.NIGHTLY_TAG}"
+
+                    currentBuild.displayName = env.NIGHTLY_TAG
+                }
+            }
+        }
+
+        stage('Build & Deploy OptaPlanner') {
+            steps {
+                script {
+                    def buildParams = getDefaultBuildParams(getBuildBranch())
+                    addSkipTestsParam(buildParams)
+                    addSkipIntegrationTestsParam(buildParams)
+                    def quickstartsBranch = getBuildBranch() == 'main' ? 'development' : getBuildBranch()
+                    addStringParam(buildParams, 'QUICKSTARTS_BUILD_BRANCH_NAME', quickstartsBranch)
+
+                    buildJob(OPTAPLANNER_DEPLOY, buildParams)
+                }
+            }
+            post {
+                failure {
+                    addFailedStage(OPTAPLANNER_DEPLOY)
+                }
+            }
+        }
+    }
+    post {
+        unsuccessful {
+            sendPipelineErrorNotification()
+        }
+    }
+}
+
+def buildJob(String jobName, List buildParams, String jobKey = jobName) {
+    echo "[${jobKey}] Build ${jobName} with params ${buildParams}"
+
+    def job = build(job: "${jobName}", wait: true, parameters: buildParams, propagate: false)
+    JOBS[jobKey] = job
+
+    // Set Unstable if job did not succeed
+    if (!isJobSucceeded(jobKey)) {
+        addUnstableStage(jobKey)
+        unstable("Job ${jobName} finished with result ${job.getResult()}")
+    }
+    return job
+}
+
+def getJob(String jobKey) {
+    return JOBS[jobKey]
+}
+
+String getJobUrl(String jobKey) {
+    echo "getJobUrl for ${jobKey}"
+    return getJob(jobKey)?.getAbsoluteUrl() ?: ''
+}
+
+boolean isJobSucceeded(String jobKey) {
+    return getJob(jobKey)?.getResult() == 'SUCCESS'
+}
+
+void addFailedStage(String jobKey = '') {
+    FAILED_STAGES.put("${STAGE_NAME}", jobKey)
+}
+void addUnstableStage(String jobKey = '') {
+    UNSTABLE_STAGES.put("${STAGE_NAME}", jobKey)
+}
+
+void sendPipelineErrorNotification() {
+    String bodyMsg = "Optaplanner nightly job #${BUILD_NUMBER} was: ${currentBuild.currentResult}"
+
+    paramsStr = ''
+    if (params.SKIP_TESTS) {
+        paramsStr += '\n- Tests skipped'
+    }
+    bodyMsg += paramsStr ? "\n\nConfiguration:${paramsStr}" : '\n'
+
+    if (FAILED_STAGES.size() > 0) {
+        bodyMsg += '\nFailed stages: \n- '
+        bodyMsg += FAILED_STAGES.collect { "${it.key} => ${getJobUrl(it.value)}" }.join('\n- ')
+    }
+    bodyMsg += '\n'
+    if (UNSTABLE_STAGES.size() > 0) {
+        bodyMsg += '\nUnstable stages: \n- '
+        bodyMsg += UNSTABLE_STAGES.collect { "${it.key} => ${getJobUrl(it.value)}" }.join('\n- ')
+    }
+    bodyMsg += '\n'
+    bodyMsg += "\nPlease look here: ${BUILD_URL}"
+    emailext body: bodyMsg, subject: "[${getBuildBranch()}][d] Full Pipeline",
+                to: env.OPTAPLANNER_CI_EMAIL_TO
+}
+
+List getDefaultBuildParams(String buildBranchName = '', String key = '') {
+    buildBranchName = buildBranchName ?: getBuildBranch()
+    List params = []
+    addStringParam(params, 'DISPLAY_NAME', "${key ? "${key}-" : ''}${env.NIGHTLY_TAG}")
+    addBooleanParam(params, 'SEND_NOTIFICATION', true)
+
+    return params
+}
+
+void addSkipTestsParam(buildParams) {
+    addBooleanParam(buildParams, 'SKIP_TESTS', params.SKIP_TESTS)
+}
+
+void addSkipIntegrationTestsParam(buildParams) {
+    addBooleanParam(buildParams, 'SKIP_INTEGRATION_TESTS', params.SKIP_TESTS)
+}
+
+void addStringParam(List buildParams, String key, String value) {
+    buildParams.add(string(name: key, value: value))
+}
+
+void addBooleanParam(List buildParams, String key, boolean value) {
+    buildParams.add(booleanParam(name: key, value: value))
+}
+
+String getBuildBranch() {
+    return env.GIT_BRANCH_NAME
+}
+
+String getGitAuthor() {
+    return env.GIT_AUTHOR
+}

--- a/.ci/jenkins/Jenkinsfile.release
+++ b/.ci/jenkins/Jenkinsfile.release
@@ -1,0 +1,379 @@
+import org.jenkinsci.plugins.workflow.libs.Library
+
+@Library('jenkins-pipeline-shared-libraries')_
+
+OPTAPLANNER_DEPLOY = 'optaplanner-deploy'
+OPTAPLANNER_PROMOTE = 'optaplanner-promote'
+
+ARTIFACTS_STAGING_STAGE = 'stage.artifacts.staging'
+ARTIFACTS_RELEASE_STAGE = 'stage.artifacts.release'
+
+JOB_PROPERTY_PREFIX = 'build'
+JOB_RESULT_PROPERTY_KEY = 'result'
+JOB_URL_PROPERTY_KEY = 'absoluteUrl'
+JOB_DECISION_PROPERTY_KEY = 'decision'
+JOB_DECISION_MESSAGE_PROPERTY_KEY = 'decisionMessage'
+
+releaseProperties = [:]
+
+pipeline {
+    agent {
+        label 'kie-rhel7 && !master'
+    }
+
+    // parameters {
+    // For parameters, check into ./dsl/jobs.groovy file
+    // }
+
+    environment {
+        // Some generated env is also defined into ./dsl/jobs.groovy file
+
+        CI_EMAIL = credentials("${JENKINS_EMAIL_CREDS_ID}")
+    }
+
+    stages {
+        stage('Initialize') {
+            steps {
+                script {
+                    // Restore config from previous run
+                    if (params.RESTORE_FROM_PREVIOUS_JOB) {
+                        releaseProperties = readPropertiesFromUrl(params.RESTORE_FROM_PREVIOUS_JOB, 'release.properties')
+                        echo "Release properties imported from previous job: ${releaseProperties}"
+                    }
+
+                    assert getOptaPlannerVersion()
+
+                    currentBuild.displayName = getDisplayName()
+
+                    sendNotification("Release Pipeline has started...\nOptaplanner version = ${getOptaPlannerVersion()}\n=> ${env.BUILD_URL}")
+
+                    // Safety measure to not publish to main JBoss
+                    if (getGitAuthor() != 'kiegroup' && !getArtifactsRepositoryParam()) {
+                        sendNotification("Git Author is different from `kiegroup` and no `ARTIFACTS_REPOSITORY` parameter has been provided. Are you sure you want to continue ? => ${env.BUILD_URL}input")
+                        input message: 'Should the pipeline continue with no `ARTIFACTS_REPOSITORY` defined ?', ok: 'Yes'
+                    }
+                }
+            }
+            post {
+                always {
+                    setReleasePropertyIfneeded('optaplanner.version', getOptaPlannerVersion())
+                    setReleasePropertyIfneeded('optaplanner.branch', getOptaPlannerReleaseBranch())
+                }
+            }
+        }
+
+        stage('Build & Deploy OptaPlanner') {
+            steps {
+                script {
+                    def buildParams = getDefaultBuildParams(getOptaPlannerVersion())
+                    addSkipTestsParam(buildParams)
+                    addSkipIntegrationTestsParam(buildParams)
+                    addStringParam(buildParams, 'QUICKSTARTS_BUILD_BRANCH_NAME', getOptaPlannerReleaseBranch())
+                    buildJob(OPTAPLANNER_DEPLOY, buildParams)
+                }
+            }
+        }
+
+        stage('Artifacts\' staging finalization') {
+            steps {
+                script {
+                    if (!areArtifactsStaged()) {
+                        sendNotification("All artifacts have been staged. You can find them here: ${getStagingRepository()}")
+                    }
+                    setArtifactsStaged()
+                }
+            }
+        }
+
+        stage('Are staged artifacts released?') {
+            when {
+                // Execute only if artifacts repository was not given, which means the staging repository has been created
+                expression { return !getArtifactsRepositoryParam() && !areArtifactsReleased() }
+            }
+            steps {
+                script {
+                    String body = "${getOptaPlannerVersion()} artifacts are ready for release.\n" +
+                                 "Please release the staging repositories and then confirm here: ${env.BUILD_URL}input"
+                    sendNotification(body)
+                    input message: 'Has the staging repository been released ?', ok: 'Yes'
+
+                    sendNotification('Artifacts have been released. Finalizing now the release ...')
+                    setArtifactsReleased()
+                }
+            }
+        }
+
+        stage('Promote OptaPlanner') {
+            when {
+                expression { return isJobConsideredOk(OPTAPLANNER_DEPLOY) }
+            }
+            steps {
+                script {
+                    def buildParams = getDefaultBuildParams(getOptaPlannerVersion())
+                    addDeployBuildUrlParam(buildParams, OPTAPLANNER_DEPLOY)
+
+                    buildJob(OPTAPLANNER_PROMOTE, buildParams)
+                }
+            }
+        }
+    }
+    post {
+        always {
+            script {
+                saveReleaseProperties()
+            }
+            cleanWs()
+        }
+        success {
+            script {
+                sendSuccessfulReleaseNotification()
+            }
+        }
+        unsuccessful {
+            sendErrorNotification()
+        }
+    }
+}
+
+def buildJob(String jobName, List buildParams) {
+    if (!hasJob(jobName) || (getJobResult(jobName) != 'SUCCESS' && getJobDecision(jobName) == 'retry')) {
+        sendStageNotification()
+        echo "Build ${jobName} with params ${buildParams}"
+        def job = build(job: "./${jobName}", wait: true, parameters: buildParams, propagate: false)
+        removeJobDecision(jobName)
+        registerJobExecution(jobName, job.result, job.absoluteUrl)
+    } else {
+        echo 'Job was already executed. Retrieving information...'
+    }
+
+    saveReleaseProperties()
+
+    def jobResult = getJobResult(jobName)
+    def jobUrl = getJobUrl(jobName)
+    def jobDecision = getJobDecision(jobName)
+    if (jobResult != 'SUCCESS') {
+        if (jobDecision != 'continue' && jobDecision != 'skip') {
+            echo "Sending a notification about an unsuccessful job build ${jobName}."
+            sendNotification("`${jobName}` finished with status `${jobResult}`.\nSee: ${jobUrl}\n\nPlease provide which action should be done (retry ? continue ? skip ? abort ?): ${env.BUILD_URL}input")
+
+            // abort is handled automatically by the pipeline in the input
+            def result = input message: "Job `${jobName}` is in status ${jobResult}. What do you want to do ?\nBeware that skipping a deploy job will not launch the promote part.", parameters: [choice(name: 'ACTION', choices: ['retry', 'continue', 'skip'].join('\n')), string(name: 'MESSAGE', description: 'If you want to add information to your action...')]
+            def inputDecision = result['ACTION']
+            def inputMessage = result['MESSAGE']
+            registerJobDecision(jobName, inputDecision, inputMessage)
+
+            String resultStr = "`${jobName}` failure => Decision was made to ${inputDecision}."
+            if (inputMessage) {
+                resultStr += "Additional Information: `${inputMessage}`"
+            }
+            sendNotification(resultStr)
+
+            if (inputDecision == 'retry') {
+                // If retry, remove job and build again
+                return buildJob(jobName, buildParams)
+            }
+        } else {
+            echo "Job decision was '${jobDecision}'"
+        }
+    } else {
+        echo 'Job succeeded'
+    }
+}
+
+String getJobPropertySuffix(String jobName) {
+    return "${JOB_PROPERTY_PREFIX}.${jobName}"
+}
+
+String getJobPropertyKey(String jobName, String key) {
+    return "${getJobPropertySuffix(jobName)}.${key}"
+}
+
+def registerJobExecution(String jobName, String result, String absoluteUrl) {
+    setReleasePropertyIfneeded(getJobPropertyKey(jobName, JOB_RESULT_PROPERTY_KEY), result)
+    setReleasePropertyIfneeded(getJobPropertyKey(jobName, JOB_URL_PROPERTY_KEY), absoluteUrl)
+}
+
+def registerJobDecision(String jobName, String decision, String message = '') {
+    setReleasePropertyIfneeded(getJobPropertyKey(jobName, JOB_DECISION_PROPERTY_KEY), decision)
+    setReleasePropertyIfneeded(getJobPropertyKey(jobName, JOB_DECISION_MESSAGE_PROPERTY_KEY), message)
+}
+
+def removeJobDecision(String jobName) {
+    removeReleaseProperty(getJobPropertyKey(jobName, JOB_DECISION_PROPERTY_KEY))
+    removeReleaseProperty(getJobPropertyKey(jobName, JOB_DECISION_MESSAGE_PROPERTY_KEY))
+}
+
+List getAllJobNames() {
+    return releaseProperties.findAll { it.key.startsWith(JOB_PROPERTY_PREFIX) }.collect { it.key.split('\\.')[1] }
+}
+
+boolean hasJob(String jobName) {
+    return releaseProperties.any { it.key.startsWith(getJobPropertySuffix(jobName)) }
+}
+
+String getJobUrl(String jobName) {
+    echo "getJobUrl for ${jobName}"
+    return getReleaseProperty(getJobPropertyKey(jobName, JOB_URL_PROPERTY_KEY)) ?: ''
+}
+
+String getJobResult(String jobName) {
+    echo "getJobResult for ${jobName}"
+    return getReleaseProperty(getJobPropertyKey(jobName, JOB_RESULT_PROPERTY_KEY)) ?: ''
+}
+
+String getJobDecision(String jobName) {
+    echo "getJobDecision for ${jobName}"
+    return getReleaseProperty(getJobPropertyKey(jobName, JOB_DECISION_PROPERTY_KEY)) ?: ''
+}
+
+boolean isJobConsideredOk(String jobName) {
+    String result = getJobResult(jobName)
+    String decision = getJobDecision(jobName)
+    return result == 'SUCCESS' || (result == 'UNSTABLE' &&  decision == 'continue')
+}
+
+void saveReleaseProperties() {
+    def propertiesStr = releaseProperties.collect { entry -> "${entry.key}=${entry.value}" }.join('\n')
+    writeFile( file : 'release.properties' , text : propertiesStr)
+    archiveArtifacts artifacts: 'release.properties'
+}
+
+void sendSuccessfulReleaseNotification() {
+    String bodyMsg = 'Release is successful with those jobs:\n'
+    getAllJobNames().findAll { isJobConsideredOk(it) }.each {
+        bodyMsg += "- ${it}\n"
+    }
+    bodyMsg += "\nPlease look here: ${BUILD_URL} for more information"
+    sendNotification(bodyMsg)
+}
+
+void sendErrorNotification() {
+    sendNotification("Release job #${BUILD_NUMBER} was: ${currentBuild.currentResult}\nPlease look here: ${BUILD_URL}")
+}
+
+void sendStageNotification() {
+    sendNotification("${env.STAGE_NAME}")
+}
+
+void sendNotification(String body) {
+    echo 'Send Notification'
+    echo body
+    emailext body: body, subject: "[${env.GIT_BRANCH_NAME}] Release Pipeline",
+                to: env.CI_EMAIL
+}
+
+def readPropertiesFromUrl(String url, String propsFilename) {
+    if (!url.endsWith('/')) {
+        url += '/'
+    }
+    sh "wget ${url}artifact/${propsFilename} -O ${propsFilename}"
+    def props = readProperties file: propsFilename
+    echo props.collect { entry -> "${entry.key}=${entry.value}" }.join('\n')
+    return props
+}
+
+List getDefaultBuildParams(String version) {
+    List buildParams = []
+    addDisplayNameParam(buildParams, getDisplayName(version))
+    addStringParam(buildParams, 'PROJECT_VERSION', version)
+    return buildParams
+}
+
+void addDisplayNameParam(buildParams, name = '') {
+    name = name ?: getDisplayName()
+    addStringParam(buildParams, 'DISPLAY_NAME', name)
+}
+
+void addDeployBuildUrlParam(buildParams, jobName) {
+    addDeployBuildUrlParamOrClosure(buildParams, jobName)
+}
+
+void addDeployBuildUrlParamOrClosure(buildParams, jobName, closure = null) {
+    String url = getJobUrl(jobName)
+    if (url) {
+        addStringParam(buildParams, 'DEPLOY_BUILD_URL', getJobUrl(jobName))
+    } else if (closure) {
+        closure()
+    }
+}
+
+void addSkipTestsParam(buildParams) {
+    addBooleanParam(buildParams, 'SKIP_TESTS', params.SKIP_TESTS)
+}
+
+void addSkipIntegrationTestsParam(buildParams) {
+    addBooleanParam(buildParams, 'SKIP_INTEGRATION_TESTS', true)
+}
+
+void addStringParam(List params, String key, String value) {
+    params.add(string(name: key, value: value))
+}
+
+void addBooleanParam(List params, String key, boolean value) {
+    params.add(booleanParam(name: key, value: value))
+}
+
+String constructKey(String prefix, String paramId) {
+    return prefix ? "${prefix}_${paramId}" : paramId
+}
+
+String getDisplayName(version = '') {
+    version = version ?: getOptaPlannerVersion()
+    return "Release ${version}"
+}
+
+String getOptaPlannerVersion() {
+    return params.OPTAPLANNER_VERSION ?: getReleaseProperty('optaplanner.version')
+}
+
+String getGitAuthor() {
+    return env.GIT_AUTHOR
+}
+
+String getArtifactsRepositoryParam() {
+    return env['ARTIFACTS_REPOSITORY'] ?: ''
+}
+
+String getOptaPlannerReleaseBranch() {
+    return params.OPTAPLANNER_RELEASE_BRANCH ?: (getReleaseProperty('optaplanner.branch') ?: util.getReleaseBranchFromVersion(getOptaPlannerVersion()))
+}
+
+String getStagingRepository() {
+    return getArtifactsRepositoryParam() ?: env.DEFAULT_STAGING_REPOSITORY
+}
+
+void setReleasePropertyIfneeded(String key, def value) {
+    if (value) {
+        releaseProperties[key] = value
+    }
+}
+
+void removeReleaseProperty(String key) {
+    if (hasReleaseProperty(key)) {
+        releaseProperties.remove(key)
+    }
+}
+
+boolean hasReleaseProperty(String key) {
+    return releaseProperties.containsKey(key)
+}
+
+def getReleaseProperty(String key) {
+    return releaseProperties[key]
+}
+
+boolean areArtifactsStaged() {
+    return hasReleaseProperty(ARTIFACTS_STAGING_STAGE)
+}
+
+void setArtifactsStaged() {
+    setReleasePropertyIfneeded(ARTIFACTS_STAGING_STAGE, true)
+}
+
+boolean areArtifactsReleased() {
+    return hasReleaseProperty(ARTIFACTS_RELEASE_STAGE)
+}
+
+void setArtifactsReleased() {
+    setReleasePropertyIfneeded(ARTIFACTS_RELEASE_STAGE, true)
+}

--- a/.ci/jenkins/config/branch.yaml
+++ b/.ci/jenkins/config/branch.yaml
@@ -1,0 +1,67 @@
+environment:
+  quarkus:
+    main:
+      enabled: true
+    branch:
+      enabled: true
+      version: '2.10'
+    lts:
+      enabled: true
+      version: '2.7'
+
+  native:
+    enabled: true
+
+  mandrel:
+    enabled: true
+    builder_image: quay.io/quarkus/ubi-quarkus-mandrel:22.0-java11
+
+  runtimes_bdd:
+    enabled: true
+
+productized_branch: true
+
+disable:
+  triggers: false
+
+repositories:
+  - name: optaplanner
+    branch: main
+  - name: optaweb-employee-rostering
+    branch: main
+  - name: optaweb-vehicle-routing
+    branch: main
+  - name: optaplanner-quickstarts
+    branch: development
+
+git:
+  author:
+    name: kiegroup
+    credentials_id: kie-ci
+    token_credentials_id: kie-ci3-token
+  bot_author:
+    name: bsig-gh-bot
+    credentials_id: bsig-gh-bot
+  jenkins_config_path: .ci/jenkins
+maven:
+  settings_file_id: kogito_release_settings
+  nexus:
+    release_url: https://repository.jboss.org/nexus
+    release_repository: jboss-releases-repository
+    staging_profile_url: https://repository.jboss.org/nexus/content/groups/kogito-public/
+    staging_profile_id: 2161b7b8da0080
+    build_promotion_profile_id: ea49ccd6f174
+  artifacts_repository: ''
+  pr_checks:
+    repository:
+      url: https://bxms-qe.rhev-ci-vms.eng.rdu2.redhat.com:8443/nexus/content/repositories/kogito-runtimes-pr-full-testing/
+      creds_id: unpacks-zip-on-qa-nexus
+cloud:
+  image:
+    registry_credentials_nightly: nightly_kogito
+    registry_credentials_release: release_kogito
+    registry: quay.io
+    namespace: kiegroup
+    latest_git_branch: main
+jenkins:
+  email_creds_id: OPTAPLANNER_CI_EMAIL

--- a/.ci/jenkins/config/main.yaml
+++ b/.ci/jenkins/config/main.yaml
@@ -1,0 +1,25 @@
+ecosystem:
+  main_project: optaplanner
+  projects:
+  - name: optaplanner
+    regexs:
+    - opta.*
+
+git:
+  branches:
+  - name: main
+  main_branch:
+    default: main
+
+seed:
+  config_file:
+    git:
+      repository: optaplanner
+      author:
+        name: kiegroup
+        credentials_id: kie-ci
+      branch: main
+    path: .ci/jenkins/config/branch.yaml
+
+jenkins:
+  email_creds_id: OPTAPLANNER_CI_EMAIL

--- a/.ci/jenkins/dsl/test.sh
+++ b/.ci/jenkins/dsl/test.sh
@@ -1,5 +1,11 @@
 #!/bin/bash -e
 
+script_dir_path=$(cd `dirname "${BASH_SOURCE[0]}"`; pwd -P)
+
+export DSL_DEFAULT_MAIN_CONFIG_FILE_REPO=kiegroup/optaplanner
+export DSL_DEFAULT_MAIN_CONFIG_FILE_REF=main
+export DSL_DEFAULT_MAIN_CONFIG_FILE_PATH=.ci/jenkins/config/main.yaml
+
 file=$(mktemp)
 # For more usage of the script, use ./test.sh -h
 curl -o ${file} https://raw.githubusercontent.com/kiegroup/kogito-pipelines/main/dsl/seed/scripts/seed_test.sh

--- a/.github/workflows/jenkins-tests-PR.yml
+++ b/.github/workflows/jenkins-tests-PR.yml
@@ -10,13 +10,9 @@ jobs:
   dsl-tests:
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout 
-      uses: actions/checkout@v2
-
-    - name: Set up JDK 1.11
-      uses: actions/setup-java@v1
+    - name: DSL tests
+      uses: kiegroup/kogito-pipelines/.ci/actions/dsl-tests@main
       with:
-        java-version: 11
-
-    - name: Test DSL
-      run: .ci/jenkins/dsl/test.sh -h ${{ github.head_ref }} -r ${{ github.event.pull_request.head.repo.full_name }} -b ${{ github.base_ref }} -t ${{ github.event.pull_request.base.repo.full_name }} .ci/jenkins/dsl
+        main-config-file-repo: kiegroup/optaplanner
+        main-config-file-ref: main
+        main-config-file-path: .ci/jenkins/config/main.yaml


### PR DESCRIPTION
Extract OptaPlanner DSL config and move specific pipelines to OptaPlanner repository.
That way OptaPlanner will benefit from its own release branch and setup.

There is way for optimization, for example nightly/release jobs calling only one deploy job. But ideally, optawebs and optaplanner-quickstarts should have their own deploy/promote jobs.
This will come later in another enhancement and should not impact yet the jobs.

Tests:
- [x] Test DSL generation
- [x] Test Nightly job
- [x] Check PR job
- [x] Test Release job
- [x] Test quarkus update all job
- [x] Test prepare release branch job
- [x] Test update optaplanner drools job