### PR TITLE
re-edited OptaPlanner release procedure

### DIFF
--- a/build/release/release-procedure.adoc
+++ b/build/release/release-procedure.adoc
@@ -75,7 +75,7 @@ Most links in this document take the 8.27.x branch as an example!
 Run
 https://eng-jenkins-csb-business-automation.apps.ocp-c1.prod.psi.redhat.com/job/KIE/job/optaplanner/job/8.27.x/job/tools/job/update-drools-optaplanner/[update-drools-optaplanner]. +
 IMPORTANT: this job should be triggered only if the artifacts of Drools version (as an example `drools-bom`) are already on https://repo1.maven.org/maven2/org/drools/drools-bom[Maven Central].
-Also the Drools version has to be updated on OptaPlanner main branch running
+Also, the Drools version has to be updated on the OptaPlanner main branch by running
 https://eng-jenkins-csb-business-automation.apps.ocp-c1.prod.psi.redhat.com/job/KIE/job/optaplanner/job/main/job/tools/job/update-drools-optaplanner/[update-drools-optaplanner] on main branch.
 
 === 4. Release OptaPlanner

--- a/build/release/release-procedure.adoc
+++ b/build/release/release-procedure.adoc
@@ -80,7 +80,7 @@ https://eng-jenkins-csb-business-automation.apps.ocp-c1.prod.psi.redhat.com/job/
 
 === 4. Release OptaPlanner
 
-The OptaPlanner release pipeline can be triggered now based on the created new branch in step 2.
+The OptaPlanner release pipeline can now be triggered using the branch created in step 2.
 Run https://eng-jenkins-csb-business-automation.apps.ocp-c1.prod.psi.redhat.com/job/KIE/job/optaplanner/job/8.27.x/job/release/job/optaplanner-release[optaplanner-release].
 The OptaPlanner release pipeline runs the https://eng-jenkins-csb-business-automation.apps.ocp-c1.prod.psi.redhat.com/job/KIE/job/optaplanner/job/8.27.x/job/release/job/optaplanner-deploy[optaplanner-deploy] job
 which updates the project versions of OptaPlanner, Quickstarts and OptaWeb Vehicle Routing, builds these projects and deploys their artifacts to Nexus.

--- a/build/release/release-procedure.adoc
+++ b/build/release/release-procedure.adoc
@@ -74,7 +74,7 @@ Most links in this document take the 8.27.x branch as an example!
 
 Run
 https://eng-jenkins-csb-business-automation.apps.ocp-c1.prod.psi.redhat.com/job/KIE/job/optaplanner/job/8.27.x/job/tools/job/update-drools-optaplanner/[update-drools-optaplanner]. +
-IMPORTANT: this job should be triggered only if the artifacts of Drools version (as an example drools-bom) are already on https://repo1.maven.org/maven2/org/drools/drools-bom[Maven Central].
+IMPORTANT: this job should be triggered only if the artifacts of Drools version (as an example `drools-bom`) are already on https://repo1.maven.org/maven2/org/drools/drools-bom[Maven Central].
 Also the Drools version has to be updated on OptaPlanner main branch running
 https://eng-jenkins-csb-business-automation.apps.ocp-c1.prod.psi.redhat.com/job/KIE/job/optaplanner/job/main/job/tools/job/update-drools-optaplanner/[update-drools-optaplanner] on main branch.
 

--- a/build/release/release-procedure.adoc
+++ b/build/release/release-procedure.adoc
@@ -72,7 +72,7 @@ Most links in this document take the 8.27.x branch as an example!
 
 === 3. Update Drools
 
-Since OptaPlanner is not released anymore as a part of the Kogito release pipeline the Drools version is not upgraded automatically. This has to be done by running
+Run
 https://eng-jenkins-csb-business-automation.apps.ocp-c1.prod.psi.redhat.com/job/KIE/job/optaplanner/job/8.27.x/job/tools/job/update-drools-optaplanner/[update-drools-optaplanner]. +
 IMPORTANT: this job should be triggered only if the artifacts of Drools version (as an example drools-bom) are already on https://repo1.maven.org/maven2/org/drools/drools-bom[Maven Central].
 Also the Drools version has to be updated on OptaPlanner main branch running

