### PR TITLE
PLANNER-2818 Bavet join must not create out tuple if filtering returns false

### DIFF
--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/bi/BavetAbstractBiConstraintStream.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/bi/BavetAbstractBiConstraintStream.java
@@ -87,20 +87,15 @@ public abstract class BavetAbstractBiConstraintStream<Solution_, A, B> extends B
                 new BavetJoinBridgeUniConstraintStream<>(constraintFactory, other, false);
         BavetJoinTriConstraintStream<Solution_, A, B, C> joinStream =
                 new BavetJoinTriConstraintStream<>(constraintFactory, leftBridge, rightBridge,
-                        joinerComber.getMergedJoiner());
+                        joinerComber.getMergedJoiner(), joinerComber.getMergedFiltering());
         leftBridge.setJoinStream(joinStream);
         rightBridge.setJoinStream(joinStream);
 
-        joinStream = constraintFactory.share(joinStream, joinStream_ -> {
+        return constraintFactory.share(joinStream, joinStream_ -> {
             // Connect the bridges upstream, as it is an actual new join.
             getChildStreamList().add(leftBridge);
             other.getChildStreamList().add(rightBridge);
         });
-        if (joinerComber.getMergedFiltering() == null) {
-            return joinStream;
-        } else {
-            return joinStream.filter(joinerComber.getMergedFiltering());
-        }
     }
 
     // ************************************************************************

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/bi/BavetJoinBiConstraintStream.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/bi/BavetJoinBiConstraintStream.java
@@ -2,6 +2,7 @@ package org.optaplanner.constraint.streams.bavet.bi;
 
 import java.util.Objects;
 import java.util.Set;
+import java.util.function.BiPredicate;
 
 import org.optaplanner.constraint.streams.bavet.BavetConstraintFactory;
 import org.optaplanner.constraint.streams.bavet.common.AbstractJoinNode;
@@ -23,15 +24,17 @@ public final class BavetJoinBiConstraintStream<Solution_, A, B> extends BavetAbs
     private final BavetJoinBridgeUniConstraintStream<Solution_, A> leftParent;
     private final BavetJoinBridgeUniConstraintStream<Solution_, B> rightParent;
     private final DefaultBiJoiner<A, B> joiner;
+    private final BiPredicate<A, B> filtering;
 
     public BavetJoinBiConstraintStream(BavetConstraintFactory<Solution_> constraintFactory,
             BavetJoinBridgeUniConstraintStream<Solution_, A> leftParent,
             BavetJoinBridgeUniConstraintStream<Solution_, B> rightParent,
-            DefaultBiJoiner<A, B> joiner) {
+            DefaultBiJoiner<A, B> joiner, BiPredicate<A, B> filtering) {
         super(constraintFactory, leftParent.getRetrievalSemantics());
         this.leftParent = leftParent;
         this.rightParent = rightParent;
         this.joiner = joiner;
+        this.filtering = filtering;
     }
 
     @Override
@@ -69,7 +72,7 @@ public final class BavetJoinBiConstraintStream<Solution_, A, B> extends BavetAbs
                         buildHelper.reserveTupleStoreIndex(rightParent.getTupleSource()),
                         buildHelper.reserveTupleStoreIndex(rightParent.getTupleSource()),
                         buildHelper.reserveTupleStoreIndex(rightParent.getTupleSource()),
-                        downstream, outputStoreSize + 2,
+                        downstream, filtering, outputStoreSize + 2,
                         outputStoreSize, outputStoreSize + 1,
                         indexerFactory.buildIndexer(true), indexerFactory.buildIndexer(false))
                 : new UnindexedJoinBiNode<>(
@@ -77,7 +80,7 @@ public final class BavetJoinBiConstraintStream<Solution_, A, B> extends BavetAbs
                         buildHelper.reserveTupleStoreIndex(leftParent.getTupleSource()),
                         buildHelper.reserveTupleStoreIndex(rightParent.getTupleSource()),
                         buildHelper.reserveTupleStoreIndex(rightParent.getTupleSource()),
-                        downstream, outputStoreSize + 2,
+                        downstream, filtering, outputStoreSize + 2,
                         outputStoreSize, outputStoreSize + 1);
         buildHelper.addNode(node, leftParent, rightParent);
     }

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/bi/BavetJoinBiConstraintStream.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/bi/BavetJoinBiConstraintStream.java
@@ -97,20 +97,21 @@ public final class BavetJoinBiConstraintStream<Solution_, A, B> extends BavetAbs
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        BavetJoinBiConstraintStream<?, ?, ?> that = (BavetJoinBiConstraintStream<?, ?, ?>) o;
+        BavetJoinBiConstraintStream<?, ?, ?> other = (BavetJoinBiConstraintStream<?, ?, ?>) o;
         /*
          * Bridge streams do not implement equality because their equals() would have to point back to this stream,
          * resulting in StackOverflowError.
          * Therefore we need to check bridge parents to see where this join node comes from.
          */
-        return Objects.equals(leftParent.getParent(), that.leftParent.getParent())
-                && Objects.equals(rightParent.getParent(), that.rightParent.getParent())
-                && Objects.equals(joiner, that.joiner);
+        return Objects.equals(leftParent.getParent(), other.leftParent.getParent())
+                && Objects.equals(rightParent.getParent(), other.rightParent.getParent())
+                && Objects.equals(joiner, other.joiner)
+                && Objects.equals(filtering, other.filtering);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(leftParent.getParent(), rightParent.getParent(), joiner);
+        return Objects.hash(leftParent.getParent(), rightParent.getParent(), joiner, filtering);
     }
 
     @Override

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/bi/IndexedJoinBiNode.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/bi/IndexedJoinBiNode.java
@@ -1,5 +1,6 @@
 package org.optaplanner.constraint.streams.bavet.bi;
 
+import java.util.function.BiPredicate;
 import java.util.function.Function;
 
 import org.optaplanner.constraint.streams.bavet.common.AbstractIndexedJoinNode;
