### PR TITLE
Fix void with-method

### DIFF
--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/config/phase/custom/CustomPhaseConfig.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/config/phase/custom/CustomPhaseConfig.java
@@ -73,8 +73,9 @@ public class CustomPhaseConfig extends PhaseConfig<CustomPhaseConfig> {
         return this;
     }
 
-    public void withCustomProperties(Map<String, String> customProperties) {
+    public CustomPhaseConfig withCustomProperties(Map<String, String> customProperties) {
         this.customProperties = customProperties;
+        return this;
     }
 
     public CustomPhaseConfig withCustomPhaseCommandList(List<CustomPhaseCommand> customPhaseCommandList) {


### PR DESCRIPTION
Trivial two-line bug fix.

CustomPhaseConfig.withCustomProperties(Map) was void. Now returns the
instance after setting the property.

### JIRA

There is no issue for this, as far as I know.