--- a/build/release/release-procedure.adoc
+++ b/build/release/release-procedure.adoc
@@ -61,47 +61,43 @@ postliminary actions.
 === 1. Release the version in Jira
 
 Navigate to the https://issues.redhat.com/projects/PLANNER?selectedItem=com.atlassian.jira.jira-projects-plugin:release-page[Releases page in JIRA],
-find the version to be released and pick “Release” from the Actions.
+find the version to be released and pick “Release” from the Actions. Create a next version for OptaPlanner and release the current version but WITHOUT
+release date.
 
-=== 2. Run `kogito-release-pipeline`
+=== 2. Create a new branch for OptaPlanner release
 
-OptaPlanner is released as a part of the Kogito release pipeline. Thus, a person releasing Kogito triggers the pipeline.
-Make sure you agree with this person on setting the correct OptaPlanner version before running the pipeline.
+Run on Jenkins https://eng-jenkins-csb-business-automation.apps.ocp-c1.prod.psi.redhat.com/job/KIE/job/optaplanner/job/0-prepare-release-branch[0-prepare-release-branch]
+to create a new branch where to release from. +
+Most links in this document take the 8.27.x branch as an example!
 
-=== 3. Upgrade versions to the next snapshot
-*_This step is yet to be automated._*
+=== 3. Update Drools
 
-After the pipeline finishes, upgrade the version on the `main` branch of OptaPlanner to the next minor snapshot version,
-e.g. 8.0.0.Final -> 8.1.0-SNAPSHOT. Upgrade also the version of Drools by editing
-the value of the property `version.org.drools` in the `optaplanner-build-parent`.
+Since OptaPlanner is not released anymore as a part of the Kogito release pipeline the Drools version is not upgraded automatically. This has to be done by running
+https://eng-jenkins-csb-business-automation.apps.ocp-c1.prod.psi.redhat.com/job/KIE/job/optaplanner/job/8.27.x/job/tools/job/update-drools-optaplanner/[update-drools-optaplanner]. +
+IMPORTANT: this job should be triggered only if the artifacts of Drools version (as an example drools-bom) are already on https://repo1.maven.org/maven2/org/drools/drools-bom[Maven Central].
+Also the Drools version has to be updated on OptaPlanner main branch running
+https://eng-jenkins-csb-business-automation.apps.ocp-c1.prod.psi.redhat.com/job/KIE/job/optaplanner/job/main/job/tools/job/update-drools-optaplanner/[update-drools-optaplanner] on main branch.
 
-=== 4. Release OptaPlanner Quickstarts
-*_This step is yet to be automated._*
+=== 4. Release OptaPlanner
 
-. Create a release branch from the `development` branch.
-. Upgrade the OptaPlanner version in the `parent` section of the `pom.xml` and via the `version.org.optaplanner`
-property in all quickstarts, including Gradle build files, to the release version.
-. https://issues.redhat.com/browse/PLANNER-2230[Sync-up the stable branch from the release branch.]
-. Open a PR to the `stable` branch.
-. Create and push a tag for the release.
-. Upgrade the version to the next patch snapshot version on the release branch.
-.. Make sure the project builds.
-. Push the release branch.
-. Upgrade the version of the project to the next minor snapshot version via a PR to the `development` branch.
+The OptaPlanner release pipeline can be triggered now based on the created new branch in step 2.
+Run https://eng-jenkins-csb-business-automation.apps.ocp-c1.prod.psi.redhat.com/job/KIE/job/optaplanner/job/8.27.x/job/release/job/optaplanner-release[optaplanner-release].
+The OptaPlanner release pipeline runs the https://eng-jenkins-csb-business-automation.apps.ocp-c1.prod.psi.redhat.com/job/KIE/job/optaplanner/job/8.27.x/job/release/job/optaplanner-deploy[optaplanner-deploy] job
+which updates the project versions of OptaPlanner, Quickstarts and OptaWeb Vehicle Routing, builds these projects and deploys their artifacts to Nexus.
+After this deployment step it promotes the projects. In this promote step PRs to upgrade the projects will be raised and merged as well as the tag created and pushed.
 
