### PR TITLE
PLANNER-2767 Implement the operator status API

### DIFF
--- a/optaplanner-operator/src/main/java/org/optaplanner/operator/impl/solver/model/ConfigMapDependentResource.java
+++ b/optaplanner-operator/src/main/java/org/optaplanner/operator/impl/solver/model/ConfigMapDependentResource.java
@@ -26,10 +26,8 @@ public final class ConfigMapDependentResource extends CRUDKubernetesDependentRes
     @Override
     protected ConfigMap desired(OptaPlannerSolver solver, Context<OptaPlannerSolver> context) {
         Map<String, String> data = new HashMap<>();
-        if (solver.getStatus() != null) {
-            data.put(SOLVER_MESSAGE_INPUT_KEY, solver.getStatus().getInputMessageAddress());
-            data.put(SOLVER_MESSAGE_OUTPUT_KEY, solver.getStatus().getOutputMessageAddress());
-        }
+        data.put(SOLVER_MESSAGE_INPUT_KEY, solver.getInputMessageAddressName());
+        data.put(SOLVER_MESSAGE_OUTPUT_KEY, solver.getOutputMessageAddressName());
         data.put(SOLVER_MESSAGE_AMQ_HOST_KEY, solver.getSpec().getAmqBroker().getHost());
         data.put(SOLVER_MESSAGE_AMQ_PORT_KEY, String.valueOf(solver.getSpec().getAmqBroker().getPort()));
 

--- a/optaplanner-operator/src/main/java/org/optaplanner/operator/impl/solver/model/OptaPlannerSolver.java
+++ b/optaplanner-operator/src/main/java/org/optaplanner/operator/impl/solver/model/OptaPlannerSolver.java
@@ -16,6 +16,11 @@ import io.fabric8.kubernetes.model.annotation.Version;
 public final class OptaPlannerSolver extends CustomResource<OptaPlannerSolverSpec, OptaPlannerSolverStatus>
         implements Namespaced {
 
+    @Override
+    protected OptaPlannerSolverStatus initStatus() {
+        return new OptaPlannerSolverStatus();
+    }
+
     // TODO: Move all the following methods away if this class ever becomes an API.
     @JsonIgnore
     public String getNamespace() {

--- a/optaplanner-operator/src/main/java/org/optaplanner/operator/impl/solver/model/OptaPlannerSolverStatus.java
+++ b/optaplanner-operator/src/main/java/org/optaplanner/operator/impl/solver/model/OptaPlannerSolverStatus.java
@@ -1,32 +1,94 @@
 package org.optaplanner.operator.impl.solver.model;
 
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+import io.fabric8.kubernetes.api.model.Condition;
+import io.fabric8.kubernetes.api.model.ConditionBuilder;
+
+/*
+    For more details about the Status and Conditions, see
+    https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties
+ */
 public final class OptaPlannerSolverStatus {
-    private String errorMessage;
+
+    public static final String CONDITION_TYPE_READY = "Ready";
+    private static final String CONDITION_REASON_IN_PROGRESS = "InProgress";
+
+    private static final String CONDITION_REASON_SOLVER_READY = "SolverReady";
+
+    /**
+     * @return the current timestamp in ISO 8601 format, e.g. "2022-09-02T12:36:10.571Z".
+     */
+    private static String currentTimestamp() {
+        return ZonedDateTime.now(ZoneOffset.UTC).format(DateTimeFormatter.ISO_INSTANT);
+    }
+
+    public static OptaPlannerSolverStatus unknown(Long generation) {
+        OptaPlannerSolverStatus optaPlannerSolverStatus = new OptaPlannerSolverStatus();
+        Condition condition = new ConditionBuilder()
+                .withLastTransitionTime(currentTimestamp())
+                .withObservedGeneration(generation)
+                .withReason(CONDITION_REASON_IN_PROGRESS)
+                .withStatus(ConditionStatus.UNKNOWN.getName())
+                .withType(CONDITION_TYPE_READY)
+                .build();
+        optaPlannerSolverStatus.setConditions(List.of(condition));
+        return optaPlannerSolverStatus;
+    }
+
+    public static OptaPlannerSolverStatus ready(Long generation) {
+        OptaPlannerSolverStatus optaPlannerSolverStatus = new OptaPlannerSolverStatus();
+        Condition condition = new ConditionBuilder()
+                .withLastTransitionTime(currentTimestamp())
+                .withObservedGeneration(generation)
+                .withStatus(ConditionStatus.TRUE.getName())
+                .withReason(CONDITION_REASON_SOLVER_READY)
+                .withType(CONDITION_TYPE_READY)
+                .build();
+        optaPlannerSolverStatus.setConditions(List.of(condition));
+        return optaPlannerSolverStatus;
+    }
+
+    public static OptaPlannerSolverStatus error(Long generation, Throwable error) {
+        OptaPlannerSolverStatus optaPlannerSolverStatus = new OptaPlannerSolverStatus();
+        Condition condition = new ConditionBuilder()
+                .withLastTransitionTime(currentTimestamp())
+                .withObservedGeneration(generation)
+                .withStatus(ConditionStatus.FALSE.getName())
+                .withType(CONDITION_TYPE_READY)
+                .withReason(error.getClass().getSimpleName())
+                .withMessage(error.getMessage())
+                .build();
+        optaPlannerSolverStatus.setConditions(List.of(condition));
+        return optaPlannerSolverStatus;
+    }
+
+    public enum ConditionStatus {
+        UNKNOWN("Unknown"),
+        TRUE("True"),
+        FALSE("False");
+
+        private final String name;
+
+        ConditionStatus(String name) {
+            this.name = name;
+        }
+
+        public String getName() {
+            return name;
+        }
+    }
+
+    private List<Condition> conditions;
+
     private String inputMessageAddress;
     private String outputMessageAddress;
 
     public OptaPlannerSolverStatus() {
         // required by Jackson
-    }
-
-    private OptaPlannerSolverStatus(String errorMessage) {
-        this.errorMessage = errorMessage;
-    }
-
-    public static OptaPlannerSolverStatus success() {
-        return new OptaPlannerSolverStatus(null);
-    }
-
-    public static OptaPlannerSolverStatus error(Exception exception) {
-        return new OptaPlannerSolverStatus(exception.getMessage());
-    }
-
-    public String getErrorMessage() {
-        return errorMessage;
-    }
-
-    public void setErrorMessage(String errorMessage) {
-        this.errorMessage = errorMessage;
     }
 
     public String getInputMessageAddress() {
@@ -43,5 +105,13 @@ public final class OptaPlannerSolverStatus {
 
     public void setOutputMessageAddress(String outputMessageAddress) {
         this.outputMessageAddress = outputMessageAddress;
+    }
+
+    public List<Condition> getConditions() {
+        return conditions;
+    }
+
+    public void setConditions(List<Condition> conditions) {
+        this.conditions = conditions;
     }
 }


### PR DESCRIPTION
Based on https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties.
<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.
-->

### JIRA
https://issues.redhat.com/browse/PLANNER-2767

<!-- Add a JIRA ticket link if it exists. -->
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
- https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
- https://github.com/kiegroup/drools/pull/3000
- https://github.com/kiegroup/optaplanner/pull/899
- etc.
-->

### Checklist
- [ ] Documentation updated if applicable.
- [ ] Upgrade recipe provided if applicable.

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request checks</b>  
  Please add comment: <b>Jenkins retest this</b>

- for a <b>specific pull request check</b>  
  please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-vehicle-routing] tests</b>
  
- for a <b>full downstream build</b> 
  - for <b>jenkins</b> job: 
    please add comment: <b>Jenkins run fdb</b>
  - for <b>github actions</b> job: 
    add the label `run_fdb`

- for a <b>compile downstream build</b>  
  please add comment: <b>Jenkins run cdb</b>

- for a <b>full production downstream build</b>  
  please add comment: <b>Jenkins execute product fdb</b>

- for an <b>upstream build</b>  
  please add comment: <b>Jenkins run upstream</b>

- for <b>quarkus branch checks</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins run quarkus-branch</b>

- for a <b>quarkus branch specific check</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-vehicle-routing] quarkus-branch</b>

- for <b>quarkus main checks</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins run quarkus-main</b>

- for a <b>specific quarkus main check</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-vehicle-routing] quarkus-branch</b>

- for <b>native checks</b>  
  Run native checks  
  Please add comment: <b>Jenkins run native</b>

- for a <b>specific native check</b>  
  Run native checks 
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-vehicle-routing] native</b>

- for <b>mandrel checks</b>  
  Run native checks against Mandrel image
  Please add comment: <b>Jenkins run mandrel</b>

- for a <b>specific mandrel check</b>  
  Run native checks against Mandrel image  
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-vehicle-routing] mandrel</b>
</details>

### CI Status

 You can check OptaPlanner repositories CI status from [Chain Status webpage](https://kiegroup.github.io/optaplanner/).