### PR TITLE
PLANNER-2768 Use a final version of quarkus-operator-sdk

### DIFF
--- a/build/optaplanner-build-parent/pom.xml
+++ b/build/optaplanner-build-parent/pom.xml
@@ -26,8 +26,7 @@
     <version.ch.qos.logback>1.2.9</version.ch.qos.logback>
     <version.org.apache.logging.log4j>2.17.2</version.org.apache.logging.log4j>
     <version.com.thoughtworks.xstream>1.4.19</version.com.thoughtworks.xstream>
-    <version.io.javaoperatorsdk>3.0.2</version.io.javaoperatorsdk>
-    <version.io.quarkiverse.operatorsdk>4.0.0.RC</version.io.quarkiverse.operatorsdk>
+    <version.io.quarkiverse.operatorsdk>4.0.0</version.io.quarkiverse.operatorsdk>
     <version.io.quarkus>2.11.2.Final</version.io.quarkus>
     <version.io.strimzi>0.28.0</version.io.strimzi>
     <version.org.apache.commons.math3>3.6.1</version.org.apache.commons.math3>
@@ -149,11 +148,6 @@
         <groupId>io.quarkiverse.operatorsdk</groupId>
         <artifactId>quarkus-operator-sdk</artifactId>
         <version>${version.io.quarkiverse.operatorsdk}</version>
-      </dependency>
-      <dependency>
-        <groupId>io.javaoperatorsdk</groupId>
-        <artifactId>operator-framework-core</artifactId>
-        <version>${version.io.javaoperatorsdk}</version>
       </dependency>
       <dependency>
         <groupId>io.strimzi</groupId>

--- a/optaplanner-operator/pom.xml
+++ b/optaplanner-operator/pom.xml
@@ -36,10 +36,6 @@
         </exclusion>
       </exclusions>
     </dependency>
-    <dependency>
-      <groupId>io.javaoperatorsdk</groupId>
-      <artifactId>operator-framework-core</artifactId>
-    </dependency>
 
     <!-- Test dependencies. -->
     <dependency>

--- a/optaplanner-operator/src/main/java/org/optaplanner/operator/impl/solver/model/ConfigMapDependentResource.java
+++ b/optaplanner-operator/src/main/java/org/optaplanner/operator/impl/solver/model/ConfigMapDependentResource.java
@@ -7,11 +7,11 @@ import io.fabric8.kubernetes.api.model.ConfigMap;
 import io.fabric8.kubernetes.api.model.ConfigMapBuilder;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.javaoperatorsdk.operator.api.reconciler.Context;
-import io.javaoperatorsdk.operator.processing.dependent.kubernetes.CRUKubernetesDependentResource;
+import io.javaoperatorsdk.operator.processing.dependent.kubernetes.CRUDKubernetesDependentResource;
 import io.javaoperatorsdk.operator.processing.dependent.kubernetes.KubernetesDependent;
 
 @KubernetesDependent
