### PR TITLE
PLANNER-2781 Thread-safe ConstraintVerifier

### DIFF
--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/BavetConstraintStreamScoreDirectorFactoryService.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/BavetConstraintStreamScoreDirectorFactoryService.java
@@ -7,6 +7,7 @@ import java.util.function.Supplier;
 import org.optaplanner.constraint.streams.common.AbstractConstraintStreamScoreDirectorFactory;
 import org.optaplanner.constraint.streams.common.AbstractConstraintStreamScoreDirectorFactoryService;
 import org.optaplanner.core.api.score.Score;
+import org.optaplanner.core.api.score.stream.ConstraintFactory;
 import org.optaplanner.core.api.score.stream.ConstraintProvider;
 import org.optaplanner.core.api.score.stream.ConstraintStreamImplType;
 import org.optaplanner.core.config.score.director.ScoreDirectorFactoryConfig;
@@ -72,5 +73,10 @@ public final class BavetConstraintStreamScoreDirectorFactoryService<Solution_, S
                     ", there can be no droolsAlphaNetworkCompilationEnabled (" + droolsAlphaNetworkCompilationEnabled + ").");
         }
         return new BavetConstraintStreamScoreDirectorFactory<>(solutionDescriptor, constraintProvider);
+    }
+
+    @Override
+    public ConstraintFactory buildConstraintFactory(SolutionDescriptor<Solution_> solutionDescriptor) {
+        return new BavetConstraintFactory<>(solutionDescriptor);
     }
 }

--- a/core/optaplanner-constraint-streams-common/src/main/java/org/optaplanner/constraint/streams/common/AbstractConstraintStreamScoreDirectorFactory.java
+++ b/core/optaplanner-constraint-streams-common/src/main/java/org/optaplanner/constraint/streams/common/AbstractConstraintStreamScoreDirectorFactory.java
@@ -22,6 +22,12 @@ public abstract class AbstractConstraintStreamScoreDirectorFactory<Solution_, Sc
         super(solutionDescriptor);
     }
 
+    /**
+     * Creates a new score director, inserts facts and calculates score.
+     *
+     * @param facts never null
+     * @return never null
+     */
     public abstract AbstractScoreInliner<Score_> fireAndForget(Object... facts);
 
     public abstract Constraint[] getConstraints();

--- a/core/optaplanner-constraint-streams-common/src/main/java/org/optaplanner/constraint/streams/common/AbstractConstraintStreamScoreDirectorFactoryService.java
+++ b/core/optaplanner-constraint-streams-common/src/main/java/org/optaplanner/constraint/streams/common/AbstractConstraintStreamScoreDirectorFactoryService.java
@@ -1,6 +1,7 @@
 package org.optaplanner.constraint.streams.common;
 
 import org.optaplanner.core.api.score.Score;
+import org.optaplanner.core.api.score.stream.ConstraintFactory;
 import org.optaplanner.core.api.score.stream.ConstraintProvider;
 import org.optaplanner.core.api.score.stream.ConstraintStreamImplType;
 import org.optaplanner.core.impl.domain.solution.descriptor.SolutionDescriptor;
@@ -14,5 +15,7 @@ public abstract class AbstractConstraintStreamScoreDirectorFactoryService<Soluti
     public abstract AbstractConstraintStreamScoreDirectorFactory<Solution_, Score_> buildScoreDirectorFactory(
             SolutionDescriptor<Solution_> solutionDescriptor, ConstraintProvider constraintProvider,
             boolean droolsAlphaNetworkCompilationEnabled);
+
+    public abstract ConstraintFactory buildConstraintFactory(SolutionDescriptor<Solution_> solutionDescriptor);
 
 }

--- a/core/optaplanner-constraint-streams-drools/src/main/java/org/optaplanner/constraint/streams/drools/DroolsConstraintStreamScoreDirectorFactoryService.java
+++ b/core/optaplanner-constraint-streams-drools/src/main/java/org/optaplanner/constraint/streams/drools/DroolsConstraintStreamScoreDirectorFactoryService.java
@@ -8,6 +8,7 @@ import java.util.function.Supplier;
 import org.optaplanner.constraint.streams.common.AbstractConstraintStreamScoreDirectorFactory;
 import org.optaplanner.constraint.streams.common.AbstractConstraintStreamScoreDirectorFactoryService;
 import org.optaplanner.core.api.score.Score;
+import org.optaplanner.core.api.score.stream.ConstraintFactory;
 import org.optaplanner.core.api.score.stream.ConstraintProvider;
 import org.optaplanner.core.api.score.stream.ConstraintStreamImplType;
 import org.optaplanner.core.config.score.director.ScoreDirectorFactoryConfig;
@@ -74,4 +75,10 @@ public final class DroolsConstraintStreamScoreDirectorFactoryService<Solution_, 
         return new DroolsConstraintStreamScoreDirectorFactory<>(solutionDescriptor, constraintProvider,
                 droolsAlphaNetworkCompilationEnabled);
     }
+
+    @Override
+    public ConstraintFactory buildConstraintFactory(SolutionDescriptor<Solution_> solutionDescriptor) {
+        return new DroolsConstraintFactory<>(solutionDescriptor);
+    }
+
 }

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/config/util/ConfigUtils.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/config/util/ConfigUtils.java
@@ -471,18 +471,6 @@ public class ConfigUtils {
         return memberAccessor;
     }
 