@@ -11,12 +12,13 @@ import org.optaplanner.constraint.streams.bavet.uni.UniTuple;
 final class IndexedJoinBiNode<A, B> extends AbstractIndexedJoinNode<UniTuple<A>, B, BiTuple<A, B>, BiTupleImpl<A, B>> {
 
     private final Function<A, IndexProperties> mappingA;
+    private final BiPredicate<A, B> filtering;
     private final int outputStoreSize;
 
     public IndexedJoinBiNode(Function<A, IndexProperties> mappingA, Function<B, IndexProperties> mappingB,
             int inputStoreIndexA, int inputStoreIndexEntryA, int inputStoreIndexOutTupleListA,
             int inputStoreIndexB, int inputStoreIndexEntryB, int inputStoreIndexOutTupleListB,
-            TupleLifecycle<BiTuple<A, B>> nextNodesTupleLifecycle,
+            TupleLifecycle<BiTuple<A, B>> nextNodesTupleLifecycle, BiPredicate<A, B> filtering,
             int outputStoreSize,
             int outputStoreIndexOutEntryA, int outputStoreIndexOutEntryB,
             Indexer<UniTuple<A>> indexerA,
@@ -24,10 +26,11 @@ final class IndexedJoinBiNode<A, B> extends AbstractIndexedJoinNode<UniTuple<A>,
         super(mappingB,
                 inputStoreIndexA, inputStoreIndexEntryA, inputStoreIndexOutTupleListA,
                 inputStoreIndexB, inputStoreIndexEntryB, inputStoreIndexOutTupleListB,
-                nextNodesTupleLifecycle,
+                nextNodesTupleLifecycle, filtering != null,
                 outputStoreIndexOutEntryA, outputStoreIndexOutEntryB,
                 indexerA, indexerB);
         this.mappingA = mappingA;
+        this.filtering = filtering;
         this.outputStoreSize = outputStoreSize;
     }
 
@@ -49,6 +52,11 @@ final class IndexedJoinBiNode<A, B> extends AbstractIndexedJoinNode<UniTuple<A>,
     @Override
     protected void setOutTupleRightFact(BiTupleImpl<A, B> outTuple, UniTuple<B> rightTuple) {
         outTuple.factB = rightTuple.getFactA();
+    }
+
+    @Override
+    protected boolean testFiltering(UniTuple<A> leftTuple, UniTuple<B> rightTuple) {
+        return filtering.test(leftTuple.getFactA(), rightTuple.getFactA());
     }
 
 }

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/bi/UnindexedJoinBiNode.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/bi/UnindexedJoinBiNode.java
@@ -1,5 +1,7 @@
 package org.optaplanner.constraint.streams.bavet.bi;
 
+import java.util.function.BiPredicate;
+
 import org.optaplanner.constraint.streams.bavet.common.AbstractUnindexedJoinNode;
 import org.optaplanner.constraint.streams.bavet.common.TupleLifecycle;
 import org.optaplanner.constraint.streams.bavet.uni.UniTuple;
@@ -7,17 +9,20 @@ import org.optaplanner.constraint.streams.bavet.uni.UniTuple;
 final class UnindexedJoinBiNode<A, B>
         extends AbstractUnindexedJoinNode<UniTuple<A>, B, BiTuple<A, B>, BiTupleImpl<A, B>> {
 
+    private final BiPredicate<A, B> filtering;
     private final int outputStoreSize;
 
     public UnindexedJoinBiNode(
             int inputStoreIndexLeftEntry, int inputStoreIndexLeftOutTupleList,
             int inputStoreIndexRightEntry, int inputStoreIndexRightOutTupleList,
-            TupleLifecycle<BiTuple<A, B>> nextNodesTupleLifecycle, int outputStoreSize,
+            TupleLifecycle<BiTuple<A, B>> nextNodesTupleLifecycle, BiPredicate<A, B> filtering,
+            int outputStoreSize,
             int outputStoreIndexLeftOutEntry, int outputStoreIndexRightOutEntry) {
         super(inputStoreIndexLeftEntry, inputStoreIndexLeftOutTupleList,
                 inputStoreIndexRightEntry, inputStoreIndexRightOutTupleList,
-                nextNodesTupleLifecycle,
+                nextNodesTupleLifecycle, filtering != null,
                 outputStoreIndexLeftOutEntry, outputStoreIndexRightOutEntry);
+        this.filtering = filtering;
         this.outputStoreSize = outputStoreSize;
     }
 
@@ -34,6 +39,11 @@ final class UnindexedJoinBiNode<A, B>
     @Override
     protected void setOutTupleRightFact(BiTupleImpl<A, B> outTuple, UniTuple<B> rightTuple) {
         outTuple.factB = rightTuple.getFactA();
+    }
+
+    @Override
+    protected boolean testFiltering(UniTuple<A> leftTuple, UniTuple<B> rightTuple) {
+        return filtering.test(leftTuple.getFactA(), rightTuple.getFactA());
     }
 
 }

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/common/AbstractConditionalTupleLifecycle.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/common/AbstractConditionalTupleLifecycle.java
@@ -34,4 +34,9 @@ public abstract class AbstractConditionalTupleLifecycle<Tuple_ extends Tuple>
 
     abstract protected boolean test(Tuple_ tuple);
 