-== Kogito Release Pipeline
+=== 5. OptaPlanner post release steps
+Once OptaPlanner has been released and its artifacts are on Maven Central the release procedure can proceed
+with https://eng-jenkins-csb-business-automation.apps.ocp-c1.prod.psi.redhat.com/job/KIE/job/optaplanner/job/8.27.x/job/release/job/optaplanner-post-release[optaplanner-post-release]. +
+This job +
 
-The `kogito-release-pipeline` is a Jenkins pipeline that covers releases of the Kogito and the OptaPlanner projects
-together. As both projects consist of several Github repositories, the top-level `kogito-release-pipeline` orchestrates
-multiple pipelines that operate on the project, or the repository level.
+* resets https://github.com/kiegroup/optaplanner-quickstarts[Quickstarts] to stable branch
+* uploads OptaPlanner distribution from https://github.com/kiegroup/optaplanner-quickstarts[Quickstarts]
+* updates the https://github.com/kiegroup/optaplanner-website[OptaPlanner website]
+* updates OptaPlanner version in https://github.com/kiegroup/kie-benchmarks/blob/main/optaplanner-benchmarks/pom.xml#L21[kie-benchmarks]
 
-Please refer to the https://github.com/kiegroup/kogito-pipelines/blob/main/docs/nightly_and_release.md[Kogito release pipeline documentation]
-for more details.
+=== 6. Set release date for OptaPlanner release into JIRA
 
-=== Actions covered by the Kogito release pipeline
-* Create releases branches and upgrade the projects to the release version.
-* Build the projects and deploy maven artefacts into a staging repository on JBoss Nexus.
-* Promote maven artifacts from the staging repository to a public one and later release this repository to Maven Central.
-* Upload the documentation and the distribution of all projects to the `filemgmt.jboss.org`.
-* Update links in the optaplanner-website to point to the released artifacts.
-* Upgrade version to the next bugfix snapshot on the release branch.
+Navigate to the https://issues.redhat.com/projects/PLANNER?selectedItem=com.atlassian.jira.jira-projects-plugin:release-page[Releases page in JIRA],
+find the already released and current version and edit it. Add the release date.
+


### PR DESCRIPTION
<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.
-->

### JIRA

<!-- Add a JIRA ticket link if it exists. -->
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
- https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
- https://github.com/kiegroup/drools/pull/3000
- https://github.com/kiegroup/optaplanner/pull/899
- etc.
-->

### Checklist
- [ ] Documentation updated if applicable.
- [ ] Upgrade recipe provided if applicable.

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request checks</b>  
  Please add comment: <b>Jenkins retest this</b>

- for a <b>specific pull request check</b>  
  please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-vehicle-routing] tests</b>
  
- for a <b>full downstream build</b> 
  - for <b>jenkins</b> job: 
    please add comment: <b>Jenkins run fdb</b>
  - for <b>github actions</b> job: 
    add the label `run_fdb`

- for a <b>compile downstream build</b>  
  please add comment: <b>Jenkins run cdb</b>

- for a <b>full production downstream build</b>  
  please add comment: <b>Jenkins execute product fdb</b>

- for an <b>upstream build</b>  
  please add comment: <b>Jenkins run upstream</b>

- for <b>quarkus branch checks</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins run quarkus-branch</b>

- for a <b>quarkus branch specific check</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-vehicle-routing] quarkus-branch</b>

- for <b>quarkus main checks</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins run quarkus-main</b>

- for a <b>specific quarkus main check</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-vehicle-routing] quarkus-branch</b>

- for <b>native checks</b>  
  Run native checks  
  Please add comment: <b>Jenkins run native</b>

- for a <b>specific native check</b>  
  Run native checks 
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-vehicle-routing] native</b>

- for <b>mandrel checks</b>  
  Run native checks against Mandrel image
  Please add comment: <b>Jenkins run mandrel</b>

- for a <b>specific mandrel check</b>  
  Run native checks against Mandrel image  
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-vehicle-routing] mandrel</b>
</details>

### CI Status

 You can check OptaPlanner repositories CI status from [Chain Status webpage](https://kiegroup.github.io/optaplanner/).