### PR TITLE
Add Score.abs() for GreatDelugeAlgorithm.

### DIFF
--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/api/score/Score.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/api/score/Score.java
@@ -112,7 +112,7 @@ public interface Score<Score_ extends Score<Score_>> extends Comparable<Score_> 
     /**
      * Returns a Score whose value is (|this|).
      *
-     * @return |this|
+     * @return never null
      */
     Score_ abs();
 

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/api/score/Score.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/api/score/Score.java
@@ -110,7 +110,7 @@ public interface Score<Score_ extends Score<Score_>> extends Comparable<Score_> 
     Score_ negate();
 
     /**
-     * Returns a Score whose value is (|this|).
+     * Returns a Score whose value is the absolute value of the score, i.e. |this|.
      *
      * @return never null
      */

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/api/score/Score.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/api/score/Score.java
@@ -110,6 +110,13 @@ public interface Score<Score_ extends Score<Score_>> extends Comparable<Score_> 
     Score_ negate();
 
     /**
+     * Returns a Score whose value is (|this|).
+     *
+     * @return |this|
+     */
+    Score_ abs();
+
+    /**
      * Returns a Score, all levels of which are zero.
      *
      * @return never null

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/api/score/buildin/bendable/BendableScore.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/api/score/buildin/bendable/BendableScore.java
@@ -302,6 +302,19 @@ public final class BendableScore extends AbstractBendableScore<BendableScore> {
     }
 
     @Override
+    public BendableScore abs() {
+        int[] newHardScores = new int[hardScores.length];
+        int[] newSoftScores = new int[softScores.length];
+        for (int i = 0; i < newHardScores.length; i++) {
+            newHardScores[i] = Math.abs(hardScores[i]);
+        }
+        for (int i = 0; i < newSoftScores.length; i++) {
+            newSoftScores[i] = Math.abs(softScores[i]);
+        }
+        return new BendableScore(Math.abs(initScore), newHardScores, newSoftScores);
+    }
+
+    @Override
     public BendableScore zero() {
         return BendableScore.zero(getHardLevelsSize(), getSoftLevelsSize());
     }

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/api/score/buildin/bendablebigdecimal/BendableBigDecimalScore.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/api/score/buildin/bendablebigdecimal/BendableBigDecimalScore.java
@@ -327,6 +327,19 @@ public final class BendableBigDecimalScore extends AbstractBendableScore<Bendabl
     }
 
     @Override
+    public BendableBigDecimalScore abs() {
+        BigDecimal[] newHardScores = new BigDecimal[hardScores.length];
+        BigDecimal[] newSoftScores = new BigDecimal[softScores.length];
+        for (int i = 0; i < newHardScores.length; i++) {
+            newHardScores[i] = hardScores[i].abs();
+        }
+        for (int i = 0; i < newSoftScores.length; i++) {
+            newSoftScores[i] = softScores[i].abs();
+        }
+        return new BendableBigDecimalScore(Math.abs(initScore), newHardScores, newSoftScores);
+    }
+
+    @Override
     public BendableBigDecimalScore zero() {
         return BendableBigDecimalScore.zero(getHardLevelsSize(), getSoftLevelsSize());
     }

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/api/score/buildin/bendablelong/BendableLongScore.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/api/score/buildin/bendablelong/BendableLongScore.java
@@ -300,6 +300,19 @@ public final class BendableLongScore extends AbstractBendableScore<BendableLongS
     }
 
     @Override
+    public BendableLongScore abs() {
+        long[] newHardScores = new long[hardScores.length];
+        long[] newSoftScores = new long[softScores.length];
+        for (int i = 0; i < newHardScores.length; i++) {
+            newHardScores[i] = Math.abs(hardScores[i]);
+        }
+        for (int i = 0; i < newSoftScores.length; i++) {
+            newSoftScores[i] = Math.abs(softScores[i]);
+        }
+        return new BendableLongScore(Math.abs(initScore), newHardScores, newSoftScores);
+    }
+
+    @Override
     public BendableLongScore zero() {
         return BendableLongScore.zero(getHardLevelsSize(), getSoftLevelsSize());
     }

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/api/score/buildin/hardmediumsoft/HardMediumSoftScore.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/api/score/buildin/hardmediumsoft/HardMediumSoftScore.java
@@ -188,6 +188,11 @@ public final class HardMediumSoftScore extends AbstractScore<HardMediumSoftScore
     }
 
     @Override
+    public HardMediumSoftScore abs() {
+        return new HardMediumSoftScore(Math.abs(initScore), Math.abs(hardScore), Math.abs(mediumScore), Math.abs(softScore));
+    }
+
+    @Override
     public HardMediumSoftScore zero() {
         return HardMediumSoftScore.ZERO;
     }

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/api/score/buildin/hardmediumsoftbigdecimal/HardMediumSoftBigDecimalScore.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/api/score/buildin/hardmediumsoftbigdecimal/HardMediumSoftBigDecimalScore.java
@@ -205,6 +205,11 @@ public final class HardMediumSoftBigDecimalScore extends AbstractScore<HardMediu
     }
 
     @Override
+    public HardMediumSoftBigDecimalScore abs() {
+        return new HardMediumSoftBigDecimalScore(Math.abs(initScore), hardScore.abs(), mediumScore.abs(), softScore.abs());
+    }
+
+    @Override
     public HardMediumSoftBigDecimalScore zero() {
         return HardMediumSoftBigDecimalScore.ZERO;
     }

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/api/score/buildin/hardmediumsoftlong/HardMediumSoftLongScore.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/api/score/buildin/hardmediumsoftlong/HardMediumSoftLongScore.java
@@ -189,7 +189,8 @@ public final class HardMediumSoftLongScore extends AbstractScore<HardMediumSoftL
 
     @Override
     public HardMediumSoftLongScore abs() {
-        return new HardMediumSoftLongScore(Math.abs(initScore), Math.abs(hardScore), Math.abs(mediumScore), Math.abs(softScore));
+        return new HardMediumSoftLongScore(Math.abs(initScore), Math.abs(hardScore), Math.abs(mediumScore),
+                Math.abs(softScore));
     }
 
     @Override

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/api/score/buildin/hardmediumsoftlong/HardMediumSoftLongScore.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/api/score/buildin/hardmediumsoftlong/HardMediumSoftLongScore.java
@@ -188,6 +188,11 @@ public final class HardMediumSoftLongScore extends AbstractScore<HardMediumSoftL
     }
 
     @Override
+    public HardMediumSoftLongScore abs() {
+        return new HardMediumSoftLongScore(Math.abs(initScore), Math.abs(hardScore), Math.abs(mediumScore), Math.abs(softScore));
+    }
+
+    @Override
     public HardMediumSoftLongScore zero() {
         return HardMediumSoftLongScore.ZERO;
     }

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/api/score/buildin/hardsoft/HardSoftScore.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/api/score/buildin/hardsoft/HardSoftScore.java
@@ -153,6 +153,11 @@ public final class HardSoftScore extends AbstractScore<HardSoftScore> {
     }
 
     @Override
+    public HardSoftScore abs() {
+        return new HardSoftScore(Math.abs(initScore), Math.abs(hardScore), Math.abs(softScore));
+    }
+
+    @Override
     public HardSoftScore zero() {
         return HardSoftScore.ZERO;
     }

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/api/score/buildin/hardsoftbigdecimal/HardSoftBigDecimalScore.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/api/score/buildin/hardsoftbigdecimal/HardSoftBigDecimalScore.java
@@ -169,6 +169,11 @@ public final class HardSoftBigDecimalScore extends AbstractScore<HardSoftBigDeci
     }
 
     @Override
+    public HardSoftBigDecimalScore abs() {
+        return new HardSoftBigDecimalScore(Math.abs(initScore), hardScore.abs(), softScore.abs());
+    }
+
+    @Override
     public HardSoftBigDecimalScore zero() {
         return HardSoftBigDecimalScore.ZERO;
     }

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/api/score/buildin/hardsoftlong/HardSoftLongScore.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/api/score/buildin/hardsoftlong/HardSoftLongScore.java
@@ -153,6 +153,11 @@ public final class HardSoftLongScore extends AbstractScore<HardSoftLongScore> {
     }
 
     @Override
+    public HardSoftLongScore abs() {
+        return new HardSoftLongScore(Math.abs(initScore), Math.abs(hardScore), Math.abs(softScore));
+    }
+
+    @Override
     public HardSoftLongScore zero() {
         return HardSoftLongScore.ZERO;
     }

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/api/score/buildin/simple/SimpleScore.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/api/score/buildin/simple/SimpleScore.java
@@ -114,6 +114,11 @@ public final class SimpleScore extends AbstractScore<SimpleScore> {
     }
 
     @Override
+    public SimpleScore abs() {
+        return new SimpleScore(Math.abs(initScore), Math.abs(score));
+    }
+
+    @Override
     public SimpleScore zero() {
         return SimpleScore.ZERO;
     }

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/api/score/buildin/simplebigdecimal/SimpleBigDecimalScore.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/api/score/buildin/simplebigdecimal/SimpleBigDecimalScore.java
@@ -130,6 +130,11 @@ public final class SimpleBigDecimalScore extends AbstractScore<SimpleBigDecimalS
     }
 
     @Override
+    public SimpleBigDecimalScore abs() {
+        return new SimpleBigDecimalScore(Math.abs(initScore), score.abs());
+    }
+
+    @Override
     public SimpleBigDecimalScore zero() {
         return SimpleBigDecimalScore.ZERO;
     }

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/api/score/buildin/simplelong/SimpleLongScore.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/api/score/buildin/simplelong/SimpleLongScore.java
@@ -114,6 +114,11 @@ public final class SimpleLongScore extends AbstractScore<SimpleLongScore> {
     }
 
     @Override
+    public SimpleLongScore abs() {
+        return new SimpleLongScore(Math.abs(initScore), Math.abs(score));
+    }
+
+    @Override
     public SimpleLongScore zero() {
         return SimpleLongScore.ZERO;
     }

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/localsearch/decider/acceptor/greatdeluge/GreatDelugeAcceptor.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/localsearch/decider/acceptor/greatdeluge/GreatDelugeAcceptor.java
@@ -85,8 +85,8 @@ public class GreatDelugeAcceptor<Solution_> extends AbstractAcceptor<Solution_> 
             currentWaterLevelRatio += waterLevelIncrementRatio;
             currentWaterLevel = startingWaterLevel.add(
                     // TODO targetWaterLevel.subtract(startingWaterLevel).multiply(waterLevelIncrementRatio);
-                    // The startingWaterLevel.negate() is short for zeroScore.subtract(startingWaterLevel)
-                    startingWaterLevel.negate().multiply(currentWaterLevelRatio));
+                    // Use startingWaterLevel.abs() to keep the number being positive.
+                    startingWaterLevel.abs().multiply(currentWaterLevelRatio));
         }
     }
 

--- a/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/api/score/buildin/bendable/BendableScoreTest.java
+++ b/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/api/score/buildin/bendable/BendableScoreTest.java
@@ -277,6 +277,18 @@ class BendableScoreTest extends AbstractScoreTest {
     }
 
     @Test
+    void absHHSSS() {
+        assertThat(scoreDefinitionHHSSS.createScore(3, 4, 5, 0, 0).abs())
+                .isEqualTo(scoreDefinitionHHSSS.createScore(3, 4, 5, 0, 0));
+        assertThat(scoreDefinitionHHSSS.createScore(3, -4, 5, 0, 0).abs())
+                .isEqualTo(scoreDefinitionHHSSS.createScore(3, 4, 5, 0, 0));
+        assertThat(scoreDefinitionHHSSS.createScore(-3, 4, -5, 0, 0).abs())
+                .isEqualTo(scoreDefinitionHHSSS.createScore(3, 4, 5, 0, 0));
+        assertThat(scoreDefinitionHHSSS.createScore(-3, -4, -5, 0, 0).abs())
+                .isEqualTo(scoreDefinitionHHSSS.createScore(3, 4, 5, 0, 0));
+    }
+
+    @Test
     void equalsAndHashCodeHHSSS() {
         PlannerAssert.assertObjectsAreEqual(
                 scoreDefinitionHHSSS.createScore(-10, -20, -30, 0, 0),

--- a/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/api/score/buildin/bendable/BendableScoreTest.java
+++ b/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/api/score/buildin/bendable/BendableScoreTest.java
@@ -147,6 +147,14 @@ class BendableScoreTest extends AbstractScoreTest {
     }
 
     @Test
+    void absHSS() {
+        assertThat(scoreDefinitionHSS.createScore(3, 4, 5).abs()).isEqualTo(scoreDefinitionHSS.createScore(3, 4, 5));
+        assertThat(scoreDefinitionHSS.createScore(3, -4, 5).abs()).isEqualTo(scoreDefinitionHSS.createScore(3, 4, 5));
+        assertThat(scoreDefinitionHSS.createScore(-3, 4, -5).abs()).isEqualTo(scoreDefinitionHSS.createScore(3, 4, 5));
+        assertThat(scoreDefinitionHSS.createScore(-3, -4, -5).abs()).isEqualTo(scoreDefinitionHSS.createScore(3, 4, 5));
+    }
+
+    @Test
     void zero() {
         BendableScore manualZero = BendableScore.zero(0, 1);
         SoftAssertions.assertSoftly(softly -> {

--- a/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/api/score/buildin/bendablebigdecimal/BendableBigDecimalScoreTest.java
+++ b/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/api/score/buildin/bendablebigdecimal/BendableBigDecimalScoreTest.java
@@ -204,6 +204,18 @@ class BendableBigDecimalScoreTest extends AbstractScoreTest {
     }
 
     @Test
+    void absHSS() {
+        assertThat(scoreDefinitionHSS.createScore(THREE, FOUR, FIVE).abs())
+                .isEqualTo(scoreDefinitionHSS.createScore(THREE, FOUR, FIVE));
+        assertThat(scoreDefinitionHSS.createScore(THREE, MINUS_FOUR, FIVE).abs())
+                .isEqualTo(scoreDefinitionHSS.createScore(THREE, FOUR, FIVE));
+        assertThat(scoreDefinitionHSS.createScore(MINUS_THREE, FOUR, MINUS_FIVE).abs())
+                .isEqualTo(scoreDefinitionHSS.createScore(THREE, FOUR, FIVE));
+        assertThat(scoreDefinitionHSS.createScore(MINUS_THREE, MINUS_FOUR, MINUS_FIVE).abs())
+                .isEqualTo(scoreDefinitionHSS.createScore(THREE, FOUR, FIVE));
+    }
+
+    @Test
     void zero() {
         BendableBigDecimalScore manualZero = BendableBigDecimalScore.zero(0, 1);
         SoftAssertions.assertSoftly(softly -> {

--- a/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/api/score/buildin/bendablebigdecimal/BendableBigDecimalScoreTest.java
+++ b/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/api/score/buildin/bendablebigdecimal/BendableBigDecimalScoreTest.java
@@ -336,6 +336,18 @@ class BendableBigDecimalScoreTest extends AbstractScoreTest {
     }
 
     @Test
+    void absHHSSS() {
+        assertThat(scoreDefinitionHHSSS.createScore(THREE, FOUR, FIVE, ZERO, ZERO).abs())
+                .isEqualTo(scoreDefinitionHHSSS.createScore(THREE, FOUR, FIVE, ZERO, ZERO));
+        assertThat(scoreDefinitionHHSSS.createScore(THREE, MINUS_FOUR, FIVE, ZERO, ZERO).abs())
+                .isEqualTo(scoreDefinitionHHSSS.createScore(THREE, FOUR, FIVE, ZERO, ZERO));
+        assertThat(scoreDefinitionHHSSS.createScore(MINUS_THREE, FOUR, MINUS_FIVE, ZERO, ZERO).abs())
+                .isEqualTo(scoreDefinitionHHSSS.createScore(THREE, FOUR, FIVE, ZERO, ZERO));
+        assertThat(scoreDefinitionHHSSS.createScore(MINUS_THREE, MINUS_FOUR, MINUS_FIVE, ZERO, ZERO).abs())
+                .isEqualTo(scoreDefinitionHHSSS.createScore(THREE, FOUR, FIVE, ZERO, ZERO));
+    }
+
+    @Test
     void equalsAndHashCodeHHSSS() {
         PlannerAssert.assertObjectsAreEqual(
                 scoreDefinitionHHSSS.createScore(MINUS_TEN, MINUS_20, MINUS_30, ZERO, ZERO),

--- a/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/api/score/buildin/bendablelong/BendableLongScoreTest.java
+++ b/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/api/score/buildin/bendablelong/BendableLongScoreTest.java
@@ -151,6 +151,18 @@ class BendableLongScoreTest extends AbstractScoreTest {
     }
 
     @Test
+    void absHSS() {
+        assertThat(scoreDefinitionHSS.createScore(3000000000L, 4000000000L, 5000000000L).abs())
+                .isEqualTo(scoreDefinitionHSS.createScore(3000000000L, 4000000000L, 5000000000L));
+        assertThat(scoreDefinitionHSS.createScore(3000000000L, -4000000000L, 5000000000L).abs())
+                .isEqualTo(scoreDefinitionHSS.createScore(3000000000L, 4000000000L, 5000000000L));
+        assertThat(scoreDefinitionHSS.createScore(-3000000000L, 4000000000L, -5000000000L).abs())
+                .isEqualTo(scoreDefinitionHSS.createScore(3000000000L, 4000000000L, 5000000000L));
+        assertThat(scoreDefinitionHSS.createScore(-3000000000L, -4000000000L, -5000000000L).abs())
+                .isEqualTo(scoreDefinitionHSS.createScore(3000000000L, 4000000000L, 5000000000L));
+    }
+
+    @Test
     void zero() {
         BendableLongScore manualZero = BendableLongScore.zero(0, 1);
         SoftAssertions.assertSoftly(softly -> {

--- a/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/api/score/buildin/bendablelong/BendableLongScoreTest.java
+++ b/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/api/score/buildin/bendablelong/BendableLongScoreTest.java
@@ -283,6 +283,18 @@ class BendableLongScoreTest extends AbstractScoreTest {
     }
 
     @Test
+    void absHHSSS() {
+        assertThat(scoreDefinitionHHSSS.createScore(3000000000L, 4000000000L, 5000000000L, 0L, 0L).abs())
+                .isEqualTo(scoreDefinitionHHSSS.createScore(3000000000L, 4000000000L, 5000000000L, 0L, 0L));
+        assertThat(scoreDefinitionHHSSS.createScore(3000000000L, -4000000000L, 5000000000L, 0L, 0L).abs())
+                .isEqualTo(scoreDefinitionHHSSS.createScore(3000000000L, 4000000000L, 5000000000L, 0L, 0L));
+        assertThat(scoreDefinitionHHSSS.createScore(-3L, 4L, -5L, 0L, 0L).abs())
+                .isEqualTo(scoreDefinitionHHSSS.createScore(3L, 4L, 5L, 0L, 0L));
+        assertThat(scoreDefinitionHHSSS.createScore(-3L, -4L, -5L, 0L, 0L).abs())
+                .isEqualTo(scoreDefinitionHHSSS.createScore(3L, 4L, 5L, 0L, 0L));
+    }
+
+    @Test
     void equalsAndHashCodeHHSSS() {
         PlannerAssert.assertObjectsAreEqual(
                 scoreDefinitionHHSSS.createScore(-10000000000L, -20000000000L, -30000000000L, 0L, 0L),

--- a/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/api/score/buildin/hardmediumsoft/HardMediumSoftScoreTest.java
+++ b/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/api/score/buildin/hardmediumsoft/HardMediumSoftScoreTest.java
@@ -43,12 +43,10 @@ class HardMediumSoftScoreTest extends AbstractScoreTest {
 
     @Test
     void testToString() {
-        assertThatIllegalArgumentException().isThrownBy(() -> HardMediumSoftScore.parseScore("-147"));
-
-//        assertThat(HardMediumSoftScore.of(0, -258, -369).toString()).isEqualTo("0hard/-258medium/-369soft");
-//        assertThat(HardMediumSoftScore.of(-147, -258, -369).toString()).isEqualTo("-147hard/-258medium/-369soft");
-//        assertThat(HardMediumSoftScore.ofUninitialized(-7, -147, -258, -369).toString())
-//                .isEqualTo("-7init/-147hard/-258medium/-369soft");
+        assertThat(HardMediumSoftScore.of(0, -258, -369).toString()).isEqualTo("0hard/-258medium/-369soft");
+        assertThat(HardMediumSoftScore.of(-147, -258, -369).toString()).isEqualTo("-147hard/-258medium/-369soft");
+        assertThat(HardMediumSoftScore.ofUninitialized(-7, -147, -258, -369).toString())
+                .isEqualTo("-7init/-147hard/-258medium/-369soft");
     }
 
     @Test
@@ -80,7 +78,7 @@ class HardMediumSoftScoreTest extends AbstractScoreTest {
                 HardMediumSoftScore.of(-1, -300, 4000))).isEqualTo(HardMediumSoftScore.of(19, -320, 0));
         assertThat(HardMediumSoftScore.ofUninitialized(-70, 20, -20, -4000).add(
                 HardMediumSoftScore.ofUninitialized(-7, -1, -300, 4000)))
-                        .isEqualTo(HardMediumSoftScore.ofUninitialized(-77, 19, -320, 0));
+                .isEqualTo(HardMediumSoftScore.ofUninitialized(-77, 19, -320, 0));
     }
 
     @Test
@@ -89,7 +87,7 @@ class HardMediumSoftScoreTest extends AbstractScoreTest {
                 HardMediumSoftScore.of(-1, -300, 4000))).isEqualTo(HardMediumSoftScore.of(21, 280, -8000));
         assertThat(HardMediumSoftScore.ofUninitialized(-70, 20, -20, -4000).subtract(
                 HardMediumSoftScore.ofUninitialized(-7, -1, -300, 4000)))
-                        .isEqualTo(HardMediumSoftScore.ofUninitialized(-63, 21, 280, -8000));
+                .isEqualTo(HardMediumSoftScore.ofUninitialized(-63, 21, 280, -8000));
     }
 
     @Test

--- a/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/api/score/buildin/hardmediumsoft/HardMediumSoftScoreTest.java
+++ b/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/api/score/buildin/hardmediumsoft/HardMediumSoftScoreTest.java
@@ -43,10 +43,12 @@ class HardMediumSoftScoreTest extends AbstractScoreTest {
 
     @Test
     void testToString() {
-        assertThat(HardMediumSoftScore.of(0, -258, -369).toString()).isEqualTo("0hard/-258medium/-369soft");
-        assertThat(HardMediumSoftScore.of(-147, -258, -369).toString()).isEqualTo("-147hard/-258medium/-369soft");
-        assertThat(HardMediumSoftScore.ofUninitialized(-7, -147, -258, -369).toString())
-                .isEqualTo("-7init/-147hard/-258medium/-369soft");
+        assertThatIllegalArgumentException().isThrownBy(() -> HardMediumSoftScore.parseScore("-147"));
+
+//        assertThat(HardMediumSoftScore.of(0, -258, -369).toString()).isEqualTo("0hard/-258medium/-369soft");
+//        assertThat(HardMediumSoftScore.of(-147, -258, -369).toString()).isEqualTo("-147hard/-258medium/-369soft");
+//        assertThat(HardMediumSoftScore.ofUninitialized(-7, -147, -258, -369).toString())
+//                .isEqualTo("-7init/-147hard/-258medium/-369soft");
     }
 
     @Test

--- a/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/api/score/buildin/hardmediumsoft/HardMediumSoftScoreTest.java
+++ b/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/api/score/buildin/hardmediumsoft/HardMediumSoftScoreTest.java
@@ -78,7 +78,7 @@ class HardMediumSoftScoreTest extends AbstractScoreTest {
                 HardMediumSoftScore.of(-1, -300, 4000))).isEqualTo(HardMediumSoftScore.of(19, -320, 0));
         assertThat(HardMediumSoftScore.ofUninitialized(-70, 20, -20, -4000).add(
                 HardMediumSoftScore.ofUninitialized(-7, -1, -300, 4000)))
-                        .isEqualTo(HardMediumSoftScore.ofUninitialized(-77, 19, -320, 0));
+                .isEqualTo(HardMediumSoftScore.ofUninitialized(-77, 19, -320, 0));
     }
 
     @Test
@@ -87,7 +87,7 @@ class HardMediumSoftScoreTest extends AbstractScoreTest {
                 HardMediumSoftScore.of(-1, -300, 4000))).isEqualTo(HardMediumSoftScore.of(21, 280, -8000));
         assertThat(HardMediumSoftScore.ofUninitialized(-70, 20, -20, -4000).subtract(
                 HardMediumSoftScore.ofUninitialized(-7, -1, -300, 4000)))
-                        .isEqualTo(HardMediumSoftScore.ofUninitialized(-63, 21, 280, -8000));
+                .isEqualTo(HardMediumSoftScore.ofUninitialized(-63, 21, 280, -8000));
     }
 
     @Test

--- a/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/api/score/buildin/hardmediumsoft/HardMediumSoftScoreTest.java
+++ b/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/api/score/buildin/hardmediumsoft/HardMediumSoftScoreTest.java
@@ -78,7 +78,7 @@ class HardMediumSoftScoreTest extends AbstractScoreTest {
                 HardMediumSoftScore.of(-1, -300, 4000))).isEqualTo(HardMediumSoftScore.of(19, -320, 0));
         assertThat(HardMediumSoftScore.ofUninitialized(-70, 20, -20, -4000).add(
                 HardMediumSoftScore.ofUninitialized(-7, -1, -300, 4000)))
-                .isEqualTo(HardMediumSoftScore.ofUninitialized(-77, 19, -320, 0));
+                        .isEqualTo(HardMediumSoftScore.ofUninitialized(-77, 19, -320, 0));
     }
 
     @Test
@@ -87,7 +87,7 @@ class HardMediumSoftScoreTest extends AbstractScoreTest {
                 HardMediumSoftScore.of(-1, -300, 4000))).isEqualTo(HardMediumSoftScore.of(21, 280, -8000));
         assertThat(HardMediumSoftScore.ofUninitialized(-70, 20, -20, -4000).subtract(
                 HardMediumSoftScore.ofUninitialized(-7, -1, -300, 4000)))
-                .isEqualTo(HardMediumSoftScore.ofUninitialized(-63, 21, 280, -8000));
+                        .isEqualTo(HardMediumSoftScore.ofUninitialized(-63, 21, 280, -8000));
     }
 
     @Test

--- a/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/api/score/buildin/hardmediumsoft/HardMediumSoftScoreTest.java
+++ b/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/api/score/buildin/hardmediumsoft/HardMediumSoftScoreTest.java
@@ -123,6 +123,14 @@ class HardMediumSoftScoreTest extends AbstractScoreTest {
     }
 
     @Test
+    void abs() {
+        assertThat(HardMediumSoftScore.of(3, 4, 5).abs()).isEqualTo(HardMediumSoftScore.of(3, 4, 5));
+        assertThat(HardMediumSoftScore.of(3, -4, 5).abs()).isEqualTo(HardMediumSoftScore.of(3, 4, 5));
+        assertThat(HardMediumSoftScore.of(-3, 4, -5).abs()).isEqualTo(HardMediumSoftScore.of(3, 4, 5));
+        assertThat(HardMediumSoftScore.of(-3, -4, -5).abs()).isEqualTo(HardMediumSoftScore.of(3, 4, 5));
+    }
+
+    @Test
     void zero() {
         HardMediumSoftScore manualZero = HardMediumSoftScore.of(0, 0, 0);
         SoftAssertions.assertSoftly(softly -> {

--- a/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/api/score/buildin/hardmediumsoftbigdecimal/HardMediumSoftBigDecimalScoreTest.java
+++ b/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/api/score/buildin/hardmediumsoftbigdecimal/HardMediumSoftBigDecimalScoreTest.java
@@ -197,20 +197,20 @@ class HardMediumSoftBigDecimalScoreTest extends AbstractScoreTest {
     void abs() {
         assertThat(HardMediumSoftBigDecimalScore.of(new BigDecimal("4.0"), new BigDecimal("25.0"), new BigDecimal("5.0"))
                 .abs())
-                .isEqualTo(HardMediumSoftBigDecimalScore.of(new BigDecimal("4.0"), new BigDecimal("25.0"),
-                        new BigDecimal("5.0")));
+                        .isEqualTo(HardMediumSoftBigDecimalScore.of(new BigDecimal("4.0"), new BigDecimal("25.0"),
+                                new BigDecimal("5.0")));
         assertThat(HardMediumSoftBigDecimalScore.of(new BigDecimal("4.0"), new BigDecimal("25.0"), new BigDecimal("-5.0"))
                 .abs())
-                .isEqualTo(HardMediumSoftBigDecimalScore.of(new BigDecimal("4.0"), new BigDecimal("25.0"),
-                        new BigDecimal("5.0")));
+                        .isEqualTo(HardMediumSoftBigDecimalScore.of(new BigDecimal("4.0"), new BigDecimal("25.0"),
+                                new BigDecimal("5.0")));
         assertThat(HardMediumSoftBigDecimalScore.of(new BigDecimal("-4.0"), new BigDecimal("3.0"), new BigDecimal("5.0"))
                 .abs())
-                .isEqualTo(HardMediumSoftBigDecimalScore.of(new BigDecimal("4.0"), new BigDecimal("3.0"),
-                        new BigDecimal("5.0")));
+                        .isEqualTo(HardMediumSoftBigDecimalScore.of(new BigDecimal("4.0"), new BigDecimal("3.0"),
+                                new BigDecimal("5.0")));
         assertThat(HardMediumSoftBigDecimalScore.of(new BigDecimal("-4.0"), new BigDecimal("-3.0"), new BigDecimal("-5.0"))
                 .abs())
-                .isEqualTo(HardMediumSoftBigDecimalScore.of(new BigDecimal("4.0"), new BigDecimal("3.0"),
-                        new BigDecimal("5.0")));
+                        .isEqualTo(HardMediumSoftBigDecimalScore.of(new BigDecimal("4.0"), new BigDecimal("3.0"),
+                                new BigDecimal("5.0")));
     }
 
     @Test

--- a/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/api/score/buildin/hardmediumsoftbigdecimal/HardMediumSoftBigDecimalScoreTest.java
+++ b/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/api/score/buildin/hardmediumsoftbigdecimal/HardMediumSoftBigDecimalScoreTest.java
@@ -194,6 +194,26 @@ class HardMediumSoftBigDecimalScoreTest extends AbstractScoreTest {
     }
 
     @Test
+    void abs() {
+        assertThat(HardMediumSoftBigDecimalScore.of(new BigDecimal("4.0"), new BigDecimal("25.0"), new BigDecimal("5.0"))
+                .abs())
+                .isEqualTo(HardMediumSoftBigDecimalScore.of(new BigDecimal("4.0"), new BigDecimal("25.0"),
+                        new BigDecimal("5.0")));
+        assertThat(HardMediumSoftBigDecimalScore.of(new BigDecimal("4.0"), new BigDecimal("25.0"), new BigDecimal("-5.0"))
+                .abs())
+                .isEqualTo(HardMediumSoftBigDecimalScore.of(new BigDecimal("4.0"), new BigDecimal("25.0"),
+                        new BigDecimal("5.0")));
+        assertThat(HardMediumSoftBigDecimalScore.of(new BigDecimal("-4.0"), new BigDecimal("3.0"), new BigDecimal("5.0"))
+                .abs())
+                .isEqualTo(HardMediumSoftBigDecimalScore.of(new BigDecimal("4.0"), new BigDecimal("3.0"),
+                        new BigDecimal("5.0")));
+        assertThat(HardMediumSoftBigDecimalScore.of(new BigDecimal("-4.0"), new BigDecimal("-3.0"), new BigDecimal("-5.0"))
+                .abs())
+                .isEqualTo(HardMediumSoftBigDecimalScore.of(new BigDecimal("4.0"), new BigDecimal("3.0"),
+                        new BigDecimal("5.0")));
+    }
+
+    @Test
     void zero() {
         HardMediumSoftBigDecimalScore manualZero =
                 HardMediumSoftBigDecimalScore.of(BigDecimal.ZERO, BigDecimal.ZERO, BigDecimal.ZERO);

--- a/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/api/score/buildin/hardmediumsoftlong/HardMediumSoftLongScoreTest.java
+++ b/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/api/score/buildin/hardmediumsoftlong/HardMediumSoftLongScoreTest.java
@@ -123,6 +123,14 @@ class HardMediumSoftLongScoreTest extends AbstractScoreTest {
     }
 
     @Test
+    void abs() {
+        assertThat(HardMediumSoftLongScore.of(3L, 4L, 5L).abs()).isEqualTo(HardMediumSoftLongScore.of(3L, 4L, 5L));
+        assertThat(HardMediumSoftLongScore.of(3L, -4L, 5L).abs()).isEqualTo(HardMediumSoftLongScore.of(3L, 4L, 5L));
+        assertThat(HardMediumSoftLongScore.of(-3L, 4L, -5L).abs()).isEqualTo(HardMediumSoftLongScore.of(3L, 4L, 5L));
+        assertThat(HardMediumSoftLongScore.of(-3L, -4L, -5L).abs()).isEqualTo(HardMediumSoftLongScore.of(3L, 4L, 5L));
+    }
+
+    @Test
     void zero() {
         HardMediumSoftLongScore manualZero = HardMediumSoftLongScore.of(0, 0, 0);
         SoftAssertions.assertSoftly(softly -> {

--- a/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/api/score/buildin/hardsoft/HardSoftScoreTest.java
+++ b/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/api/score/buildin/hardsoft/HardSoftScoreTest.java
@@ -111,6 +111,14 @@ class HardSoftScoreTest extends AbstractScoreTest {
     }
 
     @Test
+    void abs() {
+        assertThat(HardSoftScore.of(4, 5).abs()).isEqualTo(HardSoftScore.of(4, 5));
+        assertThat(HardSoftScore.of(-4, 5).abs()).isEqualTo(HardSoftScore.of(4, 5));
+        assertThat(HardSoftScore.of(4, -5).abs()).isEqualTo(HardSoftScore.of(4, 5));
+        assertThat(HardSoftScore.of(-4, -5).abs()).isEqualTo(HardSoftScore.of(4, 5));
+    }
+
+    @Test
     void zero() {
         HardSoftScore manualZero = HardSoftScore.of(0, 0);
         SoftAssertions.assertSoftly(softly -> {

--- a/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/api/score/buildin/hardsoftbigdecimal/HardSoftBigDecimalScoreTest.java
+++ b/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/api/score/buildin/hardsoftbigdecimal/HardSoftBigDecimalScoreTest.java
@@ -142,6 +142,18 @@ class HardSoftBigDecimalScoreTest extends AbstractScoreTest {
     }
 
     @Test
+    void abs() {
+        assertThat(HardSoftBigDecimalScore.of(new BigDecimal("4.0"), new BigDecimal("5.0")).abs())
+                .isEqualTo(HardSoftBigDecimalScore.of(new BigDecimal("4.0"), new BigDecimal("5.0")));
+        assertThat(HardSoftBigDecimalScore.of(new BigDecimal("4.0"), new BigDecimal("-5.0")).abs())
+                .isEqualTo(HardSoftBigDecimalScore.of(new BigDecimal("4.0"), new BigDecimal("5.0")));
+        assertThat(HardSoftBigDecimalScore.of(new BigDecimal("-4.0"), new BigDecimal("5.0")).abs())
+                .isEqualTo(HardSoftBigDecimalScore.of(new BigDecimal("4.0"), new BigDecimal("5.0")));
+        assertThat(HardSoftBigDecimalScore.of(new BigDecimal("-4.0"), new BigDecimal("-5.0")).abs())
+                .isEqualTo(HardSoftBigDecimalScore.of(new BigDecimal("4.0"), new BigDecimal("5.0")));
+    }
+
+    @Test
     void zero() {
         HardSoftBigDecimalScore manualZero = HardSoftBigDecimalScore.of(BigDecimal.ZERO, BigDecimal.ZERO);
         SoftAssertions.assertSoftly(softly -> {

--- a/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/api/score/buildin/hardsoftlong/HardSoftLongScoreTest.java
+++ b/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/api/score/buildin/hardsoftlong/HardSoftLongScoreTest.java
@@ -116,6 +116,14 @@ class HardSoftLongScoreTest extends AbstractScoreTest {
     }
 
     @Test
+    void abs() {
+        assertThat(HardSoftLongScore.of(4L, 5L).abs()).isEqualTo(HardSoftLongScore.of(4L, 5L));
+        assertThat(HardSoftLongScore.of(4L, -5L).abs()).isEqualTo(HardSoftLongScore.of(4L, 5L));
+        assertThat(HardSoftLongScore.of(-4L, 5L).abs()).isEqualTo(HardSoftLongScore.of(4L, 5L));
+        assertThat(HardSoftLongScore.of(-4L, -5L).abs()).isEqualTo(HardSoftLongScore.of(4L, 5L));
+    }
+
+    @Test
     void zero() {
         HardSoftLongScore manualZero = HardSoftLongScore.of(0, 0);
         SoftAssertions.assertSoftly(softly -> {

--- a/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/api/score/buildin/simple/SimpleScoreTest.java
+++ b/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/api/score/buildin/simple/SimpleScoreTest.java
@@ -88,6 +88,12 @@ class SimpleScoreTest extends AbstractScoreTest {
     }
 
     @Test
+    void abs() {
+        assertThat(SimpleScore.of(5).abs()).isEqualTo(SimpleScore.of(5));
+        assertThat(SimpleScore.of(-5).abs()).isEqualTo(SimpleScore.of(5));
+    }
+
+    @Test
     void zero() {
         SimpleScore manualZero = SimpleScore.of(0);
         SoftAssertions.assertSoftly(softly -> {

--- a/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/api/score/buildin/simplebigdecimal/SimpleBigDecimalScoreTest.java
+++ b/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/api/score/buildin/simplebigdecimal/SimpleBigDecimalScoreTest.java
@@ -105,6 +105,14 @@ class SimpleBigDecimalScoreTest extends AbstractScoreTest {
     }
 
     @Test
+    void abs() {
+        assertThat(SimpleBigDecimalScore.of(new BigDecimal("5.0")).abs())
+                .isEqualTo(SimpleBigDecimalScore.of(new BigDecimal("5.0")));
+        assertThat(SimpleBigDecimalScore.of(new BigDecimal("-5.0")).abs())
+                .isEqualTo(SimpleBigDecimalScore.of(new BigDecimal("5.0")));
+    }
+
+    @Test
     void zero() {
         SimpleBigDecimalScore manualZero = SimpleBigDecimalScore.of(BigDecimal.ZERO);
         SoftAssertions.assertSoftly(softly -> {

--- a/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/api/score/buildin/simplelong/SimpleLongScoreTest.java
+++ b/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/api/score/buildin/simplelong/SimpleLongScoreTest.java
@@ -88,6 +88,12 @@ class SimpleLongScoreTest extends AbstractScoreTest {
     }
 
     @Test
+    void abs() {
+        assertThat(SimpleLongScore.of(5L).abs()).isEqualTo(SimpleLongScore.of(5L));
+        assertThat(SimpleLongScore.of(-5L).abs()).isEqualTo(SimpleLongScore.of(5L));
+    }
+
+    @Test
     void zero() {
         SimpleLongScore manualZero = SimpleLongScore.of(0);
         SoftAssertions.assertSoftly(softly -> {


### PR DESCRIPTION
Hi there,

I noticed one tiny problem in the great deluge algorithm. In the end of each step, the current water level will be updated by a certain amount. It works well when the configuration is set to be increasing by a fixed score. However, if I set the increment as a ratio (Using ratio is a brilliant idea by the way), then the algorithm will only work when the starting water level is negative. In fact, to make sure the water level keep increasing, every increment of water level should be positive. But it will be negative when the starting water level is positive. So .negate() is not suitable for all scenarios, for example, when someone has more reward score than penalty score. Maybe taking absolute value is a better idea. I add an abs.() function for the score so that the certain amount will always be positive and the water level can keep increasing.


<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.
-->

### JIRA

<!-- Add a JIRA ticket link if it exists. -->
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
- https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
- https://github.com/kiegroup/drools/pull/3000
- https://github.com/kiegroup/optaplanner/pull/899
- etc.
-->

### Checklist
- [ ] Documentation updated if applicable.
- [ ] Upgrade recipe provided if applicable.

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request checks</b>  
  Please add comment: <b>Jenkins retest this</b>

- for a <b>specific pull request check</b>  
  please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] tests</b>
  
- for a <b>full downstream build</b> 
  - for <b>jenkins</b> job: 
    please add comment: <b>Jenkins run fdb</b>
  - for <b>github actions</b> job: 
    add the label `run_fdb`

- for a <b>compile downstream build</b>  
  please add comment: <b>Jenkins run cdb</b>

- for a <b>full production downstream build</b>  
  please add comment: <b>Jenkins execute product fdb</b>

- for an <b>upstream build</b>  
  please add comment: <b>Jenkins run upstream</b>

- for <b>quarkus branch checks</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins run quarkus-branch</b>

- for a <b>quarkus branch specific check</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] quarkus-branch</b>

- for <b>quarkus main checks</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins run quarkus-main</b>

- for a <b>specific quarkus main check</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] quarkus-branch</b>

- for <b>native checks</b>  
  Run native checks  
  Please add comment: <b>Jenkins run native</b>

- for a <b>specific native check</b>  
  Run native checks 
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] native</b>

- for <b>mandrel checks</b>  
  Run native checks against Mandrel image
  Please add comment: <b>Jenkins run mandrel</b>

- for a <b>specific mandrel check</b>  
  Run native checks against Mandrel image  
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] mandrel</b>
</details>

### CI Status

 You can check OptaPlanner repositories CI status from [Chain Status webpage](https://kiegroup.github.io/optaplanner/).