+    @Override
+    public String toString() {
+        return "Conditional " + tupleLifecycle;
+    }
+
 }

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/common/AbstractFlattenLastNode.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/common/AbstractFlattenLastNode.java
@@ -105,12 +105,11 @@ public abstract class AbstractFlattenLastNode<InTuple_ extends Tuple, OutTuple_ 
 
     @Override
     public void retract(InTuple_ tuple) {
-        List<OutTuple_> outTupleList = (List<OutTuple_>) tuple.getStore(flattenLastStoreIndex);
+        List<OutTuple_> outTupleList = (List<OutTuple_>) tuple.removeStore(flattenLastStoreIndex);
         if (outTupleList == null) {
             // No fail fast if null because we don't track which tuples made it through the filter predicate(s)
             return;
         }
-        tuple.setStore(flattenLastStoreIndex, null);
         for (OutTuple_ item : outTupleList) {
             removeTuple(item);
         }

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/common/AbstractGroupNode.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/common/AbstractGroupNode.java
@@ -216,12 +216,11 @@ public abstract class AbstractGroupNode<InTuple_ extends Tuple, OutTuple_ extend
 
     @Override
     public void retract(InTuple_ tuple) {
-        GroupPart<Group<MutableOutTuple_, GroupKey_, ResultContainer_>> groupPart = tuple.getStore(groupStoreIndex);
+        GroupPart<Group<MutableOutTuple_, GroupKey_, ResultContainer_>> groupPart = tuple.removeStore(groupStoreIndex);
         if (groupPart == null) {
             // No fail fast if null because we don't track which tuples made it through the filter predicate(s)
             return;
         }
-        tuple.setStore(groupStoreIndex, null);
         Group<MutableOutTuple_, GroupKey_, ResultContainer_> group = groupPart.group;
         groupPart.undoAccumulate();
         killTuple(group);

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/common/AbstractIndexedIfExistsNode.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/common/AbstractIndexedIfExistsNode.java
@@ -135,12 +135,11 @@ public abstract class AbstractIndexedIfExistsNode<LeftTuple_ extends Tuple, Righ
 
     @Override
     public final void retractLeft(LeftTuple_ leftTuple) {
-        IndexProperties indexProperties = leftTuple.getStore(inputStoreIndexLeftProperties);
+        IndexProperties indexProperties = leftTuple.removeStore(inputStoreIndexLeftProperties);
         if (indexProperties == null) {
             // No fail fast if null because we don't track which tuples made it through the filter predicate(s)
             return;
         }
-        leftTuple.setStore(inputStoreIndexLeftProperties, null);
         TupleListEntry<ExistsCounter<LeftTuple_>> counterEntry = leftTuple.getStore(inputStoreIndexLeftCounterEntry);
         ExistsCounter<LeftTuple_> counter = counterEntry.getElement();
 
@@ -239,15 +238,13 @@ public abstract class AbstractIndexedIfExistsNode<LeftTuple_ extends Tuple, Righ
 
     @Override
     public final void retractRight(UniTuple<Right_> rightTuple) {
-        IndexProperties indexProperties = rightTuple.getStore(inputStoreIndexRightProperties);
+        IndexProperties indexProperties = rightTuple.removeStore(inputStoreIndexRightProperties);
         if (indexProperties == null) {
             // No fail fast if null because we don't track which tuples made it through the filter predicate(s)
             return;
         }
-        rightTuple.setStore(inputStoreIndexRightProperties, null);
-        TupleListEntry<UniTuple<Right_>> rightEntry = rightTuple.getStore(inputStoreIndexRightEntry);
+        TupleListEntry<UniTuple<Right_>> rightEntry = rightTuple.removeStore(inputStoreIndexRightEntry);
         indexerRight.remove(indexProperties, rightEntry);
-        rightTuple.setStore(inputStoreIndexRightEntry, null);
         if (!isFiltering) {
             indexerLeft.forEach(indexProperties, this::decrementCounterRight);
         } else {

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/common/AbstractIndexedJoinNode.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/common/AbstractIndexedJoinNode.java
@@ -35,11 +35,11 @@ public abstract class AbstractIndexedJoinNode<LeftTuple_ extends Tuple, Right_, 
     protected AbstractIndexedJoinNode(Function<Right_, IndexProperties> mappingRight,
             int inputStoreIndexLeftProperties, int inputStoreIndexLeftEntry, int inputStoreIndexLeftOutTupleList,
             int inputStoreIndexRightProperties, int inputStoreIndexRightEntry, int inputStoreIndexRightOutTupleList,
-            TupleLifecycle<OutTuple_> nextNodesTupleLifecycle,
+            TupleLifecycle<OutTuple_> nextNodesTupleLifecycle, boolean isFiltering,
             int outputStoreIndexLeftOutEntry, int outputStoreIndexRightOutEntry,
             Indexer<LeftTuple_> indexerLeft, Indexer<UniTuple<Right_>> indexerRight) {
         super(inputStoreIndexLeftOutTupleList, inputStoreIndexRightOutTupleList,
-                nextNodesTupleLifecycle, outputStoreIndexLeftOutEntry, outputStoreIndexRightOutEntry);
+                nextNodesTupleLifecycle, isFiltering, outputStoreIndexLeftOutEntry, outputStoreIndexRightOutEntry);
         this.mappingRight = mappingRight;
         this.inputStoreIndexLeftProperties = inputStoreIndexLeftProperties;
         this.inputStoreIndexLeftEntry = inputStoreIndexLeftEntry;
@@ -67,6 +67,11 @@ public abstract class AbstractIndexedJoinNode<LeftTuple_ extends Tuple, Right_, 
         IndexProperties oldIndexProperties = leftTuple.getStore(inputStoreIndexLeftProperties);
         if (oldIndexProperties == null) {
             // No fail fast if null because we don't track which tuples made it through the filter predicate(s)
+            insertLeft(leftTuple);
+            return;
+        }
+        if (isFiltering) { // TODO do it smarter
+            retractLeft(leftTuple);
             insertLeft(leftTuple);
             return;
         }
@@ -132,6 +137,11 @@ public abstract class AbstractIndexedJoinNode<LeftTuple_ extends Tuple, Right_, 
         IndexProperties oldIndexProperties = rightTuple.getStore(inputStoreIndexRightProperties);
         if (oldIndexProperties == null) {
             // No fail fast if null because we don't track which tuples made it through the filter predicate(s)
+            insertRight(rightTuple);
+            return;
+        }
+        if (isFiltering) { // TODO do it smarter
+            retractRight(rightTuple);
             insertRight(rightTuple);
             return;
         }

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/common/AbstractIndexedJoinNode.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/common/AbstractIndexedJoinNode.java
@@ -104,18 +104,15 @@ public abstract class AbstractIndexedJoinNode<LeftTuple_ extends Tuple, Right_, 
 
     @Override
     public final void retractLeft(LeftTuple_ leftTuple) {
-        IndexProperties indexProperties = leftTuple.getStore(inputStoreIndexLeftProperties);
+        IndexProperties indexProperties = leftTuple.removeStore(inputStoreIndexLeftProperties);
         if (indexProperties == null) {
             // No fail fast if null because we don't track which tuples made it through the filter predicate(s)
             return;
         }
-        TupleListEntry<LeftTuple_> leftEntry = leftTuple.getStore(inputStoreIndexLeftEntry);
-        TupleList<MutableOutTuple_> outTupleListLeft = leftTuple.getStore(inputStoreIndexLeftOutTupleList);
+        TupleListEntry<LeftTuple_> leftEntry = leftTuple.removeStore(inputStoreIndexLeftEntry);
+        TupleList<MutableOutTuple_> outTupleListLeft = leftTuple.removeStore(inputStoreIndexLeftOutTupleList);
         indexerLeft.remove(indexProperties, leftEntry);
         outTupleListLeft.forEach(this::retractOutTuple);
-        leftTuple.setStore(inputStoreIndexLeftProperties, null);
-        leftTuple.setStore(inputStoreIndexLeftEntry, null);
-        leftTuple.setStore(inputStoreIndexLeftOutTupleList, null);
     }
 
     @Override
@@ -173,18 +170,15 @@ public abstract class AbstractIndexedJoinNode<LeftTuple_ extends Tuple, Right_, 
 
     @Override
     public final void retractRight(UniTuple<Right_> rightTuple) {
-        IndexProperties indexProperties = rightTuple.getStore(inputStoreIndexRightProperties);
+        IndexProperties indexProperties = rightTuple.removeStore(inputStoreIndexRightProperties);
         if (indexProperties == null) {
             // No fail fast if null because we don't track which tuples made it through the filter predicate(s)
             return;
         }
-        TupleListEntry<UniTuple<Right_>> rightEntry = rightTuple.getStore(inputStoreIndexRightEntry);
-        TupleList<MutableOutTuple_> outTupleListRight = rightTuple.getStore(inputStoreIndexRightOutTupleList);
+        TupleListEntry<UniTuple<Right_>> rightEntry = rightTuple.removeStore(inputStoreIndexRightEntry);
+        TupleList<MutableOutTuple_> outTupleListRight = rightTuple.removeStore(inputStoreIndexRightOutTupleList);
         indexerRight.remove(indexProperties, rightEntry);
         outTupleListRight.forEach(this::retractOutTuple);
-        rightTuple.setStore(inputStoreIndexRightProperties, null);
-        rightTuple.setStore(inputStoreIndexRightEntry, null);
-        rightTuple.setStore(inputStoreIndexRightOutTupleList, null);
     }
 
     protected abstract IndexProperties createIndexPropertiesLeft(LeftTuple_ leftTuple);

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/common/AbstractJoinNode.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/common/AbstractJoinNode.java
@@ -87,12 +87,10 @@ public abstract class AbstractJoinNode<LeftTuple_ extends Tuple, Right_, OutTupl
     }
 
     protected final void retractOutTuple(MutableOutTuple_ outTuple) {
-        TupleListEntry<MutableOutTuple_> outEntryLeft = outTuple.getStore(outputStoreIndexLeftOutEntry);
+        TupleListEntry<MutableOutTuple_> outEntryLeft = outTuple.removeStore(outputStoreIndexLeftOutEntry);
         outEntryLeft.remove();
-        outTuple.setStore(outputStoreIndexLeftOutEntry, null);
-        TupleListEntry<MutableOutTuple_> outEntryRight = outTuple.getStore(outputStoreIndexRightOutEntry);
+        TupleListEntry<MutableOutTuple_> outEntryRight = outTuple.removeStore(outputStoreIndexRightOutEntry);
         outEntryRight.remove();
-        outTuple.setStore(outputStoreIndexRightOutEntry, null);
         doRetractOutTuple(outTuple);
     }
 

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/common/AbstractMapNode.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/common/AbstractMapNode.java
@@ -60,12 +60,11 @@ public abstract class AbstractMapNode<InTuple_ extends Tuple, Right_>
 
     @Override
     public void retract(InTuple_ tuple) {
-        UniTuple<Right_> outTuple = tuple.getStore(inputStoreIndex);
+        UniTuple<Right_> outTuple = tuple.removeStore(inputStoreIndex);
         if (outTuple == null) {
             // No fail fast if null because we don't track which tuples made it through the filter predicate(s)
             return;
         }
-        tuple.setStore(inputStoreIndex, null);
         outTuple.setState(BavetTupleState.DYING);
         dirtyTupleQueue.add(outTuple);
     }

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/common/AbstractTuple.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/common/AbstractTuple.java
@@ -43,4 +43,19 @@ public abstract class AbstractTuple implements Tuple {
         }
         store = value;
     }
+
+    @Override
+    public <Value_> Value_ removeStore(int index) {
+        Value_ value;
+        if (storeIsArray) {
+            Object[] array = (Object[]) store;
+            value = (Value_) array[index];
+            array[index] = null;
+        } else {
+            value = (Value_) store;
+            store = null;
+        }
+        return value;
+    }
+
 }

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/common/AbstractUnindexedIfExistsNode.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/common/AbstractUnindexedIfExistsNode.java
@@ -90,7 +90,7 @@ public abstract class AbstractUnindexedIfExistsNode<LeftTuple_ extends Tuple, Ri
 
     @Override
     public final void retractLeft(LeftTuple_ leftTuple) {
-        TupleListEntry<ExistsCounter<LeftTuple_>> counterEntry = leftTuple.getStore(inputStoreIndexLeftCounterEntry);
+        TupleListEntry<ExistsCounter<LeftTuple_>> counterEntry = leftTuple.removeStore(inputStoreIndexLeftCounterEntry);
         if (counterEntry == null) {
             // No fail fast if null because we don't track which tuples made it through the filter predicate(s)
             return;
@@ -153,13 +153,12 @@ public abstract class AbstractUnindexedIfExistsNode<LeftTuple_ extends Tuple, Ri
 
     @Override
     public final void retractRight(UniTuple<Right_> rightTuple) {
-        TupleListEntry<UniTuple<Right_>> rightEntry = rightTuple.getStore(inputStoreIndexRightEntry);
+        TupleListEntry<UniTuple<Right_>> rightEntry = rightTuple.removeStore(inputStoreIndexRightEntry);
         if (rightEntry == null) {
             // No fail fast if null because we don't track which tuples made it through the filter predicate(s)
             return;
         }
         rightEntry.remove();
-        rightTuple.setStore(inputStoreIndexRightEntry, null);
         if (!isFiltering) {
             leftCounterList.forEach(this::decrementCounterRight);
         } else {

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/common/AbstractUnindexedJoinNode.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/common/AbstractUnindexedJoinNode.java
@@ -54,17 +54,17 @@ public abstract class AbstractUnindexedJoinNode<LeftTuple_ extends Tuple, Right_
             insertLeft(leftTuple);
             return;
         }
-        if (isFiltering) { // TODO do it smarter
-            retractLeft(leftTuple);
-            insertLeft(leftTuple);
-            return;
-        }
-        // Propagate the update for downstream filters, matchWeighers, ...
         TupleList<MutableOutTuple_> outTupleListLeft = leftTuple.getStore(inputStoreIndexLeftOutTupleList);
-        outTupleListLeft.forEach(outTuple -> {
-            setOutTupleLeftFacts(outTuple, leftTuple);
-            doUpdateOutTuple(outTuple);
-        });
+        if (!isFiltering) {
+            // Propagate the update for downstream filters, matchWeighers, ...
+            outTupleListLeft.forEach(outTuple -> {
+                setOutTupleLeftFacts(outTuple, leftTuple);
+                doUpdateOutTuple(outTuple);
+            });
+        } else {
+            outTupleListLeft.forEach(this::retractOutTuple);
+            rightTupleList.forEach(rightTuple -> insertOutTuple(leftTuple, rightTuple));
+        }
     }
 
     @Override
@@ -102,17 +102,17 @@ public abstract class AbstractUnindexedJoinNode<LeftTuple_ extends Tuple, Right_
             insertRight(rightTuple);
             return;
         }
-        if (isFiltering) { // TODO do it smarter
-            retractRight(rightTuple);
-            insertRight(rightTuple);
-            return;
-        }
-        // Propagate the update for downstream filters, matchWeighers, ...
         TupleList<MutableOutTuple_> outTupleListRight = rightTuple.getStore(inputStoreIndexRightOutTupleList);
-        outTupleListRight.forEach(outTuple -> {
-            setOutTupleRightFact(outTuple, rightTuple);
-            doUpdateOutTuple(outTuple);
-        });
+        if (!isFiltering) {
+            // Propagate the update for downstream filters, matchWeighers, ...
+            outTupleListRight.forEach(outTuple -> {
+                setOutTupleRightFact(outTuple, rightTuple);
+                doUpdateOutTuple(outTuple);
+            });
+        } else {
+            outTupleListRight.forEach(this::retractOutTuple);
+            leftTupleList.forEach(leftTuple -> insertOutTuple(leftTuple, rightTuple));
+        }
     }
 
     @Override

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/common/AbstractUnindexedJoinNode.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/common/AbstractUnindexedJoinNode.java
@@ -24,10 +24,11 @@ public abstract class AbstractUnindexedJoinNode<LeftTuple_ extends Tuple, Right_
     protected AbstractUnindexedJoinNode(
             int inputStoreIndexLeftEntry, int inputStoreIndexLeftOutTupleList,
             int inputStoreIndexRightEntry, int inputStoreIndexRightOutTupleList,
-            TupleLifecycle<OutTuple_> nextNodesTupleLifecycle,
+            TupleLifecycle<OutTuple_> nextNodesTupleLifecycle, boolean isFiltering,
             int outputStoreIndexLeftOutEntry, int outputStoreIndexRightOutEntry) {
         super(inputStoreIndexLeftOutTupleList, inputStoreIndexRightOutTupleList,
-                nextNodesTupleLifecycle, outputStoreIndexLeftOutEntry, outputStoreIndexRightOutEntry);
+                nextNodesTupleLifecycle, isFiltering,
+                outputStoreIndexLeftOutEntry, outputStoreIndexRightOutEntry);
         this.inputStoreIndexLeftEntry = inputStoreIndexLeftEntry;
         this.inputStoreIndexRightEntry = inputStoreIndexRightEntry;
     }
@@ -50,6 +51,11 @@ public abstract class AbstractUnindexedJoinNode<LeftTuple_ extends Tuple, Right_
         TupleListEntry<LeftTuple_> leftEntry = leftTuple.getStore(inputStoreIndexLeftEntry);
         if (leftEntry == null) {
             // No fail fast if null because we don't track which tuples made it through the filter predicate(s)
+            insertLeft(leftTuple);
+            return;
+        }
+        if (isFiltering) { // TODO do it smarter
+            retractLeft(leftTuple);
             insertLeft(leftTuple);
             return;
         }
@@ -93,6 +99,11 @@ public abstract class AbstractUnindexedJoinNode<LeftTuple_ extends Tuple, Right_
         TupleListEntry<UniTuple<Right_>> rightEntry = rightTuple.getStore(inputStoreIndexRightEntry);
         if (rightEntry == null) {
             // No fail fast if null because we don't track which tuples made it through the filter predicate(s)
+            insertRight(rightTuple);
+            return;
+        }
+        if (isFiltering) { // TODO do it smarter
+            retractRight(rightTuple);
             insertRight(rightTuple);
             return;
         }

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/common/AbstractUnindexedJoinNode.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/common/AbstractUnindexedJoinNode.java
@@ -69,16 +69,14 @@ public abstract class AbstractUnindexedJoinNode<LeftTuple_ extends Tuple, Right_
 
     @Override
     public final void retractLeft(LeftTuple_ leftTuple) {
-        TupleListEntry<LeftTuple_> leftEntry = leftTuple.getStore(inputStoreIndexLeftEntry);
+        TupleListEntry<LeftTuple_> leftEntry = leftTuple.removeStore(inputStoreIndexLeftEntry);
         if (leftEntry == null) {
             // No fail fast if null because we don't track which tuples made it through the filter predicate(s)
             return;
         }
-        TupleList<MutableOutTuple_> outTupleListLeft = leftTuple.getStore(inputStoreIndexLeftOutTupleList);
+        TupleList<MutableOutTuple_> outTupleListLeft = leftTuple.removeStore(inputStoreIndexLeftOutTupleList);
         leftEntry.remove();
         outTupleListLeft.forEach(this::retractOutTuple);
-        leftTuple.setStore(inputStoreIndexLeftEntry, null);
-        leftTuple.setStore(inputStoreIndexLeftOutTupleList, null);
     }
 
     @Override
@@ -117,16 +115,14 @@ public abstract class AbstractUnindexedJoinNode<LeftTuple_ extends Tuple, Right_
 
     @Override
     public final void retractRight(UniTuple<Right_> rightTuple) {
-        TupleListEntry<UniTuple<Right_>> rightEntry = rightTuple.getStore(inputStoreIndexRightEntry);
+        TupleListEntry<UniTuple<Right_>> rightEntry = rightTuple.removeStore(inputStoreIndexRightEntry);
         if (rightEntry == null) {
             // No fail fast if null because we don't track which tuples made it through the filter predicate(s)
             return;
         }
-        TupleList<MutableOutTuple_> outTupleListRight = rightTuple.getStore(inputStoreIndexRightOutTupleList);
+        TupleList<MutableOutTuple_> outTupleListRight = rightTuple.removeStore(inputStoreIndexRightOutTupleList);
         rightEntry.remove();
         outTupleListRight.forEach(this::retractOutTuple);
-        rightTuple.setStore(inputStoreIndexRightEntry, null);
-        rightTuple.setStore(inputStoreIndexRightOutTupleList, null);
     }
 
 }

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/common/AggregatedTupleLifecycle.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/common/AggregatedTupleLifecycle.java
@@ -27,4 +27,10 @@ final class AggregatedTupleLifecycle<Tuple_ extends Tuple> implements TupleLifec
             lifecycle.retract(tuple);
         }
     }
