### PR TITLE
Clean up selector factories' build methods

### DIFF
--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/AbstractFromConfigFactory.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/AbstractFromConfigFactory.java
@@ -37,6 +37,14 @@ public abstract class AbstractFromConfigFactory<Solution_, Config_ extends Abstr
         return entitySelectorConfig;
     }
 
+    protected EntityDescriptor<Solution_> deduceEntityDescriptor(HeuristicConfigPolicy<Solution_> configPolicy,
+            Class<?> entityClass) {
+        SolutionDescriptor<Solution_> solutionDescriptor = configPolicy.getSolutionDescriptor();
+        return entityClass == null
+                ? deduceEntityDescriptor(solutionDescriptor)
+                : deduceEntityDescriptor(solutionDescriptor, entityClass);
+    }
+
     protected EntityDescriptor<Solution_> deduceEntityDescriptor(SolutionDescriptor<Solution_> solutionDescriptor,
             Class<?> entityClass) {
         EntityDescriptor<Solution_> entityDescriptor =

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/AbstractFromConfigFactory.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/AbstractFromConfigFactory.java
@@ -41,14 +41,13 @@ public abstract class AbstractFromConfigFactory<Solution_, Config_ extends Abstr
             Class<?> entityClass) {
         SolutionDescriptor<Solution_> solutionDescriptor = configPolicy.getSolutionDescriptor();
         return entityClass == null
-                ? deduceEntityDescriptor(solutionDescriptor)
-                : deduceEntityDescriptor(solutionDescriptor, entityClass);
+                ? getTheOnlyEntityDescriptor(solutionDescriptor)
+                : getEntityDescriptorForClass(solutionDescriptor, entityClass);
     }
 
