### PR TITLE
Setup Jenkins label for authorized users

### DIFF
--- a/.ci/jenkins/config/branch.yaml
+++ b/.ci/jenkins/config/branch.yaml
@@ -20,11 +20,6 @@ disable:
   triggers: false
 repositories:
 - name: optaplanner
-  branch: main
-- name: optaweb-vehicle-routing
-  branch: main
-- name: optaplanner-quickstarts
-  branch: development
 git:
   author:
     name: kiegroup

--- a/.ci/jenkins/config/main.yaml
+++ b/.ci/jenkins/config/main.yaml
@@ -6,19 +6,17 @@ ecosystem:
     - opta.*
 git:
   branches:
-  - name: main
-    seed:
-      branch: main
+  - name: optaplanner_pr_jenkins_label_upstream
   main_branch:
-    default: main
+    default: optaplanner_pr_jenkins_label_upstream
 seed:
   config_file:
     git:
       repository: optaplanner
       author:
-        name: kiegroup
+        name: radtriste
         credentials_id: kie-ci
-      branch: main
+      branch: optaplanner_pr_jenkins_label_upstream
     path: .ci/jenkins/config/branch.yaml
 jenkins:
   email_creds_id: OPTAPLANNER_CI_EMAIL

--- a/.ci/jenkins/dsl/jobs.groovy
+++ b/.ci/jenkins/dsl/jobs.groovy
@@ -209,16 +209,16 @@ Map getMultijobPRConfig(Folder jobFolder) {
                     // As we have only Community edition
                     DISABLE_SONARCLOUD: !Utils.isMainBranch(this),
                 ]
-            ], [
-                id: 'optaweb-vehicle-routing',
-                repository: 'optaweb-vehicle-routing'
-            ], [
-                id: 'optaplanner-quickstarts',
-                repository: 'optaplanner-quickstarts',
-                env : [
-                    BUILD_MVN_OPTS_CURRENT: '-Dfull',
-                    OPTAPLANNER_BUILD_MVN_OPTS_UPSTREAM: '-Dfull'
-                ]
+            // ], [
+            //     id: 'optaweb-vehicle-routing',
+            //     repository: 'optaweb-vehicle-routing'
+            // ], [
+            //     id: 'optaplanner-quickstarts',
+            //     repository: 'optaplanner-quickstarts',
+            //     env : [
+            //         BUILD_MVN_OPTS_CURRENT: '-Dfull',
+            //         OPTAPLANNER_BUILD_MVN_OPTS_UPSTREAM: '-Dfull'
+            //     ]
             ]
         ]
     ]

--- a/.ci/jenkins/dsl/jobs.groovy
+++ b/.ci/jenkins/dsl/jobs.groovy
@@ -229,7 +229,11 @@ Map getMultijobPRConfig(Folder jobFolder) {
 }
 
 // Optaplanner PR checks
-KogitoJobUtils.createAllEnvsPerRepoPRJobs(this) { jobFolder -> getMultijobPRConfig(jobFolder) }
+KogitoJobUtils.createAllEnvsPerRepoPRJobs(this, { jobFolder -> getMultijobPRConfig(jobFolder) }) {
+    def jobParams = KogitoJobUtils.getDefaultJobParams(this)
+    jobParams.pr.use_gha_label_triggers = true
+    return jobParams
+}
 setupDeployJob(Folder.PULLREQUEST_RUNTIMES_BDD)
 
 // Init branch

--- a/.github/workflows/jpa_integration_ci.yml
+++ b/.github/workflows/jpa_integration_ci.yml
@@ -24,6 +24,7 @@ on:
       - '**.adoc'
       - '*.txt'
       - '.ci/**'
+      - '.github/**' # to remove
 
 defaults:
   run:

--- a/.github/workflows/jpa_integration_ci.yml
+++ b/.github/workflows/jpa_integration_ci.yml
@@ -24,6 +24,7 @@ on:
       - '**.adoc'
       - '*.txt'
       - '.ci/**'
+      - '.github/**' # TO remove
 
 defaults:
   run:

--- a/.github/workflows/jpa_integration_ci.yml
+++ b/.github/workflows/jpa_integration_ci.yml
@@ -24,7 +24,6 @@ on:
       - '**.adoc'
       - '*.txt'
       - '.ci/**'
-      - '.github/**' # TO remove
 
 defaults:
   run:

--- a/.github/workflows/labeling.yml
+++ b/.github/workflows/labeling.yml
@@ -18,11 +18,11 @@ jobs:
           organization: kiegroup
           username: ${{ github.event.pull_request.user.login }}
           token: ${{ secrets.KIE_CI_READ_ORG_TOKEN }}
