### PR TITLE
Resolve unchecked and rawtype warnings in field cloners

### DIFF
--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/domain/solution/cloner/BooleanFieldCloner.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/domain/solution/cloner/BooleanFieldCloner.java
@@ -3,16 +3,12 @@ package org.optaplanner.core.impl.domain.solution.cloner;
 import java.lang.reflect.Field;
 import java.util.function.Consumer;
 
-final class BooleanFieldCloner<C> implements FieldCloner<C> {
+final class BooleanFieldCloner implements FieldCloner {
 
-    private static final FieldCloner INSTANCE = new BooleanFieldCloner();
-
-    public static <C> FieldCloner<C> getInstance() {
-        return INSTANCE;
-    }
+    static final FieldCloner INSTANCE = new BooleanFieldCloner();
 
     @Override
-    public void clone(DeepCloningUtils deepCloningUtils, Field field, Class<? extends C> instanceClass,
+    public <C> void clone(DeepCloningUtils deepCloningUtils, Field field, Class<? extends C> instanceClass,
             C original, C clone, Consumer<Object> deferredValueConsumer) {
         boolean originalValue = getFieldValue(original, field);
         setFieldValue(clone, field, originalValue);

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/domain/solution/cloner/ByteFieldCloner.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/domain/solution/cloner/ByteFieldCloner.java
@@ -3,16 +3,12 @@ package org.optaplanner.core.impl.domain.solution.cloner;
 import java.lang.reflect.Field;
 import java.util.function.Consumer;
 
-final class ByteFieldCloner<C> implements FieldCloner<C> {
+final class ByteFieldCloner implements FieldCloner {
 
-    private static final FieldCloner INSTANCE = new ByteFieldCloner();
-
-    public static <C> FieldCloner<C> getInstance() {
-        return INSTANCE;
-    }
+    static final FieldCloner INSTANCE = new ByteFieldCloner();
 
     @Override
-    public void clone(DeepCloningUtils deepCloningUtils, Field field, Class<? extends C> instanceClass,
+    public <C> void clone(DeepCloningUtils deepCloningUtils, Field field, Class<? extends C> instanceClass,
             C original, C clone, Consumer<Object> deferredValueConsumer) {
         byte originalValue = getFieldValue(original, field);
         setFieldValue(clone, field, originalValue);

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/domain/solution/cloner/CharFieldCloner.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/domain/solution/cloner/CharFieldCloner.java
@@ -3,16 +3,12 @@ package org.optaplanner.core.impl.domain.solution.cloner;
 import java.lang.reflect.Field;
 import java.util.function.Consumer;
 
-final class CharFieldCloner<C> implements FieldCloner<C> {
+final class CharFieldCloner implements FieldCloner {
 
-    private static final FieldCloner INSTANCE = new CharFieldCloner();
-
-    public static <C> FieldCloner<C> getInstance() {
-        return INSTANCE;
-    }
+    static final FieldCloner INSTANCE = new CharFieldCloner();
 
     @Override
-    public void clone(DeepCloningUtils deepCloningUtils, Field field, Class<? extends C> instanceClass,
+    public <C> void clone(DeepCloningUtils deepCloningUtils, Field field, Class<? extends C> instanceClass,
             C original, C clone, Consumer<Object> deferredValueConsumer) {
         char originalValue = getFieldValue(original, field);
         setFieldValue(clone, field, originalValue);

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/domain/solution/cloner/DeepCloningFieldCloner.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/domain/solution/cloner/DeepCloningFieldCloner.java
@@ -3,16 +3,12 @@ package org.optaplanner.core.impl.domain.solution.cloner;
 import java.lang.reflect.Field;
 import java.util.function.Consumer;
 
-final class DeepCloningFieldCloner<C> implements FieldCloner<C> {
+final class DeepCloningFieldCloner implements FieldCloner {
 
-    private static final FieldCloner INSTANCE = new DeepCloningFieldCloner();
-
-    public static <C> FieldCloner<C> getInstance() {
-        return INSTANCE;
-    }
+    static final FieldCloner INSTANCE = new DeepCloningFieldCloner();
 
     @Override
-    public void clone(DeepCloningUtils deepCloningUtils, Field field, Class<? extends C> instanceClass, C original, C clone,
+    public <C> void clone(DeepCloningUtils deepCloningUtils, Field field, Class<? extends C> instanceClass, C original, C clone,
             Consumer<Object> deferredValueConsumer) {
         Object originalValue = FieldCloner.getFieldValue(original, field);
         if (isDeepCloneField(deepCloningUtils, field, instanceClass, originalValue)) { // Deffer filling in the field.

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/domain/solution/cloner/DoubleFieldCloner.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/domain/solution/cloner/DoubleFieldCloner.java
@@ -3,16 +3,12 @@ package org.optaplanner.core.impl.domain.solution.cloner;
 import java.lang.reflect.Field;
 import java.util.function.Consumer;
 
-final class DoubleFieldCloner<C> implements FieldCloner<C> {
+final class DoubleFieldCloner implements FieldCloner {
 
-    private static final FieldCloner INSTANCE = new DoubleFieldCloner();
-
-    public static <C> FieldCloner<C> getInstance() {
-        return INSTANCE;
-    }
+    static final FieldCloner INSTANCE = new DoubleFieldCloner();
 
     @Override
-    public void clone(DeepCloningUtils deepCloningUtils, Field field, Class<? extends C> instanceClass,
+    public <C> void clone(DeepCloningUtils deepCloningUtils, Field field, Class<? extends C> instanceClass,
             C original, C clone, Consumer<Object> deferredValueConsumer) {
         double originalValue = getFieldValue(original, field);
         setFieldValue(clone, field, originalValue);

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/domain/solution/cloner/FieldCloner.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/domain/solution/cloner/FieldCloner.java
@@ -4,7 +4,7 @@ import java.lang.reflect.Field;
 import java.util.function.Consumer;
 
 @FunctionalInterface
-interface FieldCloner<C> {
+interface FieldCloner {
 
     static Object getFieldValue(Object bean, Field field) {
         try {
@@ -43,7 +43,7 @@ interface FieldCloner<C> {
      * @param deferredValueConsumer null if {@link #mayDeferClone()} is false
      * @throws RuntimeException if reflective field read or write fails
      */
-    void clone(DeepCloningUtils deepCloningUtils, Field field, Class<? extends C> instanceClass, C original, C clone,
+    <C> void clone(DeepCloningUtils deepCloningUtils, Field field, Class<? extends C> instanceClass, C original, C clone,
             Consumer<Object> deferredValueConsumer);
 
     /**

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/domain/solution/cloner/FloatFieldCloner.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/domain/solution/cloner/FloatFieldCloner.java
@@ -3,16 +3,12 @@ package org.optaplanner.core.impl.domain.solution.cloner;
 import java.lang.reflect.Field;
 import java.util.function.Consumer;
 
-final class FloatFieldCloner<C> implements FieldCloner<C> {
+final class FloatFieldCloner implements FieldCloner {
 
-    private static final FieldCloner INSTANCE = new FloatFieldCloner();
-
-    public static <C> FieldCloner<C> getInstance() {
-        return INSTANCE;
-    }
+    static final FieldCloner INSTANCE = new FloatFieldCloner();
 
     @Override
-    public void clone(DeepCloningUtils deepCloningUtils, Field field, Class<? extends C> instanceClass,
+    public <C> void clone(DeepCloningUtils deepCloningUtils, Field field, Class<? extends C> instanceClass,
             C original, C clone, Consumer<Object> deferredValueConsumer) {
         float originalValue = getFieldValue(original, field);
         setFieldValue(clone, field, originalValue);

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/domain/solution/cloner/IntFieldCloner.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/domain/solution/cloner/IntFieldCloner.java
@@ -3,16 +3,12 @@ package org.optaplanner.core.impl.domain.solution.cloner;
 import java.lang.reflect.Field;
 import java.util.function.Consumer;
 
-final class IntFieldCloner<C> implements FieldCloner<C> {
+final class IntFieldCloner implements FieldCloner {
 
-    private static final FieldCloner INSTANCE = new IntFieldCloner();
-
-    public static <C> FieldCloner<C> getInstance() {
-        return INSTANCE;
-    }
+    static final FieldCloner INSTANCE = new IntFieldCloner();
 
     @Override
-    public void clone(DeepCloningUtils deepCloningUtils, Field field, Class<? extends C> instanceClass,
+    public <C> void clone(DeepCloningUtils deepCloningUtils, Field field, Class<? extends C> instanceClass,
             C original, C clone, Consumer<Object> deferredValueConsumer) {
         int originalValue = getFieldValue(original, field);
         setFieldValue(clone, field, originalValue);

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/domain/solution/cloner/LongFieldCloner.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/domain/solution/cloner/LongFieldCloner.java
@@ -3,16 +3,12 @@ package org.optaplanner.core.impl.domain.solution.cloner;
 import java.lang.reflect.Field;
 import java.util.function.Consumer;
 
-final class LongFieldCloner<C> implements FieldCloner<C> {
+final class LongFieldCloner implements FieldCloner {
 
-    private static final FieldCloner INSTANCE = new LongFieldCloner();
-
-    public static <C> FieldCloner<C> getInstance() {
-        return INSTANCE;
-    }
+    static final FieldCloner INSTANCE = new LongFieldCloner();
 
     @Override
-    public void clone(DeepCloningUtils deepCloningUtils, Field field, Class<? extends C> instanceClass,
+    public <C> void clone(DeepCloningUtils deepCloningUtils, Field field, Class<? extends C> instanceClass,
             C original, C clone, Consumer<Object> deferredValueConsumer) {
         long originalValue = getFieldValue(original, field);
         setFieldValue(clone, field, originalValue);

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/domain/solution/cloner/ShallowCloningFieldCloner.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/domain/solution/cloner/ShallowCloningFieldCloner.java
@@ -3,16 +3,12 @@ package org.optaplanner.core.impl.domain.solution.cloner;
 import java.lang.reflect.Field;
 import java.util.function.Consumer;
 
-final class ShallowCloningFieldCloner<C> implements FieldCloner<C> {
+final class ShallowCloningFieldCloner implements FieldCloner {
 
-    private static final FieldCloner INSTANCE = new ShallowCloningFieldCloner();
-
-    public static <C> FieldCloner<C> getInstance() {
-        return INSTANCE;
-    }
+    static final FieldCloner INSTANCE = new ShallowCloningFieldCloner();
 
     @Override
-    public void clone(DeepCloningUtils deepCloningUtils, Field field, Class<? extends C> instanceClass,
+    public <C> void clone(DeepCloningUtils deepCloningUtils, Field field, Class<? extends C> instanceClass,
             C original, C clone, Consumer<Object> deferredValueConsumer) {
         Object originalValue = FieldCloner.getFieldValue(original, field);
         FieldCloner.setFieldValue(clone, field, originalValue);

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/domain/solution/cloner/ShortFieldCloner.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/domain/solution/cloner/ShortFieldCloner.java
@@ -3,16 +3,12 @@ package org.optaplanner.core.impl.domain.solution.cloner;
 import java.lang.reflect.Field;
 import java.util.function.Consumer;
 
-final class ShortFieldCloner<C> implements FieldCloner<C> {
+final class ShortFieldCloner implements FieldCloner {
 
-    private static final FieldCloner INSTANCE = new ShortFieldCloner();
-
-    public static <C> FieldCloner<C> getInstance() {
-        return INSTANCE;
-    }
+    static final FieldCloner INSTANCE = new ShortFieldCloner();
 
     @Override
-    public void clone(DeepCloningUtils deepCloningUtils, Field field, Class<? extends C> instanceClass,
+    public <C> void clone(DeepCloningUtils deepCloningUtils, Field field, Class<? extends C> instanceClass,
             C original, C clone, Consumer<Object> deferredValueConsumer) {
         short originalValue = getFieldValue(original, field);
         setFieldValue(clone, field, originalValue);


### PR DESCRIPTION
The FieldCloner class doesn't need to be generic. The type parameter is
only needed in the clone() method to ensure that the `instanceClass`,
`original` and `clone` are all of the same type.

This change makes the code simpler by removing the type parameter where
it's not needed, and resolves several unchecked and rawtype warnings.

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request checks</b>  
  Please add comment: <b>Jenkins retest this</b>

- for a <b>specific pull request check</b>  
  please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-vehicle-routing] tests</b>
  
- for a <b>full downstream build</b> 
  - for <b>jenkins</b> job: 
    please add comment: <b>Jenkins run fdb</b>
  - for <b>github actions</b> job: 
    add the label `run_fdb`

- for a <b>compile downstream build</b>  
  please add comment: <b>Jenkins run cdb</b>

- for a <b>full production downstream build</b>  
  please add comment: <b>Jenkins execute product fdb</b>

- for an <b>upstream build</b>  
  please add comment: <b>Jenkins run upstream</b>

- for <b>quarkus branch checks</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins run quarkus-branch</b>

- for a <b>quarkus branch specific check</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-vehicle-routing] quarkus-branch</b>

- for <b>quarkus main checks</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins run quarkus-main</b>

- for a <b>specific quarkus main check</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-vehicle-routing] quarkus-branch</b>

- for <b>native checks</b>  
  Run native checks  
  Please add comment: <b>Jenkins run native</b>

- for a <b>specific native check</b>  
  Run native checks 
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-vehicle-routing] native</b>

- for <b>mandrel checks</b>  
  Run native checks against Mandrel image
  Please add comment: <b>Jenkins run mandrel</b>

- for a <b>specific mandrel check</b>  
  Run native checks against Mandrel image  
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-vehicle-routing] mandrel</b>
</details>

### CI Status

 You can check OptaPlanner repositories CI status from [Chain Status webpage](https://kiegroup.github.io/optaplanner/).