### PR TITLE
Add warning ConstraintVerifier not thread safe

### DIFF
--- a/optaplanner-docs/src/modules/ROOT/pages/constraint-streams/constraint-streams.adoc
+++ b/optaplanner-docs/src/modules/ROOT/pages/constraint-streams/constraint-streams.adoc
@@ -849,7 +849,11 @@ See <<constraintStreamsDealingWithDuplicateTuplesUsingDistinct,`distinct()`>> fo
 
 Constraint streams include the Constraint Verifier unit testing harness.
 To use it, first add a test scoped dependency to the `optaplanner-test` JAR.
-
+[WARNING]
+====
+You CANNOT use the same ConstraintVerifier instance in multiple concurrent tests. It is NOT thread safe and WILL cause errors that do not make sense.
+For example tests that have `@Execution(ExecutionMode.CONCURRENT)` on them.
+====
 [[constraintStreamsTestingIsolatedConstraints]]
 === Testing constraints in isolation
 

--- a/optaplanner-docs/src/modules/ROOT/pages/constraint-streams/constraint-streams.adoc
+++ b/optaplanner-docs/src/modules/ROOT/pages/constraint-streams/constraint-streams.adoc
@@ -851,7 +851,7 @@ Constraint streams include the Constraint Verifier unit testing harness.
 To use it, first add a test scoped dependency to the `optaplanner-test` JAR.
 [WARNING]
 ====
-You CANNOT use the same ConstraintVerifier instance in multiple concurrent tests. It is NOT thread safe and WILL cause errors that do not make sense.
+`ConstraintVerifier` is not thread-safe and must not be used in concurrent tests.
 For example tests that have `@Execution(ExecutionMode.CONCURRENT)` on them.
 ====
 [[constraintStreamsTestingIsolatedConstraints]]


### PR DESCRIPTION
I've had a lot of hair pulling with what should have been common sense from my side (don't assume everything is thread safe), but i think a warning can help some people because the errors it causes really do not make any sense.
See the conversation on zulipchat where all the hair pulling happened: https://kie.zulipchat.com/#narrow/stream/232679-optaplanner/topic/NoClassDefFound.20error
<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.
-->
### Checklist
- [x] Documentation updated if applicable.

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request checks</b>  
  Please add comment: <b>Jenkins retest this</b>

- for a <b>specific pull request check</b>  
  please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-vehicle-routing] tests</b>
  
- for a <b>full downstream build</b> 
  - for <b>jenkins</b> job: 
    please add comment: <b>Jenkins run fdb</b>
  - for <b>github actions</b> job: 
    add the label `run_fdb`

- for a <b>compile downstream build</b>  
  please add comment: <b>Jenkins run cdb</b>

- for a <b>full production downstream build</b>  
  please add comment: <b>Jenkins execute product fdb</b>

- for an <b>upstream build</b>  
  please add comment: <b>Jenkins run upstream</b>

- for <b>quarkus branch checks</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins run quarkus-branch</b>

- for a <b>quarkus branch specific check</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-vehicle-routing] quarkus-branch</b>

- for <b>quarkus main checks</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins run quarkus-main</b>

- for a <b>specific quarkus main check</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-vehicle-routing] quarkus-branch</b>

- for <b>native checks</b>  
  Run native checks  
  Please add comment: <b>Jenkins run native</b>

- for a <b>specific native check</b>  
  Run native checks 
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-vehicle-routing] native</b>

- for <b>mandrel checks</b>  
  Run native checks against Mandrel image
  Please add comment: <b>Jenkins run mandrel</b>

- for a <b>specific mandrel check</b>  
  Run native checks against Mandrel image  
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-vehicle-routing] mandrel</b>
</details>

### CI Status

 You can check OptaPlanner repositories CI status from [Chain Status webpage](https://kiegroup.github.io/optaplanner/).