### PR TITLE
PLANNER-2801 Fix flaky test by not sharing maps across threads

### DIFF
--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/nurserostering/domain/contract/Contract.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/nurserostering/domain/contract/Contract.java
@@ -57,4 +57,8 @@ public class Contract extends AbstractPersistable {
         return weekendDefinition.getWeekendLength();
     }
 
+    public ContractLine getFirstConstractLine() {
+        return contractLineList.get(0);
+    }
+
 }


### PR DESCRIPTION
The other change in DefaultSingleConstraintAssertion is there just to clean up the code while I was investigating it. 
It has no relation to the bug, which is solely in the test.