+
+    @Override
+    public String toString() {
+        return "size = " + lifecycles.length;
+    }
+
 }

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/common/LeftTupleLifecycleImpl.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/common/LeftTupleLifecycleImpl.java
@@ -25,4 +25,10 @@ final class LeftTupleLifecycleImpl<Tuple_ extends Tuple>
     public void retract(Tuple_ tuple) {
         leftTupleLifecycle.retractLeft(tuple);
     }
+
+    @Override
+    public String toString() {
+        return "left " + leftTupleLifecycle;
+    }
+
 }

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/common/RightTupleLifecycleImpl.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/common/RightTupleLifecycleImpl.java
@@ -25,4 +25,10 @@ final class RightTupleLifecycleImpl<Tuple_ extends Tuple>
     public void retract(Tuple_ tuple) {
         rightTupleLifecycle.retractRight(tuple);
     }
+
+    @Override
+    public String toString() {
+        return "right " + rightTupleLifecycle;
+    }
+
 }

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/common/Tuple.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/common/Tuple.java
@@ -24,5 +24,4 @@ public interface Tuple {
 
     <Value_> Value_ removeStore(int index);
 
-
 }

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/common/Tuple.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/common/Tuple.java
@@ -22,4 +22,7 @@ public interface Tuple {
 
     void setStore(int index, Object value);
 
+    <Value_> Value_ removeStore(int index);
+
+
 }

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/common/collection/TupleListEntry.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/common/collection/TupleListEntry.java
@@ -41,6 +41,10 @@ public final class TupleListEntry<T> {
         return element;
     }
 
