### PR TITLE
CS-B: Do not index simple joins

### DIFF
--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/bi/IndexedIfExistsBiNode.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/bi/IndexedIfExistsBiNode.java
@@ -4,19 +4,20 @@ import java.util.Set;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 
-import org.optaplanner.constraint.streams.bavet.common.AbstractIfExistsNode;
+import org.optaplanner.constraint.streams.bavet.common.AbstractIndexedIfExistsNode;
+import org.optaplanner.constraint.streams.bavet.common.Counter;
 import org.optaplanner.constraint.streams.bavet.common.TupleLifecycle;
 import org.optaplanner.constraint.streams.bavet.common.index.IndexProperties;
 import org.optaplanner.constraint.streams.bavet.common.index.Indexer;
 import org.optaplanner.constraint.streams.bavet.uni.UniTuple;
 import org.optaplanner.core.api.function.TriPredicate;
 
-final class IfExistsBiWithUniNode<A, B, C> extends AbstractIfExistsNode<BiTuple<A, B>, C> {
+final class IndexedIfExistsBiNode<A, B, C> extends AbstractIndexedIfExistsNode<BiTuple<A, B>, C> {
 
     private final BiFunction<A, B, IndexProperties> mappingAB;
     private final TriPredicate<A, B, C> filtering;
 
-    public IfExistsBiWithUniNode(boolean shouldExist,
+    public IndexedIfExistsBiNode(boolean shouldExist,
             BiFunction<A, B, IndexProperties> mappingAB, Function<C, IndexProperties> mappingC,
             int inputStoreIndexAB, int inputStoreIndexC,
             TupleLifecycle<BiTuple<A, B>> tupleLifecycle,

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/bi/IndexedJoinBiNode.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/bi/IndexedJoinBiNode.java
@@ -3,18 +3,18 @@ package org.optaplanner.constraint.streams.bavet.bi;
 import java.util.Map;
 import java.util.function.Function;
 
-import org.optaplanner.constraint.streams.bavet.common.AbstractJoinNode;
+import org.optaplanner.constraint.streams.bavet.common.AbstractIndexedJoinNode;
 import org.optaplanner.constraint.streams.bavet.common.TupleLifecycle;
 import org.optaplanner.constraint.streams.bavet.common.index.IndexProperties;
 import org.optaplanner.constraint.streams.bavet.common.index.Indexer;
 import org.optaplanner.constraint.streams.bavet.uni.UniTuple;
 
-final class JoinBiNode<A, B> extends AbstractJoinNode<UniTuple<A>, B, BiTuple<A, B>, BiTupleImpl<A, B>> {
+final class IndexedJoinBiNode<A, B> extends AbstractIndexedJoinNode<UniTuple<A>, B, BiTuple<A, B>, BiTupleImpl<A, B>> {
 
     private final Function<A, IndexProperties> mappingA;
     private final int outputStoreSize;
 
-    public JoinBiNode(Function<A, IndexProperties> mappingA, Function<B, IndexProperties> mappingB,
+    public IndexedJoinBiNode(Function<A, IndexProperties> mappingA, Function<B, IndexProperties> mappingB,
             int inputStoreIndexA, int inputStoreIndexB,
             TupleLifecycle<BiTuple<A, B>> nextNodesTupleLifecycle,
             int outputStoreSize,

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/bi/UnindexedIfExistsBiNode.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/bi/UnindexedIfExistsBiNode.java
@@ -1,0 +1,28 @@
+package org.optaplanner.constraint.streams.bavet.bi;
+
+import org.optaplanner.constraint.streams.bavet.common.AbstractUnindexedIfExistsNode;
+import org.optaplanner.constraint.streams.bavet.common.TupleLifecycle;
+import org.optaplanner.constraint.streams.bavet.uni.UniTuple;
+import org.optaplanner.core.api.function.TriPredicate;
+
+final class UnindexedIfExistsBiNode<A, B, C> extends AbstractUnindexedIfExistsNode<BiTuple<A, B>, C> {
+
+    private final TriPredicate<A, B, C> filtering;
+
+    public UnindexedIfExistsBiNode(boolean shouldExist, TupleLifecycle<BiTuple<A, B>> tupleLifecycle,
+            TriPredicate<A, B, C> filtering) {
+        super(shouldExist, tupleLifecycle, filtering != null);
+        this.filtering = filtering;
+    }
+
+    @Override
+    protected boolean testFiltering(BiTuple<A, B> leftTuple, UniTuple<C> rightTuple) {
+        return filtering.test(leftTuple.getFactA(), leftTuple.getFactB(), rightTuple.getFactA());
+    }
+
+    @Override
+    public String toString() {
+        return "IfExistsBiWithUniNode";
+    }
+
+}

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/bi/UnindexedJoinBiNode.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/bi/UnindexedJoinBiNode.java
@@ -1,0 +1,37 @@
+package org.optaplanner.constraint.streams.bavet.bi;
+
+import org.optaplanner.constraint.streams.bavet.common.AbstractUnindexedJoinNode;
+import org.optaplanner.constraint.streams.bavet.common.TupleLifecycle;
+import org.optaplanner.constraint.streams.bavet.uni.UniTuple;
+
+final class UnindexedJoinBiNode<A, B>
+        extends AbstractUnindexedJoinNode<UniTuple<A>, B, BiTuple<A, B>, BiTupleImpl<A, B>> {
+
+    private final int outputStoreSize;
+
+    public UnindexedJoinBiNode(TupleLifecycle<BiTuple<A, B>> nextNodesTupleLifecycle, int outputStoreSize) {
+        super(nextNodesTupleLifecycle);
+        this.outputStoreSize = outputStoreSize;
+    }
+
+    @Override
+    protected BiTupleImpl<A, B> createOutTuple(UniTuple<A> leftTuple, UniTuple<B> rightTuple) {
+        return new BiTupleImpl<>(leftTuple.getFactA(), rightTuple.getFactA(), outputStoreSize);
+    }
+
+    @Override
+    protected void updateOutTupleLeft(BiTupleImpl<A, B> outTuple, UniTuple<A> leftTuple) {
+        outTuple.factA = leftTuple.getFactA();
+    }
+
+    @Override
+    protected void updateOutTupleRight(BiTupleImpl<A, B> outTuple, UniTuple<B> rightTuple) {
+        outTuple.factB = rightTuple.getFactA();
+    }
+
+    @Override
+    public String toString() {
+        return "JoinBiNode";
+    }
+
+}

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/common/AbstractIfExistsNode.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/common/AbstractIfExistsNode.java
@@ -3,310 +3,86 @@ package org.optaplanner.constraint.streams.bavet.common;
 import static org.optaplanner.constraint.streams.bavet.common.BavetTupleState.DEAD;
 
 import java.util.ArrayDeque;
-import java.util.LinkedHashSet;
 import java.util.Queue;
 import java.util.Set;
-import java.util.function.Function;
-import java.util.function.IntPredicate;
 
-import org.optaplanner.constraint.streams.bavet.common.index.IndexProperties;
-import org.optaplanner.constraint.streams.bavet.common.index.Indexer;
 import org.optaplanner.constraint.streams.bavet.uni.UniTuple;
 
 public abstract class AbstractIfExistsNode<LeftTuple_ extends Tuple, Right_>
         extends AbstractNode
         implements LeftTupleLifecycle<LeftTuple_>, RightTupleLifecycle<UniTuple<Right_>> {
 
-    private final boolean shouldExist;
-    private final Function<Right_, IndexProperties> mappingRight;
-    private final int inputStoreIndexLeft;
-    private final int inputStoreIndexRight;
+    protected final boolean shouldExist;
     /**
      * Calls for example {@link AbstractScorer#insert(Tuple)}, and/or ...
      */
     private final TupleLifecycle<LeftTuple_> nextNodesTupleLifecycle;
 
     // No outputStoreSize because this node is not a tuple source, even though it has a dirtyCounterQueue.
+    protected final Queue<Counter<LeftTuple_>> dirtyCounterQueue;
+    protected final boolean isFiltering;
 
-    private final Indexer<LeftTuple_, Counter<LeftTuple_>> indexerLeft;
-    private final Indexer<UniTuple<Right_>, Set<Counter<LeftTuple_>>> indexerRight;
-    private final Queue<Counter<LeftTuple_>> dirtyCounterQueue;
-    private final boolean isFiltering;
-
-    protected AbstractIfExistsNode(boolean shouldExist,
-            Function<Right_, IndexProperties> mappingRight,
-            int inputStoreIndexLeft, int inputStoreIndexRight,
-            TupleLifecycle<LeftTuple_> nextNodeTupleLifecycle,
-            Indexer<LeftTuple_, Counter<LeftTuple_>> indexerLeft,
-            Indexer<UniTuple<Right_>, Set<Counter<LeftTuple_>>> indexerRight,
+    protected AbstractIfExistsNode(boolean shouldExist, TupleLifecycle<LeftTuple_> nextNodeTupleLifecycle,
             boolean isFiltering) {
         this.shouldExist = shouldExist;
-        this.mappingRight = mappingRight;
-        this.inputStoreIndexLeft = inputStoreIndexLeft;
-        this.inputStoreIndexRight = inputStoreIndexRight;
         this.nextNodesTupleLifecycle = nextNodeTupleLifecycle;
-        this.indexerLeft = indexerLeft;
-        this.indexerRight = indexerRight;
         this.dirtyCounterQueue = new ArrayDeque<>(1000);
         this.isFiltering = isFiltering;
     }
 
-    @Override
-    public final void insertLeft(LeftTuple_ leftTuple) {
-        if (leftTuple.getStore(inputStoreIndexLeft) != null) {
-            throw new IllegalStateException("Impossible state: the input for the tuple (" + leftTuple
-                    + ") was already added in the tupleStore.");
-        }
-        IndexProperties indexProperties = createIndexProperties(leftTuple);
-        leftTuple.setStore(inputStoreIndexLeft, indexProperties);
+    protected abstract boolean testFiltering(LeftTuple_ leftTuple, UniTuple<Right_> rightTuple);
 
-        Counter<LeftTuple_> counter = new Counter<>(leftTuple, shouldExist);
-        indexerLeft.put(indexProperties, leftTuple, counter);
-
-        indexerRight.visit(indexProperties, (rightTuple, counterSetRight) -> {
-            if (!isFiltering || testFiltering(leftTuple, rightTuple)) {
-                counter.countRight++;
-                counterSetRight.add(counter);
+    protected final void processInsert(LeftTuple_ leftTuple, UniTuple<Right_> rightTuple, Counter<LeftTuple_> counter,
+            Set<Counter<LeftTuple_>> counterSetRight) {
+        if (!isFiltering || testFiltering(leftTuple, rightTuple)) {
+            if (counter.countRight == 0) {
+                if (shouldExist) {
+                    insertCounter(counter);
+                } else {
+                    retractCounter(counter);
+                }
             }
-        });
-        if (counter.isAlive()) {
-            counter.state = BavetTupleState.CREATING;
-            dirtyCounterQueue.add(counter);
+            counter.countRight++;
+            counterSetRight.add(counter);
         }
     }
 
-    @Override
-    public final void updateLeft(LeftTuple_ leftTuple) {
-        IndexProperties oldIndexProperties = leftTuple.getStore(inputStoreIndexLeft);
-        if (oldIndexProperties == null) {
-            // No fail fast if null because we don't track which tuples made it through the filter predicate(s)
-            insertLeft(leftTuple);
-            return;
-        }
-        IndexProperties newIndexProperties = createIndexProperties(leftTuple);
-
-        if (oldIndexProperties.equals(newIndexProperties)) {
-            // No need for re-indexing because the index properties didn't change
-            Counter<LeftTuple_> counter = indexerLeft.get(oldIndexProperties, leftTuple);
-            // The indexers contain counters in the DEAD state, to track the rightCount.
-            if (!isFiltering) {
-                switch (counter.state) {
-                    case CREATING:
-                    case UPDATING:
-                    case DYING:
-                    case ABORTING:
-                    case DEAD:
-                        // Counter state does not change because the index properties didn't change
-                        break;
-                    case OK:
-                        // Still needed to propagate the update for downstream filters, matchWeighters, ...
-                        counter.state = BavetTupleState.UPDATING;
-                        dirtyCounterQueue.add(counter);
-                        break;
-                    default:
-                        throw new IllegalStateException("Impossible state: The counter (" + counter.state + ") in node (" +
-                                this + ") is in an unexpected state (" + counter.state + ").");
-                }
-            } else {
-                // Call filtering for the leftTuple and rightTuple combinations again
-                counter.countRight = 0;
-                indexerRight.visit(oldIndexProperties, (rightTuple, counterSetRight) -> {
-                    if (testFiltering(leftTuple, rightTuple)) {
-                        counter.countRight++;
-                    } else {
-                        counterSetRight.remove(counter);
-                    }
-                });
-                if (counter.isAlive()) {
-                    // Insert or update
+    protected final void processUpdate(LeftTuple_ leftTuple, UniTuple<Right_> rightTuple, Counter<LeftTuple_> counter,
+            Set<Counter<LeftTuple_>> counterSetRight) {
+        if (testFiltering(leftTuple, rightTuple)) {
+            if (counter.countRight == 0) {
+                if (shouldExist) {
                     insertOrUpdateCounter(counter);
                 } else {
-                    // Retract or remain dead
                     retractOrRemainDeadCounter(counter);
                 }
             }
-        } else {
-            Counter<LeftTuple_> counter = deindexLeft(leftTuple, oldIndexProperties);
-
-            counter.countRight = 0;
-            leftTuple.setStore(inputStoreIndexLeft, newIndexProperties);
-            indexerLeft.put(newIndexProperties, leftTuple, counter);
-            indexerRight.visit(newIndexProperties, (rightTuple, counterSetRight) -> {
-                if (!isFiltering || testFiltering(leftTuple, rightTuple)) {
-                    counter.countRight++;
-                    counterSetRight.add(counter);
-                }
-            });
-
-            if (counter.isAlive()) {
-                insertOrUpdateCounter(counter);
-            } else {
-                retractOrRemainDeadCounter(counter);
-            }
+            counter.countRight++;
+            counterSetRight.add(counter);
         }
     }
 
-    private Counter<LeftTuple_> deindexLeft(LeftTuple_ leftTuple, IndexProperties oldIndexProperties) {
-        Counter<LeftTuple_> counter = indexerLeft.remove(oldIndexProperties, leftTuple);
-        indexerRight.visit(oldIndexProperties, (rightTuple, counterSetRight) -> {
-            boolean changed = counterSetRight.remove(counter);
-            // If filtering is active, not all counterSets contain the counter and we don't track which ones do
-            if (!changed && !isFiltering) {
-                throw new IllegalStateException("Impossible state: the tuple (" + leftTuple
-                        + ") with indexProperties (" + oldIndexProperties
-                        + ") has a counter on the AB side that doesn't exist on the C side.");
-            }
-        });
-        return counter;
-    }
-
-    @Override
-    public final void retractLeft(LeftTuple_ leftTuple) {
-        IndexProperties indexProperties = leftTuple.getStore(inputStoreIndexLeft);
-        if (indexProperties == null) {
-            // No fail fast if null because we don't track which tuples made it through the filter predicate(s)
-            return;
-        }
-        leftTuple.setStore(inputStoreIndexLeft, null);
-
-        Counter<LeftTuple_> counter = deindexLeft(leftTuple, indexProperties);
-        if (counter.isAlive()) {
-            retractCounter(counter);
+    protected final void processCounterUpdate(Counter<LeftTuple_> counter) {
+        switch (counter.state) {
+            case CREATING:
+            case UPDATING:
+            case DYING:
+            case ABORTING:
+            case DEAD:
+                // Counter state does not change because the index properties didn't change
+                break;
+            case OK:
+                // Still needed to propagate the update for downstream filters, matchWeighters, ...
+                counter.state = BavetTupleState.UPDATING;
+                dirtyCounterQueue.add(counter);
+                break;
+            default:
+                throw new IllegalStateException("Impossible state: The counter (" + counter.state + ") in node (" +
+                        this + ") is in an unexpected state (" + counter.state + ").");
         }
     }
 
-    @Override
-    public final void insertRight(UniTuple<Right_> rightTuple) {
-        if (rightTuple.getStore(inputStoreIndexRight) != null) {
-            throw new IllegalStateException("Impossible state: the input for the tuple (" + rightTuple
-                    + ") was already added in the tupleStore.");
-        }
-        IndexProperties indexProperties = mappingRight.apply(rightTuple.getFactA());
-        rightTuple.setStore(inputStoreIndexRight, indexProperties);
-
-        // TODO Maybe predict capacity with Math.max(16, counterMapA.size())
-        Set<Counter<LeftTuple_>> counterSetRight = new LinkedHashSet<>();
-        indexRight(rightTuple, indexProperties, counterSetRight);
-    }
-
-    private void indexRight(UniTuple<Right_> rightTuple, IndexProperties indexProperties,
-            Set<Counter<LeftTuple_>> counterSetRight) {
-        indexerRight.put(indexProperties, rightTuple, counterSetRight);
-        indexerLeft.visit(indexProperties, (leftTuple, counter) -> {
-            if (!isFiltering || testFiltering(leftTuple, rightTuple)) {
-                if (counter.countRight == 0) {
-                    if (shouldExist) {
-                        insertCounter(counter);
-                    } else {
-                        retractCounter(counter);
-                    }
-                }
-                counter.countRight++;
-                counterSetRight.add(counter);
-            }
-        });
-    }
-
-    @Override
-    public final void updateRight(UniTuple<Right_> rightTuple) {
-        IndexProperties oldIndexProperties = rightTuple.getStore(inputStoreIndexRight);
-        if (oldIndexProperties == null) {
-            // No fail fast if null because we don't track which tuples made it through the filter predicate(s)
-            insertRight(rightTuple);
-            return;
-        }
-        IndexProperties newIndexProperties = mappingRight.apply(rightTuple.getFactA());
-
-        if (oldIndexProperties.equals(newIndexProperties)) {
-            // No need for re-indexing because the index properties didn't change
-            if (isFiltering) {
-                // Call filtering for the leftTuple and rightTuple combinations again
-                Set<Counter<LeftTuple_>> counterSetRight = indexerRight.get(oldIndexProperties, rightTuple);
-                processAndClearCounters(counterSetRight);
-
-                indexerLeft.visit(newIndexProperties, (leftTuple, counter) -> {
-                    if (testFiltering(leftTuple, rightTuple)) {
-                        if (counter.countRight == 0) {
-                            if (shouldExist) {
-                                insertOrUpdateCounter(counter);
-                            } else {
-                                retractOrRemainDeadCounter(counter);
-                            }
-                        }
-                        counter.countRight++;
-                        counterSetRight.add(counter);
-                    }
-                });
-            }
-        } else {
-            Set<Counter<LeftTuple_>> counterSetRight = indexerRight.remove(oldIndexProperties, rightTuple);
-            processAndClearCounters(counterSetRight);
-
-            rightTuple.setStore(inputStoreIndexRight, newIndexProperties);
-            indexRight(rightTuple, newIndexProperties, counterSetRight);
-        }
-    }
-
-    private void processAndClearCounters(Set<Counter<LeftTuple_>> counterSetRight) {
-        processCounters(counterSetRight);
-        counterSetRight.clear();
-    }
-
-    private void processCounters(Set<Counter<LeftTuple_>> counterSetRight) {
-        for (Counter<LeftTuple_> counter : counterSetRight) {
-            counter.countRight--;
-            if (counter.countRight == 0) {
-                if (shouldExist) {
-                    retractCounter(counter);
-                } else {
-                    insertCounter(counter);
-                }
-            }
-        }
-    }
-
-    @Override
-    public final void retractRight(UniTuple<Right_> rightTuple) {
-        IndexProperties indexProperties = rightTuple.getStore(inputStoreIndexRight);
-        if (indexProperties == null) {
-            // No fail fast if null because we don't track which tuples made it through the filter predicate(s)
-            return;
-        }
-        rightTuple.setStore(inputStoreIndexRight, null);
-        Set<Counter<LeftTuple_>> counterSetRight = indexerRight.remove(indexProperties, rightTuple);
-        processCounters(counterSetRight);
-    }
-
-    protected abstract IndexProperties createIndexProperties(LeftTuple_ leftTuple);
-
-    protected abstract boolean testFiltering(LeftTuple_ leftTuple, UniTuple<Right_> rightTuple);
-
-    public static final class Counter<Tuple_ extends Tuple> {
-
-        private static final IntPredicate ZERO_COUNT = count -> count == 0;
-        private static final IntPredicate NON_ZERO_COUNT = count -> count > 0;
-
-        private final Tuple_ leftTuple;
-        private final IntPredicate alivePredicate;
-        private BavetTupleState state = DEAD;
-        private int countRight = 0;
-
-        private Counter(Tuple_ leftTuple, boolean shouldExist) {
-            this.leftTuple = leftTuple;
-            this.alivePredicate = shouldExist ? NON_ZERO_COUNT : ZERO_COUNT;
-        }
-
-        private boolean isAlive() {
-            return alivePredicate.test(countRight);
-        }
-
-        @Override
-        public String toString() {
-            return "Counter(" + leftTuple + ")";
-        }
-    }
-
-    private void insertCounter(Counter<LeftTuple_> counter) {
+    protected final void insertCounter(Counter<LeftTuple_> counter) {
         switch (counter.state) {
             case DYING:
                 counter.state = BavetTupleState.UPDATING;
@@ -324,7 +100,7 @@ public abstract class AbstractIfExistsNode<LeftTuple_ extends Tuple, Right_>
         }
     }
 
-    private void insertOrUpdateCounter(Counter<LeftTuple_> counter) {
+    protected final void insertOrUpdateCounter(Counter<LeftTuple_> counter) {
         // Insert or update
         switch (counter.state) {
             case CREATING:
@@ -351,7 +127,7 @@ public abstract class AbstractIfExistsNode<LeftTuple_ extends Tuple, Right_>
         }
     }
 
-    private void retractOrRemainDeadCounter(Counter<LeftTuple_> counter) {
+    protected final void retractOrRemainDeadCounter(Counter<LeftTuple_> counter) {
         // Retract or remain dead
         switch (counter.state) {
             case CREATING:
@@ -377,7 +153,7 @@ public abstract class AbstractIfExistsNode<LeftTuple_ extends Tuple, Right_>
         }
     }
 
-    private void retractCounter(Counter<LeftTuple_> counter) {
+    protected final void retractCounter(Counter<LeftTuple_> counter) {
         switch (counter.state) {
             case CREATING:
                 // Kill it before it propagates
@@ -398,7 +174,7 @@ public abstract class AbstractIfExistsNode<LeftTuple_ extends Tuple, Right_>
     }
 
     @Override
-    public void calculateScore() {
+    public final void calculateScore() {
         for (Counter<LeftTuple_> counter : dirtyCounterQueue) {
             switch (counter.state) {
                 case CREATING:

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/common/AbstractIndexedIfExistsNode.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/common/AbstractIndexedIfExistsNode.java
@@ -1,0 +1,225 @@
+package org.optaplanner.constraint.streams.bavet.common;
+
+import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.function.Function;
+
+import org.optaplanner.constraint.streams.bavet.common.index.IndexProperties;
+import org.optaplanner.constraint.streams.bavet.common.index.Indexer;
+import org.optaplanner.constraint.streams.bavet.uni.UniTuple;
+
+public abstract class AbstractIndexedIfExistsNode<LeftTuple_ extends Tuple, Right_>
+        extends AbstractIfExistsNode<LeftTuple_, Right_>
+        implements LeftTupleLifecycle<LeftTuple_>, RightTupleLifecycle<UniTuple<Right_>> {
+
+    private final Function<Right_, IndexProperties> mappingRight;
+    private final int inputStoreIndexLeft;
+    private final int inputStoreIndexRight;
+    private final Indexer<LeftTuple_, Counter<LeftTuple_>> indexerLeft;
+    private final Indexer<UniTuple<Right_>, Set<Counter<LeftTuple_>>> indexerRight;
+
+    protected AbstractIndexedIfExistsNode(boolean shouldExist,
+            Function<Right_, IndexProperties> mappingRight,
+            int inputStoreIndexLeft, int inputStoreIndexRight,
+            TupleLifecycle<LeftTuple_> nextNodeTupleLifecycle,
+            Indexer<LeftTuple_, Counter<LeftTuple_>> indexerLeft,
+            Indexer<UniTuple<Right_>, Set<Counter<LeftTuple_>>> indexerRight,
+            boolean isFiltering) {
+        super(shouldExist, nextNodeTupleLifecycle, isFiltering);
+        this.mappingRight = mappingRight;
+        this.inputStoreIndexLeft = inputStoreIndexLeft;
+        this.inputStoreIndexRight = inputStoreIndexRight;
+        this.indexerLeft = indexerLeft;
+        this.indexerRight = indexerRight;
+    }
+
+    @Override
+    public final void insertLeft(LeftTuple_ leftTuple) {
+        if (leftTuple.getStore(inputStoreIndexLeft) != null) {
+            throw new IllegalStateException("Impossible state: the input for the tuple (" + leftTuple
+                    + ") was already added in the tupleStore.");
+        }
+        IndexProperties indexProperties = createIndexProperties(leftTuple);
+        leftTuple.setStore(inputStoreIndexLeft, indexProperties);
+
+        Counter<LeftTuple_> counter = new Counter<>(leftTuple, shouldExist);
+        indexerLeft.put(indexProperties, leftTuple, counter);
+
+        indexerRight.visit(indexProperties, (rightTuple, counterSetRight) -> {
+            if (!isFiltering || testFiltering(leftTuple, rightTuple)) {
+                counter.countRight++;
+                counterSetRight.add(counter);
+            }
+        });
+        if (counter.isAlive()) {
+            counter.state = BavetTupleState.CREATING;
+            dirtyCounterQueue.add(counter);
+        }
+    }
+
+    @Override
+    public final void updateLeft(LeftTuple_ leftTuple) {
+        IndexProperties oldIndexProperties = leftTuple.getStore(inputStoreIndexLeft);
+        if (oldIndexProperties == null) {
+            // No fail fast if null because we don't track which tuples made it through the filter predicate(s)
+            insertLeft(leftTuple);
+            return;
+        }
+        IndexProperties newIndexProperties = createIndexProperties(leftTuple);
+
+        if (oldIndexProperties.equals(newIndexProperties)) {
+            // No need for re-indexing because the index properties didn't change
+            Counter<LeftTuple_> counter = indexerLeft.get(oldIndexProperties, leftTuple);
+            // The indexers contain counters in the DEAD state, to track the rightCount.
+            if (!isFiltering) {
+                processCounterUpdate(counter);
+            } else {
+                // Call filtering for the leftTuple and rightTuple combinations again
+                counter.countRight = 0;
+                indexerRight.visit(oldIndexProperties, (rightTuple, counterSetRight) -> {
+                    if (testFiltering(leftTuple, rightTuple)) {
+                        counter.countRight++;
+                    } else {
+                        counterSetRight.remove(counter);
+                    }
+                });
+                if (counter.isAlive()) {
+                    // Insert or update
+                    insertOrUpdateCounter(counter);
+                } else {
+                    // Retract or remain dead
+                    retractOrRemainDeadCounter(counter);
+                }
+            }
+        } else {
+            Counter<LeftTuple_> counter = deindexLeft(leftTuple, oldIndexProperties);
+
+            counter.countRight = 0;
+            leftTuple.setStore(inputStoreIndexLeft, newIndexProperties);
+            indexerLeft.put(newIndexProperties, leftTuple, counter);
+            indexerRight.visit(newIndexProperties, (rightTuple, counterSetRight) -> {
+                if (!isFiltering || testFiltering(leftTuple, rightTuple)) {
+                    counter.countRight++;
+                    counterSetRight.add(counter);
+                }
+            });
+
+            if (counter.isAlive()) {
+                insertOrUpdateCounter(counter);
+            } else {
+                retractOrRemainDeadCounter(counter);
+            }
+        }
+    }
+
+    private Counter<LeftTuple_> deindexLeft(LeftTuple_ leftTuple, IndexProperties oldIndexProperties) {
+        Counter<LeftTuple_> counter = indexerLeft.remove(oldIndexProperties, leftTuple);
+        indexerRight.visit(oldIndexProperties, (rightTuple, counterSetRight) -> {
+            boolean changed = counterSetRight.remove(counter);
+            // If filtering is active, not all counterSets contain the counter and we don't track which ones do
+            if (!changed && !isFiltering) {
+                throw new IllegalStateException("Impossible state: the tuple (" + leftTuple
+                        + ") with indexProperties (" + oldIndexProperties
+                        + ") has a counter on the left side that doesn't exist on the right side.");
+            }
+        });
+        return counter;
+    }
+
+    @Override
+    public final void retractLeft(LeftTuple_ leftTuple) {
+        IndexProperties indexProperties = leftTuple.getStore(inputStoreIndexLeft);
+        if (indexProperties == null) {
+            // No fail fast if null because we don't track which tuples made it through the filter predicate(s)
+            return;
+        }
+        leftTuple.setStore(inputStoreIndexLeft, null);
+
+        Counter<LeftTuple_> counter = deindexLeft(leftTuple, indexProperties);
+        if (counter.isAlive()) {
+            retractCounter(counter);
+        }
+    }
+
+    @Override
+    public final void insertRight(UniTuple<Right_> rightTuple) {
+        if (rightTuple.getStore(inputStoreIndexRight) != null) {
+            throw new IllegalStateException("Impossible state: the input for the tuple (" + rightTuple
+                    + ") was already added in the tupleStore.");
+        }
+        IndexProperties indexProperties = mappingRight.apply(rightTuple.getFactA());
+        rightTuple.setStore(inputStoreIndexRight, indexProperties);
+
+        // TODO Maybe predict capacity with Math.max(16, counterMapA.size())
+        Set<Counter<LeftTuple_>> counterSetRight = new LinkedHashSet<>();
+        indexRight(rightTuple, indexProperties, counterSetRight);
+    }
+
+    private void indexRight(UniTuple<Right_> rightTuple, IndexProperties indexProperties,
+            Set<Counter<LeftTuple_>> counterSetRight) {
+        indexerRight.put(indexProperties, rightTuple, counterSetRight);
+        indexerLeft.visit(indexProperties,
+                (leftTuple, counter) -> processInsert(leftTuple, rightTuple, counter, counterSetRight));
+    }
+
+    @Override
+    public final void updateRight(UniTuple<Right_> rightTuple) {
+        IndexProperties oldIndexProperties = rightTuple.getStore(inputStoreIndexRight);
+        if (oldIndexProperties == null) {
+            // No fail fast if null because we don't track which tuples made it through the filter predicate(s)
+            insertRight(rightTuple);
+            return;
+        }
+        IndexProperties newIndexProperties = mappingRight.apply(rightTuple.getFactA());
+
+        if (oldIndexProperties.equals(newIndexProperties)) {
+            // No need for re-indexing because the index properties didn't change
+            if (isFiltering) {
+                // Call filtering for the leftTuple and rightTuple combinations again
+                Set<Counter<LeftTuple_>> counterSetRight = indexerRight.get(oldIndexProperties, rightTuple);
+                processAndClearCounters(counterSetRight);
+                indexerLeft.visit(newIndexProperties,
+                        (leftTuple, counter) -> processUpdate(leftTuple, rightTuple, counter, counterSetRight));
+            }
+        } else {
+            Set<Counter<LeftTuple_>> counterSetRight = indexerRight.remove(oldIndexProperties, rightTuple);
+            processAndClearCounters(counterSetRight);
+
+            rightTuple.setStore(inputStoreIndexRight, newIndexProperties);
+            indexRight(rightTuple, newIndexProperties, counterSetRight);
+        }
+    }
+
+    private void processAndClearCounters(Set<Counter<LeftTuple_>> counterSetRight) {
+        processCounters(counterSetRight);
+        counterSetRight.clear();
+    }
+
+    private void processCounters(Set<Counter<LeftTuple_>> counterSetRight) {
+        for (Counter<LeftTuple_> counter : counterSetRight) {
+            counter.countRight--;
+            if (counter.countRight == 0) {
+                if (shouldExist) {
+                    retractCounter(counter);
+                } else {
+                    insertCounter(counter);
+                }
+            }
+        }
+    }
+
+    @Override
+    public final void retractRight(UniTuple<Right_> rightTuple) {
+        IndexProperties indexProperties = rightTuple.getStore(inputStoreIndexRight);
+        if (indexProperties == null) {
+            // No fail fast if null because we don't track which tuples made it through the filter predicate(s)
+            return;
+        }
+        rightTuple.setStore(inputStoreIndexRight, null);
+        Set<Counter<LeftTuple_>> counterSetRight = indexerRight.remove(indexProperties, rightTuple);
+        processCounters(counterSetRight);
+    }
+
+    protected abstract IndexProperties createIndexProperties(LeftTuple_ leftTuple);
+
+}

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/common/AbstractIndexedJoinNode.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/common/AbstractIndexedJoinNode.java
@@ -1,0 +1,183 @@
+package org.optaplanner.constraint.streams.bavet.common;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.function.Function;
+
+import org.optaplanner.constraint.streams.bavet.common.index.IndexProperties;
+import org.optaplanner.constraint.streams.bavet.common.index.Indexer;
+import org.optaplanner.constraint.streams.bavet.uni.UniTuple;
+
+public abstract class AbstractIndexedJoinNode<LeftTuple_ extends Tuple, Right_, OutTuple_ extends Tuple, MutableOutTuple_ extends OutTuple_>
+        extends AbstractJoinNode<LeftTuple_, Right_, OutTuple_, MutableOutTuple_>
+        implements LeftTupleLifecycle<LeftTuple_>, RightTupleLifecycle<UniTuple<Right_>> {
+
+    private final Function<Right_, IndexProperties> mappingRight;
+    private final int inputStoreIndexLeft;
+    private final int inputStoreIndexRight;
+    /**
+     * Calls for example {@link AbstractScorer#insert(Tuple)} and/or ...
+     */
+    private final Indexer<LeftTuple_, Map<UniTuple<Right_>, MutableOutTuple_>> indexerLeft;
+    private final Indexer<UniTuple<Right_>, Map<LeftTuple_, MutableOutTuple_>> indexerRight;
+
+    protected AbstractIndexedJoinNode(Function<Right_, IndexProperties> mappingRight, int inputStoreIndexLeft,
+            int inputStoreIndexRight, TupleLifecycle<OutTuple_> nextNodesTupleLifecycle,
+            Indexer<LeftTuple_, Map<UniTuple<Right_>, MutableOutTuple_>> indexerLeft,
+            Indexer<UniTuple<Right_>, Map<LeftTuple_, MutableOutTuple_>> indexerRight) {
+        super(nextNodesTupleLifecycle);
+        this.mappingRight = mappingRight;
+        this.inputStoreIndexLeft = inputStoreIndexLeft;
+        this.inputStoreIndexRight = inputStoreIndexRight;
+        this.indexerLeft = indexerLeft;
+        this.indexerRight = indexerRight;
+    }
+
+    @Override
+    public final void insertLeft(LeftTuple_ leftTuple) {
+        if (leftTuple.getStore(inputStoreIndexLeft) != null) {
+            throw new IllegalStateException("Impossible state: the input for the tuple (" + leftTuple
+                    + ") was already added in the tupleStore.");
+        }
+        IndexProperties indexProperties = createIndexPropertiesLeft(leftTuple);
+        leftTuple.setStore(inputStoreIndexLeft, indexProperties);
+
+        Map<UniTuple<Right_>, MutableOutTuple_> outTupleMapLeft = new LinkedHashMap<>();
+        indexAndPropagateLeft(leftTuple, indexProperties, outTupleMapLeft);
+    }
+
+    private void indexAndPropagateLeft(LeftTuple_ leftTuple, IndexProperties newIndexProperties,
+            Map<UniTuple<Right_>, MutableOutTuple_> outTupleMapLeft) {
+        indexerLeft.put(newIndexProperties, leftTuple, outTupleMapLeft);
+        indexerRight.visit(newIndexProperties,
+                (rightTuple, emptyMap) -> indexAndPropagate(outTupleMapLeft, leftTuple, rightTuple));
+    }
+
+    private void indexAndPropagate(Map<UniTuple<Right_>, MutableOutTuple_> outTupleMapLeft, LeftTuple_ leftTuple,
+            UniTuple<Right_> rightTuple) {
+        MutableOutTuple_ outTuple = createOutTuple(leftTuple, rightTuple);
+        outTupleMapLeft.put(rightTuple, outTuple);
+        dirtyTupleQueue.add(outTuple);
+    }
+
+    @Override
+    public final void updateLeft(LeftTuple_ leftTuple) {
+        IndexProperties oldIndexProperties = leftTuple.getStore(inputStoreIndexLeft);
+        if (oldIndexProperties == null) {
+            // No fail fast if null because we don't track which tuples made it through the filter predicate(s)
+            insertLeft(leftTuple);
+            return;
+        }
+        IndexProperties newIndexProperties = createIndexPropertiesLeft(leftTuple);
+
+        if (oldIndexProperties.equals(newIndexProperties)) {
+            // No need for re-indexing because the index properties didn't change
+            // Still needed to propagate the update for downstream filters, matchWeighters, ...
+            Map<UniTuple<Right_>, MutableOutTuple_> outTupleMapLeft = indexerLeft.get(oldIndexProperties, leftTuple);
+            for (MutableOutTuple_ outTuple : outTupleMapLeft.values()) {
+                updateOutTupleLeft(outTuple, leftTuple);
+                updateTuple(outTuple);
+            }
+        } else {
+            Map<UniTuple<Right_>, MutableOutTuple_> outTupleMapLeft = indexerLeft.remove(oldIndexProperties, leftTuple);
+            for (OutTuple_ outTuple : outTupleMapLeft.values()) {
+                retractTuple(outTuple);
+            }
+            outTupleMapLeft.clear();
+
+            leftTuple.setStore(inputStoreIndexLeft, newIndexProperties);
+            indexAndPropagateLeft(leftTuple, newIndexProperties, outTupleMapLeft);
+        }
+    }
+
+    @Override
+    public final void retractLeft(LeftTuple_ leftTuple) {
+        IndexProperties indexProperties = leftTuple.getStore(inputStoreIndexLeft);
+        if (indexProperties == null) {
+            // No fail fast if null because we don't track which tuples made it through the filter predicate(s)
+            return;
+        }
+        leftTuple.setStore(inputStoreIndexLeft, null);
+
+        Map<UniTuple<Right_>, MutableOutTuple_> outTupleMapLeft = indexerLeft.remove(indexProperties, leftTuple);
+        for (OutTuple_ outTuple : outTupleMapLeft.values()) {
+            retractTuple(outTuple);
+        }
+    }
+
+    @Override
+    public final void insertRight(UniTuple<Right_> rightTuple) {
+        if (rightTuple.getStore(inputStoreIndexRight) != null) {
+            throw new IllegalStateException("Impossible state: the input for the tuple (" + rightTuple
+                    + ") was already added in the tupleStore.");
+        }
+        IndexProperties indexProperties = mappingRight.apply(rightTuple.getFactA());
+        rightTuple.setStore(inputStoreIndexRight, indexProperties);
+        indexAndPropagateRight(rightTuple, indexProperties);
+    }
+
+    private void indexAndPropagateRight(UniTuple<Right_> rightTuple, IndexProperties indexProperties) {
+        indexerRight.put(indexProperties, rightTuple, Collections.emptyMap());
+        indexerLeft.visit(indexProperties,
+                (leftTuple, outTupleMapLeft) -> indexAndPropagate(outTupleMapLeft, leftTuple, rightTuple));
+    }
+
+    @Override
+    public final void updateRight(UniTuple<Right_> rightTuple) {
+        IndexProperties oldIndexProperties = rightTuple.getStore(inputStoreIndexRight);
+        if (oldIndexProperties == null) {
+            // No fail fast if null because we don't track which tuples made it through the filter predicate(s)
+            insertRight(rightTuple);
+            return;
+        }
+        IndexProperties newIndexProperties = mappingRight.apply(rightTuple.getFactA());
+
+        if (oldIndexProperties.equals(newIndexProperties)) {
+            // No need for re-indexing because the index properties didn't change
+            // Still needed to propagate the update for downstream filters, matchWeighters, ...
+            indexerLeft.visit(oldIndexProperties, (leftTuple, outTupleMapLeft) -> {
+                MutableOutTuple_ outTuple = outTupleMapLeft.get(rightTuple);
+                updateOutTupleRight(outTuple, rightTuple);
+                if (outTuple == null) {
+                    throw new IllegalStateException("Impossible state: the tuple (" + leftTuple
+                            + ") with indexProperties (" + oldIndexProperties
+                            + ") has tuples on the right side that didn't exist on the left side.");
+                }
+                updateTuple(outTuple);
+            });
+        } else {
+            deindexRightTuple(oldIndexProperties, rightTuple);
+            rightTuple.setStore(inputStoreIndexRight, newIndexProperties);
+            indexAndPropagateRight(rightTuple, newIndexProperties);
+        }
+    }
+
+    private void deindexRightTuple(IndexProperties indexProperties, UniTuple<Right_> rightTuple) {
+        indexerRight.remove(indexProperties, rightTuple);
+        // Remove out tuples from the other side
+        indexerLeft.visit(indexProperties, (leftTuple, outTupleMapLeft) -> {
+            OutTuple_ outTuple = outTupleMapLeft.remove(rightTuple);
+            if (outTuple == null) {
+                throw new IllegalStateException("Impossible state: the tuple (" + leftTuple
+                        + ") with indexProperties (" + indexProperties
+                        + ") has tuples on the right side that didn't exist on the left side.");
+            }
+            retractTuple(outTuple);
+        });
+    }
+
+    @Override
+    public final void retractRight(UniTuple<Right_> rightTuple) {
+        IndexProperties indexProperties = rightTuple.getStore(inputStoreIndexRight);
+        if (indexProperties == null) {
+            // No fail fast if null because we don't track which tuples made it through the filter predicate(s)
+            return;
+        }
+        rightTuple.setStore(inputStoreIndexRight, null);
+        deindexRightTuple(indexProperties, rightTuple);
+    }
+
+    protected abstract IndexProperties createIndexPropertiesLeft(LeftTuple_ leftTuple);
+
+}

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/common/AbstractJoinNode.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/common/AbstractJoinNode.java
@@ -1,189 +1,24 @@
 package org.optaplanner.constraint.streams.bavet.common;
 
 import java.util.ArrayDeque;
-import java.util.Collections;
-import java.util.LinkedHashMap;
-import java.util.Map;
 import java.util.Queue;
-import java.util.function.Function;
 
-import org.optaplanner.constraint.streams.bavet.common.index.IndexProperties;
-import org.optaplanner.constraint.streams.bavet.common.index.Indexer;
 import org.optaplanner.constraint.streams.bavet.uni.UniTuple;
 
 public abstract class AbstractJoinNode<LeftTuple_ extends Tuple, Right_, OutTuple_ extends Tuple, MutableOutTuple_ extends OutTuple_>
         extends AbstractNode
         implements LeftTupleLifecycle<LeftTuple_>, RightTupleLifecycle<UniTuple<Right_>> {
 
-    private final Function<Right_, IndexProperties> mappingRight;
-    private final int inputStoreIndexLeft;
-    private final int inputStoreIndexRight;
     /**
      * Calls for example {@link AbstractScorer#insert(Tuple)} and/or ...
      */
     private final TupleLifecycle<OutTuple_> nextNodesTupleLifecycle;
-    private final Indexer<LeftTuple_, Map<UniTuple<Right_>, MutableOutTuple_>> indexerLeft;
-    private final Indexer<UniTuple<Right_>, Map<LeftTuple_, MutableOutTuple_>> indexerRight;
-    private final Queue<OutTuple_> dirtyTupleQueue;
+    protected final Queue<OutTuple_> dirtyTupleQueue;
 
-    protected AbstractJoinNode(Function<Right_, IndexProperties> mappingRight, int inputStoreIndexLeft,
-            int inputStoreIndexRight, TupleLifecycle<OutTuple_> nextNodesTupleLifecycle,
-            Indexer<LeftTuple_, Map<UniTuple<Right_>, MutableOutTuple_>> indexerLeft,
-            Indexer<UniTuple<Right_>, Map<LeftTuple_, MutableOutTuple_>> indexerRight) {
-        this.mappingRight = mappingRight;
-        this.inputStoreIndexLeft = inputStoreIndexLeft;
-        this.inputStoreIndexRight = inputStoreIndexRight;
+    protected AbstractJoinNode(TupleLifecycle<OutTuple_> nextNodesTupleLifecycle) {
         this.nextNodesTupleLifecycle = nextNodesTupleLifecycle;
-        this.indexerLeft = indexerLeft;
-        this.indexerRight = indexerRight;
         dirtyTupleQueue = new ArrayDeque<>(1000);
     }
-
-    @Override
-    public final void insertLeft(LeftTuple_ leftTuple) {
-        if (leftTuple.getStore(inputStoreIndexLeft) != null) {
-            throw new IllegalStateException("Impossible state: the input for the tuple (" + leftTuple
-                    + ") was already added in the tupleStore.");
-        }
-        IndexProperties indexProperties = createIndexPropertiesLeft(leftTuple);
-        leftTuple.setStore(inputStoreIndexLeft, indexProperties);
-
-        Map<UniTuple<Right_>, MutableOutTuple_> outTupleMapLeft = new LinkedHashMap<>();
-        indexAndPropagateLeft(leftTuple, indexProperties, outTupleMapLeft);
-    }
-
-    private void indexAndPropagateLeft(LeftTuple_ leftTuple, IndexProperties newIndexProperties,
-            Map<UniTuple<Right_>, MutableOutTuple_> outTupleMapLeft) {
-        indexerLeft.put(newIndexProperties, leftTuple, outTupleMapLeft);
-        indexerRight.visit(newIndexProperties,
-                (rightTuple, emptyMap) -> indexAndPropagate(outTupleMapLeft, leftTuple, rightTuple));
-    }
-
-    private void indexAndPropagate(Map<UniTuple<Right_>, MutableOutTuple_> outTupleMapLeft, LeftTuple_ leftTuple,
-            UniTuple<Right_> rightTuple) {
-        MutableOutTuple_ outTuple = createOutTuple(leftTuple, rightTuple);
-        outTupleMapLeft.put(rightTuple, outTuple);
-        dirtyTupleQueue.add(outTuple);
-    }
-
-    @Override
-    public final void updateLeft(LeftTuple_ leftTuple) {
-        IndexProperties oldIndexProperties = leftTuple.getStore(inputStoreIndexLeft);
-        if (oldIndexProperties == null) {
-            // No fail fast if null because we don't track which tuples made it through the filter predicate(s)
-            insertLeft(leftTuple);
-            return;
-        }
-        IndexProperties newIndexProperties = createIndexPropertiesLeft(leftTuple);
-
-        if (oldIndexProperties.equals(newIndexProperties)) {
-            // No need for re-indexing because the index properties didn't change
-            // Still needed to propagate the update for downstream filters, matchWeighters, ...
-            Map<UniTuple<Right_>, MutableOutTuple_> outTupleMapLeft = indexerLeft.get(oldIndexProperties, leftTuple);
-            for (MutableOutTuple_ outTuple : outTupleMapLeft.values()) {
-                updateOutTupleLeft(outTuple, leftTuple);
-                updateTuple(outTuple);
-            }
-        } else {
-            Map<UniTuple<Right_>, MutableOutTuple_> outTupleMapLeft = indexerLeft.remove(oldIndexProperties, leftTuple);
-            for (OutTuple_ outTuple : outTupleMapLeft.values()) {
-                retractTuple(outTuple);
-            }
-            outTupleMapLeft.clear();
-
-            leftTuple.setStore(inputStoreIndexLeft, newIndexProperties);
-            indexAndPropagateLeft(leftTuple, newIndexProperties, outTupleMapLeft);
-        }
-    }
-
-    @Override
-    public final void retractLeft(LeftTuple_ leftTuple) {
-        IndexProperties indexProperties = leftTuple.getStore(inputStoreIndexLeft);
-        if (indexProperties == null) {
-            // No fail fast if null because we don't track which tuples made it through the filter predicate(s)
-            return;
-        }
-        leftTuple.setStore(inputStoreIndexLeft, null);
-
-        Map<UniTuple<Right_>, MutableOutTuple_> outTupleMapLeft = indexerLeft.remove(indexProperties, leftTuple);
-        for (OutTuple_ outTuple : outTupleMapLeft.values()) {
-            retractTuple(outTuple);
-        }
-    }
-
-    @Override
-    public final void insertRight(UniTuple<Right_> rightTuple) {
-        if (rightTuple.getStore(inputStoreIndexRight) != null) {
-            throw new IllegalStateException("Impossible state: the input for the tuple (" + rightTuple
-                    + ") was already added in the tupleStore.");
-        }
-        IndexProperties indexProperties = mappingRight.apply(rightTuple.getFactA());
-        rightTuple.setStore(inputStoreIndexRight, indexProperties);
-        indexAndPropagateRight(rightTuple, indexProperties);
-    }
-
-    private void indexAndPropagateRight(UniTuple<Right_> rightTuple, IndexProperties indexProperties) {
-        indexerRight.put(indexProperties, rightTuple, Collections.emptyMap());
-        indexerLeft.visit(indexProperties,
-                (leftTuple, outTupleMapLeft) -> indexAndPropagate(outTupleMapLeft, leftTuple, rightTuple));
-    }
-
-    @Override
-    public final void updateRight(UniTuple<Right_> rightTuple) {
-        IndexProperties oldIndexProperties = rightTuple.getStore(inputStoreIndexRight);
-        if (oldIndexProperties == null) {
-            // No fail fast if null because we don't track which tuples made it through the filter predicate(s)
-            insertRight(rightTuple);
-            return;
-        }
-        IndexProperties newIndexProperties = mappingRight.apply(rightTuple.getFactA());
-
-        if (oldIndexProperties.equals(newIndexProperties)) {
-            // No need for re-indexing because the index properties didn't change
-            // Still needed to propagate the update for downstream filters, matchWeighters, ...
-            indexerLeft.visit(oldIndexProperties, (leftTuple, outTupleMapLeft) -> {
-                MutableOutTuple_ outTuple = outTupleMapLeft.get(rightTuple);
-                updateOutTupleRight(outTuple, rightTuple);
-                if (outTuple == null) {
-                    throw new IllegalStateException("Impossible state: the tuple (" + leftTuple
-                            + ") with indexProperties (" + oldIndexProperties
-                            + ") has tuples on the right side that didn't exist on the left side.");
-                }
-                updateTuple(outTuple);
-            });
-        } else {
-            deindexRightTuple(oldIndexProperties, rightTuple);
-            rightTuple.setStore(inputStoreIndexRight, newIndexProperties);
-            indexAndPropagateRight(rightTuple, newIndexProperties);
-        }
-    }
-
-    private void deindexRightTuple(IndexProperties indexProperties, UniTuple<Right_> rightTuple) {
-        indexerRight.remove(indexProperties, rightTuple);
-        // Remove out tuples from the other side
-        indexerLeft.visit(indexProperties, (leftTuple, outTupleMapLeft) -> {
-            OutTuple_ outTuple = outTupleMapLeft.remove(rightTuple);
-            if (outTuple == null) {
-                throw new IllegalStateException("Impossible state: the tuple (" + leftTuple
-                        + ") with indexProperties (" + indexProperties
-                        + ") has tuples on the right side that didn't exist on the left side.");
-            }
-            retractTuple(outTuple);
-        });
-    }
-
-    @Override
-    public final void retractRight(UniTuple<Right_> rightTuple) {
-        IndexProperties indexProperties = rightTuple.getStore(inputStoreIndexRight);
-        if (indexProperties == null) {
-            // No fail fast if null because we don't track which tuples made it through the filter predicate(s)
-            return;
-        }
-        rightTuple.setStore(inputStoreIndexRight, null);
-        deindexRightTuple(indexProperties, rightTuple);
-    }
-
-    protected abstract IndexProperties createIndexPropertiesLeft(LeftTuple_ leftTuple);
 
     protected abstract MutableOutTuple_ createOutTuple(LeftTuple_ leftTuple, UniTuple<Right_> rightTuple);
 
@@ -191,7 +26,7 @@ public abstract class AbstractJoinNode<LeftTuple_ extends Tuple, Right_, OutTupl
 
     protected abstract void updateOutTupleRight(MutableOutTuple_ outTuple, UniTuple<Right_> rightTuple);
 
-    private void updateTuple(OutTuple_ outTuple) {
+    protected final void updateTuple(OutTuple_ outTuple) {
         switch (outTuple.getState()) {
             case CREATING:
             case UPDATING:
@@ -211,7 +46,7 @@ public abstract class AbstractJoinNode<LeftTuple_ extends Tuple, Right_, OutTupl
         }
     }
 
-    private void retractTuple(OutTuple_ outTuple) {
+    protected final void retractTuple(OutTuple_ outTuple) {
         switch (outTuple.getState()) {
             case CREATING:
                 // Don't add the tuple to the dirtyTupleQueue twice
@@ -238,7 +73,7 @@ public abstract class AbstractJoinNode<LeftTuple_ extends Tuple, Right_, OutTupl
     }
 
     @Override
-    public void calculateScore() {
+    public final void calculateScore() {
         for (OutTuple_ tuple : dirtyTupleQueue) {
             switch (tuple.getState()) {
                 case CREATING:

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/common/AbstractUnindexedIfExistsNode.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/common/AbstractUnindexedIfExistsNode.java
@@ -1,0 +1,145 @@
+package org.optaplanner.constraint.streams.bavet.common;
+
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+
+import org.optaplanner.constraint.streams.bavet.uni.UniTuple;
+
+public abstract class AbstractUnindexedIfExistsNode<LeftTuple_ extends Tuple, Right_>
+        extends AbstractIfExistsNode<LeftTuple_, Right_>
+        implements LeftTupleLifecycle<LeftTuple_>, RightTupleLifecycle<UniTuple<Right_>> {
+
+    private final Map<LeftTuple_, Counter<LeftTuple_>> leftMap = new LinkedHashMap<>();
+    private final Map<UniTuple<Right_>, Set<Counter<LeftTuple_>>> rightMap = new LinkedHashMap<>();
+
+    protected AbstractUnindexedIfExistsNode(boolean shouldExist, TupleLifecycle<LeftTuple_> nextNodeTupleLifecycle,
+            boolean isFiltering) {
+        super(shouldExist, nextNodeTupleLifecycle, isFiltering);
+    }
+
+    @Override
+    public final void insertLeft(LeftTuple_ leftTuple) {
+        Counter<LeftTuple_> counter = new Counter<>(leftTuple, shouldExist);
+        leftMap.put(leftTuple, counter);
+        for (Map.Entry<UniTuple<Right_>, Set<Counter<LeftTuple_>>> entry : rightMap.entrySet()) {
+            UniTuple<Right_> rightTuple = entry.getKey();
+            if (!isFiltering || testFiltering(leftTuple, rightTuple)) {
+                counter.countRight++;
+                Set<Counter<LeftTuple_>> counterSetRight = entry.getValue();
+                counterSetRight.add(counter);
+            }
+        }
+        if (counter.isAlive()) {
+            counter.state = BavetTupleState.CREATING;
+            dirtyCounterQueue.add(counter);
+        }
+    }
+
+    @Override
+    public final void updateLeft(LeftTuple_ leftTuple) {
+        Counter<LeftTuple_> counter = leftMap.get(leftTuple);
+        if (counter == null) {
+            // No fail fast if null because we don't track which tuples made it through the filter predicate(s)
+            insertLeft(leftTuple);
+            return;
+        }
+        // The indexers contain counters in the DEAD state, to track the rightCount.
+        if (!isFiltering) {
+            processCounterUpdate(counter);
+        } else {
+            // Call filtering for the leftTuple and rightTuple combinations again
+            counter.countRight = 0;
+            for (Map.Entry<UniTuple<Right_>, Set<Counter<LeftTuple_>>> entry : rightMap.entrySet()) {
+                UniTuple<Right_> rightTuple = entry.getKey();
+                if (testFiltering(leftTuple, rightTuple)) {
+                    counter.countRight++;
+                } else {
+                    Set<Counter<LeftTuple_>> counterSetRight = entry.getValue();
+                    counterSetRight.remove(counter);
+                }
+            }
+            if (counter.isAlive()) {
+                // Insert or update
+                insertOrUpdateCounter(counter);
+            } else {
+                // Retract or remain dead
+                retractOrRemainDeadCounter(counter);
+            }
+        }
+    }
+
+    @Override
+    public final void retractLeft(LeftTuple_ leftTuple) {
+        Counter<LeftTuple_> counter = leftMap.remove(leftTuple);
+        if (counter == null) {
+            // No fail fast if null because we don't track which tuples made it through the filter predicate(s)
+            return;
+        }
+        for (Set<Counter<LeftTuple_>> counterSetRight : rightMap.values()) {
+            boolean changed = counterSetRight.remove(counter);
+            // If filtering is active, not all counterSets contain the counter and we don't track which ones do
+            if (!changed && !isFiltering) {
+                throw new IllegalStateException("Impossible state: the tuple (" + leftTuple
+                        + ") has a counter on the left side that doesn't exist on the right side.");
+            }
+        }
+        if (counter.isAlive()) {
+            retractCounter(counter);
+        }
+    }
+
+    @Override
+    public final void insertRight(UniTuple<Right_> rightTuple) {
+        Set<Counter<LeftTuple_>> counterSetRight = new LinkedHashSet<>();
+        rightMap.put(rightTuple, counterSetRight);
+        for (Map.Entry<LeftTuple_, Counter<LeftTuple_>> entry : leftMap.entrySet()) {
+            LeftTuple_ leftTuple = entry.getKey();
+            Counter<LeftTuple_> counter = entry.getValue();
+            processInsert(leftTuple, rightTuple, counter, counterSetRight);
+        }
+    }
+
+    @Override
+    public final void updateRight(UniTuple<Right_> rightTuple) {
+        Set<Counter<LeftTuple_>> counterSetRight = rightMap.get(rightTuple);
+        if (counterSetRight == null) {
+            // No fail fast if null because we don't track which tuples made it through the filter predicate(s)
+            insertRight(rightTuple);
+        } else if (isFiltering) {
+            // Call filtering for the leftTuple and rightTuple combinations again
+            processCounters(counterSetRight);
+            counterSetRight.clear();
+            for (Map.Entry<LeftTuple_, Counter<LeftTuple_>> entry : leftMap.entrySet()) {
+                LeftTuple_ leftTuple = entry.getKey();
+                Counter<LeftTuple_> counter = entry.getValue();
+                processUpdate(leftTuple, rightTuple, counter, counterSetRight);
+            }
+        }
+    }
+
+    private void processCounters(Set<Counter<LeftTuple_>> counterSetRight) {
+        for (Counter<LeftTuple_> counter : counterSetRight) {
+            counter.countRight--;
+            if (counter.countRight == 0) {
+                if (shouldExist) {
+                    retractCounter(counter);
+                } else {
+                    insertCounter(counter);
+                }
+            }
+        }
+    }
+
+    @Override
+    public final void retractRight(UniTuple<Right_> rightTuple) {
+        Set<Counter<LeftTuple_>> counterSetRight = rightMap.remove(rightTuple);
+        if (counterSetRight == null) {
+            // No fail fast if null because we don't track which tuples made it through the filter predicate(s)
+            return;
+        }
+        processCounters(counterSetRight);
+    }
+
+}

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/common/AbstractUnindexedJoinNode.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/common/AbstractUnindexedJoinNode.java
@@ -1,0 +1,109 @@
+package org.optaplanner.constraint.streams.bavet.common;
+
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+
+import org.optaplanner.constraint.streams.bavet.uni.UniTuple;
+
+public abstract class AbstractUnindexedJoinNode<LeftTuple_ extends Tuple, Right_, OutTuple_ extends Tuple, MutableOutTuple_ extends OutTuple_>
+        extends AbstractJoinNode<LeftTuple_, Right_, OutTuple_, MutableOutTuple_>
+        implements LeftTupleLifecycle<LeftTuple_>, RightTupleLifecycle<UniTuple<Right_>> {
+
+    private final Map<LeftTuple_, Map<UniTuple<Right_>, MutableOutTuple_>> leftToRightMap = new LinkedHashMap<>();
+    private final Set<UniTuple<Right_>> rightSet = new LinkedHashSet<>();
+
+    protected AbstractUnindexedJoinNode(TupleLifecycle<OutTuple_> nextNodesTupleLifecycle) {
+        super(nextNodesTupleLifecycle);
+    }
+
+    @Override
+    public final void insertLeft(LeftTuple_ leftTuple) {
+        Map<UniTuple<Right_>, MutableOutTuple_> outTupleMapLeft = new LinkedHashMap<>();
+        leftToRightMap.put(leftTuple, outTupleMapLeft);
+        for (UniTuple<Right_> rightTuple : rightSet) {
+            insert(outTupleMapLeft, leftTuple, rightTuple);
+        }
+    }
+
+    private void insert(Map<UniTuple<Right_>, MutableOutTuple_> outTupleMapLeft, LeftTuple_ leftTuple,
+            UniTuple<Right_> rightTuple) {
+        MutableOutTuple_ outTuple = createOutTuple(leftTuple, rightTuple);
+        outTupleMapLeft.put(rightTuple, outTuple);
+        dirtyTupleQueue.add(outTuple);
+    }
+
+    @Override
+    public final void updateLeft(LeftTuple_ leftTuple) {
+        Map<UniTuple<Right_>, MutableOutTuple_> outTupleMapLeft = leftToRightMap.get(leftTuple);
+        if (outTupleMapLeft == null) { // We don't track which tuples made it through the filter predicate(s).
+            insertLeft(leftTuple);
+            return;
+        }
+        for (MutableOutTuple_ outTuple : outTupleMapLeft.values()) {
+            updateOutTupleLeft(outTuple, leftTuple);
+            updateTuple(outTuple);
+        }
+    }
+
+    @Override
+    public final void retractLeft(LeftTuple_ leftTuple) {
+        Map<UniTuple<Right_>, MutableOutTuple_> outTupleMapLeft = leftToRightMap.remove(leftTuple);
+        if (outTupleMapLeft == null) { // We don't track which tuples made it through the filter predicate(s).
+            return;
+        }
+        for (OutTuple_ outTuple : outTupleMapLeft.values()) {
+            retractTuple(outTuple);
+        }
+    }
+
+    @Override
+    public final void insertRight(UniTuple<Right_> rightTuple) {
+        rightSet.add(rightTuple);
+        for (Map.Entry<LeftTuple_, Map<UniTuple<Right_>, MutableOutTuple_>> entry : leftToRightMap.entrySet()) {
+            LeftTuple_ leftTuple = entry.getKey();
+            Map<UniTuple<Right_>, MutableOutTuple_> outTupleMapLeft = entry.getValue();
+            insert(outTupleMapLeft, leftTuple, rightTuple);
+        }
+    }
+
+    @Override
+    public final void updateRight(UniTuple<Right_> rightTuple) {
+        if (!rightSet.contains(rightTuple)) { // We don't track which tuples made it through the filter predicate(s).
+            insertRight(rightTuple);
+            return;
+        }
+        for (Map.Entry<LeftTuple_, Map<UniTuple<Right_>, MutableOutTuple_>> entry : leftToRightMap.entrySet()) {
+            LeftTuple_ leftTuple = entry.getKey();
+            Map<UniTuple<Right_>, MutableOutTuple_> outTupleMapLeft = entry.getValue();
+            MutableOutTuple_ outTuple = outTupleMapLeft.get(rightTuple);
+            updateOutTupleRight(outTuple, rightTuple);
+            if (outTuple == null) {
+                throw new IllegalStateException("Impossible state: the tuple (" + leftTuple
+                        + ") has tuples on the right side that didn't exist on the left side.");
+            }
+            updateTuple(outTuple);
+        }
+    }
+
+    @Override
+    public final void retractRight(UniTuple<Right_> rightTuple) {
+        boolean removed = rightSet.remove(rightTuple);
+        if (!removed) {
+            // We don't track which tuples made it through the filter predicate(s).
+            return;
+        }
+        for (Map.Entry<LeftTuple_, Map<UniTuple<Right_>, MutableOutTuple_>> entry : leftToRightMap.entrySet()) {
+            LeftTuple_ leftTuple = entry.getKey();
+            Map<UniTuple<Right_>, MutableOutTuple_> outTupleMapLeft = entry.getValue();
+            OutTuple_ outTuple = outTupleMapLeft.remove(rightTuple);
+            if (outTuple == null) {
+                throw new IllegalStateException("Impossible state: the tuple (" + leftTuple
+                        + ") has tuples on the right side that didn't exist on the left side.");
+            }
+            retractTuple(outTuple);
+        }
+    }
+
+}

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/common/Counter.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/common/Counter.java
@@ -1,0 +1,30 @@
+package org.optaplanner.constraint.streams.bavet.common;
+
+import static org.optaplanner.constraint.streams.bavet.common.BavetTupleState.DEAD;
+
+import java.util.function.IntPredicate;
+
+public final class Counter<Tuple_ extends Tuple> {
+
+    private static final IntPredicate ZERO_COUNT = count -> count == 0;
+    private static final IntPredicate NON_ZERO_COUNT = count -> count > 0;
+
+    final Tuple_ leftTuple;
+    final IntPredicate alivePredicate;
+    BavetTupleState state = DEAD;
+    int countRight = 0;
+
+    Counter(Tuple_ leftTuple, boolean shouldExist) {
+        this.leftTuple = leftTuple;
+        this.alivePredicate = shouldExist ? NON_ZERO_COUNT : ZERO_COUNT;
+    }
+
+    boolean isAlive() {
+        return alivePredicate.test(countRight);
+    }
+
+    @Override
+    public String toString() {
+        return "Counter(" + leftTuple + ")";
+    }
+}

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/common/index/Indexer.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/common/index/Indexer.java
@@ -4,7 +4,7 @@ import java.util.Map;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
-import org.optaplanner.constraint.streams.bavet.common.AbstractJoinNode;
+import org.optaplanner.constraint.streams.bavet.common.AbstractIndexedJoinNode;
 import org.optaplanner.constraint.streams.bavet.common.BavetTupleState;
 import org.optaplanner.constraint.streams.bavet.common.Tuple;
 
@@ -18,7 +18,7 @@ import org.optaplanner.constraint.streams.bavet.common.Tuple;
  * <p>
  * It returns a {@code Map<X, V>} instead of {@code Set<X>} for performance,
  * to avoid doing the same hash lookup twice in the client.
- * For example {@link AbstractJoinNode} uses the value to store a set of child tuples justified by the X instance.
+ * For example {@link AbstractIndexedJoinNode} uses the value to store a set of child tuples justified by the X instance.
  * <p>
  * The fact X is wrapped in a Tuple, because the {@link BavetTupleState} is needed by clients of
  * {@link #visit(IndexProperties, Consumer)}.

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/common/index/IndexerFactory.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/common/index/IndexerFactory.java
@@ -32,6 +32,10 @@ public class IndexerFactory {
         }
     }
 
+    public boolean hasJoiners() {
+        return joinerTypes.length > 0;
+    }
+
     public <Tuple_ extends Tuple, Value_> Indexer<Tuple_, Value_> buildIndexer(boolean isLeftBridge) {
         /*
          * Indexers form a parent-child hierarchy, each child has exactly one parent.

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/common/index/JoinerUtils.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/common/index/JoinerUtils.java
@@ -13,8 +13,6 @@ import org.optaplanner.core.api.function.TriFunction;
 
 public final class JoinerUtils {
 
-    private static final NoneIndexProperties NONE_INDEX_PROPERTY = NoneIndexProperties.INSTANCE;
-
     private JoinerUtils() {
 
     }
@@ -23,7 +21,7 @@ public final class JoinerUtils {
         int joinerCount = joiner.getJoinerCount();
         switch (joinerCount) {
             case 0:
-                return (A a) -> NONE_INDEX_PROPERTY;
+                return (A a) -> NoneIndexProperties.INSTANCE;
             case 1:
                 Function<A, Object> mapping = joiner.getLeftMapping(0);
                 return (A a) -> new SingleIndexProperties(mapping.apply(a));
@@ -51,7 +49,7 @@ public final class JoinerUtils {
         int joinerCount = joiner.getJoinerCount();
         switch (joinerCount) {
             case 0:
-                return (A a, B b) -> NONE_INDEX_PROPERTY;
+                return (A a, B b) -> NoneIndexProperties.INSTANCE;
             case 1:
                 BiFunction<A, B, Object> mapping = joiner.getLeftMapping(0);
                 return (A a, B b) -> new SingleIndexProperties(mapping.apply(a, b));
@@ -80,7 +78,7 @@ public final class JoinerUtils {
         int joinerCount = joiner.getJoinerCount();
         switch (joinerCount) {
             case 0:
-                return (A a, B b, C c) -> NONE_INDEX_PROPERTY;
+                return (A a, B b, C c) -> NoneIndexProperties.INSTANCE;
             case 1:
                 TriFunction<A, B, C, Object> mapping = joiner.getLeftMapping(0);
                 return (A a, B b, C c) -> new SingleIndexProperties(mapping.apply(a, b, c));
@@ -110,7 +108,7 @@ public final class JoinerUtils {
         int joinerCount = joiner.getJoinerCount();
         switch (joinerCount) {
             case 0:
-                return (A a, B b, C c, D d) -> NONE_INDEX_PROPERTY;
+                return (A a, B b, C c, D d) -> NoneIndexProperties.INSTANCE;
             case 1:
                 QuadFunction<A, B, C, D, Object> mapping = joiner.getLeftMapping(0);
                 return (A a, B b, C c, D d) -> new SingleIndexProperties(mapping.apply(a, b, c, d));
@@ -140,7 +138,7 @@ public final class JoinerUtils {
         int joinerCount = joiner.getJoinerCount();
         switch (joinerCount) {
             case 0:
-                return (Right_ right) -> NONE_INDEX_PROPERTY;
+                return (Right_ right) -> NoneIndexProperties.INSTANCE;
             case 1:
                 Function<Right_, Object> mapping = joiner.getRightMapping(0);
                 return (Right_ right) -> new SingleIndexProperties(mapping.apply(right));

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/quad/IndexedIfExistsQuadNode.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/quad/IndexedIfExistsQuadNode.java
@@ -3,7 +3,8 @@ package org.optaplanner.constraint.streams.bavet.quad;
 import java.util.Set;
 import java.util.function.Function;
 
-import org.optaplanner.constraint.streams.bavet.common.AbstractIfExistsNode;
+import org.optaplanner.constraint.streams.bavet.common.AbstractIndexedIfExistsNode;
+import org.optaplanner.constraint.streams.bavet.common.Counter;
 import org.optaplanner.constraint.streams.bavet.common.TupleLifecycle;
 import org.optaplanner.constraint.streams.bavet.common.index.IndexProperties;
 import org.optaplanner.constraint.streams.bavet.common.index.Indexer;
@@ -11,12 +12,12 @@ import org.optaplanner.constraint.streams.bavet.uni.UniTuple;
 import org.optaplanner.core.api.function.PentaPredicate;
 import org.optaplanner.core.api.function.QuadFunction;
 
-final class IfExistsQuadWithUniNode<A, B, C, D, E> extends AbstractIfExistsNode<QuadTuple<A, B, C, D>, E> {
+final class IndexedIfExistsQuadNode<A, B, C, D, E> extends AbstractIndexedIfExistsNode<QuadTuple<A, B, C, D>, E> {
 
     private final QuadFunction<A, B, C, D, IndexProperties> mappingABCD;
     private final PentaPredicate<A, B, C, D, E> filtering;
 
-    public IfExistsQuadWithUniNode(boolean shouldExist,
+    public IndexedIfExistsQuadNode(boolean shouldExist,
             QuadFunction<A, B, C, D, IndexProperties> mappingABCD, Function<E, IndexProperties> mappingD,
             int inputStoreIndexABC, int inputStoreIndexD,
             TupleLifecycle<QuadTuple<A, B, C, D>> nextNodesTupleLifecycle,

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/quad/IndexedJoinQuadNode.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/quad/IndexedJoinQuadNode.java
@@ -3,7 +3,7 @@ package org.optaplanner.constraint.streams.bavet.quad;
 import java.util.Map;
 import java.util.function.Function;
 
-import org.optaplanner.constraint.streams.bavet.common.AbstractJoinNode;
+import org.optaplanner.constraint.streams.bavet.common.AbstractIndexedJoinNode;
 import org.optaplanner.constraint.streams.bavet.common.TupleLifecycle;
 import org.optaplanner.constraint.streams.bavet.common.index.IndexProperties;
 import org.optaplanner.constraint.streams.bavet.common.index.Indexer;
@@ -11,13 +11,13 @@ import org.optaplanner.constraint.streams.bavet.tri.TriTuple;
 import org.optaplanner.constraint.streams.bavet.uni.UniTuple;
 import org.optaplanner.core.api.function.TriFunction;
 
-final class JoinQuadNode<A, B, C, D>
-        extends AbstractJoinNode<TriTuple<A, B, C>, D, QuadTuple<A, B, C, D>, QuadTupleImpl<A, B, C, D>> {
+final class IndexedJoinQuadNode<A, B, C, D>
+        extends AbstractIndexedJoinNode<TriTuple<A, B, C>, D, QuadTuple<A, B, C, D>, QuadTupleImpl<A, B, C, D>> {
 
     private final TriFunction<A, B, C, IndexProperties> mappingABC;
     private final int outputStoreSize;
 
-    public JoinQuadNode(TriFunction<A, B, C, IndexProperties> mappingABC, Function<D, IndexProperties> mappingD,
+    public IndexedJoinQuadNode(TriFunction<A, B, C, IndexProperties> mappingABC, Function<D, IndexProperties> mappingD,
             int inputStoreIndexAB, int inputStoreIndexC,
             TupleLifecycle<QuadTuple<A, B, C, D>> nextNodesTupleLifecycle,
             int outputStoreSize,

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/quad/UnindexedIfExistsQuadNode.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/quad/UnindexedIfExistsQuadNode.java
@@ -1,0 +1,30 @@
+package org.optaplanner.constraint.streams.bavet.quad;
+
+import org.optaplanner.constraint.streams.bavet.common.AbstractUnindexedIfExistsNode;
+import org.optaplanner.constraint.streams.bavet.common.TupleLifecycle;
+import org.optaplanner.constraint.streams.bavet.uni.UniTuple;
+import org.optaplanner.core.api.function.PentaPredicate;
+
+final class UnindexedIfExistsQuadNode<A, B, C, D, E> extends AbstractUnindexedIfExistsNode<QuadTuple<A, B, C, D>, E> {
+
+    private final PentaPredicate<A, B, C, D, E> filtering;
+
+    public UnindexedIfExistsQuadNode(boolean shouldExist,
+            TupleLifecycle<QuadTuple<A, B, C, D>> nextNodesTupleLifecycle,
+            PentaPredicate<A, B, C, D, E> filtering) {
+        super(shouldExist, nextNodesTupleLifecycle, filtering != null);
+        this.filtering = filtering;
+    }
+
+    @Override
+    protected boolean testFiltering(QuadTuple<A, B, C, D> leftTuple, UniTuple<E> rightTuple) {
+        return filtering.test(leftTuple.getFactA(), leftTuple.getFactB(), leftTuple.getFactC(), leftTuple.getFactD(),
+                rightTuple.getFactA());
+    }
+
+    @Override
+    public String toString() {
+        return "IfExistsQuadWithUniNode";
+    }
+
+}

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/quad/UnindexedJoinQuadNode.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/quad/UnindexedJoinQuadNode.java
@@ -1,0 +1,41 @@
+package org.optaplanner.constraint.streams.bavet.quad;
+
+import org.optaplanner.constraint.streams.bavet.common.AbstractUnindexedJoinNode;
+import org.optaplanner.constraint.streams.bavet.common.TupleLifecycle;
+import org.optaplanner.constraint.streams.bavet.tri.TriTuple;
+import org.optaplanner.constraint.streams.bavet.uni.UniTuple;
+
+final class UnindexedJoinQuadNode<A, B, C, D>
+        extends AbstractUnindexedJoinNode<TriTuple<A, B, C>, D, QuadTuple<A, B, C, D>, QuadTupleImpl<A, B, C, D>> {
+
+    private final int outputStoreSize;
+
+    public UnindexedJoinQuadNode(TupleLifecycle<QuadTuple<A, B, C, D>> nextNodesTupleLifecycle, int outputStoreSize) {
+        super(nextNodesTupleLifecycle);
+        this.outputStoreSize = outputStoreSize;
+    }
+
+    @Override
+    protected void updateOutTupleLeft(QuadTupleImpl<A, B, C, D> outTuple, TriTuple<A, B, C> leftTuple) {
+        outTuple.factA = leftTuple.getFactA();
+        outTuple.factB = leftTuple.getFactB();
+        outTuple.factC = leftTuple.getFactC();
+    }
+
+    @Override
+    protected void updateOutTupleRight(QuadTupleImpl<A, B, C, D> outTuple, UniTuple<D> rightTuple) {
+        outTuple.factD = rightTuple.getFactA();
+    }
+
+    @Override
+    protected QuadTupleImpl<A, B, C, D> createOutTuple(TriTuple<A, B, C> leftTuple, UniTuple<D> rightTuple) {
+        return new QuadTupleImpl<>(leftTuple.getFactA(), leftTuple.getFactB(), leftTuple.getFactC(), rightTuple.getFactA(),
+                outputStoreSize);
+    }
+
+    @Override
+    public String toString() {
+        return "JoinQuadNode";
+    }
+
+}

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/tri/IndexedIfExistsTriNode.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/tri/IndexedIfExistsTriNode.java
@@ -3,7 +3,8 @@ package org.optaplanner.constraint.streams.bavet.tri;
 import java.util.Set;
 import java.util.function.Function;
 
-import org.optaplanner.constraint.streams.bavet.common.AbstractIfExistsNode;
+import org.optaplanner.constraint.streams.bavet.common.AbstractIndexedIfExistsNode;
+import org.optaplanner.constraint.streams.bavet.common.Counter;
 import org.optaplanner.constraint.streams.bavet.common.TupleLifecycle;
 import org.optaplanner.constraint.streams.bavet.common.index.IndexProperties;
 import org.optaplanner.constraint.streams.bavet.common.index.Indexer;
@@ -11,12 +12,12 @@ import org.optaplanner.constraint.streams.bavet.uni.UniTuple;
 import org.optaplanner.core.api.function.QuadPredicate;
 import org.optaplanner.core.api.function.TriFunction;
 
-final class IfExistsTriWithUniNode<A, B, C, D> extends AbstractIfExistsNode<TriTuple<A, B, C>, D> {
+final class IndexedIfExistsTriNode<A, B, C, D> extends AbstractIndexedIfExistsNode<TriTuple<A, B, C>, D> {
 
     private final TriFunction<A, B, C, IndexProperties> mappingABC;
     private final QuadPredicate<A, B, C, D> filtering;
 
-    public IfExistsTriWithUniNode(boolean shouldExist,
+    public IndexedIfExistsTriNode(boolean shouldExist,
             TriFunction<A, B, C, IndexProperties> mappingABC, Function<D, IndexProperties> mappingD,
             int inputStoreIndexABC, int inputStoreIndexD,
             TupleLifecycle<TriTuple<A, B, C>> nextNodesTupleLifecycle,

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/tri/IndexedJoinTriNode.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/tri/IndexedJoinTriNode.java
@@ -5,18 +5,19 @@ import java.util.function.BiFunction;
 import java.util.function.Function;
 
 import org.optaplanner.constraint.streams.bavet.bi.BiTuple;
-import org.optaplanner.constraint.streams.bavet.common.AbstractJoinNode;
+import org.optaplanner.constraint.streams.bavet.common.AbstractIndexedJoinNode;
 import org.optaplanner.constraint.streams.bavet.common.TupleLifecycle;
 import org.optaplanner.constraint.streams.bavet.common.index.IndexProperties;
 import org.optaplanner.constraint.streams.bavet.common.index.Indexer;
 import org.optaplanner.constraint.streams.bavet.uni.UniTuple;
 
-final class JoinTriNode<A, B, C> extends AbstractJoinNode<BiTuple<A, B>, C, TriTuple<A, B, C>, TriTupleImpl<A, B, C>> {
+final class IndexedJoinTriNode<A, B, C>
+        extends AbstractIndexedJoinNode<BiTuple<A, B>, C, TriTuple<A, B, C>, TriTupleImpl<A, B, C>> {
 
     private final BiFunction<A, B, IndexProperties> mappingAB;
     private final int outputStoreSize;
 
-    public JoinTriNode(BiFunction<A, B, IndexProperties> mappingAB, Function<C, IndexProperties> mappingC,
+    public IndexedJoinTriNode(BiFunction<A, B, IndexProperties> mappingAB, Function<C, IndexProperties> mappingC,
             int inputStoreIndexAB, int inputStoreIndexC,
             TupleLifecycle<TriTuple<A, B, C>> nextNodesTupleLifecycle,
             int outputStoreSize,

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/tri/UnindexedIfExistsTriNode.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/tri/UnindexedIfExistsTriNode.java
@@ -1,0 +1,28 @@
+package org.optaplanner.constraint.streams.bavet.tri;
+
+import org.optaplanner.constraint.streams.bavet.common.AbstractUnindexedIfExistsNode;
+import org.optaplanner.constraint.streams.bavet.common.TupleLifecycle;
+import org.optaplanner.constraint.streams.bavet.uni.UniTuple;
+import org.optaplanner.core.api.function.QuadPredicate;
+
+final class UnindexedIfExistsTriNode<A, B, C, D> extends AbstractUnindexedIfExistsNode<TriTuple<A, B, C>, D> {
+
+    private final QuadPredicate<A, B, C, D> filtering;
+
+    public UnindexedIfExistsTriNode(boolean shouldExist, TupleLifecycle<TriTuple<A, B, C>> nextNodesTupleLifecycle,
+            QuadPredicate<A, B, C, D> filtering) {
+        super(shouldExist, nextNodesTupleLifecycle, filtering != null);
+        this.filtering = filtering;
+    }
+
+    @Override
+    protected boolean testFiltering(TriTuple<A, B, C> leftTuple, UniTuple<D> rightTuple) {
+        return filtering.test(leftTuple.getFactA(), leftTuple.getFactB(), leftTuple.getFactC(), rightTuple.getFactA());
+    }
+
+    @Override
+    public String toString() {
+        return "IfExistsTriWithUniNode";
+    }
+
+}

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/tri/UnindexedJoinTriNode.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/tri/UnindexedJoinTriNode.java
@@ -1,0 +1,39 @@
+package org.optaplanner.constraint.streams.bavet.tri;
+
+import org.optaplanner.constraint.streams.bavet.bi.BiTuple;
+import org.optaplanner.constraint.streams.bavet.common.AbstractUnindexedJoinNode;
+import org.optaplanner.constraint.streams.bavet.common.TupleLifecycle;
+import org.optaplanner.constraint.streams.bavet.uni.UniTuple;
+
+final class UnindexedJoinTriNode<A, B, C>
+        extends AbstractUnindexedJoinNode<BiTuple<A, B>, C, TriTuple<A, B, C>, TriTupleImpl<A, B, C>> {
+
+    private final int outputStoreSize;
+
+    public UnindexedJoinTriNode(TupleLifecycle<TriTuple<A, B, C>> nextNodesTupleLifecycle, int outputStoreSize) {
+        super(nextNodesTupleLifecycle);
+        this.outputStoreSize = outputStoreSize;
+    }
+
+    @Override
+    protected TriTupleImpl<A, B, C> createOutTuple(BiTuple<A, B> leftTuple, UniTuple<C> rightTuple) {
+        return new TriTupleImpl<>(leftTuple.getFactA(), leftTuple.getFactB(), rightTuple.getFactA(), outputStoreSize);
+    }
+
+    @Override
+    protected void updateOutTupleLeft(TriTupleImpl<A, B, C> outTuple, BiTuple<A, B> leftTuple) {
+        outTuple.factA = leftTuple.getFactA();
+        outTuple.factB = leftTuple.getFactB();
+    }
+
+    @Override
+    protected void updateOutTupleRight(TriTupleImpl<A, B, C> outTuple, UniTuple<C> rightTuple) {
+        outTuple.factC = rightTuple.getFactA();
+    }
+
+    @Override
+    public String toString() {
+        return "JoinTriNode";
+    }
+
+}

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/uni/IndexedIfExistsUniNode.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/uni/IndexedIfExistsUniNode.java
@@ -4,17 +4,18 @@ import java.util.Set;
 import java.util.function.BiPredicate;
 import java.util.function.Function;
 
-import org.optaplanner.constraint.streams.bavet.common.AbstractIfExistsNode;
+import org.optaplanner.constraint.streams.bavet.common.AbstractIndexedIfExistsNode;
+import org.optaplanner.constraint.streams.bavet.common.Counter;
 import org.optaplanner.constraint.streams.bavet.common.TupleLifecycle;
 import org.optaplanner.constraint.streams.bavet.common.index.IndexProperties;
 import org.optaplanner.constraint.streams.bavet.common.index.Indexer;
 
-final class IfExistsUniWithUniNode<A, B> extends AbstractIfExistsNode<UniTuple<A>, B> {
+final class IndexedIfExistsUniNode<A, B> extends AbstractIndexedIfExistsNode<UniTuple<A>, B> {
 
     private final Function<A, IndexProperties> mappingA;
     private final BiPredicate<A, B> filtering;
 
-    public IfExistsUniWithUniNode(boolean shouldExist,
+    public IndexedIfExistsUniNode(boolean shouldExist,
             Function<A, IndexProperties> mappingA, Function<B, IndexProperties> mappingB,
             int inputStoreIndexA, int inputStoreIndexB,
             TupleLifecycle<UniTuple<A>> nextNodesTupleLifecycle,

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/uni/UnindexedIfExistsUniNode.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/uni/UnindexedIfExistsUniNode.java
@@ -1,0 +1,28 @@
+package org.optaplanner.constraint.streams.bavet.uni;
+
+import java.util.function.BiPredicate;
+
+import org.optaplanner.constraint.streams.bavet.common.AbstractUnindexedIfExistsNode;
+import org.optaplanner.constraint.streams.bavet.common.TupleLifecycle;
+
+final class UnindexedIfExistsUniNode<A, B> extends AbstractUnindexedIfExistsNode<UniTuple<A>, B> {
+
+    private final BiPredicate<A, B> filtering;
+
+    public UnindexedIfExistsUniNode(boolean shouldExist, TupleLifecycle<UniTuple<A>> nextNodesTupleLifecycle,
+            BiPredicate<A, B> filtering) {
+        super(shouldExist, nextNodesTupleLifecycle, filtering != null);
+        this.filtering = filtering;
+    }
+
+    @Override
+    protected boolean testFiltering(UniTuple<A> leftTuple, UniTuple<B> rightTuple) {
+        return filtering.test(leftTuple.getFactA(), rightTuple.getFactA());
+    }
+
+    @Override
+    public String toString() {
+        return "IfExistsUniWithUniNode";
+    }
+
+}


### PR DESCRIPTION
Joins that do not use Joiners do not need to be sent through the IndexProperties+NoneIndexer machinery.
Some examples improve by ~10 %.