### PR TITLE
CS-B: Reduce memory churn

### DIFF
--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/common/AbstractFlattenLastNode.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/common/AbstractFlattenLastNode.java
@@ -30,8 +30,7 @@ public abstract class AbstractFlattenLastNode<InTuple_ extends Tuple, OutTuple_ 
 
     @Override
     public void insert(InTuple_ tuple) {
-        Object[] tupleStore = tuple.getStore();
-        if (tupleStore[flattenLastStoreIndex] != null) {
+        if (tuple.getStore(flattenLastStoreIndex) != null) {
             throw new IllegalStateException("Impossible state: the input for the tuple (" + tuple
                     + ") was already added in the tupleStore.");
         }
@@ -40,7 +39,7 @@ public abstract class AbstractFlattenLastNode<InTuple_ extends Tuple, OutTuple_ 
             addTuple(tuple, item, outTupleList);
         }
         if (!outTupleList.isEmpty()) {
-            tupleStore[flattenLastStoreIndex] = outTupleList;
+            tuple.setStore(flattenLastStoreIndex, outTupleList);
         }
     }
 
@@ -54,8 +53,7 @@ public abstract class AbstractFlattenLastNode<InTuple_ extends Tuple, OutTuple_ 
 
     @Override
     public void update(InTuple_ tuple) {
-        Object[] tupleStore = tuple.getStore();
-        List<OutTuple_> outTupleList = (List<OutTuple_>) tupleStore[flattenLastStoreIndex];
+        List<OutTuple_> outTupleList = (List<OutTuple_>) tuple.getStore(flattenLastStoreIndex);
         if (outTupleList == null) {
             // No fail fast if null because we don't track which tuples made it through the filter predicate(s).
             insert(tuple);
@@ -107,13 +105,12 @@ public abstract class AbstractFlattenLastNode<InTuple_ extends Tuple, OutTuple_ 
 
     @Override
     public void retract(InTuple_ tuple) {
-        Object[] tupleStore = tuple.getStore();
-        List<OutTuple_> outTupleList = (List<OutTuple_>) tupleStore[flattenLastStoreIndex];
+        List<OutTuple_> outTupleList = (List<OutTuple_>) tuple.getStore(flattenLastStoreIndex);
         if (outTupleList == null) {
             // No fail fast if null because we don't track which tuples made it through the filter predicate(s)
             return;
         }
-        tupleStore[flattenLastStoreIndex] = null;
+        tuple.setStore(flattenLastStoreIndex, null);
         for (OutTuple_ item : outTupleList) {
             removeTuple(item);
         }

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/common/AbstractJoinNode.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/common/AbstractJoinNode.java
@@ -41,13 +41,12 @@ public abstract class AbstractJoinNode<LeftTuple_ extends Tuple, Right_, OutTupl
 
     @Override
     public final void insertLeft(LeftTuple_ leftTuple) {
-        Object[] tupleStore = leftTuple.getStore();
-        if (tupleStore[inputStoreIndexLeft] != null) {
+        if (leftTuple.getStore(inputStoreIndexLeft) != null) {
             throw new IllegalStateException("Impossible state: the input for the tuple (" + leftTuple
                     + ") was already added in the tupleStore.");
         }
         IndexProperties indexProperties = createIndexPropertiesLeft(leftTuple);
-        tupleStore[inputStoreIndexLeft] = indexProperties;
+        leftTuple.setStore(inputStoreIndexLeft, indexProperties);
 
         Map<UniTuple<Right_>, MutableOutTuple_> outTupleMapLeft = new LinkedHashMap<>();
         indexAndPropagateLeft(leftTuple, indexProperties, outTupleMapLeft);
@@ -69,8 +68,7 @@ public abstract class AbstractJoinNode<LeftTuple_ extends Tuple, Right_, OutTupl
 
     @Override
     public final void updateLeft(LeftTuple_ leftTuple) {
-        Object[] tupleStore = leftTuple.getStore();
-        IndexProperties oldIndexProperties = (IndexProperties) tupleStore[inputStoreIndexLeft];
+        IndexProperties oldIndexProperties = leftTuple.getStore(inputStoreIndexLeft);
         if (oldIndexProperties == null) {
             // No fail fast if null because we don't track which tuples made it through the filter predicate(s)
             insertLeft(leftTuple);
@@ -93,20 +91,19 @@ public abstract class AbstractJoinNode<LeftTuple_ extends Tuple, Right_, OutTupl
             }
             outTupleMapLeft.clear();
 
-            tupleStore[inputStoreIndexLeft] = newIndexProperties;
+            leftTuple.setStore(inputStoreIndexLeft, newIndexProperties);
             indexAndPropagateLeft(leftTuple, newIndexProperties, outTupleMapLeft);
         }
     }
 
     @Override
     public final void retractLeft(LeftTuple_ leftTuple) {
-        Object[] tupleStore = leftTuple.getStore();
-        IndexProperties indexProperties = (IndexProperties) tupleStore[inputStoreIndexLeft];
+        IndexProperties indexProperties = leftTuple.getStore(inputStoreIndexLeft);
         if (indexProperties == null) {
             // No fail fast if null because we don't track which tuples made it through the filter predicate(s)
             return;
         }
-        tupleStore[inputStoreIndexLeft] = null;
+        leftTuple.setStore(inputStoreIndexLeft, null);
 
         Map<UniTuple<Right_>, MutableOutTuple_> outTupleMapLeft = indexerLeft.remove(indexProperties, leftTuple);
         for (OutTuple_ outTuple : outTupleMapLeft.values()) {
@@ -116,13 +113,12 @@ public abstract class AbstractJoinNode<LeftTuple_ extends Tuple, Right_, OutTupl
 
     @Override
     public final void insertRight(UniTuple<Right_> rightTuple) {
-        Object[] tupleStore = rightTuple.getStore();
-        if (tupleStore[inputStoreIndexRight] != null) {
+        if (rightTuple.getStore(inputStoreIndexRight) != null) {
             throw new IllegalStateException("Impossible state: the input for the tuple (" + rightTuple
                     + ") was already added in the tupleStore.");
         }
         IndexProperties indexProperties = mappingRight.apply(rightTuple.getFactA());
-        tupleStore[inputStoreIndexRight] = indexProperties;
+        rightTuple.setStore(inputStoreIndexRight, indexProperties);
         indexAndPropagateRight(rightTuple, indexProperties);
     }
 
@@ -134,8 +130,7 @@ public abstract class AbstractJoinNode<LeftTuple_ extends Tuple, Right_, OutTupl
 
     @Override
     public final void updateRight(UniTuple<Right_> rightTuple) {
-        Object[] tupleStore = rightTuple.getStore();
-        IndexProperties oldIndexProperties = (IndexProperties) tupleStore[inputStoreIndexRight];
+        IndexProperties oldIndexProperties = rightTuple.getStore(inputStoreIndexRight);
         if (oldIndexProperties == null) {
             // No fail fast if null because we don't track which tuples made it through the filter predicate(s)
             insertRight(rightTuple);
@@ -158,7 +153,7 @@ public abstract class AbstractJoinNode<LeftTuple_ extends Tuple, Right_, OutTupl
             });
         } else {
             deindexRightTuple(oldIndexProperties, rightTuple);
-            tupleStore[inputStoreIndexRight] = newIndexProperties;
+            rightTuple.setStore(inputStoreIndexRight, newIndexProperties);
             indexAndPropagateRight(rightTuple, newIndexProperties);
         }
     }
@@ -179,13 +174,12 @@ public abstract class AbstractJoinNode<LeftTuple_ extends Tuple, Right_, OutTupl
 
     @Override
     public final void retractRight(UniTuple<Right_> rightTuple) {
-        Object[] tupleStore = rightTuple.getStore();
-        IndexProperties indexProperties = (IndexProperties) tupleStore[inputStoreIndexRight];
+        IndexProperties indexProperties = rightTuple.getStore(inputStoreIndexRight);
         if (indexProperties == null) {
             // No fail fast if null because we don't track which tuples made it through the filter predicate(s)
             return;
         }
-        tupleStore[inputStoreIndexRight] = null;
+        rightTuple.setStore(inputStoreIndexRight, null);
         deindexRightTuple(indexProperties, rightTuple);
     }
 

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/common/AbstractScorer.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/common/AbstractScorer.java
@@ -19,35 +19,32 @@ public abstract class AbstractScorer<Tuple_ extends Tuple> implements TupleLifec
 
     @Override
     public final void insert(Tuple_ tuple) {
-        Object[] tupleStore = tuple.getStore();
-        if (tupleStore[inputStoreIndex] != null) {
+        if (tuple.getStore(inputStoreIndex) != null) {
             throw new IllegalStateException("Impossible state: the input for the tuple (" + tuple
                     + ") was already added in the tupleStore.");
         }
-        tupleStore[inputStoreIndex] = impact(tuple);
+        tuple.setStore(inputStoreIndex, impact(tuple));
     }
 
     @Override
     public final void update(Tuple_ tuple) {
-        Object[] tupleStore = tuple.getStore();
-        UndoScoreImpacter undoScoreImpacter = (UndoScoreImpacter) tupleStore[inputStoreIndex];
+        UndoScoreImpacter undoScoreImpacter = tuple.getStore(inputStoreIndex);
         // No fail fast if null because we don't track which tuples made it through the filter predicate(s)
         if (undoScoreImpacter != null) {
             undoScoreImpacter.run();
         }
-        tupleStore[inputStoreIndex] = impact(tuple);
+        tuple.setStore(inputStoreIndex, impact(tuple));
     }
 
     protected abstract UndoScoreImpacter impact(Tuple_ tuple);
 
     @Override
     public final void retract(Tuple_ tuple) {
-        Object[] tupleStore = tuple.getStore();
-        UndoScoreImpacter undoScoreImpacter = (UndoScoreImpacter) tupleStore[inputStoreIndex];
+        UndoScoreImpacter undoScoreImpacter = tuple.getStore(inputStoreIndex);
         // No fail fast if null because we don't track which tuples made it through the filter predicate(s)
         if (undoScoreImpacter != null) {
             undoScoreImpacter.run();
-            tupleStore[inputStoreIndex] = null;
+            tuple.setStore(inputStoreIndex, null);
         }
     }
 

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/common/AbstractTuple.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/common/AbstractTuple.java
@@ -4,15 +4,17 @@ public abstract class AbstractTuple implements Tuple {
 
     /*
      * We create a lot of tuples, many of them having store size of 1.
-     * If an array of 1 was created for each such tuple, memory would be wasted.
-     * This trade-off of memory efficiency for access time is proven beneficial.
+     * If an array of size 1 was created for each such tuple, memory would be wasted and indirection created.
+     * This trade-off of increased memory efficiency for marginally slower access time is proven beneficial.
      */
-    private Object store;
+    private final boolean storeIsArray;
 
+    private Object store;
     public BavetTupleState state = BavetTupleState.CREATING;
 
     protected AbstractTuple(int storeSize) {
-        store = (storeSize < 2) ? null : new Object[storeSize];
+        this.store = (storeSize < 2) ? null : new Object[storeSize];
+        this.storeIsArray = store != null;
     }
 
     @Override
@@ -27,7 +29,7 @@ public abstract class AbstractTuple implements Tuple {
 
     @Override
     public final <Value_> Value_ getStore(int index) {
-        if (store instanceof Object[]) {
+        if (storeIsArray) {
             return (Value_) ((Object[]) store)[index];
         }
         return (Value_) store;
@@ -35,7 +37,7 @@ public abstract class AbstractTuple implements Tuple {
 
     @Override
     public final void setStore(int index, Object value) {
-        if (store instanceof Object[]) {
+        if (storeIsArray) {
             ((Object[]) store)[index] = value;
             return;
         }

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/common/AbstractTuple.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/common/AbstractTuple.java
@@ -2,12 +2,17 @@ package org.optaplanner.constraint.streams.bavet.common;
 
 public abstract class AbstractTuple implements Tuple {
 
-    public final Object[] store;
+    /*
+     * We create a lot of tuples, many of them having store size of 1.
+     * If an array of 1 was created for each such tuple, memory would be wasted.
+     * This trade-off of memory efficiency for access time is proven beneficial.
+     */
+    private Object store;
 
     public BavetTupleState state = BavetTupleState.CREATING;
 
     protected AbstractTuple(int storeSize) {
-        store = (storeSize <= 0) ? null : new Object[storeSize];
+        store = (storeSize < 2) ? null : new Object[storeSize];
     }
 
     @Override
@@ -21,8 +26,19 @@ public abstract class AbstractTuple implements Tuple {
     }
 
     @Override
-    public final Object[] getStore() {
-        return store;
+    public final <Value_> Value_ getStore(int index) {
+        if (store instanceof Object[]) {
+            return (Value_) ((Object[]) store)[index];
+        }
+        return (Value_) store;
     }
 
+    @Override
+    public final void setStore(int index, Object value) {
+        if (store instanceof Object[]) {
+            ((Object[]) store)[index] = value;
+            return;
+        }
+        store = value;
+    }
 }

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/common/Group.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/common/Group.java
@@ -2,7 +2,7 @@ package org.optaplanner.constraint.streams.bavet.common;
 
 import java.util.Objects;
 
-public final class Group<OutTuple_ extends Tuple, GroupKey_, ResultContainer_> {
+final class Group<OutTuple_ extends Tuple, GroupKey_, ResultContainer_> {
 
     public final GroupKey_ groupKey;
     public final ResultContainer_ resultContainer;

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/common/Tuple.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/common/Tuple.java
@@ -16,6 +16,8 @@ public interface Tuple {
 
     void setState(BavetTupleState state);
 
-    Object[] getStore();
+    <Value_> Value_ getStore(int index);
+
+    void setStore(int index, Object value);
 
 }

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/common/index/SingleIndexProperties.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/common/index/SingleIndexProperties.java
@@ -31,8 +31,8 @@ final class SingleIndexProperties implements IndexProperties {
     }
 
     @Override
-    public int hashCode() {
-        return Objects.hash(property);
+    public int hashCode() { // Not using Objects.hash(Object...) as that would create an array on the hot path.
+        return Objects.hashCode(property);
     }
 
     @Override

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/common/index/ThreeIndexProperties.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/common/index/ThreeIndexProperties.java
@@ -43,8 +43,11 @@ final class ThreeIndexProperties implements IndexProperties {
     }
 
     @Override
-    public int hashCode() {
-        return Objects.hash(propertyA, propertyB, propertyC);
+    public int hashCode() { // Not using Objects.hash(Object...) as that would create an array on the hot path.
+        int result = Objects.hashCode(propertyA);
+        result = 31 * result + Objects.hashCode(propertyB);
+        result = 31 * result + Objects.hashCode(propertyC);
+        return result;
     }
 
     @Override

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/common/index/TwoIndexProperties.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/common/index/TwoIndexProperties.java
@@ -38,8 +38,10 @@ final class TwoIndexProperties implements IndexProperties {
     }
 
     @Override
-    public int hashCode() {
-        return Objects.hash(propertyA, propertyB);
+    public int hashCode() { // Not using Objects.hash(Object...) as that would create an array on the hot path.
+        int result = Objects.hashCode(propertyA);
+        result = 31 * result + Objects.hashCode(propertyB);
+        return result;
     }
 
     @Override

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/common/package-info.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/common/package-info.java
@@ -1,0 +1,8 @@
+/**
+ * This package contains performance-sensitive code.
+ * Much of it is directly on the hot path of the solver.
+ * It contains various micro-optimizations, the benefits of which have been confirmed by extensive benchmarking.
+ * When it comes to this code, assumptions and pre-conceived notions of JVM performance should not be trusted.
+ * Instead, any likely performance-altering modifications to this code should be carefully benchmarked.
+ */
+package org.optaplanner.constraint.streams.bavet.common;

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/util/MutablePairImpl.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/util/MutablePairImpl.java
@@ -45,8 +45,10 @@ final class MutablePairImpl<A, B> implements MutablePair<A, B> {
     }
 
     @Override
-    public int hashCode() {
-        return Objects.hash(key, value);
+    public int hashCode() { // Not using Objects.hash(Object...) as that would create an array on the hot path.
+        int result = Objects.hashCode(key);
+        result = 31 * result + Objects.hashCode(value);
+        return result;
     }
 
     @Override

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/util/MutableQuadrupleImpl.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/util/MutableQuadrupleImpl.java
@@ -74,8 +74,12 @@ final class MutableQuadrupleImpl<A, B, C, D> implements MutableQuadruple<A, B, C
     }
 
     @Override
-    public int hashCode() {
-        return Objects.hash(a, b, c, d);
+    public int hashCode() { // Not using Objects.hash(Object...) as that would create an array on the hot path.
+        int result = Objects.hashCode(a);
+        result = 31 * result + Objects.hashCode(b);
+        result = 31 * result + Objects.hashCode(c);
+        result = 31 * result + Objects.hashCode(d);
+        return result;
     }
 
     @Override

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/util/MutableTripleImpl.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/util/MutableTripleImpl.java
@@ -60,8 +60,11 @@ final class MutableTripleImpl<A, B, C> implements MutableTriple<A, B, C> {
     }
 
     @Override
-    public int hashCode() {
-        return Objects.hash(a, b, c);
+    public int hashCode() { // Not using Objects.hash(Object...) as that would create an array on the hot path.
+        int result = Objects.hashCode(a);
+        result = 31 * result + Objects.hashCode(b);
+        result = 31 * result + Objects.hashCode(c);
+        return result;
     }
 
     @Override

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/util/PairImpl.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/util/PairImpl.java
@@ -33,8 +33,10 @@ final class PairImpl<A, B> implements Pair<A, B> {
     }
 
     @Override
-    public int hashCode() {
-        return Objects.hash(key, value);
+    public int hashCode() { // Not using Objects.hash(Object...) as that would create an array on the hot path.
+        int result = Objects.hashCode(key);
+        result = 31 * result + Objects.hashCode(value);
+        return result;
     }
 
     @Override

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/util/QuadrupleImpl.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/util/QuadrupleImpl.java
@@ -50,8 +50,12 @@ final class QuadrupleImpl<A, B, C, D> implements Quadruple<A, B, C, D> {
     }
 
     @Override
-    public int hashCode() {
-        return Objects.hash(a, b, c, d);
+    public int hashCode() { // Not using Objects.hash(Object...) as that would create an array on the hot path.
+        int result = Objects.hashCode(a);
+        result = 31 * result + Objects.hashCode(b);
+        result = 31 * result + Objects.hashCode(c);
+        result = 31 * result + Objects.hashCode(d);
+        return result;
     }
 
     @Override

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/util/TripleImpl.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/util/TripleImpl.java
@@ -42,8 +42,11 @@ final class TripleImpl<A, B, C> implements Triple<A, B, C> {
     }
 
     @Override
-    public int hashCode() {
-        return Objects.hash(a, b, c);
+    public int hashCode() { // Not using Objects.hash(Object...) as that would create an array on the hot path.
+        int result = Objects.hashCode(a);
+        result = 31 * result + Objects.hashCode(b);
+        result = 31 * result + Objects.hashCode(c);
+        return result;
     }
 
     @Override


### PR DESCRIPTION
Brings a couple percentage points in constraint provider performance due to not allocating certain structures on the hot path.