+    public TupleList<T> getList() {
+        return list;
+    }
+
     @Override
     public String toString() {
         return element.toString();

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/quad/BavetJoinQuadConstraintStream.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/quad/BavetJoinQuadConstraintStream.java
@@ -15,6 +15,7 @@ import org.optaplanner.constraint.streams.bavet.tri.BavetJoinBridgeTriConstraint
 import org.optaplanner.constraint.streams.bavet.tri.TriTuple;
 import org.optaplanner.constraint.streams.bavet.uni.BavetJoinBridgeUniConstraintStream;
 import org.optaplanner.constraint.streams.common.quad.DefaultQuadJoiner;
+import org.optaplanner.core.api.function.QuadPredicate;
 import org.optaplanner.core.api.score.Score;
 import org.optaplanner.core.api.score.stream.ConstraintStream;
 
@@ -26,15 +27,17 @@ public final class BavetJoinQuadConstraintStream<Solution_, A, B, C, D>
     private final BavetJoinBridgeUniConstraintStream<Solution_, D> rightParent;
 
     private final DefaultQuadJoiner<A, B, C, D> joiner;
+    private final QuadPredicate<A, B, C, D> filtering;
 
     public BavetJoinQuadConstraintStream(BavetConstraintFactory<Solution_> constraintFactory,
             BavetJoinBridgeTriConstraintStream<Solution_, A, B, C> leftParent,
             BavetJoinBridgeUniConstraintStream<Solution_, D> rightParent,
-            DefaultQuadJoiner<A, B, C, D> joiner) {
+            DefaultQuadJoiner<A, B, C, D> joiner, QuadPredicate<A, B, C, D> filtering) {
         super(constraintFactory, leftParent.getRetrievalSemantics());
         this.leftParent = leftParent;
         this.rightParent = rightParent;
         this.joiner = joiner;
+        this.filtering = filtering;
     }
 
     @Override
@@ -73,7 +76,7 @@ public final class BavetJoinQuadConstraintStream<Solution_, A, B, C, D>
                                 buildHelper.reserveTupleStoreIndex(rightParent.getTupleSource()),
                                 buildHelper.reserveTupleStoreIndex(rightParent.getTupleSource()),
                                 buildHelper.reserveTupleStoreIndex(rightParent.getTupleSource()),
-                                downstream, outputStoreSize + 2,
+                                downstream, filtering, outputStoreSize + 2,
                                 outputStoreSize, outputStoreSize + 1,
                                 indexerFactory.buildIndexer(true), indexerFactory.buildIndexer(false))
                         : new UnindexedJoinQuadNode<>(
@@ -81,7 +84,7 @@ public final class BavetJoinQuadConstraintStream<Solution_, A, B, C, D>
                                 buildHelper.reserveTupleStoreIndex(leftParent.getTupleSource()),
                                 buildHelper.reserveTupleStoreIndex(rightParent.getTupleSource()),
                                 buildHelper.reserveTupleStoreIndex(rightParent.getTupleSource()),
-                                downstream, outputStoreSize + 2,
+                        downstream, filtering, outputStoreSize + 2,
                                 outputStoreSize, outputStoreSize + 1);
         buildHelper.addNode(node, leftParent, rightParent);
     }

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/quad/BavetJoinQuadConstraintStream.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/quad/BavetJoinQuadConstraintStream.java
@@ -109,12 +109,13 @@ public final class BavetJoinQuadConstraintStream<Solution_, A, B, C, D>
          */
         return Objects.equals(leftParent.getParent(), other.leftParent.getParent())
                 && Objects.equals(rightParent.getParent(), other.rightParent.getParent())
