### PR TITLE
PLANNER-2752 Check Jar/Class-Files for compliance with Android

### DIFF
--- a/build/optaplanner-build-parent/pom.xml
+++ b/build/optaplanner-build-parent/pom.xml
@@ -820,6 +820,39 @@
         <sonar.pullrequest.base>${env.ghprbTargetBranch}</sonar.pullrequest.base>
       </properties>
     </profile>
+    <profile>
+      <id>android-api-compatibility-check</id>
+      <activation>
+        <property>
+          <name>android-api-compatibility-check</name>
+        </property>
+      </activation>
+        <build>
+          <pluginManagement>
+            <plugins>
+            <plugin>
+              <groupId>org.codehaus.mojo</groupId>
+              <artifactId>animal-sniffer-maven-plugin</artifactId>
+              <version>1.20</version>
+              <configuration>
+                <signature>
+                  <groupId>net.sf.androidscents.signature</groupId>
+                  <artifactId>android-api-level-32</artifactId>
+                  <version>12_r1</version>
+                </signature>
+              </configuration>
+              <executions>
+                <execution>
+                  <goals>
+                    <goal>check</goal>
+                  </goals>
+                </execution>
+              </executions>
+            </plugin>
+            </plugins>
+          </pluginManagement>
+      </build>
+    </profile>
 
     <profile>
       <id>quickProfile</id>
@@ -829,6 +862,7 @@
         </property>
       </activation>
       <properties>
+        <animal.sniffer.skip>true</animal.sniffer.skip>
         <enforcer.skip>true</enforcer.skip>
         <revapi.skip>true</revapi.skip>
         <skipTests>true</skipTests>
@@ -862,5 +896,4 @@
       </build>
     </profile>
   </profiles>
-
 </project>

--- a/build/optaplanner-build-parent/pom.xml
+++ b/build/optaplanner-build-parent/pom.xml
@@ -820,39 +820,6 @@
         <sonar.pullrequest.base>${env.ghprbTargetBranch}</sonar.pullrequest.base>
       </properties>
     </profile>
-    <profile>
-      <id>android-api-compatibility-check</id>
-      <activation>
-        <property>
-          <name>android-api-compatibility-check</name>
-        </property>
-      </activation>
-        <build>
-          <pluginManagement>
-            <plugins>
-            <plugin>
-              <groupId>org.codehaus.mojo</groupId>
-              <artifactId>animal-sniffer-maven-plugin</artifactId>
-              <version>1.20</version>
-              <configuration>
-                <signature>
-                  <groupId>net.sf.androidscents.signature</groupId>
-                  <artifactId>android-api-level-32</artifactId>
-                  <version>12_r1</version>
-                </signature>
-              </configuration>
-              <executions>
-                <execution>
-                  <goals>
-                    <goal>check</goal>
-                  </goals>
-                </execution>
-              </executions>
-            </plugin>
-            </plugins>
-          </pluginManagement>
-      </build>
-    </profile>
 
     <profile>
       <id>quickProfile</id>
@@ -862,7 +829,6 @@
         </property>
       </activation>
       <properties>
-        <animal.sniffer.skip>true</animal.sniffer.skip>
         <enforcer.skip>true</enforcer.skip>
         <revapi.skip>true</revapi.skip>
         <skipTests>true</skipTests>
@@ -879,6 +845,31 @@
         </property>
       </activation>
       <build>
+        <pluginManagement>
+          <plugins>
+            <plugin>
+              <groupId>org.codehaus.mojo</groupId>
+              <artifactId>animal-sniffer-maven-plugin</artifactId>
+              <version>1.20</version>
+              <configuration>
+                <signature>
+                  <groupId>net.sf.androidscents.signature</groupId>
+                  <artifactId>android-api-level-32</artifactId>
+                  <version>12_r1</version>
+                </signature>
+              </configuration>
+              <executions>
+                <execution>
+                  <id>animal-sniffer</id>
+                  <phase>verify</phase>
+                  <goals>
+                    <goal>check</goal>
+                  </goals>
+                </execution>
+              </executions>
+            </plugin>
+          </plugins>
+        </pluginManagement>
         <plugins>
           <plugin> <!-- Make sure the build fails-fast on Javadoc issues. -->
             <artifactId>maven-javadoc-plugin</artifactId>

