### PR TITLE
[BXMSPROD-1770] Added OS preparation step

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -52,6 +52,9 @@ How to retest this PR or trigger a specific build:
   - for <b>github actions</b> job: 
     add the label `run_fdb`
 
+- for a <b>windows build</b>
+  please add the label `windows_check`
+
 - for a <b>compile downstream build</b>  
   please add comment: <b>Jenkins run cdb</b>
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -52,9 +52,6 @@ How to retest this PR or trigger a specific build:
   - for <b>github actions</b> job: 
     add the label `run_fdb`
 
-- for a <b>windows build</b>
-  please add the label `windows_check`
-
 - for a <b>compile downstream build</b>  
   please add comment: <b>Jenkins run cdb</b>
 

--- a/.github/workflows/full-downstream.yml
+++ b/.github/workflows/full-downstream.yml
@@ -14,14 +14,23 @@ on:
       - '.ci/**'
 
 jobs:
+  os-prep:
+    runs-on: ubuntu-latest
+    outputs:
+      os: ${{ steps.set-os.outputs.operating-systems }}
+    steps:
+      - name: OS Preparation
+        id: set-os
+        uses: kiegroup/droolsjbpm-build-bootstrap/.ci/actions/os-preparation@main
   build-chain:
+    needs: os-prep
     if: contains(github.event.pull_request.labels.*.name, 'run_fdb')
     concurrency:
       group: fdb-${{ github.head_ref }}
       cancel-in-progress: true
     strategy:
       matrix:
-        os: [ ubuntu-latest ]
+        os: ${{ fromJSON(needs.os-prep.outputs.os) }}
         java-version: [ 11 ]
         maven-version: [ '3.8.6' ]
       fail-fast: false

--- a/.github/workflows/full-downstream.yml
+++ b/.github/workflows/full-downstream.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - name: OS Preparation
         id: set-os
-        uses: kiegroup/droolsjbpm-build-bootstrap/.ci/actions/os-preparation@main
+        uses: kiegroup/kogito-pipelines/.ci/actions/os-preparation@main
   build-chain:
     needs: os-prep
     if: contains(github.event.pull_request.labels.*.name, 'run_fdb')

--- a/.github/workflows/full-downstream.yml
+++ b/.github/workflows/full-downstream.yml
@@ -14,23 +14,14 @@ on:
       - '.ci/**'
 
 jobs:
-  os-prep:
-    runs-on: ubuntu-latest
-    outputs:
-      os: ${{ steps.set-os.outputs.operating-systems }}
-    steps:
-      - name: OS Preparation
-        id: set-os
-        uses: kiegroup/kogito-pipelines/.ci/actions/os-preparation@main
   build-chain:
-    needs: os-prep
     if: contains(github.event.pull_request.labels.*.name, 'run_fdb')
     concurrency:
       group: fdb-${{ github.head_ref }}
       cancel-in-progress: true
     strategy:
       matrix:
-        os: ${{ fromJSON(needs.os-prep.outputs.os) }}
+        os: [ ubuntu-latest ]
         java-version: [ 11 ]
         maven-version: [ '3.8.6' ]
       fail-fast: false

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -38,7 +38,7 @@ jobs:
     steps:
       - name: OS Preparation
         id: set-os
-        uses: lampajr/kogito-pipelines/.ci/actions/os-preparation@BXMSPROD-1770_os_preparation
+        uses: kiegroup/kogito-pipelines/.ci/actions/os-preparation@main
   build-chain:
     needs: os-prep
     concurrency:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -38,7 +38,7 @@ jobs:
     steps:
       - name: OS Preparation
         id: set-os
-        uses: kiegroup/droolsjbpm-build-bootstrap/.ci/actions/os-preparation@main
+        uses: lampajr/kogito-pipelines/.ci/actions/os-preparation@BXMSPROD-1770_os_preparation
   build-chain:
     needs: os-prep
     concurrency:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -14,7 +14,7 @@ on:
       - '*.txt'
       - '.ci/**'
   pull_request:
-    types: [ opened, synchronize, reopened ]
+    types: [opened, synchronize, reopened, labeled]
     branches:
       - main
       - 8.*
@@ -31,13 +31,22 @@ defaults:
     shell: bash
 
 jobs:
+  os-prep:
+    runs-on: ubuntu-latest
+    outputs:
+      os: ${{ steps.set-os.outputs.operating-systems }}
+    steps:
+      - name: OS Preparation
+        id: set-os
+        uses: kiegroup/droolsjbpm-build-bootstrap/.ci/actions/os-preparation@main
   build-chain:
+    needs: os-prep
     concurrency:
       group: pull_request-${{ github.event_name }}-${{ github.head_ref }}-${{ matrix.os }}-${{ matrix.java-version }}
       cancel-in-progress: true
     strategy:
       matrix:
-        os: [ ubuntu-latest, windows-latest ]
+        os: ${{ fromJSON(needs.os-prep.outputs.os) }}
         java-version: [ 11, 17, 18 ]
         maven-version: [ '3.8.6' ]
       fail-fast: false


### PR DESCRIPTION
JIRA:
- https://issues.redhat.com/browse/BXMSPROD-1770

referenced Pull Requests:
- https://github.com/kiegroup/kogito-pipelines/pull/590

Added OS preparation step.

If we agree on this solution I'll revert the commit [9346bcd](https://github.com/kiegroup/optaplanner/pull/2146/commits/9346bcd1616013541c5f8ed4613030ced630c875) and propagate the same fix on all other kogito-related projects.

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
- https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
- https://github.com/kiegroup/drools/pull/3000
- https://github.com/kiegroup/optaplanner/pull/899
- etc.
-->

### Checklist
- [ ] Documentation updated if applicable.
- [ ] Upgrade recipe provided if applicable.

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request checks</b>  
  Please add comment: <b>Jenkins retest this</b>

- for a <b>specific pull request check</b>  
  please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-vehicle-routing] tests</b>
  
- for a <b>full downstream build</b> 
  - for <b>jenkins</b> job: 
    please add comment: <b>Jenkins run fdb</b>
  - for <b>github actions</b> job: 
    add the label `run_fdb`

- for a <b>compile downstream build</b>  
  please add comment: <b>Jenkins run cdb</b>

- for a <b>full production downstream build</b>  
  please add comment: <b>Jenkins execute product fdb</b>

- for an <b>upstream build</b>  
  please add comment: <b>Jenkins run upstream</b>

- for <b>quarkus branch checks</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins run quarkus-branch</b>

- for a <b>quarkus branch specific check</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-vehicle-routing] quarkus-branch</b>

- for <b>quarkus main checks</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins run quarkus-main</b>

- for a <b>specific quarkus main check</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-vehicle-routing] quarkus-branch</b>

- for <b>native checks</b>  
  Run native checks  
  Please add comment: <b>Jenkins run native</b>

- for a <b>specific native check</b>  
  Run native checks 
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-vehicle-routing] native</b>

- for <b>mandrel checks</b>  
  Run native checks against Mandrel image
  Please add comment: <b>Jenkins run mandrel</b>

- for a <b>specific mandrel check</b>  
  Run native checks against Mandrel image  
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-vehicle-routing] mandrel</b>
</details>

### CI Status

 You can check OptaPlanner repositories CI status from [Chain Status webpage](https://kiegroup.github.io/optaplanner/).