### PR TITLE
Desugared use of APIs incompatible with Android

### DIFF
--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/BavetConstraintSessionFactory.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/BavetConstraintSessionFactory.java
@@ -74,7 +74,7 @@ public final class BavetConstraintSessionFactory<Solution_, Score_ extends Score
                 }
             }
         }
-        return new BavetConstraintSession<>(scoreInliner, declaredClassToNodeMap, nodeList.toArray(AbstractNode[]::new));
+        return new BavetConstraintSession<>(scoreInliner, declaredClassToNodeMap, nodeList.toArray(new AbstractNode[0]));
     }
 
 }

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/BavetConstraintStreamScoreDirectorFactory.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/BavetConstraintStreamScoreDirectorFactory.java
@@ -49,7 +49,7 @@ public final class BavetConstraintStreamScoreDirectorFactory<Solution_, Score_ e
 
     @Override
     public Constraint[] getConstraints() {
-        return constraintList.toArray(Constraint[]::new);
+        return constraintList.toArray(new Constraint[0]);
     }
 
 }

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/score/stream/JoinerSupport.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/score/stream/JoinerSupport.java
@@ -1,5 +1,6 @@
 package org.optaplanner.core.impl.score.stream;
 
+import java.util.Iterator;
 import java.util.ServiceLoader;
 
 public final class JoinerSupport {
@@ -10,11 +11,14 @@ public final class JoinerSupport {
         if (INSTANCE == null) {
             synchronized (JoinerSupport.class) {
                 if (INSTANCE == null) {
-                    INSTANCE = ServiceLoader.load(JoinerService.class)
-                            .findFirst()
-                            .orElseThrow(() -> new IllegalStateException("Joiners not found.\n"
-                                    + "Maybe include org.optaplanner:optaplanner-constraint-streams dependency in your project?\n"
-                                    + "Maybe ensure your uberjar bundles META-INF/services from included JAR files?"));
+                    Iterator<JoinerService> servicesIterator = ServiceLoader.load(JoinerService.class).iterator();
+                    if (!servicesIterator.hasNext()) {
+                        throw new IllegalStateException("Joiners not found.\n"
+                                + "Maybe include org.optaplanner:optaplanner-constraint-streams dependency in your project?\n"
+                                + "Maybe ensure your uberjar bundles META-INF/services from included JAR files?");
+                    } else {
+                        INSTANCE = servicesIterator.next();
+                    }
                 }
             }
         }

--- a/optaplanner-docs/src/modules/ROOT/pages/integration/integration.adoc
+++ b/optaplanner-docs/src/modules/ROOT/pages/integration/integration.adoc
@@ -562,18 +562,19 @@ Integration with OSGi is not supported.
 Android is not a complete JVM (because some JDK libraries are missing),
 but OptaPlanner works on Android with xref:score-calculation/score-calculation.adoc#easyJavaScoreCalculation[easy Java] or xref:score-calculation/score-calculation.adoc#incrementalJavaScoreCalculation[incremental Java] score calculation.
 The Drools rule engine does not work on Android yet,
-so xref:constraint-streams/constraint-streams.adoc#constraintStreams[Constraint Streams] and xref:drools-score-calculation/drools-score-calculation.adoc#droolsScoreCalculation[Drools score calculation] doesn't work on Android and its dependencies need to be excluded.
+so xref:constraint-streams/constraint-streams.adoc#constraintStreams[Constraint Streams] and xref:drools-score-calculation/drools-score-calculation.adoc#droolsScoreCalculation[Drools score calculation (Deprecated)] doesn't work on Android and its dependencies need to be excluded.
 
 *Workaround to use OptaPlanner on Android:*
 
-. Add a dependency to the `build.gradle` file in your Android project to exclude `org.drools` and `xmlpull` dependencies:
+. Add a dependency to the `build.gradle` file in your Android project to exclude OptaPlanner's `optaplanner-constraint-streams-drools` and `optaplanner-constraint-drl` modules:
 +
 [source,gradle]
 ----
 dependencies {
     ...
-    compile('org.optaplanner:optaplanner-core:...') {
-        exclude group: 'org.drools'
+    implementation('org.optaplanner:optaplanner-core:...') {
+        exclude group: 'org.optaplanner', module: 'optaplanner-constraint-streams-drools'
+        exclude group: 'org.optaplanner', module: 'optaplanner-constraint-drl'
     }
     ...
 }


### PR DESCRIPTION
Android unfortunately supports only a subset of the current JDK API. This has so far not been a problem for OptaPlanner, but after some recent changes OptaPlanner apparently started using some of the unsupported APIs, causing runtime crashes.

[ServiceLoader.findFirst()](https://developer.android.com/reference/java/util/ServiceLoader) is not currently supported by Android. `Collection.toArray(IntFunction<T[]>)` [is available as of Android API Level 33](https://developer.android.com/reference/java/util/Collection#toArray(java.util.function.IntFunction%3CT[]%3E)) but [is not available as a "desugared" API yet](https://developer.android.com/studio/write/java8-support-table), which means it can not be used in apps that want to maintain backwards compatibility.

Fortunately, this is easily fixed. Both APIs are convenience methods, not adding any crucial new features. This PR replaces their use with the slightly-less-nice-looking-but-Android-compatible counterparts. I didn't touch any usage for example in the Drools module, as that isn't compatible with Android in the first place.