--- a/build/optaplanner-build-parent/pom.xml
+++ b/build/optaplanner-build-parent/pom.xml
@@ -857,6 +857,10 @@
                   <artifactId>android-api-level-32</artifactId>
                   <version>12_r1</version>
                 </signature>
+                <ignores>
+                  <ignore>java.lang.invoke.LambdaMetafactory</ignore>
+                  <ignore>java.lang.invoke.MethodHandle</ignore>
+                </ignores>
               </configuration>
               <executions>
                 <execution>

--- a/core/optaplanner-constraint-drl/pom.xml
+++ b/core/optaplanner-constraint-drl/pom.xml
@@ -108,6 +108,10 @@
           </ignoredUnusedDeclaredDependencies>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>animal-sniffer-maven-plugin</artifactId>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/core/optaplanner-constraint-drl/pom.xml
+++ b/core/optaplanner-constraint-drl/pom.xml
@@ -108,10 +108,6 @@
           </ignoredUnusedDeclaredDependencies>
         </configuration>
       </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>animal-sniffer-maven-plugin</artifactId>
-      </plugin>
     </plugins>
   </build>
 </project>

--- a/core/optaplanner-constraint-streams-bavet/pom.xml
+++ b/core/optaplanner-constraint-streams-bavet/pom.xml
@@ -98,4 +98,14 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>animal-sniffer-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
 </project>

--- a/core/optaplanner-constraint-streams-common/pom.xml
+++ b/core/optaplanner-constraint-streams-common/pom.xml
@@ -83,4 +83,14 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>animal-sniffer-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+
 </project>

--- a/core/optaplanner-core-impl/pom.xml
+++ b/core/optaplanner-core-impl/pom.xml
@@ -131,6 +131,10 @@
           </sources>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>animal-sniffer-maven-plugin</artifactId>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/core/optaplanner-core/pom.xml
+++ b/core/optaplanner-core/pom.xml
@@ -53,6 +53,10 @@
           <skip>true</skip> <!-- This is an empty JAR to drag in dependencies; dep checks make no sense here. -->
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>animal-sniffer-maven-plugin</artifactId>
+      </plugin>
     </plugins>
   </build>
 

--- a/optaplanner-persistence/pom.xml
+++ b/optaplanner-persistence/pom.xml
@@ -44,4 +44,13 @@
     </dependencies>
   </dependencyManagement>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>animal-sniffer-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+
 </project>


### PR DESCRIPTION
Add android-api-compatibility-check profile that checks signature of optaplanner-core-impl if it is compatible with the current android version

<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.
-->

### JIRA

<!-- Add a JIRA ticket link if it exists. -->
https://issues.redhat.com/browse/PLANNER-2752


### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
- https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
- https://github.com/kiegroup/drools/pull/3000
- https://github.com/kiegroup/optaplanner/pull/899
- etc.
-->

### Checklist
- [ ] Documentation updated if applicable.
- [ ] Upgrade recipe provided if applicable.

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request checks</b>  
  Please add comment: <b>Jenkins retest this</b>

- for a <b>specific pull request check</b>  
  please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] tests</b>
  
- for a <b>full downstream build</b> 
  - for <b>jenkins</b> job: 
    please add comment: <b>Jenkins run fdb</b>
  - for <b>github actions</b> job: 
    add the label `run_fdb`

- for a <b>compile downstream build</b>  
  please add comment: <b>Jenkins run cdb</b>

- for a <b>full production downstream build</b>  
  please add comment: <b>Jenkins execute product fdb</b>

- for an <b>upstream build</b>  
  please add comment: <b>Jenkins run upstream</b>

- for <b>quarkus branch checks</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins run quarkus-branch</b>

- for a <b>quarkus branch specific check</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] quarkus-branch</b>

- for <b>quarkus main checks</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins run quarkus-main</b>

- for a <b>specific quarkus main check</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] quarkus-branch</b>

- for <b>native checks</b>  
  Run native checks  
  Please add comment: <b>Jenkins run native</b>

- for a <b>specific native check</b>  
  Run native checks 
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] native</b>

- for <b>mandrel checks</b>  
  Run native checks against Mandrel image
  Please add comment: <b>Jenkins run mandrel</b>

- for a <b>specific mandrel check</b>  
  Run native checks against Mandrel image  
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] mandrel</b>
</details>

### CI Status

 You can check OptaPlanner repositories CI status from [Chain Status webpage](https://kiegroup.github.io/optaplanner/).