### PR TITLE
Execute some OP tests in parallel

### DIFF
--- a/build/optaplanner-build-parent/pom.xml
+++ b/build/optaplanner-build-parent/pom.xml
@@ -52,7 +52,7 @@
     <version.compiler.plugin>3.8.1</version.compiler.plugin>
     <!-- The first version that supports analysis of classes compiled by Java 11. -->
     <version.dependency.plugin>3.1.2</version.dependency.plugin>
-    <version.surefire.plugin>3.0.0-M5</version.surefire.plugin>
+    <version.surefire.plugin>3.0.0-M7</version.surefire.plugin>
     <!-- Versions plugin should stay on version 2.5
       until https://github.com/mojohaus/versions-maven-plugin/issues/312 is fixed -->
     <version.versions.plugin>2.5</version.versions.plugin>

--- a/core/optaplanner-constraint-streams-common/src/test/java/org/optaplanner/constraint/streams/common/AbstractConstraintStreamTest.java
+++ b/core/optaplanner-constraint-streams-common/src/test/java/org/optaplanner/constraint/streams/common/AbstractConstraintStreamTest.java
@@ -13,6 +13,8 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.optaplanner.core.api.score.Score;
 import org.optaplanner.core.api.score.buildin.simple.SimpleScore;
 import org.optaplanner.core.api.score.constraint.ConstraintMatch;
@@ -25,6 +27,7 @@ import org.optaplanner.core.impl.score.director.InnerScoreDirector;
 import org.optaplanner.core.impl.testdata.domain.score.lavish.TestdataLavishSolution;
 
 @ExtendWith(ConstraintStreamTestExtension.class)