-    public static <C> MemberAccessor findPlanningIdMemberAccessor(Class<C> clazz, DomainAccessType domainAccessType) {
-        Member member = getSingleMember(clazz, PlanningId.class);
-        if (member == null) {
-            return null;
-        }
-        MemberAccessor memberAccessor =
-                MemberAccessorFactory.buildMemberAccessor(member, FIELD_OR_READ_METHOD, PlanningId.class,
-                        domainAccessType);
-        assertPlanningIdMemberIsComparable(clazz, member, memberAccessor);
-        return memberAccessor;
-    }
-
     private static void assertPlanningIdMemberIsComparable(Class<?> clazz, Member member, MemberAccessor memberAccessor) {
         if (!memberAccessor.getType().isPrimitive() && !Comparable.class.isAssignableFrom(memberAccessor.getType())) {
             throw new IllegalArgumentException("The class (" + clazz

--- a/optaplanner-docs/src/modules/ROOT/pages/constraint-streams/constraint-streams.adoc
+++ b/optaplanner-docs/src/modules/ROOT/pages/constraint-streams/constraint-streams.adoc
@@ -849,11 +849,8 @@ See <<constraintStreamsDealingWithDuplicateTuplesUsingDistinct,`distinct()`>> fo
 
 Constraint streams include the Constraint Verifier unit testing harness.
 To use it, first add a test scoped dependency to the `optaplanner-test` JAR.
-[WARNING]
-====
-`ConstraintVerifier` is not thread-safe and must not be used in concurrent tests.
-For example tests that have `@Execution(ExecutionMode.CONCURRENT)` on them.
-====
+
+
 [[constraintStreamsTestingIsolatedConstraints]]
 === Testing constraints in isolation
 

--- a/optaplanner-examples/src/test/java/org/optaplanner/examples/cheaptime/score/CheapTimeConstraintProviderTest.java
+++ b/optaplanner-examples/src/test/java/org/optaplanner/examples/cheaptime/score/CheapTimeConstraintProviderTest.java
@@ -48,11 +48,6 @@ class CheapTimeConstraintProviderTest extends
     private static final Task TASK_2 = new Task(2, PERIOD_1, PERIOD_3, 1, 3_000_000,
             REQUIREMENT_TASK2_RESOURCE0, REQUIREMENT_TASK2_RESOURCE1, REQUIREMENT_TASK2_RESOURCE2);
 
-    @Override
-    protected ConstraintVerifier<CheapTimeConstraintProvider, CheapTimeSolution> createConstraintVerifier() {
-        return ConstraintVerifier.build(new CheapTimeConstraintProvider(), CheapTimeSolution.class, TaskAssignment.class);
-    }
-
     @ConstraintProviderTest
     void startTimeLimitsFrom(ConstraintVerifier<CheapTimeConstraintProvider, CheapTimeSolution> constraintVerifier) {
         // Actual task assignment falls on the minimum prescribed by the task.
@@ -149,6 +144,11 @@ class CheapTimeConstraintProviderTest extends
         constraintVerifier.verifyThat(CheapTimeConstraintProvider::startEarly)
                 .given(taskAssignment1, taskAssignment2)
                 .penalizesBy(taskAssignment1.getStartPeriod() + taskAssignment2.getStartPeriod());
+    }
+
+    @Override
+    protected ConstraintVerifier<CheapTimeConstraintProvider, CheapTimeSolution> createConstraintVerifier() {
+        return ConstraintVerifier.build(new CheapTimeConstraintProvider(), CheapTimeSolution.class, TaskAssignment.class);
     }
 
 }

--- a/optaplanner-examples/src/test/java/org/optaplanner/examples/cheaptime/score/CheapTimeConstraintProviderTest.java
+++ b/optaplanner-examples/src/test/java/org/optaplanner/examples/cheaptime/score/CheapTimeConstraintProviderTest.java
@@ -1,6 +1,5 @@
 package org.optaplanner.examples.cheaptime.score;
 
-import org.junit.jupiter.api.Test;
 import org.optaplanner.examples.cheaptime.domain.CheapTimeSolution;
 import org.optaplanner.examples.cheaptime.domain.Machine;
 import org.optaplanner.examples.cheaptime.domain.MachineCapacity;
@@ -9,9 +8,12 @@ import org.optaplanner.examples.cheaptime.domain.Resource;
 import org.optaplanner.examples.cheaptime.domain.Task;
 import org.optaplanner.examples.cheaptime.domain.TaskAssignment;
 import org.optaplanner.examples.cheaptime.domain.TaskRequirement;
+import org.optaplanner.examples.common.score.AbstractConstraintProviderTest;
+import org.optaplanner.examples.common.score.ConstraintProviderTest;
 import org.optaplanner.test.api.score.stream.ConstraintVerifier;
 
-class CheapTimeConstraintProviderTest {
+class CheapTimeConstraintProviderTest extends
+        AbstractConstraintProviderTest<CheapTimeConstraintProvider, CheapTimeSolution> {
 
     private static final Period PERIOD_0 = new Period(0, 100_000);
     private static final Period PERIOD_1 = new Period(1, 150_000);
@@ -46,11 +48,13 @@ class CheapTimeConstraintProviderTest {
     private static final Task TASK_2 = new Task(2, PERIOD_1, PERIOD_3, 1, 3_000_000,
             REQUIREMENT_TASK2_RESOURCE0, REQUIREMENT_TASK2_RESOURCE1, REQUIREMENT_TASK2_RESOURCE2);
 
-    private final ConstraintVerifier<CheapTimeConstraintProvider, CheapTimeSolution> constraintVerifier =
-            ConstraintVerifier.build(new CheapTimeConstraintProvider(), CheapTimeSolution.class, TaskAssignment.class);
+    @Override
+    protected ConstraintVerifier<CheapTimeConstraintProvider, CheapTimeSolution> createConstraintVerifier() {
+        return ConstraintVerifier.build(new CheapTimeConstraintProvider(), CheapTimeSolution.class, TaskAssignment.class);
+    }
 
-    @Test
-    void startTimeLimitsFrom() {
+    @ConstraintProviderTest
+    void startTimeLimitsFrom(ConstraintVerifier<CheapTimeConstraintProvider, CheapTimeSolution> constraintVerifier) {
         // Actual task assignment falls on the minimum prescribed by the task.
         TaskAssignment correctTaskAssignment1 = new TaskAssignment(TASK_0, MACHINE_O, PERIOD_0);
         // Actual task assignment falls past the minimum prescribed by the task.
@@ -62,8 +66,8 @@ class CheapTimeConstraintProviderTest {
                 .penalizesBy(1); // Wrong task assignment is penalized by one period.
     }
 
-    @Test
-    void startTimeLimitsTo() {
+    @ConstraintProviderTest
+    void startTimeLimitsTo(ConstraintVerifier<CheapTimeConstraintProvider, CheapTimeSolution> constraintVerifier) {
         // Actual task assignment falls on the maximum prescribed by the task.
         TaskAssignment correctTaskAssignment1 = new TaskAssignment(TASK_2, MACHINE_O, PERIOD_3);
         // Actual task assignment falls before the maximum prescribed by the task.
@@ -75,8 +79,8 @@ class CheapTimeConstraintProviderTest {
                 .penalizesBy(1); // Wrong task assignment is penalized by one period.
     }
 
-    @Test
-    void maximumCapacity() {
+    @ConstraintProviderTest
+    void maximumCapacity(ConstraintVerifier<CheapTimeConstraintProvider, CheapTimeSolution> constraintVerifier) {
         TaskAssignment taskAssignment1 = new TaskAssignment(TASK_0, MACHINE_O, PERIOD_0);
         TaskAssignment taskAssignment2 = new TaskAssignment(TASK_1, MACHINE_O, PERIOD_1);
         TaskAssignment taskAssignment3 = new TaskAssignment(TASK_2, MACHINE_1, PERIOD_1);
@@ -86,8 +90,9 @@ class CheapTimeConstraintProviderTest {
                 .penalizesBy(2);
     }
 
-    @Test
-    void activeMachinePowerCost() { // Machines with task assignments are penalized based on task duration.
+    @ConstraintProviderTest
+    void activeMachinePowerCost(ConstraintVerifier<CheapTimeConstraintProvider, CheapTimeSolution> constraintVerifier) {
+        // Machines with task assignments are penalized based on task duration.
         TaskAssignment taskAssignment = new TaskAssignment(TASK_0, MACHINE_O, PERIOD_0);
         constraintVerifier.verifyThat(CheapTimeConstraintProvider::activeMachinePowerCost)
                 .given(taskAssignment, MACHINE_O, MACHINE_1, PERIOD_0, PERIOD_1, PERIOD_2, PERIOD_3)
@@ -100,8 +105,8 @@ class CheapTimeConstraintProviderTest {
                 .penalizesBy(3);
     }
 
-    @Test
-    void activeMachineSpinUpAndDownCost() {
+    @ConstraintProviderTest
+    void activeMachineSpinUpAndDownCost(ConstraintVerifier<CheapTimeConstraintProvider, CheapTimeSolution> constraintVerifier) {
         TaskAssignment taskAssignment = new TaskAssignment(TASK_0, MACHINE_O, PERIOD_0);
         constraintVerifier.verifyThat(CheapTimeConstraintProvider::activeMachineSpinUpAndDownCost)
                 .given(taskAssignment, MACHINE_O, MACHINE_1, PERIOD_0, PERIOD_1, PERIOD_2, PERIOD_3)
@@ -112,8 +117,9 @@ class CheapTimeConstraintProviderTest {
                 .penalizesBy(5);
     }
 
-    @Test
-    void idleCosts() { // When a machine is on without a task, we incur a cost.
+    @ConstraintProviderTest
+    void idleCosts(ConstraintVerifier<CheapTimeConstraintProvider, CheapTimeSolution> constraintVerifier) {
+        // When a machine is on without a task, we incur a cost.
         TaskAssignment taskAssignment1 = new TaskAssignment(TASK_0, MACHINE_O, PERIOD_0);
         TaskAssignment taskAssignment2 = new TaskAssignment(TASK_2, MACHINE_O, PERIOD_3);
         constraintVerifier.verifyThat(CheapTimeConstraintProvider::idleCosts)
@@ -122,8 +128,8 @@ class CheapTimeConstraintProviderTest {
 
     }
 
-    @Test
-    void taskPowerCost() {
+    @ConstraintProviderTest
+    void taskPowerCost(ConstraintVerifier<CheapTimeConstraintProvider, CheapTimeSolution> constraintVerifier) {
         TaskAssignment taskAssignment1 = new TaskAssignment(TASK_0, MACHINE_O, PERIOD_0);
         TaskAssignment taskAssignment2 = new TaskAssignment(TASK_1, MACHINE_1, PERIOD_1);
         constraintVerifier.verifyThat(CheapTimeConstraintProvider::taskPowerCost)
@@ -136,8 +142,8 @@ class CheapTimeConstraintProviderTest {
                 .penalizesBy(6);
     }
 
-    @Test
-    void startEarly() {
+    @ConstraintProviderTest
+    void startEarly(ConstraintVerifier<CheapTimeConstraintProvider, CheapTimeSolution> constraintVerifier) {
         TaskAssignment taskAssignment1 = new TaskAssignment(TASK_0, MACHINE_O, PERIOD_1);
         TaskAssignment taskAssignment2 = new TaskAssignment(TASK_1, MACHINE_1, PERIOD_2);
         constraintVerifier.verifyThat(CheapTimeConstraintProvider::startEarly)

--- a/optaplanner-examples/src/test/java/org/optaplanner/examples/cloudbalancing/score/CloudBalancingConstraintProviderTest.java
+++ b/optaplanner-examples/src/test/java/org/optaplanner/examples/cloudbalancing/score/CloudBalancingConstraintProviderTest.java
@@ -1,18 +1,17 @@
 package org.optaplanner.examples.cloudbalancing.score;
 
-import org.junit.jupiter.api.Test;
 import org.optaplanner.examples.cloudbalancing.domain.CloudBalance;
 import org.optaplanner.examples.cloudbalancing.domain.CloudComputer;
 import org.optaplanner.examples.cloudbalancing.domain.CloudProcess;
+import org.optaplanner.examples.common.score.AbstractConstraintProviderTest;
+import org.optaplanner.examples.common.score.ConstraintProviderTest;
 import org.optaplanner.test.api.score.stream.ConstraintVerifier;
 
-class CloudBalancingConstraintProviderTest {
+class CloudBalancingConstraintProviderTest
+        extends AbstractConstraintProviderTest<CloudBalancingConstraintProvider, CloudBalance> {
 
-    private final ConstraintVerifier<CloudBalancingConstraintProvider, CloudBalance> constraintVerifier =
-            ConstraintVerifier.build(new CloudBalancingConstraintProvider(), CloudBalance.class, CloudProcess.class);
-
-    @Test
-    void requiredCpuPowerTotal() {
+    @ConstraintProviderTest
+    void requiredCpuPowerTotal(ConstraintVerifier<CloudBalancingConstraintProvider, CloudBalance> constraintVerifier) {
         CloudComputer computer1 = new CloudComputer(1, 1, 1, 1, 2);
         CloudComputer computer2 = new CloudComputer(2, 2, 2, 2, 4);
         CloudProcess unassignedProcess = new CloudProcess(0, 1, 1, 1);
@@ -30,8 +29,8 @@ class CloudBalancingConstraintProviderTest {
                 .penalizesBy(1); // Only the first computer.
     }
 
-    @Test
-    void requiredMemoryTotal() {
+    @ConstraintProviderTest
+    void requiredMemoryTotal(ConstraintVerifier<CloudBalancingConstraintProvider, CloudBalance> constraintVerifier) {
         CloudComputer computer1 = new CloudComputer(1, 1, 1, 1, 2);
         CloudComputer computer2 = new CloudComputer(2, 2, 2, 2, 4);
         CloudProcess unassignedProcess = new CloudProcess(0, 1, 1, 1);
@@ -49,8 +48,8 @@ class CloudBalancingConstraintProviderTest {
                 .penalizesBy(1); // Only the first computer.
     }
 
-    @Test
-    void requiredNetworkBandwidthTotal() {
+    @ConstraintProviderTest
+    void requiredNetworkBandwidthTotal(ConstraintVerifier<CloudBalancingConstraintProvider, CloudBalance> constraintVerifier) {
         CloudComputer computer1 = new CloudComputer(1, 1, 1, 1, 2);
         CloudComputer computer2 = new CloudComputer(2, 2, 2, 2, 4);
         CloudProcess unassignedProcess = new CloudProcess(0, 1, 1, 1);
@@ -68,8 +67,8 @@ class CloudBalancingConstraintProviderTest {
                 .penalizesBy(1); // Only the first computer.
     }
 
-    @Test
-    void computerCost() {
+    @ConstraintProviderTest
+    void computerCost(ConstraintVerifier<CloudBalancingConstraintProvider, CloudBalance> constraintVerifier) {
         CloudComputer computer1 = new CloudComputer(1, 1, 1, 1, 2);
         CloudComputer computer2 = new CloudComputer(2, 2, 2, 2, 4);
         CloudProcess unassignedProcess = new CloudProcess(0, 1, 1, 1);
@@ -81,4 +80,9 @@ class CloudBalancingConstraintProviderTest {
                 .penalizesBy(2);
     }
 
+    @Override
+    protected ConstraintVerifier<CloudBalancingConstraintProvider, CloudBalance> createConstraintVerifier() {
+        return ConstraintVerifier.build(new CloudBalancingConstraintProvider(), CloudBalance.class, CloudProcess.class);
+
+    }
 }

--- a/optaplanner-examples/src/test/java/org/optaplanner/examples/coachshuttlegathering/score/CoachShuttleGatheringConstraintProviderTest.java
+++ b/optaplanner-examples/src/test/java/org/optaplanner/examples/coachshuttlegathering/score/CoachShuttleGatheringConstraintProviderTest.java
@@ -2,7 +2,6 @@ package org.optaplanner.examples.coachshuttlegathering.score;
 
 import java.util.Collections;
 
-import org.junit.jupiter.api.Test;
 import org.optaplanner.examples.coachshuttlegathering.domain.BusHub;
 import org.optaplanner.examples.coachshuttlegathering.domain.BusOrStop;
 import org.optaplanner.examples.coachshuttlegathering.domain.BusStop;
@@ -12,16 +11,16 @@ import org.optaplanner.examples.coachshuttlegathering.domain.Shuttle;
 import org.optaplanner.examples.coachshuttlegathering.domain.StopOrHub;
 import org.optaplanner.examples.coachshuttlegathering.domain.location.RoadLocation;
 import org.optaplanner.examples.coachshuttlegathering.domain.location.RoadLocationArc;
+import org.optaplanner.examples.common.score.AbstractConstraintProviderTest;
+import org.optaplanner.examples.common.score.ConstraintProviderTest;
 import org.optaplanner.test.api.score.stream.ConstraintVerifier;
 
-class CoachShuttleGatheringConstraintProviderTest {
-    private final ConstraintVerifier<CoachShuttleGatheringConstraintProvider, CoachShuttleGatheringSolution> constraintVerifier =
-            ConstraintVerifier
-                    .build(new CoachShuttleGatheringConstraintProvider(), CoachShuttleGatheringSolution.class,
-                            BusOrStop.class, StopOrHub.class, BusStop.class, Shuttle.class, Coach.class);
+class CoachShuttleGatheringConstraintProviderTest
+        extends AbstractConstraintProviderTest<CoachShuttleGatheringConstraintProvider, CoachShuttleGatheringSolution> {
 
-    @Test
-    void coachStopLimit() {
+    @ConstraintProviderTest
+    void coachStopLimit(
+            ConstraintVerifier<CoachShuttleGatheringConstraintProvider, CoachShuttleGatheringSolution> constraintVerifier) {
         Coach coach = new Coach();
         coach.setStopLimit(2);
         BusStop stop1 = new BusStop(0L, coach, coach);
@@ -46,8 +45,9 @@ class CoachShuttleGatheringConstraintProviderTest {
                 .penalizesBy(2L * 1000000);
     }
 
-    @Test
-    void shuttleCapacity() {
+    @ConstraintProviderTest
+    void shuttleCapacity(
+            ConstraintVerifier<CoachShuttleGatheringConstraintProvider, CoachShuttleGatheringSolution> constraintVerifier) {
         Shuttle shuttle = new Shuttle();
         BusStop destination = new BusStop();
         shuttle.setDestination(destination);
@@ -75,8 +75,9 @@ class CoachShuttleGatheringConstraintProviderTest {
                 .penalizesBy(2L * 1000);
     }
 
-    @Test
-    void coachCapacity() {
+    @ConstraintProviderTest
+    void coachCapacity(
+            ConstraintVerifier<CoachShuttleGatheringConstraintProvider, CoachShuttleGatheringSolution> constraintVerifier) {
         Coach coach = new Coach();
         Shuttle shuttle = new Shuttle();
         BusStop transferStop = new BusStop(0L, shuttle, coach);
@@ -117,8 +118,9 @@ class CoachShuttleGatheringConstraintProviderTest {
                 .penalizesBy(1L * 1000);
     }
 
-    @Test
-    void coachCapacityShuttleButNoShuttle() {
+    @ConstraintProviderTest
+    void coachCapacityShuttleButNoShuttle(
+            ConstraintVerifier<CoachShuttleGatheringConstraintProvider, CoachShuttleGatheringSolution> constraintVerifier) {
         Coach coach = new Coach();
         BusHub destination = new BusHub();
         coach.setDestination(destination);
@@ -145,8 +147,9 @@ class CoachShuttleGatheringConstraintProviderTest {
                 .penalizesBy(2L * 1000);
     }
 
-    @Test
-    void transportTime() {
+    @ConstraintProviderTest
+    void transportTime(
+            ConstraintVerifier<CoachShuttleGatheringConstraintProvider, CoachShuttleGatheringSolution> constraintVerifier) {
         Coach bus = new Coach();
         BusStop busStop = new BusStop();
         busStop.setPreviousBusOrStop(bus);
@@ -170,8 +173,9 @@ class CoachShuttleGatheringConstraintProviderTest {
                 .penalizesBy(5L);
     }
 
-    @Test
-    void shuttleDestinationIsCoachOrHub() {
+    @ConstraintProviderTest
+    void shuttleDestinationIsCoachOrHub(
+            ConstraintVerifier<CoachShuttleGatheringConstraintProvider, CoachShuttleGatheringSolution> constraintVerifier) {
         Shuttle shuttle = new Shuttle();
         Coach coach = new Coach();
         BusStop destination = new BusStop();
@@ -189,8 +193,9 @@ class CoachShuttleGatheringConstraintProviderTest {
                 .penalizesBy(0L);
     }
 
-    @Test
-    void shuttleSetupCost() {
+    @ConstraintProviderTest
+    void shuttleSetupCost(
+            ConstraintVerifier<CoachShuttleGatheringConstraintProvider, CoachShuttleGatheringSolution> constraintVerifier) {
         Shuttle shuttle = new Shuttle();
         Coach coach = new Coach();
         BusStop destination = new BusStop();
@@ -218,8 +223,9 @@ class CoachShuttleGatheringConstraintProviderTest {
                 .penalizesBy(0L);
     }
 
-    @Test
-    void distanceFromPrevious() {
+    @ConstraintProviderTest
+    void distanceFromPrevious(
+            ConstraintVerifier<CoachShuttleGatheringConstraintProvider, CoachShuttleGatheringSolution> constraintVerifier) {
         Coach bus = new Coach();
         BusStop busStop = new BusStop();
 
@@ -244,8 +250,9 @@ class CoachShuttleGatheringConstraintProviderTest {
                 .penalizesBy(1L);
     }
 
-    @Test
-    void distanceBusStopToBusDestination() {
+    @ConstraintProviderTest
+    void distanceBusStopToBusDestination(
+            ConstraintVerifier<CoachShuttleGatheringConstraintProvider, CoachShuttleGatheringSolution> constraintVerifier) {
         Coach bus = new Coach();
         BusStop busStop = new BusStop();
         BusHub busHub = new BusHub();
@@ -273,8 +280,9 @@ class CoachShuttleGatheringConstraintProviderTest {
                 .penalizesBy(1L);
     }
 
-    @Test
-    void distanceCoachDirectlyToDestination() {
+    @ConstraintProviderTest
+    void distanceCoachDirectlyToDestination(
+            ConstraintVerifier<CoachShuttleGatheringConstraintProvider, CoachShuttleGatheringSolution> constraintVerifier) {
         Coach bus = new Coach();
         BusHub busHub = new BusHub();
 
@@ -296,5 +304,12 @@ class CoachShuttleGatheringConstraintProviderTest {
         constraintVerifier.verifyThat(CoachShuttleGatheringConstraintProvider::distanceCoachDirectlyToDestination)
                 .given(bus)
                 .penalizesBy(1L);
+    }
+
+    @Override
+    protected ConstraintVerifier<CoachShuttleGatheringConstraintProvider, CoachShuttleGatheringSolution>
+            createConstraintVerifier() {
+        return ConstraintVerifier.build(new CoachShuttleGatheringConstraintProvider(), CoachShuttleGatheringSolution.class,
+                BusOrStop.class, StopOrHub.class, BusStop.class, Shuttle.class, Coach.class);
     }
 }

--- a/optaplanner-examples/src/test/java/org/optaplanner/examples/common/score/AbstractConstraintProviderTest.java
+++ b/optaplanner-examples/src/test/java/org/optaplanner/examples/common/score/AbstractConstraintProviderTest.java
@@ -6,25 +6,37 @@ import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 import java.util.stream.Stream;
 
+import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.params.provider.Arguments;
 import org.optaplanner.core.api.score.stream.ConstraintProvider;
 import org.optaplanner.core.api.score.stream.ConstraintStreamImplType;
 import org.optaplanner.test.api.score.stream.ConstraintVerifier;
 
+/**
+ * @see ConstraintProviderTest
+ */
 @TestInstance(PER_CLASS)
+@DisplayNameGeneration(SimplifiedTestNameGenerator.class)
 public abstract class AbstractConstraintProviderTest<ConstraintProvider_ extends ConstraintProvider, Solution_> {
 
     private final ConstraintVerifier<ConstraintProvider_, Solution_> bavetConstraintVerifier = createConstraintVerifier()
             .withConstraintStreamImplType(ConstraintStreamImplType.BAVET);
-    private final ConstraintVerifier<ConstraintProvider_, Solution_> droolsConstraintVerifier = createConstraintVerifier()
-            .withConstraintStreamImplType(ConstraintStreamImplType.DROOLS);
+    private final ConstraintVerifier<ConstraintProvider_, Solution_> droolsWithoutAncConstraintVerifier =
+            createConstraintVerifier()
+                    .withConstraintStreamImplType(ConstraintStreamImplType.DROOLS)
+                    .withDroolsAlphaNetworkCompilationEnabled(false);
+    private final ConstraintVerifier<ConstraintProvider_, Solution_> droolsWithAncConstraintVerifier =
+            createConstraintVerifier()
+                    .withConstraintStreamImplType(ConstraintStreamImplType.DROOLS)
+                    .withDroolsAlphaNetworkCompilationEnabled(true);
 
     protected abstract ConstraintVerifier<ConstraintProvider_, Solution_> createConstraintVerifier();
 
-    protected final Stream<? extends Arguments> provideArguments() {
+    protected final Stream<? extends Arguments> getDroolsAndBavetConstraintVerifierImpls() {
         return Stream.of(
                 arguments(named("BAVET", bavetConstraintVerifier)),
-                arguments(named("DROOLS", droolsConstraintVerifier)));
+                arguments(named("DROOLS (without ANC)", droolsWithoutAncConstraintVerifier)),
+                arguments(named("DROOLS (with ANC)", droolsWithAncConstraintVerifier)));
     }
 }

--- a/optaplanner-examples/src/test/java/org/optaplanner/examples/common/score/AbstractConstraintProviderTest.java
+++ b/optaplanner-examples/src/test/java/org/optaplanner/examples/common/score/AbstractConstraintProviderTest.java
@@ -1,0 +1,30 @@
+package org.optaplanner.examples.common.score;
+
+import static org.junit.jupiter.api.Named.named;
+import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.params.provider.Arguments;
+import org.optaplanner.core.api.score.stream.ConstraintProvider;
+import org.optaplanner.core.api.score.stream.ConstraintStreamImplType;
+import org.optaplanner.test.api.score.stream.ConstraintVerifier;
+
+@TestInstance(PER_CLASS)
+public abstract class AbstractConstraintProviderTest<ConstraintProvider_ extends ConstraintProvider, Solution_> {
+
+    private final ConstraintVerifier<ConstraintProvider_, Solution_> bavetConstraintVerifier = createConstraintVerifier()
+            .withConstraintStreamImplType(ConstraintStreamImplType.BAVET);
+    private final ConstraintVerifier<ConstraintProvider_, Solution_> droolsConstraintVerifier = createConstraintVerifier()
+            .withConstraintStreamImplType(ConstraintStreamImplType.DROOLS);
+
+    protected abstract ConstraintVerifier<ConstraintProvider_, Solution_> createConstraintVerifier();
+
+    protected final Stream<? extends Arguments> provideArguments() {
+        return Stream.of(
+                arguments(named("BAVET", bavetConstraintVerifier)),
+                arguments(named("DROOLS", droolsConstraintVerifier)));
+    }
+}

--- a/optaplanner-examples/src/test/java/org/optaplanner/examples/common/score/ConstraintProviderTest.java
+++ b/optaplanner-examples/src/test/java/org/optaplanner/examples/common/score/ConstraintProviderTest.java
@@ -8,9 +8,18 @@ import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
+/**
+ * Tests using {@link org.optaplanner.test.api.score.stream.ConstraintVerifier} should use this annotation
+ * instead of @{@link org.junit.jupiter.api.Test}.
+ * This brings several benefits, such as parallel execution and testing on both Bavet and Drools.
+ *
+ * <p>
+ * Each such test expects exactly one argument of type {@link org.optaplanner.test.api.score.stream.ConstraintVerifier}.
+ * Values for that argument are read from {@link AbstractConstraintProviderTest#getDroolsAndBavetConstraintVerifierImpls()}.
+ */
 @Retention(RetentionPolicy.RUNTIME)
 @Execution(ExecutionMode.CONCURRENT)
 @ParameterizedTest(name = "constraintStreamImplType = {0}")
-@MethodSource("provideArguments")
+@MethodSource("getDroolsAndBavetConstraintVerifierImpls")
 public @interface ConstraintProviderTest {
 }

--- a/optaplanner-examples/src/test/java/org/optaplanner/examples/common/score/ConstraintProviderTest.java
+++ b/optaplanner-examples/src/test/java/org/optaplanner/examples/common/score/ConstraintProviderTest.java
@@ -1,0 +1,16 @@
+package org.optaplanner.examples.common.score;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Execution(ExecutionMode.CONCURRENT)
+@ParameterizedTest(name = "constraintStreamImplType = {0}")
+@MethodSource("provideArguments")
+public @interface ConstraintProviderTest {
+}

--- a/optaplanner-examples/src/test/java/org/optaplanner/examples/common/score/SimplifiedTestNameGenerator.java
+++ b/optaplanner-examples/src/test/java/org/optaplanner/examples/common/score/SimplifiedTestNameGenerator.java
@@ -1,0 +1,29 @@
+package org.optaplanner.examples.common.score;
+
+import java.lang.reflect.Method;
+
+import org.junit.jupiter.api.DisplayNameGenerator;
+
+/**
+ * Prints test names without the arguments.
+ */
+final class SimplifiedTestNameGenerator implements DisplayNameGenerator {
+
+    private static final DisplayNameGenerator PARENT =
+            DisplayNameGenerator.getDisplayNameGenerator(Simple.class);
+
+    @Override
+    public String generateDisplayNameForClass(Class<?> testClass) {
+        return PARENT.generateDisplayNameForClass(testClass);
+    }
+
+    @Override
+    public String generateDisplayNameForNestedClass(Class<?> nestedClass) {
+        return PARENT.generateDisplayNameForNestedClass(nestedClass);
+    }
+
+    @Override
+    public String generateDisplayNameForMethod(Class<?> testClass, Method testMethod) {
+        return testMethod.getName();
+    }
+}

--- a/optaplanner-examples/src/test/java/org/optaplanner/examples/conferencescheduling/score/ConferenceSchedulingConstraintProviderTest.java
+++ b/optaplanner-examples/src/test/java/org/optaplanner/examples/conferencescheduling/score/ConferenceSchedulingConstraintProviderTest.java
@@ -8,7 +8,8 @@ import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.HashSet;
 
-import org.junit.jupiter.api.Test;
+import org.optaplanner.examples.common.score.AbstractConstraintProviderTest;
+import org.optaplanner.examples.common.score.ConstraintProviderTest;
 import org.optaplanner.examples.conferencescheduling.domain.ConferenceConstraintConfiguration;
 import org.optaplanner.examples.conferencescheduling.domain.ConferenceSolution;
 import org.optaplanner.examples.conferencescheduling.domain.Room;
@@ -17,11 +18,8 @@ import org.optaplanner.examples.conferencescheduling.domain.Talk;
 import org.optaplanner.examples.conferencescheduling.domain.Timeslot;
 import org.optaplanner.test.api.score.stream.ConstraintVerifier;
 
-class ConferenceSchedulingConstraintProviderTest {
-
-    private final ConstraintVerifier<ConferenceSchedulingConstraintProvider, ConferenceSolution> constraintVerifier =
-            ConstraintVerifier.build(new ConferenceSchedulingConstraintProvider(), ConferenceSolution.class,
-                    Talk.class);
+class ConferenceSchedulingConstraintProviderTest
+        extends AbstractConstraintProviderTest<ConferenceSchedulingConstraintProvider, ConferenceSolution> {
 
     private static final LocalDateTime START = LocalDateTime.of(2000, 2, 1, 9, 0);
 
@@ -46,8 +44,9 @@ class ConferenceSchedulingConstraintProviderTest {
     // Hard constraints
     // ************************************************************************
 
-    @Test
-    void roomUnavailableTimeslot() {
+    @ConstraintProviderTest
+    void roomUnavailableTimeslot(
+            ConstraintVerifier<ConferenceSchedulingConstraintProvider, ConferenceSolution> constraintVerifier) {
         Room room1 = new Room(1)
                 .withUnavailableTimeslotSet(singleton(MONDAY_9_TO_10));
         Room room2 = new Room(2)
@@ -64,8 +63,8 @@ class ConferenceSchedulingConstraintProviderTest {
                 .penalizesBy(MONDAY_9_TO_10.getDurationInMinutes()); // room1 is in an unavailable timeslot.
     }
 
-    @Test
-    void roomConflict() {
+    @ConstraintProviderTest
+    void roomConflict(ConstraintVerifier<ConferenceSchedulingConstraintProvider, ConferenceSolution> constraintVerifier) {
         Room room = new Room(1)
                 .withUnavailableTimeslotSet(singleton(MONDAY_9_TO_10));
         Talk talk1 = new Talk(1)
@@ -83,8 +82,9 @@ class ConferenceSchedulingConstraintProviderTest {
                 .penalizesBy(MONDAY_9_TO_10.getDurationInMinutes()); // talk1 and talk2 are in conflict.
     }
 
-    @Test
-    void speakerUnavailableTimeslot() {
+    @ConstraintProviderTest
+    void speakerUnavailableTimeslot(
+            ConstraintVerifier<ConferenceSchedulingConstraintProvider, ConferenceSolution> constraintVerifier) {
         Room room = new Room(0);
         Speaker speaker1 = new Speaker(1)
                 .withUnavailableTimeslotSet(singleton(MONDAY_9_TO_10));
@@ -104,8 +104,8 @@ class ConferenceSchedulingConstraintProviderTest {
                 .penalizesBy(MONDAY_9_TO_10.getDurationInMinutes()); // speaker1 is in an unavailable timeslot.
     }
 
-    @Test
-    void speakerConflict() {
+    @ConstraintProviderTest
+    void speakerConflict(ConstraintVerifier<ConferenceSchedulingConstraintProvider, ConferenceSolution> constraintVerifier) {
         Room room = new Room(0);
         Speaker speaker = new Speaker(1);
         Talk talk1 = new Talk(1)
@@ -126,8 +126,9 @@ class ConferenceSchedulingConstraintProviderTest {
                 .penalizesBy(MONDAY_9_TO_10.getDurationInMinutes()); // talk1 and talk2 are in conflict.
     }
 
-    @Test
-    void talkPrerequisiteTalks() {
+    @ConstraintProviderTest
+    void talkPrerequisiteTalks(
+            ConstraintVerifier<ConferenceSchedulingConstraintProvider, ConferenceSolution> constraintVerifier) {
         Room room = new Room(0);
         Talk talk1 = new Talk(1)
                 .withRoom(room)
@@ -147,8 +148,9 @@ class ConferenceSchedulingConstraintProviderTest {
                 .penalizesBy(MONDAY_9_TO_10.getDurationInMinutes() * 2); // talk2 is not after talk1.
     }
 
-    @Test
-    void talkMutuallyExclusiveTalksTags() {
+    @ConstraintProviderTest
+    void talkMutuallyExclusiveTalksTags(
+            ConstraintVerifier<ConferenceSchedulingConstraintProvider, ConferenceSolution> constraintVerifier) {
         Room room = new Room(0);
         Talk talk1 = new Talk(1)
                 .withRoom(room)
@@ -168,8 +170,9 @@ class ConferenceSchedulingConstraintProviderTest {
                 .penalizesBy(MONDAY_9_TO_10.getDurationInMinutes() * 2); // talk2 and talk3 excluded twice.
     }
 
-    @Test
-    void consecutiveTalksPause() {
+    @ConstraintProviderTest
+    void consecutiveTalksPause(
+            ConstraintVerifier<ConferenceSchedulingConstraintProvider, ConferenceSolution> constraintVerifier) {
         Room room = new Room(0);
         Speaker speaker1 = new Speaker(1);
         Speaker speaker2 = new Speaker(2);
@@ -197,8 +200,8 @@ class ConferenceSchedulingConstraintProviderTest {
                 .penalizesBy(MONDAY_9_TO_10.getDurationInMinutes() * 4); // talk1+talk2 , talk2+talk3.
     }
 
-    @Test
-    void crowdControl() {
+    @ConstraintProviderTest
+    void crowdControl(ConstraintVerifier<ConferenceSchedulingConstraintProvider, ConferenceSolution> constraintVerifier) {
         Room room = new Room(0);
         Talk talk1 = new Talk(1)
                 .withRoom(room)
@@ -229,8 +232,9 @@ class ConferenceSchedulingConstraintProviderTest {
                 .penalizesBy(MONDAY_9_TO_10.getDurationInMinutes() * 3); // talk1, talk2, talk3.
     }
 
-    @Test
-    void speakerRequiredTimeslotTags() {
+    @ConstraintProviderTest
+    void speakerRequiredTimeslotTags(
+            ConstraintVerifier<ConferenceSchedulingConstraintProvider, ConferenceSolution> constraintVerifier) {
         Room room = new Room(0);
         Speaker speaker1 = new Speaker(1)
                 .withRequiredTimeslotTagSet(singleton("a"));
@@ -252,8 +256,9 @@ class ConferenceSchedulingConstraintProviderTest {
                 .penalizesBy(MONDAY_10_TO_11.getDurationInMinutes());
     }
 
-    @Test
-    void speakerProhibitedTimeslotTags() {
+    @ConstraintProviderTest
+    void speakerProhibitedTimeslotTags(
+            ConstraintVerifier<ConferenceSchedulingConstraintProvider, ConferenceSolution> constraintVerifier) {
         Room room = new Room(0);
         Speaker speaker1 = new Speaker(1)
                 .withProhibitedTimeslotTagSet(singleton("a"));
@@ -275,8 +280,9 @@ class ConferenceSchedulingConstraintProviderTest {
                 .penalizesBy(MONDAY_9_TO_10.getDurationInMinutes());
     }
 
-    @Test
-    void talkRequiredTimeslotTags() {
+    @ConstraintProviderTest
+    void talkRequiredTimeslotTags(
+            ConstraintVerifier<ConferenceSchedulingConstraintProvider, ConferenceSolution> constraintVerifier) {
         Room room = new Room(0);
         Talk talk1 = new Talk(1)
                 .withRoom(room)
@@ -292,8 +298,9 @@ class ConferenceSchedulingConstraintProviderTest {
                 .penalizesBy(MONDAY_10_TO_11.getDurationInMinutes());
     }
 
-    @Test
-    void talkProhibitedTimeslotTags() {
+    @ConstraintProviderTest
+    void talkProhibitedTimeslotTags(
+            ConstraintVerifier<ConferenceSchedulingConstraintProvider, ConferenceSolution> constraintVerifier) {
         Room room = new Room(0);
         Talk talk1 = new Talk(1)
                 .withRoom(room)
@@ -309,8 +316,9 @@ class ConferenceSchedulingConstraintProviderTest {
                 .penalizesBy(MONDAY_9_TO_10.getDurationInMinutes());
     }
 
-    @Test
-    void speakerRequiredRoomTags() {
+    @ConstraintProviderTest
+    void speakerRequiredRoomTags(
+            ConstraintVerifier<ConferenceSchedulingConstraintProvider, ConferenceSolution> constraintVerifier) {
         Room room = new Room(0)
                 .withTagSet(singleton("a"));
         Speaker speaker1 = new Speaker(1)
@@ -331,8 +339,9 @@ class ConferenceSchedulingConstraintProviderTest {
                 .penalizesBy(MONDAY_10_TO_11.getDurationInMinutes());
     }
 
-    @Test
-    void speakerProhibitedRoomTags() {
+    @ConstraintProviderTest
+    void speakerProhibitedRoomTags(
+            ConstraintVerifier<ConferenceSchedulingConstraintProvider, ConferenceSolution> constraintVerifier) {
         Room room = new Room(0)
                 .withTagSet(singleton("a"));
         Speaker speaker1 = new Speaker(1)
@@ -353,8 +362,9 @@ class ConferenceSchedulingConstraintProviderTest {
                 .penalizesBy(MONDAY_9_TO_10.getDurationInMinutes());
     }
 
-    @Test
-    void talkRequiredRoomTags() {
+    @ConstraintProviderTest
+    void talkRequiredRoomTags(
+            ConstraintVerifier<ConferenceSchedulingConstraintProvider, ConferenceSolution> constraintVerifier) {
         Room room = new Room(0)
                 .withTagSet(singleton("a"));
         Talk talk1 = new Talk(1)
@@ -371,8 +381,9 @@ class ConferenceSchedulingConstraintProviderTest {
                 .penalizesBy(MONDAY_10_TO_11.getDurationInMinutes());
     }
 
-    @Test
-    void talkProhibitedRoomTags() {
+    @ConstraintProviderTest
+    void talkProhibitedRoomTags(
+            ConstraintVerifier<ConferenceSchedulingConstraintProvider, ConferenceSolution> constraintVerifier) {
         Room room = new Room(0)
                 .withTagSet(singleton("a"));
         Talk talk1 = new Talk(1)
@@ -393,8 +404,8 @@ class ConferenceSchedulingConstraintProviderTest {
     // Medium constraints
     // ************************************************************************
 
-    @Test
-    void publishedTimeslot() {
+    @ConstraintProviderTest
+    void publishedTimeslot(ConstraintVerifier<ConferenceSchedulingConstraintProvider, ConferenceSolution> constraintVerifier) {
         Room room = new Room(0);
         Talk talk1 = new Talk(1)
                 .withRoom(room)
@@ -414,8 +425,8 @@ class ConferenceSchedulingConstraintProviderTest {
     // Soft constraints
     // ************************************************************************
 
-    @Test
-    void publishedRoom() {
+    @ConstraintProviderTest
+    void publishedRoom(ConstraintVerifier<ConferenceSchedulingConstraintProvider, ConferenceSolution> constraintVerifier) {
         Room room1 = new Room(0);
         Room room2 = new Room(1);
         Talk talk1 = new Talk(1)
@@ -432,8 +443,8 @@ class ConferenceSchedulingConstraintProviderTest {
                 .penalizesBy(1);
     }
 
-    @Test
-    void themeTrackConflict() {
+    @ConstraintProviderTest
+    void themeTrackConflict(ConstraintVerifier<ConferenceSchedulingConstraintProvider, ConferenceSolution> constraintVerifier) {
         Room room = new Room(0);
         Talk talk1 = new Talk(1)
                 .withRoom(room)
@@ -457,8 +468,9 @@ class ConferenceSchedulingConstraintProviderTest {
                 .penalizesBy(60); // talk1 + talk2.
     }
 
-    @Test
-    void themeTrackRoomStability() {
+    @ConstraintProviderTest
+    void themeTrackRoomStability(
+            ConstraintVerifier<ConferenceSchedulingConstraintProvider, ConferenceSolution> constraintVerifier) {
         Room room1 = new Room(0);
         Room room2 = new Room(1);
         Talk talk1 = new Talk(1)
@@ -483,8 +495,8 @@ class ConferenceSchedulingConstraintProviderTest {
                 .penalizesBy(120); // talk1 + talk2.
     }
 
-    @Test
-    void sectorConflict() {
+    @ConstraintProviderTest
+    void sectorConflict(ConstraintVerifier<ConferenceSchedulingConstraintProvider, ConferenceSolution> constraintVerifier) {
         Room room = new Room(0);
         Talk talk1 = new Talk(1)
                 .withRoom(room)
@@ -508,8 +520,9 @@ class ConferenceSchedulingConstraintProviderTest {
                 .penalizesBy(60); // talk1 + talk2.
     }
 
-    @Test
-    void audienceTypeDiversity() {
+    @ConstraintProviderTest
+    void audienceTypeDiversity(
+            ConstraintVerifier<ConferenceSchedulingConstraintProvider, ConferenceSolution> constraintVerifier) {
         Room room = new Room(0);
         Talk talk1 = new Talk(1)
                 .withRoom(room)
@@ -533,8 +546,9 @@ class ConferenceSchedulingConstraintProviderTest {
                 .rewardsWith(60); // talk1 + talk2.
     }
 
-    @Test
-    void audienceTypeThemeTrackConflict() {
+    @ConstraintProviderTest
+    void audienceTypeThemeTrackConflict(
+            ConstraintVerifier<ConferenceSchedulingConstraintProvider, ConferenceSolution> constraintVerifier) {
         Room room = new Room(0);
         Talk talk1 = new Talk(1)
                 .withRoom(room)
@@ -572,8 +586,9 @@ class ConferenceSchedulingConstraintProviderTest {
                 .penalizesBy(60); // talk1 + talk2.
     }
 
-    @Test
-    void audienceLevelDiversity() {
+    @ConstraintProviderTest
+    void audienceLevelDiversity(
+            ConstraintVerifier<ConferenceSchedulingConstraintProvider, ConferenceSolution> constraintVerifier) {
         Room room = new Room(0);
         Talk talk1 = new Talk(1)
                 .withRoom(room)
@@ -597,8 +612,9 @@ class ConferenceSchedulingConstraintProviderTest {
                 .rewardsWith(120); // talk1 + talk2 v. talk3.
     }
 
-    @Test
-    void contentAudienceLevelFlowViolation() {
+    @ConstraintProviderTest
+    void contentAudienceLevelFlowViolation(
+            ConstraintVerifier<ConferenceSchedulingConstraintProvider, ConferenceSolution> constraintVerifier) {
         Room room = new Room(0);
         Talk talk1 = new Talk(1)
                 .withRoom(room)
@@ -626,8 +642,8 @@ class ConferenceSchedulingConstraintProviderTest {
                 .penalizesBy(240); // talk1 + talk2, talk2 + talk1, talk2 + talk4, talk4 + talk2.
     }
 
-    @Test
-    void contentConflict() {
+    @ConstraintProviderTest
+    void contentConflict(ConstraintVerifier<ConferenceSchedulingConstraintProvider, ConferenceSolution> constraintVerifier) {
         Room room = new Room(0);
         Talk talk1 = new Talk(1)
                 .withRoom(room)
@@ -651,8 +667,8 @@ class ConferenceSchedulingConstraintProviderTest {
                 .penalizesBy(60); // talk1 + talk2.
     }
 
-    @Test
-    void languageDiversity() {
+    @ConstraintProviderTest
+    void languageDiversity(ConstraintVerifier<ConferenceSchedulingConstraintProvider, ConferenceSolution> constraintVerifier) {
         Room room = new Room(0);
         Talk talk1 = new Talk(1)
                 .withRoom(room)
@@ -676,8 +692,8 @@ class ConferenceSchedulingConstraintProviderTest {
                 .rewardsWith(120); // talk1 + talk3.
     }
 
-    @Test
-    void sameDayTalks() {
+    @ConstraintProviderTest
+    void sameDayTalks(ConstraintVerifier<ConferenceSchedulingConstraintProvider, ConferenceSolution> constraintVerifier) {
         Room room = new Room(0);
         Talk talk1 = new Talk(1)
                 .withRoom(room)
@@ -715,8 +731,8 @@ class ConferenceSchedulingConstraintProviderTest {
                 .penalizesBy(960);
     }
 
-    @Test
-    void popularTalks() {
+    @ConstraintProviderTest
+    void popularTalks(ConstraintVerifier<ConferenceSchedulingConstraintProvider, ConferenceSolution> constraintVerifier) {
         Room smallerRoom = new Room(0)
                 .withCapacity(10);
         Room biggerRoom = new Room(1)
@@ -739,8 +755,9 @@ class ConferenceSchedulingConstraintProviderTest {
                 .penalizesBy(120); // talk1 + talk3
     }
 
-    @Test
-    void speakerPreferredTimeslotTags() {
+    @ConstraintProviderTest
+    void speakerPreferredTimeslotTags(
+            ConstraintVerifier<ConferenceSchedulingConstraintProvider, ConferenceSolution> constraintVerifier) {
         Room room = new Room(0);
         Speaker speaker1 = new Speaker(1)
                 .withPreferredTimeslotTagSet(singleton("a"));
@@ -762,8 +779,9 @@ class ConferenceSchedulingConstraintProviderTest {
                 .penalizesBy(MONDAY_10_TO_11.getDurationInMinutes());
     }
 
-    @Test
-    void speakerUndesiredTimeslotTags() {
+    @ConstraintProviderTest
+    void speakerUndesiredTimeslotTags(
+            ConstraintVerifier<ConferenceSchedulingConstraintProvider, ConferenceSolution> constraintVerifier) {
         Room room = new Room(0);
         Speaker speaker1 = new Speaker(1)
                 .withUndesiredTimeslotTagSet(singleton("a"));
@@ -785,8 +803,9 @@ class ConferenceSchedulingConstraintProviderTest {
                 .penalizesBy(MONDAY_9_TO_10.getDurationInMinutes());
     }
 
-    @Test
-    void talkPreferredTimeslotTags() {
+    @ConstraintProviderTest
+    void talkPreferredTimeslotTags(
+            ConstraintVerifier<ConferenceSchedulingConstraintProvider, ConferenceSolution> constraintVerifier) {
         Room room = new Room(0);
         Talk talk1 = new Talk(1)
                 .withRoom(room)
@@ -802,8 +821,9 @@ class ConferenceSchedulingConstraintProviderTest {
                 .penalizesBy(MONDAY_10_TO_11.getDurationInMinutes());
     }
 
-    @Test
-    void talkUndesiredTimeslotTags() {
+    @ConstraintProviderTest
+    void talkUndesiredTimeslotTags(
+            ConstraintVerifier<ConferenceSchedulingConstraintProvider, ConferenceSolution> constraintVerifier) {
         Room room = new Room(0);
         Talk talk1 = new Talk(1)
                 .withRoom(room)
@@ -819,8 +839,9 @@ class ConferenceSchedulingConstraintProviderTest {
                 .penalizesBy(MONDAY_9_TO_10.getDurationInMinutes());
     }
 
-    @Test
-    void speakerPreferredRoomTags() {
+    @ConstraintProviderTest
+    void speakerPreferredRoomTags(
+            ConstraintVerifier<ConferenceSchedulingConstraintProvider, ConferenceSolution> constraintVerifier) {
         Room room = new Room(0)
                 .withTagSet(singleton("a"));
         Speaker speaker1 = new Speaker(1)
@@ -841,8 +862,9 @@ class ConferenceSchedulingConstraintProviderTest {
                 .penalizesBy(MONDAY_10_TO_11.getDurationInMinutes());
     }
 
-    @Test
-    void speakerUndesiredRoomTags() {
+    @ConstraintProviderTest
+    void speakerUndesiredRoomTags(
+            ConstraintVerifier<ConferenceSchedulingConstraintProvider, ConferenceSolution> constraintVerifier) {
         Room room = new Room(0)
                 .withTagSet(singleton("a"));
         Speaker speaker1 = new Speaker(1)
@@ -863,8 +885,9 @@ class ConferenceSchedulingConstraintProviderTest {
                 .penalizesBy(MONDAY_9_TO_10.getDurationInMinutes());
     }
 
-    @Test
-    void talkPreferredRoomTags() {
+    @ConstraintProviderTest
+    void talkPreferredRoomTags(
+            ConstraintVerifier<ConferenceSchedulingConstraintProvider, ConferenceSolution> constraintVerifier) {
         Room room = new Room(0)
                 .withTagSet(singleton("a"));
         Talk talk1 = new Talk(1)
@@ -881,8 +904,9 @@ class ConferenceSchedulingConstraintProviderTest {
                 .penalizesBy(MONDAY_10_TO_11.getDurationInMinutes());
     }
 
-    @Test
-    void talkUndesiredRoomTags() {
+    @ConstraintProviderTest
+    void talkUndesiredRoomTags(
+            ConstraintVerifier<ConferenceSchedulingConstraintProvider, ConferenceSolution> constraintVerifier) {
         Room room = new Room(0)
                 .withTagSet(singleton("a"));
         Talk talk1 = new Talk(1)
@@ -897,5 +921,10 @@ class ConferenceSchedulingConstraintProviderTest {
         constraintVerifier.verifyThat(ConferenceSchedulingConstraintProvider::talkUndesiredRoomTags)
                 .given(talk1, talk2)
                 .penalizesBy(MONDAY_9_TO_10.getDurationInMinutes());
+    }
+
+    @Override
+    protected ConstraintVerifier<ConferenceSchedulingConstraintProvider, ConferenceSolution> createConstraintVerifier() {
+        return ConstraintVerifier.build(new ConferenceSchedulingConstraintProvider(), ConferenceSolution.class, Talk.class);
     }
 }

--- a/optaplanner-examples/src/test/java/org/optaplanner/examples/curriculumcourse/score/CurriculumCourseConstraintProviderTest.java
+++ b/optaplanner-examples/src/test/java/org/optaplanner/examples/curriculumcourse/score/CurriculumCourseConstraintProviderTest.java
@@ -1,6 +1,7 @@
 package org.optaplanner.examples.curriculumcourse.score;
 
-import org.junit.jupiter.api.Test;
+import org.optaplanner.examples.common.score.AbstractConstraintProviderTest;
+import org.optaplanner.examples.common.score.ConstraintProviderTest;
 import org.optaplanner.examples.curriculumcourse.domain.Course;
 import org.optaplanner.examples.curriculumcourse.domain.CourseSchedule;
 import org.optaplanner.examples.curriculumcourse.domain.Curriculum;
@@ -14,7 +15,8 @@ import org.optaplanner.examples.curriculumcourse.domain.UnavailablePeriodPenalty
 import org.optaplanner.examples.curriculumcourse.domain.solver.CourseConflict;
 import org.optaplanner.test.api.score.stream.ConstraintVerifier;
 
-class CurriculumCourseConstraintProviderTest {
+class CurriculumCourseConstraintProviderTest
+        extends AbstractConstraintProviderTest<CurriculumCourseConstraintProvider, CourseSchedule> {
 
     private static final Curriculum CURRICULUM_1 = new Curriculum(1, "Curriculum1");
     private static final Curriculum CURRICULUM_2 = new Curriculum(2, "Curriculum2");
@@ -33,11 +35,9 @@ class CurriculumCourseConstraintProviderTest {
     private static final Period PERIOD_2_MONDAY = new Period(1, MONDAY, SECOND_TIMESLOT);
     private static final Period PERIOD_1_TUESDAY = new Period(2, TUESDAY, FIRST_TIMESLOT);
 
-    private final ConstraintVerifier<CurriculumCourseConstraintProvider, CourseSchedule> constraintVerifier =
-            ConstraintVerifier.build(new CurriculumCourseConstraintProvider(), CourseSchedule.class, Lecture.class);
-
-    @Test
-    void conflictingLecturesDifferentCourseInSamePeriod() {
+    @ConstraintProviderTest
+    void conflictingLecturesDifferentCourseInSamePeriod(
+            ConstraintVerifier<CurriculumCourseConstraintProvider, CourseSchedule> constraintVerifier) {
         int conflictCount = 2;
         CourseConflict courseConflict = new CourseConflict(COURSE_1, COURSE_2, conflictCount);
 
@@ -52,8 +52,9 @@ class CurriculumCourseConstraintProviderTest {
                 .penalizesBy(conflictCount);
     }
 
-    @Test
-    void conflictingLecturesSameCourseInSamePeriod() {
+    @ConstraintProviderTest
+    void conflictingLecturesSameCourseInSamePeriod(
+            ConstraintVerifier<CurriculumCourseConstraintProvider, CourseSchedule> constraintVerifier) {
         // Make sure that unassigned lectures are ignored.
         Lecture unassignedLecture1 = new Lecture(0, COURSE_1, null, null);
         Lecture unassignedLecture2 = new Lecture(1, COURSE_1, null, null);
@@ -67,8 +68,8 @@ class CurriculumCourseConstraintProviderTest {
                 .penalizesBy(2);
     }
 
-    @Test
-    void roomOccupancy() {
+    @ConstraintProviderTest
+    void roomOccupancy(ConstraintVerifier<CurriculumCourseConstraintProvider, CourseSchedule> constraintVerifier) {
         // Make sure that unassigned lectures are ignored.
         Lecture unassignedLecture = new Lecture(0, COURSE_1, null, null);
         // Make sure only unique pairs are counted.
@@ -82,8 +83,8 @@ class CurriculumCourseConstraintProviderTest {
                 .penalizesBy(3);
     }
 
-    @Test
-    void unavailablePeriodPenalty() {
+    @ConstraintProviderTest
+    void unavailablePeriodPenalty(ConstraintVerifier<CurriculumCourseConstraintProvider, CourseSchedule> constraintVerifier) {
         UnavailablePeriodPenalty unavailablePeriodPenalty = new UnavailablePeriodPenalty(0, COURSE_1, PERIOD_1_MONDAY);
         Lecture matchingLecture = new Lecture(0, COURSE_1, PERIOD_1_MONDAY, ROOM_1);
         Lecture wrongCourseLecture = new Lecture(1, COURSE_2, PERIOD_1_MONDAY, ROOM_2);
@@ -93,8 +94,8 @@ class CurriculumCourseConstraintProviderTest {
                 .penalizesBy(1);
     }
 
-    @Test
-    void roomCapacity() {
+    @ConstraintProviderTest
+    void roomCapacity(ConstraintVerifier<CurriculumCourseConstraintProvider, CourseSchedule> constraintVerifier) {
         Lecture overbookedLecture = new Lecture(0, COURSE_1, PERIOD_1_MONDAY, ROOM_1);
         Lecture packedLecture = new Lecture(1, COURSE_2, PERIOD_2_MONDAY, ROOM_1);
         Lecture nearlyEmptyLecture = new Lecture(2, COURSE_3, PERIOD_1_TUESDAY, ROOM_2);
@@ -103,8 +104,8 @@ class CurriculumCourseConstraintProviderTest {
                 .penalizesBy(10); // Only penalizes the overbooked lecture.
     }
 
-    @Test
-    void minimumWorkingDays() {
+    @ConstraintProviderTest
+    void minimumWorkingDays(ConstraintVerifier<CurriculumCourseConstraintProvider, CourseSchedule> constraintVerifier) {
         Lecture meetsMinimum = new Lecture(0, COURSE_3, PERIOD_1_MONDAY, ROOM_1);
         Lecture doesNotMeetMinimumBy1 = new Lecture(1, COURSE_2, PERIOD_1_MONDAY, ROOM_2);
         Lecture doesNotMeetMinimumBy2 = new Lecture(2, COURSE_1, PERIOD_2_MONDAY, ROOM_1);
@@ -113,8 +114,8 @@ class CurriculumCourseConstraintProviderTest {
                 .penalizesBy(3);
     }
 
-    @Test
-    void curriculumCompactness() {
+    @ConstraintProviderTest
+    void curriculumCompactness(ConstraintVerifier<CurriculumCourseConstraintProvider, CourseSchedule> constraintVerifier) {
         Lecture lectureInCurriculumWithoutOthers1 = new Lecture(0, COURSE_1, PERIOD_1_MONDAY, ROOM_1);
         Lecture lectureInCurriculumWithoutOthers2 = new Lecture(1, COURSE_2, PERIOD_1_MONDAY, ROOM_1);
         constraintVerifier.verifyThat(CurriculumCourseConstraintProvider::curriculumCompactness)
@@ -122,8 +123,8 @@ class CurriculumCourseConstraintProviderTest {
                 .penalizesBy(2);
     }
 
-    @Test
-    void roomStability() {
+    @ConstraintProviderTest
+    void roomStability(ConstraintVerifier<CurriculumCourseConstraintProvider, CourseSchedule> constraintVerifier) {
         Lecture lectureOfSameCourse1 = new Lecture(0, COURSE_1, PERIOD_1_MONDAY, ROOM_1);
         Lecture lectureOfSameCourse2 = new Lecture(1, COURSE_1, PERIOD_1_MONDAY, ROOM_2);
         Lecture lectureOfSameCourse3 = new Lecture(2, COURSE_1, PERIOD_2_MONDAY, ROOM_1);
@@ -133,4 +134,8 @@ class CurriculumCourseConstraintProviderTest {
                 .penalizesBy(1); // lectureOfSameCourse2 is penalized
     }
 
+    @Override
+    protected ConstraintVerifier<CurriculumCourseConstraintProvider, CourseSchedule> createConstraintVerifier() {
+        return ConstraintVerifier.build(new CurriculumCourseConstraintProvider(), CourseSchedule.class, Lecture.class);
+    }
 }

--- a/optaplanner-examples/src/test/java/org/optaplanner/examples/examination/score/ExaminationConstraintProviderTest.java
+++ b/optaplanner-examples/src/test/java/org/optaplanner/examples/examination/score/ExaminationConstraintProviderTest.java
@@ -1,6 +1,7 @@
 package org.optaplanner.examples.examination.score;
 
-import org.junit.jupiter.api.Test;
+import org.optaplanner.examples.common.score.AbstractConstraintProviderTest;
+import org.optaplanner.examples.common.score.ConstraintProviderTest;
 import org.optaplanner.examples.examination.domain.Exam;
 import org.optaplanner.examples.examination.domain.Examination;
 import org.optaplanner.examples.examination.domain.ExaminationConstraintConfiguration;
@@ -16,17 +17,16 @@ import org.optaplanner.examples.examination.domain.Topic;
 import org.optaplanner.examples.examination.domain.solver.TopicConflict;
 import org.optaplanner.test.api.score.stream.ConstraintVerifier;
 
-class ExaminationConstraintProviderTest {
-    private final ConstraintVerifier<ExaminationConstraintProvider, Examination> constraintVerifier = ConstraintVerifier
-            .build(new ExaminationConstraintProvider(), Examination.class, Exam.class);
+class ExaminationConstraintProviderTest
+        extends AbstractConstraintProviderTest<ExaminationConstraintProvider, Examination> {
 
     private final Student student1 = new Student(1L);
     private final Student student2 = new Student(2L);
     private final Student student3 = new Student(3L);
     private final Student student4 = new Student(4L);
 
-    @Test
-    void conflictingExamsInSamePeriodTest() {
+    @ConstraintProviderTest
+    void conflictingExamsInSamePeriodTest(ConstraintVerifier<ExaminationConstraintProvider, Examination> constraintVerifier) {
         Topic topic1 = new Topic();
         Topic topic2 = new Topic();
         TopicConflict conflict = new TopicConflict(0, topic1, topic2, 2);
@@ -49,8 +49,8 @@ class ExaminationConstraintProviderTest {
                 .penalizesBy(2);
     }
 
-    @Test
-    void periodDurationTooShortTest() {
+    @ConstraintProviderTest
+    void periodDurationTooShortTest(ConstraintVerifier<ExaminationConstraintProvider, Examination> constraintVerifier) {
         LeadingExam exam = new LeadingExam()
                 .withTopic(new Topic().withDuration(2).withStudents(student1, student2))
                 .withPeriod(new Period().withDuration(1))
@@ -61,8 +61,9 @@ class ExaminationConstraintProviderTest {
                 .penalizesBy(2);
     }
 
-    @Test
-    void roomCapacityTooSmallSingleLargeExamTest() {
+    @ConstraintProviderTest
+    void roomCapacityTooSmallSingleLargeExamTest(
+            ConstraintVerifier<ExaminationConstraintProvider, Examination> constraintVerifier) {
         Period period = new Period();
         Room room = new Room().withCapacity(2);
 
@@ -76,8 +77,8 @@ class ExaminationConstraintProviderTest {
                 .penalizesBy(2);
     }
 
-    @Test
-    void roomCapacityTooSmallTwoExamsTest() {
+    @ConstraintProviderTest
+    void roomCapacityTooSmallTwoExamsTest(ConstraintVerifier<ExaminationConstraintProvider, Examination> constraintVerifier) {
         Period period = new Period();
         Room room = new Room().withCapacity(2);
 
@@ -97,8 +98,8 @@ class ExaminationConstraintProviderTest {
                 .penalizesBy(2);
     }
 
-    @Test
-    void periodPenaltyTypeTest() {
+    @ConstraintProviderTest
+    void periodPenaltyTypeTest(ConstraintVerifier<ExaminationConstraintProvider, Examination> constraintVerifier) {
         Topic topic1 = new Topic().withStudents(student1, student2);
         Topic topic2 = new Topic().withStudents(student1, student2);
 
@@ -147,8 +148,8 @@ class ExaminationConstraintProviderTest {
                 .penalizesBy(0);
     }
 
-    @Test
-    void roomPenaltyExclusiveTest() {
+    @ConstraintProviderTest
+    void roomPenaltyExclusiveTest(ConstraintVerifier<ExaminationConstraintProvider, Examination> constraintVerifier) {
         Topic topic1 = new Topic().withStudents(student1, student2);
         Topic topic2 = new Topic().withStudents(student3, student4);
 
@@ -173,8 +174,8 @@ class ExaminationConstraintProviderTest {
                 .penalizesBy(4);
     }
 
-    @Test
-    void twoExamsInARowAndInADayTest() {
+    @ConstraintProviderTest
+    void twoExamsInARowAndInADayTest(ConstraintVerifier<ExaminationConstraintProvider, Examination> constraintVerifier) {
         Topic topic1 = new Topic();
         Topic topic2 = new Topic();
         TopicConflict conflict = new TopicConflict(0, topic1, topic2, 2);
@@ -229,8 +230,8 @@ class ExaminationConstraintProviderTest {
                 .penalizesBy(0);
     }
 
-    @Test
-    void periodSpreadTest() {
+    @ConstraintProviderTest
+    void periodSpreadTest(ConstraintVerifier<ExaminationConstraintProvider, Examination> constraintVerifier) {
         ExaminationConstraintConfiguration config = new ExaminationConstraintConfiguration()
                 // At least 1 period apart.
                 .withPeriodSpreadLength(1);
@@ -272,8 +273,8 @@ class ExaminationConstraintProviderTest {
                 .penalizesBy(0);
     }
 
-    @Test
-    void mixedDurations11Test() {
+    @ConstraintProviderTest
+    void mixedDurations11Test(ConstraintVerifier<ExaminationConstraintProvider, Examination> constraintVerifier) {
         Period period = new Period();
         Room room = new Room();
         LeadingExam exam1 = new LeadingExam()
@@ -297,8 +298,8 @@ class ExaminationConstraintProviderTest {
                 .penalizesBy(0);
     }
 
-    @Test
-    void mixedDurations12Test() {
+    @ConstraintProviderTest
+    void mixedDurations12Test(ConstraintVerifier<ExaminationConstraintProvider, Examination> constraintVerifier) {
         Period period = new Period();
         Room room = new Room();
         LeadingExam exam1 = new LeadingExam()
@@ -322,8 +323,8 @@ class ExaminationConstraintProviderTest {
                 .penalizesBy(1);
     }
 
-    @Test
-    void mixedDurations123Test() {
+    @ConstraintProviderTest
+    void mixedDurations123Test(ConstraintVerifier<ExaminationConstraintProvider, Examination> constraintVerifier) {
         Period period = new Period();
         Room room = new Room();
         LeadingExam exam1 = new LeadingExam()
@@ -354,8 +355,8 @@ class ExaminationConstraintProviderTest {
                 .penalizesBy(2);
     }
 
-    @Test
-    void mixedDurations113Test() {
+    @ConstraintProviderTest
+    void mixedDurations113Test(ConstraintVerifier<ExaminationConstraintProvider, Examination> constraintVerifier) {
         Period period = new Period();
         Room room = new Room();
         LeadingExam exam1 = new LeadingExam()
@@ -386,8 +387,8 @@ class ExaminationConstraintProviderTest {
                 .penalizesBy(1);
     }
 
-    @Test
-    void mixedDurations133Test() {
+    @ConstraintProviderTest
+    void mixedDurations133Test(ConstraintVerifier<ExaminationConstraintProvider, Examination> constraintVerifier) {
         Period period = new Period();
         Room room = new Room();
         LeadingExam exam1 = new LeadingExam()
@@ -418,8 +419,8 @@ class ExaminationConstraintProviderTest {
                 .penalizesBy(1);
     }
 
-    @Test
-    void mixedDurations131Test() {
+    @ConstraintProviderTest
+    void mixedDurations131Test(ConstraintVerifier<ExaminationConstraintProvider, Examination> constraintVerifier) {
         Period period = new Period();
         Room room = new Room();
         LeadingExam exam1 = new LeadingExam()
@@ -450,8 +451,8 @@ class ExaminationConstraintProviderTest {
                 .penalizesBy(1);
     }
 
-    @Test
-    void mixedDurations431Test() {
+    @ConstraintProviderTest
+    void mixedDurations431Test(ConstraintVerifier<ExaminationConstraintProvider, Examination> constraintVerifier) {
         Period period = new Period();
         Room room = new Room();
         LeadingExam exam1 = new LeadingExam()
@@ -482,8 +483,8 @@ class ExaminationConstraintProviderTest {
                 .penalizesBy(2);
     }
 
-    @Test
-    void mixedDurations411Test() {
+    @ConstraintProviderTest
+    void mixedDurations411Test(ConstraintVerifier<ExaminationConstraintProvider, Examination> constraintVerifier) {
         Period period = new Period();
         Room room = new Room();
         LeadingExam exam1 = new LeadingExam()
@@ -514,8 +515,8 @@ class ExaminationConstraintProviderTest {
                 .penalizesBy(1);
     }
 
-    @Test
-    void mixedDurations441Test() {
+    @ConstraintProviderTest
+    void mixedDurations441Test(ConstraintVerifier<ExaminationConstraintProvider, Examination> constraintVerifier) {
         Period period = new Period();
         Room room = new Room();
         LeadingExam exam1 = new LeadingExam()
@@ -546,8 +547,8 @@ class ExaminationConstraintProviderTest {
                 .penalizesBy(1);
     }
 
-    @Test
-    void frontLoadTest() {
+    @ConstraintProviderTest
+    void frontLoadTest(ConstraintVerifier<ExaminationConstraintProvider, Examination> constraintVerifier) {
         LeadingExam exam = new LeadingExam()
                 .withPeriod(new Period().withFrontLoadLast(true))
                 .withTopic(new Topic().withFrontLoadLarge(true))
@@ -558,8 +559,8 @@ class ExaminationConstraintProviderTest {
                 .penalizesBy(1);
     }
 
-    @Test
-    void periodPenaltyTest() {
+    @ConstraintProviderTest
+    void periodPenaltyTest(ConstraintVerifier<ExaminationConstraintProvider, Examination> constraintVerifier) {
         Period period = new Period().withPenalty(5);
         Room room = new Room();
         LeadingExam exam1 = new LeadingExam()
@@ -582,8 +583,8 @@ class ExaminationConstraintProviderTest {
                 .penalizesBy(10);
     }
 
-    @Test
-    void roomPenaltyTest() {
+    @ConstraintProviderTest
+    void roomPenaltyTest(ConstraintVerifier<ExaminationConstraintProvider, Examination> constraintVerifier) {
         Room room = new Room().withPenalty(5);
         LeadingExam exam1 = new LeadingExam()
                 .withId(1L)
@@ -603,5 +604,10 @@ class ExaminationConstraintProviderTest {
         constraintVerifier.verifyThat(ExaminationConstraintProvider::roomPenalty)
                 .given(room, exam1, exam2)
                 .penalizesBy(10);
+    }
+
+    @Override
+    protected ConstraintVerifier<ExaminationConstraintProvider, Examination> createConstraintVerifier() {
+        return ConstraintVerifier.build(new ExaminationConstraintProvider(), Examination.class, Exam.class);
     }
 }

--- a/optaplanner-examples/src/test/java/org/optaplanner/examples/machinereassignment/score/MachineReassignmentConstraintProviderTest.java
+++ b/optaplanner-examples/src/test/java/org/optaplanner/examples/machinereassignment/score/MachineReassignmentConstraintProviderTest.java
@@ -6,8 +6,9 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.jupiter.api.Test;
 import org.optaplanner.core.api.score.buildin.hardsoftlong.HardSoftLongScore;
+import org.optaplanner.examples.common.score.AbstractConstraintProviderTest;
+import org.optaplanner.examples.common.score.ConstraintProviderTest;
 import org.optaplanner.examples.machinereassignment.domain.MachineReassignment;
 import org.optaplanner.examples.machinereassignment.domain.MrBalancePenalty;
 import org.optaplanner.examples.machinereassignment.domain.MrGlobalPenaltyInfo;
@@ -24,14 +25,15 @@ import org.optaplanner.examples.machinereassignment.domain.solver.MrServiceDepen
 import org.optaplanner.persistence.xstream.impl.domain.solution.XStreamSolutionFileIO;
 import org.optaplanner.test.api.score.stream.ConstraintVerifier;
 
-class MachineReassignmentConstraintProviderTest {
+class MachineReassignmentConstraintProviderTest
+        extends AbstractConstraintProviderTest<MachineReassignmentConstraintProvider, MachineReassignment> {
 
     private final ConstraintVerifier<MachineReassignmentConstraintProvider, MachineReassignment> constraintVerifier =
-            ConstraintVerifier
-                    .build(new MachineReassignmentConstraintProvider(), MachineReassignment.class, MrProcessAssignment.class);
+            ConstraintVerifier.build(new MachineReassignmentConstraintProvider(), MachineReassignment.class,
+                    MrProcessAssignment.class);
 
-    @Test
-    void maximumCapacity() {
+    @ConstraintProviderTest
+    void maximumCapacity(ConstraintVerifier<MachineReassignmentConstraintProvider, MachineReassignment> constraintVerifier) {
         MrResource resource1 = new MrResource(0, false, 1);
         MrMachine machine = new MrMachine();
         MrProcess process = new MrProcess();
@@ -46,8 +48,8 @@ class MachineReassignmentConstraintProviderTest {
                 .penalizesBy(10L);
     }
 
-    @Test
-    void transientUsage() {
+    @ConstraintProviderTest
+    void transientUsage(ConstraintVerifier<MachineReassignmentConstraintProvider, MachineReassignment> constraintVerifier) {
         MrResource normalResource = new MrResource(0, false, 5);
         MrResource transientlyConsumerResource = new MrResource(1, true, 10);
 
@@ -72,8 +74,8 @@ class MachineReassignmentConstraintProviderTest {
                 .penalizesBy(15L);
     }
 
-    @Test
-    void serviceConflict() {
+    @ConstraintProviderTest
+    void serviceConflict(ConstraintVerifier<MachineReassignmentConstraintProvider, MachineReassignment> constraintVerifier) {
         // 3 of 4 processes of the same service run on the same machine
         MrService service = new MrService();
 
@@ -99,8 +101,9 @@ class MachineReassignmentConstraintProviderTest {
                 .penalizesBy(3L);
     }
 
-    @Test
-    void serviceLocationSpread() {
+    @ConstraintProviderTest
+    void serviceLocationSpread(
+            ConstraintVerifier<MachineReassignmentConstraintProvider, MachineReassignment> constraintVerifier) {
         MrLocation location1 = new MrLocation(1L);
         MrLocation location2 = new MrLocation(2L);
 
@@ -127,8 +130,8 @@ class MachineReassignmentConstraintProviderTest {
                 .penalizesBy(3L); // 5 - 3 (expected - real location spread)
     }
 
-    @Test
-    void serviceDependency() {
+    @ConstraintProviderTest
+    void serviceDependency(ConstraintVerifier<MachineReassignmentConstraintProvider, MachineReassignment> constraintVerifier) {
         MrNeighborhood neighborhood1 = new MrNeighborhood(1L);
         MrNeighborhood neighborhood2 = new MrNeighborhood(2L);
 
@@ -161,8 +164,8 @@ class MachineReassignmentConstraintProviderTest {
                 .penalizesBy(1L);
     }
 
-    @Test
-    void loadCost() {
+    @ConstraintProviderTest
+    void loadCost(ConstraintVerifier<MachineReassignmentConstraintProvider, MachineReassignment> constraintVerifier) {
         MrResource resource1 = new MrResource(0, false, 5);
         MrResource resource2 = new MrResource(1, false, 10);
         MrMachine machine = new MrMachine();
@@ -184,8 +187,8 @@ class MachineReassignmentConstraintProviderTest {
                 .penalizesBy(25L + 50L);
     }
 
-    @Test
-    void processMoveCost() {
+    @ConstraintProviderTest
+    void processMoveCost(ConstraintVerifier<MachineReassignmentConstraintProvider, MachineReassignment> constraintVerifier) {
         MrGlobalPenaltyInfo globalPenaltyInfo = new MrGlobalPenaltyInfo();
         globalPenaltyInfo.setProcessMoveCostWeight(10);
 
@@ -208,8 +211,8 @@ class MachineReassignmentConstraintProviderTest {
                 .penalizesBy(20L);
     }
 
-    @Test
-    void serviceMoveCost() {
+    @ConstraintProviderTest
+    void serviceMoveCost(ConstraintVerifier<MachineReassignmentConstraintProvider, MachineReassignment> constraintVerifier) {
         MrGlobalPenaltyInfo globalPenaltyInfo = new MrGlobalPenaltyInfo();
         globalPenaltyInfo.setServiceMoveCostWeight(10);
 
@@ -233,8 +236,8 @@ class MachineReassignmentConstraintProviderTest {
                 .penalizesBy(2 * 10L);
     }
 
-    @Test
-    void machineMoveCost() {
+    @ConstraintProviderTest
+    void machineMoveCost(ConstraintVerifier<MachineReassignmentConstraintProvider, MachineReassignment> constraintVerifier) {
         MrGlobalPenaltyInfo globalPenaltyInfo = new MrGlobalPenaltyInfo();
         globalPenaltyInfo.setMachineMoveCostWeight(10);
 
@@ -266,8 +269,8 @@ class MachineReassignmentConstraintProviderTest {
 
     }
 
-    @Test
-    void balanceCost() {
+    @ConstraintProviderTest
+    void balanceCost(ConstraintVerifier<MachineReassignmentConstraintProvider, MachineReassignment> constraintVerifier) {
         MrResource cpu = new MrResource(0, false, 0);
         MrResource mem = new MrResource(1, false, 0);
         MrResource disk = new MrResource(2, false, 0);
@@ -310,8 +313,9 @@ class MachineReassignmentConstraintProviderTest {
                 .penalizesBy(7_001L);
     }
 
-    @Test
-    void balanceCostSingleMachine() {
+    @ConstraintProviderTest
+    void balanceCostSingleMachine(
+            ConstraintVerifier<MachineReassignmentConstraintProvider, MachineReassignment> constraintVerifier) {
         MrResource cpu = new MrResource(0L, 0, false, 1);
         MrResource mem = new MrResource(1L, 1, false, 1);
         MrResource disk = new MrResource(2L, 2, false, 1);
@@ -339,8 +343,10 @@ class MachineReassignmentConstraintProviderTest {
                 .penalizesBy(2L);
     }
 
-    @Test
-    void solutionWithMultipleConstraints() throws IOException {
+    @ConstraintProviderTest
+    void solutionWithMultipleConstraints(
+            ConstraintVerifier<MachineReassignmentConstraintProvider, MachineReassignment> constraintVerifier)
+            throws IOException {
         constraintVerifier.verifyThat()
                 .givenSolution(readSolution("model-a1-1-0hard-44306501soft.xml"))
                 .scores(HardSoftLongScore.of(-0, -44306501));
@@ -351,5 +357,11 @@ class MachineReassignmentConstraintProviderTest {
         try (InputStream inputStream = MachineReassignmentConstraintProviderTest.class.getResourceAsStream(resource)) {
             return solutionFileIO.read(inputStream);
         }
+    }
+
+    @Override
+    protected ConstraintVerifier<MachineReassignmentConstraintProvider, MachineReassignment> createConstraintVerifier() {
+        return ConstraintVerifier.build(new MachineReassignmentConstraintProvider(), MachineReassignment.class,
+                MrProcessAssignment.class);
     }
 }

--- a/optaplanner-examples/src/test/java/org/optaplanner/examples/meetingscheduling/score/MeetingSchedulingConstraintProviderTest.java
+++ b/optaplanner-examples/src/test/java/org/optaplanner/examples/meetingscheduling/score/MeetingSchedulingConstraintProviderTest.java
@@ -3,7 +3,8 @@ package org.optaplanner.examples.meetingscheduling.score;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.junit.jupiter.api.Test;
+import org.optaplanner.examples.common.score.AbstractConstraintProviderTest;
+import org.optaplanner.examples.common.score.ConstraintProviderTest;
 import org.optaplanner.examples.meetingscheduling.domain.Day;
 import org.optaplanner.examples.meetingscheduling.domain.Meeting;
 import org.optaplanner.examples.meetingscheduling.domain.MeetingAssignment;
@@ -15,14 +16,11 @@ import org.optaplanner.examples.meetingscheduling.domain.Room;
 import org.optaplanner.examples.meetingscheduling.domain.TimeGrain;
 import org.optaplanner.test.api.score.stream.ConstraintVerifier;
 
-class MeetingSchedulingConstraintProviderTest {
+class MeetingSchedulingConstraintProviderTest
+        extends AbstractConstraintProviderTest<MeetingSchedulingConstraintProvider, MeetingSchedule> {
 
-    private final ConstraintVerifier<MeetingSchedulingConstraintProvider, MeetingSchedule> constraintVerifier =
-            ConstraintVerifier.build(new MeetingSchedulingConstraintProvider(), MeetingSchedule.class,
-                    MeetingAssignment.class);
-
-    @Test
-    void roomConflictUnpenalized() {
+    @ConstraintProviderTest
+    void roomConflictUnpenalized(ConstraintVerifier<MeetingSchedulingConstraintProvider, MeetingSchedule> constraintVerifier) {
         Room room = new Room();
 
         TimeGrain timeGrain1 = new TimeGrain();
@@ -46,8 +44,8 @@ class MeetingSchedulingConstraintProviderTest {
                 .penalizesBy(0);
     }
 
-    @Test
-    void roomConflictPenalized() {
+    @ConstraintProviderTest
+    void roomConflictPenalized(ConstraintVerifier<MeetingSchedulingConstraintProvider, MeetingSchedule> constraintVerifier) {
         Room room = new Room();
 
         TimeGrain timeGrain1 = new TimeGrain();
@@ -71,8 +69,8 @@ class MeetingSchedulingConstraintProviderTest {
                 .penalizesBy(2);
     }
 
-    @Test
-    void avoidOvertimeUnpenalized() {
+    @ConstraintProviderTest
+    void avoidOvertimeUnpenalized(ConstraintVerifier<MeetingSchedulingConstraintProvider, MeetingSchedule> constraintVerifier) {
         TimeGrain timeGrain = new TimeGrain();
         timeGrain.setGrainIndex(3);
 
@@ -91,8 +89,8 @@ class MeetingSchedulingConstraintProviderTest {
                 .penalizesBy(0);
     }
 
-    @Test
-    void avoidOvertimePenalized() {
+    @ConstraintProviderTest
+    void avoidOvertimePenalized(ConstraintVerifier<MeetingSchedulingConstraintProvider, MeetingSchedule> constraintVerifier) {
         TimeGrain assignmentTimeGrain = new TimeGrain();
         assignmentTimeGrain.setGrainIndex(0);
 
@@ -108,8 +106,9 @@ class MeetingSchedulingConstraintProviderTest {
                 .penalizesBy(3);
     }
 
-    @Test
-    void requiredAttendanceConflictUnpenalized() {
+    @ConstraintProviderTest
+    void requiredAttendanceConflictUnpenalized(
+            ConstraintVerifier<MeetingSchedulingConstraintProvider, MeetingSchedule> constraintVerifier) {
         Person person = new Person();
         Meeting leftMeeting = new Meeting();
         leftMeeting.setDurationInGrains(4);
@@ -144,8 +143,9 @@ class MeetingSchedulingConstraintProviderTest {
                 .penalizesBy(0);
     }
 
-    @Test
-    void requiredAttendanceConflictPenalized() {
+    @ConstraintProviderTest
+    void requiredAttendanceConflictPenalized(
+            ConstraintVerifier<MeetingSchedulingConstraintProvider, MeetingSchedule> constraintVerifier) {
         Person person = new Person();
         Meeting leftMeeting = new Meeting();
         leftMeeting.setDurationInGrains(4);
@@ -180,8 +180,9 @@ class MeetingSchedulingConstraintProviderTest {
                 .penalizesBy(2);
     }
 
-    @Test
-    void requiredRoomCapacityUnpenalized() {
+    @ConstraintProviderTest
+    void requiredRoomCapacityUnpenalized(
+            ConstraintVerifier<MeetingSchedulingConstraintProvider, MeetingSchedule> constraintVerifier) {
         Room room = new Room();
         room.setCapacity(2);
 
@@ -206,8 +207,9 @@ class MeetingSchedulingConstraintProviderTest {
                 .penalizesBy(0);
     }
 
-    @Test
-    void requiredRoomCapacityPenalized() {
+    @ConstraintProviderTest
+    void requiredRoomCapacityPenalized(
+            ConstraintVerifier<MeetingSchedulingConstraintProvider, MeetingSchedule> constraintVerifier) {
         Room room = new Room();
         room.setCapacity(1);
 
@@ -232,8 +234,9 @@ class MeetingSchedulingConstraintProviderTest {
                 .penalizesBy(1);
     }
 
-    @Test
-    void startAndEndOnSameDayUnpenalized() {
+    @ConstraintProviderTest
+    void startAndEndOnSameDayUnpenalized(
+            ConstraintVerifier<MeetingSchedulingConstraintProvider, MeetingSchedule> constraintVerifier) {
         Day day = new Day();
         day.setDayOfYear(0);
 
@@ -257,8 +260,9 @@ class MeetingSchedulingConstraintProviderTest {
                 .penalizesBy(0);
     }
 
-    @Test
-    void startAndEndOnSameDayPenalized() {
+    @ConstraintProviderTest
+    void startAndEndOnSameDayPenalized(
+            ConstraintVerifier<MeetingSchedulingConstraintProvider, MeetingSchedule> constraintVerifier) {
         Day day = new Day();
         day.setDayOfYear(0);
 
@@ -281,8 +285,9 @@ class MeetingSchedulingConstraintProviderTest {
                 .penalizesBy(1);
     }
 
-    @Test
-    void requiredAndPreferredAttendanceConflictUnpenalized() {
+    @ConstraintProviderTest
+    void requiredAndPreferredAttendanceConflictUnpenalized(
+            ConstraintVerifier<MeetingSchedulingConstraintProvider, MeetingSchedule> constraintVerifier) {
         Person person = new Person();
 
         Meeting leftMeeting = new Meeting();
@@ -316,8 +321,9 @@ class MeetingSchedulingConstraintProviderTest {
                 .penalizesBy(0);
     }
 
-    @Test
-    void requiredAndPreferredAttendanceConflictPenalized() {
+    @ConstraintProviderTest
+    void requiredAndPreferredAttendanceConflictPenalized(
+            ConstraintVerifier<MeetingSchedulingConstraintProvider, MeetingSchedule> constraintVerifier) {
         Person person = new Person();
 
         Meeting leftMeeting = new Meeting();
@@ -351,8 +357,9 @@ class MeetingSchedulingConstraintProviderTest {
                 .penalizesBy(4);
     }
 
-    @Test
-    void preferredAttendanceConflictUnpenalized() {
+    @ConstraintProviderTest
+    void preferredAttendanceConflictUnpenalized(
+            ConstraintVerifier<MeetingSchedulingConstraintProvider, MeetingSchedule> constraintVerifier) {
         Person person = new Person();
 
         Meeting leftMeeting = new Meeting();
@@ -388,8 +395,9 @@ class MeetingSchedulingConstraintProviderTest {
                 .penalizesBy(0);
     }
 
-    @Test
-    void preferredAttendanceConflictPenalized() {
+    @ConstraintProviderTest
+    void preferredAttendanceConflictPenalized(
+            ConstraintVerifier<MeetingSchedulingConstraintProvider, MeetingSchedule> constraintVerifier) {
         Person person = new Person();
 
         Meeting leftMeeting = new Meeting();
@@ -425,8 +433,9 @@ class MeetingSchedulingConstraintProviderTest {
                 .penalizesBy(4);
     }
 
-    @Test
-    void doMeetingsAsSoonAsPossibleUnpenalized() {
+    @ConstraintProviderTest
+    void doMeetingsAsSoonAsPossibleUnpenalized(
+            ConstraintVerifier<MeetingSchedulingConstraintProvider, MeetingSchedule> constraintVerifier) {
         TimeGrain timeGrain = new TimeGrain();
         timeGrain.setGrainIndex(0);
 
@@ -442,8 +451,9 @@ class MeetingSchedulingConstraintProviderTest {
                 .penalizesBy(0);
     }
 
-    @Test
-    void doMeetingsAsSoonAsPossiblePenalized() {
+    @ConstraintProviderTest
+    void doMeetingsAsSoonAsPossiblePenalized(
+            ConstraintVerifier<MeetingSchedulingConstraintProvider, MeetingSchedule> constraintVerifier) {
         TimeGrain timeGrain = new TimeGrain();
         timeGrain.setGrainIndex(0);
 
@@ -459,8 +469,9 @@ class MeetingSchedulingConstraintProviderTest {
                 .penalizesBy(3);
     }
 
-    @Test
-    void oneBreakBetweenConsecutiveMeetingsUnpenalized() {
+    @ConstraintProviderTest
+    void oneBreakBetweenConsecutiveMeetingsUnpenalized(
+            ConstraintVerifier<MeetingSchedulingConstraintProvider, MeetingSchedule> constraintVerifier) {
         TimeGrain leftTimeGrain = new TimeGrain();
         leftTimeGrain.setGrainIndex(0);
 
@@ -481,8 +492,9 @@ class MeetingSchedulingConstraintProviderTest {
                 .penalizesBy(0);
     }
 
-    @Test
-    void oneBreakBetweenConsecutiveMeetingsPenalized() {
+    @ConstraintProviderTest
+    void oneBreakBetweenConsecutiveMeetingsPenalized(
+            ConstraintVerifier<MeetingSchedulingConstraintProvider, MeetingSchedule> constraintVerifier) {
         TimeGrain leftTimeGrain = new TimeGrain();
         leftTimeGrain.setGrainIndex(0);
 
@@ -503,8 +515,9 @@ class MeetingSchedulingConstraintProviderTest {
                 .penalizesBy(1);
     }
 
-    @Test
-    void overlappingMeetingsUnpenalized() {
+    @ConstraintProviderTest
+    void overlappingMeetingsUnpenalized(
+            ConstraintVerifier<MeetingSchedulingConstraintProvider, MeetingSchedule> constraintVerifier) {
         TimeGrain leftTimeGrain = new TimeGrain();
         leftTimeGrain.setGrainIndex(0);
 
@@ -530,8 +543,9 @@ class MeetingSchedulingConstraintProviderTest {
                 .penalizesBy(0);
     }
 
-    @Test
-    void overlappingMeetingsPenalized() {
+    @ConstraintProviderTest
+    void overlappingMeetingsPenalized(
+            ConstraintVerifier<MeetingSchedulingConstraintProvider, MeetingSchedule> constraintVerifier) {
         TimeGrain leftTimeGrain = new TimeGrain();
         leftTimeGrain.setGrainIndex(1);
 
@@ -557,8 +571,9 @@ class MeetingSchedulingConstraintProviderTest {
                 .penalizesBy(2);
     }
 
-    @Test
-    void assignLargerRoomsFirstUnpenalized() {
+    @ConstraintProviderTest
+    void assignLargerRoomsFirstUnpenalized(
+            ConstraintVerifier<MeetingSchedulingConstraintProvider, MeetingSchedule> constraintVerifier) {
         Room meetingRoom = new Room();
         meetingRoom.setCapacity(1);
 
@@ -574,8 +589,9 @@ class MeetingSchedulingConstraintProviderTest {
                 .penalizesBy(0);
     }
 
-    @Test
-    void assignLargerRoomsFirstPenalized() {
+    @ConstraintProviderTest
+    void assignLargerRoomsFirstPenalized(
+            ConstraintVerifier<MeetingSchedulingConstraintProvider, MeetingSchedule> constraintVerifier) {
         Room meetingRoom = new Room();
         meetingRoom.setCapacity(1);
 
@@ -593,8 +609,8 @@ class MeetingSchedulingConstraintProviderTest {
                 .penalizesBy(1);
     }
 
-    @Test
-    void roomStabilityUnpenalized() {
+    @ConstraintProviderTest
+    void roomStabilityUnpenalized(ConstraintVerifier<MeetingSchedulingConstraintProvider, MeetingSchedule> constraintVerifier) {
         Day day = new Day();
         day.setDayOfYear(1);
         Person person = new Person();
@@ -636,8 +652,8 @@ class MeetingSchedulingConstraintProviderTest {
                 .penalizesBy(0);
     }
 
-    @Test
-    void roomStabilityPenalized() {
+    @ConstraintProviderTest
+    void roomStabilityPenalized(ConstraintVerifier<MeetingSchedulingConstraintProvider, MeetingSchedule> constraintVerifier) {
         Day day = new Day();
         day.setDayOfYear(1);
         Person person = new Person();
@@ -677,5 +693,11 @@ class MeetingSchedulingConstraintProviderTest {
         constraintVerifier.verifyThat(MeetingSchedulingConstraintProvider::roomStability)
                 .given(leftAttendance, rightAttendance, leftAssignment, rightAssignment)
                 .penalizesBy(1);
+    }
+
+    @Override
+    protected ConstraintVerifier<MeetingSchedulingConstraintProvider, MeetingSchedule> createConstraintVerifier() {
+        return ConstraintVerifier.build(new MeetingSchedulingConstraintProvider(), MeetingSchedule.class,
+                MeetingAssignment.class);
     }
 }

--- a/optaplanner-examples/src/test/java/org/optaplanner/examples/nqueens/score/NQueensConstraintProviderTest.java
+++ b/optaplanner-examples/src/test/java/org/optaplanner/examples/nqueens/score/NQueensConstraintProviderTest.java
@@ -3,8 +3,9 @@ package org.optaplanner.examples.nqueens.score;
 import java.io.IOException;
 import java.io.InputStream;
 
-import org.junit.jupiter.api.Test;
 import org.optaplanner.core.api.score.buildin.simple.SimpleScore;
+import org.optaplanner.examples.common.score.AbstractConstraintProviderTest;
+import org.optaplanner.examples.common.score.ConstraintProviderTest;
 import org.optaplanner.examples.nqueens.domain.Column;
 import org.optaplanner.examples.nqueens.domain.NQueens;
 import org.optaplanner.examples.nqueens.domain.Queen;
@@ -12,10 +13,8 @@ import org.optaplanner.examples.nqueens.domain.Row;
 import org.optaplanner.persistence.xstream.impl.domain.solution.XStreamSolutionFileIO;
 import org.optaplanner.test.api.score.stream.ConstraintVerifier;
 
-class NQueensConstraintProviderTest {
-
-    private final ConstraintVerifier<NQueensConstraintProvider, NQueens> constraintVerifier = ConstraintVerifier
-            .build(new NQueensConstraintProvider(), NQueens.class, Queen.class);
+class NQueensConstraintProviderTest
+        extends AbstractConstraintProviderTest<NQueensConstraintProvider, NQueens> {
 
     private final Row row1 = new Row(0);
     private final Row row2 = new Row(1);
@@ -24,16 +23,16 @@ class NQueensConstraintProviderTest {
     private final Column column2 = new Column(1);
     private final Column column3 = new Column(2);
 
-    @Test
-    void noHorizontalConflictWithOneQueen() {
+    @ConstraintProviderTest
+    void noHorizontalConflictWithOneQueen(ConstraintVerifier<NQueensConstraintProvider, NQueens> constraintVerifier) {
         Queen queen1 = new Queen(0, row1, column1);
         constraintVerifier.verifyThat(NQueensConstraintProvider::horizontalConflict)
                 .given(queen1)
                 .penalizesBy(0);
     }
 
-    @Test
-    void horizontalConflictWithTwoQueens() {
+    @ConstraintProviderTest
+    void horizontalConflictWithTwoQueens(ConstraintVerifier<NQueensConstraintProvider, NQueens> constraintVerifier) {
         Queen queen1 = new Queen(0, row1, column1);
         Queen queen2 = new Queen(1, row1, column2);
         constraintVerifier.verifyThat(NQueensConstraintProvider::horizontalConflict)
@@ -41,8 +40,8 @@ class NQueensConstraintProviderTest {
                 .penalizesBy(1);
     }
 
-    @Test
-    void horizontalConflictWithThreeQueens() {
+    @ConstraintProviderTest
+    void horizontalConflictWithThreeQueens(ConstraintVerifier<NQueensConstraintProvider, NQueens> constraintVerifier) {
         Queen queen1 = new Queen(0, row1, column1);
         Queen queen2 = new Queen(1, row1, column2);
         Queen queen3 = new Queen(2, row1, column3);
@@ -51,16 +50,16 @@ class NQueensConstraintProviderTest {
                 .penalizesBy(3);
     }
 
-    @Test
-    void noAscendingDiagonalConflictWithOneQueen() {
+    @ConstraintProviderTest
+    void noAscendingDiagonalConflictWithOneQueen(ConstraintVerifier<NQueensConstraintProvider, NQueens> constraintVerifier) {
         Queen queen1 = new Queen(0, row1, column1);
         constraintVerifier.verifyThat(NQueensConstraintProvider::ascendingDiagonalConflict)
                 .given(queen1)
                 .penalizesBy(0);
     }
 
-    @Test
-    void ascendingDiagonalConflictWithTwoQueens() {
+    @ConstraintProviderTest
+    void ascendingDiagonalConflictWithTwoQueens(ConstraintVerifier<NQueensConstraintProvider, NQueens> constraintVerifier) {
         Queen queen1 = new Queen(0, row1, column2);
         Queen queen2 = new Queen(1, row2, column1);
         constraintVerifier.verifyThat(NQueensConstraintProvider::ascendingDiagonalConflict)
@@ -68,8 +67,8 @@ class NQueensConstraintProviderTest {
                 .penalizesBy(1);
     }
 
-    @Test
-    void ascendingDiagonalConflictWithThreeQueens() {
+    @ConstraintProviderTest
+    void ascendingDiagonalConflictWithThreeQueens(ConstraintVerifier<NQueensConstraintProvider, NQueens> constraintVerifier) {
         Queen queen1 = new Queen(0, row1, column3);
         Queen queen2 = new Queen(1, row2, column2);
         Queen queen3 = new Queen(2, row3, column1);
@@ -78,16 +77,16 @@ class NQueensConstraintProviderTest {
                 .penalizesBy(3);
     }
 
-    @Test
-    void noDescendingDiagonalConflictWithOneQueen() {
+    @ConstraintProviderTest
+    void noDescendingDiagonalConflictWithOneQueen(ConstraintVerifier<NQueensConstraintProvider, NQueens> constraintVerifier) {
         Queen queen1 = new Queen(0, row1, column1);
         constraintVerifier.verifyThat(NQueensConstraintProvider::descendingDiagonalConflict)
                 .given(queen1)
                 .penalizesBy(0);
     }
 
-    @Test
-    void descendingDiagonalConflictWithTwoQueens() {
+    @ConstraintProviderTest
+    void descendingDiagonalConflictWithTwoQueens(ConstraintVerifier<NQueensConstraintProvider, NQueens> constraintVerifier) {
         Queen queen1 = new Queen(0, row1, column1);
         Queen queen2 = new Queen(1, row2, column2);
         constraintVerifier.verifyThat(NQueensConstraintProvider::descendingDiagonalConflict)
@@ -95,8 +94,8 @@ class NQueensConstraintProviderTest {
                 .penalizesBy(1);
     }
 
-    @Test
-    void descendingDiagonalConflictWithThreeQueens() {
+    @ConstraintProviderTest
+    void descendingDiagonalConflictWithThreeQueens(ConstraintVerifier<NQueensConstraintProvider, NQueens> constraintVerifier) {
         Queen queen1 = new Queen(0, row1, column1);
         Queen queen2 = new Queen(1, row2, column2);
         Queen queen3 = new Queen(2, row3, column3);
@@ -112,15 +111,16 @@ class NQueensConstraintProviderTest {
         }
     }
 
-    @Test
-    void givenSolutionMultipleConstraints() throws IOException {
+    @ConstraintProviderTest
+    void givenSolutionMultipleConstraints(ConstraintVerifier<NQueensConstraintProvider, NQueens> constraintVerifier)
+            throws IOException {
         constraintVerifier.verifyThat()
                 .givenSolution(readSolution("256queensScore-30.xml"))
                 .scores(SimpleScore.of(-30));
     }
 
-    @Test
-    void givenFactsMultipleConstraints() {
+    @ConstraintProviderTest
+    void givenFactsMultipleConstraints(ConstraintVerifier<NQueensConstraintProvider, NQueens> constraintVerifier) {
         Queen queen1 = new Queen(0, row1, column1);
         Queen queen2 = new Queen(1, row2, column2);
         Queen queen3 = new Queen(2, row3, column3);
@@ -129,4 +129,8 @@ class NQueensConstraintProviderTest {
                 .scores(SimpleScore.of(-3));
     }
 
+    @Override
+    protected ConstraintVerifier<NQueensConstraintProvider, NQueens> createConstraintVerifier() {
+        return ConstraintVerifier.build(new NQueensConstraintProvider(), NQueens.class, Queen.class);
+    }
 }

--- a/optaplanner-examples/src/test/java/org/optaplanner/examples/nurserostering/score/NurseRosteringConstraintProviderTest.java
+++ b/optaplanner-examples/src/test/java/org/optaplanner/examples/nurserostering/score/NurseRosteringConstraintProviderTest.java
@@ -6,10 +6,12 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
 
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.optaplanner.examples.common.score.AbstractConstraintProviderTest;
+import org.optaplanner.examples.common.score.ConstraintProviderTest;
 import org.optaplanner.examples.common.util.Pair;
 import org.optaplanner.examples.nurserostering.domain.Employee;
 import org.optaplanner.examples.nurserostering.domain.NurseRoster;
@@ -36,14 +38,12 @@ import org.optaplanner.examples.nurserostering.domain.request.ShiftOffRequest;
 import org.optaplanner.examples.nurserostering.domain.request.ShiftOnRequest;
 import org.optaplanner.test.api.score.stream.ConstraintVerifier;
 
-class NurseRosteringConstraintProviderTest {
-    private final ConstraintVerifier<NurseRosteringConstraintProvider, NurseRoster> constraintVerifier =
-            ConstraintVerifier.build(new NurseRosteringConstraintProvider(), NurseRoster.class,
-                    ShiftAssignment.class);
+class NurseRosteringConstraintProviderTest
+        extends AbstractConstraintProviderTest<NurseRosteringConstraintProvider, NurseRoster> {
 
     private final AtomicLong idSupplier = new AtomicLong(0);
-    private final Map<Pair<Integer, ShiftType>, Shift> indexShiftTypePairToShiftMap = new HashMap<>();
-    private final Map<Integer, ShiftDate> indexToShiftDateMap = new HashMap<>();
+    private final Map<Pair<Integer, ShiftType>, Shift> indexShiftTypePairToShiftMap = new ConcurrentHashMap<>();
+    private final Map<Integer, ShiftDate> indexToShiftDateMap = new ConcurrentHashMap<>();
     private final ShiftType dayShiftType = new ShiftType();
     private final ShiftType nightShiftType = new ShiftType();
 
@@ -68,6 +68,11 @@ class NurseRosteringConstraintProviderTest {
         nightShiftType.setCode("ShiftType - Night");
         nightShiftType.setIndex(1);
         nightShiftType.setDescription("Night Shift");
+    }
+
+    @Override
+    protected ConstraintVerifier<NurseRosteringConstraintProvider, NurseRoster> createConstraintVerifier() {
+        return ConstraintVerifier.build(new NurseRosteringConstraintProvider(), NurseRoster.class, ShiftAssignment.class);
     }
 
     // ******************************************************
@@ -369,8 +374,8 @@ class NurseRosteringConstraintProviderTest {
     // ******************************************************
     // TESTS
     // ******************************************************
-    @Test
-    void oneShiftPerDay() {
+    @ConstraintProviderTest
+    void oneShiftPerDay(ConstraintVerifier<NurseRosteringConstraintProvider, NurseRoster> constraintVerifier) {
         Employee employee = getEmployee();
         ShiftAssignment shift1 = getShiftAssignment(0, employee);
         ShiftAssignment shift2 = getShiftAssignment(0, employee);
@@ -382,8 +387,9 @@ class NurseRosteringConstraintProviderTest {
                 .given(shift1, shift2, shift3, shift4, shift5).penalizesBy(2);
     }
 
-    @Test
-    void minimumAndMaximumNumberOfAssignments() {
+    @ConstraintProviderTest
+    void minimumAndMaximumNumberOfAssignments(
+            ConstraintVerifier<NurseRosteringConstraintProvider, NurseRoster> constraintVerifier) {
         Contract contract = new MinMaxContractBuilder(ContractLineType.TOTAL_ASSIGNMENTS)
                 .withMinimum(2)
                 .withMaximum(3)
@@ -421,8 +427,9 @@ class NurseRosteringConstraintProviderTest {
                 .penalizesBy(0);
     }
 
-    @Test
-    void minimumNumberOfAssignmentsNoAssignments() {
+    @ConstraintProviderTest
+    void minimumNumberOfAssignmentsNoAssignments(
+            ConstraintVerifier<NurseRosteringConstraintProvider, NurseRoster> constraintVerifier) {
         Contract contract = new MinMaxContractBuilder(ContractLineType.TOTAL_ASSIGNMENTS)
                 .withMinimum(2)
                 .withMinimumWeight(5)
@@ -440,8 +447,8 @@ class NurseRosteringConstraintProviderTest {
                 .penalizesBy(10);
     }
 
-    @Test
-    void consecutiveWorkingDays() {
+    @ConstraintProviderTest
+    void consecutiveWorkingDays(ConstraintVerifier<NurseRosteringConstraintProvider, NurseRoster> constraintVerifier) {
         Contract contract = new MinMaxContractBuilder(ContractLineType.CONSECUTIVE_WORKING_DAYS)
                 .withMinimum(2)
                 .withMaximum(3)
@@ -484,8 +491,8 @@ class NurseRosteringConstraintProviderTest {
                 .penalizesBy(0);
     }
 
-    @Test
-    void consecutiveFreeDays() {
+    @ConstraintProviderTest
+    void consecutiveFreeDays(ConstraintVerifier<NurseRosteringConstraintProvider, NurseRoster> constraintVerifier) {
         Contract contract = new MinMaxContractBuilder(ContractLineType.CONSECUTIVE_FREE_DAYS)
                 .withMinimum(2)
                 .withMaximum(3)
@@ -549,8 +556,9 @@ class NurseRosteringConstraintProviderTest {
                 .penalizesBy(12);
     }
 
-    @Test
-    void maximumConsecutiveFreeDaysNoAssignments() {
+    @ConstraintProviderTest
+    void maximumConsecutiveFreeDaysNoAssignments(
+            ConstraintVerifier<NurseRosteringConstraintProvider, NurseRoster> constraintVerifier) {
         Contract contract = new MinMaxContractBuilder(ContractLineType.CONSECUTIVE_FREE_DAYS)
                 .withMaximum(1)
                 .withMaximumWeight(1)
@@ -574,8 +582,8 @@ class NurseRosteringConstraintProviderTest {
                 .penalizesBy(5);
     }
 
-    @Test
-    void consecutiveWorkingWeekends() {
+    @ConstraintProviderTest
+    void consecutiveWorkingWeekends(ConstraintVerifier<NurseRosteringConstraintProvider, NurseRoster> constraintVerifier) {
         Contract contract = new MinMaxContractBuilder(ContractLineType.CONSECUTIVE_WORKING_WEEKENDS)
                 .withMinimum(2)
                 .withMinimumWeight(2)
@@ -622,8 +630,8 @@ class NurseRosteringConstraintProviderTest {
 
     }
 
-    @Test
-    void startOnNotFirstDayOfWeekend() {
+    @ConstraintProviderTest
+    void startOnNotFirstDayOfWeekend(ConstraintVerifier<NurseRosteringConstraintProvider, NurseRoster> constraintVerifier) {
         Contract contract = new BooleanContractBuilder(ContractLineType.COMPLETE_WEEKENDS)
                 .withWeight(3)
                 .build();
@@ -667,8 +675,8 @@ class NurseRosteringConstraintProviderTest {
 
     }
 
-    @Test
-    void endOnNotLastDayOfWeekend() {
+    @ConstraintProviderTest
+    void endOnNotLastDayOfWeekend(ConstraintVerifier<NurseRosteringConstraintProvider, NurseRoster> constraintVerifier) {
         Contract contract = new BooleanContractBuilder(ContractLineType.COMPLETE_WEEKENDS)
                 .withWeight(3)
                 .build();
@@ -712,8 +720,9 @@ class NurseRosteringConstraintProviderTest {
 
     }
 
-    @Test
-    void identicalShiftTypesDuringWeekend() {
+    @ConstraintProviderTest
+    void identicalShiftTypesDuringWeekend(
+            ConstraintVerifier<NurseRosteringConstraintProvider, NurseRoster> constraintVerifier) {
         Contract contract = new BooleanContractBuilder(ContractLineType.IDENTICAL_SHIFT_TYPES_DURING_WEEKEND)
                 .withWeight(3)
                 .build();
@@ -759,8 +768,8 @@ class NurseRosteringConstraintProviderTest {
 
     }
 
-    @Test
-    void dayOffRequest() {
+    @ConstraintProviderTest
+    void dayOffRequest(ConstraintVerifier<NurseRosteringConstraintProvider, NurseRoster> constraintVerifier) {
         Employee employee = getEmployee();
         DayOffRequest dayOffRequest1 = getDayOffRequest(employee, getShiftDate(1), 3);
         DayOffRequest dayOffRequest2 = getDayOffRequest(employee, getShiftDate(3), 5);
@@ -791,8 +800,8 @@ class NurseRosteringConstraintProviderTest {
                 .penalizesBy(0);
     }
 
-    @Test
-    void dayOnRequest() {
+    @ConstraintProviderTest
+    void dayOnRequest(ConstraintVerifier<NurseRosteringConstraintProvider, NurseRoster> constraintVerifier) {
         Employee employee = getEmployee();
         DayOnRequest dayOnRequest1 = getDayOnRequest(employee, getShiftDate(1), 3);
         DayOnRequest dayOnRequest2 = getDayOnRequest(employee, getShiftDate(3), 5);
@@ -823,8 +832,8 @@ class NurseRosteringConstraintProviderTest {
                 .penalizesBy(8);
     }
 
-    @Test
-    void shiftOffRequest() {
+    @ConstraintProviderTest
+    void shiftOffRequest(ConstraintVerifier<NurseRosteringConstraintProvider, NurseRoster> constraintVerifier) {
         Employee employee = getEmployee();
         ShiftAssignment shift1Day = getShiftAssignment(1, employee, dayShiftType);
         ShiftAssignment shift1Night = getShiftAssignment(1, employee, nightShiftType);
@@ -860,8 +869,8 @@ class NurseRosteringConstraintProviderTest {
                 .penalizesBy(0);
     }
 
-    @Test
-    void shiftOnRequest() {
+    @ConstraintProviderTest
+    void shiftOnRequest(ConstraintVerifier<NurseRosteringConstraintProvider, NurseRoster> constraintVerifier) {
         Employee employee = getEmployee();
         ShiftAssignment shift1Day = getShiftAssignment(1, employee, dayShiftType);
         ShiftAssignment shift1Night = getShiftAssignment(1, employee, nightShiftType);
@@ -897,8 +906,8 @@ class NurseRosteringConstraintProviderTest {
                 .penalizesBy(8);
     }
 
-    @Test
-    void alternativeSkill() {
+    @ConstraintProviderTest
+    void alternativeSkill(ConstraintVerifier<NurseRosteringConstraintProvider, NurseRoster> constraintVerifier) {
         Contract contract = new BooleanContractBuilder(ContractLineType.ALTERNATIVE_SKILL_CATEGORY)
                 .withWeight(3)
                 .build();
@@ -936,8 +945,9 @@ class NurseRosteringConstraintProviderTest {
                 .penalizesBy(6);
     }
 
-    @Test
-    void unwantedPatternFreeBefore2DaysWithAWorkDayPattern() {
+    @ConstraintProviderTest
+    void unwantedPatternFreeBefore2DaysWithAWorkDayPattern(
+            ConstraintVerifier<NurseRosteringConstraintProvider, NurseRoster> constraintVerifier) {
         Pair<PatternContractLine, Contract> patternContractPair = new PatternContractBuilder()
                 .freeBefore2DaysWithAWorkDay(DayOfWeek.WEDNESDAY)
                 .build();
@@ -993,8 +1003,9 @@ class NurseRosteringConstraintProviderTest {
                 .penalizesBy(0);
     }
 
-    @Test
-    void unwantedPatternShiftType2DaysPattern() {
+    @ConstraintProviderTest
+    void unwantedPatternShiftType2DaysPattern(
+            ConstraintVerifier<NurseRosteringConstraintProvider, NurseRoster> constraintVerifier) {
         Pair<PatternContractLine, Contract> patternContractPair = new PatternContractBuilder()
                 .shiftType2DaysPattern(dayShiftType, nightShiftType)
                 .build();
@@ -1046,8 +1057,9 @@ class NurseRosteringConstraintProviderTest {
 
     }
 
-    @Test
-    void unwantedPatternShiftType2DaysPatternNullSecondShiftType() {
+    @ConstraintProviderTest
+    void unwantedPatternShiftType2DaysPatternNullSecondShiftType(
+            ConstraintVerifier<NurseRosteringConstraintProvider, NurseRoster> constraintVerifier) {
         Pair<PatternContractLine, Contract> patternContractPair = new PatternContractBuilder()
                 .shiftType2DaysPattern(dayShiftType, null)
                 .build();
@@ -1099,8 +1111,9 @@ class NurseRosteringConstraintProviderTest {
 
     }
 
-    @Test
-    void unwantedPatternShiftType3DaysPattern() {
+    @ConstraintProviderTest
+    void unwantedPatternShiftType3DaysPattern(
+            ConstraintVerifier<NurseRosteringConstraintProvider, NurseRoster> constraintVerifier) {
         Pair<PatternContractLine, Contract> patternContractPair = new PatternContractBuilder()
                 .shiftType3DaysPattern(dayShiftType, nightShiftType, nightShiftType)
                 .build();

--- a/optaplanner-examples/src/test/java/org/optaplanner/examples/pas/score/PatientAdmissionScheduleConstraintProviderTest.java
+++ b/optaplanner-examples/src/test/java/org/optaplanner/examples/pas/score/PatientAdmissionScheduleConstraintProviderTest.java
@@ -3,12 +3,13 @@ package org.optaplanner.examples.pas.score;
 import java.util.function.BiFunction;
 import java.util.stream.Stream;
 
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.optaplanner.core.api.score.stream.Constraint;
 import org.optaplanner.core.api.score.stream.ConstraintFactory;
+import org.optaplanner.examples.common.score.AbstractConstraintProviderTest;
+import org.optaplanner.examples.common.score.ConstraintProviderTest;
 import org.optaplanner.examples.pas.domain.AdmissionPart;
 import org.optaplanner.examples.pas.domain.Bed;
 import org.optaplanner.examples.pas.domain.BedDesignation;
@@ -28,7 +29,8 @@ import org.optaplanner.examples.pas.domain.RoomSpecialism;
 import org.optaplanner.examples.pas.domain.Specialism;
 import org.optaplanner.test.api.score.stream.ConstraintVerifier;
 
-class PatientAdmissionScheduleConstraintProviderTest {
+class PatientAdmissionScheduleConstraintProviderTest
+        extends AbstractConstraintProviderTest<PatientAdmissionScheduleConstraintProvider, PatientAdmissionSchedule> {
 
     private static final Night ZERO_NIGHT = new Night(0);
     private static final Night FIVE_NIGHT = new Night(5);
@@ -40,7 +42,7 @@ class PatientAdmissionScheduleConstraintProviderTest {
                     .build(new PatientAdmissionScheduleConstraintProvider(), PatientAdmissionSchedule.class,
                             BedDesignation.class);
 
-    private static Stream genderLimitationsProvider() {
+    private static Stream<Arguments> genderLimitationsProvider() {
         return Stream.of(
                 Arguments.of(Gender.FEMALE, GenderLimitation.MALE_ONLY,
                         (BiFunction<PatientAdmissionScheduleConstraintProvider, ConstraintFactory, Constraint>) PatientAdmissionScheduleConstraintProvider::femaleInMaleRoomConstraint),
@@ -48,7 +50,7 @@ class PatientAdmissionScheduleConstraintProviderTest {
                         (BiFunction<PatientAdmissionScheduleConstraintProvider, ConstraintFactory, Constraint>) PatientAdmissionScheduleConstraintProvider::maleInFemaleRoomConstraint));
     }
 
-    private static Stream departmentAgeLimitationProvider() {
+    private static Stream<Arguments> departmentAgeLimitationProvider() {
         Department adultDepartment = new Department();
         adultDepartment.setMinimumAge(18);
         adultDepartment.setId(1L);
@@ -64,10 +66,11 @@ class PatientAdmissionScheduleConstraintProviderTest {
                         (BiFunction<PatientAdmissionScheduleConstraintProvider, ConstraintFactory, Constraint>) PatientAdmissionScheduleConstraintProvider::departmentMaximumAgeConstraint));
     }
 
-    @ParameterizedTest
+    // Not using @ConstraintProviderTest as it does not mix with custom parameters.
+    @ParameterizedTest(name = "gender = {0}, limitation = {1}")
     @MethodSource("genderLimitationsProvider")
     void genderRoomLimitationConstraintTest(Gender gender, GenderLimitation genderLimitation,
-            BiFunction constraintFunction) {
+            BiFunction<PatientAdmissionScheduleConstraintProvider, ConstraintFactory, Constraint> constraintFunction) {
 
         Room room = new Room();
         room.setGenderLimitation(genderLimitation);
@@ -86,8 +89,9 @@ class PatientAdmissionScheduleConstraintProviderTest {
                 .penalizesBy(6);
     }
 
-    @Test
-    void sameBedInSameNightConstraintTest() {
+    @ConstraintProviderTest
+    void sameBedInSameNightConstraintTest(
+            ConstraintVerifier<PatientAdmissionScheduleConstraintProvider, PatientAdmissionSchedule> constraintVerifier) {
 
         Patient patient = new Patient();
         Bed bed = new Bed();
@@ -102,9 +106,11 @@ class PatientAdmissionScheduleConstraintProviderTest {
                 .penalizesBy(6);
     }
 
-    @ParameterizedTest
+    // Not using @ConstraintProviderTest as it does not mix with custom parameters.
+    @ParameterizedTest(name = "department = {0}, patientAge = {1}")
     @MethodSource("departmentAgeLimitationProvider")
-    void departmentAgeLimitationConstraintTest(Department department, int patientAge, BiFunction constraintFunction) {
+    void departmentAgeLimitationConstraintTest(Department department, int patientAge,
+            BiFunction<PatientAdmissionScheduleConstraintProvider, ConstraintFactory, Constraint> constraintFunction) {
 
         Room room = new Room();
         room.setDepartment(department);
@@ -123,8 +129,9 @@ class PatientAdmissionScheduleConstraintProviderTest {
                 .penalizesBy(6);
     }
 
-    @Test
-    void requiredPatientEquipmentConstraintTest() {
+    @ConstraintProviderTest
+    void requiredPatientEquipmentConstraintTest(
+            ConstraintVerifier<PatientAdmissionScheduleConstraintProvider, PatientAdmissionSchedule> constraintVerifier) {
 
         Patient patient = new Patient();
         Room room = new Room();
@@ -156,8 +163,9 @@ class PatientAdmissionScheduleConstraintProviderTest {
                 .penalizesBy(6);
     }
 
-    @Test
-    void differentGenderInSameGenderRoomInSameNightConstraintTest() {
+    @ConstraintProviderTest
+    void differentGenderInSameGenderRoomInSameNightConstraintTest(
+            ConstraintVerifier<PatientAdmissionScheduleConstraintProvider, PatientAdmissionSchedule> constraintVerifier) {
 
         Room room = new Room();
         room.setGenderLimitation(GenderLimitation.SAME_GENDER);
@@ -188,8 +196,9 @@ class PatientAdmissionScheduleConstraintProviderTest {
                 .penalizesBy(6);
     }
 
-    @Test
-    void assignEveryPatientToABedConstraintTest() {
+    @ConstraintProviderTest
+    void assignEveryPatientToABedConstraintTest(
+            ConstraintVerifier<PatientAdmissionScheduleConstraintProvider, PatientAdmissionSchedule> constraintVerifier) {
 
         Patient patient = new Patient();
 
@@ -202,8 +211,9 @@ class PatientAdmissionScheduleConstraintProviderTest {
                 .penalizesBy(6);
     }
 
-    @Test()
-    void preferredMaximumRoomCapacityConstraintTest() {
+    @ConstraintProviderTest()
+    void preferredMaximumRoomCapacityConstraintTest(
+            ConstraintVerifier<PatientAdmissionScheduleConstraintProvider, PatientAdmissionSchedule> constraintVerifier) {
 
         Patient patientWithRoomPreferences = new Patient();
         patientWithRoomPreferences.setPreferredMaximumRoomCapacity(3);
@@ -223,8 +233,9 @@ class PatientAdmissionScheduleConstraintProviderTest {
                 .penalizesBy(6);
     }
 
-    @Test
-    void preferredPatientEquipmentConstraintTest() {
+    @ConstraintProviderTest
+    void preferredPatientEquipmentConstraintTest(
+            ConstraintVerifier<PatientAdmissionScheduleConstraintProvider, PatientAdmissionSchedule> constraintVerifier) {
 
         Patient patient = new Patient();
 
@@ -256,8 +267,9 @@ class PatientAdmissionScheduleConstraintProviderTest {
                 .penalizesBy(6);
     }
 
-    @Test
-    void departmentSpecialismConstraintTest() {
+    @ConstraintProviderTest
+    void departmentSpecialismConstraintTest(
+            ConstraintVerifier<PatientAdmissionScheduleConstraintProvider, PatientAdmissionSchedule> constraintVerifier) {
 
         Patient patient = new Patient();
 
@@ -291,8 +303,9 @@ class PatientAdmissionScheduleConstraintProviderTest {
                 .penalizesBy(6);
     }
 
-    @Test
-    void roomSpecialismConstraintTest() {
+    @ConstraintProviderTest
+    void roomSpecialismConstraintTest(
+            ConstraintVerifier<PatientAdmissionScheduleConstraintProvider, PatientAdmissionSchedule> constraintVerifier) {
 
         Patient patient = new Patient();
 
@@ -319,8 +332,9 @@ class PatientAdmissionScheduleConstraintProviderTest {
                 .penalizesBy(6);
     }
 
-    @Test
-    void roomSpecialismNotFirstPriorityConstraintConstraintTest() {
+    @ConstraintProviderTest
+    void roomSpecialismNotFirstPriorityConstraintConstraintTest(
+            ConstraintVerifier<PatientAdmissionScheduleConstraintProvider, PatientAdmissionSchedule> constraintVerifier) {
 
         Patient patient = new Patient();
 
@@ -346,5 +360,12 @@ class PatientAdmissionScheduleConstraintProviderTest {
         constraintVerifier.verifyThat(PatientAdmissionScheduleConstraintProvider::roomSpecialismNotFirstPriorityConstraint)
                 .given(designationWithRoomSpecialism1, designationWithRoomSpecialism2, roomSpecialism)
                 .penalizesBy(6);
+    }
+
+    @Override
+    protected ConstraintVerifier<PatientAdmissionScheduleConstraintProvider, PatientAdmissionSchedule>
+            createConstraintVerifier() {
+        return ConstraintVerifier.build(new PatientAdmissionScheduleConstraintProvider(), PatientAdmissionSchedule.class,
+                BedDesignation.class);
     }
 }

--- a/optaplanner-examples/src/test/java/org/optaplanner/examples/tennis/score/TennisConstraintProviderTest.java
+++ b/optaplanner-examples/src/test/java/org/optaplanner/examples/tennis/score/TennisConstraintProviderTest.java
@@ -1,6 +1,7 @@
 package org.optaplanner.examples.tennis.score;
 
-import org.junit.jupiter.api.Test;
+import org.optaplanner.examples.common.score.AbstractConstraintProviderTest;
+import org.optaplanner.examples.common.score.ConstraintProviderTest;
 import org.optaplanner.examples.tennis.domain.Day;
 import org.optaplanner.examples.tennis.domain.Team;
 import org.optaplanner.examples.tennis.domain.TeamAssignment;
@@ -8,7 +9,8 @@ import org.optaplanner.examples.tennis.domain.TennisSolution;
 import org.optaplanner.examples.tennis.domain.UnavailabilityPenalty;
 import org.optaplanner.test.api.score.stream.ConstraintVerifier;
 
-class TennisConstraintProviderTest {
+class TennisConstraintProviderTest
+        extends AbstractConstraintProviderTest<TennisConstraintProvider, TennisSolution> {
 
     private static final Day DAY0 = new Day(0, 0);
     private static final Day DAY1 = new Day(1, 1);
@@ -17,11 +19,8 @@ class TennisConstraintProviderTest {
     private static final Team TEAM1 = new Team(1, "B");
     private static final Team TEAM2 = new Team(2, "C");
 
-    private final ConstraintVerifier<TennisConstraintProvider, TennisSolution> constraintVerifier =
-            ConstraintVerifier.build(new TennisConstraintProvider(), TennisSolution.class, TeamAssignment.class);
-
-    @Test
-    void oneAssignmentPerDayPerTeam() {
+    @ConstraintProviderTest
+    void oneAssignmentPerDayPerTeam(ConstraintVerifier<TennisConstraintProvider, TennisSolution> constraintVerifier) {
         TeamAssignment assignment1 = new TeamAssignment(0, DAY0, 0);
         assignment1.setTeam(TEAM0);
         TeamAssignment assignment2 = new TeamAssignment(1, DAY0, 1);
@@ -38,8 +37,8 @@ class TennisConstraintProviderTest {
                 .penalizesBy(3); // TEAM0 by 2, TEAM1 by 1.
     }
 
-    @Test
-    void unavailabilityPenalty() {
+    @ConstraintProviderTest
+    void unavailabilityPenalty(ConstraintVerifier<TennisConstraintProvider, TennisSolution> constraintVerifier) {
         TeamAssignment assignment1 = new TeamAssignment(0, DAY0, 0);
         assignment1.setTeam(TEAM0);
         TeamAssignment assignment2 = new TeamAssignment(1, DAY1, 0);
@@ -57,8 +56,8 @@ class TennisConstraintProviderTest {
                 .penalizesBy(2); // TEAM0 by 1, TEAM1 by 1.
     }
 
-    @Test
-    void fairAssignmentCountPerTeam() {
+    @ConstraintProviderTest
+    void fairAssignmentCountPerTeam(ConstraintVerifier<TennisConstraintProvider, TennisSolution> constraintVerifier) {
         TeamAssignment assignment1 = new TeamAssignment(0, DAY0, 0);
         assignment1.setTeam(TEAM0);
         TeamAssignment assignment2 = new TeamAssignment(1, DAY1, 0);
@@ -77,8 +76,8 @@ class TennisConstraintProviderTest {
                 .penalizesBy(2449);
     }
 
-    @Test
-    void evenlyConfrontationCount() {
+    @ConstraintProviderTest
+    void evenlyConfrontationCount(ConstraintVerifier<TennisConstraintProvider, TennisSolution> constraintVerifier) {
         TeamAssignment assignment1 = new TeamAssignment(0, DAY0, 0);
         assignment1.setTeam(TEAM0);
         TeamAssignment assignment2 = new TeamAssignment(1, DAY0, 0);
@@ -97,4 +96,8 @@ class TennisConstraintProviderTest {
                 .penalizesBy(3000);
     }
 
+    @Override
+    protected ConstraintVerifier<TennisConstraintProvider, TennisSolution> createConstraintVerifier() {
+        return ConstraintVerifier.build(new TennisConstraintProvider(), TennisSolution.class, TeamAssignment.class);
+    }
 }

--- a/optaplanner-examples/src/test/java/org/optaplanner/examples/vehiclerouting/score/VehicleRoutingConstraintProviderTest.java
+++ b/optaplanner-examples/src/test/java/org/optaplanner/examples/vehiclerouting/score/VehicleRoutingConstraintProviderTest.java
@@ -1,6 +1,7 @@
 package org.optaplanner.examples.vehiclerouting.score;
 
-import org.junit.jupiter.api.Test;
+import org.optaplanner.examples.common.score.AbstractConstraintProviderTest;
+import org.optaplanner.examples.common.score.ConstraintProviderTest;
 import org.optaplanner.examples.vehiclerouting.domain.Customer;
 import org.optaplanner.examples.vehiclerouting.domain.Depot;
 import org.optaplanner.examples.vehiclerouting.domain.Standstill;
@@ -12,18 +13,16 @@ import org.optaplanner.examples.vehiclerouting.domain.timewindowed.TimeWindowedC
 import org.optaplanner.examples.vehiclerouting.domain.timewindowed.TimeWindowedDepot;
 import org.optaplanner.test.api.score.stream.ConstraintVerifier;
 
-class VehicleRoutingConstraintProviderTest {
-
-    private final ConstraintVerifier<VehicleRoutingConstraintProvider, VehicleRoutingSolution> constraintVerifier =
-            ConstraintVerifier.build(new VehicleRoutingConstraintProvider(), VehicleRoutingSolution.class, Standstill.class,
-                    Customer.class, TimeWindowedCustomer.class);
+class VehicleRoutingConstraintProviderTest
+        extends AbstractConstraintProviderTest<VehicleRoutingConstraintProvider, VehicleRoutingSolution> {
 
     private final Location location1 = new AirLocation(1L, 0.0, 0.0);
     private final Location location2 = new AirLocation(2L, 0.0, 4.0);
     private final Location location3 = new AirLocation(3L, 3.0, 0.0);
 
-    @Test
-    void vehicleCapacityUnpenalized() {
+    @ConstraintProviderTest
+    void vehicleCapacityUnpenalized(
+            ConstraintVerifier<VehicleRoutingConstraintProvider, VehicleRoutingSolution> constraintVerifier) {
         Vehicle vehicleA = new Vehicle(1L, 100, new Depot(1L, location1));
         Customer customer1 = new Customer(2L, location2, 80);
         customer1.setPreviousStandstill(vehicleA);
@@ -35,8 +34,9 @@ class VehicleRoutingConstraintProviderTest {
                 .penalizesBy(0);
     }
 
-    @Test
-    void vehicleCapacityPenalized() {
+    @ConstraintProviderTest
+    void vehicleCapacityPenalized(
+            ConstraintVerifier<VehicleRoutingConstraintProvider, VehicleRoutingSolution> constraintVerifier) {
         Vehicle vehicleA = new Vehicle(1L, 100, new Depot(1L, location1));
         Customer customer1 = new Customer(2L, location2, 80);
         customer1.setPreviousStandstill(vehicleA);
@@ -52,8 +52,9 @@ class VehicleRoutingConstraintProviderTest {
                 .penalizesBy(20);
     }
 
-    @Test
-    void distanceToPreviousStandstill() {
+    @ConstraintProviderTest
+    void distanceToPreviousStandstill(
+            ConstraintVerifier<VehicleRoutingConstraintProvider, VehicleRoutingSolution> constraintVerifier) {
         Vehicle vehicleA = new Vehicle(1L, 100, new Depot(1L, location1));
         Customer customer1 = new Customer(2L, location2, 80);
         customer1.setPreviousStandstill(vehicleA);
@@ -69,8 +70,9 @@ class VehicleRoutingConstraintProviderTest {
                 .penalizesBy(9000L);
     }
 
-    @Test
-    void distanceFromLastCustomerToDepot() {
+    @ConstraintProviderTest
+    void distanceFromLastCustomerToDepot(
+            ConstraintVerifier<VehicleRoutingConstraintProvider, VehicleRoutingSolution> constraintVerifier) {
         Vehicle vehicleA = new Vehicle(1L, 100, new Depot(1L, location1));
         Customer customer1 = new Customer(2L, location2, 80);
         customer1.setPreviousStandstill(vehicleA);
@@ -86,8 +88,8 @@ class VehicleRoutingConstraintProviderTest {
                 .penalizesBy(3000L);
     }
 
-    @Test
-    void arrivalAfterDueTime() {
+    @ConstraintProviderTest
+    void arrivalAfterDueTime(ConstraintVerifier<VehicleRoutingConstraintProvider, VehicleRoutingSolution> constraintVerifier) {
         Vehicle vehicleA = new Vehicle(1L, 100, new TimeWindowedDepot(1L, location1, 8_00_00L, 18_00_00L));
         TimeWindowedCustomer customer1 = new TimeWindowedCustomer(2L, location2, 1, 8_00_00L, 18_00_00L, 1_00_00L);
         customer1.setPreviousStandstill(vehicleA);
@@ -105,4 +107,9 @@ class VehicleRoutingConstraintProviderTest {
                 .penalizesBy(90_00L);
     }
 
+    @Override
+    protected ConstraintVerifier<VehicleRoutingConstraintProvider, VehicleRoutingSolution> createConstraintVerifier() {
+        return ConstraintVerifier.build(new VehicleRoutingConstraintProvider(), VehicleRoutingSolution.class, Standstill.class,
+                Customer.class, TimeWindowedCustomer.class);
+    }
 }

--- a/optaplanner-test/src/main/java/org/optaplanner/test/api/score/stream/ConstraintVerifier.java
+++ b/optaplanner-test/src/main/java/org/optaplanner/test/api/score/stream/ConstraintVerifier.java
@@ -16,6 +16,12 @@ import org.optaplanner.core.config.util.ConfigUtils;
 import org.optaplanner.core.impl.domain.solution.descriptor.SolutionDescriptor;
 import org.optaplanner.test.impl.score.stream.DefaultConstraintVerifier;
 
+/**
+ * Implementations of this class must be thread-safe, in order to enable parallel test execution.
+ *
+ * @param <ConstraintProvider_>
+ * @param <Solution_>
+ */
 public interface ConstraintVerifier<ConstraintProvider_ extends ConstraintProvider, Solution_> {
 
     /**

--- a/optaplanner-test/src/main/java/org/optaplanner/test/api/score/stream/ConstraintVerifier.java
+++ b/optaplanner-test/src/main/java/org/optaplanner/test/api/score/stream/ConstraintVerifier.java
@@ -17,7 +17,7 @@ import org.optaplanner.core.impl.domain.solution.descriptor.SolutionDescriptor;
 import org.optaplanner.test.impl.score.stream.DefaultConstraintVerifier;
 
 /**
- * Implementations of this class must be thread-safe, in order to enable parallel test execution.
+ * Implementations must be thread-safe, in order to enable parallel test execution.
  *
  * @param <ConstraintProvider_>
  * @param <Solution_>

--- a/optaplanner-test/src/main/java/org/optaplanner/test/impl/score/stream/ConfiguredConstraintVerifier.java
+++ b/optaplanner-test/src/main/java/org/optaplanner/test/impl/score/stream/ConfiguredConstraintVerifier.java
@@ -1,0 +1,81 @@
+package org.optaplanner.test.impl.score.stream;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.UUID;
+import java.util.function.BiFunction;
+
+import org.optaplanner.constraint.streams.common.AbstractConstraintStreamScoreDirectorFactory;
+import org.optaplanner.core.api.score.Score;
+import org.optaplanner.core.api.score.stream.Constraint;
+import org.optaplanner.core.api.score.stream.ConstraintFactory;
+import org.optaplanner.core.api.score.stream.ConstraintProvider;
+import org.optaplanner.core.api.score.stream.ConstraintStreamImplType;
+import org.optaplanner.core.impl.domain.solution.descriptor.SolutionDescriptor;
+
+/**
+ * Represents a {@link org.optaplanner.test.api.score.stream.ConstraintVerifier} with pre-set values
+ * for {@link #getConstraintStreamImplType()} and {@link #getDroolsAlphaNetworkCompilationEnabled()}.
+ * A new instance of this class will be created should either of these change.
+ *
+ * <p>
+ * This class still needs to be thread-safe,
+ * as it handles {@link java.util.ServiceLoader} and score director factories.
+ *
+ * @param <ConstraintProvider_>
+ * @param <Solution_>
+ * @param <Score_>
+ */
+final class ConfiguredConstraintVerifier<ConstraintProvider_ extends ConstraintProvider, Solution_, Score_ extends Score<Score_>> {
+
+    /**
+     * Exists so that people can not, even by accident, pick the same constraint ID as the default cache key.
+     */
+    private final String defaultScoreDirectorFactoryMapKey = UUID.randomUUID().toString();
+
+    private final ConstraintProvider_ constraintProvider;
+    /**
+     * {@link java.util.ServiceLoader} is sensitive to classloaders.
+     * Therefore we ensure that all SPI operations are bound to the current thread's classloader.
+     * This also allows us to avoid thread safety concerns in the {@link ScoreDirectorFactoryCache}.
+     */
+    @SuppressWarnings("java:S5164") // Suppress SonarCloud warning; this is safe in the context of tests.
+    private final ThreadLocal<ScoreDirectorFactoryCache<ConstraintProvider_, Solution_, Score_>> scoreDirectorFactoryContainerThreadLocal;
+
+    private final ConstraintStreamImplType constraintStreamImplType;
+    private final boolean droolsAlphaNetworkCompilationEnabled;
+
+    public ConfiguredConstraintVerifier(ConstraintProvider_ constraintProvider,
+            SolutionDescriptor<Solution_> solutionDescriptor, ConstraintStreamImplType constraintStreamImplType,
+            boolean droolsAlphaNetworkCompilationEnabled) {
+        this.constraintProvider = constraintProvider;
+        this.scoreDirectorFactoryContainerThreadLocal =
+                ThreadLocal.withInitial(() -> new ScoreDirectorFactoryCache<>(this, solutionDescriptor));
+        this.constraintStreamImplType = constraintStreamImplType;
+        this.droolsAlphaNetworkCompilationEnabled = droolsAlphaNetworkCompilationEnabled;
+    }
+
+    public ConstraintStreamImplType getConstraintStreamImplType() {
+        return constraintStreamImplType;
+    }
+
+    public boolean getDroolsAlphaNetworkCompilationEnabled() {
+        return droolsAlphaNetworkCompilationEnabled;
+    }
+
+    public DefaultSingleConstraintVerification<Solution_, Score_> verifyThat(
+            BiFunction<ConstraintProvider_, ConstraintFactory, Constraint> constraintFunction) {
+        requireNonNull(constraintFunction);
+        AbstractConstraintStreamScoreDirectorFactory<Solution_, Score_> scoreDirectorFactory =
+                scoreDirectorFactoryContainerThreadLocal.get().getScoreDirectorFactory(constraintFunction, constraintProvider);
+        return new DefaultSingleConstraintVerification<>(scoreDirectorFactory);
+    }
+
+    public DefaultMultiConstraintVerification<Solution_, Score_> verifyThat() {
+        AbstractConstraintStreamScoreDirectorFactory<Solution_, Score_> scoreDirectorFactory =
+                scoreDirectorFactoryContainerThreadLocal.get()
+                        .getScoreDirectorFactory(defaultScoreDirectorFactoryMapKey, constraintProvider);
+        return new DefaultMultiConstraintVerification<>(scoreDirectorFactory, constraintProvider);
+    }
+
+}

--- a/optaplanner-test/src/main/java/org/optaplanner/test/impl/score/stream/DefaultConstraintVerifier.java
+++ b/optaplanner-test/src/main/java/org/optaplanner/test/impl/score/stream/DefaultConstraintVerifier.java
@@ -26,14 +26,15 @@ import org.optaplanner.test.api.score.stream.ConstraintVerifier;
 public final class DefaultConstraintVerifier<ConstraintProvider_ extends ConstraintProvider, Solution_, Score_ extends Score<Score_>>
         implements ConstraintVerifier<ConstraintProvider_, Solution_> {
 
-    private final ServiceLoader<ScoreDirectorFactoryService> serviceLoader;
+    private final ServiceLoader<ScoreDirectorFactoryService<Solution_, Score_>> serviceLoader;
     private final ConstraintProvider_ constraintProvider;
     private final SolutionDescriptor<Solution_> solutionDescriptor;
     private ConstraintStreamImplType constraintStreamImplType;
     private Boolean droolsAlphaNetworkCompilationEnabled;
 
     public DefaultConstraintVerifier(ConstraintProvider_ constraintProvider, SolutionDescriptor<Solution_> solutionDescriptor) {
-        this.serviceLoader = ServiceLoader.load(ScoreDirectorFactoryService.class);
+        ServiceLoader uncastServiceLoader = ServiceLoader.load(ScoreDirectorFactoryService.class);
+        this.serviceLoader = uncastServiceLoader;
         this.constraintProvider = constraintProvider;
         this.solutionDescriptor = solutionDescriptor;
     }

--- a/optaplanner-test/src/main/java/org/optaplanner/test/impl/score/stream/DefaultConstraintVerifier.java
+++ b/optaplanner-test/src/main/java/org/optaplanner/test/impl/score/stream/DefaultConstraintVerifier.java
@@ -1,23 +1,12 @@
 package org.optaplanner.test.impl.score.stream;
 
 import static java.util.Objects.requireNonNull;
-import static org.optaplanner.core.api.score.stream.ConstraintStreamImplType.DROOLS;
 
-import java.util.Comparator;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 import java.util.Objects;
-import java.util.ServiceLoader;
 import java.util.UUID;
-import java.util.concurrent.locks.Lock;
-import java.util.concurrent.locks.ReadWriteLock;
-import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.function.BiFunction;
-import java.util.stream.Collectors;
 
 import org.optaplanner.constraint.streams.common.AbstractConstraintStreamScoreDirectorFactory;
-import org.optaplanner.constraint.streams.common.AbstractConstraintStreamScoreDirectorFactoryService;
 import org.optaplanner.core.api.score.Score;
 import org.optaplanner.core.api.score.stream.Constraint;
 import org.optaplanner.core.api.score.stream.ConstraintFactory;
@@ -25,8 +14,6 @@ import org.optaplanner.core.api.score.stream.ConstraintProvider;
 import org.optaplanner.core.api.score.stream.ConstraintStreamImplType;
 import org.optaplanner.core.config.util.ConfigUtils;
 import org.optaplanner.core.impl.domain.solution.descriptor.SolutionDescriptor;
-import org.optaplanner.core.impl.score.director.ScoreDirectorFactoryService;
-import org.optaplanner.core.impl.score.director.ScoreDirectorType;
 import org.optaplanner.test.api.score.stream.ConstraintVerifier;
 
 public final class DefaultConstraintVerifier<ConstraintProvider_ extends ConstraintProvider, Solution_, Score_ extends Score<Score_>>
@@ -36,30 +23,23 @@ public final class DefaultConstraintVerifier<ConstraintProvider_ extends Constra
      * Exists so that people can not, even by accident, pick the same constraint ID as the default map key.
      */
     private final String defaultScoreDirectorFactoryMapKey = UUID.randomUUID().toString();
-    private final Map<String, AbstractConstraintStreamScoreDirectorFactory<Solution_, Score_>> scoreDirectorFactoryMap =
-            new HashMap<>();
 
-    private final ServiceLoader<ScoreDirectorFactoryService<Solution_, Score_>> serviceLoader;
     private final ConstraintProvider_ constraintProvider;
-    private final SolutionDescriptor<Solution_> solutionDescriptor;
-    private final Lock scoreDirectorFactoryMapReadLock;
-    private final Lock scoreDirectorFactoryMapWriteLock;
+    /**
+     * {@link java.util.ServiceLoader} is sensitive to classloaders.
+     * Therefore we ensure that all SPI operations are bound to the current thread's classloader.
+     * This also allows us to avoid thread safety concerns in the {@link ScoreDirectorFactoryCache}.
+     */
+    private final ThreadLocal<ScoreDirectorFactoryCache<ConstraintProvider_, Solution_, Score_>> scoreDirectorFactoryContainerThreadLocal;
 
-    private ConstraintStreamImplType constraintStreamImplType;
-    private Boolean droolsAlphaNetworkCompilationEnabled;
+    // Need to be volatile as they will be accessed from the thread-local score director factory cache.
+    private volatile ConstraintStreamImplType constraintStreamImplType;
+    private volatile Boolean droolsAlphaNetworkCompilationEnabled;
 
     public DefaultConstraintVerifier(ConstraintProvider_ constraintProvider, SolutionDescriptor<Solution_> solutionDescriptor) {
-        ServiceLoader uncastServiceLoader = ServiceLoader.load(ScoreDirectorFactoryService.class);
-        this.serviceLoader = uncastServiceLoader;
         this.constraintProvider = constraintProvider;
-        this.solutionDescriptor = solutionDescriptor;
-        /*
-         * Creating score director factory is expensive and possibly not thread-safe.
-         * We want to make sure these operations are mutually exclusive.
-         */
-        ReadWriteLock readWriteLock = new ReentrantReadWriteLock();
-        this.scoreDirectorFactoryMapReadLock = readWriteLock.readLock();
-        this.scoreDirectorFactoryMapWriteLock = readWriteLock.writeLock();
+        this.scoreDirectorFactoryContainerThreadLocal =
+                ThreadLocal.withInitial(() -> new ScoreDirectorFactoryCache<>(this, solutionDescriptor));
     }
 
     public ConstraintStreamImplType getConstraintStreamImplType() {
@@ -71,17 +51,11 @@ public final class DefaultConstraintVerifier<ConstraintProvider_ extends Constra
             ConstraintStreamImplType constraintStreamImplType) {
         requireNonNull(constraintStreamImplType);
         this.constraintStreamImplType = constraintStreamImplType;
-        clearScoreDirectorFactoryMap();
         return this;
     }
 
-    private void clearScoreDirectorFactoryMap() {
-        scoreDirectorFactoryMapWriteLock.lock();
-        try {
-            this.scoreDirectorFactoryMap.clear(); // All score director factories are invalidated.
-        } finally {
-            scoreDirectorFactoryMapWriteLock.unlock();
-        }
+    public Boolean getDroolsAlphaNetworkCompilationEnabled() {
+        return droolsAlphaNetworkCompilationEnabled;
     }
 
     public boolean isDroolsAlphaNetworkCompilationEnabled() {
@@ -92,7 +66,6 @@ public final class DefaultConstraintVerifier<ConstraintProvider_ extends Constra
     public ConstraintVerifier<ConstraintProvider_, Solution_> withDroolsAlphaNetworkCompilationEnabled(
             boolean droolsAlphaNetworkCompilationEnabled) {
         this.droolsAlphaNetworkCompilationEnabled = droolsAlphaNetworkCompilationEnabled;
-        clearScoreDirectorFactoryMap();
         return this;
     }
 
@@ -105,94 +78,15 @@ public final class DefaultConstraintVerifier<ConstraintProvider_ extends Constra
             BiFunction<ConstraintProvider_, ConstraintFactory, Constraint> constraintFunction) {
         requireNonNull(constraintFunction);
         AbstractConstraintStreamScoreDirectorFactory<Solution_, Score_> scoreDirectorFactory =
-                getScoreDirectorFactory(constraintFunction);
+                scoreDirectorFactoryContainerThreadLocal.get().getScoreDirectorFactory(constraintFunction, constraintProvider);
         return new DefaultSingleConstraintVerification<>(scoreDirectorFactory);
-    }
-
-    private AbstractConstraintStreamScoreDirectorFactory<Solution_, Score_> getScoreDirectorFactory(
-            BiFunction<ConstraintProvider_, ConstraintFactory, Constraint> constraintFunction) {
-        AbstractConstraintStreamScoreDirectorFactoryService<Solution_, Score_> scoreDirectorFactoryService =
-                getScoreDirectorFactoryService(serviceLoader, constraintStreamImplType);
-        // Creating score director factory is potentially expensive; cache it per constraint.
-        Constraint constraint = constraintFunction.apply(constraintProvider,
-                scoreDirectorFactoryService.buildConstraintFactory(solutionDescriptor));
-        String constraintId = constraint.getConstraintId();
-        return getOrCreateScoreDirectorFactory(scoreDirectorFactoryService, constraintId,
-                constraintFactory -> new Constraint[] {
-                        constraintFunction.apply(constraintProvider, constraintFactory)
-                });
-    }
-
-    /**
-     * Ensures that score director factories are created in a thread-safe manner,
-     * and that for each key only one instance is ever created.
-     *
-     * @param scoreDirectorFactoryService never null, used to create the score director factory
-     * @param key never null, unique identifier of the constraint provider
-     * @param constraintProvider never null, the constraint provider to be used by the score director factory
-     * @return never null
-     */
-    private AbstractConstraintStreamScoreDirectorFactory<Solution_, Score_> getOrCreateScoreDirectorFactory(
-            AbstractConstraintStreamScoreDirectorFactoryService<Solution_, Score_> scoreDirectorFactoryService,
-            String key, ConstraintProvider constraintProvider) {
-        scoreDirectorFactoryMapReadLock.lock();
-        try { // If already calculated, don't require the write lock.
-            AbstractConstraintStreamScoreDirectorFactory<Solution_, Score_> scoreDirectorFactory =
-                    scoreDirectorFactoryMap.get(key);
-            if (scoreDirectorFactory != null) {
-                return scoreDirectorFactory;
-            }
-        } finally {
-            scoreDirectorFactoryMapReadLock.unlock();
-        }
-        scoreDirectorFactoryMapWriteLock.lock();
-        try {
-            return scoreDirectorFactoryMap.computeIfAbsent(key, k -> {
-                boolean isDroolsAlphaNetworkCompilationEnabled =
-                        droolsAlphaNetworkCompilationEnabled == null
-                                ? scoreDirectorFactoryService.supportsImplType(DROOLS)
-                                        && isDroolsAlphaNetworkCompilationEnabled()
-                                : droolsAlphaNetworkCompilationEnabled;
-                return scoreDirectorFactoryService.buildScoreDirectorFactory(solutionDescriptor, constraintProvider,
-                        isDroolsAlphaNetworkCompilationEnabled);
-            });
-        } finally {
-            scoreDirectorFactoryMapWriteLock.unlock();
-        }
-    }
-
-    private static <Solution_, Score_ extends Score<Score_>>
-            AbstractConstraintStreamScoreDirectorFactoryService<Solution_, Score_>
-            getScoreDirectorFactoryService(ServiceLoader<ScoreDirectorFactoryService<Solution_, Score_>> serviceLoader,
-                    ConstraintStreamImplType constraintStreamImplType) {
-        List<AbstractConstraintStreamScoreDirectorFactoryService<Solution_, Score_>> services = serviceLoader.stream()
-                .map(ServiceLoader.Provider::get)
-                .filter(s -> s.getSupportedScoreDirectorType() == ScoreDirectorType.CONSTRAINT_STREAMS)
-                .map(s -> (AbstractConstraintStreamScoreDirectorFactoryService<Solution_, Score_>) s)
-                .filter(s -> constraintStreamImplType == null || s.supportsImplType(constraintStreamImplType))
-                .sorted(Comparator
-                        .comparingInt(
-                                (AbstractConstraintStreamScoreDirectorFactoryService<Solution_, Score_> service) -> service
-                                        .getPriority())
-                        .reversed()) // CS-D will be picked if both are available.
-                .collect(Collectors.toList());
-        if (services.isEmpty()) {
-            throw new IllegalStateException(
-                    "Constraint Streams implementation was not found on the classpath.\n"
-                            + "Maybe include org.optaplanner:optaplanner-constraint-streams-drools dependency "
-                            + "or org.optaplanner:optaplanner-constraint-streams-bavet in your project?\n"
-                            + "Maybe ensure your uberjar bundles META-INF/services from included JAR files?");
-        }
-        return services.get(0);
     }
 
     @Override
     public DefaultMultiConstraintVerification<Solution_, Score_> verifyThat() {
-        AbstractConstraintStreamScoreDirectorFactoryService<Solution_, Score_> scoreDirectorFactoryService =
-                getScoreDirectorFactoryService(serviceLoader, constraintStreamImplType);
         AbstractConstraintStreamScoreDirectorFactory<Solution_, Score_> scoreDirectorFactory =
-                getOrCreateScoreDirectorFactory(scoreDirectorFactoryService, defaultScoreDirectorFactoryMapKey,
-                        constraintProvider);
+                scoreDirectorFactoryContainerThreadLocal.get()
+                        .getScoreDirectorFactory(defaultScoreDirectorFactoryMapKey, constraintProvider);
         return new DefaultMultiConstraintVerification<>(scoreDirectorFactory, constraintProvider);
     }
 

--- a/optaplanner-test/src/main/java/org/optaplanner/test/impl/score/stream/DefaultConstraintVerifier.java
+++ b/optaplanner-test/src/main/java/org/optaplanner/test/impl/score/stream/DefaultConstraintVerifier.java
@@ -3,10 +3,9 @@ package org.optaplanner.test.impl.score.stream;
 import static java.util.Objects.requireNonNull;
 
 import java.util.Objects;
-import java.util.UUID;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiFunction;
 
-import org.optaplanner.constraint.streams.common.AbstractConstraintStreamScoreDirectorFactory;
 import org.optaplanner.core.api.score.Score;
 import org.optaplanner.core.api.score.stream.Constraint;
 import org.optaplanner.core.api.score.stream.ConstraintFactory;
@@ -19,35 +18,38 @@ import org.optaplanner.test.api.score.stream.ConstraintVerifier;
 public final class DefaultConstraintVerifier<ConstraintProvider_ extends ConstraintProvider, Solution_, Score_ extends Score<Score_>>
         implements ConstraintVerifier<ConstraintProvider_, Solution_> {
 
-    /**
-     * Exists so that people can not, even by accident, pick the same constraint ID as the default cache key.
-     */
-    private final String defaultScoreDirectorFactoryMapKey = UUID.randomUUID().toString();
-
     private final ConstraintProvider_ constraintProvider;
+    private final SolutionDescriptor<Solution_> solutionDescriptor;
     /**
-     * {@link java.util.ServiceLoader} is sensitive to classloaders.
-     * Therefore we ensure that all SPI operations are bound to the current thread's classloader.
-     * This also allows us to avoid thread safety concerns in the {@link ScoreDirectorFactoryCache}.
+     * {@link ConstraintVerifier} is mutable,
+     * due to {@link #withConstraintStreamImplType(ConstraintStreamImplType)} and
+     * {@link #withDroolsAlphaNetworkCompilationEnabled(boolean)}.
+     * Since these methods can be run at any time, possibly invalidating the pre-built score director factories,
+     * the easiest way of dealing with the issue is to keep an internal immutable constraint verifier instance
+     * and clearing it every time the configuration changes.
+     * The code that was using the old configuration will continue running on the old instance,
+     * which will eventually be garbage-collected.
+     * Any new code will get a new instance with the new configuration applied.
      */
-    private final ThreadLocal<ScoreDirectorFactoryCache<ConstraintProvider_, Solution_, Score_>> scoreDirectorFactoryContainerThreadLocal;
+    private final AtomicReference<ConfiguredConstraintVerifier<ConstraintProvider_, Solution_, Score_>> configuredConstraintVerifierRef =
+            new AtomicReference<>();
 
-    // Need to be volatile as they will be accessed from the thread-local score director factory cache.
+    // Volatile as these variables may be read and written by multiple threads.
+    // All access to these variables is synchronized.
     private volatile ConstraintStreamImplType constraintStreamImplType;
     private volatile Boolean droolsAlphaNetworkCompilationEnabled;
 
     public DefaultConstraintVerifier(ConstraintProvider_ constraintProvider, SolutionDescriptor<Solution_> solutionDescriptor) {
         this.constraintProvider = constraintProvider;
-        this.scoreDirectorFactoryContainerThreadLocal =
-                ThreadLocal.withInitial(() -> new ScoreDirectorFactoryCache<>(this, solutionDescriptor));
+        this.solutionDescriptor = solutionDescriptor;
     }
 
-    public ConstraintStreamImplType getConstraintStreamImplType() {
+    public synchronized ConstraintStreamImplType getConstraintStreamImplType() {
         return constraintStreamImplType;
     }
 
     @Override
-    public ConstraintVerifier<ConstraintProvider_, Solution_> withConstraintStreamImplType(
+    public synchronized ConstraintVerifier<ConstraintProvider_, Solution_> withConstraintStreamImplType(
             ConstraintStreamImplType constraintStreamImplType) {
         requireNonNull(constraintStreamImplType);
         if (droolsAlphaNetworkCompilationEnabled != null &&
@@ -57,25 +59,23 @@ public final class DefaultConstraintVerifier<ConstraintProvider_ extends Constra
                     + "." + constraintStreamImplType + " while Drools Alpha Network Compilation enabled.");
         }
         this.constraintStreamImplType = constraintStreamImplType;
+        this.configuredConstraintVerifierRef.set(null);
         return this;
     }
 
-    public Boolean getDroolsAlphaNetworkCompilationEnabled() {
-        return droolsAlphaNetworkCompilationEnabled;
-    }
-
-    public boolean isDroolsAlphaNetworkCompilationEnabled() {
+    public synchronized boolean isDroolsAlphaNetworkCompilationEnabled() {
         return Objects.requireNonNullElse(droolsAlphaNetworkCompilationEnabled, !ConfigUtils.isNativeImage());
     }
 
     @Override
-    public ConstraintVerifier<ConstraintProvider_, Solution_> withDroolsAlphaNetworkCompilationEnabled(
+    public synchronized ConstraintVerifier<ConstraintProvider_, Solution_> withDroolsAlphaNetworkCompilationEnabled(
             boolean droolsAlphaNetworkCompilationEnabled) {
         if (droolsAlphaNetworkCompilationEnabled && getConstraintStreamImplType() == ConstraintStreamImplType.BAVET) {
             throw new IllegalArgumentException("Can not enable Drools Alpha Network Compilation with "
                     + ConstraintStreamImplType.class.getSimpleName() + "." + ConstraintStreamImplType.BAVET + ".");
         }
         this.droolsAlphaNetworkCompilationEnabled = droolsAlphaNetworkCompilationEnabled;
+        this.configuredConstraintVerifierRef.set(null);
         return this;
     }
 
@@ -86,18 +86,24 @@ public final class DefaultConstraintVerifier<ConstraintProvider_ extends Constra
     @Override
     public DefaultSingleConstraintVerification<Solution_, Score_> verifyThat(
             BiFunction<ConstraintProvider_, ConstraintFactory, Constraint> constraintFunction) {
-        requireNonNull(constraintFunction);
-        AbstractConstraintStreamScoreDirectorFactory<Solution_, Score_> scoreDirectorFactory =
-                scoreDirectorFactoryContainerThreadLocal.get().getScoreDirectorFactory(constraintFunction, constraintProvider);
-        return new DefaultSingleConstraintVerification<>(scoreDirectorFactory);
+        var configuredConstraintVerifier = getOrCreateConfiguredConstraintVerifier();
+        return configuredConstraintVerifier.verifyThat(constraintFunction);
+    }
+
+    private ConfiguredConstraintVerifier<ConstraintProvider_, Solution_, Score_> getOrCreateConfiguredConstraintVerifier() {
+        return this.configuredConstraintVerifierRef.updateAndGet(v -> {
+            if (v == null) {
+                return new ConfiguredConstraintVerifier<>(constraintProvider, solutionDescriptor,
+                        getConstraintStreamImplType(), isDroolsAlphaNetworkCompilationEnabled());
+            }
+            return v;
+        });
     }
 
     @Override
     public DefaultMultiConstraintVerification<Solution_, Score_> verifyThat() {
-        AbstractConstraintStreamScoreDirectorFactory<Solution_, Score_> scoreDirectorFactory =
-                scoreDirectorFactoryContainerThreadLocal.get()
-                        .getScoreDirectorFactory(defaultScoreDirectorFactoryMapKey, constraintProvider);
-        return new DefaultMultiConstraintVerification<>(scoreDirectorFactory, constraintProvider);
+        var configuredConstraintVerifier = getOrCreateConfiguredConstraintVerifier();
+        return configuredConstraintVerifier.verifyThat();
     }
 
 }

--- a/optaplanner-test/src/main/java/org/optaplanner/test/impl/score/stream/DefaultConstraintVerifier.java
+++ b/optaplanner-test/src/main/java/org/optaplanner/test/impl/score/stream/DefaultConstraintVerifier.java
@@ -20,7 +20,7 @@ public final class DefaultConstraintVerifier<ConstraintProvider_ extends Constra
         implements ConstraintVerifier<ConstraintProvider_, Solution_> {
 
     /**
-     * Exists so that people can not, even by accident, pick the same constraint ID as the default map key.
+     * Exists so that people can not, even by accident, pick the same constraint ID as the default cache key.
      */
     private final String defaultScoreDirectorFactoryMapKey = UUID.randomUUID().toString();
 

--- a/optaplanner-test/src/main/java/org/optaplanner/test/impl/score/stream/DefaultConstraintVerifier.java
+++ b/optaplanner-test/src/main/java/org/optaplanner/test/impl/score/stream/DefaultConstraintVerifier.java
@@ -33,8 +33,8 @@ public final class DefaultConstraintVerifier<ConstraintProvider_ extends Constra
      */
     private final AtomicReference<ConfiguredConstraintVerifier<ConstraintProvider_, Solution_, Score_>> configuredConstraintVerifierRef =
             new AtomicReference<>();
-    private final AtomicReference<ConstraintStreamImplType> constraintStreamImplType = new AtomicReference<>();
-    private final AtomicReference<Boolean> droolsAlphaNetworkCompilationEnabled = new AtomicReference<>();
+    private final AtomicReference<ConstraintStreamImplType> constraintStreamImplTypeRef = new AtomicReference<>();
+    private final AtomicReference<Boolean> droolsAlphaNetworkCompilationEnabledRef = new AtomicReference<>();
 
     public DefaultConstraintVerifier(ConstraintProvider_ constraintProvider, SolutionDescriptor<Solution_> solutionDescriptor) {
         this.constraintProvider = constraintProvider;
@@ -42,27 +42,27 @@ public final class DefaultConstraintVerifier<ConstraintProvider_ extends Constra
     }
 
     public ConstraintStreamImplType getConstraintStreamImplType() {
-        return constraintStreamImplType.get();
+        return constraintStreamImplTypeRef.get();
     }
 
     @Override
     public ConstraintVerifier<ConstraintProvider_, Solution_> withConstraintStreamImplType(
             ConstraintStreamImplType constraintStreamImplType) {
         requireNonNull(constraintStreamImplType);
-        var droolsAlphaNetworkCompilationEnabled = this.droolsAlphaNetworkCompilationEnabled.get();
+        var droolsAlphaNetworkCompilationEnabled = this.droolsAlphaNetworkCompilationEnabledRef.get();
         if (droolsAlphaNetworkCompilationEnabled != null &&
                 droolsAlphaNetworkCompilationEnabled &&
                 constraintStreamImplType != ConstraintStreamImplType.DROOLS) {
             throw new IllegalArgumentException("Can not switch to " + ConstraintStreamImplType.class.getSimpleName()
                     + "." + constraintStreamImplType + " while Drools Alpha Network Compilation enabled.");
         }
-        this.constraintStreamImplType.set(constraintStreamImplType);
+        this.constraintStreamImplTypeRef.set(constraintStreamImplType);
         this.configuredConstraintVerifierRef.set(null);
         return this;
     }
 
     public boolean isDroolsAlphaNetworkCompilationEnabled() {
-        return Objects.requireNonNullElse(droolsAlphaNetworkCompilationEnabled.get(), !ConfigUtils.isNativeImage());
+        return Objects.requireNonNullElse(droolsAlphaNetworkCompilationEnabledRef.get(), !ConfigUtils.isNativeImage());
     }
 
     @Override
@@ -72,7 +72,7 @@ public final class DefaultConstraintVerifier<ConstraintProvider_ extends Constra
             throw new IllegalArgumentException("Can not enable Drools Alpha Network Compilation with "
                     + ConstraintStreamImplType.class.getSimpleName() + "." + ConstraintStreamImplType.BAVET + ".");
         }
-        this.droolsAlphaNetworkCompilationEnabled.set(droolsAlphaNetworkCompilationEnabled);
+        this.droolsAlphaNetworkCompilationEnabledRef.set(droolsAlphaNetworkCompilationEnabled);
         this.configuredConstraintVerifierRef.set(null);
         return this;
     }

--- a/optaplanner-test/src/main/java/org/optaplanner/test/impl/score/stream/DefaultConstraintVerifier.java
+++ b/optaplanner-test/src/main/java/org/optaplanner/test/impl/score/stream/DefaultConstraintVerifier.java
@@ -50,6 +50,12 @@ public final class DefaultConstraintVerifier<ConstraintProvider_ extends Constra
     public ConstraintVerifier<ConstraintProvider_, Solution_> withConstraintStreamImplType(
             ConstraintStreamImplType constraintStreamImplType) {
         requireNonNull(constraintStreamImplType);
+        if (droolsAlphaNetworkCompilationEnabled != null &&
+                droolsAlphaNetworkCompilationEnabled &&
+                constraintStreamImplType != ConstraintStreamImplType.DROOLS) {
+            throw new IllegalArgumentException("Can not switch to " + ConstraintStreamImplType.class.getSimpleName()
+                    + "." + constraintStreamImplType + " while Drools Alpha Network Compilation enabled.");
+        }
         this.constraintStreamImplType = constraintStreamImplType;
         return this;
     }
@@ -65,6 +71,10 @@ public final class DefaultConstraintVerifier<ConstraintProvider_ extends Constra
     @Override
     public ConstraintVerifier<ConstraintProvider_, Solution_> withDroolsAlphaNetworkCompilationEnabled(
             boolean droolsAlphaNetworkCompilationEnabled) {
+        if (droolsAlphaNetworkCompilationEnabled && getConstraintStreamImplType() == ConstraintStreamImplType.BAVET) {
+            throw new IllegalArgumentException("Can not enable Drools Alpha Network Compilation with "
+                    + ConstraintStreamImplType.class.getSimpleName() + "." + ConstraintStreamImplType.BAVET + ".");
+        }
         this.droolsAlphaNetworkCompilationEnabled = droolsAlphaNetworkCompilationEnabled;
         return this;
     }

--- a/optaplanner-test/src/main/java/org/optaplanner/test/impl/score/stream/DefaultMultiConstraintAssertion.java
+++ b/optaplanner-test/src/main/java/org/optaplanner/test/impl/score/stream/DefaultMultiConstraintAssertion.java
@@ -30,7 +30,7 @@ public final class DefaultMultiConstraintAssertion<Score_ extends Score<Score_>>
     }
 
     @Override
-    public final void scores(Score<?> score, String message) {
+    public void scores(Score<?> score, String message) {
         if (actualScore.equals(score)) {
             return;
         }

--- a/optaplanner-test/src/main/java/org/optaplanner/test/impl/score/stream/DefaultMultiConstraintVerification.java
+++ b/optaplanner-test/src/main/java/org/optaplanner/test/impl/score/stream/DefaultMultiConstraintVerification.java
@@ -19,16 +19,16 @@ public final class DefaultMultiConstraintVerification<Solution_, Score_ extends 
             ConstraintProvider constraintProvider) {
         this.scoreDirectorFactory = scoreDirectorFactory;
         this.constraintProvider = constraintProvider;
-        this.sessionBasedAssertionBuilder = new SessionBasedAssertionBuilder(scoreDirectorFactory);
+        this.sessionBasedAssertionBuilder = new SessionBasedAssertionBuilder<>(scoreDirectorFactory);
     }
 
     @Override
-    public final DefaultMultiConstraintAssertion<Score_> given(Object... facts) {
+    public DefaultMultiConstraintAssertion<Score_> given(Object... facts) {
         return sessionBasedAssertionBuilder.multiConstraintGiven(constraintProvider, facts);
     }
 
     @Override
-    public final DefaultMultiConstraintAssertion<Score_> givenSolution(Solution_ solution) {
+    public DefaultMultiConstraintAssertion<Score_> givenSolution(Solution_ solution) {
         try (InnerScoreDirector<Solution_, Score_> scoreDirector =
                 scoreDirectorFactory.buildScoreDirector(true, true)) {
             scoreDirector.setWorkingSolution(Objects.requireNonNull(solution));

--- a/optaplanner-test/src/main/java/org/optaplanner/test/impl/score/stream/DefaultSingleConstraintVerification.java
+++ b/optaplanner-test/src/main/java/org/optaplanner/test/impl/score/stream/DefaultSingleConstraintVerification.java
@@ -15,16 +15,16 @@ public final class DefaultSingleConstraintVerification<Solution_, Score_ extends
 
     DefaultSingleConstraintVerification(AbstractConstraintStreamScoreDirectorFactory<Solution_, Score_> scoreDirectorFactory) {
         this.scoreDirectorFactory = scoreDirectorFactory;
-        this.sessionBasedAssertionBuilder = new SessionBasedAssertionBuilder(scoreDirectorFactory);
+        this.sessionBasedAssertionBuilder = new SessionBasedAssertionBuilder<>(scoreDirectorFactory);
     }
 
     @Override
-    public final DefaultSingleConstraintAssertion<Solution_, Score_> given(Object... facts) {
+    public DefaultSingleConstraintAssertion<Solution_, Score_> given(Object... facts) {
         return sessionBasedAssertionBuilder.singleConstraintGiven(facts);
     }
 
     @Override
-    public final DefaultSingleConstraintAssertion<Solution_, Score_> givenSolution(Solution_ solution) {
+    public DefaultSingleConstraintAssertion<Solution_, Score_> givenSolution(Solution_ solution) {
         try (InnerScoreDirector<Solution_, Score_> scoreDirector = scoreDirectorFactory.buildScoreDirector(true, true)) {
             scoreDirector.setWorkingSolution(Objects.requireNonNull(solution));
             return new DefaultSingleConstraintAssertion<>(scoreDirectorFactory, scoreDirector.calculateScore(),

--- a/optaplanner-test/src/main/java/org/optaplanner/test/impl/score/stream/ScoreDirectorFactoryCache.java
+++ b/optaplanner-test/src/main/java/org/optaplanner/test/impl/score/stream/ScoreDirectorFactoryCache.java
@@ -48,8 +48,7 @@ final class ScoreDirectorFactoryCache<ConstraintProvider_ extends ConstraintProv
             SolutionDescriptor<Solution_> solutionDescriptor) {
         this.parent = Objects.requireNonNull(parent);
         this.solutionDescriptor = Objects.requireNonNull(solutionDescriptor);
-        ServiceLoader uncastServiceLoader = ServiceLoader.load(ScoreDirectorFactoryService.class);
-        this.serviceLoader = uncastServiceLoader;
+        this.serviceLoader = (ServiceLoader) ServiceLoader.load(ScoreDirectorFactoryService.class);
     }
 
     private AbstractConstraintStreamScoreDirectorFactoryService<Solution_, Score_> getScoreDirectorFactoryService() {

--- a/optaplanner-test/src/main/java/org/optaplanner/test/impl/score/stream/ScoreDirectorFactoryCache.java
+++ b/optaplanner-test/src/main/java/org/optaplanner/test/impl/score/stream/ScoreDirectorFactoryCache.java
@@ -99,14 +99,13 @@ final class ScoreDirectorFactoryCache<ConstraintProvider_ extends ConstraintProv
      */
     public AbstractConstraintStreamScoreDirectorFactory<Solution_, Score_> getScoreDirectorFactory(String key,
             ConstraintProvider constraintProvider) {
-        return scoreDirectorFactoryMap.compute(key, (k, v) -> {
-            AbstractConstraintStreamScoreDirectorFactoryService<Solution_, Score_> scoreDirectorFactoryService =
-                    getScoreDirectorFactoryService();
-            if (v == null || didParentConfigurationChange(scoreDirectorFactoryService)) {
-                return createScoreDirectorFactory(scoreDirectorFactoryService, constraintProvider);
-            }
-            return v;
-        });
+        AbstractConstraintStreamScoreDirectorFactoryService<Solution_, Score_> scoreDirectorFactoryService =
+                getScoreDirectorFactoryService();
+        if (didParentConfigurationChange(scoreDirectorFactoryService)) {
+            scoreDirectorFactoryMap.clear(); // Parent configuration changed; existing score directors invalid.
+        }
+        return scoreDirectorFactoryMap.computeIfAbsent(key,
+                k -> createScoreDirectorFactory(scoreDirectorFactoryService, constraintProvider));
     }
 
     private boolean didParentConfigurationChange(

--- a/optaplanner-test/src/main/java/org/optaplanner/test/impl/score/stream/ScoreDirectorFactoryCache.java
+++ b/optaplanner-test/src/main/java/org/optaplanner/test/impl/score/stream/ScoreDirectorFactoryCache.java
@@ -53,13 +53,12 @@ final class ScoreDirectorFactoryCache<ConstraintProvider_ extends ConstraintProv
 
     private AbstractConstraintStreamScoreDirectorFactoryService<Solution_, Score_> getScoreDirectorFactoryService() {
         ConstraintStreamImplType constraintStreamImplType = parent.getConstraintStreamImplType();
-        // CS-D will be picked if both are available.
         return serviceLoader.stream()
                 .map(ServiceLoader.Provider::get)
                 .filter(s -> s.getSupportedScoreDirectorType() == ScoreDirectorType.CONSTRAINT_STREAMS)
                 .map(s -> (AbstractConstraintStreamScoreDirectorFactoryService<Solution_, Score_>) s)
                 .filter(s -> constraintStreamImplType == null || s.supportsImplType(constraintStreamImplType))
-                .max(Comparator.comparingInt(ScoreDirectorFactoryService::getPriority))
+                .max(Comparator.comparingInt(ScoreDirectorFactoryService::getPriority)) // Picks CS-D if both available.
                 .orElseThrow(() -> new IllegalStateException(
                         "Constraint Streams implementation was not found on the classpath.\n"
                                 + "Maybe include org.optaplanner:optaplanner-constraint-streams-drools dependency "

--- a/optaplanner-test/src/main/java/org/optaplanner/test/impl/score/stream/ScoreDirectorFactoryCache.java
+++ b/optaplanner-test/src/main/java/org/optaplanner/test/impl/score/stream/ScoreDirectorFactoryCache.java
@@ -1,0 +1,151 @@
+package org.optaplanner.test.impl.score.stream;
+
+import static org.optaplanner.core.api.score.stream.ConstraintStreamImplType.BAVET;
+import static org.optaplanner.core.api.score.stream.ConstraintStreamImplType.DROOLS;
+
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.ServiceLoader;
+import java.util.function.BiFunction;
+
+import org.optaplanner.constraint.streams.common.AbstractConstraintStreamScoreDirectorFactory;
+import org.optaplanner.constraint.streams.common.AbstractConstraintStreamScoreDirectorFactoryService;
+import org.optaplanner.core.api.score.Score;
+import org.optaplanner.core.api.score.stream.Constraint;
+import org.optaplanner.core.api.score.stream.ConstraintFactory;
+import org.optaplanner.core.api.score.stream.ConstraintProvider;
+import org.optaplanner.core.api.score.stream.ConstraintStreamImplType;
+import org.optaplanner.core.impl.domain.solution.descriptor.SolutionDescriptor;
+import org.optaplanner.core.impl.score.director.ScoreDirectorFactoryService;
+import org.optaplanner.core.impl.score.director.ScoreDirectorType;
+
+/**
+ * Designed for access from a single thread.
+ *
+ * @param <ConstraintProvider_>
+ * @param <Solution_>
+ * @param <Score_>
+ */
+final class ScoreDirectorFactoryCache<ConstraintProvider_ extends ConstraintProvider, Solution_, Score_ extends Score<Score_>> {
+
+    /**
+     * Score director factory creation is expensive; we cache it.
+     * The cache needs to be recomputed every time that the parent's configuration changes.
+     */
+    private final Map<String, AbstractConstraintStreamScoreDirectorFactory<Solution_, Score_>> scoreDirectorFactoryMap =
+            new HashMap<>();
+
+    private final DefaultConstraintVerifier<ConstraintProvider_, Solution_, Score_> parent;
+    private final SolutionDescriptor<Solution_> solutionDescriptor;
+    private final ServiceLoader<ScoreDirectorFactoryService<Solution_, Score_>> serviceLoader;
+
+    private ConstraintStreamImplType lastKnownConstraintStreamImplType = null;
+    private boolean lastKnownDroolsAlphaNetworkCompilationEnabled = false;
+
+    public ScoreDirectorFactoryCache(DefaultConstraintVerifier<ConstraintProvider_, Solution_, Score_> parent,
+            SolutionDescriptor<Solution_> solutionDescriptor) {
+        this.parent = Objects.requireNonNull(parent);
+        this.solutionDescriptor = Objects.requireNonNull(solutionDescriptor);
+        ServiceLoader uncastServiceLoader = ServiceLoader.load(ScoreDirectorFactoryService.class);
+        this.serviceLoader = uncastServiceLoader;
+    }
+
+    private AbstractConstraintStreamScoreDirectorFactoryService<Solution_, Score_> getScoreDirectorFactoryService() {
+        ConstraintStreamImplType constraintStreamImplType = parent.getConstraintStreamImplType();
+        // CS-D will be picked if both are available.
+        return serviceLoader.stream()
+                .map(ServiceLoader.Provider::get)
+                .filter(s -> s.getSupportedScoreDirectorType() == ScoreDirectorType.CONSTRAINT_STREAMS)
+                .map(s -> (AbstractConstraintStreamScoreDirectorFactoryService<Solution_, Score_>) s)
+                .filter(s -> constraintStreamImplType == null || s.supportsImplType(constraintStreamImplType))
+                .max(Comparator.comparingInt(ScoreDirectorFactoryService::getPriority))
+                .orElseThrow(() -> new IllegalStateException(
+                        "Constraint Streams implementation was not found on the classpath.\n"
+                                + "Maybe include org.optaplanner:optaplanner-constraint-streams-drools dependency "
+                                + "or org.optaplanner:optaplanner-constraint-streams-bavet in your project?\n"
+                                + "Maybe ensure your uberjar bundles META-INF/services from included JAR files?"));
+    }
+
+    /**
+     * Retrieve {@link AbstractConstraintStreamScoreDirectorFactory} from the cache,
+     * or create and cache a new instance using the {@link AbstractConstraintStreamScoreDirectorFactoryService}.
+     * Cache key is the ID of the single constraint returned by calling the constraintFunction.
+     *
+     * @param constraintFunction never null, determines the single constraint to be used from the constraint provider
+     * @param constraintProvider never null, determines the constraint provider to be used
+     * @return never null
+     */
+    public AbstractConstraintStreamScoreDirectorFactory<Solution_, Score_> getScoreDirectorFactory(
+            BiFunction<ConstraintProvider_, ConstraintFactory, Constraint> constraintFunction,
+            ConstraintProvider_ constraintProvider) {
+        AbstractConstraintStreamScoreDirectorFactoryService<Solution_, Score_> scoreDirectorFactoryService =
+                getScoreDirectorFactoryService();
+        Constraint constraint = constraintFunction.apply(constraintProvider,
+                scoreDirectorFactoryService.buildConstraintFactory(solutionDescriptor));
+        String constraintId = constraint.getConstraintId();
+        return getScoreDirectorFactory(constraintId,
+                constraintFactory -> new Constraint[] {
+                        constraint
+                });
+    }
+
+    /**
+     * Retrieve {@link AbstractConstraintStreamScoreDirectorFactory} from the cache,
+     * or create and cache a new instance using the {@link AbstractConstraintStreamScoreDirectorFactoryService}.
+     *
+     * @param key never null, unique identifier of the factory in the cache
+     * @param constraintProvider never null, constraint provider to create the factory from; ignored on cache hit
+     * @return never null
+     */
+    public AbstractConstraintStreamScoreDirectorFactory<Solution_, Score_> getScoreDirectorFactory(String key,
+            ConstraintProvider constraintProvider) {
+        return scoreDirectorFactoryMap.compute(key, (k, v) -> {
+            AbstractConstraintStreamScoreDirectorFactoryService<Solution_, Score_> scoreDirectorFactoryService =
+                    getScoreDirectorFactoryService();
+            if (v == null || didParentConfigurationChange(scoreDirectorFactoryService)) {
+                return createScoreDirectorFactory(scoreDirectorFactoryService, constraintProvider);
+            }
+            return v;
+        });
+    }
+
+    private boolean didParentConfigurationChange(
+            AbstractConstraintStreamScoreDirectorFactoryService<Solution_, Score_> scoreDirectorFactoryService) {
+        boolean currentDroolsAlphaNetworkCompilationEnabled =
+                determineDroolsAlphaNetworkCompilationEnabled(scoreDirectorFactoryService);
+        if (currentDroolsAlphaNetworkCompilationEnabled != lastKnownDroolsAlphaNetworkCompilationEnabled) {
+            return true;
+        }
+        ConstraintStreamImplType currentConstraintStreamImplType =
+                determineConstraintStreamImplType(scoreDirectorFactoryService);
+        return currentConstraintStreamImplType != lastKnownConstraintStreamImplType;
+    }
+
+    private boolean determineDroolsAlphaNetworkCompilationEnabled(
+            AbstractConstraintStreamScoreDirectorFactoryService<Solution_, Score_> scoreDirectorFactoryService) {
+        Boolean parentDroolsAlphaNetworkCompilationEnabled = parent.getDroolsAlphaNetworkCompilationEnabled();
+        return parentDroolsAlphaNetworkCompilationEnabled == null
+                ? determineConstraintStreamImplType(scoreDirectorFactoryService) == DROOLS
+                        && parent.isDroolsAlphaNetworkCompilationEnabled()
+                : parentDroolsAlphaNetworkCompilationEnabled;
+    }
+
+    private ConstraintStreamImplType determineConstraintStreamImplType(
+            AbstractConstraintStreamScoreDirectorFactoryService<Solution_, Score_> scoreDirectorFactoryService) {
+        return scoreDirectorFactoryService.supportsImplType(BAVET) ? BAVET : DROOLS;
+    }
+
+    private AbstractConstraintStreamScoreDirectorFactory<Solution_, Score_> createScoreDirectorFactory(
+            AbstractConstraintStreamScoreDirectorFactoryService<Solution_, Score_> scoreDirectorFactoryService,
+            ConstraintProvider constraintProvider) {
+        this.lastKnownConstraintStreamImplType = determineConstraintStreamImplType(scoreDirectorFactoryService);
+        this.lastKnownDroolsAlphaNetworkCompilationEnabled =
+                determineDroolsAlphaNetworkCompilationEnabled(scoreDirectorFactoryService);
+
+        return scoreDirectorFactoryService.buildScoreDirectorFactory(solutionDescriptor, constraintProvider,
+                this.lastKnownDroolsAlphaNetworkCompilationEnabled);
+    }
+
+}


### PR DESCRIPTION
Makes ConstraintVerifier thread-safe by using ServiceLoader in a ThreadLocal.
Also caches ScoreDirectorFactories, speeding up tests.
Finally switches constraint provider tests in examples to use concurrency, to dogfood the new feature.