### PR TITLE
Fix Animal Sniffer plugin management

### DIFF
--- a/build/optaplanner-build-parent/pom.xml
+++ b/build/optaplanner-build-parent/pom.xml
@@ -563,6 +563,31 @@
             </transformSchemas>
           </configuration>
         </plugin>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>animal-sniffer-maven-plugin</artifactId>
+          <version>1.20</version>
+          <configuration>
+            <signature>
+              <groupId>net.sf.androidscents.signature</groupId>
+              <artifactId>android-api-level-32</artifactId>
+              <version>12_r1</version>
+            </signature>
+            <ignores>
+              <ignore>java.lang.invoke.LambdaMetafactory</ignore>
+              <ignore>java.lang.invoke.MethodHandle</ignore>
+            </ignores>
+          </configuration>
+          <executions>
+            <execution>
+              <id>animal-sniffer</id>
+              <phase>verify</phase>
+              <goals>
+                <goal>check</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
       </plugins>
     </pluginManagement>
     <plugins>
@@ -834,6 +859,7 @@
         <skipTests>true</skipTests>
         <skipITs>true</skipITs>
         <formatter.skip>true</formatter.skip>
+        <animal.sniffer.skip>true</animal.sniffer.skip>
       </properties>
     </profile>
 
@@ -845,35 +871,6 @@
         </property>
       </activation>
       <build>
-        <pluginManagement>
-          <plugins>
-            <plugin>
-              <groupId>org.codehaus.mojo</groupId>
-              <artifactId>animal-sniffer-maven-plugin</artifactId>
-              <version>1.20</version>
-              <configuration>
-                <signature>
-                  <groupId>net.sf.androidscents.signature</groupId>
-                  <artifactId>android-api-level-32</artifactId>
-                  <version>12_r1</version>
-                </signature>
-                <ignores>
-                  <ignore>java.lang.invoke.LambdaMetafactory</ignore>
-                  <ignore>java.lang.invoke.MethodHandle</ignore>
-                </ignores>
-              </configuration>
-              <executions>
-                <execution>
-                  <id>animal-sniffer</id>
-                  <phase>verify</phase>
-                  <goals>
-                    <goal>check</goal>
-                  </goals>
-                </execution>
-              </executions>
-            </plugin>
-          </plugins>
-        </pluginManagement>
         <plugins>
           <plugin> <!-- Make sure the build fails-fast on Javadoc issues. -->
             <artifactId>maven-javadoc-plugin</artifactId>


### PR DESCRIPTION
1. Plugin management shouldn't be conditional if the plugin is used
   unconditionally in some modules. That results in a warning about
using a plugin without specifying its version.

2. The general approach is: run everything by default, use `-Dquickly` if
   you want to build faster.

Example of the mentioned warning:
> [WARNING] Some problems were encountered while building the effective model for org.optaplanner:optaplanner-core:jar:8.26.0-SNAPSHOT
[WARNING] 'build.plugins.plugin.version' for org.codehaus.mojo:animal-sniffer-maven-plugin is missing. @ line 56, column 15

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request checks</b>  
  Please add comment: <b>Jenkins retest this</b>

- for a <b>specific pull request check</b>  
  please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-vehicle-routing] tests</b>
  
- for a <b>full downstream build</b> 
  - for <b>jenkins</b> job: 
    please add comment: <b>Jenkins run fdb</b>
  - for <b>github actions</b> job: 
    add the label `run_fdb`

- for a <b>compile downstream build</b>  
  please add comment: <b>Jenkins run cdb</b>

- for a <b>full production downstream build</b>  
  please add comment: <b>Jenkins execute product fdb</b>

- for an <b>upstream build</b>  
  please add comment: <b>Jenkins run upstream</b>

- for <b>quarkus branch checks</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins run quarkus-branch</b>

- for a <b>quarkus branch specific check</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-vehicle-routing] quarkus-branch</b>

- for <b>quarkus main checks</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins run quarkus-main</b>

- for a <b>specific quarkus main check</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-vehicle-routing] quarkus-branch</b>

- for <b>native checks</b>  
  Run native checks  
  Please add comment: <b>Jenkins run native</b>

- for a <b>specific native check</b>  
  Run native checks 
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-vehicle-routing] native</b>

- for <b>mandrel checks</b>  
  Run native checks against Mandrel image
  Please add comment: <b>Jenkins run mandrel</b>

- for a <b>specific mandrel check</b>  
  Run native checks against Mandrel image  
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-vehicle-routing] mandrel</b>
</details>

### CI Status

 You can check OptaPlanner repositories CI status from [Chain Status webpage](https://kiegroup.github.io/optaplanner/).