-                && Objects.equals(joiner, other.joiner);
+                && Objects.equals(joiner, other.joiner)
+                && Objects.equals(filtering, other.filtering);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(leftParent.getParent(), rightParent.getParent(), joiner);
+        return Objects.hash(leftParent.getParent(), rightParent.getParent(), joiner, filtering);
     }
 
     @Override

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/quad/BavetJoinQuadConstraintStream.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/quad/BavetJoinQuadConstraintStream.java
@@ -84,7 +84,7 @@ public final class BavetJoinQuadConstraintStream<Solution_, A, B, C, D>
                                 buildHelper.reserveTupleStoreIndex(leftParent.getTupleSource()),
                                 buildHelper.reserveTupleStoreIndex(rightParent.getTupleSource()),
                                 buildHelper.reserveTupleStoreIndex(rightParent.getTupleSource()),
-                        downstream, filtering, outputStoreSize + 2,
+                                downstream, filtering, outputStoreSize + 2,
                                 outputStoreSize, outputStoreSize + 1);
         buildHelper.addNode(node, leftParent, rightParent);
     }

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/quad/UnindexedJoinQuadNode.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/quad/UnindexedJoinQuadNode.java
@@ -4,22 +4,32 @@ import org.optaplanner.constraint.streams.bavet.common.AbstractUnindexedJoinNode
 import org.optaplanner.constraint.streams.bavet.common.TupleLifecycle;
 import org.optaplanner.constraint.streams.bavet.tri.TriTuple;
 import org.optaplanner.constraint.streams.bavet.uni.UniTuple;
