### PR TITLE
Fallback config to branch 8.24.x

### DIFF
--- a/.ci/jenkins/config/main.yaml
+++ b/.ci/jenkins/config/main.yaml
@@ -7,7 +7,7 @@ ecosystem:
 git:
   branches:
   - name: main
-  - name: optaplanner-8.24.x
+  - name: 8.24.x
   main_branch:
     default: main
 seed:


### PR DESCRIPTION
depends on https://github.com/kiegroup/optaplanner/pull/2054

`optaplanner-8.24.x` is causing issues in nightly pipelines so falling back to simple `8.24.x`