### PR TITLE
Patch the ecosystem CI to enable testing with Jandex 3.0

### DIFF
--- a/.github/jandex_3.patch
+++ b/.github/jandex_3.patch
@@ -1,0 +1,76 @@
+From 282eee0646062326c8fccacb8fc30cbaa4bff509 Mon Sep 17 00:00:00 2001
+From: Radovan Synek <rsynek@redhat.com>
+Date: Mon, 19 Sep 2022 20:07:48 +0200
+Subject: [PATCH] Ensure Jandex 3.0 compatibility
+
+---
+ build/optaplanner-build-parent/pom.xml           |  5 +++++
+ .../optaplanner-persistence-jpa/pom.xml          | 16 ++++++++++++++++
+ .../quarkus/deployment/OptaPlannerProcessor.java |  2 +-
+ 3 files changed, 22 insertions(+), 1 deletion(-)
+
+diff --git a/build/optaplanner-build-parent/pom.xml b/build/optaplanner-build-parent/pom.xml
+index 9254e5121f..72fe9a1d9e 100644
+--- a/build/optaplanner-build-parent/pom.xml
++++ b/build/optaplanner-build-parent/pom.xml
+@@ -103,6 +103,11 @@
+         <scope>import</scope>
+       </dependency>
+       <!-- Normal dependencies versions-->
++      <dependency>
++        <groupId>io.smallrye</groupId>
++        <artifactId>jandex</artifactId>
++        <version>3.0.1</version>
++      </dependency>
+       <dependency>
+         <groupId>ch.qos.logback</groupId>
+         <artifactId>logback-core</artifactId>
+diff --git a/optaplanner-persistence/optaplanner-persistence-jpa/pom.xml b/optaplanner-persistence/optaplanner-persistence-jpa/pom.xml
+index 4feaca12a1..0fa3e1932a 100644
+--- a/optaplanner-persistence/optaplanner-persistence-jpa/pom.xml
++++ b/optaplanner-persistence/optaplanner-persistence-jpa/pom.xml
+@@ -79,6 +79,12 @@
+       <!-- Used at compile time by *ScoreHibernateType -->
+       <optional>true</optional>
+     </dependency>
++    <!-- A transitive dependency of hibernate-core that is excluded in the quarkus-bom. -->
++    <dependency>
++      <groupId>io.smallrye</groupId>
++      <artifactId>jandex</artifactId>
++      <optional>true</optional>
++    </dependency>
+     <dependency>
+       <groupId>jakarta.transaction</groupId>
+       <artifactId>jakarta.transaction-api</artifactId>
+@@ -186,6 +192,16 @@
+           </additionalClasspathElements>
+         </configuration>
+       </plugin>
++      <plugin>
++        <groupId>org.apache.maven.plugins</groupId>
++        <artifactId>maven-dependency-plugin</artifactId>
++        <configuration>
++          <ignoredUnusedDeclaredDependencies>
++            <!-- A transitive dependency that the quarkus-bom excludes from hibernate-core. -->
++            <dependency>io.smallrye:jandex</dependency>
++          </ignoredUnusedDeclaredDependencies>
++        </configuration>
++      </plugin>
+     </plugins>
+   </build>
+
+diff --git a/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/main/java/org/optaplanner/quarkus/deployment/OptaPlannerProcessor.java b/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/main/java/org/optaplanner/quarkus/deployment/OptaPlannerProcessor.java
+index 750d09aa91..eb820c02b6 100644
+--- a/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/main/java/org/optaplanner/quarkus/deployment/OptaPlannerProcessor.java
++++ b/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/main/java/org/optaplanner/quarkus/deployment/OptaPlannerProcessor.java
+@@ -443,7 +443,7 @@ class OptaPlannerProcessor {
+                                     ") for @" + annotationInstance.name().withoutPackagePrefix() + ".");
+             }
+
+-            if (!declaringClass.annotations().containsKey(DotNames.PLANNING_ENTITY)) {
++            if (!declaringClass.annotationsMap().containsKey(DotNames.PLANNING_ENTITY)) {
+                 throw new IllegalStateException(prefix + "with a @" +
+                         annotationInstance.name().withoutPackagePrefix() +
+                         " annotation is in a class (" + declaringClass.name()
+--
+2.25.1

--- a/.github/quarkus-ecosystem-test
+++ b/.github/quarkus-ecosystem-test
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -e
+
+# TODO: Remove after branching 8.29.x.
+git apply .github/jandex_3.patch
+
+# update the versions
+mvn --settings .github/quarkus-ecosystem-maven-settings.xml -B versions:set-property -Dproperty=version.io.quarkus -DnewVersion=${QUARKUS_VERSION} -DgenerateBackupPoms=false
+
+# run the tests
+mvn --settings .github/quarkus-ecosystem-maven-settings.xml -B clean install -Dnative -Dquarkus.native.container-build=true --fail-at-end


### PR DESCRIPTION
A temporary fix of the Quarkus Ecosystem CI. Applies a patch to make OptaPlanner compatible with Jandex 3.0.

Remove after creating the 8.29.x branch.

<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.
-->

### JIRA

<!-- Add a JIRA ticket link if it exists. -->
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
- https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
- https://github.com/kiegroup/drools/pull/3000
- https://github.com/kiegroup/optaplanner/pull/899
- etc.
-->

### Checklist
- [ ] Documentation updated if applicable.
- [ ] Release notes updated if applicable.
- [ ] Upgrade recipe provided if applicable.

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request checks</b>  
  Please add comment: <b>Jenkins retest this</b>

- for a <b>specific pull request check</b>  
  please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-vehicle-routing] tests</b>
  
- for a <b>full downstream build</b> 
  - for <b>jenkins</b> job: 
    please add comment: <b>Jenkins run fdb</b>
  - for <b>github actions</b> job: 
    add the label `run_fdb`

- for a <b>compile downstream build</b>  
  please add comment: <b>Jenkins run cdb</b>

- for a <b>full production downstream build</b>  
  please add comment: <b>Jenkins execute product fdb</b>

- for an <b>upstream build</b>  
  please add comment: <b>Jenkins run upstream</b>

- for <b>quarkus branch checks</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins run quarkus-branch</b>

- for a <b>quarkus branch specific check</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-vehicle-routing] quarkus-branch</b>

- for <b>quarkus main checks</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins run quarkus-main</b>

- for a <b>specific quarkus main check</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-vehicle-routing] quarkus-branch</b>

- for <b>native checks</b>  
  Run native checks  
  Please add comment: <b>Jenkins run native</b>

- for a <b>specific native check</b>  
  Run native checks 
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-vehicle-routing] native</b>

- for <b>mandrel checks</b>  
  Run native checks against Mandrel image
  Please add comment: <b>Jenkins run mandrel</b>

- for a <b>specific mandrel check</b>  
  Run native checks against Mandrel image  
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-vehicle-routing] mandrel</b>
</details>

### CI Status

 You can check OptaPlanner repositories CI status from [Chain Status webpage](https://kiegroup.github.io/optaplanner/).