+import org.optaplanner.core.api.function.QuadPredicate;
 
 final class UnindexedJoinQuadNode<A, B, C, D>
         extends AbstractUnindexedJoinNode<TriTuple<A, B, C>, D, QuadTuple<A, B, C, D>, QuadTupleImpl<A, B, C, D>> {
 
+    private final QuadPredicate<A, B, C, D> filtering;
     private final int outputStoreSize;
 
     public UnindexedJoinQuadNode(
             int inputStoreIndexLeftEntry, int inputStoreIndexLeftOutTupleList,
             int inputStoreIndexRightEntry, int inputStoreIndexRightOutTupleList,
-            TupleLifecycle<QuadTuple<A, B, C, D>> nextNodesTupleLifecycle, int outputStoreSize,
+            TupleLifecycle<QuadTuple<A, B, C, D>> nextNodesTupleLifecycle, QuadPredicate<A, B, C, D> filtering,
+            int outputStoreSize,
             int outputStoreIndexLeftOutEntry, int outputStoreIndexRightOutEntry) {
         super(inputStoreIndexLeftEntry, inputStoreIndexLeftOutTupleList,
                 inputStoreIndexRightEntry, inputStoreIndexRightOutTupleList,
-                nextNodesTupleLifecycle,
+                nextNodesTupleLifecycle, filtering != null,
                 outputStoreIndexLeftOutEntry, outputStoreIndexRightOutEntry);
+        this.filtering = filtering;
         this.outputStoreSize = outputStoreSize;
+    }
+
+    @Override
+    protected QuadTupleImpl<A, B, C, D> createOutTuple(TriTuple<A, B, C> leftTuple, UniTuple<D> rightTuple) {
+        return new QuadTupleImpl<>(leftTuple.getFactA(), leftTuple.getFactB(), leftTuple.getFactC(), rightTuple.getFactA(),
+                outputStoreSize);
     }
 
     @Override
@@ -35,9 +45,8 @@ final class UnindexedJoinQuadNode<A, B, C, D>
     }
 
     @Override
-    protected QuadTupleImpl<A, B, C, D> createOutTuple(TriTuple<A, B, C> leftTuple, UniTuple<D> rightTuple) {
-        return new QuadTupleImpl<>(leftTuple.getFactA(), leftTuple.getFactB(), leftTuple.getFactC(), rightTuple.getFactA(),
-                outputStoreSize);
+    protected boolean testFiltering(TriTuple<A, B, C> leftTuple, UniTuple<D> rightTuple) {
+        return filtering.test(leftTuple.getFactA(), leftTuple.getFactB(), leftTuple.getFactC(), rightTuple.getFactA());
     }
 
 }

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/tri/BavetAbstractTriConstraintStream.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/tri/BavetAbstractTriConstraintStream.java
@@ -87,20 +87,15 @@ public abstract class BavetAbstractTriConstraintStream<Solution_, A, B, C> exten
                 new BavetJoinBridgeUniConstraintStream<>(constraintFactory, other, false);
         BavetJoinQuadConstraintStream<Solution_, A, B, C, D> joinStream =
                 new BavetJoinQuadConstraintStream<>(constraintFactory, leftBridge, rightBridge,
-                        joinerComber.getMergedJoiner());
+                        joinerComber.getMergedJoiner(), joinerComber.getMergedFiltering());
         leftBridge.setJoinStream(joinStream);
         rightBridge.setJoinStream(joinStream);
 
