### PR TITLE
PLANNER-2757 Use the CS impl that is available

### DIFF
--- a/core/optaplanner-constraint-drl/src/main/java/org/optaplanner/constraint/drl/DrlScoreDirectorFactoryService.java
+++ b/core/optaplanner-constraint-drl/src/main/java/org/optaplanner/constraint/drl/DrlScoreDirectorFactoryService.java
@@ -4,6 +4,7 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Supplier;
 
@@ -95,7 +96,9 @@ public final class DrlScoreDirectorFactoryService<Solution_, Score_ extends Scor
             }
         }
 
-        if (config.isDroolsAlphaNetworkCompilationEnabled()) {
+        boolean isDroolsAlphaNetworkEnabled =
+                Objects.requireNonNullElse(config.getDroolsAlphaNetworkCompilationEnabled(), true);
+        if (isDroolsAlphaNetworkEnabled) {
             KieBaseUpdaterANC.generateAndSetInMemoryANC(kieBase); // Enable Alpha Network Compiler for performance.
         }
         return new DrlScoreDirectorFactory<>(solutionDescriptor, kieBase);

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/BavetConstraintStreamScoreDirectorFactoryService.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/BavetConstraintStreamScoreDirectorFactoryService.java
@@ -1,6 +1,7 @@
 package org.optaplanner.constraint.streams.bavet;
 
-import java.util.Objects;
+import static org.optaplanner.core.api.score.stream.ConstraintStreamImplType.DROOLS;
+
 import java.util.function.Supplier;
 
 import org.optaplanner.constraint.streams.common.AbstractConstraintStreamScoreDirectorFactory;
@@ -18,6 +19,11 @@ public final class BavetConstraintStreamScoreDirectorFactoryService<Solution_, S
         extends AbstractConstraintStreamScoreDirectorFactoryService<Solution_, Score_> {
 
     @Override
+    public int getPriority() {
+        return Integer.MIN_VALUE;
+    }
+
+    @Override
     public ScoreDirectorType getSupportedScoreDirectorType() {
         return ScoreDirectorType.CONSTRAINT_STREAMS;
     }
@@ -25,9 +31,8 @@ public final class BavetConstraintStreamScoreDirectorFactoryService<Solution_, S
     @Override
     public Supplier<AbstractScoreDirectorFactory<Solution_, Score_>> buildScoreDirectorFactory(ClassLoader classLoader,
             SolutionDescriptor<Solution_> solutionDescriptor, ScoreDirectorFactoryConfig config) {
-        ConstraintStreamImplType constraintStreamImplType_ =
-                Objects.requireNonNullElse(config.getConstraintStreamImplType(), ConstraintStreamImplType.DROOLS);
-        if (constraintStreamImplType_ != ConstraintStreamImplType.BAVET) {
+        ConstraintStreamImplType constraintStreamImplType_ = config.getConstraintStreamImplType();
+        if (constraintStreamImplType_ == DROOLS) {
             return null;
         }
         if (config.getConstraintProviderClass() != null) {

--- a/core/optaplanner-constraint-streams-drools/src/main/java/org/optaplanner/constraint/streams/drools/DroolsConstraintStreamScoreDirectorFactoryService.java
+++ b/core/optaplanner-constraint-streams-drools/src/main/java/org/optaplanner/constraint/streams/drools/DroolsConstraintStreamScoreDirectorFactoryService.java
@@ -1,5 +1,7 @@
 package org.optaplanner.constraint.streams.drools;
 
+import static org.optaplanner.core.api.score.stream.ConstraintStreamImplType.BAVET;
+
 import java.util.Objects;
 import java.util.function.Supplier;
 
@@ -27,7 +29,7 @@ public final class DroolsConstraintStreamScoreDirectorFactoryService<Solution_, 
             SolutionDescriptor<Solution_> solutionDescriptor, ScoreDirectorFactoryConfig config) {
         ConstraintStreamImplType constraintStreamImplType_ =
                 Objects.requireNonNullElse(config.getConstraintStreamImplType(), ConstraintStreamImplType.DROOLS);
-        if (constraintStreamImplType_ != ConstraintStreamImplType.DROOLS) {
+        if (constraintStreamImplType_ == BAVET) {
             return null;
         }
         if (config.getConstraintProviderClass() != null) {

--- a/core/optaplanner-constraint-streams-drools/src/main/java/org/optaplanner/constraint/streams/drools/DroolsConstraintStreamScoreDirectorFactoryService.java
+++ b/core/optaplanner-constraint-streams-drools/src/main/java/org/optaplanner/constraint/streams/drools/DroolsConstraintStreamScoreDirectorFactoryService.java
@@ -43,7 +43,8 @@ public final class DroolsConstraintStreamScoreDirectorFactoryService<Solution_, 
                         "constraintProviderClass", config.getConstraintProviderClass());
                 ConfigUtils.applyCustomProperties(constraintProvider, "constraintProviderClass",
                         config.getConstraintProviderCustomProperties(), "constraintProviderCustomProperties");
-                boolean isDroolsAlphaNetworkEnabled = config.isDroolsAlphaNetworkCompilationEnabled();
+                boolean isDroolsAlphaNetworkEnabled =
+                        Objects.requireNonNullElse(config.getDroolsAlphaNetworkCompilationEnabled(), true);
                 if (config.getGizmoKieBaseSupplier() != null) {
                     return new DroolsConstraintStreamScoreDirectorFactory<>(solutionDescriptor,
                             (KieBaseDescriptor<Solution_>) config.getGizmoKieBaseSupplier(),

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/config/score/director/ScoreDirectorFactoryConfig.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/config/score/director/ScoreDirectorFactoryConfig.java
@@ -4,6 +4,7 @@ import java.io.File;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
@@ -390,6 +391,28 @@ public class ScoreDirectorFactoryConfig extends AbstractConfig<ScoreDirectorFact
         classVisitor.accept(incrementalScoreCalculatorClass);
         if (assertionScoreDirectorFactory != null) {
             assertionScoreDirectorFactory.visitReferencedClasses(classVisitor);
+        }
+    }
+
+    private boolean isUsingDrools() {
+        if (scoreDrlList != null || scoreDrlFileList != null) { // We know we're in DRL.
+            return true;
+        } else if (constraintProviderClass == null) { // We know we're neither in DRL nor in CS.
+            return false;
+        }
+        return (constraintStreamImplType == null || constraintStreamImplType == ConstraintStreamImplType.DROOLS);
+    }
+
+    @Deprecated(forRemoval = true)
+    public boolean isDroolsAlphaNetworkCompilationEnabled() {
+        if (!isUsingDrools()) {
+            return false;
+        }
+        boolean ancEnabledValue = Objects.requireNonNullElse(getDroolsAlphaNetworkCompilationEnabled(), true);
+        if (ancEnabledValue) { // ANC does not work in native images.
+            return !ConfigUtils.isNativeImage();
+        } else {
+            return false;
         }
     }
 

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/config/score/director/ScoreDirectorFactoryConfig.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/config/score/director/ScoreDirectorFactoryConfig.java
@@ -4,7 +4,6 @@ import java.io.File;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
@@ -391,27 +390,6 @@ public class ScoreDirectorFactoryConfig extends AbstractConfig<ScoreDirectorFact
         classVisitor.accept(incrementalScoreCalculatorClass);
         if (assertionScoreDirectorFactory != null) {
             assertionScoreDirectorFactory.visitReferencedClasses(classVisitor);
-        }
-    }
-
-    private boolean isUsingDrools() {
-        if (scoreDrlList != null || scoreDrlFileList != null) { // We know we're in DRL.
-            return true;
-        } else if (constraintProviderClass == null) { // We know we're neither in DRL nor in CS.
-            return false;
-        }
-        return (constraintStreamImplType == null || constraintStreamImplType == ConstraintStreamImplType.DROOLS);
-    }
-
-    public boolean isDroolsAlphaNetworkCompilationEnabled() {
-        if (!isUsingDrools()) {
-            return false;
-        }
-        boolean ancEnabledValue = Objects.requireNonNullElse(getDroolsAlphaNetworkCompilationEnabled(), true);
-        if (ancEnabledValue) { // ANC does not work in native images.
-            return !ConfigUtils.isNativeImage();
-        } else {
-            return false;
         }
     }
 

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/score/director/ScoreDirectorFactoryFactory.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/score/director/ScoreDirectorFactoryFactory.java
@@ -72,6 +72,11 @@ public class ScoreDirectorFactoryFactory<Solution_, Score_ extends Score<Score_>
                 new EnumMap<>(ScoreDirectorType.class);
         boolean isBavet = false;
         for (ScoreDirectorFactoryService<Solution_, Score_> service : scoreDirectorFactoryServiceLoader) {
+            /*
+             * Drools will be available if one the classpath and user did not request BAVET.
+             * Bavet will be available if on the classpath and user did not request DROOLS.
+             * The following logic deals with the decision of which to pick if both available.
+             */
             Supplier<AbstractScoreDirectorFactory<Solution_, Score_>> factory =
                     service.buildScoreDirectorFactory(classLoader, solutionDescriptor, config);
             if (factory != null) {

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/score/director/ScoreDirectorFactoryFactory.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/score/director/ScoreDirectorFactoryFactory.java
@@ -1,5 +1,7 @@
 package org.optaplanner.core.impl.score.director;
 
+import static org.optaplanner.core.api.score.stream.ConstraintStreamImplType.BAVET;
+import static org.optaplanner.core.api.score.stream.ConstraintStreamImplType.DROOLS;
 import static org.optaplanner.core.impl.score.director.ScoreDirectorType.CONSTRAINT_STREAMS;
 import static org.optaplanner.core.impl.score.director.ScoreDirectorType.DRL;
 import static org.optaplanner.core.impl.score.director.ScoreDirectorType.EASY;
@@ -17,7 +19,6 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.optaplanner.core.api.score.Score;
-import org.optaplanner.core.api.score.stream.ConstraintStreamImplType;
 import org.optaplanner.core.config.score.director.ScoreDirectorFactoryConfig;
 import org.optaplanner.core.config.score.trend.InitializingScoreTrendLevel;
 import org.optaplanner.core.config.solver.EnvironmentMode;
@@ -138,10 +139,12 @@ public class ScoreDirectorFactoryFactory<Solution_, Score_ extends Score<Score_>
             }
             return constraintStreamScoreDirectorFactorySupplier.get();
         } else if (config.getConstraintProviderClass() != null) {
+            String expectedModule = config.getConstraintStreamImplType() == BAVET
+                    ? "optaplanner-constraint-streams-bavet"
+                    : "optaplanner-constraint-streams-drools";
             throw new IllegalStateException("Constraint Streams requested via constraintProviderClass (" +
                     config.getConstraintProviderClass() + ") but the supporting classes were not found on the classpath.\n"
-                    + "Maybe include org.optaplanner:optaplanner-constraint-streams-drools or "
-                    + "org.optaplanner:optaplanner-constraint-streams-bavet dependency in your project?\n"
+                    + "Maybe include org.optaplanner:" + expectedModule + " dependency in your project?\n"
                     + "Maybe ensure your uberjar bundles META-INF/services from included JAR files?");
         }
 
@@ -202,7 +205,7 @@ public class ScoreDirectorFactoryFactory<Solution_, Score_ extends Score<Score_>
         if (config.getDroolsAlphaNetworkCompilationEnabled() != null) {
             throw new IllegalStateException("If there is no scoreDrl (" + config.getScoreDrlList()
                     + "), scoreDrlFile (" + config.getScoreDrlFileList() + ") or constraintProviderClass ("
-                    + config.getConstraintProviderClass() + ") with " + ConstraintStreamImplType.DROOLS + " impl type ("
+                    + config.getConstraintProviderClass() + ") with " + DROOLS + " impl type ("
                     + config.getConstraintStreamImplType() + "), there can be no droolsAlphaNetworkCompilationEnabled ("
                     + config.getDroolsAlphaNetworkCompilationEnabled() + ") either.");
         }
@@ -211,7 +214,7 @@ public class ScoreDirectorFactoryFactory<Solution_, Score_ extends Score<Score_>
     private void validateNoGizmoKieBaseSupplier() {
         if (config.getGizmoKieBaseSupplier() != null) {
             throw new IllegalStateException("If there is no constraintProviderClass ("
-                    + config.getConstraintProviderClass() + ") with " + ConstraintStreamImplType.DROOLS + " impl type ("
+                    + config.getConstraintProviderClass() + ") with " + DROOLS + " impl type ("
                     + config.getConstraintStreamImplType() + "), there can be no gizmoKieBaseSupplier ("
                     + config.getGizmoKieBaseSupplier() + ") either.");
         }

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/score/director/ScoreDirectorFactoryFactory.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/score/director/ScoreDirectorFactoryFactory.java
@@ -70,10 +70,36 @@ public class ScoreDirectorFactoryFactory<Solution_, Score_ extends Score<Score_>
                 ServiceLoader.load(ScoreDirectorFactoryService.class);
         Map<ScoreDirectorType, Supplier<AbstractScoreDirectorFactory<Solution_, Score_>>> scoreDirectorFactorySupplierMap =
                 new EnumMap<>(ScoreDirectorType.class);
+        boolean isBavet = false;
         for (ScoreDirectorFactoryService<Solution_, Score_> service : scoreDirectorFactoryServiceLoader) {
             Supplier<AbstractScoreDirectorFactory<Solution_, Score_>> factory =
                     service.buildScoreDirectorFactory(classLoader, solutionDescriptor, config);
             if (factory != null) {
+                if (service.getSupportedScoreDirectorType() == CONSTRAINT_STREAMS) {
+                    switch (service.getPriority()) {
+                        case Integer.MAX_VALUE:
+                            // Drools will be registered as the CS impl.
+                            isBavet = false;
+                            break;
+                        case Integer.MIN_VALUE:
+                            if (scoreDirectorFactorySupplierMap.containsKey(CONSTRAINT_STREAMS)) {
+                                /*
+                                 * We already have a CS service registered, and it is of a higher priority.
+                                 * This means Drools was loaded first, but Bavet is available too.
+                                 * Such situation can only happen if the user did not specify an impl type.
+                                 * Therefore, we skip Bavet as Drools is the default and already registered.
+                                 */
+                                continue;
+                            } else {
+                                // Bavet will be registered as the CS impl.
+                                isBavet = true;
+                            }
+                            break;
+                        default:
+                            throw new IllegalStateException(
+                                    "Impossible state: Unknown service priority (" + service.getPriority() + ")");
+                    }
+                }
                 scoreDirectorFactorySupplierMap.put(service.getSupportedScoreDirectorType(), factory);
             }
         }
@@ -102,7 +128,6 @@ public class ScoreDirectorFactoryFactory<Solution_, Score_ extends Score<Score_>
             return incrementalScoreDirectorFactorySupplier.get();
         }
 
-        boolean isBavet = config.getConstraintStreamImplType() == ConstraintStreamImplType.BAVET;
         if (constraintStreamScoreDirectorFactorySupplier != null) {
             if (isBavet) {
                 validateNoDroolsAlphaNetworkCompilation();

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/score/director/ScoreDirectorFactoryService.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/score/director/ScoreDirectorFactoryService.java
@@ -18,6 +18,16 @@ import org.optaplanner.core.impl.domain.solution.descriptor.SolutionDescriptor;
 public interface ScoreDirectorFactoryService<Solution_, Score_ extends Score<Score_>> {
 
     /**
+     * If multiple services are available for the same config, the one with the higher priority is picked.
+     * Used by the CS services to ensure Drools is picked if both Drools and Bavet are available.
+     *
+     * @return
+     */
+    default int getPriority() {
+        return Integer.MAX_VALUE;
+    }
+
+    /**
      *
      * @return never null, the score director type that is implemented by the factory
      */

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/test/java/org/optaplanner/quarkus/verifier/OptaPlannerConstraintVerifierTest.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/test/java/org/optaplanner/quarkus/verifier/OptaPlannerConstraintVerifierTest.java
@@ -6,39 +6,28 @@ import javax.inject.Inject;
 
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.optaplanner.core.api.score.buildin.simple.SimpleScore;
-import org.optaplanner.core.api.score.stream.ConstraintStreamImplType;
-import org.optaplanner.core.config.util.ConfigUtils;
 import org.optaplanner.quarkus.testdata.normal.constraints.TestdataQuarkusConstraintProvider;
 import org.optaplanner.quarkus.testdata.normal.domain.TestdataQuarkusEntity;
 import org.optaplanner.quarkus.testdata.normal.domain.TestdataQuarkusSolution;
 import org.optaplanner.test.api.score.stream.ConstraintVerifier;
-import org.optaplanner.test.impl.score.stream.DefaultConstraintVerifier;
 
 import io.quarkus.test.QuarkusUnitTest;
 
-class OptaPlannerConstraintVerifierDroolsStreamImplTest {
+class OptaPlannerConstraintVerifierTest {
     @RegisterExtension
     static final QuarkusUnitTest config = new QuarkusUnitTest()
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
                     .addClasses(TestdataQuarkusEntity.class,
-                            TestdataQuarkusSolution.class, TestdataQuarkusConstraintProvider.class)
-                    .addAsResource("org/optaplanner/quarkus/verifier/droolsSolverConfig.xml", "solverConfig.xml"));
+                            TestdataQuarkusSolution.class, TestdataQuarkusConstraintProvider.class));
 
     @Inject
     ConstraintVerifier<TestdataQuarkusConstraintProvider, TestdataQuarkusSolution> constraintVerifier;
 
     @Test
     void constraintVerifierDroolsStreamImpl() {
-        Assertions.assertEquals(ConstraintStreamImplType.DROOLS,
-                ((DefaultConstraintVerifier<?, ?, ?>) constraintVerifier)
-                        .getConstraintStreamImplType());
-        Assertions.assertEquals(!ConfigUtils.isNativeImage(),
-                ((DefaultConstraintVerifier<?, ?, ?>) constraintVerifier)
-                        .isDroolsAlphaNetworkCompilationEnabled());
         TestdataQuarkusSolution solution = new TestdataQuarkusSolution();
         TestdataQuarkusEntity entityA = new TestdataQuarkusEntity();
         TestdataQuarkusEntity entityB = new TestdataQuarkusEntity();

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/test/resources/org/optaplanner/quarkus/verifier/droolsSolverConfig.xml
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/test/resources/org/optaplanner/quarkus/verifier/droolsSolverConfig.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<solver xmlns="https://www.optaplanner.org/xsd/solver" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="https://www.optaplanner.org/xsd/solver https://www.optaplanner.org/xsd/solver/solver.xsd">
+  <scoreDirectorFactory>
+    <constraintProviderClass>org.optaplanner.quarkus.testdata.normal.constraints.TestdataQuarkusConstraintProvider</constraintProviderClass>
+    <constraintStreamImplType>DROOLS</constraintStreamImplType>
+  </scoreDirectorFactory>
+</solver>

--- a/optaplanner-spring-integration/optaplanner-spring-boot-autoconfigure/pom.xml
+++ b/optaplanner-spring-integration/optaplanner-spring-boot-autoconfigure/pom.xml
@@ -30,7 +30,6 @@
     <dependency>
       <groupId>org.optaplanner</groupId>
       <artifactId>optaplanner-core</artifactId>
-      <optional>true</optional>
     </dependency>
 
     <!-- Need this so we can @Autowire ConstraintVerifier -->

--- a/optaplanner-spring-integration/optaplanner-spring-boot-autoconfigure/src/main/java/org/optaplanner/spring/boot/autoconfigure/OptaPlannerAutoConfiguration.java
+++ b/optaplanner-spring-integration/optaplanner-spring-boot-autoconfigure/src/main/java/org/optaplanner/spring/boot/autoconfigure/OptaPlannerAutoConfiguration.java
@@ -141,7 +141,7 @@ public class OptaPlannerAutoConfiguration implements BeanClassLoaderAware {
                 //  requires OptaPlannerAutoConfiguration to have a no-args constructor)
                 final String noConstraintProviderErrorMsg =
                         "Cannot provision a ConstraintVerifier because there is no ConstraintProvider class.";
-                return new ConstraintVerifier<ConstraintProvider_, SolutionClass_>() {
+                return new ConstraintVerifier<>() {
                     @Override
                     public ConstraintVerifier<ConstraintProvider_, SolutionClass_>
                             withConstraintStreamImplType(ConstraintStreamImplType constraintStreamImplType) {
@@ -167,7 +167,7 @@ public class OptaPlannerAutoConfiguration implements BeanClassLoaderAware {
                 };
             }
 
-            return (ConstraintVerifier<ConstraintProvider_, SolutionClass_>) ConstraintVerifier.create(solverConfig);
+            return ConstraintVerifier.create(solverConfig);
         }
     }
 

--- a/optaplanner-spring-integration/optaplanner-spring-boot-autoconfigure/src/test/resources/org/optaplanner/spring/boot/autoconfigure/droolsSolverConfig.xml
+++ b/optaplanner-spring-integration/optaplanner-spring-boot-autoconfigure/src/test/resources/org/optaplanner/spring/boot/autoconfigure/droolsSolverConfig.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<solver xmlns="https://www.optaplanner.org/xsd/solver" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="https://www.optaplanner.org/xsd/solver https://www.optaplanner.org/xsd/solver/solver.xsd">
+  <scoreDirectorFactory>
+    <constraintProviderClass>org.optaplanner.spring.boot.autoconfigure.normal.constraints.TestdataSpringConstraintProvider</constraintProviderClass>
+    <constraintStreamImplType>DROOLS</constraintStreamImplType>
+    <droolsAlphaNetworkCompilationEnabled>false</droolsAlphaNetworkCompilationEnabled>
+  </scoreDirectorFactory>
+</solver>

--- a/optaplanner-test/src/main/java/org/optaplanner/test/impl/score/stream/DefaultConstraintVerifier.java
+++ b/optaplanner-test/src/main/java/org/optaplanner/test/impl/score/stream/DefaultConstraintVerifier.java
@@ -1,6 +1,7 @@
 package org.optaplanner.test.impl.score.stream;
 
 import static java.util.Objects.requireNonNull;
+import static org.optaplanner.core.api.score.stream.ConstraintStreamImplType.DROOLS;
 
 import java.util.Comparator;
 import java.util.List;
@@ -105,9 +106,10 @@ public final class DefaultConstraintVerifier<ConstraintProvider_ extends Constra
                             + "Maybe ensure your uberjar bundles META-INF/services from included JAR files?");
         }
         AbstractConstraintStreamScoreDirectorFactoryService<Solution_, Score_> service = services.get(0);
-        boolean isDrools = service.supportsImplType(ConstraintStreamImplType.DROOLS);
         boolean isDroolsAlphaNetworkCompilationEnabled =
-                droolsAlphaNetworkCompilationEnabled == null ? isDrools : droolsAlphaNetworkCompilationEnabled;
+                droolsAlphaNetworkCompilationEnabled == null
+                        ? service.supportsImplType(DROOLS) && isDroolsAlphaNetworkCompilationEnabled()
+                        : droolsAlphaNetworkCompilationEnabled;
         return service.buildScoreDirectorFactory(solutionDescriptor, constraintProvider,
                 isDroolsAlphaNetworkCompilationEnabled);
     }

--- a/optaplanner-test/src/main/java/org/optaplanner/test/impl/score/stream/DefaultConstraintVerifier.java
+++ b/optaplanner-test/src/main/java/org/optaplanner/test/impl/score/stream/DefaultConstraintVerifier.java
@@ -2,9 +2,12 @@ package org.optaplanner.test.impl.score.stream;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.Comparator;
+import java.util.List;
 import java.util.Objects;
 import java.util.ServiceLoader;
 import java.util.function.BiFunction;
+import java.util.stream.Collectors;
 
 import org.optaplanner.constraint.streams.common.AbstractConstraintStreamScoreDirectorFactory;
 import org.optaplanner.constraint.streams.common.AbstractConstraintStreamScoreDirectorFactoryService;
@@ -35,7 +38,7 @@ public final class DefaultConstraintVerifier<ConstraintProvider_ extends Constra
     }
 
     public ConstraintStreamImplType getConstraintStreamImplType() {
-        return Objects.requireNonNullElse(constraintStreamImplType, ConstraintStreamImplType.DROOLS);
+        return constraintStreamImplType;
     }
 
     @Override
@@ -80,27 +83,33 @@ public final class DefaultConstraintVerifier<ConstraintProvider_ extends Constra
 
     private AbstractConstraintStreamScoreDirectorFactory<Solution_, Score_> createScoreDirectorFactory(
             ConstraintProvider constraintProvider) {
-        boolean isDroolsAlphaNetworkCompilationEnabled =
-                droolsAlphaNetworkCompilationEnabled == null ? getConstraintStreamImplType() != ConstraintStreamImplType.BAVET
-                        : droolsAlphaNetworkCompilationEnabled;
-        return serviceLoader.stream()
+        List<AbstractConstraintStreamScoreDirectorFactoryService<Solution_, Score_>> services = serviceLoader.stream()
                 .map(ServiceLoader.Provider::get)
                 .filter(s -> s.getSupportedScoreDirectorType() == ScoreDirectorType.CONSTRAINT_STREAMS)
                 .map(s -> (AbstractConstraintStreamScoreDirectorFactoryService<Solution_, Score_>) s)
-                .filter(s -> s.supportsImplType(getConstraintStreamImplType()))
-                .map(s -> s.buildScoreDirectorFactory(solutionDescriptor, constraintProvider,
-                        isDroolsAlphaNetworkCompilationEnabled))
-                .filter(Objects::nonNull)
-                .findFirst()
-                .orElseThrow(() -> {
-                    String expectedModule = getConstraintStreamImplType() == ConstraintStreamImplType.BAVET
-                            ? "optaplanner-constraint-streams-bavet"
-                            : "optaplanner-constraint-streams-drools";
-                    throw new IllegalStateException(
-                            "Constraint Streams implementation was not found on the classpath.\n"
-                                    + "Maybe include org.optaplanner:" + expectedModule + " dependency in your project?\n"
-                                    + "Maybe ensure your uberjar bundles META-INF/services from included JAR files?");
-                });
+                .filter(s -> {
+                    ConstraintStreamImplType implType = constraintStreamImplType;
+                    return implType == null || s.supportsImplType(implType);
+                })
+                .sorted(Comparator
+                        .comparingInt(
+                                (AbstractConstraintStreamScoreDirectorFactoryService<Solution_, Score_> service) -> service
+                                        .getPriority())
+                        .reversed()) // CS-D will be picked if both are available.
+                .collect(Collectors.toList());
+        if (services.isEmpty()) {
+            throw new IllegalStateException(
+                    "Constraint Streams implementation was not found on the classpath.\n"
+                            + "Maybe include org.optaplanner:optaplanner-constraint-streams-drools dependency "
+                            + "or org.optaplanner:optaplanner-constraint-streams-bavet in your project?\n"
+                            + "Maybe ensure your uberjar bundles META-INF/services from included JAR files?");
+        }
+        AbstractConstraintStreamScoreDirectorFactoryService<Solution_, Score_> service = services.get(0);
+        boolean isDrools = service.supportsImplType(ConstraintStreamImplType.DROOLS);
+        boolean isDroolsAlphaNetworkCompilationEnabled =
+                droolsAlphaNetworkCompilationEnabled == null ? isDrools : droolsAlphaNetworkCompilationEnabled;
+        return service.buildScoreDirectorFactory(solutionDescriptor, constraintProvider,
+                isDroolsAlphaNetworkCompilationEnabled);
     }
 
     @Override


### PR DESCRIPTION
If they explicitly specify a constraintStreamImplType, then it should fail fast if it's not on the classpath
Otherwise if only one is on the classpath, use that one.
If both are on the classpath, use - for now - drools.