### PR TITLE
Decouple HeuristicConfigPolicy and ScoreDirectorFactory plus related tests cleanup

### DIFF
--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/constructionheuristic/decider/forager/ConstructionHeuristicForagerFactory.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/constructionheuristic/decider/forager/ConstructionHeuristicForagerFactory.java
@@ -20,7 +20,7 @@ public class ConstructionHeuristicForagerFactory<Solution_> {
     public ConstructionHeuristicForager<Solution_> buildForager(HeuristicConfigPolicy<Solution_> configPolicy) {
         ConstructionHeuristicPickEarlyType pickEarlyType_;
         if (foragerConfig.getPickEarlyType() == null) {
-            pickEarlyType_ = configPolicy.getScoreDirectorFactory().getInitializingScoreTrend().isOnlyDown()
+            pickEarlyType_ = configPolicy.getInitializingScoreTrend().isOnlyDown()
                     ? ConstructionHeuristicPickEarlyType.FIRST_NON_DETERIORATING_SCORE
                     : ConstructionHeuristicPickEarlyType.NEVER;
         } else {

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/exhaustivesearch/DefaultExhaustiveSearchPhaseFactory.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/exhaustivesearch/DefaultExhaustiveSearchPhaseFactory.java
@@ -148,7 +148,7 @@ public class DefaultExhaustiveSearchPhaseFactory<Solution_>
         MoveSelector<Solution_> moveSelector = MoveSelectorFactory.<Solution_> create(moveSelectorConfig_)
                 .buildMoveSelector(configPolicy, SelectionCacheType.JUST_IN_TIME, SelectionOrder.ORIGINAL);
         ScoreBounder scoreBounder = scoreBounderEnabled
-                ? new TrendBasedScoreBounder(configPolicy.getScoreDirectorFactory())
+                ? new TrendBasedScoreBounder(configPolicy.getScoreDefinition(), configPolicy.getInitializingScoreTrend())
                 : null;
         ExhaustiveSearchDecider<Solution_> decider = new ExhaustiveSearchDecider<>(configPolicy.getLogIndentation(),
                 bestSolutionRecaller, termination,

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/exhaustivesearch/node/bounder/TrendBasedScoreBounder.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/exhaustivesearch/node/bounder/TrendBasedScoreBounder.java
@@ -3,7 +3,6 @@ package org.optaplanner.core.impl.exhaustivesearch.node.bounder;
 import org.optaplanner.core.api.score.Score;
 import org.optaplanner.core.api.score.director.ScoreDirector;
 import org.optaplanner.core.impl.score.definition.ScoreDefinition;
-import org.optaplanner.core.impl.score.director.InnerScoreDirectorFactory;
 import org.optaplanner.core.impl.score.trend.InitializingScoreTrend;
 
 public class TrendBasedScoreBounder implements ScoreBounder {
@@ -11,9 +10,9 @@ public class TrendBasedScoreBounder implements ScoreBounder {
     protected final ScoreDefinition scoreDefinition;
     protected final InitializingScoreTrend initializingScoreTrend;
 
-    public TrendBasedScoreBounder(InnerScoreDirectorFactory scoreDirectorFactory) {
-        scoreDefinition = scoreDirectorFactory.getScoreDefinition();
-        initializingScoreTrend = scoreDirectorFactory.getInitializingScoreTrend();
+    public TrendBasedScoreBounder(ScoreDefinition scoreDefinition, InitializingScoreTrend initializingScoreTrend) {
+        this.scoreDefinition = scoreDefinition;
+        this.initializingScoreTrend = initializingScoreTrend;
     }
 
     @Override

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/HeuristicConfigPolicy.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/HeuristicConfigPolicy.java
@@ -14,7 +14,7 @@ import org.optaplanner.core.impl.heuristic.selector.entity.mimic.EntityMimicReco
 import org.optaplanner.core.impl.heuristic.selector.value.ValueSelector;
 import org.optaplanner.core.impl.heuristic.selector.value.mimic.ValueMimicRecorder;
 import org.optaplanner.core.impl.score.definition.ScoreDefinition;
-import org.optaplanner.core.impl.score.director.InnerScoreDirectorFactory;
+import org.optaplanner.core.impl.score.trend.InitializingScoreTrend;
 import org.optaplanner.core.impl.solver.thread.ChildThreadType;
 import org.optaplanner.core.impl.solver.thread.DefaultSolverThreadFactory;
 
@@ -25,7 +25,8 @@ public class HeuristicConfigPolicy<Solution_> {
     private final Integer moveThreadCount;
     private final Integer moveThreadBufferSize;
     private final Class<? extends ThreadFactory> threadFactoryClass;
-    private final InnerScoreDirectorFactory<Solution_, ?> scoreDirectorFactory;
+    private final InitializingScoreTrend initializingScoreTrend;
+    private final SolutionDescriptor<Solution_> solutionDescriptor;
 
     private final EntitySorterManner entitySorterManner;
     private final ValueSorterManner valueSorterManner;
@@ -42,7 +43,8 @@ public class HeuristicConfigPolicy<Solution_> {
         this.moveThreadCount = builder.moveThreadCount;
         this.moveThreadBufferSize = builder.moveThreadBufferSize;
         this.threadFactoryClass = builder.threadFactoryClass;
-        this.scoreDirectorFactory = builder.scoreDirectorFactory;
+        this.initializingScoreTrend = builder.initializingScoreTrend;
+        this.solutionDescriptor = builder.solutionDescriptor;
         this.entitySorterManner = builder.entitySorterManner;
         this.valueSorterManner = builder.valueSorterManner;
         this.reinitializeVariableFilterEnabled = builder.reinitializeVariableFilterEnabled;
@@ -65,16 +67,16 @@ public class HeuristicConfigPolicy<Solution_> {
         return moveThreadBufferSize;
     }
 
+    public InitializingScoreTrend getInitializingScoreTrend() {
+        return initializingScoreTrend;
+    }
+
     public SolutionDescriptor<Solution_> getSolutionDescriptor() {
-        return scoreDirectorFactory.getSolutionDescriptor();
+        return solutionDescriptor;
     }
 
     public ScoreDefinition getScoreDefinition() {
-        return scoreDirectorFactory.getScoreDefinition();
-    }
-
-    public InnerScoreDirectorFactory<Solution_, ?> getScoreDirectorFactory() {
-        return scoreDirectorFactory;
+        return solutionDescriptor.getScoreDefinition();
     }
 
     public EntitySorterManner getEntitySorterManner() {
@@ -98,8 +100,8 @@ public class HeuristicConfigPolicy<Solution_> {
     // ************************************************************************
 
     public Builder<Solution_> cloneBuilder() {
-        return new Builder<>(environmentMode, moveThreadCount, moveThreadBufferSize, threadFactoryClass, scoreDirectorFactory)
-                .withLogIndentation(logIndentation);
+        return new Builder<>(environmentMode, moveThreadCount, moveThreadBufferSize, threadFactoryClass, initializingScoreTrend,
+                solutionDescriptor).withLogIndentation(logIndentation);
     }
 
     public HeuristicConfigPolicy<Solution_> createPhaseConfigPolicy() {
@@ -170,7 +172,8 @@ public class HeuristicConfigPolicy<Solution_> {
         private final Integer moveThreadCount;
         private final Integer moveThreadBufferSize;
         private final Class<? extends ThreadFactory> threadFactoryClass;
-        private final InnerScoreDirectorFactory<Solution_, ?> scoreDirectorFactory;
+        private final InitializingScoreTrend initializingScoreTrend;
+        private final SolutionDescriptor<Solution_> solutionDescriptor;
 
         private String logIndentation = "";
 
@@ -182,12 +185,13 @@ public class HeuristicConfigPolicy<Solution_> {
 
         public Builder(EnvironmentMode environmentMode, Integer moveThreadCount,
                 Integer moveThreadBufferSize, Class<? extends ThreadFactory> threadFactoryClass,
-                InnerScoreDirectorFactory<Solution_, ?> scoreDirectorFactory) {
+                InitializingScoreTrend initializingScoreTrend, SolutionDescriptor<Solution_> solutionDescriptor) {
             this.environmentMode = environmentMode;
             this.moveThreadCount = moveThreadCount;
             this.moveThreadBufferSize = moveThreadBufferSize;
             this.threadFactoryClass = threadFactoryClass;
-            this.scoreDirectorFactory = scoreDirectorFactory;
+            this.initializingScoreTrend = initializingScoreTrend;
+            this.solutionDescriptor = solutionDescriptor;
         }
 
         public Builder<Solution_> withLogIndentation(String logIndentation) {

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/solver/DefaultSolverFactory.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/solver/DefaultSolverFactory.java
@@ -110,9 +110,13 @@ public final class DefaultSolverFactory<Solution_> implements SolverFactory<Solu
         Integer moveThreadCount_ = new MoveThreadCountResolver().resolveMoveThreadCount(solverConfig.getMoveThreadCount());
         BestSolutionRecaller<Solution_> bestSolutionRecaller =
                 BestSolutionRecallerFactory.create().buildBestSolutionRecaller(environmentMode_);
-        HeuristicConfigPolicy<Solution_> configPolicy = new HeuristicConfigPolicy.Builder<>(environmentMode_,
-                moveThreadCount_, solverConfig.getMoveThreadBufferSize(), solverConfig.getThreadFactoryClass(),
-                scoreDirectorFactory).build();
+        HeuristicConfigPolicy<Solution_> configPolicy = new HeuristicConfigPolicy.Builder<>(
+                environmentMode_,
+                moveThreadCount_,
+                solverConfig.getMoveThreadBufferSize(),
+                solverConfig.getThreadFactoryClass(),
+                scoreDirectorFactory.getInitializingScoreTrend(),
+                solutionDescriptor).build();
         TerminationConfig terminationConfig_ =
                 Objects.requireNonNullElseGet(solverConfig.getTerminationConfig(), TerminationConfig::new);
         BasicPlumbingTermination<Solution_> basicPlumbingTermination = new BasicPlumbingTermination<>(daemon_);

--- a/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/config/constructionheuristic/placer/PooledEntityPlacerFactoryTest.java
+++ b/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/config/constructionheuristic/placer/PooledEntityPlacerFactoryTest.java
@@ -1,18 +1,14 @@
 package org.optaplanner.core.config.constructionheuristic.placer;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 import org.junit.jupiter.api.Test;
-import org.optaplanner.core.api.score.buildin.simple.SimpleScore;
 import org.optaplanner.core.config.heuristic.selector.move.generic.ChangeMoveSelectorConfig;
 import org.optaplanner.core.config.heuristic.selector.value.ValueSelectorConfig;
 import org.optaplanner.core.config.solver.EnvironmentMode;
 import org.optaplanner.core.impl.constructionheuristic.placer.PooledEntityPlacerFactory;
 import org.optaplanner.core.impl.domain.solution.descriptor.SolutionDescriptor;
 import org.optaplanner.core.impl.heuristic.HeuristicConfigPolicy;
-import org.optaplanner.core.impl.score.director.InnerScoreDirectorFactory;
 import org.optaplanner.core.impl.testdata.domain.TestdataEntity;
 import org.optaplanner.core.impl.testdata.domain.TestdataSolution;
 
@@ -40,9 +36,7 @@ class PooledEntityPlacerFactoryTest {
 
     public HeuristicConfigPolicy<TestdataSolution>
             buildHeuristicConfigPolicy(SolutionDescriptor<TestdataSolution> solutionDescriptor) {
-        InnerScoreDirectorFactory<TestdataSolution, SimpleScore> scoreDirectorFactory = mock(InnerScoreDirectorFactory.class);
-        when(scoreDirectorFactory.getSolutionDescriptor()).thenReturn(solutionDescriptor);
-        return new HeuristicConfigPolicy.Builder<>(EnvironmentMode.REPRODUCIBLE, null, null, null, scoreDirectorFactory)
+        return new HeuristicConfigPolicy.Builder<>(EnvironmentMode.REPRODUCIBLE, null, null, null, null, solutionDescriptor)
                 .build();
     }
 }

--- a/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/constructionheuristic/placer/entity/PlacementAssertions.java
+++ b/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/constructionheuristic/placer/entity/PlacementAssertions.java
@@ -9,9 +9,9 @@ import org.optaplanner.core.impl.constructionheuristic.placer.Placement;
 import org.optaplanner.core.impl.heuristic.move.Move;
 import org.optaplanner.core.impl.heuristic.selector.move.generic.ChangeMove;
 
-public abstract class AbstractEntityPlacerTest {
+final class PlacementAssertions {
 
-    public static <Solution_> void assertEntityPlacement(Placement<Solution_> placement, String entityCode,
+    static <Solution_> void assertEntityPlacement(Placement<Solution_> placement, String entityCode,
             String... valueCodes) {
         Iterator<Move<Solution_>> iterator = placement.iterator();
         assertThat(iterator).isNotNull();
@@ -24,7 +24,7 @@ public abstract class AbstractEntityPlacerTest {
         assertThat(iterator.hasNext()).isFalse();
     }
 
-    public static <Solution_> void assertValuePlacement(Placement<Solution_> placement, String valueCode,
+    static <Solution_> void assertValuePlacement(Placement<Solution_> placement, String valueCode,
             String... entityCodes) {
         Iterator<Move<Solution_>> iterator = placement.iterator();
         assertThat(iterator).isNotNull();
@@ -37,4 +37,6 @@ public abstract class AbstractEntityPlacerTest {
         assertThat(iterator.hasNext()).isFalse();
     }
 
+    private PlacementAssertions() {
+    }
 }

--- a/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/constructionheuristic/placer/entity/PooledEntityPlacerFactoryTest.java
+++ b/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/constructionheuristic/placer/entity/PooledEntityPlacerFactoryTest.java
@@ -1,8 +1,9 @@
-package org.optaplanner.core.config.constructionheuristic.placer;
+package org.optaplanner.core.impl.constructionheuristic.placer.entity;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.jupiter.api.Test;
+import org.optaplanner.core.config.constructionheuristic.placer.PooledEntityPlacerConfig;
 import org.optaplanner.core.config.heuristic.selector.move.generic.ChangeMoveSelectorConfig;
 import org.optaplanner.core.config.heuristic.selector.value.ValueSelectorConfig;
 import org.optaplanner.core.config.solver.EnvironmentMode;

--- a/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/constructionheuristic/placer/entity/PooledEntityPlacerFactoryTest.java
+++ b/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/constructionheuristic/placer/entity/PooledEntityPlacerFactoryTest.java
@@ -1,14 +1,13 @@
 package org.optaplanner.core.impl.constructionheuristic.placer.entity;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.optaplanner.core.impl.heuristic.HeuristicConfigPolicyTestUtils.buildHeuristicConfigPolicy;
 
 import org.junit.jupiter.api.Test;
 import org.optaplanner.core.config.constructionheuristic.placer.PooledEntityPlacerConfig;
 import org.optaplanner.core.config.heuristic.selector.move.generic.ChangeMoveSelectorConfig;
 import org.optaplanner.core.config.heuristic.selector.value.ValueSelectorConfig;
-import org.optaplanner.core.config.solver.EnvironmentMode;
 import org.optaplanner.core.impl.constructionheuristic.placer.PooledEntityPlacerFactory;
-import org.optaplanner.core.impl.domain.solution.descriptor.SolutionDescriptor;
 import org.optaplanner.core.impl.heuristic.HeuristicConfigPolicy;
 import org.optaplanner.core.impl.testdata.domain.TestdataEntity;
 import org.optaplanner.core.impl.testdata.domain.TestdataSolution;
@@ -17,12 +16,10 @@ class PooledEntityPlacerFactoryTest {
 
     @Test
     void unfoldNew() {
-        SolutionDescriptor<TestdataSolution> solutionDescriptor = TestdataSolution.buildSolutionDescriptor();
-
         ChangeMoveSelectorConfig moveSelectorConfig = new ChangeMoveSelectorConfig();
         moveSelectorConfig.setValueSelectorConfig(new ValueSelectorConfig("value"));
 
-        HeuristicConfigPolicy<TestdataSolution> configPolicy = buildHeuristicConfigPolicy(solutionDescriptor);
+        HeuristicConfigPolicy<TestdataSolution> configPolicy = buildHeuristicConfigPolicy();
         PooledEntityPlacerConfig placerConfig = PooledEntityPlacerFactory.unfoldNew(configPolicy, moveSelectorConfig);
 
         assertThat(placerConfig.getMoveSelectorConfig()).isExactlyInstanceOf(ChangeMoveSelectorConfig.class);
@@ -33,11 +30,5 @@ class PooledEntityPlacerFactoryTest {
         assertThat(changeMoveSelectorConfig.getEntitySelectorConfig().getMimicSelectorRef())
                 .isEqualTo(TestdataEntity.class.getName());
         assertThat(changeMoveSelectorConfig.getValueSelectorConfig().getVariableName()).isEqualTo("value");
-    }
-
-    public HeuristicConfigPolicy<TestdataSolution>
-            buildHeuristicConfigPolicy(SolutionDescriptor<TestdataSolution> solutionDescriptor) {
-        return new HeuristicConfigPolicy.Builder<>(EnvironmentMode.REPRODUCIBLE, null, null, null, null, solutionDescriptor)
-                .build();
     }
 }

--- a/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/constructionheuristic/placer/entity/PooledEntityPlacerTest.java
+++ b/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/constructionheuristic/placer/entity/PooledEntityPlacerTest.java
@@ -19,7 +19,7 @@ import org.optaplanner.core.impl.phase.scope.AbstractStepScope;
 import org.optaplanner.core.impl.solver.scope.SolverScope;
 import org.optaplanner.core.impl.testdata.domain.TestdataSolution;
 
-class PooledEntityPlacerTest extends AbstractEntityPlacerTest {
+class PooledEntityPlacerTest {
 
     @Test
     void oneMoveSelector() {

--- a/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/constructionheuristic/placer/entity/QueuedEntityPlacerFactoryTest.java
+++ b/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/constructionheuristic/placer/entity/QueuedEntityPlacerFactoryTest.java
@@ -3,6 +3,7 @@ package org.optaplanner.core.impl.constructionheuristic.placer.entity;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.optaplanner.core.impl.constructionheuristic.placer.entity.PlacementAssertions.assertEntityPlacement;
 
 import java.util.Arrays;
 import java.util.Iterator;
@@ -26,7 +27,7 @@ import org.optaplanner.core.impl.testdata.domain.TestdataValue;
 import org.optaplanner.core.impl.testdata.domain.multivar.TestdataMultiVarEntity;
 import org.optaplanner.core.impl.testdata.domain.multivar.TestdataMultiVarSolution;
 
-class QueuedEntityPlacerFactoryTest extends AbstractEntityPlacerTest {
+class QueuedEntityPlacerFactoryTest {
 
     @Test
     void buildFromUnfoldNew() {

--- a/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/constructionheuristic/placer/entity/QueuedEntityPlacerFactoryTest.java
+++ b/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/constructionheuristic/placer/entity/QueuedEntityPlacerFactoryTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.optaplanner.core.impl.constructionheuristic.placer.entity.PlacementAssertions.assertEntityPlacement;
+import static org.optaplanner.core.impl.heuristic.HeuristicConfigPolicyTestUtils.buildHeuristicConfigPolicy;
 
 import java.util.Arrays;
 import java.util.Iterator;
@@ -13,7 +14,6 @@ import org.optaplanner.core.api.score.buildin.simple.SimpleScore;
 import org.optaplanner.core.config.constructionheuristic.placer.QueuedEntityPlacerConfig;
 import org.optaplanner.core.config.heuristic.selector.move.generic.ChangeMoveSelectorConfig;
 import org.optaplanner.core.config.heuristic.selector.value.ValueSelectorConfig;
-import org.optaplanner.core.config.solver.EnvironmentMode;
 import org.optaplanner.core.impl.constructionheuristic.placer.Placement;
 import org.optaplanner.core.impl.constructionheuristic.placer.QueuedEntityPlacer;
 import org.optaplanner.core.impl.constructionheuristic.placer.QueuedEntityPlacerFactory;
@@ -68,12 +68,6 @@ class QueuedEntityPlacerFactoryTest {
         Placement<TestdataMultiVarSolution> placement = placementIterator.next();
 
         assertEntityPlacement(placement, "e1", "e1v1", "e1v2", "e2v1", "e2v2");
-    }
-
-    public HeuristicConfigPolicy<TestdataMultiVarSolution>
-            buildHeuristicConfigPolicy(SolutionDescriptor<TestdataMultiVarSolution> solutionDescriptor) {
-        return new HeuristicConfigPolicy.Builder<>(EnvironmentMode.REPRODUCIBLE, null, null, null, null, solutionDescriptor)
-                .build();
     }
 
     private TestdataMultiVarSolution generateTestdataSolution() {

--- a/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/constructionheuristic/placer/entity/QueuedEntityPlacerFactoryTest.java
+++ b/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/constructionheuristic/placer/entity/QueuedEntityPlacerFactoryTest.java
@@ -20,9 +20,7 @@ import org.optaplanner.core.impl.domain.solution.descriptor.SolutionDescriptor;
 import org.optaplanner.core.impl.heuristic.HeuristicConfigPolicy;
 import org.optaplanner.core.impl.phase.scope.AbstractPhaseScope;
 import org.optaplanner.core.impl.phase.scope.AbstractStepScope;
-import org.optaplanner.core.impl.score.buildin.SimpleScoreDefinition;
 import org.optaplanner.core.impl.score.director.InnerScoreDirector;
-import org.optaplanner.core.impl.score.director.InnerScoreDirectorFactory;
 import org.optaplanner.core.impl.solver.scope.SolverScope;
 import org.optaplanner.core.impl.testdata.domain.TestdataValue;
 import org.optaplanner.core.impl.testdata.domain.multivar.TestdataMultiVarEntity;
@@ -73,11 +71,7 @@ class QueuedEntityPlacerFactoryTest extends AbstractEntityPlacerTest {
 
     public HeuristicConfigPolicy<TestdataMultiVarSolution>
             buildHeuristicConfigPolicy(SolutionDescriptor<TestdataMultiVarSolution> solutionDescriptor) {
-        InnerScoreDirectorFactory<TestdataMultiVarSolution, SimpleScore> scoreDirectorFactory =
-                mock(InnerScoreDirectorFactory.class);
-        when(scoreDirectorFactory.getSolutionDescriptor()).thenReturn(solutionDescriptor);
-        when(scoreDirectorFactory.getScoreDefinition()).thenReturn(new SimpleScoreDefinition());
-        return new HeuristicConfigPolicy.Builder<>(EnvironmentMode.REPRODUCIBLE, null, null, null, scoreDirectorFactory)
+        return new HeuristicConfigPolicy.Builder<>(EnvironmentMode.REPRODUCIBLE, null, null, null, null, solutionDescriptor)
                 .build();
     }
 

--- a/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/constructionheuristic/placer/entity/QueuedEntityPlacerTest.java
+++ b/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/constructionheuristic/placer/entity/QueuedEntityPlacerTest.java
@@ -3,6 +3,7 @@ package org.optaplanner.core.impl.constructionheuristic.placer.entity;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.optaplanner.core.impl.constructionheuristic.placer.entity.PlacementAssertions.assertEntityPlacement;
 import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertAllCodesOfIterator;
 import static org.optaplanner.core.impl.testdata.util.PlannerAssert.verifyPhaseLifecycle;
 
@@ -31,7 +32,7 @@ import org.optaplanner.core.impl.testdata.domain.TestdataValue;
 import org.optaplanner.core.impl.testdata.domain.multivar.TestdataMultiVarEntity;
 import org.optaplanner.core.impl.testdata.domain.multivar.TestdataMultiVarSolution;
 
-class QueuedEntityPlacerTest extends AbstractEntityPlacerTest {
+class QueuedEntityPlacerTest {
 
     @Test
     void oneMoveSelector() {

--- a/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/constructionheuristic/placer/entity/QueuedValuePlacerFactoryTest.java
+++ b/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/constructionheuristic/placer/entity/QueuedValuePlacerFactoryTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.optaplanner.core.impl.constructionheuristic.placer.entity.PlacementAssertions.assertValuePlacement;
+import static org.optaplanner.core.impl.heuristic.HeuristicConfigPolicyTestUtils.buildHeuristicConfigPolicy;
 
 import java.util.Arrays;
 import java.util.Iterator;
@@ -11,12 +12,9 @@ import java.util.Iterator;
 import org.junit.jupiter.api.Test;
 import org.optaplanner.core.api.score.buildin.simple.SimpleScore;
 import org.optaplanner.core.config.constructionheuristic.placer.QueuedValuePlacerConfig;
-import org.optaplanner.core.config.solver.EnvironmentMode;
 import org.optaplanner.core.impl.constructionheuristic.placer.Placement;
 import org.optaplanner.core.impl.constructionheuristic.placer.QueuedValuePlacer;
 import org.optaplanner.core.impl.constructionheuristic.placer.QueuedValuePlacerFactory;
-import org.optaplanner.core.impl.domain.solution.descriptor.SolutionDescriptor;
-import org.optaplanner.core.impl.heuristic.HeuristicConfigPolicy;
 import org.optaplanner.core.impl.phase.scope.AbstractPhaseScope;
 import org.optaplanner.core.impl.phase.scope.AbstractStepScope;
 import org.optaplanner.core.impl.score.director.InnerScoreDirector;
@@ -53,12 +51,6 @@ class QueuedValuePlacerFactoryTest {
         Placement<TestdataSolution> placement = placementIterator.next();
 
         assertValuePlacement(placement, "v1", "e1", "e2");
-    }
-
-    public HeuristicConfigPolicy<TestdataSolution> buildHeuristicConfigPolicy() {
-        SolutionDescriptor<TestdataSolution> solutionDescriptor = TestdataSolution.buildSolutionDescriptor();
-        return new HeuristicConfigPolicy.Builder<>(EnvironmentMode.REPRODUCIBLE, null, null, null, null, solutionDescriptor)
-                .build();
     }
 
     private TestdataSolution generateSolution() {

--- a/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/constructionheuristic/placer/entity/QueuedValuePlacerFactoryTest.java
+++ b/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/constructionheuristic/placer/entity/QueuedValuePlacerFactoryTest.java
@@ -3,6 +3,7 @@ package org.optaplanner.core.impl.constructionheuristic.placer.entity;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.optaplanner.core.impl.constructionheuristic.placer.entity.PlacementAssertions.assertValuePlacement;
 
 import java.util.Arrays;
 import java.util.Iterator;
@@ -24,7 +25,7 @@ import org.optaplanner.core.impl.testdata.domain.TestdataEntity;
 import org.optaplanner.core.impl.testdata.domain.TestdataSolution;
 import org.optaplanner.core.impl.testdata.domain.TestdataValue;
 
-class QueuedValuePlacerFactoryTest extends AbstractEntityPlacerTest {
+class QueuedValuePlacerFactoryTest {
 
     @Test
     void buildEntityPlacer_withoutConfiguredMoveSelector() {

--- a/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/constructionheuristic/placer/entity/QueuedValuePlacerFactoryTest.java
+++ b/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/constructionheuristic/placer/entity/QueuedValuePlacerFactoryTest.java
@@ -18,9 +18,7 @@ import org.optaplanner.core.impl.domain.solution.descriptor.SolutionDescriptor;
 import org.optaplanner.core.impl.heuristic.HeuristicConfigPolicy;
 import org.optaplanner.core.impl.phase.scope.AbstractPhaseScope;
 import org.optaplanner.core.impl.phase.scope.AbstractStepScope;
-import org.optaplanner.core.impl.score.buildin.SimpleScoreDefinition;
 import org.optaplanner.core.impl.score.director.InnerScoreDirector;
-import org.optaplanner.core.impl.score.director.InnerScoreDirectorFactory;
 import org.optaplanner.core.impl.solver.scope.SolverScope;
 import org.optaplanner.core.impl.testdata.domain.TestdataEntity;
 import org.optaplanner.core.impl.testdata.domain.TestdataSolution;
@@ -58,10 +56,7 @@ class QueuedValuePlacerFactoryTest extends AbstractEntityPlacerTest {
 
     public HeuristicConfigPolicy<TestdataSolution> buildHeuristicConfigPolicy() {
         SolutionDescriptor<TestdataSolution> solutionDescriptor = TestdataSolution.buildSolutionDescriptor();
-        InnerScoreDirectorFactory<TestdataSolution, SimpleScore> scoreDirectorFactory = mock(InnerScoreDirectorFactory.class);
-        when(scoreDirectorFactory.getSolutionDescriptor()).thenReturn(solutionDescriptor);
-        when(scoreDirectorFactory.getScoreDefinition()).thenReturn(new SimpleScoreDefinition());
-        return new HeuristicConfigPolicy.Builder<>(EnvironmentMode.REPRODUCIBLE, null, null, null, scoreDirectorFactory)
+        return new HeuristicConfigPolicy.Builder<>(EnvironmentMode.REPRODUCIBLE, null, null, null, null, solutionDescriptor)
                 .build();
     }
 

--- a/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/constructionheuristic/placer/entity/QueuedValuePlacerTest.java
+++ b/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/constructionheuristic/placer/entity/QueuedValuePlacerTest.java
@@ -3,6 +3,7 @@ package org.optaplanner.core.impl.constructionheuristic.placer.entity;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.optaplanner.core.impl.constructionheuristic.placer.entity.PlacementAssertions.assertValuePlacement;
 import static org.optaplanner.core.impl.testdata.util.PlannerAssert.verifyPhaseLifecycle;
 
 import java.util.Iterator;
@@ -25,7 +26,7 @@ import org.optaplanner.core.impl.testdata.domain.TestdataEntity;
 import org.optaplanner.core.impl.testdata.domain.TestdataSolution;
 import org.optaplanner.core.impl.testdata.domain.TestdataValue;
 
-class QueuedValuePlacerTest extends AbstractEntityPlacerTest {
+class QueuedValuePlacerTest {
 
     @Test
     void oneMoveSelector() {

--- a/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/heuristic/HeuristicConfigPolicyTestUtils.java
+++ b/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/heuristic/HeuristicConfigPolicyTestUtils.java
@@ -1,20 +1,21 @@
-package org.optaplanner.core.impl.heuristic.selector;
+package org.optaplanner.core.impl.heuristic;
 
 import org.optaplanner.core.config.solver.EnvironmentMode;
 import org.optaplanner.core.impl.domain.solution.descriptor.SolutionDescriptor;
-import org.optaplanner.core.impl.heuristic.HeuristicConfigPolicy;
 import org.optaplanner.core.impl.testdata.domain.TestdataSolution;
 
-public abstract class AbstractSelectorFactoryTest {
+public final class HeuristicConfigPolicyTestUtils {
 
-    public HeuristicConfigPolicy<TestdataSolution> buildHeuristicConfigPolicy() {
+    public static HeuristicConfigPolicy<TestdataSolution> buildHeuristicConfigPolicy() {
         return buildHeuristicConfigPolicy(TestdataSolution.buildSolutionDescriptor());
     }
 
-    public <Solution_> HeuristicConfigPolicy<Solution_>
+    public static <Solution_> HeuristicConfigPolicy<Solution_>
             buildHeuristicConfigPolicy(SolutionDescriptor<Solution_> solutionDescriptor) {
         return new HeuristicConfigPolicy.Builder<>(EnvironmentMode.REPRODUCIBLE, null, null, null, null, solutionDescriptor)
                 .build();
     }
 
+    private HeuristicConfigPolicyTestUtils() {
+    }
 }

--- a/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/heuristic/selector/AbstractSelectorFactoryTest.java
+++ b/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/heuristic/selector/AbstractSelectorFactoryTest.java
@@ -1,14 +1,8 @@
 package org.optaplanner.core.impl.heuristic.selector;
 
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-
-import org.optaplanner.core.api.score.buildin.simple.SimpleScore;
 import org.optaplanner.core.config.solver.EnvironmentMode;
 import org.optaplanner.core.impl.domain.solution.descriptor.SolutionDescriptor;
 import org.optaplanner.core.impl.heuristic.HeuristicConfigPolicy;
-import org.optaplanner.core.impl.score.buildin.SimpleScoreDefinition;
-import org.optaplanner.core.impl.score.director.InnerScoreDirectorFactory;
 import org.optaplanner.core.impl.testdata.domain.TestdataSolution;
 
 public abstract class AbstractSelectorFactoryTest {
@@ -19,10 +13,7 @@ public abstract class AbstractSelectorFactoryTest {
 
     public <Solution_> HeuristicConfigPolicy<Solution_>
             buildHeuristicConfigPolicy(SolutionDescriptor<Solution_> solutionDescriptor) {
-        InnerScoreDirectorFactory<Solution_, SimpleScore> scoreDirectorFactory = mock(InnerScoreDirectorFactory.class);
-        when(scoreDirectorFactory.getSolutionDescriptor()).thenReturn(solutionDescriptor);
-        when(scoreDirectorFactory.getScoreDefinition()).thenReturn(new SimpleScoreDefinition());
-        return new HeuristicConfigPolicy.Builder<>(EnvironmentMode.REPRODUCIBLE, null, null, null, scoreDirectorFactory)
+        return new HeuristicConfigPolicy.Builder<>(EnvironmentMode.REPRODUCIBLE, null, null, null, null, solutionDescriptor)
                 .build();
     }
 

--- a/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/heuristic/selector/entity/EntitySelectorFactoryTest.java
+++ b/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/heuristic/selector/entity/EntitySelectorFactoryTest.java
@@ -3,6 +3,7 @@ package org.optaplanner.core.impl.heuristic.selector.entity;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.mockito.Mockito.mock;
+import static org.optaplanner.core.impl.heuristic.HeuristicConfigPolicyTestUtils.buildHeuristicConfigPolicy;
 
 import java.util.Comparator;
 
@@ -12,7 +13,6 @@ import org.optaplanner.core.config.heuristic.selector.common.SelectionCacheType;
 import org.optaplanner.core.config.heuristic.selector.common.SelectionOrder;
 import org.optaplanner.core.config.heuristic.selector.entity.EntitySelectorConfig;
 import org.optaplanner.core.impl.heuristic.HeuristicConfigPolicy;
-import org.optaplanner.core.impl.heuristic.selector.AbstractSelectorFactoryTest;
 import org.optaplanner.core.impl.heuristic.selector.SelectorTestUtils;
 import org.optaplanner.core.impl.heuristic.selector.common.decorator.SelectionProbabilityWeightFactory;
 import org.optaplanner.core.impl.heuristic.selector.common.decorator.SelectionSorterWeightFactory;
@@ -22,7 +22,7 @@ import org.optaplanner.core.impl.heuristic.selector.entity.decorator.SortingEnti
 import org.optaplanner.core.impl.testdata.domain.TestdataEntity;
 import org.optaplanner.core.impl.testdata.domain.TestdataSolution;
 
-class EntitySelectorFactoryTest extends AbstractSelectorFactoryTest {
+class EntitySelectorFactoryTest {
 
     @Test
     void phaseOriginal() {

--- a/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/heuristic/selector/move/MoveSelectorFactoryTest.java
+++ b/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/heuristic/selector/move/MoveSelectorFactoryTest.java
@@ -2,6 +2,7 @@ package org.optaplanner.core.impl.heuristic.selector.move;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.optaplanner.core.impl.heuristic.HeuristicConfigPolicyTestUtils.buildHeuristicConfigPolicy;
 
 import java.util.Comparator;
 import java.util.function.Consumer;
@@ -14,7 +15,6 @@ import org.optaplanner.core.config.heuristic.selector.common.decorator.Selection
 import org.optaplanner.core.config.heuristic.selector.move.MoveSelectorConfig;
 import org.optaplanner.core.impl.heuristic.HeuristicConfigPolicy;
 import org.optaplanner.core.impl.heuristic.move.DummyMove;
-import org.optaplanner.core.impl.heuristic.selector.AbstractSelectorFactoryTest;
 import org.optaplanner.core.impl.heuristic.selector.SelectorTestUtils;
 import org.optaplanner.core.impl.heuristic.selector.common.decorator.SelectionProbabilityWeightFactory;
 import org.optaplanner.core.impl.heuristic.selector.move.decorator.CachingMoveSelector;
@@ -23,7 +23,7 @@ import org.optaplanner.core.impl.heuristic.selector.move.decorator.ShufflingMove
 import org.optaplanner.core.impl.heuristic.selector.move.decorator.SortingMoveSelector;
 import org.optaplanner.core.impl.testdata.domain.TestdataSolution;
 
-class MoveSelectorFactoryTest extends AbstractSelectorFactoryTest {
+class MoveSelectorFactoryTest {
 
     @Test
     void phaseOriginal() {

--- a/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/heuristic/selector/move/generic/ChangeMoveSelectorFactoryTest.java
+++ b/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/heuristic/selector/move/generic/ChangeMoveSelectorFactoryTest.java
@@ -2,6 +2,7 @@ package org.optaplanner.core.impl.heuristic.selector.move.generic;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.optaplanner.core.impl.heuristic.HeuristicConfigPolicyTestUtils.buildHeuristicConfigPolicy;
 
 import org.junit.jupiter.api.Test;
 import org.optaplanner.core.config.heuristic.selector.common.SelectionCacheType;
@@ -10,7 +11,6 @@ import org.optaplanner.core.config.heuristic.selector.entity.EntitySelectorConfi
 import org.optaplanner.core.config.heuristic.selector.move.generic.ChangeMoveSelectorConfig;
 import org.optaplanner.core.config.heuristic.selector.value.ValueSelectorConfig;
 import org.optaplanner.core.impl.domain.solution.descriptor.SolutionDescriptor;
-import org.optaplanner.core.impl.heuristic.selector.AbstractSelectorFactoryTest;
 import org.optaplanner.core.impl.heuristic.selector.move.MoveSelector;
 import org.optaplanner.core.impl.heuristic.selector.move.MoveSelectorFactory;
 import org.optaplanner.core.impl.heuristic.selector.move.composite.UnionMoveSelector;
@@ -19,7 +19,7 @@ import org.optaplanner.core.impl.testdata.domain.multientity.TestdataHerdEntity;
 import org.optaplanner.core.impl.testdata.domain.multientity.TestdataMultiEntitySolution;
 import org.optaplanner.core.impl.testdata.domain.multivar.TestdataMultiVarSolution;
 
-class ChangeMoveSelectorFactoryTest extends AbstractSelectorFactoryTest {
+class ChangeMoveSelectorFactoryTest {
 
     @Test
     void deducibleMultiVar() {

--- a/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/heuristic/selector/move/generic/SwapMoveSelectorFactoryTest.java
+++ b/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/heuristic/selector/move/generic/SwapMoveSelectorFactoryTest.java
@@ -2,6 +2,7 @@ package org.optaplanner.core.impl.heuristic.selector.move.generic;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.optaplanner.core.impl.heuristic.HeuristicConfigPolicyTestUtils.buildHeuristicConfigPolicy;
 
 import java.util.Arrays;
 
@@ -11,7 +12,6 @@ import org.optaplanner.core.config.heuristic.selector.common.SelectionOrder;
 import org.optaplanner.core.config.heuristic.selector.entity.EntitySelectorConfig;
 import org.optaplanner.core.config.heuristic.selector.move.generic.SwapMoveSelectorConfig;
 import org.optaplanner.core.impl.domain.solution.descriptor.SolutionDescriptor;
-import org.optaplanner.core.impl.heuristic.selector.AbstractSelectorFactoryTest;
 import org.optaplanner.core.impl.heuristic.selector.move.MoveSelector;
 import org.optaplanner.core.impl.heuristic.selector.move.MoveSelectorFactory;
 import org.optaplanner.core.impl.heuristic.selector.move.composite.UnionMoveSelector;
@@ -22,7 +22,7 @@ import org.optaplanner.core.impl.testdata.domain.multientity.TestdataLeadEntity;
 import org.optaplanner.core.impl.testdata.domain.multientity.TestdataMultiEntitySolution;
 import org.optaplanner.core.impl.testdata.domain.multivar.TestdataMultiVarSolution;
 
-class SwapMoveSelectorFactoryTest extends AbstractSelectorFactoryTest {
+class SwapMoveSelectorFactoryTest {
 
     @Test
     void deducibleMultiVar() {

--- a/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/heuristic/selector/value/ValueSelectorFactoryTest.java
+++ b/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/heuristic/selector/value/ValueSelectorFactoryTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.optaplanner.core.impl.heuristic.HeuristicConfigPolicyTestUtils.buildHeuristicConfigPolicy;
 
 import java.util.Comparator;
 
@@ -15,7 +16,6 @@ import org.optaplanner.core.config.heuristic.selector.value.ValueSelectorConfig;
 import org.optaplanner.core.impl.domain.entity.descriptor.EntityDescriptor;
 import org.optaplanner.core.impl.domain.variable.descriptor.GenuineVariableDescriptor;
 import org.optaplanner.core.impl.heuristic.HeuristicConfigPolicy;
-import org.optaplanner.core.impl.heuristic.selector.AbstractSelectorFactoryTest;
 import org.optaplanner.core.impl.heuristic.selector.SelectorTestUtils;
 import org.optaplanner.core.impl.heuristic.selector.common.decorator.SelectionFilter;
 import org.optaplanner.core.impl.heuristic.selector.common.decorator.SelectionProbabilityWeightFactory;
@@ -28,7 +28,7 @@ import org.optaplanner.core.impl.testdata.domain.TestdataEntity;
 import org.optaplanner.core.impl.testdata.domain.TestdataSolution;
 import org.optaplanner.core.impl.testdata.domain.TestdataValue;
 
-class ValueSelectorFactoryTest extends AbstractSelectorFactoryTest {
+class ValueSelectorFactoryTest {
 
     @Test
     void phaseOriginal() {

--- a/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/score/buildin/AbstractScoreDefinitionTest.java
+++ b/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/score/buildin/AbstractScoreDefinitionTest.java
@@ -1,5 +1,0 @@
-package org.optaplanner.core.impl.score.buildin;
-
-public abstract class AbstractScoreDefinitionTest {
-
-}

--- a/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/score/buildin/HardSoftScoreDefinitionTest.java
+++ b/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/score/buildin/HardSoftScoreDefinitionTest.java
@@ -7,7 +7,7 @@ import org.optaplanner.core.api.score.buildin.hardsoft.HardSoftScore;
 import org.optaplanner.core.config.score.trend.InitializingScoreTrendLevel;
 import org.optaplanner.core.impl.score.trend.InitializingScoreTrend;
 
-class HardSoftScoreDefinitionTest extends AbstractScoreDefinitionTest {
+class HardSoftScoreDefinitionTest {
 
     @Test
     void getZeroScore() {


### PR DESCRIPTION
Benefits:
- ScoreDirectorFactory cannot leak from the policy object.
- Callers looking for the InitializingScoreTrend do not have to traverse through the SDF.
- Easier to create a HeuristicConfigPolicy instance because SDF is no longer needed (tests do not have to create an SDF mock).

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request checks</b>  
  Please add comment: <b>Jenkins retest this</b>

- for a <b>specific pull request check</b>  
  please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-vehicle-routing] tests</b>
  
- for a <b>full downstream build</b> 
  - for <b>jenkins</b> job: 
    please add comment: <b>Jenkins run fdb</b>
  - for <b>github actions</b> job: 
    add the label `run_fdb`

- for a <b>compile downstream build</b>  
  please add comment: <b>Jenkins run cdb</b>

- for a <b>full production downstream build</b>  
  please add comment: <b>Jenkins execute product fdb</b>

- for an <b>upstream build</b>  
  please add comment: <b>Jenkins run upstream</b>

- for <b>quarkus branch checks</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins run quarkus-branch</b>

- for a <b>quarkus branch specific check</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-vehicle-routing] quarkus-branch</b>

- for <b>quarkus main checks</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins run quarkus-main</b>

- for a <b>specific quarkus main check</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-vehicle-routing] quarkus-branch</b>

- for <b>native checks</b>  
  Run native checks  
  Please add comment: <b>Jenkins run native</b>

- for a <b>specific native check</b>  
  Run native checks 
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-vehicle-routing] native</b>

- for <b>mandrel checks</b>  
  Run native checks against Mandrel image
  Please add comment: <b>Jenkins run mandrel</b>

- for a <b>specific mandrel check</b>  
  Run native checks against Mandrel image  
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-vehicle-routing] mandrel</b>
</details>

### CI Status

 You can check OptaPlanner repositories CI status from [Chain Status webpage](https://kiegroup.github.io/optaplanner/).