+@Execution(ExecutionMode.CONCURRENT)
 public abstract class AbstractConstraintStreamTest {
 
     protected static final String TEST_CONSTRAINT_NAME = "testConstraintName";

--- a/core/optaplanner-core-impl/src/test/resources/junit-platform.properties
+++ b/core/optaplanner-core-impl/src/test/resources/junit-platform.properties
@@ -1,0 +1,4 @@
+junit.jupiter.execution.parallel.enabled = true
+junit.jupiter.execution.parallel.config.strategy = dynamic
+junit.jupiter.execution.parallel.config.dynamic.factor = 0.5
+

--- a/optaplanner-examples/pom.xml
+++ b/optaplanner-examples/pom.xml
@@ -148,6 +148,12 @@
     </dependency>
     <dependency>
       <groupId>org.optaplanner</groupId>
+      <artifactId>optaplanner-core-impl</artifactId>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.optaplanner</groupId>
       <artifactId>optaplanner-test</artifactId>
       <scope>test</scope>
     </dependency>

--- a/optaplanner-examples/src/test/java/org/optaplanner/examples/common/TurtleTest.java
+++ b/optaplanner-examples/src/test/java/org/optaplanner/examples/common/TurtleTest.java
@@ -8,6 +8,8 @@ import java.lang.annotation.Target;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 
 /**
  * Turtle tests are not run by default. They are only run if {@code -DrunTurtleTests=true} because it takes days.
@@ -16,6 +18,7 @@ import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 @Retention(RetentionPolicy.RUNTIME)
 @Inherited
 @Test
+@Execution(ExecutionMode.CONCURRENT)
 @EnabledIfSystemProperty(named = TestSystemProperties.RUN_TURTLE_TESTS, matches = "true")
 public @interface TurtleTest {
 

--- a/optaplanner-examples/src/test/java/org/optaplanner/examples/common/app/AbstractBenchmarkConfigTest.java
+++ b/optaplanner-examples/src/test/java/org/optaplanner/examples/common/app/AbstractBenchmarkConfigTest.java
@@ -6,6 +6,8 @@ import java.util.stream.Stream;
 
 import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.TestFactory;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.optaplanner.benchmark.api.PlannerBenchmark;
 import org.optaplanner.benchmark.api.PlannerBenchmarkFactory;
 import org.optaplanner.benchmark.impl.DefaultPlannerBenchmark;
@@ -19,6 +21,7 @@ public abstract class AbstractBenchmarkConfigTest {
     protected abstract CommonBenchmarkApp getBenchmarkApp();
 
     @TestFactory
+    @Execution(ExecutionMode.CONCURRENT)
     Stream<DynamicTest> testBenchmarkApp() {
         return getBenchmarkApp().getArgOptions().stream()
                 .map(argOption -> dynamicTest(argOption.toString(), () -> buildPlannerBenchmark(argOption)));

--- a/optaplanner-examples/src/test/java/org/optaplanner/examples/common/app/AbstractPhaseTest.java
+++ b/optaplanner-examples/src/test/java/org/optaplanner/examples/common/app/AbstractPhaseTest.java
@@ -10,6 +10,8 @@ import java.util.stream.Stream;
 import org.junit.jupiter.api.DynamicContainer;
 import org.junit.jupiter.api.TestFactory;
 import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.optaplanner.core.api.domain.solution.PlanningSolution;
 import org.optaplanner.core.api.score.ScoreManager;
 import org.optaplanner.core.api.solver.Solver;
@@ -37,6 +39,7 @@ public abstract class AbstractPhaseTest<Solution_, T> extends LoggingTest {
     }
 
     @TestFactory
+    @Execution(ExecutionMode.CONCURRENT)
     @Timeout(600)
     Stream<DynamicContainer> runPhase() {
         CommonApp<Solution_> commonApp = createCommonApp();

--- a/optaplanner-examples/src/test/java/org/optaplanner/examples/common/app/SolverPerformanceTest.java
+++ b/optaplanner-examples/src/test/java/org/optaplanner/examples/common/app/SolverPerformanceTest.java
@@ -14,6 +14,8 @@ import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestFactory;
 import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.optaplanner.core.api.domain.solution.PlanningSolution;
 import org.optaplanner.core.api.score.Score;
 import org.optaplanner.core.api.score.ScoreExplanation;
@@ -53,6 +55,7 @@ public abstract class SolverPerformanceTest<Solution_, Score_ extends Score<Scor
     }
 
     @TestFactory
+    @Execution(ExecutionMode.CONCURRENT)
     @Timeout(600)
     Stream<DynamicTest> runSpeedTest() {
         return moveThreadCounts().flatMap(moveThreadCount -> testData().map(testData -> dynamicTest(

--- a/optaplanner-examples/src/test/java/org/optaplanner/examples/common/persistence/ImportDataFilesTest.java
+++ b/optaplanner-examples/src/test/java/org/optaplanner/examples/common/persistence/ImportDataFilesTest.java
@@ -15,6 +15,8 @@ import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.filefilter.DirectoryFileFilter;
 import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.TestFactory;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.optaplanner.core.api.domain.solution.PlanningSolution;
 import org.optaplanner.examples.common.app.CommonApp;
 import org.optaplanner.examples.common.app.LoggingTest;
@@ -50,6 +52,7 @@ public abstract class ImportDataFilesTest<Solution_> extends LoggingTest {
     }
 
     @TestFactory
+    @Execution(ExecutionMode.CONCURRENT)
     Stream<DynamicTest> readSolution() {
         AbstractSolutionImporter<Solution_> solutionImporter = createSolutionImporter();
         return getInputFiles(getDataDirName(), solutionImporter).stream()

--- a/optaplanner-examples/src/test/java/org/optaplanner/examples/common/persistence/OpenDataFilesTest.java
+++ b/optaplanner-examples/src/test/java/org/optaplanner/examples/common/persistence/OpenDataFilesTest.java
@@ -12,6 +12,8 @@ import org.apache.commons.io.FileUtils;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.TestFactory;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.optaplanner.core.api.domain.solution.PlanningSolution;
 import org.optaplanner.core.api.score.Score;
 import org.optaplanner.examples.common.app.CommonApp;
@@ -49,14 +51,14 @@ public abstract class OpenDataFilesTest<Solution_> extends LoggingTest {
     }
 
     @TestFactory
+    @Execution(ExecutionMode.CONCURRENT)
     Stream<DynamicTest> readAndWriteSolution() {
         CommonApp<Solution_> commonApp = createCommonApp();
-        SolutionFileIO<Solution_> solutionFileIO = commonApp.createSolutionFileIO();
-        SolutionBusiness<Solution_, ?> solutionBusiness = commonApp.createSolutionBusiness();
         return getSolutionFiles(commonApp).stream()
                 .map(solutionFile -> dynamicTest(
                         solutionFile.getName(),
-                        () -> readAndWriteSolution(solutionBusiness, solutionFileIO, solutionFile)));
+                        () -> readAndWriteSolution(commonApp.createSolutionBusiness(), commonApp.createSolutionFileIO(),
+                                solutionFile)));
     }
 
     private <Score_ extends Score<Score_>> void readAndWriteSolution(SolutionBusiness<Solution_, Score_> solutionBusiness,


### PR DESCRIPTION
Reduced the run time of optaplanner-examples from 9min13s to 7min16s on my quad-core machine. (A reduction in run time of ~20 %.)

However, the biggest benefit of this change will come with turtle tests, which (when run on a powerful machine) will no longer take days, rather hours.

This is unlikely to make any impact on GHA, as those machines have 2 cores and this is configured to use 50 % of available cores.