### PR TITLE
PLANNER-2800 Avoid NegativeArraySizeException when zero feasible levels

### DIFF
--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/solver/termination/TerminationFactory.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/solver/termination/TerminationFactory.java
@@ -63,7 +63,14 @@ public class TerminationFactory<Solution_> {
                 throw new IllegalArgumentException("The termination bestScoreFeasible ("
                         + terminationConfig.getBestScoreFeasible() + ") cannot be false.");
             }
-            double[] timeGradientWeightFeasibleNumbers = new double[scoreDefinition.getFeasibleLevelsSize() - 1];
+            int feasibleLevelsSize = scoreDefinition.getFeasibleLevelsSize();
+            if (feasibleLevelsSize < 1) {
+                throw new IllegalStateException("The termination with bestScoreFeasible ("
+                        + terminationConfig.getBestScoreFeasible()
+                        + ") can only be used with a score type that has at least 1 feasible level but the scoreDefinition ("
+                        + scoreDefinition + ") has feasibleLevelsSize (" + feasibleLevelsSize + "), which is less than 1.");
+            }
+            double[] timeGradientWeightFeasibleNumbers = new double[feasibleLevelsSize - 1];
             Arrays.fill(timeGradientWeightFeasibleNumbers, 0.50); // Number pulled out of thin air
             terminationList.add(new BestScoreFeasibleTermination<>(scoreDefinition, timeGradientWeightFeasibleNumbers));
         }

--- a/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/solver/termination/TerminationFactoryTest.java
+++ b/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/solver/termination/TerminationFactoryTest.java
@@ -15,6 +15,7 @@ import org.optaplanner.core.config.solver.termination.TerminationCompositionStyl
 import org.optaplanner.core.config.solver.termination.TerminationConfig;
 import org.optaplanner.core.impl.heuristic.HeuristicConfigPolicy;
 import org.optaplanner.core.impl.score.buildin.HardSoftScoreDefinition;
+import org.optaplanner.core.impl.score.buildin.SimpleScoreDefinition;
 import org.optaplanner.core.impl.testdata.domain.TestdataSolution;
 
 class TerminationFactoryTest {
@@ -176,5 +177,17 @@ class TerminationFactoryTest {
         assertThatIllegalStateException()
                 .isThrownBy(() -> terminationFactory.buildTimeBasedTermination(heuristicConfigPolicy))
                 .withMessageContaining("can only be used if an unimproved*SpentLimit");
+    }
+
+    @Test
+    void bestScoreFeasible_requiresAtLeastOneFeasibleLevel() {
+        HeuristicConfigPolicy<TestdataSolution> heuristicConfigPolicy = mock(HeuristicConfigPolicy.class);
+        when(heuristicConfigPolicy.getScoreDefinition()).thenReturn(new SimpleScoreDefinition());
+        TerminationConfig terminationConfig = new TerminationConfig().withBestScoreFeasible(true);
+
+        TerminationFactory<TestdataSolution> terminationFactory = TerminationFactory.create(terminationConfig);
+        assertThatIllegalStateException()
+                .isThrownBy(() -> terminationFactory.buildTermination(heuristicConfigPolicy))
+                .withMessageContaining("can only be used with a score type that has at least 1 feasible level");
     }
 }


### PR DESCRIPTION
### JIRA
https://issues.redhat.com/browse/PLANNER-2800
<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request checks</b>  
  Please add comment: <b>Jenkins retest this</b>

- for a <b>specific pull request check</b>  
  please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-vehicle-routing] tests</b>
  
- for a <b>full downstream build</b> 
  - for <b>jenkins</b> job: 
    please add comment: <b>Jenkins run fdb</b>
  - for <b>github actions</b> job: 
    add the label `run_fdb`

- for a <b>compile downstream build</b>  
  please add comment: <b>Jenkins run cdb</b>

- for a <b>full production downstream build</b>  
  please add comment: <b>Jenkins execute product fdb</b>

- for an <b>upstream build</b>  
  please add comment: <b>Jenkins run upstream</b>

- for <b>quarkus branch checks</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins run quarkus-branch</b>

- for a <b>quarkus branch specific check</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-vehicle-routing] quarkus-branch</b>

- for <b>quarkus main checks</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins run quarkus-main</b>

- for a <b>specific quarkus main check</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-vehicle-routing] quarkus-branch</b>

- for <b>native checks</b>  
  Run native checks  
  Please add comment: <b>Jenkins run native</b>

- for a <b>specific native check</b>  
  Run native checks 
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-vehicle-routing] native</b>

- for <b>mandrel checks</b>  
  Run native checks against Mandrel image
  Please add comment: <b>Jenkins run mandrel</b>

- for a <b>specific mandrel check</b>  
  Run native checks against Mandrel image  
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-vehicle-routing] mandrel</b>
</details>

### CI Status

 You can check OptaPlanner repositories CI status from [Chain Status webpage](https://kiegroup.github.io/optaplanner/).