-    protected EntityDescriptor<Solution_> deduceEntityDescriptor(SolutionDescriptor<Solution_> solutionDescriptor,
+    private EntityDescriptor<Solution_> getEntityDescriptorForClass(SolutionDescriptor<Solution_> solutionDescriptor,
             Class<?> entityClass) {
-        EntityDescriptor<Solution_> entityDescriptor =
-                solutionDescriptor.getEntityDescriptorStrict(Objects.requireNonNull(entityClass));
+        EntityDescriptor<Solution_> entityDescriptor = solutionDescriptor.getEntityDescriptorStrict(entityClass);
         if (entityDescriptor == null) {
             throw new IllegalArgumentException("The config (" + config
                     + ") has an entityClass (" + entityClass + ") that is not a known planning entity.\n"
@@ -60,7 +59,7 @@ public abstract class AbstractFromConfigFactory<Solution_, Config_ extends Abstr
         return entityDescriptor;
     }
 
-    protected EntityDescriptor<Solution_> deduceEntityDescriptor(SolutionDescriptor<Solution_> solutionDescriptor) {
+    protected EntityDescriptor<Solution_> getTheOnlyEntityDescriptor(SolutionDescriptor<Solution_> solutionDescriptor) {
         Collection<EntityDescriptor<Solution_>> entityDescriptors = solutionDescriptor.getGenuineEntityDescriptors();
         if (entityDescriptors.size() != 1) {
             throw new IllegalArgumentException("The config (" + config
@@ -71,10 +70,16 @@ public abstract class AbstractFromConfigFactory<Solution_, Config_ extends Abstr
         return entityDescriptors.iterator().next();
     }
 
-    protected GenuineVariableDescriptor<Solution_> deduceVariableDescriptor(
-            EntityDescriptor<Solution_> entityDescriptor, String variableName) {
-        GenuineVariableDescriptor<Solution_> variableDescriptor =
-                entityDescriptor.getGenuineVariableDescriptor(Objects.requireNonNull(variableName));
+    protected GenuineVariableDescriptor<Solution_> deduceGenuineVariableDescriptor(EntityDescriptor<Solution_> entityDescriptor,
+            String variableName) {
+        return variableName == null
+                ? getTheOnlyVariableDescriptor(entityDescriptor)
+                : getVariableDescriptorForName(entityDescriptor, variableName);
+    }
+
+    private GenuineVariableDescriptor<Solution_> getVariableDescriptorForName(EntityDescriptor<Solution_> entityDescriptor,
+            String variableName) {
+        GenuineVariableDescriptor<Solution_> variableDescriptor = entityDescriptor.getGenuineVariableDescriptor(variableName);
         if (variableDescriptor == null) {
             throw new IllegalArgumentException("The config (" + config
                     + ") has a variableName (" + variableName
@@ -85,8 +90,7 @@ public abstract class AbstractFromConfigFactory<Solution_, Config_ extends Abstr
         return variableDescriptor;
     }
 
-    protected GenuineVariableDescriptor<Solution_> deduceVariableDescriptor(
-            EntityDescriptor<Solution_> entityDescriptor) {
+    protected GenuineVariableDescriptor<Solution_> getTheOnlyVariableDescriptor(EntityDescriptor<Solution_> entityDescriptor) {
         List<GenuineVariableDescriptor<Solution_>> variableDescriptorList =
                 entityDescriptor.getGenuineVariableDescriptorList();
         if (variableDescriptorList.size() != 1) {

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/AbstractFromConfigFactory.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/AbstractFromConfigFactory.java
@@ -77,7 +77,7 @@ public abstract class AbstractFromConfigFactory<Solution_, Config_ extends Abstr
                 : getVariableDescriptorForName(entityDescriptor, variableName);
     }
 
-    private GenuineVariableDescriptor<Solution_> getVariableDescriptorForName(EntityDescriptor<Solution_> entityDescriptor,
+    protected GenuineVariableDescriptor<Solution_> getVariableDescriptorForName(EntityDescriptor<Solution_> entityDescriptor,
             String variableName) {
         GenuineVariableDescriptor<Solution_> variableDescriptor = entityDescriptor.getGenuineVariableDescriptor(variableName);
         if (variableDescriptor == null) {

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/constructionheuristic/placer/PooledEntityPlacerFactory.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/constructionheuristic/placer/PooledEntityPlacerFactory.java
@@ -47,7 +47,7 @@ public class PooledEntityPlacerFactory<Solution_>
             }
             if (entitySelectorConfig == null) {
                 EntityDescriptor<Solution_> entityDescriptor = new PooledEntityPlacerFactory<Solution_>(config)
-                        .deduceEntityDescriptor(configPolicy.getSolutionDescriptor());
+                        .getTheOnlyEntityDescriptor(configPolicy.getSolutionDescriptor());
                 entitySelectorConfig =
                         AbstractFromConfigFactory.getDefaultEntitySelectorConfigForEntity(configPolicy, entityDescriptor);
                 changeMoveSelectorConfig.setEntitySelectorConfig(entitySelectorConfig);
@@ -73,7 +73,7 @@ public class PooledEntityPlacerFactory<Solution_>
     }
 
     private MoveSelectorConfig buildMoveSelectorConfig(HeuristicConfigPolicy<Solution_> configPolicy) {
-        EntityDescriptor<Solution_> entityDescriptor = deduceEntityDescriptor(configPolicy.getSolutionDescriptor());
+        EntityDescriptor<Solution_> entityDescriptor = getTheOnlyEntityDescriptor(configPolicy.getSolutionDescriptor());
         EntitySelectorConfig entitySelectorConfig =
                 AbstractFromConfigFactory.getDefaultEntitySelectorConfigForEntity(configPolicy, entityDescriptor);
 

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/constructionheuristic/placer/QueuedEntityPlacerFactory.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/constructionheuristic/placer/QueuedEntityPlacerFactory.java
@@ -99,7 +99,7 @@ public class QueuedEntityPlacerFactory<Solution_>
     public EntitySelectorConfig buildEntitySelectorConfig(HeuristicConfigPolicy<Solution_> configPolicy) {
         EntitySelectorConfig entitySelectorConfig_;
         if (config.getEntitySelectorConfig() == null) {
-            EntityDescriptor<Solution_> entityDescriptor = deduceEntityDescriptor(configPolicy.getSolutionDescriptor());
+            EntityDescriptor<Solution_> entityDescriptor = getTheOnlyEntityDescriptor(configPolicy.getSolutionDescriptor());
             entitySelectorConfig_ = getDefaultEntitySelectorConfigForEntity(configPolicy, entityDescriptor);
         } else {
             entitySelectorConfig_ = config.getEntitySelectorConfig();

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/constructionheuristic/placer/QueuedValuePlacerFactory.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/constructionheuristic/placer/QueuedValuePlacerFactory.java
@@ -60,7 +60,7 @@ public class QueuedValuePlacerFactory<Solution_>
         if (config.getValueSelectorConfig() == null) {
             valueSelectorConfig_ = new ValueSelectorConfig();
             Class<?> entityClass = entityDescriptor.getEntityClass();
-            GenuineVariableDescriptor<Solution_> variableDescriptor = deduceVariableDescriptor(entityDescriptor);
+            GenuineVariableDescriptor<Solution_> variableDescriptor = getTheOnlyVariableDescriptor(entityDescriptor);
             valueSelectorConfig_.setId(entityClass.getName() + "." + variableDescriptor.getVariableName());
             valueSelectorConfig_.setVariableName(variableDescriptor.getVariableName());
             if (ValueSelectorConfig.hasSorter(configPolicy.getValueSorterManner(), variableDescriptor)) {

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/constructionheuristic/placer/QueuedValuePlacerFactory.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/constructionheuristic/placer/QueuedValuePlacerFactory.java
@@ -31,9 +31,7 @@ public class QueuedValuePlacerFactory<Solution_>
 
     @Override
     public QueuedValuePlacer<Solution_> buildEntityPlacer(HeuristicConfigPolicy<Solution_> configPolicy) {
-        EntityDescriptor<Solution_> entityDescriptor =
-                config.getEntityClass() == null ? deduceEntityDescriptor(configPolicy.getSolutionDescriptor())
-                        : deduceEntityDescriptor(configPolicy.getSolutionDescriptor(), config.getEntityClass());
+        EntityDescriptor<Solution_> entityDescriptor = deduceEntityDescriptor(configPolicy, config.getEntityClass());
         ValueSelectorConfig valueSelectorConfig_ = buildValueSelectorConfig(configPolicy, entityDescriptor);
         ValueSelector<Solution_> valueSelector = ValueSelectorFactory.<Solution_> create(valueSelectorConfig_)
                 .buildValueSelector(configPolicy, entityDescriptor, SelectionCacheType.PHASE, SelectionOrder.ORIGINAL,

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/entity/EntitySelectorFactory.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/entity/EntitySelectorFactory.java
@@ -82,9 +82,7 @@ public class EntitySelectorFactory<Solution_> extends AbstractSelectorFactory<So
         if (config.getMimicSelectorRef() != null) {
             return buildMimicReplaying(configPolicy);
         }
-        EntityDescriptor<Solution_> entityDescriptor =
-                config.getEntityClass() == null ? deduceEntityDescriptor(configPolicy.getSolutionDescriptor())
-                        : deduceEntityDescriptor(configPolicy.getSolutionDescriptor(), config.getEntityClass());
+        EntityDescriptor<Solution_> entityDescriptor = deduceEntityDescriptor(configPolicy, config.getEntityClass());
         SelectionCacheType resolvedCacheType = SelectionCacheType.resolve(config.getCacheType(), minimumCacheType);
         SelectionOrder resolvedSelectionOrder = SelectionOrder.resolve(config.getSelectionOrder(), inheritedSelectionOrder);
 
@@ -122,14 +120,13 @@ public class EntitySelectorFactory<Solution_> extends AbstractSelectorFactory<So
                         config.getNearbySelectionConfig(), config.getFilterClass(), config.getSorterManner(),
                         config.getSorterComparatorClass(), config.getSorterWeightFactoryClass(), config.getSorterOrder(),
                         config.getSorterClass(), config.getProbabilityWeightFactoryClass(), config.getSelectedCountLimit())
-                .filter(Objects::nonNull).findFirst().isPresent();
+                .anyMatch(Objects::nonNull);
         if (anyConfigurationParameterDefined) {
             throw new IllegalArgumentException("The entitySelectorConfig (" + config
                     + ") with mimicSelectorRef (" + config.getMimicSelectorRef()
                     + ") has another property that is not null.");
         }
-        EntityMimicRecorder<Solution_> entityMimicRecorder =
-                configPolicy.getEntityMimicRecorder(config.getMimicSelectorRef());
+        EntityMimicRecorder<Solution_> entityMimicRecorder = configPolicy.getEntityMimicRecorder(config.getMimicSelectorRef());
         if (entityMimicRecorder == null) {
             throw new IllegalArgumentException("The entitySelectorConfig (" + config
                     + ") has a mimicSelectorRef (" + config.getMimicSelectorRef()

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/entity/pillar/PillarSelectorFactory.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/entity/pillar/PillarSelectorFactory.java
@@ -56,10 +56,9 @@ public class PillarSelectorFactory<Solution_>
         }
         boolean subPillarEnabled = subPillarType != SubPillarType.NONE;
         // EntitySelector uses SelectionOrder.ORIGINAL because a DefaultPillarSelector STEP caches the values
-        EntitySelectorConfig entitySelectorConfig_ =
-                config.getEntitySelectorConfig() == null ? new EntitySelectorConfig()
-                        : config.getEntitySelectorConfig();
-        EntitySelector<Solution_> entitySelector = EntitySelectorFactory.<Solution_> create(entitySelectorConfig_)
+        EntitySelectorConfig entitySelectorConfig =
+                Objects.requireNonNullElseGet(config.getEntitySelectorConfig(), EntitySelectorConfig::new);
+        EntitySelector<Solution_> entitySelector = EntitySelectorFactory.<Solution_> create(entitySelectorConfig)
                 .buildEntitySelector(configPolicy, minimumCacheType, SelectionOrder.ORIGINAL);
         List<GenuineVariableDescriptor<Solution_>> variableDescriptors =
                 deduceVariableDescriptorList(entitySelector.getEntityDescriptor(), variableNameIncludeList);

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/composite/AbstractCompositeMoveSelectorFactory.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/composite/AbstractCompositeMoveSelectorFactory.java
@@ -23,8 +23,7 @@ abstract class AbstractCompositeMoveSelectorFactory<Solution_, MoveSelectorConfi
             boolean randomSelection) {
         return innerMoveSelectorList.stream()
                 .map(moveSelectorConfig -> {
-                    MoveSelectorFactory<Solution_> innerMoveSelectorFactory =
-                            MoveSelectorFactory.create(moveSelectorConfig);
+                    MoveSelectorFactory<Solution_> innerMoveSelectorFactory = MoveSelectorFactory.create(moveSelectorConfig);
                     SelectionOrder selectionOrder = SelectionOrder.fromRandomSelectionBoolean(randomSelection);
                     return innerMoveSelectorFactory.buildMoveSelector(configPolicy, minimumCacheType, selectionOrder);
                 }).collect(Collectors.toList());

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/ChangeMoveSelectorFactory.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/ChangeMoveSelectorFactory.java
@@ -39,18 +39,15 @@ public class ChangeMoveSelectorFactory<Solution_>
             throw new IllegalStateException("The entitySelectorConfig (" + config.getEntitySelectorConfig()
                     + ") should haven been initialized during unfolding.");
         }
-        EntitySelectorFactory<Solution_> entitySelectorFactory =
-                EntitySelectorFactory.create(config.getEntitySelectorConfig());
-        EntitySelector<Solution_> entitySelector = entitySelectorFactory.buildEntitySelector(configPolicy,
-                minimumCacheType, SelectionOrder.fromRandomSelectionBoolean(randomSelection));
         if (config.getValueSelectorConfig() == null) {
             throw new IllegalStateException("The valueSelectorConfig (" + config.getValueSelectorConfig()
                     + ") should haven been initialized during unfolding.");
         }
-        ValueSelectorFactory<Solution_> valueSelectorFactory = ValueSelectorFactory.create(config.getValueSelectorConfig());
-        ValueSelector<Solution_> valueSelector = valueSelectorFactory.buildValueSelector(configPolicy,
-                entitySelector.getEntityDescriptor(),
-                minimumCacheType, SelectionOrder.fromRandomSelectionBoolean(randomSelection));
+        SelectionOrder selectionOrder = SelectionOrder.fromRandomSelectionBoolean(randomSelection);
+        EntitySelector<Solution_> entitySelector = EntitySelectorFactory.<Solution_> create(config.getEntitySelectorConfig())
+                .buildEntitySelector(configPolicy, minimumCacheType, selectionOrder);
+        ValueSelector<Solution_> valueSelector = ValueSelectorFactory.<Solution_> create(config.getValueSelectorConfig())
+                .buildValueSelector(configPolicy, entitySelector.getEntityDescriptor(), minimumCacheType, selectionOrder);
         if (valueSelector.getVariableDescriptor().isListVariable()) {
             if (!(valueSelector instanceof EntityIndependentValueSelector)) {
                 throw new IllegalArgumentException("The changeMoveSelector (" + this

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/PillarChangeMoveSelectorFactory.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/PillarChangeMoveSelectorFactory.java
@@ -27,18 +27,18 @@ public class PillarChangeMoveSelectorFactory<Solution_>
     @Override
     protected MoveSelector<Solution_> buildBaseMoveSelector(HeuristicConfigPolicy<Solution_> configPolicy,
             SelectionCacheType minimumCacheType, boolean randomSelection) {
-        PillarSelectorConfig pillarSelectorConfig_ =
-                Objects.requireNonNullElse(config.getPillarSelectorConfig(), new PillarSelectorConfig());
+        PillarSelectorConfig pillarSelectorConfig =
+                Objects.requireNonNullElseGet(config.getPillarSelectorConfig(), PillarSelectorConfig::new);
+        ValueSelectorConfig valueSelectorConfig =
+                Objects.requireNonNullElseGet(config.getValueSelectorConfig(), ValueSelectorConfig::new);
         List<String> variableNameIncludeList = config.getValueSelectorConfig() == null
                 || config.getValueSelectorConfig().getVariableName() == null ? null
                         : Collections.singletonList(config.getValueSelectorConfig().getVariableName());
-        PillarSelector<Solution_> pillarSelector = PillarSelectorFactory.<Solution_> create(pillarSelectorConfig_)
-                .buildPillarSelector(configPolicy, config.getSubPillarType(), config.getSubPillarSequenceComparatorClass(),
-                        minimumCacheType, SelectionOrder.fromRandomSelectionBoolean(randomSelection), variableNameIncludeList);
-        ValueSelectorConfig valueSelectorConfig_ = Objects.requireNonNullElse(config.getValueSelectorConfig(),
-                new ValueSelectorConfig());
         SelectionOrder selectionOrder = SelectionOrder.fromRandomSelectionBoolean(randomSelection);
-        ValueSelector<Solution_> valueSelector = ValueSelectorFactory.<Solution_> create(valueSelectorConfig_)
+        PillarSelector<Solution_> pillarSelector = PillarSelectorFactory.<Solution_> create(pillarSelectorConfig)
+                .buildPillarSelector(configPolicy, config.getSubPillarType(), config.getSubPillarSequenceComparatorClass(),
+                        minimumCacheType, selectionOrder, variableNameIncludeList);
+        ValueSelector<Solution_> valueSelector = ValueSelectorFactory.<Solution_> create(valueSelectorConfig)
                 .buildValueSelector(configPolicy, pillarSelector.getEntityDescriptor(), minimumCacheType, selectionOrder);
         return new PillarChangeMoveSelector<>(pillarSelector, valueSelector, randomSelection);
     }

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/PillarSwapMoveSelectorFactory.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/PillarSwapMoveSelectorFactory.java
@@ -26,17 +26,16 @@ public class PillarSwapMoveSelectorFactory<Solution_>
             SelectionCacheType minimumCacheType, boolean randomSelection) {
         PillarSelectorConfig leftPillarSelectorConfig =
                 Objects.requireNonNullElseGet(config.getPillarSelectorConfig(), PillarSelectorConfig::new);
-        PillarSelector<Solution_> leftPillarSelector =
-                buildPillarSelector(leftPillarSelectorConfig, configPolicy, minimumCacheType, randomSelection);
         PillarSelectorConfig rightPillarSelectorConfig =
                 Objects.requireNonNullElse(config.getSecondaryPillarSelectorConfig(), leftPillarSelectorConfig);
+        PillarSelector<Solution_> leftPillarSelector =
+                buildPillarSelector(leftPillarSelectorConfig, configPolicy, minimumCacheType, randomSelection);
         PillarSelector<Solution_> rightPillarSelector =
                 buildPillarSelector(rightPillarSelectorConfig, configPolicy, minimumCacheType, randomSelection);
 
         List<GenuineVariableDescriptor<Solution_>> variableDescriptorList =
                 deduceVariableDescriptorList(leftPillarSelector.getEntityDescriptor(), config.getVariableNameIncludeList());
-        return new PillarSwapMoveSelector<>(leftPillarSelector, rightPillarSelector, variableDescriptorList,
-                randomSelection);
+        return new PillarSwapMoveSelector<>(leftPillarSelector, rightPillarSelector, variableDescriptorList, randomSelection);
     }
 
     private PillarSelector<Solution_> buildPillarSelector(PillarSelectorConfig pillarSelectorConfig,

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/chained/KOptMoveSelectorFactory.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/chained/KOptMoveSelectorFactory.java
@@ -1,5 +1,7 @@
 package org.optaplanner.core.impl.heuristic.selector.move.generic.chained;
 
+import java.util.Objects;
+
 import org.optaplanner.core.config.heuristic.selector.common.SelectionCacheType;
 import org.optaplanner.core.config.heuristic.selector.common.SelectionOrder;
 import org.optaplanner.core.config.heuristic.selector.entity.EntitySelectorConfig;
@@ -25,19 +27,17 @@ public class KOptMoveSelectorFactory<Solution_>
     @Override
     protected MoveSelector<Solution_> buildBaseMoveSelector(HeuristicConfigPolicy<Solution_> configPolicy,
             SelectionCacheType minimumCacheType, boolean randomSelection) {
-        EntitySelectorConfig entitySelectorConfig_ =
-                config.getEntitySelectorConfig() == null ? new EntitySelectorConfig() : config.getEntitySelectorConfig();
-        EntitySelector<Solution_> entitySelector =
-                EntitySelectorFactory.<Solution_> create(entitySelectorConfig_)
-                        .buildEntitySelector(configPolicy, minimumCacheType,
-                                SelectionOrder.fromRandomSelectionBoolean(randomSelection));
-        ValueSelectorConfig valueSelectorConfig_ =
-                config.getValueSelectorConfig() == null ? new ValueSelectorConfig() : config.getValueSelectorConfig();
+        EntitySelectorConfig entitySelectorConfig =
+                Objects.requireNonNullElseGet(config.getEntitySelectorConfig(), EntitySelectorConfig::new);
+        ValueSelectorConfig valueSelectorConfig =
+                Objects.requireNonNullElseGet(config.getValueSelectorConfig(), ValueSelectorConfig::new);
+        SelectionOrder selectionOrder = SelectionOrder.fromRandomSelectionBoolean(randomSelection);
+        EntitySelector<Solution_> entitySelector = EntitySelectorFactory.<Solution_> create(entitySelectorConfig)
+                .buildEntitySelector(configPolicy, minimumCacheType, selectionOrder);
         ValueSelector<Solution_>[] valueSelectors = new ValueSelector[K - 1];
         for (int i = 0; i < valueSelectors.length; i++) {
-            valueSelectors[i] = ValueSelectorFactory.<Solution_> create(valueSelectorConfig_)
-                    .buildValueSelector(configPolicy, entitySelector.getEntityDescriptor(), minimumCacheType,
-                            SelectionOrder.fromRandomSelectionBoolean(randomSelection));
+            valueSelectors[i] = ValueSelectorFactory.<Solution_> create(valueSelectorConfig)
+                    .buildValueSelector(configPolicy, entitySelector.getEntityDescriptor(), minimumCacheType, selectionOrder);
 
         }
         return new KOptMoveSelector<>(entitySelector, valueSelectors, randomSelection);

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/chained/SubChainChangeMoveSelectorFactory.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/chained/SubChainChangeMoveSelectorFactory.java
@@ -28,21 +28,16 @@ public class SubChainChangeMoveSelectorFactory<Solution_>
     @Override
     protected MoveSelector<Solution_> buildBaseMoveSelector(HeuristicConfigPolicy<Solution_> configPolicy,
             SelectionCacheType minimumCacheType, boolean randomSelection) {
-        EntityDescriptor<Solution_> entityDescriptor =
-                config.getEntityClass() == null ? deduceEntityDescriptor(configPolicy.getSolutionDescriptor())
-                        : deduceEntityDescriptor(configPolicy.getSolutionDescriptor(), config.getEntityClass());
-        SubChainSelectorConfig subChainSelectorConfig_ =
-                config.getSubChainSelectorConfig() == null ? new SubChainSelectorConfig()
-                        : config.getSubChainSelectorConfig();
-        SubChainSelector<Solution_> subChainSelector =
-                SubChainSelectorFactory.<Solution_> create(subChainSelectorConfig_)
-                        .buildSubChainSelector(configPolicy, entityDescriptor, minimumCacheType,
-                                SelectionOrder.fromRandomSelectionBoolean(randomSelection));
-        ValueSelectorConfig valueSelectorConfig_ =
-                config.getValueSelectorConfig() == null ? new ValueSelectorConfig() : config.getValueSelectorConfig();
-        ValueSelector<Solution_> valueSelector = ValueSelectorFactory.<Solution_> create(valueSelectorConfig_)
-                .buildValueSelector(configPolicy, entityDescriptor, minimumCacheType,
-                        SelectionOrder.fromRandomSelectionBoolean(randomSelection));
+        EntityDescriptor<Solution_> entityDescriptor = deduceEntityDescriptor(configPolicy, config.getEntityClass());
+        SubChainSelectorConfig subChainSelectorConfig =
+                Objects.requireNonNullElseGet(config.getSubChainSelectorConfig(), SubChainSelectorConfig::new);
+        ValueSelectorConfig valueSelectorConfig =
+                Objects.requireNonNullElseGet(config.getValueSelectorConfig(), ValueSelectorConfig::new);
+        SelectionOrder selectionOrder = SelectionOrder.fromRandomSelectionBoolean(randomSelection);
+        SubChainSelector<Solution_> subChainSelector = SubChainSelectorFactory.<Solution_> create(subChainSelectorConfig)
+                .buildSubChainSelector(configPolicy, entityDescriptor, minimumCacheType, selectionOrder);
+        ValueSelector<Solution_> valueSelector = ValueSelectorFactory.<Solution_> create(valueSelectorConfig)
+                .buildValueSelector(configPolicy, entityDescriptor, minimumCacheType, selectionOrder);
         if (!(valueSelector instanceof EntityIndependentValueSelector)) {
             throw new IllegalArgumentException("The moveSelectorConfig (" + config
                     + ") needs to be based on an "

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/chained/SubChainSwapMoveSelectorFactory.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/chained/SubChainSwapMoveSelectorFactory.java
@@ -23,22 +23,18 @@ public class SubChainSwapMoveSelectorFactory<Solution_>
     @Override
     protected MoveSelector<Solution_> buildBaseMoveSelector(HeuristicConfigPolicy<Solution_> configPolicy,
             SelectionCacheType minimumCacheType, boolean randomSelection) {
-        EntityDescriptor<Solution_> entityDescriptor =
-                config.getEntityClass() == null ? deduceEntityDescriptor(configPolicy.getSolutionDescriptor())
-                        : deduceEntityDescriptor(configPolicy.getSolutionDescriptor(), config.getEntityClass());
-        SubChainSelectorConfig subChainSelectorConfig_ =
-                config.getSubChainSelectorConfig() == null ? new SubChainSelectorConfig()
-                        : config.getSubChainSelectorConfig();
+        EntityDescriptor<Solution_> entityDescriptor = deduceEntityDescriptor(configPolicy, config.getEntityClass());
+        SubChainSelectorConfig subChainSelectorConfig =
+                Objects.requireNonNullElseGet(config.getSubChainSelectorConfig(), SubChainSelectorConfig::new);
+        SubChainSelectorConfig secondarySubChainSelectorConfig =
+                Objects.requireNonNullElse(config.getSecondarySubChainSelectorConfig(), subChainSelectorConfig);
+        SelectionOrder selectionOrder = SelectionOrder.fromRandomSelectionBoolean(randomSelection);
         SubChainSelector<Solution_> leftSubChainSelector =
-                SubChainSelectorFactory.<Solution_> create(subChainSelectorConfig_)
-                        .buildSubChainSelector(configPolicy, entityDescriptor, minimumCacheType,
-                                SelectionOrder.fromRandomSelectionBoolean(randomSelection));
-        SubChainSelectorConfig rightSubChainSelectorConfig =
-                Objects.requireNonNullElse(config.getSecondarySubChainSelectorConfig(), subChainSelectorConfig_);
+                SubChainSelectorFactory.<Solution_> create(subChainSelectorConfig)
+                        .buildSubChainSelector(configPolicy, entityDescriptor, minimumCacheType, selectionOrder);
         SubChainSelector<Solution_> rightSubChainSelector =
-                SubChainSelectorFactory.<Solution_> create(rightSubChainSelectorConfig)
-                        .buildSubChainSelector(configPolicy, entityDescriptor, minimumCacheType,
-                                SelectionOrder.fromRandomSelectionBoolean(randomSelection));
+                SubChainSelectorFactory.<Solution_> create(secondarySubChainSelectorConfig)
+                        .buildSubChainSelector(configPolicy, entityDescriptor, minimumCacheType, selectionOrder);
         return new SubChainSwapMoveSelector<>(leftSubChainSelector, rightSubChainSelector, randomSelection,
                 Objects.requireNonNullElse(config.getSelectReversingMoveToo(), true));
     }

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/chained/TailChainSwapMoveSelectorFactory.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/chained/TailChainSwapMoveSelectorFactory.java
@@ -1,5 +1,7 @@
 package org.optaplanner.core.impl.heuristic.selector.move.generic.chained;
 
+import java.util.Objects;
+
 import org.optaplanner.core.config.heuristic.selector.common.SelectionCacheType;
 import org.optaplanner.core.config.heuristic.selector.common.SelectionOrder;
 import org.optaplanner.core.config.heuristic.selector.entity.EntitySelectorConfig;
@@ -23,18 +25,15 @@ public class TailChainSwapMoveSelectorFactory<Solution_>
     @Override
     protected MoveSelector<Solution_> buildBaseMoveSelector(HeuristicConfigPolicy<Solution_> configPolicy,
             SelectionCacheType minimumCacheType, boolean randomSelection) {
-        EntitySelectorConfig entitySelectorConfig_ =
-                config.getEntitySelectorConfig() == null ? new EntitySelectorConfig() : config.getEntitySelectorConfig();
-        EntitySelector<Solution_> entitySelector =
-                EntitySelectorFactory.<Solution_> create(entitySelectorConfig_)
-                        .buildEntitySelector(configPolicy, minimumCacheType,
-                                SelectionOrder.fromRandomSelectionBoolean(randomSelection));
-        ValueSelectorConfig valueSelectorConfig_ =
-                config.getValueSelectorConfig() == null ? new ValueSelectorConfig() : config.getValueSelectorConfig();
-        ValueSelector<Solution_> valueSelector =
-                ValueSelectorFactory.<Solution_> create(valueSelectorConfig_)
-                        .buildValueSelector(configPolicy, entitySelector.getEntityDescriptor(), minimumCacheType,
-                                SelectionOrder.fromRandomSelectionBoolean(randomSelection));
+        EntitySelectorConfig entitySelectorConfig =
+                Objects.requireNonNullElseGet(config.getEntitySelectorConfig(), EntitySelectorConfig::new);
+        ValueSelectorConfig valueSelectorConfig =
+                Objects.requireNonNullElseGet(config.getValueSelectorConfig(), ValueSelectorConfig::new);
+        SelectionOrder selectionOrder = SelectionOrder.fromRandomSelectionBoolean(randomSelection);
+        EntitySelector<Solution_> entitySelector = EntitySelectorFactory.<Solution_> create(entitySelectorConfig)
+                .buildEntitySelector(configPolicy, minimumCacheType, selectionOrder);
+        ValueSelector<Solution_> valueSelector = ValueSelectorFactory.<Solution_> create(valueSelectorConfig)
+                .buildValueSelector(configPolicy, entitySelector.getEntityDescriptor(), minimumCacheType, selectionOrder);
         return new TailChainSwapMoveSelector<>(entitySelector, valueSelector, randomSelection);
     }
 }

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/value/ValueSelectorFactory.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/value/ValueSelectorFactory.java
@@ -59,18 +59,9 @@ public class ValueSelectorFactory<Solution_>
 
     public GenuineVariableDescriptor<Solution_> extractVariableDescriptor(HeuristicConfigPolicy<Solution_> configPolicy,
             EntityDescriptor<Solution_> entityDescriptor) {
-        entityDescriptor = downcastEntityDescriptor(configPolicy, entityDescriptor);
-        if (config.getVariableName() != null) {
-            GenuineVariableDescriptor<Solution_> variableDescriptor =
-                    entityDescriptor.getGenuineVariableDescriptor(config.getVariableName());
-            if (variableDescriptor == null) {
-                throw new IllegalArgumentException("The selectorConfig (" + config
-                        + ") has a variableName (" + config.getVariableName()
-                        + ") which is not a valid planning variable on entityClass ("
-                        + entityDescriptor.getEntityClass() + ").\n"
-                        + entityDescriptor.buildInvalidVariableNameExceptionMessage(config.getVariableName()));
-            }
-            return variableDescriptor;
+        String variableName = config.getVariableName();
+        if (variableName != null) {
+            return getVariableDescriptorForName(downcastEntityDescriptor(configPolicy, entityDescriptor), variableName);
         } else if (config.getMimicSelectorRef() != null) {
             return configPolicy.getValueMimicRecorder(config.getMimicSelectorRef()).getVariableDescriptor();
         } else {

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/value/ValueSelectorFactory.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/value/ValueSelectorFactory.java
@@ -100,7 +100,7 @@ public class ValueSelectorFactory<Solution_>
             SelectionOrder inheritedSelectionOrder, boolean applyReinitializeVariableFiltering,
             boolean applyUnassignedValueFiltering) {
         GenuineVariableDescriptor<Solution_> variableDescriptor = deduceGenuineVariableDescriptor(
-                downcastEntityDescriptor(configPolicy, entityDescriptor));
+                downcastEntityDescriptor(configPolicy, entityDescriptor), config.getVariableName());
         if (config.getMimicSelectorRef() != null) {
             ValueSelector<Solution_> valueSelector = buildMimicReplaying(configPolicy);
             valueSelector =
@@ -142,12 +142,6 @@ public class ValueSelectorFactory<Solution_>
                 applyReinitializeVariableFiltering(applyReinitializeVariableFiltering, variableDescriptor, valueSelector);
         valueSelector = applyDowncasting(valueSelector);
         return valueSelector;
-    }
-
-    private GenuineVariableDescriptor<Solution_> deduceGenuineVariableDescriptor(EntityDescriptor<Solution_> entityDescriptor) {
-        return config.getVariableName() == null
-                ? deduceVariableDescriptor(entityDescriptor)
-                : deduceVariableDescriptor(entityDescriptor, config.getVariableName());
     }
 
     protected ValueSelector<Solution_> buildMimicReplaying(HeuristicConfigPolicy<Solution_> configPolicy) {

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/value/chained/SubChainSelectorFactory.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/value/chained/SubChainSelectorFactory.java
@@ -54,12 +54,11 @@ public class SubChainSelectorFactory<Solution_> {
                     + ") must not be higher than " + SelectionCacheType.STEP
                     + " because the chains change every step.");
         }
-        ValueSelectorConfig valueSelectorConfig_ = config.getValueSelectorConfig() == null ? new ValueSelectorConfig()
-                : config.getValueSelectorConfig();
+        ValueSelectorConfig valueSelectorConfig =
+                Objects.requireNonNullElseGet(config.getValueSelectorConfig(), ValueSelectorConfig::new);
         // ValueSelector uses SelectionOrder.ORIGINAL because a SubChainSelector STEP caches the values
-        ValueSelector<Solution_> valueSelector =
-                ValueSelectorFactory.<Solution_> create(valueSelectorConfig_)
-                        .buildValueSelector(configPolicy, entityDescriptor, minimumCacheType, SelectionOrder.ORIGINAL);
+        ValueSelector<Solution_> valueSelector = ValueSelectorFactory.<Solution_> create(valueSelectorConfig)
+                .buildValueSelector(configPolicy, entityDescriptor, minimumCacheType, SelectionOrder.ORIGINAL);
         if (!(valueSelector instanceof EntityIndependentValueSelector)) {
             throw new IllegalArgumentException("The minimumCacheType (" + this
                     + ") needs to be based on an "


### PR DESCRIPTION
I made some improvements to the code that builds selectors from configs. It should be now easier to understand because it's slightly less code and its structure is more consistent across all factories.

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request checks</b>  
  Please add comment: <b>Jenkins retest this</b>

- for a <b>specific pull request check</b>  
  please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-vehicle-routing] tests</b>
  
- for a <b>full downstream build</b> 
  - for <b>jenkins</b> job: 
    please add comment: <b>Jenkins run fdb</b>
  - for <b>github actions</b> job: 
    add the label `run_fdb`

- for a <b>compile downstream build</b>  
  please add comment: <b>Jenkins run cdb</b>

- for a <b>full production downstream build</b>  
  please add comment: <b>Jenkins execute product fdb</b>

- for an <b>upstream build</b>  
  please add comment: <b>Jenkins run upstream</b>

- for <b>quarkus branch checks</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins run quarkus-branch</b>

- for a <b>quarkus branch specific check</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-vehicle-routing] quarkus-branch</b>

- for <b>quarkus main checks</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins run quarkus-main</b>

- for a <b>specific quarkus main check</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-vehicle-routing] quarkus-branch</b>

- for <b>native checks</b>  
  Run native checks  
  Please add comment: <b>Jenkins run native</b>

- for a <b>specific native check</b>  
  Run native checks 
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-vehicle-routing] native</b>

- for <b>mandrel checks</b>  
  Run native checks against Mandrel image
  Please add comment: <b>Jenkins run mandrel</b>

- for a <b>specific mandrel check</b>  
  Run native checks against Mandrel image  
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-vehicle-routing] mandrel</b>
</details>

### CI Status

 You can check OptaPlanner repositories CI status from [Chain Status webpage](https://kiegroup.github.io/optaplanner/).