### PR TITLE
Handle null case in OptaPlanner processor; replace usages of getDANCE with isDANCE

### DIFF
--- a/core/optaplanner-constraint-drl/src/main/java/org/optaplanner/constraint/drl/DrlScoreDirectorFactoryService.java
+++ b/core/optaplanner-constraint-drl/src/main/java/org/optaplanner/constraint/drl/DrlScoreDirectorFactoryService.java
@@ -97,7 +97,7 @@ public final class DrlScoreDirectorFactoryService<Solution_, Score_ extends Scor
         }
 
         boolean isDroolsAlphaNetworkEnabled =
-                Objects.requireNonNullElse(config.getDroolsAlphaNetworkCompilationEnabled(), true);
+                Objects.requireNonNullElse(config.isDroolsAlphaNetworkCompilationEnabled(), true);
         if (isDroolsAlphaNetworkEnabled) {
             KieBaseUpdaterANC.generateAndSetInMemoryANC(kieBase); // Enable Alpha Network Compiler for performance.
         }

--- a/core/optaplanner-constraint-streams-drools/src/main/java/org/optaplanner/constraint/streams/drools/DroolsConstraintStreamScoreDirectorFactoryService.java
+++ b/core/optaplanner-constraint-streams-drools/src/main/java/org/optaplanner/constraint/streams/drools/DroolsConstraintStreamScoreDirectorFactoryService.java
@@ -44,7 +44,7 @@ public final class DroolsConstraintStreamScoreDirectorFactoryService<Solution_, 
                 ConfigUtils.applyCustomProperties(constraintProvider, "constraintProviderClass",
                         config.getConstraintProviderCustomProperties(), "constraintProviderCustomProperties");
                 boolean isDroolsAlphaNetworkEnabled =