-      - name: User belongs to organization - Add Jenkins CI label
+      - name: User belongs to organization - Add Safe for CI label
         uses: actions-ecosystem/action-add-labels@v1
         if: ${{ steps.is_organization_member.outputs.result }}
         with:
-          labels: jenkins-ci
+          labels: safe_for_ci
       - name: User does not belong to the organization
         uses: peter-evans/create-or-update-comment@v2
         if: ${{ ! steps.is_organization_member.outputs.result }}

--- a/.github/workflows/labeling.yml
+++ b/.github/workflows/labeling.yml
@@ -19,16 +19,15 @@ jobs:
           token: ${{ secrets.KIE_CI_READ_ORG_TOKEN }}
       - name: Debug that user belongs to it
         run: |
-          echo "Username = ${{ github.event.pull_request.user.login }}"
-          echo "User belongs = ${{ steps.is_organization_member.outputs.result }}"
+          echo "User belongs to kiegroup = ${{ steps.is_organization_member.outputs.result }}"
       
-      # - name: Check if organization member does not belong
-      #   id: is_organization_member_not_belong
-      #   uses: jamessingleton/is-organization-member@1.0.1
-      #   with:
-      #     organization: kiegroup13456
-      #     username: ${{ github.event.pull_request.user.login }}
-      #     token: ${{ secrets.GITHUB_TOKEN }}
-      # - name: Debug that user NOT belongs to it
-      #   run: |
-      #     echo "User belongs = ${{ steps.is_organization_member_not_belong.outputs.result }}"
+      - name: Check if organization member does not belong
+        id: is_organization_member_not_belong
+        uses: radtriste/is-organization-member@debug_gha
+        with:
+          organization: kiegroup
+          username: anyuser
+          token: ${{ secrets.KIE_CI_READ_ORG_TOKEN }}
+      - name: Debug that user NOT belongs to it
+        run: |
+          echo "User belongs to  = ${{ steps.is_organization_member_not_belong.outputs.result }}"

--- a/.github/workflows/labeling.yml
+++ b/.github/workflows/labeling.yml
@@ -17,17 +17,18 @@ jobs:
           organization: kiegroup
           username: ${{ github.event.pull_request.user.login }}
           token: ${{ secrets.KIE_CI_READ_ORG_TOKEN }}
-      - name: Debug that user belongs to it
-        run: |
-          echo "User belongs to kiegroup = ${{ steps.is_organization_member.outputs.result }}"
-      
-      - name: Check if organization member does not belong
-        id: is_organization_member_not_belong
-        uses: radtriste/is-organization-member@debug_gha
+      - name: User belongs to organization - Add Jenkins CI label
+        uses: actions-ecosystem/action-add-labels@v1
+        if: ${{ steps.is_organization_member.outputs.result }}
         with:
-          organization: kiegroup
-          username: anyuser
-          token: ${{ secrets.KIE_CI_READ_ORG_TOKEN }}
-      - name: Debug that user NOT belongs to it
-        run: |
-          echo "User belongs to  = ${{ steps.is_organization_member_not_belong.outputs.result }}"
+          labels: jenkins-ci
+      - name: User does not belong to the organization
+        uses: actions/github-script@v6
+        with:
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.pull_request.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: '👋 Thanks for reporting!'
+            })

--- a/.github/workflows/labeling.yml
+++ b/.github/workflows/labeling.yml
@@ -1,0 +1,34 @@
+on:
+  # pull_request_target:
+  pull_request: # TODO to set back after testing
+    branches:
+      - main
+      - 8.*
+
+jobs:
+  label_pr:
+    name: Set correct label to PR
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check if organization member belongs
+        id: is_organization_member
+        uses: radtriste/is-organization-member@debug_gha
+        with:
+          organization: kiegroup
+          username: ${{ github.event.pull_request.user.login }}
+          token: ${{ secrets.KIE_CI_READ_ORG_TOKEN }}
+      - name: Debug that user belongs to it
+        run: |
+          echo "Username = ${{ github.event.pull_request.user.login }}"
+          echo "User belongs = ${{ steps.is_organization_member.outputs.result }}"
+      
+      # - name: Check if organization member does not belong
+      #   id: is_organization_member_not_belong
+      #   uses: jamessingleton/is-organization-member@1.0.1
+      #   with:
+      #     organization: kiegroup13456
+      #     username: ${{ github.event.pull_request.user.login }}
+      #     token: ${{ secrets.GITHUB_TOKEN }}
+      # - name: Debug that user NOT belongs to it
+      #   run: |
+      #     echo "User belongs = ${{ steps.is_organization_member_not_belong.outputs.result }}"

