### PR TITLE
PLANNER-2756: Add constraint stream type property for Quarkus and Spring Boot

### DIFF
--- a/optaplanner-docs/src/modules/ROOT/pages/integration/config-properties.adoc
+++ b/optaplanner-docs/src/modules/ROOT/pages/integration/config-properties.adoc
@@ -45,6 +45,11 @@ Defaults to `REFLECTION`.
 The other possible value is `GIZMO`.
 endif::[]
 
+{property_prefix}optaplanner.solver.constraint-stream-impl-type::
+What Constraint Stream implementation to use.
+See xref:constraint-streams/constraint-streams.adoc#constraintStreamsImplementations[the variant implementation types section] for more details.
+Defaults to `DROOLS`. The other possible value is `BAVET`.
+
 {property_prefix}optaplanner.solver.termination.spent-limit::
 How long the solver can run.
 For example: `30s` is 30 seconds. `5m` is 5 minutes. `2h` is 2 hours. `1d` is 1 day.

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/main/java/org/optaplanner/quarkus/deployment/OptaPlannerProcessor.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/main/java/org/optaplanner/quarkus/deployment/OptaPlannerProcessor.java
@@ -371,6 +371,8 @@ class OptaPlannerProcessor {
         optaPlannerBuildTimeConfig.solver.environmentMode.ifPresent(solverConfig::setEnvironmentMode);
         optaPlannerBuildTimeConfig.solver.daemon.ifPresent(solverConfig::setDaemon);
         optaPlannerBuildTimeConfig.solver.domainAccessType.ifPresent(solverConfig::setDomainAccessType);
+        optaPlannerBuildTimeConfig.solver.constraintStreamImplType.ifPresent(solverConfig::withConstraintStreamImplType);
+
         if (solverConfig.getDomainAccessType() == null) {
             solverConfig.setDomainAccessType(DomainAccessType.GIZMO);
         }

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/main/java/org/optaplanner/quarkus/deployment/config/SolverBuildTimeConfig.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/main/java/org/optaplanner/quarkus/deployment/config/SolverBuildTimeConfig.java
@@ -3,6 +3,7 @@ package org.optaplanner.quarkus.deployment.config;
 import java.util.Optional;
 
 import org.optaplanner.core.api.domain.common.DomainAccessType;
+import org.optaplanner.core.api.score.stream.ConstraintStreamImplType;
 import org.optaplanner.core.config.solver.EnvironmentMode;
 import org.optaplanner.core.config.solver.SolverConfig;
 import org.optaplanner.quarkus.config.SolverRuntimeConfig;
@@ -40,5 +41,11 @@ public class SolverBuildTimeConfig {
      */
     @ConfigItem
     public Optional<DomainAccessType> domainAccessType;
+
+    /**
+     * What constraint stream implementation to use. Defaults to {@link ConstraintStreamImplType#DROOLS}.
+     */
+    @ConfigItem
+    public Optional<ConstraintStreamImplType> constraintStreamImplType;
 
 }

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/test/java/org/optaplanner/quarkus/OptaPlannerProcessorSolverPropertiesTest.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/test/java/org/optaplanner/quarkus/OptaPlannerProcessorSolverPropertiesTest.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.optaplanner.core.api.domain.common.DomainAccessType;
 import org.optaplanner.core.api.score.buildin.simple.SimpleScore;
+import org.optaplanner.core.api.score.stream.ConstraintStreamImplType;
 import org.optaplanner.core.api.solver.SolverFactory;
 import org.optaplanner.core.config.solver.EnvironmentMode;
 import org.optaplanner.core.config.solver.SolverConfig;
@@ -29,6 +30,7 @@ class OptaPlannerProcessorSolverPropertiesTest {
     static final QuarkusUnitTest config = new QuarkusUnitTest()
             .overrideConfigKey("quarkus.optaplanner.solver.environment-mode", "FULL_ASSERT")
             .overrideConfigKey("quarkus.optaplanner.solver.daemon", "true")
+            .overrideConfigKey("quarkus.optaplanner.solver.constraint-stream-impl-type", "BAVET")
             .overrideConfigKey("quarkus.optaplanner.solver.move-thread-count", "2")
             .overrideConfigKey("quarkus.optaplanner.solver.domain-access-type", "REFLECTION")
             .overrideConfigKey("quarkus.optaplanner.solver.termination.spent-limit", "4h")
@@ -49,6 +51,8 @@ class OptaPlannerProcessorSolverPropertiesTest {
         assertTrue(solverConfig.getDaemon());
         assertEquals("2", solverConfig.getMoveThreadCount());
         assertEquals(DomainAccessType.REFLECTION, solverConfig.getDomainAccessType());
+        assertEquals(ConstraintStreamImplType.BAVET,
+                solverConfig.getScoreDirectorFactoryConfig().getConstraintStreamImplType());
 
         assertNotNull(solverFactory);
     }

--- a/optaplanner-spring-integration/optaplanner-spring-boot-autoconfigure/src/main/java/org/optaplanner/spring/boot/autoconfigure/OptaPlannerAutoConfiguration.java
+++ b/optaplanner-spring-integration/optaplanner-spring-boot-autoconfigure/src/main/java/org/optaplanner/spring/boot/autoconfigure/OptaPlannerAutoConfiguration.java
@@ -188,6 +188,9 @@ public class OptaPlannerAutoConfiguration implements BeanClassLoaderAware {
             if (solverProperties.getDomainAccessType() != null) {
                 solverConfig.setDomainAccessType(solverProperties.getDomainAccessType());
             }
+            if (solverProperties.getConstraintStreamImplType() != null) {
+                solverConfig.withConstraintStreamImplType(solverProperties.getConstraintStreamImplType());
+            }
             if (solverProperties.getDaemon() != null) {
                 solverConfig.setDaemon(solverProperties.getDaemon());
             }

--- a/optaplanner-spring-integration/optaplanner-spring-boot-autoconfigure/src/main/java/org/optaplanner/spring/boot/autoconfigure/config/SolverProperties.java
+++ b/optaplanner-spring-integration/optaplanner-spring-boot-autoconfigure/src/main/java/org/optaplanner/spring/boot/autoconfigure/config/SolverProperties.java
@@ -1,6 +1,7 @@
 package org.optaplanner.spring.boot.autoconfigure.config;
 
 import org.optaplanner.core.api.domain.common.DomainAccessType;
+import org.optaplanner.core.api.score.stream.ConstraintStreamImplType;
 import org.optaplanner.core.config.solver.EnvironmentMode;
 import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
@@ -33,6 +34,11 @@ public class SolverProperties {
      * and all planning annotations must be on public members.
      */
     private DomainAccessType domainAccessType;
+
+    /**
+     * What constraint stream implementation to use. Defaults to {@link ConstraintStreamImplType#DROOLS}.
+     */
+    private ConstraintStreamImplType constraintStreamImplType;
 
     @NestedConfigurationProperty
     private TerminationProperties termination;
@@ -71,6 +77,14 @@ public class SolverProperties {
 
     public void setDomainAccessType(DomainAccessType domainAccessType) {
         this.domainAccessType = domainAccessType;
+    }
+
+    public ConstraintStreamImplType getConstraintStreamImplType() {
+        return constraintStreamImplType;
+    }
+
+    public void setConstraintStreamImplType(ConstraintStreamImplType constraintStreamImplType) {
+        this.constraintStreamImplType = constraintStreamImplType;
     }
 
     public TerminationProperties getTermination() {

--- a/optaplanner-spring-integration/optaplanner-spring-boot-autoconfigure/src/test/java/org/optaplanner/spring/boot/autoconfigure/OptaPlannerAutoConfigurationTest.java
+++ b/optaplanner-spring-integration/optaplanner-spring-boot-autoconfigure/src/test/java/org/optaplanner/spring/boot/autoconfigure/OptaPlannerAutoConfigurationTest.java
@@ -197,6 +197,15 @@ class OptaPlannerAutoConfigurationTest {
                     assertThat(solverConfig.getMoveThreadCount()).isEqualTo("2");
                     assertThat(context.getBean(SolverFactory.class)).isNotNull();
                 });
+        contextRunner
+                .withClassLoader(defaultConstraintsDrlFilteredClassLoader)
+                .withPropertyValues("optaplanner.solver.constraint-stream-impl-type=BAVET")
+                .run(context -> {
+                    SolverConfig solverConfig = context.getBean(SolverConfig.class);
+                    assertThat(solverConfig.getScoreDirectorFactoryConfig().getConstraintStreamImplType())
+                            .isEqualTo(ConstraintStreamImplType.BAVET);
+                    assertThat(context.getBean(SolverFactory.class)).isNotNull();
+                });
     }
 
     @Test


### PR DESCRIPTION
<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.
-->

### JIRA

<!-- Add a JIRA ticket link if it exists. -->
https://issues.redhat.com/browse/PLANNER-2756

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
- https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
- https://github.com/kiegroup/drools/pull/3000
- https://github.com/kiegroup/optaplanner/pull/899
- etc.
-->

### Checklist
- [ ] Documentation updated if applicable.
- [ ] Upgrade recipe provided if applicable.

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request checks</b>  
  Please add comment: <b>Jenkins retest this</b>

- for a <b>specific pull request check</b>  
  please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-vehicle-routing] tests</b>
  
- for a <b>full downstream build</b> 
  - for <b>jenkins</b> job: 
    please add comment: <b>Jenkins run fdb</b>
  - for <b>github actions</b> job: 
    add the label `run_fdb`

- for a <b>compile downstream build</b>  
  please add comment: <b>Jenkins run cdb</b>

- for a <b>full production downstream build</b>  
  please add comment: <b>Jenkins execute product fdb</b>

- for an <b>upstream build</b>  
  please add comment: <b>Jenkins run upstream</b>

- for <b>quarkus branch checks</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins run quarkus-branch</b>

- for a <b>quarkus branch specific check</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-vehicle-routing] quarkus-branch</b>

- for <b>quarkus main checks</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins run quarkus-main</b>

- for a <b>specific quarkus main check</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-vehicle-routing] quarkus-branch</b>

- for <b>native checks</b>  
  Run native checks  
  Please add comment: <b>Jenkins run native</b>

- for a <b>specific native check</b>  
  Run native checks 
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-vehicle-routing] native</b>

- for <b>mandrel checks</b>  
  Run native checks against Mandrel image
  Please add comment: <b>Jenkins run mandrel</b>

- for a <b>specific mandrel check</b>  
  Run native checks against Mandrel image  
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-vehicle-routing] mandrel</b>
</details>

### CI Status

 You can check OptaPlanner repositories CI status from [Chain Status webpage](https://kiegroup.github.io/optaplanner/).