-                        Objects.requireNonNullElse(config.getDroolsAlphaNetworkCompilationEnabled(), true);
+                        Objects.requireNonNullElse(config.isDroolsAlphaNetworkCompilationEnabled(), true);
                 if (config.getGizmoKieBaseSupplier() != null) {
                     return new DroolsConstraintStreamScoreDirectorFactory<>(solutionDescriptor,
                             (KieBaseDescriptor<Solution_>) config.getGizmoKieBaseSupplier(),

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/config/score/director/ScoreDirectorFactoryConfig.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/config/score/director/ScoreDirectorFactoryConfig.java
@@ -403,12 +403,14 @@ public class ScoreDirectorFactoryConfig extends AbstractConfig<ScoreDirectorFact
         return (constraintStreamImplType == null || constraintStreamImplType == ConstraintStreamImplType.DROOLS);
     }
 
+    // TODO: Replace all usages of this message with {@link getDroolsAlphaNetworkCompilationEnabled()} when
+    //       https://github.com/quarkusio/quarkus/issues/26889 is fixed.
     @Deprecated(forRemoval = true)
     public boolean isDroolsAlphaNetworkCompilationEnabled() {
         if (!isUsingDrools()) {
             return false;
         }
-        boolean ancEnabledValue = Objects.requireNonNullElse(getDroolsAlphaNetworkCompilationEnabled(), true);
+        boolean ancEnabledValue = Objects.requireNonNullElse(droolsAlphaNetworkCompilationEnabled, true);
         if (ancEnabledValue) { // ANC does not work in native images.
             return !ConfigUtils.isNativeImage();
         } else {

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/main/java/org/optaplanner/quarkus/deployment/OptaPlannerProcessor.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/main/java/org/optaplanner/quarkus/deployment/OptaPlannerProcessor.java
@@ -241,7 +241,7 @@ class OptaPlannerProcessor {
             // DroolsAlphaNetworkCompilationEnabled is a three-state boolean (null, true, false); if it not
             // null, ScoreDirectorFactoryFactory will throw an error if Drools isn't use (i.e. BAVET or Easy/Incremental)
             if (solverConfig.getScoreDirectorFactoryConfig().getConstraintProviderClass() != null && solverConfig
-                    .getScoreDirectorFactoryConfig().getConstraintStreamImplType() == ConstraintStreamImplType.DROOLS) {
+                    .getScoreDirectorFactoryConfig().getConstraintStreamImplType() != ConstraintStreamImplType.BAVET) {
                 disableANC(solverConfig);
             } else if (solverConfig.getScoreDirectorFactoryConfig().getScoreDrlList() != null
                     || solverConfig.getScoreDirectorFactoryConfig().getScoreDrlFileList() == null) {
@@ -299,7 +299,7 @@ class OptaPlannerProcessor {
             final ConstraintStreamImplType constraintStreamImplType =
                     solverConfig.getScoreDirectorFactoryConfig().getConstraintStreamImplType();
             Boolean droolsAlphaNetworkCompilationEnabled =
-                    solverConfig.getScoreDirectorFactoryConfig().getDroolsAlphaNetworkCompilationEnabled();
+                    solverConfig.getScoreDirectorFactoryConfig().isDroolsAlphaNetworkCompilationEnabled();
             syntheticBeanBuildItemBuildProducer.produce(SyntheticBeanBuildItem.configure(DotNames.CONSTRAINT_VERIFIER)
                     .scope(Singleton.class)
                     .creator(methodCreator -> {


### PR DESCRIPTION
Due to a Quarkus recorder bug https://github.com/quarkusio/quarkus/issues/26889,
the droolsAlphaNetworkCompilationEnabled (DANCE) is never actual set (i.e. it is always
null) in Quarkus, meaning we need to use isDroolsAlphaNetworkCompilationEnabled(), which is computed,
instead of getDroolsAlphaNetworkCompilationEnabled(), which just returns
droolsAlphaNetworkCompilationEnabled.

This fixes the native build, which was broken because DANCE was always
null, causing it to be enabled in native mode, which DANCE is not
compatiable with.

<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.
-->

### JIRA

<!-- Add a JIRA ticket link if it exists. -->
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
- https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
- https://github.com/kiegroup/drools/pull/3000
- https://github.com/kiegroup/optaplanner/pull/899
- etc.
-->

### Checklist
- [ ] Documentation updated if applicable.
- [ ] Upgrade recipe provided if applicable.

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request checks</b>  
  Please add comment: <b>Jenkins retest this</b>

- for a <b>specific pull request check</b>  
  please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-vehicle-routing] tests</b>
  
- for a <b>full downstream build</b> 
  - for <b>jenkins</b> job: 
    please add comment: <b>Jenkins run fdb</b>
  - for <b>github actions</b> job: 
    add the label `run_fdb`

- for a <b>compile downstream build</b>  
  please add comment: <b>Jenkins run cdb</b>

- for a <b>full production downstream build</b>  
  please add comment: <b>Jenkins execute product fdb</b>

- for an <b>upstream build</b>  
  please add comment: <b>Jenkins run upstream</b>

- for <b>quarkus branch checks</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins run quarkus-branch</b>

- for a <b>quarkus branch specific check</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-vehicle-routing] quarkus-branch</b>

- for <b>quarkus main checks</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins run quarkus-main</b>

- for a <b>specific quarkus main check</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-vehicle-routing] quarkus-branch</b>

- for <b>native checks</b>  
  Run native checks  
  Please add comment: <b>Jenkins run native</b>

- for a <b>specific native check</b>  
  Run native checks 
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-vehicle-routing] native</b>

- for <b>mandrel checks</b>  
  Run native checks against Mandrel image
  Please add comment: <b>Jenkins run mandrel</b>

- for a <b>specific mandrel check</b>  
  Run native checks against Mandrel image  
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-vehicle-routing] mandrel</b>
</details>

### CI Status

 You can check OptaPlanner repositories CI status from [Chain Status webpage](https://kiegroup.github.io/optaplanner/).