### PR TITLE
PLANNER-2795 Reduce CI verbosity

### DIFF
--- a/.ci/jenkins/Jenkinsfile.deploy
+++ b/.ci/jenkins/Jenkinsfile.deploy
@@ -247,7 +247,7 @@ pipeline {
             }
         }
         unsuccessful {
-            sendNotification()
+            sendErrorNotification()
         }
         cleanup {
             script {
@@ -258,9 +258,10 @@ pipeline {
     }
 }
 
-void sendNotification() {
+void sendErrorNotification() {
     if (params.SEND_NOTIFICATION) {
-        mailer.sendMarkdownTestSummaryNotification('Deploy', "[${getBuildBranch()}] Optaplanner", [env.OPTAPLANNER_CI_EMAIL_TO])
+        String additionalInfo = "[${getBuildBranch()}] Optaplanner - Deploy"
+        mailer.sendMarkdownTestSummaryNotification("CI failures", [env.OPTAPLANNER_CI_EMAIL_TO], additionalInfo)
     } else {
         echo 'No notification sent per configuration'
     }

--- a/.ci/jenkins/Jenkinsfile.deploy
+++ b/.ci/jenkins/Jenkinsfile.deploy
@@ -260,7 +260,7 @@ pipeline {
 
 void sendErrorNotification() {
     if (params.SEND_NOTIFICATION) {
-        String additionalInfo = "[${getBuildBranch()}] Optaplanner - Deploy"
+        String additionalInfo = "**[${getBuildBranch()}] Optaplanner - Deploy**"
         mailer.sendMarkdownTestSummaryNotification("CI failures", [env.OPTAPLANNER_CI_EMAIL_TO], additionalInfo)
     } else {
         echo 'No notification sent per configuration'

--- a/.ci/jenkins/Jenkinsfile.init-branch
+++ b/.ci/jenkins/Jenkinsfile.init-branch
@@ -84,7 +84,7 @@ pipeline {
     }
     post {
         unsuccessful {
-            sendNotification()
+            sendErrorNotification()
         }
         cleanup {
             script {
@@ -94,9 +94,10 @@ pipeline {
     }
 }
 
-void sendNotification() {
+void sendErrorNotification() {
     if (params.SEND_NOTIFICATION) {
-        mailer.sendMarkdownTestSummaryNotification('Init', "[${getBuildBranch()}] Optaplanner", [env.OPTAPLANNER_CI_EMAIL_TO])
+        String additionalInfo = "[${getBuildBranch()}] Optaplanner - Init"
+        mailer.sendMarkdownTestSummaryNotification("CI failures", [env.OPTAPLANNER_CI_EMAIL_TO], additionalInfo)
     } else {
         echo 'No notification sent per configuration'
     }

--- a/.ci/jenkins/Jenkinsfile.init-branch
+++ b/.ci/jenkins/Jenkinsfile.init-branch
@@ -96,7 +96,7 @@ pipeline {
 
 void sendErrorNotification() {
     if (params.SEND_NOTIFICATION) {
-        String additionalInfo = "[${getBuildBranch()}] Optaplanner - Init"
+        String additionalInfo = "**[${getBuildBranch()}] Optaplanner - Init**"
         mailer.sendMarkdownTestSummaryNotification("CI failures", [env.OPTAPLANNER_CI_EMAIL_TO], additionalInfo)
     } else {
         echo 'No notification sent per configuration'

--- a/.ci/jenkins/Jenkinsfile.promote
+++ b/.ci/jenkins/Jenkinsfile.promote
@@ -203,7 +203,7 @@ pipeline {
     }
     post {
         unsuccessful {
-            sendNotification()
+            sendErrorNotification()
         }
         cleanup {
             script {
@@ -214,9 +214,10 @@ pipeline {
     }
 }
 
-void sendNotification() {
+void sendErrorNotification() {
     if (params.SEND_NOTIFICATION) {
-        mailer.sendMarkdownTestSummaryNotification('Promote', "[${getBuildBranch()}] Optaplanner", [env.OPTAPLANNER_CI_EMAIL_TO])
+        String additionalInfo = "[${getBuildBranch()}] Optaplanner - Promote"
+        mailer.sendMarkdownTestSummaryNotification("CI failures", [env.OPTAPLANNER_CI_EMAIL_TO], additionalInfo)
     } else {
         echo 'No notification sent per configuration'
     }

--- a/.ci/jenkins/Jenkinsfile.promote
+++ b/.ci/jenkins/Jenkinsfile.promote
@@ -216,7 +216,7 @@ pipeline {
 
 void sendErrorNotification() {
     if (params.SEND_NOTIFICATION) {
-        String additionalInfo = "[${getBuildBranch()}] Optaplanner - Promote"
+        String additionalInfo = "**[${getBuildBranch()}] Optaplanner - Promote**"
         mailer.sendMarkdownTestSummaryNotification("CI failures", [env.OPTAPLANNER_CI_EMAIL_TO], additionalInfo)
     } else {
         echo 'No notification sent per configuration'

--- a/.ci/jenkins/Jenkinsfile.turtle
+++ b/.ci/jenkins/Jenkinsfile.turtle
@@ -54,8 +54,13 @@ pipeline {
             script {
                 junit testResults: '**/target/surefire-reports/**/*.xml, **/target/failsafe-reports/**/*.xml', allowEmptyResults: true
                 util.archiveConsoleLog()
-                sendEmail()
             }
+        }
+        success {
+            sendSuccessNotification()
+        }
+        unsuccessful {
+            sendErrorNotification()
         }
         cleanup {
             cleanWs()
@@ -81,8 +86,17 @@ String getConstraintStreamImplType() {
     return env.CONSTRAINT_STREAM_IMPL_TYPE
 }
 
-void sendEmail() {
-    echo 'Sending a summary email.'
-    String body = "${getConstraintStreamImplType()}\n"
-    mailer.sendMarkdownTestSummaryNotification('OptaPlanner turtle tests', 'OptaPlanner turtle tests', [env.OPTAPLANNER_CI_EMAIL], body)
+void sendErrorNotification() {
+    mailer.sendMarkdownTestSummaryNotification("CI failures", [env.OPTAPLANNER_CI_EMAIL_TO], getNotificationAdditionalInfo())
+}
+
+void sendErrorNotification() {
+    mailer.sendMarkdownTestSummaryNotification("CI success", [env.OPTAPLANNER_CI_EMAIL_TO], getNotificationAdditionalInfo())
+}
+
+String getNotificationAdditionalInfo() {
+    return """
+    [${getBuildBranch()}] Optaplanner - Turtle tests
+    "${getConstraintStreamImplType()}"
+    """
 }

--- a/.ci/jenkins/Jenkinsfile.turtle
+++ b/.ci/jenkins/Jenkinsfile.turtle
@@ -97,6 +97,6 @@ void sendSuccessNotification() {
 String getNotificationAdditionalInfo() {
     return """
     **[${getBuildBranch()}] Optaplanner - Turtle tests**
-    **"${getConstraintStreamImplType()}"**
+    **${getConstraintStreamImplType()}**
     """
 }

--- a/.ci/jenkins/Jenkinsfile.turtle
+++ b/.ci/jenkins/Jenkinsfile.turtle
@@ -90,7 +90,7 @@ void sendErrorNotification() {
     mailer.sendMarkdownTestSummaryNotification("CI failures", [env.OPTAPLANNER_CI_EMAIL_TO], getNotificationAdditionalInfo())
 }
 
-void sendErrorNotification() {
+void sendSuccessNotification() {
     mailer.sendMarkdownTestSummaryNotification("CI success", [env.OPTAPLANNER_CI_EMAIL_TO], getNotificationAdditionalInfo())
 }
 

--- a/.ci/jenkins/Jenkinsfile.turtle
+++ b/.ci/jenkins/Jenkinsfile.turtle
@@ -96,7 +96,7 @@ void sendErrorNotification() {
 
 String getNotificationAdditionalInfo() {
     return """
-    [${getBuildBranch()}] Optaplanner - Turtle tests
-    "${getConstraintStreamImplType()}"
+    **[${getBuildBranch()}] Optaplanner - Turtle tests**
+    **"${getConstraintStreamImplType()}"**
     """
 }

--- a/.ci/jenkins/project/Jenkinsfile.drools
+++ b/.ci/jenkins/project/Jenkinsfile.drools
@@ -109,7 +109,7 @@ pipeline {
     }
     post {
         unsuccessful {
-            sendNotification()
+            sendErrorNotification()
         }
         cleanup {
             script {
@@ -119,8 +119,12 @@ pipeline {
     }
 }
 
-void sendNotification() {
-    mailer.sendMarkdownTestSummaryNotification("${NOTIFICATION_JOB_NAME}", "[${getBuildBranch()}] Optaplanner", [env.OPTAPLANNER_CI_EMAIL_TO], "cc @*drools-team*")
+void sendErrorNotification() {
+    String additionalInfo = """
+    [${getBuildBranch()}] Optaplanner${NOTIFICATION_JOB_NAME ? " - ${NOTIFICATION_JOB_NAME}" : ''}
+    cc @*drools-team*
+    """
+    mailer.sendMarkdownTestSummaryNotification("CI failures", [env.OPTAPLANNER_CI_EMAIL_TO], additionalInfo)
 }
 
 void checkoutOptaplannerRepo() {

--- a/.ci/jenkins/project/Jenkinsfile.drools
+++ b/.ci/jenkins/project/Jenkinsfile.drools
@@ -121,7 +121,7 @@ pipeline {
 
 void sendErrorNotification() {
     String additionalInfo = """
-    [${getBuildBranch()}] Optaplanner${NOTIFICATION_JOB_NAME ? " - ${NOTIFICATION_JOB_NAME}" : ''}
+    **[${getBuildBranch()}] Optaplanner${NOTIFICATION_JOB_NAME ? " - ${NOTIFICATION_JOB_NAME}" : ''}**
     cc @*drools-team*
     """
     mailer.sendMarkdownTestSummaryNotification("CI failures", [env.OPTAPLANNER_CI_EMAIL_TO], additionalInfo)

--- a/.ci/jenkins/project/Jenkinsfile.init-branch
+++ b/.ci/jenkins/project/Jenkinsfile.init-branch
@@ -95,7 +95,11 @@ pipeline {
     }
     post {
         unsuccessful {
-            sendPipelineErrorNotification()
+            script {
+                if (currentBuild.currentResult != 'UNSTABLE') {
+                    sendPipelineErrorNotification()   
+                }
+            }
         }
     }
 }

--- a/.ci/jenkins/project/Jenkinsfile.native
+++ b/.ci/jenkins/project/Jenkinsfile.native
@@ -71,7 +71,7 @@ pipeline {
             }
         }
         unsuccessful {
-            sendNotification()
+            sendErrorNotification()
         }
         cleanup {
             script {
@@ -81,8 +81,10 @@ pipeline {
     }
 }
 
-void sendNotification() {
-    mailer.sendMarkdownTestSummaryNotification("${NOTIFICATION_JOB_NAME}", "[${params.BUILD_BRANCH_NAME}] Optaplanner", [env.OPTAPLANNER_CI_EMAIL_TO])
+
+void sendErrorNotification() {
+    String additionalInfo = "[${getBuildBranch()}] Optaplanner${NOTIFICATION_JOB_NAME ? " - ${NOTIFICATION_JOB_NAME}" : ''}"
+    mailer.sendMarkdownTestSummaryNotification("CI failures", [env.OPTAPLANNER_CI_EMAIL_TO], additionalInfo)
 }
 
 void checkoutOptaplannerRepo() {

--- a/.ci/jenkins/project/Jenkinsfile.native
+++ b/.ci/jenkins/project/Jenkinsfile.native
@@ -83,7 +83,7 @@ pipeline {
 
 
 void sendErrorNotification() {
-    String additionalInfo = "[${getBuildBranch()}] Optaplanner${NOTIFICATION_JOB_NAME ? " - ${NOTIFICATION_JOB_NAME}" : ''}"
+    String additionalInfo = "**[${getBuildBranch()}] Optaplanner${NOTIFICATION_JOB_NAME ? " - ${NOTIFICATION_JOB_NAME}" : ''}**"
     mailer.sendMarkdownTestSummaryNotification("CI failures", [env.OPTAPLANNER_CI_EMAIL_TO], additionalInfo)
 }
 

--- a/.ci/jenkins/project/Jenkinsfile.nightly
+++ b/.ci/jenkins/project/Jenkinsfile.nightly
@@ -70,7 +70,9 @@ pipeline {
     }
     post {
         unsuccessful {
-            sendPipelineErrorNotification()
+            if (currentBuild.currentResult != 'UNSTABLE') {
+                sendPipelineErrorNotification()   
+            }
         }
     }
 }

--- a/.ci/jenkins/project/Jenkinsfile.post-release
+++ b/.ci/jenkins/project/Jenkinsfile.post-release
@@ -142,7 +142,7 @@ pipeline {
     }
     post {
         unsuccessful {
-            sendNotification()
+            sendErrorNotification()
         }
         cleanup {
             script {
@@ -153,7 +153,7 @@ pipeline {
     }
 }
 
-void sendNotification() {
+void sendErrorNotification() {
     mailer.sendMarkdownTestSummaryNotification('Post-release', "[${getBuildBranch()}] Optaplanner", [env.OPTAPLANNER_CI_EMAIL_TO])
 }
 

--- a/.ci/jenkins/project/Jenkinsfile.quarkus
+++ b/.ci/jenkins/project/Jenkinsfile.quarkus
@@ -92,7 +92,7 @@ pipeline {
     }
     post {
         unsuccessful {
-            sendNotification()
+            sendErrorNotification()
         }
         cleanup {
             script {
@@ -102,8 +102,9 @@ pipeline {
     }
 }
 
-void sendNotification() {
-    mailer.sendMarkdownTestSummaryNotification("Quarkus ${getQuarkusBranch()}", "[${getBuildBranch()}] Optaplanner", [env.OPTAPLANNER_CI_EMAIL_TO])
+void sendErrorNotification() {
+    String additionalInfo = "[${getBuildBranch()}] Optaplanner - Quarkus ${getQuarkusBranch()}}"
+    mailer.sendMarkdownTestSummaryNotification("CI failures", [env.OPTAPLANNER_CI_EMAIL_TO], additionalInfo)
 }
 
 void checkoutOptaplannerRepo() {

--- a/.ci/jenkins/project/Jenkinsfile.quarkus
+++ b/.ci/jenkins/project/Jenkinsfile.quarkus
@@ -103,7 +103,7 @@ pipeline {
 }
 
 void sendErrorNotification() {
-    String additionalInfo = "[${getBuildBranch()}] Optaplanner - Quarkus ${getQuarkusBranch()}}"
+    String additionalInfo = "**[${getBuildBranch()}] Optaplanner - Quarkus ${getQuarkusBranch()}**"
     mailer.sendMarkdownTestSummaryNotification("CI failures", [env.OPTAPLANNER_CI_EMAIL_TO], additionalInfo)
 }
 

--- a/.ci/jenkins/project/Jenkinsfile.release
+++ b/.ci/jenkins/project/Jenkinsfile.release
@@ -130,7 +130,9 @@ pipeline {
             }
         }
         unsuccessful {
-            sendErrorNotification()
+            if (currentBuild.currentResult != 'UNSTABLE') {
+                sendPipelineErrorNotification()
+            }
         }
     }
 }
@@ -239,15 +241,12 @@ void saveReleaseProperties() {
 }
 
 void sendSuccessfulReleaseNotification() {
-    String bodyMsg = 'Release is successful with those jobs:\n'
-    getAllJobNames().findAll { isJobConsideredOk(it) }.each {
-        bodyMsg += "- ${it}\n"
-    }
+    String bodyMsg = 'Release has successfully completed !:\n'
     bodyMsg += "\nPlease look here: ${BUILD_URL} for more information"
     sendNotification(bodyMsg)
 }
 
-void sendErrorNotification() {
+void sendPipelineErrorNotification() {
     sendNotification("Release job #${BUILD_NUMBER} was: ${currentBuild.currentResult}\nPlease look here: ${BUILD_URL}")
 }
 


### PR DESCRIPTION
https://issues.redhat.com/browse/PLANNER-2795

- All failed builds (regardless of branch/job name/etc) go to the CI failures topic in optaplanner-dev.
- All success build (regardless of branch/job name/etc) go to the CI success topic in optaplanner-dev.

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request checks</b>  
  Please add comment: <b>Jenkins retest this</b>

- for a <b>specific pull request check</b>  
  please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-vehicle-routing] tests</b>
  
- for a <b>full downstream build</b> 
  - for <b>jenkins</b> job: 
    please add comment: <b>Jenkins run fdb</b>
  - for <b>github actions</b> job: 
    add the label `run_fdb`

- for a <b>compile downstream build</b>  
  please add comment: <b>Jenkins run cdb</b>

- for a <b>full production downstream build</b>  
  please add comment: <b>Jenkins execute product fdb</b>

- for an <b>upstream build</b>  
  please add comment: <b>Jenkins run upstream</b>

- for <b>quarkus branch checks</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins run quarkus-branch</b>

- for a <b>quarkus branch specific check</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-vehicle-routing] quarkus-branch</b>

- for <b>quarkus main checks</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins run quarkus-main</b>

- for a <b>specific quarkus main check</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-vehicle-routing] quarkus-branch</b>

- for <b>native checks</b>  
  Run native checks  
  Please add comment: <b>Jenkins run native</b>

- for a <b>specific native check</b>  
  Run native checks 
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-vehicle-routing] native</b>

- for <b>mandrel checks</b>  
  Run native checks against Mandrel image
  Please add comment: <b>Jenkins run mandrel</b>

- for a <b>specific mandrel check</b>  
  Run native checks against Mandrel image  
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-vehicle-routing] mandrel</b>
</details>

### CI Status

 You can check OptaPlanner repositories CI status from [Chain Status webpage](https://kiegroup.github.io/optaplanner/).