--- a/.github/workflows/labeling.yml
+++ b/.github/workflows/labeling.yml
@@ -1,5 +1,6 @@
 on:
-  pull_request_target:
+  # pull_request_target: # TODO set back
+  pull_request:
     branches:
       - main
       - 8.*

--- a/.github/workflows/labeling.yml
+++ b/.github/workflows/labeling.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - name: Check if organization member belongs
         id: is_organization_member
-        uses: radtriste/is-organization-member@debug_gha
+        uses: radtriste/is-organization-member@kiegroup_use
         with:
           organization: kiegroup
           username: ${{ github.event.pull_request.user.login }}

--- a/.github/workflows/labeling.yml
+++ b/.github/workflows/labeling.yml
@@ -7,7 +7,7 @@ on:
 
 env:
   LABEL_CI: 'safe_for_ci'
-  GATEKEEPER_TEAM: optaplanner_gatekeepers
+  GATEKEEPER_TEAM: optaplanner-gatekeepers
 
 jobs:
   label_pr:
@@ -33,5 +33,5 @@ jobs:
         with:
           issue-number: ${{ github.event.pull_request.number }}
           body: |
-            Could not determined if PR is safe for CI to run.
+            Could not determine if PR is safe for CI to run.
             @${{ env.GATEKEEPER_TEAM }}, please review and add the `${{ env.LABEL_CI }}` label if PR is ok to run.

--- a/.github/workflows/labeling.yml
+++ b/.github/workflows/labeling.yml
@@ -5,6 +5,10 @@ on:
       - 8.*
     types: [ labeled ] # TODO to set back after Jenkins DSL testing
 
+env:
+  LABEL_CI: 'safe_for_ci'
+  GATEKEEPER_TEAM: optaplanner_gatekeepers
+
 jobs:
   label_pr:
     name: Set correct label to PR
@@ -29,4 +33,5 @@ jobs:
         with:
           issue-number: ${{ github.event.pull_request.number }}
           body: |
-            User is not allowed to launch Jenkins CI. Please 'any_mentioned_user', add the label manually.
+            Could not determined if PR is safe for CI to run.
+            @${{ env.GATEKEEPER_TEAM }}, please review and add the `${{ env.LABEL_CI }}` label if PR is ok to run.

--- a/.github/workflows/labeling.yml
+++ b/.github/workflows/labeling.yml
@@ -1,3 +1,5 @@
+name: Labelling
+
 on:
   # pull_request_target: # TODO set back
   pull_request:
@@ -11,8 +13,8 @@ env:
   GATEKEEPER_TEAM: optaplanner-gatekeepers
 
 jobs:
-  label_pr:
-    name: Set correct label to PR
+  safe_for_ci:
+    name: Check if safe for CI
     if: contains(github.event.pull_request.labels.*.name, 'dsl-test') # TODO to set back after Jenkins DSL testing
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/labeling.yml
+++ b/.github/workflows/labeling.yml
@@ -24,6 +24,7 @@ jobs:
           labels: jenkins-ci
       - name: User does not belong to the organization
         uses: peter-evans/create-or-update-comment@v2
+        if: ${{ ! steps.is_organization_member.outputs.result }}
         with:
           issue-number: ${{ github.event.pull_request.number }}
           body: |

--- a/.github/workflows/labeling.yml
+++ b/.github/workflows/labeling.yml
@@ -1,13 +1,14 @@
 on:
-  # pull_request_target:
-  pull_request: # TODO to set back after testing
+  pull_request_target:
     branches:
       - main
       - 8.*
+    types: [ labeled ] # TODO to set back after Jenkins DSL testing
 
 jobs:
   label_pr:
     name: Set correct label to PR
+    if: contains(github.event.pull_request.labels.*.name, 'dsl_test') # TODO to set back after Jenkins DSL testing
     runs-on: ubuntu-latest
     steps:
       - name: Check if organization member belongs

--- a/.github/workflows/labeling.yml
+++ b/.github/workflows/labeling.yml
@@ -12,7 +12,7 @@ env:
 jobs:
   label_pr:
     name: Set correct label to PR
-    if: contains(github.event.pull_request.labels.*.name, 'dsl_test') # TODO to set back after Jenkins DSL testing
+    if: contains(github.event.pull_request.labels.*.name, 'dsl-test') # TODO to set back after Jenkins DSL testing
     runs-on: ubuntu-latest
     steps:
       - name: Check if organization member belongs

