### PR TITLE
[RHBOP] [BXMSPROD-1826] Added nightly jenkins pipeline

### DIFF
--- a/.ci/jenkins/Jenkinsfile.prod.nightly
+++ b/.ci/jenkins/Jenkinsfile.prod.nightly
@@ -49,8 +49,8 @@ pipeline {
                             def projectCollection = ['drools', 'optaplanner', 'optaplanner-quickstarts', 'optaweb-vehicle-routing']
                             def projectVariableMap = ['kiegroup_optaplanner': 'optaplannerVersion', 'kiegroup_drools': 'droolsProductVersion']
                             def additionalVariables = [
-                                'droolsProductVersion': env.DROOLS_PRODUCT_VERSION
-                                //'drools-scmRevision': getDroolsBranch(), 
+                                'droolsProductVersion': env.DROOLS_PRODUCT_VERSION,
+                                'drools-scmRevision': getDroolsBranch()
                             ]
                             configFileProvider([configFile(fileId: '49737697-ebd6-4396-9c22-11f7714808eb', variable: 'PRODUCTION_PROJECT_LIST')]) {
                                 pmebuild.buildProjects(projectCollection, "${SETTINGS_XML_ID}", "$WORKSPACE/build_config/rhbop/nightly", "${env.PME_CLI_PATH}", projectVariableMap, additionalVariables, [:])
@@ -122,9 +122,9 @@ pipeline {
                         def PME_BUILD_VARIABLES = env.PME_BUILD_VARIABLES.split(';').collect{ it.split('=')}.inject([:]) {map, item -> map << [(item.length == 2 ? item[0] : null): (item.length == 2 ? item[1] : null)]}
 
                         def optaplannerArchiveUrl = "https://bxms-qe.rhev-ci-vms.eng.rdu2.redhat.com:8443/nexus/content/groups/rhbop-main-nightly/org/optaplanner/"
-                        def optaplannerSourcesFileUrl = "${env.STAGING_SERVER_URL}/rhbop/RHBOP-${PRODUCT_VERSION}.nightly/rhbop-${PRODUCT_VERSION}-optaplanner-sources-${PME_BUILD_VARIABLES['datetimeSuffix']}.zip"
-                        def optaplannerQuickstartsSourcesFileUrl = "${env.STAGING_SERVER_URL}/rhbop/RHBOP-${PRODUCT_VERSION}.nightly/rhbop-${PRODUCT_VERSION}-optaplanner-quickstarts-sources-${PME_BUILD_VARIABLES['datetimeSuffix']}.zip"
-                        def optawebSourcesFileUrl = "${env.STAGING_SERVER_URL}/rhbop/RHBOP-${PRODUCT_VERSION}.nightly/rhbop-${PRODUCT_VERSION}-optaweb-vehicle-routing-sources-${PME_BUILD_VARIABLES['datetimeSuffix']}.zip"
+                        def optaplannerSourcesFileUrl = "${env.STAGING_SERVER_URL}rhbop/RHBOP-${PRODUCT_VERSION}.nightly/rhbop-${PRODUCT_VERSION}-optaplanner-sources-${PME_BUILD_VARIABLES['datetimeSuffix']}.zip"
+                        def optaplannerQuickstartsSourcesFileUrl = "${env.STAGING_SERVER_URL}rhbop/RHBOP-${PRODUCT_VERSION}.nightly/rhbop-${PRODUCT_VERSION}-optaplanner-quickstarts-sources-${PME_BUILD_VARIABLES['datetimeSuffix']}.zip"
+                        def optawebSourcesFileUrl = "${env.STAGING_SERVER_URL}rhbop/RHBOP-${PRODUCT_VERSION}.nightly/rhbop-${PRODUCT_VERSION}-optaweb-vehicle-routing-sources-${PME_BUILD_VARIABLES['datetimeSuffix']}.zip"
                         def topic = "VirtualTopic.qe.ci.ba.rhbop.${env.UMB_VERSION}.nightly.trigger"
                         def eventType = "rhbop-${env.UMB_VERSION}-nightly-qe-trigger"
                         def messageBody = getMessageBody(

--- a/.ci/jenkins/Jenkinsfile.prod.nightly
+++ b/.ci/jenkins/Jenkinsfile.prod.nightly
@@ -80,9 +80,9 @@ pipeline {
                         def PME_BUILD_VARIABLES = env.PME_BUILD_VARIABLES.split(';').collect{ it.split('=')}.inject([:]) {map, item -> map << [(item.length == 2 ? item[0] : null): (item.length == 2 ? item[1] : null)]}
                         def folder="${env.RCM_GUEST_FOLDER}/rhbop/RHBOP-${PRODUCT_VERSION}.nightly"
 
-                        uploadSources("optaplanner", folder, PME_BUILD_VARIABLES)
-                        uploadSources("optaplanner-quickstarts", folder, PME_BUILD_VARIABLES)
-                        uploadSources("optaweb-vehicle-routing", folder, PME_BUILD_VARIABLES)
+                        uploadSources("optaplanner", folder, PME_BUILD_VARIABLES['datetimeSuffix'])
+                        uploadSources("optaplanner-quickstarts", folder, PME_BUILD_VARIABLES['datetimeSuffix'])
+                        uploadSources("optaweb-vehicle-routing", folder, PME_BUILD_VARIABLES['datetimeSuffix'])
 
                     } else {
                         println "[WARNING] No sources to upload. None project has been built."
@@ -180,9 +180,9 @@ def getMessageBody(String optaplannerArchiveUrl, String optaplannerSourcesUrl, S
 }"""    
 }
 
-def uploadSources(String project, String folder, Map pmeVariables) {
+def uploadSources(String project, String folder, String suffix) {
     echo "[INFO] Start uploading $project sources zip file.."
-    def sourcesFilename = "rhbop-${PRODUCT_VERSION}-$project-sources-${pmeVariables['datetimeSuffix']}.zip"
+    def sourcesFilename = "rhbop-${PRODUCT_VERSION}-$project-sources-${suffix}.zip"
     sh "zip -r $sourcesFilename $WORKSPACE/kiegroup_$project -x '*.git*'"
     sshagent(credentials: ['rcm-publish-server']) {
         sh "ssh 'rhba@${env.RCM_HOST}' 'mkdir -p ${folder}'"

--- a/.ci/jenkins/Jenkinsfile.prod.nightly
+++ b/.ci/jenkins/Jenkinsfile.prod.nightly
@@ -121,7 +121,7 @@ pipeline {
                         echo '[INFO] Sending RHBOP UMB message to QE.'
                         def PME_BUILD_VARIABLES = env.PME_BUILD_VARIABLES.split(';').collect{ it.split('=')}.inject([:]) {map, item -> map << [(item.length == 2 ? item[0] : null): (item.length == 2 ? item[1] : null)]}
 
-                        def optaplannerArchiveUrl = "https://bxms-qe.rhev-ci-vms.eng.rdu2.redhat.com:8443/nexus/content/groups/rhbop-main-nightly/org/optaplanner/"
+                        def optaplannerArchiveUrl = "https://bxms-qe.rhev-ci-vms.eng.rdu2.redhat.com:8443/nexus/content/groups/rhbop-main-nightly/"
                         def optaplannerSourcesFileUrl = "${env.STAGING_SERVER_URL}rhbop/RHBOP-${PRODUCT_VERSION}.nightly/rhbop-${PRODUCT_VERSION}-optaplanner-sources-${PME_BUILD_VARIABLES['datetimeSuffix']}.zip"
                         def optaplannerQuickstartsSourcesFileUrl = "${env.STAGING_SERVER_URL}rhbop/RHBOP-${PRODUCT_VERSION}.nightly/rhbop-${PRODUCT_VERSION}-optaplanner-quickstarts-sources-${PME_BUILD_VARIABLES['datetimeSuffix']}.zip"
                         def optawebSourcesFileUrl = "${env.STAGING_SERVER_URL}rhbop/RHBOP-${PRODUCT_VERSION}.nightly/rhbop-${PRODUCT_VERSION}-optaweb-vehicle-routing-sources-${PME_BUILD_VARIABLES['datetimeSuffix']}.zip"
@@ -193,9 +193,7 @@ def getMessageBody(String optaplannerArchiveUrl, String optaplannerSourcesUrl, S
     "version": ${new groovy.json.JsonBuilder(versions).toString()},
     "scm_hash": ${new groovy.json.JsonBuilder(scmHashes).toString()},
     "built_projects": ${new groovy.json.JsonBuilder(alreadyBuiltProjectsArray).toString()},
-    "archives": {
-        "optaplanner": "${optaplannerArchiveUrl}"
-    },
+    "archives": "${optaplannerArchiveUrl}",
     "sources": {
         "optaplanner": "${optaplannerSourcesUrl}",
         "optaplanner-quickstarts": "${optaplannerQuickstartsSourcesUrl}",

--- a/.ci/jenkins/Jenkinsfile.prod.nightly
+++ b/.ci/jenkins/Jenkinsfile.prod.nightly
@@ -1,0 +1,193 @@
+@Library('jenkins-pipeline-shared-libraries')_
+
+pipeline {
+    agent {
+        label 'kie-rhel7 && kie-mem24g && !master'
+    }
+    tools {
+        maven 'kie-maven-3.8.6'
+        jdk 'kie-jdk11'
+    }
+    parameters {
+        string(description: 'The deployment URL', name: 'KIE_GROUP_DEPLOYMENT_REPO_URL')
+        booleanParam(description: 'Skip Tests? True as default', name: 'SKIP_TESTS', defaultValue: true)
+        string(description: 'The UMB message version', name: 'UMB_VERSION', defaultValue: 'main')
+        string(description: 'The product version', name: 'PRODUCT_VERSION')
+        string(description: 'The drools product version', name: 'DROOLS_PRODUCT_VERSION')
+        string(description: 'The config repository branch', name: 'CONFIG_BRANCH', defaultValue: 'main')
+    }
+    options {
+        buildDiscarder logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '10')
+    }
+    environment {
+        DATE_TIME_SUFFIX_FORMAT = 'yyyyMMddHH'
+    }
+    stages {
+        stage('Initialize') {
+            steps {
+                sh 'printenv'
+            }
+        }
+        stage('Clone build configuration repo') {
+            steps {
+                script {
+                    def currentBranch = env.CONFIG_BRANCH ?: env.DEFAULT_CONFIG_BRANCH ?: env.BRANCH_NAME ?: env.GIT_BRANCH
+                    println "Checking out ${env.BUILD_CONFIGURATION_REPO_URL}:${currentBranch} into build_config folder"
+                    sh "git clone -b ${currentBranch} --single-branch ${env.BUILD_CONFIGURATION_REPO_URL} build_config"
+                }
+            }
+        }
+        stage('Build Nightly projects') {
+            steps {
+                catchError(buildResult: 'UNSTABLE', stageResult: 'FAILURE')
+                {
+                    script {
+                        def pipelineHelper = new PipelineHelper(this)
+                        pipelineHelper.retry(
+                        {
+                            def SETTINGS_XML_ID = '5d9884a1-178a-4d67-a3ac-9735d2df2cef'
+                            def projectCollection = ['drools', 'optaplanner', 'optaplanner-quickstarts', 'optaweb-vehicle-routing']
+                            def projectVariableMap = ['kiegroup_optaplanner': 'optaplannerVersion', 'kiegroup_drools': 'droolsProductVersion']
+                            def additionalVariables = [
+                                'droolsProductVersion': env.DROOLS_PRODUCT_VERSION, 
+                                'drools-scmRevision': getDroolsBranch(), 
+                            ]
+                            configFileProvider([configFile(fileId: '49737697-ebd6-4396-9c22-11f7714808eb', variable: 'PRODUCTION_PROJECT_LIST')]) {
+                                pmebuild.buildProjects(projectCollection, "${SETTINGS_XML_ID}", "$WORKSPACE/build_config/rhbop/nightly", "${env.PME_CLI_PATH}", projectVariableMap, additionalVariables, [:])
+                            }
+                        }, 2, 480*60)
+                    }
+                }
+            }
+        }
+        stage('Upload artifacts to repository') {
+            steps {
+                script {
+                    echo "[INFO] Start uploading ${env.WORKSPACE}/deployDirectory"
+                    dir("${env.WORKSPACE}/deployDirectory") {
+                        withCredentials([usernameColonPassword(credentialsId: "${env.NIGHTLY_DEPLOYMENT_CREDENTIAL}", variable: 'deploymentCredentials')]) {
+                            sh "zip -qr kiegroup ."
+                            sh "curl --fail --upload-file kiegroup.zip -u $deploymentCredentials -v ${KIE_GROUP_DEPLOYMENT_REPO_URL}"
+                        }
+                    }
+                }
+            }
+        }
+        stage('Upload sources') {
+            steps {
+                script {
+                    if(env.ALREADY_BUILT_PROJECTS?.trim()) {
+                        echo "[INFO] Start uploading sources zip file"
+                        def PME_BUILD_VARIABLES = env.PME_BUILD_VARIABLES.split(';').collect{ it.split('=')}.inject([:]) {map, item -> map << [(item.length == 2 ? item[0] : null): (item.length == 2 ? item[1] : null)]}
+
+                        sh "zip -r sources-${PME_BUILD_VARIABLES['datetimeSuffix']}.zip $WORKSPACE/kiegroup_* -x '*.git*'"
+                        def folder="${env.RCM_GUEST_FOLDER}/rhbop/RHBOP-${PRODUCT_VERSION}.nightly"
+                        sshagent(credentials: ['rcm-publish-server']) {
+                            sh "ssh 'rhba@${env.RCM_HOST}' 'mkdir -p ${folder}'"
+                            sh "scp -o StrictHostKeyChecking=no sources-${PME_BUILD_VARIABLES['datetimeSuffix']}.zip rhba@${env.RCM_HOST}:${folder}"
+                        }
+                    } else {
+                        println "[WARNING] No sources to upload. None project has been built."
+                    }
+                }
+            }
+        }
+        stage ('Send UMB Message to QE.') {
+            steps {
+                script {
+                    if(env.ALREADY_BUILT_PROJECTS?.trim()) {
+                        echo '[INFO] Sending RHBOP UMB message to QE.'
+                        def PME_BUILD_VARIABLES = env.PME_BUILD_VARIABLES.split(';').collect{ it.split('=')}.inject([:]) {map, item -> map << [(item.length == 2 ? item[0] : null): (item.length == 2 ? item[1] : null)]}
+
+                        def sourcesFileUrl = "${env.STAGING_SERVER_URL}/rhbop/RHBOP-${PRODUCT_VERSION}.nightly/sources-${PME_BUILD_VARIABLES['datetimeSuffix']}.zip"
+                        def topic = "VirtualTopic.qe.ci.ba.rhbop.${env.UMB_VERSION}.nightly.trigger"
+                        def eventType = "rhbop-${env.UMB_VERSION}-nightly-qe-trigger"
+                        def messageBody = getMessageBody(
+                            sourcesFileUrl, 
+                            env.ALREADY_BUILT_PROJECTS,
+                            ['rhbop': PME_BUILD_VARIABLES['optaplannerVersion'], 'drools': PME_BUILD_VARIABLES['droolsProductVersion']], 
+                            gitHashesToCollection(env.GIT_INFORMATION_HASHES)
+                        )
+                        echo "[INFO] Message Body: ${messageBody}"
+                        echo "[INFO] Topic: ${topic}"
+                        echo "[INFO] Event Type: ${eventType}"
+                        build job: env.SEND_UMB_MESSAGE_JOB_PATH, parameters: [
+                                [$class: 'StringParameterValue', name: 'MESSAGE_BODY', value: messageBody],
+                                [$class: 'StringParameterValue', name: 'TOPIC', value: topic],
+                                [$class: 'StringParameterValue', name: 'EVENT_TYPE', value: eventType]
+                        ]
+                        echo '[SUCCESS] Message was successfully sent.'
+                    } else {
+                        println "[WARNING] No artifacts to upload. None project has been built."
+                    }
+                }
+            }
+        }
+    }
+    post {
+        failure {
+            emailext body: 'RHBOP ${PRODUCT_VERSION}:nightly-build #${BUILD_NUMBER} was: ' + "${currentBuild.currentResult}" +  '\n' +
+                    'Please look here: ${BUILD_URL} \n' +
+                    ' \n' +
+                    '${BUILD_LOG, maxLines=750}', subject: 'RHBOP ${PRODUCT_VERSION}:nightly-build #${BUILD_NUMBER}: ' + "${currentBuild.currentResult}", to: 'kie-jenkins-builds@redhat.com'
+        }
+        unstable {
+            emailext body: 'RHBOP ${PRODUCT_VERSION}:nightly-build #${BUILD_NUMBER} was: ' + "${currentBuild.currentResult}" +  '\n' +
+                    'Please look here: ${BUILD_URL} \n' +
+                    ' \n' +
+                    'Failed tests: ${BUILD_URL}/testReport \n' +
+                    ' \n' +
+                    '${BUILD_LOG, maxLines=750}', subject: 'RHBOP ${PRODUCT_VERSION}:nightly-build #${BUILD_NUMBER}: ' + "${currentBuild.currentResult}", to: 'kie-jenkins-builds@redhat.com'
+        }
+        fixed {
+            emailext body: 'RHBOP ${PRODUCT_VERSION}:nightly-build #${BUILD_NUMBER} was: ' + "${currentBuild.currentResult}" +  '\n' +
+                    'Please look here: ${BUILD_URL}', subject: 'RHBOP ${PRODUCT_VERSION}:nightly-build #${BUILD_NUMBER}: ' + "${currentBuild.currentResult}", to: 'kie-jenkins-builds@redhat.com'
+        }
+        always {
+            archiveArtifacts artifacts: '**/*.maven.log', fingerprint: false, defaultExcludes: true, caseSensitive: true, allowEmptyArchive: true
+
+            echo 'Generating JUnit report...'
+            junit allowEmptyResults: true, healthScaleFactor: 1.0, testResults: '**/target/*-reports/TEST-*.xml'
+
+            echo 'Archiving logs...'
+            archiveArtifacts excludes: '**/target/checkstyle.log', artifacts: '**/*.maven.log,**/target/*.log', fingerprint: false, defaultExcludes: true, caseSensitive: true, allowEmptyArchive: true
+        }
+        cleanup {
+            cleanWs()
+        }
+    }
+}
+
+def getMessageBody(String sourcesFileUrl, String alreadyBuiltProjects, Map<String, String> versions, Map<String, String> scmHashes) {
+    // TODO: add nexus urls to specific optaplanner artifacts
+    def alreadyBuiltProjectsArray = (alreadyBuiltProjects ?: '').split(";")
+    return """
+{
+    "sources_file_url": "${sourcesFileUrl}",
+    "version": ${new groovy.json.JsonBuilder(versions).toString()},
+    "scm_hash": ${new groovy.json.JsonBuilder(scmHashes).toString()},
+    "built_projects": ${new groovy.json.JsonBuilder(alreadyBuiltProjectsArray).toString()}
+}"""    
+}
+
+def gitHashesToCollection(String gitInformationHashes) {
+    return gitInformationHashes.replaceAll(/([\w\d\-\_\.]*\/)([\w\d\-\_\.]*)/,'$2').split(';').findAll { it.split('=').size() }.collectEntries{ [it.split('=')[0], it.split('=')[1]] }
+}
+
+String getDroolsBranch() {
+    return env.CHANGE_BRANCH ?: env.BRANCH_NAME
+}
+
+String calculateKieRepoBranch(String branch) {
+    /* The Drools/OptaPlanner major version is shifted by 7 from the Kogito major version:
+    Kogito 1.x.y -> Drools 8.x.y. 
+    Kogito 1.x.y -> OptaPlanner 8.x.y. */
+    int majorVersionShift = 7
+    String [] branchSplit = branch.split("\\.")
+    if (branchSplit.length == 3) {
+        Integer optaplannerMajorVersion = Integer.parseInt(branchSplit[0]) + majorVersionShift
+        return "${optaplannerMajorVersion}.${branchSplit[1]}.${branchSplit[2]}"
+    } else {
+       return branch
+    }
+}

--- a/.ci/jenkins/Jenkinsfile.prod.nightly
+++ b/.ci/jenkins/Jenkinsfile.prod.nightly
@@ -196,7 +196,7 @@ def getMessageBody(String optaplannerArchiveUrl, String optaplannerSourcesUrl, S
     "archives": {
         "optaplanner": "${optaplannerArchiveUrl}"
     },
-    "sources: {
+    "sources": {
         "optaplanner": "${optaplannerSourcesUrl}",
         "optaplanner-quickstarts": "${optaplannerQuickstartsSourcesUrl}",
         "optaweb-vehicle-routing": "${optawebSourcesFileUrl}"

--- a/.ci/jenkins/Jenkinsfile.prod.nightly
+++ b/.ci/jenkins/Jenkinsfile.prod.nightly
@@ -2,7 +2,7 @@
 
 pipeline {
     agent {
-        label 'kie-rhel7 && kie-mem24g && !master'
+        label 'kie-rhel7 && kie-mem8g && !master'
     }
     tools {
         maven 'kie-maven-3.8.6'
@@ -52,10 +52,8 @@ pipeline {
                                 'droolsProductVersion': env.DROOLS_PRODUCT_VERSION,
                                 'drools-scmRevision': getDroolsBranch()
                             ]
-                            configFileProvider([configFile(fileId: '49737697-ebd6-4396-9c22-11f7714808eb', variable: 'PRODUCTION_PROJECT_LIST')]) {
-                                pmebuild.buildProjects(projectCollection, "${SETTINGS_XML_ID}", "$WORKSPACE/build_config/rhbop/nightly", "${env.PME_CLI_PATH}", projectVariableMap, additionalVariables, [:])
-                            }
-                        }, 2, 480*60)
+                            pmebuild.buildProjects(projectCollection, "${SETTINGS_XML_ID}", "$WORKSPACE/build_config/rhbop/nightly", "${env.PME_CLI_PATH}", projectVariableMap, additionalVariables, [:])
+                        }, 2, 180*60)
                     }
                 }
             }
@@ -125,6 +123,7 @@ pipeline {
                         def optaplannerSourcesFileUrl = "${env.STAGING_SERVER_URL}rhbop/RHBOP-${PRODUCT_VERSION}.nightly/rhbop-${PRODUCT_VERSION}-optaplanner-sources-${PME_BUILD_VARIABLES['datetimeSuffix']}.zip"
                         def optaplannerQuickstartsSourcesFileUrl = "${env.STAGING_SERVER_URL}rhbop/RHBOP-${PRODUCT_VERSION}.nightly/rhbop-${PRODUCT_VERSION}-optaplanner-quickstarts-sources-${PME_BUILD_VARIABLES['datetimeSuffix']}.zip"
                         def optawebSourcesFileUrl = "${env.STAGING_SERVER_URL}rhbop/RHBOP-${PRODUCT_VERSION}.nightly/rhbop-${PRODUCT_VERSION}-optaweb-vehicle-routing-sources-${PME_BUILD_VARIABLES['datetimeSuffix']}.zip"
+
                         def topic = "VirtualTopic.qe.ci.ba.rhbop.${env.UMB_VERSION}.nightly.trigger"
                         def eventType = "rhbop-${env.UMB_VERSION}-nightly-qe-trigger"
                         def messageBody = getMessageBody(

--- a/.ci/jenkins/Jenkinsfile.prod.nightly
+++ b/.ci/jenkins/Jenkinsfile.prod.nightly
@@ -49,8 +49,8 @@ pipeline {
                             def projectCollection = ['drools', 'optaplanner', 'optaplanner-quickstarts', 'optaweb-vehicle-routing']
                             def projectVariableMap = ['kiegroup_optaplanner': 'optaplannerVersion', 'kiegroup_drools': 'droolsProductVersion']
                             def additionalVariables = [
-                                'droolsProductVersion': env.DROOLS_PRODUCT_VERSION, 
-                                'drools-scmRevision': getDroolsBranch(), 
+                                'droolsProductVersion': env.DROOLS_PRODUCT_VERSION
+                                //'drools-scmRevision': getDroolsBranch(), 
                             ]
                             configFileProvider([configFile(fileId: '49737697-ebd6-4396-9c22-11f7714808eb', variable: 'PRODUCTION_PROJECT_LIST')]) {
                                 pmebuild.buildProjects(projectCollection, "${SETTINGS_XML_ID}", "$WORKSPACE/build_config/rhbop/nightly", "${env.PME_CLI_PATH}", projectVariableMap, additionalVariables, [:])
@@ -73,18 +73,40 @@ pipeline {
                 }
             }
         }
-        stage('Upload sources') {
+        stage('Upload optaplanner sources') {
             steps {
                 script {
                     if(env.ALREADY_BUILT_PROJECTS?.trim()) {
-                        echo "[INFO] Start uploading sources zip file"
-                        def PME_BUILD_VARIABLES = env.PME_BUILD_VARIABLES.split(';').collect{ it.split('=')}.inject([:]) {map, item -> map << [(item.length == 2 ? item[0] : null): (item.length == 2 ? item[1] : null)]}
+                        echo "[INFO] Start uploading sources zip files.."
 
-                        sh "zip -r sources-${PME_BUILD_VARIABLES['datetimeSuffix']}.zip $WORKSPACE/kiegroup_* -x '*.git*'"
+                        def PME_BUILD_VARIABLES = env.PME_BUILD_VARIABLES.split(';').collect{ it.split('=')}.inject([:]) {map, item -> map << [(item.length == 2 ? item[0] : null): (item.length == 2 ? item[1] : null)]}
                         def folder="${env.RCM_GUEST_FOLDER}/rhbop/RHBOP-${PRODUCT_VERSION}.nightly"
+
+                        // optaplanner
+                        echo "[INFO] Start uploading optaplanner sources zip file.."
+                        def optaplannerSourcesFile = "rhbop-${PRODUCT_VERSION}-optaplanner-sources-${PME_BUILD_VARIABLES['datetimeSuffix']}.zip"
+                        sh "zip -r $optaplannerSourcesFile $WORKSPACE/kiegroup_optaplanner -x '*.git*'"
                         sshagent(credentials: ['rcm-publish-server']) {
                             sh "ssh 'rhba@${env.RCM_HOST}' 'mkdir -p ${folder}'"
-                            sh "scp -o StrictHostKeyChecking=no sources-${PME_BUILD_VARIABLES['datetimeSuffix']}.zip rhba@${env.RCM_HOST}:${folder}"
+                            sh "scp -o StrictHostKeyChecking=no $optaplannerSourcesFile rhba@${env.RCM_HOST}:${folder}"
+                        }
+
+                        // optaplanner-quickstarts
+                        echo "[INFO] Start uploading optaplanner-quickstarts sources zip file.."
+                        def optaplannerQuickstartsSourcesFile = "rhbop-${PRODUCT_VERSION}-optaplanner-quickstarts-sources-${PME_BUILD_VARIABLES['datetimeSuffix']}.zip"
+                        sh "zip -r $optaplannerQuickstartsSourcesFile $WORKSPACE/kiegroup_optaplanner-quickstarts -x '*.git*'"
+                        sshagent(credentials: ['rcm-publish-server']) {
+                            sh "ssh 'rhba@${env.RCM_HOST}' 'mkdir -p ${folder}'"
+                            sh "scp -o StrictHostKeyChecking=no $optaplannerQuickstartsSourcesFile rhba@${env.RCM_HOST}:${folder}"
+                        }
+
+                        // optaweb-vehicle-routing
+                        echo "[INFO] Start uploading optaweb-vehicle-routing sources zip file.."
+                        def optawebSourcesFile = "rhbop-${PRODUCT_VERSION}-optaweb-vehicle-routing-sources-${PME_BUILD_VARIABLES['datetimeSuffix']}.zip"
+                        sh "zip -r $optawebSourcesFile $WORKSPACE/kiegroup_optaweb-vehicle-routing -x '*.git*'"
+                        sshagent(credentials: ['rcm-publish-server']) {
+                            sh "ssh 'rhba@${env.RCM_HOST}' 'mkdir -p ${folder}'"
+                            sh "scp -o StrictHostKeyChecking=no $optawebSourcesFile rhba@${env.RCM_HOST}:${folder}"
                         }
                     } else {
                         println "[WARNING] No sources to upload. None project has been built."
@@ -99,11 +121,17 @@ pipeline {
                         echo '[INFO] Sending RHBOP UMB message to QE.'
                         def PME_BUILD_VARIABLES = env.PME_BUILD_VARIABLES.split(';').collect{ it.split('=')}.inject([:]) {map, item -> map << [(item.length == 2 ? item[0] : null): (item.length == 2 ? item[1] : null)]}
 
-                        def sourcesFileUrl = "${env.STAGING_SERVER_URL}/rhbop/RHBOP-${PRODUCT_VERSION}.nightly/sources-${PME_BUILD_VARIABLES['datetimeSuffix']}.zip"
+                        def optaplannerArchiveUrl = "https://bxms-qe.rhev-ci-vms.eng.rdu2.redhat.com:8443/nexus/content/groups/rhbop-main-nightly/org/optaplanner/"
+                        def optaplannerSourcesFileUrl = "${env.STAGING_SERVER_URL}/rhbop/RHBOP-${PRODUCT_VERSION}.nightly/rhbop-${PRODUCT_VERSION}-optaplanner-sources-${PME_BUILD_VARIABLES['datetimeSuffix']}.zip"
+                        def optaplannerQuickstartsSourcesFileUrl = "${env.STAGING_SERVER_URL}/rhbop/RHBOP-${PRODUCT_VERSION}.nightly/rhbop-${PRODUCT_VERSION}-optaplanner-quickstarts-sources-${PME_BUILD_VARIABLES['datetimeSuffix']}.zip"
+                        def optawebSourcesFileUrl = "${env.STAGING_SERVER_URL}/rhbop/RHBOP-${PRODUCT_VERSION}.nightly/rhbop-${PRODUCT_VERSION}-optaweb-vehicle-routing-sources-${PME_BUILD_VARIABLES['datetimeSuffix']}.zip"
                         def topic = "VirtualTopic.qe.ci.ba.rhbop.${env.UMB_VERSION}.nightly.trigger"
                         def eventType = "rhbop-${env.UMB_VERSION}-nightly-qe-trigger"
                         def messageBody = getMessageBody(
-                            sourcesFileUrl, 
+                            optaplannerArchiveUrl,
+                            optaplannerSourcesFileUrl,
+                            optaplannerQuickstartsSourcesFileUrl,
+                            optawebSourcesFileUrl,
                             env.ALREADY_BUILT_PROJECTS,
                             ['rhbop': PME_BUILD_VARIABLES['optaplannerVersion'], 'drools': PME_BUILD_VARIABLES['droolsProductVersion']], 
                             gitHashesToCollection(env.GIT_INFORMATION_HASHES)
@@ -158,15 +186,21 @@ pipeline {
     }
 }
 
-def getMessageBody(String sourcesFileUrl, String alreadyBuiltProjects, Map<String, String> versions, Map<String, String> scmHashes) {
-    // TODO: add nexus urls to specific optaplanner artifacts
+def getMessageBody(String optaplannerArchiveUrl, String optaplannerSourcesUrl, String optaplannerQuickstartsSourcesUrl, String optawebSourcesFileUrl, String alreadyBuiltProjects, Map<String, String> versions, Map<String, String> scmHashes) {
     def alreadyBuiltProjectsArray = (alreadyBuiltProjects ?: '').split(";")
     return """
 {
-    "sources_file_url": "${sourcesFileUrl}",
     "version": ${new groovy.json.JsonBuilder(versions).toString()},
     "scm_hash": ${new groovy.json.JsonBuilder(scmHashes).toString()},
-    "built_projects": ${new groovy.json.JsonBuilder(alreadyBuiltProjectsArray).toString()}
+    "built_projects": ${new groovy.json.JsonBuilder(alreadyBuiltProjectsArray).toString()},
+    "archives": {
+        "optaplanner": "${optaplannerArchiveUrl}"
+    },
+    "sources: {
+        "optaplanner": "${optaplannerSourcesUrl}",
+        "optaplanner-quickstarts": "${optaplannerQuickstartsSourcesUrl}",
+        "optaweb-vehicle-routing": "${optawebSourcesFileUrl}"
+    }
 }"""    
 }
 
@@ -176,18 +210,4 @@ def gitHashesToCollection(String gitInformationHashes) {
 
 String getDroolsBranch() {
     return env.CHANGE_BRANCH ?: env.BRANCH_NAME
-}
-
-String calculateKieRepoBranch(String branch) {
-    /* The Drools/OptaPlanner major version is shifted by 7 from the Kogito major version:
-    Kogito 1.x.y -> Drools 8.x.y. 
-    Kogito 1.x.y -> OptaPlanner 8.x.y. */
-    int majorVersionShift = 7
-    String [] branchSplit = branch.split("\\.")
-    if (branchSplit.length == 3) {
-        Integer optaplannerMajorVersion = Integer.parseInt(branchSplit[0]) + majorVersionShift
-        return "${optaplannerMajorVersion}.${branchSplit[1]}.${branchSplit[2]}"
-    } else {
-       return branch
-    }
 }

--- a/.ci/jenkins/Jenkinsfile.prod.nightly
+++ b/.ci/jenkins/Jenkinsfile.prod.nightly
@@ -80,32 +80,10 @@ pipeline {
                         def PME_BUILD_VARIABLES = env.PME_BUILD_VARIABLES.split(';').collect{ it.split('=')}.inject([:]) {map, item -> map << [(item.length == 2 ? item[0] : null): (item.length == 2 ? item[1] : null)]}
                         def folder="${env.RCM_GUEST_FOLDER}/rhbop/RHBOP-${PRODUCT_VERSION}.nightly"
 
-                        // optaplanner
-                        echo "[INFO] Start uploading optaplanner sources zip file.."
-                        def optaplannerSourcesFile = "rhbop-${PRODUCT_VERSION}-optaplanner-sources-${PME_BUILD_VARIABLES['datetimeSuffix']}.zip"
-                        sh "zip -r $optaplannerSourcesFile $WORKSPACE/kiegroup_optaplanner -x '*.git*'"
-                        sshagent(credentials: ['rcm-publish-server']) {
-                            sh "ssh 'rhba@${env.RCM_HOST}' 'mkdir -p ${folder}'"
-                            sh "scp -o StrictHostKeyChecking=no $optaplannerSourcesFile rhba@${env.RCM_HOST}:${folder}"
-                        }
+                        uploadSources("optaplanner", folder, PME_BUILD_VARIABLES)
+                        uploadSources("optaplanner-quickstarts", folder, PME_BUILD_VARIABLES)
+                        uploadSources("optaweb-vehicle-routing", folder, PME_BUILD_VARIABLES)
 
-                        // optaplanner-quickstarts
-                        echo "[INFO] Start uploading optaplanner-quickstarts sources zip file.."
-                        def optaplannerQuickstartsSourcesFile = "rhbop-${PRODUCT_VERSION}-optaplanner-quickstarts-sources-${PME_BUILD_VARIABLES['datetimeSuffix']}.zip"
-                        sh "zip -r $optaplannerQuickstartsSourcesFile $WORKSPACE/kiegroup_optaplanner-quickstarts -x '*.git*'"
-                        sshagent(credentials: ['rcm-publish-server']) {
-                            sh "ssh 'rhba@${env.RCM_HOST}' 'mkdir -p ${folder}'"
-                            sh "scp -o StrictHostKeyChecking=no $optaplannerQuickstartsSourcesFile rhba@${env.RCM_HOST}:${folder}"
-                        }
-
-                        // optaweb-vehicle-routing
-                        echo "[INFO] Start uploading optaweb-vehicle-routing sources zip file.."
-                        def optawebSourcesFile = "rhbop-${PRODUCT_VERSION}-optaweb-vehicle-routing-sources-${PME_BUILD_VARIABLES['datetimeSuffix']}.zip"
-                        sh "zip -r $optawebSourcesFile $WORKSPACE/kiegroup_optaweb-vehicle-routing -x '*.git*'"
-                        sshagent(credentials: ['rcm-publish-server']) {
-                            sh "ssh 'rhba@${env.RCM_HOST}' 'mkdir -p ${folder}'"
-                            sh "scp -o StrictHostKeyChecking=no $optawebSourcesFile rhba@${env.RCM_HOST}:${folder}"
-                        }
                     } else {
                         println "[WARNING] No sources to upload. None project has been built."
                     }
@@ -135,6 +113,7 @@ pipeline {
                             ['rhbop': PME_BUILD_VARIABLES['optaplannerVersion'], 'drools': PME_BUILD_VARIABLES['droolsProductVersion']], 
                             gitHashesToCollection(env.GIT_INFORMATION_HASHES)
                         )
+
                         echo "[INFO] Message Body: ${messageBody}"
                         echo "[INFO] Topic: ${topic}"
                         echo "[INFO] Event Type: ${eventType}"
@@ -199,6 +178,16 @@ def getMessageBody(String optaplannerArchiveUrl, String optaplannerSourcesUrl, S
         "optaweb-vehicle-routing": "${optawebSourcesFileUrl}"
     }
 }"""    
+}
+
+def uploadSources(String project, String folder, Map pmeVariables) {
+    echo "[INFO] Start uploading $project sources zip file.."
+    def sourcesFilename = "rhbop-${PRODUCT_VERSION}-$project-sources-${pmeVariables['datetimeSuffix']}.zip"
+    sh "zip -r $sourcesFilename $WORKSPACE/kiegroup_$project -x '*.git*'"
+    sshagent(credentials: ['rcm-publish-server']) {
+        sh "ssh 'rhba@${env.RCM_HOST}' 'mkdir -p ${folder}'"
+        sh "scp -o StrictHostKeyChecking=no $sourcesFilename rhba@${env.RCM_HOST}:${folder}"
+    }
 }
 
 def gitHashesToCollection(String gitInformationHashes) {


### PR DESCRIPTION
<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.
-->

### JIRA

- https://issues.redhat.com/browse/BXMSPROD-1826

### Referenced pull requests

- https://github.com/kiegroup/kie-jenkins-scripts/pull/1327

### Checklist
- [ ] Documentation updated if applicable.
- [ ] Release notes updated if applicable.
- [ ] Upgrade recipe provided if applicable.

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request checks</b>  
  Please add comment: <b>Jenkins retest this</b>

- for a <b>specific pull request check</b>  
  please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-vehicle-routing] tests</b>
  
- for a <b>full downstream build</b> 
  - for <b>jenkins</b> job: 
    please add comment: <b>Jenkins run fdb</b>
  - for <b>github actions</b> job: 
    add the label `run_fdb`

- for a <b>compile downstream build</b>  
  please add comment: <b>Jenkins run cdb</b>

- for a <b>full production downstream build</b>  
  please add comment: <b>Jenkins execute product fdb</b>

- for an <b>upstream build</b>  
  please add comment: <b>Jenkins run upstream</b>

- for <b>quarkus branch checks</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins run quarkus-branch</b>

- for a <b>quarkus branch specific check</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-vehicle-routing] quarkus-branch</b>

- for <b>quarkus main checks</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins run quarkus-main</b>

- for a <b>specific quarkus main check</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-vehicle-routing] quarkus-branch</b>

- for <b>native checks</b>  
  Run native checks  
  Please add comment: <b>Jenkins run native</b>

- for a <b>specific native check</b>  
  Run native checks 
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-vehicle-routing] native</b>

- for <b>mandrel checks</b>  
  Run native checks against Mandrel image
  Please add comment: <b>Jenkins run mandrel</b>

- for a <b>specific mandrel check</b>  
  Run native checks against Mandrel image  
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-vehicle-routing] mandrel</b>
</details>

### CI Status

 You can check OptaPlanner repositories CI status from [Chain Status webpage](https://kiegroup.github.io/optaplanner/).
