### PR TITLE
Fix typos and improve selector factories' error messages

### DIFF
--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/config/AbstractConfig.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/config/AbstractConfig.java
@@ -6,7 +6,7 @@ import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 
 /**
- * A config class is a user friendly, validating configuration class that maps XML input.
+ * A config class is a user-friendly, validating configuration class that maps XML input.
  * It builds the runtime impl classes (which are optimized for scalability and performance instead).
  * <p>
  * A config class should adhere to "configuration by exception" in its XML/JSON input/output,
@@ -31,7 +31,7 @@ public abstract class AbstractConfig<Config_ extends AbstractConfig<Config_>> {
     public abstract Config_ inherit(Config_ inheritedConfig);
 
     /**
-     * Typically implemented by constructing a new instance and calling {@link #inherit(AbstractConfig)} on it
+     * Typically implemented by constructing a new instance and calling {@link #inherit(AbstractConfig)} on it.
      *
      * @return new instance
      */
@@ -42,8 +42,7 @@ public abstract class AbstractConfig<Config_ extends AbstractConfig<Config_>> {
      * (including those provided in child configs).
      * Required to create the bean factory in Quarkus.
      *
-     * @param classVisitor The visitor of classes, never null. Can accept null instances
-     *        of Class
+     * @param classVisitor The visitor of classes, never null. Can accept null instances of Class.
      */
     public abstract void visitReferencedClasses(Consumer<Class<?>> classVisitor);
 

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/AbstractSelectorFactory.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/AbstractSelectorFactory.java
@@ -16,7 +16,7 @@ public abstract class AbstractSelectorFactory<Solution_, SelectorConfig_ extends
             SelectionOrder resolvedSelectionOrder) {
         switch (resolvedSelectionOrder) {
             case INHERIT:
-                throw new IllegalArgumentException("The moveSelectorConfig (" + this
+                throw new IllegalArgumentException("The moveSelectorConfig (" + config
                         + ") has a resolvedSelectionOrder (" + resolvedSelectionOrder
                         + ") which should have been resolved by now.");
             case ORIGINAL:
@@ -26,7 +26,7 @@ public abstract class AbstractSelectorFactory<Solution_, SelectorConfig_ extends
             case SHUFFLED:
             case PROBABILISTIC:
                 if (resolvedCacheType.isNotCached()) {
-                    throw new IllegalArgumentException("The moveSelectorConfig (" + this
+                    throw new IllegalArgumentException("The moveSelectorConfig (" + config
                             + ") has a resolvedSelectionOrder (" + resolvedSelectionOrder
                             + ") which does not support the resolvedCacheType (" + resolvedCacheType + ").");
                 }

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/entity/pillar/PillarSelectorFactory.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/entity/pillar/PillarSelectorFactory.java
@@ -31,7 +31,7 @@ public class PillarSelectorFactory<Solution_>
     /**
      * @param configPolicy never null
      * @param subPillarType if null, defaults to {@link SubPillarType#ALL} for backwards compatibility reasons.
-     * @param subPillarSequenceComparatorClass if not null, will force entites in the pillar to come in this order
+     * @param subPillarSequenceComparatorClass if not null, will force entities in the pillar to come in this order
      * @param minimumCacheType never null, If caching is used (different from {@link SelectionCacheType#JUST_IN_TIME}),
      *        then it should be at least this {@link SelectionCacheType} because an ancestor already uses such caching
      *        and less would be pointless.

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/ChangeMoveSelectorFactory.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/ChangeMoveSelectorFactory.java
@@ -50,7 +50,7 @@ public class ChangeMoveSelectorFactory<Solution_>
                 .buildValueSelector(configPolicy, entitySelector.getEntityDescriptor(), minimumCacheType, selectionOrder);
         if (valueSelector.getVariableDescriptor().isListVariable()) {
             if (!(valueSelector instanceof EntityIndependentValueSelector)) {
-                throw new IllegalArgumentException("The changeMoveSelector (" + this
+                throw new IllegalArgumentException("The changeMoveSelector (" + config
                         + ") for a list variable needs to be based on an "
                         + EntityIndependentValueSelector.class.getSimpleName() + " (" + valueSelector + ")."
                         + " Check your valueSelectorConfig.");

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/SwapMoveSelectorFactory.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/SwapMoveSelectorFactory.java
@@ -75,7 +75,7 @@ public class SwapMoveSelectorFactory<Solution_>
         ValueSelector<Solution_> valueSelector = ValueSelectorFactory.<Solution_> create(new ValueSelectorConfig())
                 .buildValueSelector(configPolicy, entityDescriptor, minimumCacheType, inheritedSelectionOrder);
         if (!(valueSelector instanceof EntityIndependentValueSelector)) {
-            throw new IllegalArgumentException("The swapMoveSelector (" + this
+            throw new IllegalArgumentException("The swapMoveSelector (" + config
                     + ") for a list variable needs to be based on an "
                     + EntityIndependentValueSelector.class.getSimpleName() + " (" + valueSelector + ")."
                     + " Check your valueSelectorConfig.");

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/value/chained/SubChainSelectorFactory.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/value/chained/SubChainSelectorFactory.java
@@ -49,7 +49,7 @@ public class SubChainSelectorFactory<Solution_> {
             EntityDescriptor<Solution_> entityDescriptor, SelectionCacheType minimumCacheType,
             SelectionOrder inheritedSelectionOrder) {
         if (minimumCacheType.compareTo(SelectionCacheType.STEP) > 0) {
-            throw new IllegalArgumentException("The subChainSelectorConfig (" + this
+            throw new IllegalArgumentException("The subChainSelectorConfig (" + config
                     + ")'s minimumCacheType (" + minimumCacheType
                     + ") must not be higher than " + SelectionCacheType.STEP
                     + " because the chains change every step.");
@@ -60,7 +60,7 @@ public class SubChainSelectorFactory<Solution_> {
         ValueSelector<Solution_> valueSelector = ValueSelectorFactory.<Solution_> create(valueSelectorConfig)
                 .buildValueSelector(configPolicy, entityDescriptor, minimumCacheType, SelectionOrder.ORIGINAL);
         if (!(valueSelector instanceof EntityIndependentValueSelector)) {
-            throw new IllegalArgumentException("The minimumCacheType (" + this
+            throw new IllegalArgumentException("The subChainSelectorConfig (" + config
                     + ") needs to be based on an "
                     + EntityIndependentValueSelector.class.getSimpleName() + " (" + valueSelector + ")."
                     + " Check your @" + ValueRangeProvider.class.getSimpleName() + " annotations.");


### PR DESCRIPTION
The "from config" factories should use `config` in exception messages instead of `this` because they (factories) do not override `toString()` but configs do. This PR fixes the few case which break the rule.
<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request checks</b>  
  Please add comment: <b>Jenkins retest this</b>

- for a <b>specific pull request check</b>  
  please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-vehicle-routing] tests</b>
  
- for a <b>full downstream build</b> 
  - for <b>jenkins</b> job: 
    please add comment: <b>Jenkins run fdb</b>
  - for <b>github actions</b> job: 
    add the label `run_fdb`

- for a <b>compile downstream build</b>  
  please add comment: <b>Jenkins run cdb</b>

- for a <b>full production downstream build</b>  
  please add comment: <b>Jenkins execute product fdb</b>

- for an <b>upstream build</b>  
  please add comment: <b>Jenkins run upstream</b>

- for <b>quarkus branch checks</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins run quarkus-branch</b>

- for a <b>quarkus branch specific check</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-vehicle-routing] quarkus-branch</b>

- for <b>quarkus main checks</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins run quarkus-main</b>

- for a <b>specific quarkus main check</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-vehicle-routing] quarkus-branch</b>

- for <b>native checks</b>  
  Run native checks  
  Please add comment: <b>Jenkins run native</b>

- for a <b>specific native check</b>  
  Run native checks 
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-vehicle-routing] native</b>

- for <b>mandrel checks</b>  
  Run native checks against Mandrel image
  Please add comment: <b>Jenkins run mandrel</b>

- for a <b>specific mandrel check</b>  
  Run native checks against Mandrel image  
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-vehicle-routing] mandrel</b>
</details>

### CI Status

 You can check OptaPlanner repositories CI status from [Chain Status webpage](https://kiegroup.github.io/optaplanner/).