--- a/.github/workflows/labeling.yml
+++ b/.github/workflows/labeling.yml
@@ -23,12 +23,8 @@ jobs:
         with:
           labels: jenkins-ci
       - name: User does not belong to the organization
-        uses: actions/github-script@v6
+        uses: peter-evans/create-or-update-comment@v2
         with:
-          script: |
-            github.rest.issues.createComment({
-              issue_number: context.pull_request.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: '👋 Thanks for reporting!'
-            })
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            User is not allowed to launch Jenkins CI. Please 'any_mentioned_user', add the label manually.

--- a/.github/workflows/labeling.yml
+++ b/.github/workflows/labeling.yml
@@ -6,7 +6,7 @@ on:
     branches:
       - main
       - 8.*
-    types: [ labeled ] # TODO to set back after Jenkins DSL testing
+    # types: [ labeled ] # TODO to set back after Jenkins DSL testing
 
 env:
   LABEL_CI: 'safe_for_ci'
@@ -15,7 +15,7 @@ env:
 jobs:
   safe_for_ci:
     name: Check if safe for CI
-    if: contains(github.event.pull_request.labels.*.name, 'dsl-test') # TODO to set back after Jenkins DSL testing
+    # if: contains(github.event.pull_request.labels.*.name, 'dsl-test') # TODO to set back after Jenkins DSL testing
     runs-on: ubuntu-latest
     steps:
       - name: Check if organization member belongs

--- a/.github/workflows/labeling.yml
+++ b/.github/workflows/labeling.yml
@@ -30,6 +30,13 @@ jobs:
         if: ${{ steps.is_organization_member.outputs.result }}
         with:
           labels: safe_for_ci
+      - name: Launch jenkins test
+        uses: peter-evans/create-or-update-comment@v2
+        if: ${{ steps.is_organization_member.outputs.result }}
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            Jenkins test this
       - name: User does not belong to the organization
         uses: peter-evans/create-or-update-comment@v2
         if: ${{ ! steps.is_organization_member.outputs.result }}

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -25,7 +25,6 @@ on:
       - '**.adoc'
       - '*.txt'
       - '.ci/**'
-      - '.github/**' # TO remove
 
 defaults:
   run:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -25,6 +25,7 @@ on:
       - '**.adoc'
       - '*.txt'
       - '.ci/**'
+      - '.github/**' # to remove
 
 defaults:
   run:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -25,6 +25,7 @@ on:
       - '**.adoc'
       - '*.txt'
       - '.ci/**'
+      - '.github/**' # TO remove
 
 defaults:
   run:


### PR DESCRIPTION
<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.
-->

### JIRA

<!-- Add a JIRA ticket link if it exists. -->
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
- https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
- https://github.com/kiegroup/drools/pull/3000
- https://github.com/kiegroup/optaplanner/pull/899
- etc.
-->

### Checklist
- [ ] Documentation updated if applicable.
- [ ] Upgrade recipe provided if applicable.

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request checks</b>  
  Please add comment: <b>Jenkins retest this</b>

- for a <b>specific pull request check</b>  
  please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-vehicle-routing] tests</b>
  
- for a <b>full downstream build</b> 
  - for <b>jenkins</b> job: 
    please add comment: <b>Jenkins run fdb</b>
  - for <b>github actions</b> job: 
    add the label `run_fdb`

- for a <b>compile downstream build</b>  
  please add comment: <b>Jenkins run cdb</b>

- for a <b>full production downstream build</b>  
  please add comment: <b>Jenkins execute product fdb</b>

- for an <b>upstream build</b>  
  please add comment: <b>Jenkins run upstream</b>

- for <b>quarkus branch checks</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins run quarkus-branch</b>

- for a <b>quarkus branch specific check</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-vehicle-routing] quarkus-branch</b>

- for <b>quarkus main checks</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins run quarkus-main</b>

- for a <b>specific quarkus main check</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-vehicle-routing] quarkus-branch</b>

- for <b>native checks</b>  
  Run native checks  
  Please add comment: <b>Jenkins run native</b>

- for a <b>specific native check</b>  
  Run native checks 
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-vehicle-routing] native</b>

- for <b>mandrel checks</b>  
  Run native checks against Mandrel image
  Please add comment: <b>Jenkins run mandrel</b>

- for a <b>specific mandrel check</b>  
  Run native checks against Mandrel image  
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-vehicle-routing] mandrel</b>
</details>

### CI Status

 You can check OptaPlanner repositories CI status from [Chain Status webpage](https://kiegroup.github.io/optaplanner/).