-        joinStream = constraintFactory.share(joinStream, joinStream_ -> {
+        return constraintFactory.share(joinStream, joinStream_ -> {
             // Connect the bridges upstream, as it is an actual new join.
             getChildStreamList().add(leftBridge);
             other.getChildStreamList().add(rightBridge);
         });
-        if (joinerComber.getMergedFiltering() == null) {
-            return joinStream;
-        } else {
-            return joinStream.filter(joinerComber.getMergedFiltering());
-        }
     }
 
     // ************************************************************************

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/tri/BavetJoinTriConstraintStream.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/tri/BavetJoinTriConstraintStream.java
@@ -15,6 +15,7 @@ import org.optaplanner.constraint.streams.bavet.common.index.IndexerFactory;
 import org.optaplanner.constraint.streams.bavet.common.index.JoinerUtils;
 import org.optaplanner.constraint.streams.bavet.uni.BavetJoinBridgeUniConstraintStream;
 import org.optaplanner.constraint.streams.common.tri.DefaultTriJoiner;
+import org.optaplanner.core.api.function.TriPredicate;
 import org.optaplanner.core.api.score.Score;
 import org.optaplanner.core.api.score.stream.ConstraintStream;
 
@@ -26,15 +27,17 @@ public final class BavetJoinTriConstraintStream<Solution_, A, B, C>
     private final BavetJoinBridgeUniConstraintStream<Solution_, C> rightParent;
 
     private final DefaultTriJoiner<A, B, C> joiner;
+    private final TriPredicate<A, B, C> filtering;
 
     public BavetJoinTriConstraintStream(BavetConstraintFactory<Solution_> constraintFactory,
             BavetJoinBridgeBiConstraintStream<Solution_, A, B> leftParent,
             BavetJoinBridgeUniConstraintStream<Solution_, C> rightParent,
-            DefaultTriJoiner<A, B, C> joiner) {
+            DefaultTriJoiner<A, B, C> joiner, TriPredicate<A, B, C> filtering) {
         super(constraintFactory, leftParent.getRetrievalSemantics());
         this.leftParent = leftParent;
         this.rightParent = rightParent;
         this.joiner = joiner;
+        this.filtering = filtering;
     }
 
     @Override
@@ -72,7 +75,7 @@ public final class BavetJoinTriConstraintStream<Solution_, A, B, C>
                         buildHelper.reserveTupleStoreIndex(rightParent.getTupleSource()),
                         buildHelper.reserveTupleStoreIndex(rightParent.getTupleSource()),
                         buildHelper.reserveTupleStoreIndex(rightParent.getTupleSource()),
-                        downstream, outputStoreSize + 2,
+                        downstream, filtering, outputStoreSize + 2,
                         outputStoreSize, outputStoreSize + 1,
                         indexerFactory.buildIndexer(true), indexerFactory.buildIndexer(false))
                 : new UnindexedJoinTriNode<>(
@@ -80,7 +83,7 @@ public final class BavetJoinTriConstraintStream<Solution_, A, B, C>
                         buildHelper.reserveTupleStoreIndex(leftParent.getTupleSource()),
                         buildHelper.reserveTupleStoreIndex(rightParent.getTupleSource()),
                         buildHelper.reserveTupleStoreIndex(rightParent.getTupleSource()),
-                        downstream, outputStoreSize + 2,
+                        downstream, filtering, outputStoreSize + 2,
                         outputStoreSize, outputStoreSize + 1);
         buildHelper.addNode(node, leftParent, rightParent);
     }

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/tri/BavetJoinTriConstraintStream.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/tri/BavetJoinTriConstraintStream.java
@@ -108,12 +108,13 @@ public final class BavetJoinTriConstraintStream<Solution_, A, B, C>
          */
         return Objects.equals(leftParent.getParent(), other.leftParent.getParent())
                 && Objects.equals(rightParent.getParent(), other.rightParent.getParent())
-                && Objects.equals(joiner, other.joiner);
+                && Objects.equals(joiner, other.joiner)
+                && Objects.equals(filtering, other.filtering);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(leftParent.getParent(), rightParent.getParent(), joiner);
+        return Objects.hash(leftParent.getParent(), rightParent.getParent(), joiner, filtering);
     }
 
     @Override

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/tri/UnindexedJoinTriNode.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/tri/UnindexedJoinTriNode.java
@@ -4,21 +4,25 @@ import org.optaplanner.constraint.streams.bavet.bi.BiTuple;
 import org.optaplanner.constraint.streams.bavet.common.AbstractUnindexedJoinNode;
 import org.optaplanner.constraint.streams.bavet.common.TupleLifecycle;
 import org.optaplanner.constraint.streams.bavet.uni.UniTuple;
+import org.optaplanner.core.api.function.TriPredicate;
 
 final class UnindexedJoinTriNode<A, B, C>
         extends AbstractUnindexedJoinNode<BiTuple<A, B>, C, TriTuple<A, B, C>, TriTupleImpl<A, B, C>> {
 
+    private final TriPredicate<A, B, C> filtering;
     private final int outputStoreSize;
 
     public UnindexedJoinTriNode(
             int inputStoreIndexLeftEntry, int inputStoreIndexLeftOutTupleList,
             int inputStoreIndexRightEntry, int inputStoreIndexRightOutTupleList,
-            TupleLifecycle<TriTuple<A, B, C>> nextNodesTupleLifecycle, int outputStoreSize,
+            TupleLifecycle<TriTuple<A, B, C>> nextNodesTupleLifecycle, TriPredicate<A, B, C> filtering,
+            int outputStoreSize,
             int outputStoreIndexLeftOutEntry, int outputStoreIndexRightOutEntry) {
         super(inputStoreIndexLeftEntry, inputStoreIndexLeftOutTupleList,
                 inputStoreIndexRightEntry, inputStoreIndexRightOutTupleList,
-                nextNodesTupleLifecycle,
+                nextNodesTupleLifecycle, filtering != null,
                 outputStoreIndexLeftOutEntry, outputStoreIndexRightOutEntry);
+        this.filtering = filtering;
         this.outputStoreSize = outputStoreSize;
     }
 
@@ -36,6 +40,11 @@ final class UnindexedJoinTriNode<A, B, C>
     @Override
     protected void setOutTupleRightFact(TriTupleImpl<A, B, C> outTuple, UniTuple<C> rightTuple) {
         outTuple.factC = rightTuple.getFactA();
+    }
+
+    @Override
+    protected boolean testFiltering(BiTuple<A, B> leftTuple, UniTuple<C> rightTuple) {
+        return filtering.test(leftTuple.getFactA(), leftTuple.getFactB(), rightTuple.getFactA());
     }
 
 }

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/uni/BavetAbstractUniConstraintStream.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/uni/BavetAbstractUniConstraintStream.java
@@ -87,20 +87,15 @@ public abstract class BavetAbstractUniConstraintStream<Solution_, A> extends Bav
                 new BavetJoinBridgeUniConstraintStream<>(constraintFactory, other, false);
         BavetJoinBiConstraintStream<Solution_, A, B> joinStream =
                 new BavetJoinBiConstraintStream<>(constraintFactory, leftBridge, rightBridge,
-                        joinerComber.getMergedJoiner());
+                        joinerComber.getMergedJoiner(), joinerComber.getMergedFiltering());
         leftBridge.setJoinStream(joinStream);
         rightBridge.setJoinStream(joinStream);
 
-        joinStream = constraintFactory.share(joinStream, joinStream_ -> {
+        return constraintFactory.share(joinStream, joinStream_ -> {
             // Connect the bridges upstream, as it is an actual new join.
             getChildStreamList().add(leftBridge);
             other.getChildStreamList().add(rightBridge);
         });
-        if (joinerComber.getMergedFiltering() == null) {
-            return joinStream;
-        } else {
-            return joinStream.filter(joinerComber.getMergedFiltering());
-        }
     }
 
     // ************************************************************************


### PR DESCRIPTION
POC shows big speed gain in specific cases.

- [x] Updates with filtering should not nuke (retract+insert) but modify
- [x] Clean up