-public final class ConfigMapDependentResource extends CRUKubernetesDependentResource<ConfigMap, OptaPlannerSolver> {
+public final class ConfigMapDependentResource extends CRUDKubernetesDependentResource<ConfigMap, OptaPlannerSolver> {
 
     public static final String SOLVER_MESSAGE_INPUT_KEY = "solver.message.input";
     public static final String SOLVER_MESSAGE_OUTPUT_KEY = "solver.message.output";

--- a/optaplanner-operator/src/main/java/org/optaplanner/operator/impl/solver/model/DeploymentDependentResource.java
+++ b/optaplanner-operator/src/main/java/org/optaplanner/operator/impl/solver/model/DeploymentDependentResource.java
@@ -13,11 +13,11 @@ import io.fabric8.kubernetes.api.model.apps.DeploymentBuilder;
 import io.fabric8.kubernetes.api.model.apps.DeploymentSpecBuilder;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.javaoperatorsdk.operator.api.reconciler.Context;
-import io.javaoperatorsdk.operator.processing.dependent.kubernetes.CRUKubernetesDependentResource;
+import io.javaoperatorsdk.operator.processing.dependent.kubernetes.CRUDKubernetesDependentResource;
 import io.javaoperatorsdk.operator.processing.dependent.kubernetes.KubernetesDependent;
 
 @KubernetesDependent
-public final class DeploymentDependentResource extends CRUKubernetesDependentResource<Deployment, OptaPlannerSolver> {
+public final class DeploymentDependentResource extends CRUDKubernetesDependentResource<Deployment, OptaPlannerSolver> {
 
     private static final String ENV_SOLVER_MESSAGE_IN = "SOLVER_MESSAGE_INPUT";
     private static final String ENV_SOLVER_MESSAGE_OUT = "SOLVER_MESSAGE_OUTPUT";

--- a/optaplanner-operator/src/main/java/org/optaplanner/operator/impl/solver/model/keda/ScaledObjectDependentResource.java
+++ b/optaplanner-operator/src/main/java/org/optaplanner/operator/impl/solver/model/keda/ScaledObjectDependentResource.java
@@ -8,7 +8,7 @@ import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.javaoperatorsdk.operator.api.reconciler.Context;
-import io.javaoperatorsdk.operator.processing.dependent.kubernetes.CRUKubernetesDependentResource;
+import io.javaoperatorsdk.operator.processing.dependent.kubernetes.CRUDKubernetesDependentResource;
 import io.javaoperatorsdk.operator.processing.dependent.kubernetes.KubernetesDependent;
 
 /*
@@ -40,7 +40,7 @@ spec:
 */
 
 @KubernetesDependent
-public final class ScaledObjectDependentResource extends CRUKubernetesDependentResource<ScaledObject, OptaPlannerSolver> {
+public final class ScaledObjectDependentResource extends CRUDKubernetesDependentResource<ScaledObject, OptaPlannerSolver> {
 
     public static final String ARTEMIS_QUEUE_TRIGGER = "artemis-queue";
 

--- a/optaplanner-operator/src/main/java/org/optaplanner/operator/impl/solver/model/keda/TriggerAuthenticationDependentResource.java
+++ b/optaplanner-operator/src/main/java/org/optaplanner/operator/impl/solver/model/keda/TriggerAuthenticationDependentResource.java
@@ -7,7 +7,7 @@ import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
 import io.fabric8.kubernetes.api.model.SecretKeySelector;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.javaoperatorsdk.operator.api.reconciler.Context;
-import io.javaoperatorsdk.operator.processing.dependent.kubernetes.CRUKubernetesDependentResource;
+import io.javaoperatorsdk.operator.processing.dependent.kubernetes.CRUDKubernetesDependentResource;
 import io.javaoperatorsdk.operator.processing.dependent.kubernetes.KubernetesDependent;
 
 /*
@@ -30,7 +30,7 @@ spec:
 
 @KubernetesDependent
 public final class TriggerAuthenticationDependentResource
-        extends CRUKubernetesDependentResource<TriggerAuthentication, OptaPlannerSolver> {
+        extends CRUDKubernetesDependentResource<TriggerAuthentication, OptaPlannerSolver> {
 
     public static final String PARAM_USERNAME = "username";
     public static final String PARAM_PASSWORD = "password";

--- a/optaplanner-operator/src/main/java/org/optaplanner/operator/impl/solver/model/messaging/ArtemisQueueDependentResource.java
+++ b/optaplanner-operator/src/main/java/org/optaplanner/operator/impl/solver/model/messaging/ArtemisQueueDependentResource.java
@@ -8,11 +8,11 @@ import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.javaoperatorsdk.operator.api.reconciler.Context;
-import io.javaoperatorsdk.operator.processing.dependent.kubernetes.CRUKubernetesDependentResource;
+import io.javaoperatorsdk.operator.processing.dependent.kubernetes.CRUDKubernetesDependentResource;
 import io.javaoperatorsdk.operator.processing.dependent.kubernetes.KubernetesDependent;
 
 @KubernetesDependent
-public final class ArtemisQueueDependentResource extends CRUKubernetesDependentResource<ArtemisQueue, OptaPlannerSolver> {
+public final class ArtemisQueueDependentResource extends CRUDKubernetesDependentResource<ArtemisQueue, OptaPlannerSolver> {
 
     public ArtemisQueueDependentResource(MessageAddress messageAddress, KubernetesClient kubernetesClient) {
         super(ArtemisQueue.class);

--- a/pom.xml
+++ b/pom.xml
@@ -124,6 +124,7 @@
     <module>optaplanner-spring-integration</module>
     <module>optaplanner-quarkus-integration</module>
     <module>optaplanner-examples</module>
+    <module>optaplanner-operator</module>
   </modules>
 
   <profiles>
@@ -140,19 +141,5 @@
         <module>build/optaplanner-distribution-internal</module>
       </modules>
     </profile>
-    <profile>
-      <!-- TODO: This profile excludes the optaplanner-operator module from the default build. Remove the profile when
-           the io.quarkiverse.operatorsdk:quarkus-operator-sdk:4.0.0.Final is released. -->
-      <id>operator</id>
-      <activation>
-        <property>
-          <name>operator</name>
-        </property>
-      </activation>
-      <modules>
-        <module>optaplanner-operator</module>
-      </modules>
-    </profile>
   </profiles>
-
 </project>


### PR DESCRIPTION
The `io.quarkiverse:quarkus-operator-sdk` released a stable version, which means we no longer have to override the `javaoperatorsdk` version or exclude the `optaplanner-operator` from the build.

<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.
-->

### JIRA
https://issues.redhat.com/browse/PLANNER-2768

<!-- Add a JIRA ticket link if it exists. -->
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
- https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
- https://github.com/kiegroup/drools/pull/3000
- https://github.com/kiegroup/optaplanner/pull/899
- etc.
-->

### Checklist
- [ ] Documentation updated if applicable.
- [ ] Upgrade recipe provided if applicable.

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request checks</b>  
  Please add comment: <b>Jenkins retest this</b>

- for a <b>specific pull request check</b>  
  please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-vehicle-routing] tests</b>
  
- for a <b>full downstream build</b> 
  - for <b>jenkins</b> job: 
    please add comment: <b>Jenkins run fdb</b>
  - for <b>github actions</b> job: 
    add the label `run_fdb`

- for a <b>compile downstream build</b>  
  please add comment: <b>Jenkins run cdb</b>

- for a <b>full production downstream build</b>  
  please add comment: <b>Jenkins execute product fdb</b>

- for an <b>upstream build</b>  
  please add comment: <b>Jenkins run upstream</b>

- for <b>quarkus branch checks</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins run quarkus-branch</b>

- for a <b>quarkus branch specific check</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-vehicle-routing] quarkus-branch</b>

- for <b>quarkus main checks</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins run quarkus-main</b>

- for a <b>specific quarkus main check</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-vehicle-routing] quarkus-branch</b>

- for <b>native checks</b>  
  Run native checks  
  Please add comment: <b>Jenkins run native</b>

- for a <b>specific native check</b>  
  Run native checks 
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-vehicle-routing] native</b>

- for <b>mandrel checks</b>  
  Run native checks against Mandrel image
  Please add comment: <b>Jenkins run mandrel</b>

- for a <b>specific mandrel check</b>  
  Run native checks against Mandrel image  
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-vehicle-routing] mandrel</b>
</details>

### CI Status

 You can check OptaPlanner repositories CI status from [Chain Status webpage](https://kiegroup.github.io/optaplanner/).