### PR TITLE
[RHBOP] Nightly sources generation fix

### DIFF
--- a/.ci/jenkins/Jenkinsfile.prod.nightly
+++ b/.ci/jenkins/Jenkinsfile.prod.nightly
@@ -46,7 +46,7 @@ pipeline {
                         pipelineHelper.retry(
                         {
                             def SETTINGS_XML_ID = '5d9884a1-178a-4d67-a3ac-9735d2df2cef'
-                            def projectCollection = ['drools', 'optaplanner', 'optaplanner-quickstarts', 'optaweb-vehicle-routing']
+                            def projectCollection = ['drools', 'optaplanner', 'optaplanner-quickstarts', 'optaweb-vehicle-routing', 'jboss-integration/rhbop-optaplanner']
                             def projectVariableMap = ['kiegroup_optaplanner': 'optaplannerVersion', 'kiegroup_drools': 'droolsProductVersion']
                             def additionalVariables = [
                                 'droolsProductVersion': env.DROOLS_PRODUCT_VERSION,
@@ -80,24 +80,12 @@ pipeline {
                         def PME_BUILD_VARIABLES = env.PME_BUILD_VARIABLES.split(';').collect{ it.split('=')}.inject([:]) {map, item -> map << [(item.length == 2 ? item[0] : null): (item.length == 2 ? item[1] : null)]}
                         def folder="${env.RCM_GUEST_FOLDER}/rhbop/RHBOP-${PRODUCT_VERSION}.nightly"
 
-                        // rename sources directories
-                        def optaplannerSourceDir = "org.optaplanner-optaplanner-${PRODUCT_VERSION}.Final-redhat"
-                        sh "mv ${env.WORKSPACE}/kiegroup_optaplanner ${env.WORKSPACE}/$optaplannerSourceDir"
-
-                        def quickstartsSourceDir = "org.optaplanner-optaplanner-quickstarts-${PRODUCT_VERSION}.Final-redhat"
-                        sh "mv ${env.WORKSPACE}/kiegroup_optaplanner-quickstarts ${env.WORKSPACE}/$quickstartsSourceDir"
-
-                        def optawebSourceDir = "org.optaweb.optaweb-vehicle-routing-${PRODUCT_VERSION}.Final-redhat"
-                        sh "mv ${env.WORKSPACE}/kiegroup_optaweb-vehicle-routing ${env.WORKSPACE}/$optawebSourceDir"
-
                         // zip source directories
-                        dir("${env.WORKSPACE}/") {
+                        dir("${env.WORKSPACE}/deployDirectory/org/kie/rhbop/rhbop") {
                             def optaplannerSourcesFilename = computeSourcesFilename("optaplanner", PME_BUILD_VARIABLES['datetimeSuffix'])
-                            sh "zip -r $optaplannerSourcesFilename $optaplannerSourceDir -x '$optaplannerSourceDir/.git/*' -x '$optaplannerSourceDir/optaplanner-operator/*' -x '$optaplannerSourceDir/target/*'"
                             uploadSources(optaplannerSourcesFilename, folder)
 
                             def quickstartsSourcesFilename = computeSourcesFilename("optaplanner-quickstarts", PME_BUILD_VARIABLES['datetimeSuffix'])
-                            sh "zip -r $quickstartsSourcesFilename $quickstartsSourceDir $optawebSourceDir -x '$quickstartsSourceDir/.git/*' -x '$optawebSourceDir/.git/*' -x '$quickstartsSourceDir/target/*' -x '$optawebSourceDir/target/*' -x '$quickstartsSourceDir/technology/python/*' -x '$quickstartsSourceDir/technology/kubernetes/*'"
                             uploadSources(quickstartsSourcesFilename, folder)
                         }
 
@@ -197,7 +185,7 @@ def getMessageBody(String optaplannerArchiveUrl, String optaplannerSourcesUrl, S
 }
 
 def computeSourcesFilename(String project, String suffix) {
-    return "rhbop-${PRODUCT_VERSION}-$project-sources-${suffix}.zip"
+    return "rhbop-${PRODUCT_VERSION}.redhat-${suffix}-${project}-sources.zip"
 }
 
 def uploadSources(String sourcesFilename, String folder) {

--- a/.ci/jenkins/Jenkinsfile.prod.nightly
+++ b/.ci/jenkins/Jenkinsfile.prod.nightly
@@ -81,7 +81,7 @@ pipeline {
                         def folder="${env.RCM_GUEST_FOLDER}/rhbop/RHBOP-${PRODUCT_VERSION}.nightly"
 
                         // zip source directories
-                        dir("${env.WORKSPACE}/deployDirectory/org/kie/rhbop/rhbop") {
+                        dir("${env.WORKSPACE}/deployDirectory/org/kie/rhbop/rhbop/${PRODUCT_VERSION}.redhat-${PME_BUILD_VARIABLES['datetimeSuffix']}") {
                             def optaplannerSourcesFilename = computeSourcesFilename("optaplanner", PME_BUILD_VARIABLES['datetimeSuffix'])
                             uploadSources(optaplannerSourcesFilename, folder)
 
@@ -103,9 +103,8 @@ pipeline {
                         def PME_BUILD_VARIABLES = env.PME_BUILD_VARIABLES.split(';').collect{ it.split('=')}.inject([:]) {map, item -> map << [(item.length == 2 ? item[0] : null): (item.length == 2 ? item[1] : null)]}
 
                         def optaplannerArchiveUrl = "https://bxms-qe.rhev-ci-vms.eng.rdu2.redhat.com:8443/nexus/content/groups/rhbop-${getCurrentBranch()}-nightly/"
-                        def optaplannerSourcesFileUrl = "${env.STAGING_SERVER_URL}rhbop/RHBOP-${PRODUCT_VERSION}.nightly/rhbop-${PRODUCT_VERSION}-optaplanner-sources-${PME_BUILD_VARIABLES['datetimeSuffix']}.zip"
-                        def optaplannerQuickstartsSourcesFileUrl = "${env.STAGING_SERVER_URL}rhbop/RHBOP-${PRODUCT_VERSION}.nightly/rhbop-${PRODUCT_VERSION}-optaplanner-quickstarts-sources-${PME_BUILD_VARIABLES['datetimeSuffix']}.zip"
-                        def optawebSourcesFileUrl = "${env.STAGING_SERVER_URL}rhbop/RHBOP-${PRODUCT_VERSION}.nightly/rhbop-${PRODUCT_VERSION}-optaweb-vehicle-routing-sources-${PME_BUILD_VARIABLES['datetimeSuffix']}.zip"
+                        def optaplannerSourcesFileUrl = "${env.STAGING_SERVER_URL}rhbop/RHBOP-${PRODUCT_VERSION}.nightly/rhbop-${PRODUCT_VERSION}.redhat-${PME_BUILD_VARIABLES['datetimeSuffix']}-optaplanner-sources.zip"
+                        def optaplannerQuickstartsSourcesFileUrl = "${env.STAGING_SERVER_URL}rhbop/RHBOP-${PRODUCT_VERSION}.nightly/rhbop-${PRODUCT_VERSION}.redhat-${PME_BUILD_VARIABLES['datetimeSuffix']}-optaplanner-quickstarts-sources.zip"
 
                         def topic = "VirtualTopic.qe.ci.ba.rhbop.${env.UMB_VERSION}.nightly.trigger"
                         def eventType = "rhbop-${env.UMB_VERSION}-nightly-qe-trigger"
@@ -113,7 +112,6 @@ pipeline {
                             optaplannerArchiveUrl,
                             optaplannerSourcesFileUrl,
                             optaplannerQuickstartsSourcesFileUrl,
-                            optawebSourcesFileUrl,
                             env.ALREADY_BUILT_PROJECTS,
                             ['rhbop': PME_BUILD_VARIABLES['optaplannerVersion'], 'drools': PME_BUILD_VARIABLES['droolsProductVersion']], 
                             gitHashesToCollection(env.GIT_INFORMATION_HASHES)
@@ -169,7 +167,7 @@ pipeline {
     }
 }
 
-def getMessageBody(String optaplannerArchiveUrl, String optaplannerSourcesUrl, String optaplannerQuickstartsSourcesUrl, String optawebSourcesFileUrl, String alreadyBuiltProjects, Map<String, String> versions, Map<String, String> scmHashes) {
+def getMessageBody(String optaplannerArchiveUrl, String optaplannerSourcesUrl, String optaplannerQuickstartsSourcesUrl, String alreadyBuiltProjects, Map<String, String> versions, Map<String, String> scmHashes) {
     def alreadyBuiltProjectsArray = (alreadyBuiltProjects ?: '').split(";")
     return """
 {

--- a/.ci/jenkins/Jenkinsfile.prod.nightly
+++ b/.ci/jenkins/Jenkinsfile.prod.nightly
@@ -97,7 +97,7 @@ pipeline {
                             uploadSources(optaplannerSourcesFilename, folder)
 
                             def quickstartsSourcesFilename = computeSourcesFilename("optaplanner-quickstarts", PME_BUILD_VARIABLES['datetimeSuffix'])
-                            sh "zip -r $quickstartsSourcesFilename $quickstartsSourceDir $optawebSourceDir -x '$quickstartsSourceDir/.git/*' -x '$optawebSourceDir/.git/*' -x '$quickstartsSourceDir/target/*' -x '$optawebSourceDir/target/*' -x '$quickstartsSourceDir/technology/java-activemq-quarkus/*' -x '$quickstartsSourceDir/technology/kotlin-quarkus/*' -x '$quickstartsSourceDir/technology/python/*' -x '$quickstartsSourceDir/technology/kubernetes/*' -x '$quickstartsSourceDir/use-cases/call-center/*' -x '$quickstartsSourceDir/use-cases/facility-location/*' -x '$quickstartsSourceDir/use-cases/order-picking/*' -x '$quickstartsSourceDir/use-cases/maintenance-scheduling/*' -x '$quickstartsSourceDir/use-cases/vehicle-routing/*' "
+                            sh "zip -r $quickstartsSourcesFilename $quickstartsSourceDir $optawebSourceDir -x '$quickstartsSourceDir/.git/*' -x '$optawebSourceDir/.git/*' -x '$quickstartsSourceDir/target/*' -x '$optawebSourceDir/target/*' -x '$quickstartsSourceDir/technology/python/*' -x '$quickstartsSourceDir/technology/kubernetes/*'"
                             uploadSources(quickstartsSourcesFilename, folder)
                         }
 

--- a/.ci/jenkins/Jenkinsfile.prod.nightly
+++ b/.ci/jenkins/Jenkinsfile.prod.nightly
@@ -87,17 +87,17 @@ pipeline {
                         def quickstartsSourceDir = "org.optaplanner-optaplanner-quickstarts-${PRODUCT_VERSION}.Final-redhat"
                         sh "mv ${env.WORKSPACE}/kiegroup_optaplanner-quickstarts ${env.WORKSPACE}/$quickstartsSourceDir"
 
-                        def optawebSourceDir = "org.optaweb.vehiclerouting-optaweb-vehicle-routing-${PRODUCT_VERSION}.Final-redhat"
+                        def optawebSourceDir = "org.optaweb.optaweb-vehicle-routing-${PRODUCT_VERSION}.Final-redhat"
                         sh "mv ${env.WORKSPACE}/kiegroup_optaweb-vehicle-routing ${env.WORKSPACE}/$optawebSourceDir"
 
                         // zip source directories
                         dir("${env.WORKSPACE}/") {
                             def optaplannerSourcesFilename = computeSourcesFilename("optaplanner", PME_BUILD_VARIABLES['datetimeSuffix'])
-                            sh "zip -r $optaplannerSourcesFilename $optaplannerSourceDir -x '$optaplannerSourceDir/.git/*' -x '$optaplannerSourceDir/optaplanner-operator/*'  -x '$optaplannerSourceDir/optaplanner-examples/*' -x '$optaplannerSourceDir/target/*'"
+                            sh "zip -r $optaplannerSourcesFilename $optaplannerSourceDir -x '$optaplannerSourceDir/.git/*' -x '$optaplannerSourceDir/optaplanner-operator/*' -x '$optaplannerSourceDir/target/*'"
                             uploadSources(optaplannerSourcesFilename, folder)
 
                             def quickstartsSourcesFilename = computeSourcesFilename("optaplanner-quickstarts", PME_BUILD_VARIABLES['datetimeSuffix'])
-                            sh "zip -r $quickstartsSourcesFilename $quickstartsSourceDir $optawebSourceDir -x '$quickstartsSourceDir/.git/*' -x '$optawebSourceDir/.git/*' -x '$quickstartsSourceDir/target/*' -x '$optawebSourceDir/target/*'"
+                            sh "zip -r $quickstartsSourcesFilename $quickstartsSourceDir $optawebSourceDir -x '$quickstartsSourceDir/.git/*' -x '$optawebSourceDir/.git/*' -x '$quickstartsSourceDir/target/*' -x '$optawebSourceDir/target/*' -x '$quickstartsSourceDir/technology/java-activemq-quarkus/*' -x '$quickstartsSourceDir/technology/kotlin-quarkus/*' -x '$quickstartsSourceDir/technology/python/*' -x '$quickstartsSourceDir/technology/kubernetes/*' -x '$quickstartsSourceDir/use-cases/call-center/*' -x '$quickstartsSourceDir/use-cases/facility-location/*' -x '$quickstartsSourceDir/use-cases/order-picking/*' -x '$quickstartsSourceDir/use-cases/maintenance-scheduling/*' -x '$quickstartsSourceDir/use-cases/vehicle-routing/*' "
                             uploadSources(quickstartsSourcesFilename, folder)
                         }
 

--- a/pom.xml
+++ b/pom.xml
@@ -142,7 +142,7 @@
     </profile>
 
     <profile>
-      <!-- TODO: enable the module by default after the 8.29.x branch is created. -->
+      <!-- TODO: enable the module by default after the 8.29.x branch is created, exlude it from productized profile. -->
       <id>operator</id>
       <activation>
         <property>


### PR DESCRIPTION
<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.
-->

### JIRA

- https://issues.redhat.com/browse/BXMSPROD-1826

### Referenced pull requests
- https://github.com/kiegroup/optaplanner-quickstarts/pull/421
- https://github.com/jboss-integration/rhbop-optaplanner/pull/1
- https://github.com/kiegroup/optaplanner/pull/2214
- https://github.com/kiegroup/optaplanner/pull/2223

Changes:
- Rename optaweb sources folder name 
- Remove the following quickstarts examples from sources generation:
  - technology
    - python
    - kubernetes
    
### Checklist
- [ ] Documentation updated if applicable.
- [ ] Release notes updated if applicable.
- [ ] Upgrade recipe provided if applicable.

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request checks</b>  
  Please add comment: <b>Jenkins retest this</b>

- for a <b>specific pull request check</b>  
  please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-vehicle-routing] tests</b>
  
- for a <b>full downstream build</b> 
  - for <b>jenkins</b> job: 
    please add comment: <b>Jenkins run fdb</b>
  - for <b>github actions</b> job: 
    add the label `run_fdb`

- for a <b>compile downstream build</b>  
  please add comment: <b>Jenkins run cdb</b>

- for a <b>full production downstream build</b>  
  please add comment: <b>Jenkins execute product fdb</b>

- for an <b>upstream build</b>  
  please add comment: <b>Jenkins run upstream</b>

- for <b>quarkus branch checks</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins run quarkus-branch</b>

- for a <b>quarkus branch specific check</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-vehicle-routing] quarkus-branch</b>

- for <b>quarkus main checks</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins run quarkus-main</b>

- for a <b>specific quarkus main check</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-vehicle-routing] quarkus-branch</b>

- for <b>native checks</b>  
  Run native checks  
  Please add comment: <b>Jenkins run native</b>

- for a <b>specific native check</b>  
  Run native checks 
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-vehicle-routing] native</b>

- for <b>mandrel checks</b>  
  Run native checks against Mandrel image
  Please add comment: <b>Jenkins run mandrel</b>

- for a <b>specific mandrel check</b>  
  Run native checks against Mandrel image  
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-vehicle-routing] mandrel</b>
</details>

### CI Status

 You can check OptaPlanner repositories CI status from [Chain Status webpage](https://kiegroup.github.io/optaplanner/).
