### PR TITLE
PLANNER-2765 Expose the deployment template

### DIFF
--- a/optaplanner-operator/src/k8s/crd-solver.yml
+++ b/optaplanner-operator/src/k8s/crd-solver.yml
@@ -10,64 +10,2773 @@ spec:
     singular: solver
   scope: Namespaced
   versions:
-  - name: v1beta1
-    schema:
-      openAPIV3Schema:
-        properties:
-          spec:
-            properties:
-              amqBroker:
-                properties:
-                  port:
-                    type: integer
-                  managementHost:
-                    type: string
-                  host:
-                    type: string
-                  usernameSecretRef:
+    - name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          properties:
+            spec:
+              properties:
+                template:
+                  properties:
+                    metadata:
+                      properties:
+                        generateName:
+                          type: string
+                        deletionGracePeriodSeconds:
+                          type: integer
+                        deletionTimestamp:
+                          type: string
+                        clusterName:
+                          type: string
+                        resourceVersion:
+                          type: string
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        selfLink:
+                          type: string
+                        creationTimestamp:
+                          type: string
+                        finalizers:
+                          items:
+                            type: string
+                          type: array
+                        labels:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        ownerReferences:
+                          items:
+                            properties:
+                              blockOwnerDeletion:
+                                type: boolean
+                              uid:
+                                type: string
+                              apiVersion:
+                                type: string
+                              name:
+                                type: string
+                              kind:
+                                type: string
+                              controller:
+                                type: boolean
+                            type: object
+                          type: array
+                        uid:
+                          type: string
+                        generation:
+                          type: integer
+                        name:
+                          type: string
+                        managedFields:
+                          items:
+                            properties:
+                              time:
+                                type: string
+                              apiVersion:
+                                type: string
+                              fieldsV1:
+                                type: object
+                              fieldsType:
+                                type: string
+                              manager:
+                                type: string
+                              operation:
+                                type: string
+                              subresource:
+                                type: string
+                            type: object
+                          type: array
+                        namespace:
+                          type: string
+                      type: object
+                    spec:
+                      properties:
+                        volumes:
+                          items:
+                            properties:
+                              hostPath:
+                                properties:
+                                  path:
+                                    type: string
+                                  type:
+                                    type: string
+                                type: object
+                              flexVolume:
+                                properties:
+                                  readOnly:
+                                    type: boolean
+                                  options:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                  secretRef:
+                                    properties:
+                                      name:
+                                        type: string
+                                    type: object
+                                  fsType:
+                                    type: string
+                                  driver:
+                                    type: string
+                                type: object
+                              gcePersistentDisk:
+                                properties:
+                                  readOnly:
+                                    type: boolean
+                                  pdName:
+                                    type: string
+                                  partition:
+                                    type: integer
+                                  fsType:
+                                    type: string
+                                type: object
+                              ephemeral:
+                                properties:
+                                  volumeClaimTemplate:
+                                    properties:
+                                      metadata:
+                                        properties:
+                                          generateName:
+                                            type: string
+                                          deletionGracePeriodSeconds:
+                                            type: integer
+                                          deletionTimestamp:
+                                            type: string
+                                          clusterName:
+                                            type: string
+                                          resourceVersion:
+                                            type: string
+                                          annotations:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                          selfLink:
+                                            type: string
+                                          creationTimestamp:
+                                            type: string
+                                          finalizers:
+                                            items:
+                                              type: string
+                                            type: array
+                                          labels:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                          ownerReferences:
+                                            items:
+                                              properties:
+                                                blockOwnerDeletion:
+                                                  type: boolean
+                                                uid:
+                                                  type: string
+                                                apiVersion:
+                                                  type: string
+                                                name:
+                                                  type: string
+                                                kind:
+                                                  type: string
+                                                controller:
+                                                  type: boolean
+                                              type: object
+                                            type: array
+                                          uid:
+                                            type: string
+                                          generation:
+                                            type: integer
+                                          name:
+                                            type: string
+                                          managedFields:
+                                            items:
+                                              properties:
+                                                time:
+                                                  type: string
+                                                apiVersion:
+                                                  type: string
+                                                fieldsV1:
+                                                  type: object
+                                                fieldsType:
+                                                  type: string
+                                                manager:
+                                                  type: string
+                                                operation:
+                                                  type: string
+                                                subresource:
+                                                  type: string
+                                              type: object
+                                            type: array
+                                          namespace:
+                                            type: string
+                                        type: object
+                                      spec:
+                                        properties:
+                                          selector:
+                                            properties:
+                                              matchExpressions:
+                                                items:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    values:
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                    operator:
+                                                      type: string
+                                                  type: object
+                                                type: array
+                                              matchLabels:
+                                                additionalProperties:
+                                                  type: string
+                                                type: object
+                                            type: object
+                                          storageClassName:
+                                            type: string
+                                          dataSource:
+                                            properties:
+                                              name:
+                                                type: string
+                                              kind:
+                                                type: string
+                                              apiGroup:
+                                                type: string
+                                            type: object
+                                          resources:
+                                            properties:
+                                              limits:
+                                                additionalProperties:
+                                                  anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                  x-kubernetes-int-or-string: true
+                                                type: object
+                                              requests:
+                                                additionalProperties:
+                                                  anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                  x-kubernetes-int-or-string: true
+                                                type: object
+                                            type: object
+                                          dataSourceRef:
+                                            properties:
+                                              name:
+                                                type: string
+                                              kind:
+                                                type: string
+                                              apiGroup:
+                                                type: string
+                                            type: object
+                                          accessModes:
+                                            items:
+                                              type: string
+                                            type: array
+                                          volumeMode:
+                                            type: string
+                                          volumeName:
+                                            type: string
+                                        type: object
+                                    type: object
+                                type: object
+                              scaleIO:
+                                properties:
+                                  readOnly:
+                                    type: boolean
+                                  storageMode:
+                                    type: string
+                                  storagePool:
+                                    type: string
+                                  system:
+                                    type: string
+                                  gateway:
+                                    type: string
+                                  secretRef:
+                                    properties:
+                                      name:
+                                        type: string
+                                    type: object
+                                  fsType:
+                                    type: string
+                                  sslEnabled:
+                                    type: boolean
+                                  volumeName:
+                                    type: string
+                                  protectionDomain:
+                                    type: string
+                                type: object
+                              csi:
+                                properties:
+                                  nodePublishSecretRef:
+                                    properties:
+                                      name:
+                                        type: string
+                                    type: object
+                                  readOnly:
+                                    type: boolean
+                                  volumeAttributes:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                  fsType:
+                                    type: string
+                                  driver:
+                                    type: string
+                                type: object
+                              secret:
+                                properties:
+                                  optional:
+                                    type: boolean
+                                  secretName:
+                                    type: string
+                                  items:
+                                    items:
+                                      properties:
+                                        path:
+                                          type: string
+                                        key:
+                                          type: string
+                                        mode:
+                                          type: integer
+                                      type: object
+                                    type: array
+                                  defaultMode:
+                                    type: integer
+                                type: object
+                              name:
+                                type: string
+                              vsphereVolume:
+                                properties:
+                                  storagePolicyName:
+                                    type: string
+                                  storagePolicyID:
+                                    type: string
+                                  volumePath:
+                                    type: string
+                                  fsType:
+                                    type: string
+                                type: object
+                              gitRepo:
+                                properties:
+                                  revision:
+                                    type: string
+                                  repository:
+                                    type: string
+                                  directory:
+                                    type: string
+                                type: object
+                              glusterfs:
+                                properties:
+                                  path:
+                                    type: string
+                                  readOnly:
+                                    type: boolean
+                                  endpoints:
+                                    type: string
+                                type: object
+                              nfs:
+                                properties:
+                                  path:
+                                    type: string
+                                  readOnly:
+                                    type: boolean
+                                  server:
+                                    type: string
+                                type: object
+                              cinder:
+                                properties:
+                                  readOnly:
+                                    type: boolean
+                                  secretRef:
+                                    properties:
+                                      name:
+                                        type: string
+                                    type: object
+                                  fsType:
+                                    type: string
+                                  volumeID:
+                                    type: string
+                                type: object
+                              flocker:
+                                properties:
+                                  datasetUUID:
+                                    type: string
+                                  datasetName:
+                                    type: string
+                                type: object
+                              quobyte:
+                                properties:
+                                  group:
+                                    type: string
+                                  readOnly:
+                                    type: boolean
+                                  volume:
+                                    type: string
+                                  user:
+                                    type: string
+                                  registry:
+                                    type: string
+                                  tenant:
+                                    type: string
+                                type: object
+                              photonPersistentDisk:
+                                properties:
+                                  pdID:
+                                    type: string
+                                  fsType:
+                                    type: string
+                                type: object
+                              persistentVolumeClaim:
+                                properties:
+                                  readOnly:
+                                    type: boolean
+                                  claimName:
+                                    type: string
+                                type: object
+                              awsElasticBlockStore:
+                                properties:
+                                  readOnly:
+                                    type: boolean
+                                  partition:
+                                    type: integer
+                                  fsType:
+                                    type: string
+                                  volumeID:
+                                    type: string
+                                type: object
+                              configMap:
+                                properties:
+                                  optional:
+                                    type: boolean
+                                  items:
+                                    items:
+                                      properties:
+                                        path:
+                                          type: string
+                                        key:
+                                          type: string
+                                        mode:
+                                          type: integer
+                                      type: object
+                                    type: array
+                                  defaultMode:
+                                    type: integer
+                                  name:
+                                    type: string
+                                type: object
+                              storageos:
+                                properties:
+                                  readOnly:
+                                    type: boolean
+                                  volumeNamespace:
+                                    type: string
+                                  secretRef:
+                                    properties:
+                                      name:
+                                        type: string
+                                    type: object
+                                  fsType:
+                                    type: string
+                                  volumeName:
+                                    type: string
+                                type: object
+                              portworxVolume:
+                                properties:
+                                  readOnly:
+                                    type: boolean
+                                  fsType:
+                                    type: string
+                                  volumeID:
+                                    type: string
+                                type: object
+                              iscsi:
+                                properties:
+                                  readOnly:
+                                    type: boolean
+                                  chapAuthSession:
+                                    type: boolean
+                                  lun:
+                                    type: integer
+                                  targetPortal:
+                                    type: string
+                                  iscsiInterface:
+                                    type: string
+                                  portals:
+                                    items:
+                                      type: string
+                                    type: array
+                                  initiatorName:
+                                    type: string
+                                  secretRef:
+                                    properties:
+                                      name:
+                                        type: string
+                                    type: object
+                                  fsType:
+                                    type: string
+                                  iqn:
+                                    type: string
+                                  chapAuthDiscovery:
+                                    type: boolean
+                                type: object
+                              rbd:
+                                properties:
+                                  readOnly:
+                                    type: boolean
+                                  pool:
+                                    type: string
+                                  keyring:
+                                    type: string
+                                  image:
+                                    type: string
+                                  secretRef:
+                                    properties:
+                                      name:
+                                        type: string
+                                    type: object
+                                  monitors:
+                                    items:
+                                      type: string
+                                    type: array
+                                  fsType:
+                                    type: string
+                                  user:
+                                    type: string
+                                type: object
+                              azureFile:
+                                properties:
+                                  readOnly:
+                                    type: boolean
+                                  secretName:
+                                    type: string
+                                  shareName:
+                                    type: string
+                                type: object
+                              downwardAPI:
+                                properties:
+                                  items:
+                                    items:
+                                      properties:
+                                        path:
+                                          type: string
+                                        fieldRef:
+                                          properties:
+                                            apiVersion:
+                                              type: string
+                                            fieldPath:
+                                              type: string
+                                          type: object
+                                        resourceFieldRef:
+                                          properties:
+                                            containerName:
+                                              type: string
+                                            divisor:
+                                              anyOf:
+                                                - type: integer
+                                                - type: string
+                                              x-kubernetes-int-or-string: true
+                                            resource:
+                                              type: string
+                                          type: object
+                                        mode:
+                                          type: integer
+                                      type: object
+                                    type: array
+                                  defaultMode:
+                                    type: integer
+                                type: object
+                              projected:
+                                properties:
+                                  defaultMode:
+                                    type: integer
+                                  sources:
+                                    items:
+                                      properties:
+                                        secret:
+                                          properties:
+                                            optional:
+                                              type: boolean
+                                            items:
+                                              items:
+                                                properties:
+                                                  path:
+                                                    type: string
+                                                  key:
+                                                    type: string
+                                                  mode:
+                                                    type: integer
+                                                type: object
+                                              type: array
+                                            name:
+                                              type: string
+                                          type: object
+                                        configMap:
+                                          properties:
+                                            optional:
+                                              type: boolean
+                                            items:
+                                              items:
+                                                properties:
+                                                  path:
+                                                    type: string
+                                                  key:
+                                                    type: string
+                                                  mode:
+                                                    type: integer
+                                                type: object
+                                              type: array
+                                            name:
+                                              type: string
+                                          type: object
+                                        serviceAccountToken:
+                                          properties:
+                                            path:
+                                              type: string
+                                            audience:
+                                              type: string
+                                            expirationSeconds:
+                                              type: integer
+                                          type: object
+                                        downwardAPI:
+                                          properties:
+                                            items:
+                                              items:
+                                                properties:
+                                                  path:
+                                                    type: string
+                                                  fieldRef:
+                                                    properties:
+                                                      apiVersion:
+                                                        type: string
+                                                      fieldPath:
+                                                        type: string
+                                                    type: object
+                                                  resourceFieldRef:
+                                                    properties:
+                                                      containerName:
+                                                        type: string
+                                                      divisor:
+                                                        anyOf:
+                                                          - type: integer
+                                                          - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                      resource:
+                                                        type: string
+                                                    type: object
+                                                  mode:
+                                                    type: integer
+                                                type: object
+                                              type: array
+                                          type: object
+                                      type: object
+                                    type: array
+                                type: object
+                              azureDisk:
+                                properties:
+                                  readOnly:
+                                    type: boolean
+                                  diskName:
+                                    type: string
+                                  cachingMode:
+                                    type: string
+                                  fsType:
+                                    type: string
+                                  kind:
+                                    type: string
+                                  diskURI:
+                                    type: string
+                                type: object
+                              cephfs:
+                                properties:
+                                  path:
+                                    type: string
+                                  readOnly:
+                                    type: boolean
+                                  secretRef:
+                                    properties:
+                                      name:
+                                        type: string
+                                    type: object
+                                  monitors:
+                                    items:
+                                      type: string
+                                    type: array
+                                  secretFile:
+                                    type: string
+                                  user:
+                                    type: string
+                                type: object
+                              emptyDir:
+                                properties:
+                                  sizeLimit:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    x-kubernetes-int-or-string: true
+                                  medium:
+                                    type: string
+                                type: object
+                              fc:
+                                properties:
+                                  readOnly:
+                                    type: boolean
+                                  lun:
+                                    type: integer
+                                  wwids:
+                                    items:
+                                      type: string
+                                    type: array
+                                  targetWWNs:
+                                    items:
+                                      type: string
+                                    type: array
+                                  fsType:
+                                    type: string
+                                type: object
+                            type: object
+                          type: array
+                        restartPolicy:
+                          type: string
+                        terminationGracePeriodSeconds:
+                          type: integer
+                        setHostnameAsFQDN:
+                          type: boolean
+                        dnsConfig:
+                          properties:
+                            nameservers:
+                              items:
+                                type: string
+                              type: array
+                            searches:
+                              items:
+                                type: string
+                              type: array
+                            options:
+                              items:
+                                properties:
+                                  value:
+                                    type: string
+                                  name:
+                                    type: string
+                                type: object
+                              type: array
+                          type: object
+                        securityContext:
+                          properties:
+                            runAsGroup:
+                              type: integer
+                            runAsNonRoot:
+                              type: boolean
+                            windowsOptions:
+                              properties:
+                                gmsaCredentialSpecName:
+                                  type: string
+                                hostProcess:
+                                  type: boolean
+                                gmsaCredentialSpec:
+                                  type: string
+                                runAsUserName:
+                                  type: string
+                              type: object
+                            sysctls:
+                              items:
+                                properties:
+                                  value:
+                                    type: string
+                                  name:
+                                    type: string
+                                type: object
+                              type: array
+                            fsGroupChangePolicy:
+                              type: string
+                            seLinuxOptions:
+                              properties:
+                                role:
+                                  type: string
+                                type:
+                                  type: string
+                                user:
+                                  type: string
+                                level:
+                                  type: string
+                              type: object
+                            fsGroup:
+                              type: integer
+                            supplementalGroups:
+                              items:
+                                type: integer
+                              type: array
+                            runAsUser:
+                              type: integer
+                            seccompProfile:
+                              properties:
+                                type:
+                                  type: string
+                                localhostProfile:
+                                  type: string
+                              type: object
+                          type: object
+                        imagePullSecrets:
+                          items:
+                            properties:
+                              name:
+                                type: string
+                            type: object
+                          type: array
+                        subdomain:
+                          type: string
+                        serviceAccount:
+                          type: string
+                        activeDeadlineSeconds:
+                          type: integer
+                        priority:
+                          type: integer
+                        ephemeralContainers:
+                          items:
+                            properties:
+                              lifecycle:
+                                properties:
+                                  postStart:
+                                    properties:
+                                      tcpSocket:
+                                        properties:
+                                          host:
+                                            type: string
+                                          port:
+                                            anyOf:
+                                              - type: integer
+                                              - type: string
+                                            x-kubernetes-int-or-string: true
+                                        type: object
+                                      exec:
+                                        properties:
+                                          command:
+                                            items:
+                                              type: string
+                                            type: array
+                                        type: object
+                                      httpGet:
+                                        properties:
+                                          path:
+                                            type: string
+                                          scheme:
+                                            type: string
+                                          host:
+                                            type: string
+                                          httpHeaders:
+                                            items:
+                                              properties:
+                                                value:
+                                                  type: string
+                                                name:
+                                                  type: string
+                                              type: object
+                                            type: array
+                                          port:
+                                            anyOf:
+                                              - type: integer
+                                              - type: string
+                                            x-kubernetes-int-or-string: true
+                                        type: object
+                                    type: object
+                                  preStop:
+                                    properties:
+                                      tcpSocket:
+                                        properties:
+                                          host:
+                                            type: string
+                                          port:
+                                            anyOf:
+                                              - type: integer
+                                              - type: string
+                                            x-kubernetes-int-or-string: true
+                                        type: object
+                                      exec:
+                                        properties:
+                                          command:
+                                            items:
+                                              type: string
+                                            type: array
+                                        type: object
+                                      httpGet:
+                                        properties:
+                                          path:
+                                            type: string
+                                          scheme:
+                                            type: string
+                                          host:
+                                            type: string
+                                          httpHeaders:
+                                            items:
+                                              properties:
+                                                value:
+                                                  type: string
+                                                name:
+                                                  type: string
+                                              type: object
+                                            type: array
+                                          port:
+                                            anyOf:
+                                              - type: integer
+                                              - type: string
+                                            x-kubernetes-int-or-string: true
+                                        type: object
+                                    type: object
+                                type: object
+                              command:
+                                items:
+                                  type: string
+                                type: array
+                              livenessProbe:
+                                properties:
+                                  periodSeconds:
+                                    type: integer
+                                  failureThreshold:
+                                    type: integer
+                                  initialDelaySeconds:
+                                    type: integer
+                                  grpc:
+                                    properties:
+                                      port:
+                                        type: integer
+                                      service:
+                                        type: string
+                                    type: object
+                                  successThreshold:
+                                    type: integer
+                                  terminationGracePeriodSeconds:
+                                    type: integer
+                                  tcpSocket:
+                                    properties:
+                                      host:
+                                        type: string
+                                      port:
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        x-kubernetes-int-or-string: true
+                                    type: object
+                                  timeoutSeconds:
+                                    type: integer
+                                  exec:
+                                    properties:
+                                      command:
+                                        items:
+                                          type: string
+                                        type: array
+                                    type: object
+                                  httpGet:
+                                    properties:
+                                      path:
+                                        type: string
+                                      scheme:
+                                        type: string
+                                      host:
+                                        type: string
+                                      httpHeaders:
+                                        items:
+                                          properties:
+                                            value:
+                                              type: string
+                                            name:
+                                              type: string
+                                          type: object
+                                        type: array
+                                      port:
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        x-kubernetes-int-or-string: true
+                                    type: object
+                                type: object
+                              stdin:
+                                type: boolean
+                              image:
+                                type: string
+                              targetContainerName:
+                                type: string
+                              terminationMessagePolicy:
+                                type: string
+                              readinessProbe:
+                                properties:
+                                  periodSeconds:
+                                    type: integer
+                                  failureThreshold:
+                                    type: integer
+                                  initialDelaySeconds:
+                                    type: integer
+                                  grpc:
+                                    properties:
+                                      port:
+                                        type: integer
+                                      service:
+                                        type: string
+                                    type: object
+                                  successThreshold:
+                                    type: integer
+                                  terminationGracePeriodSeconds:
+                                    type: integer
+                                  tcpSocket:
+                                    properties:
+                                      host:
+                                        type: string
+                                      port:
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        x-kubernetes-int-or-string: true
+                                    type: object
+                                  timeoutSeconds:
+                                    type: integer
+                                  exec:
+                                    properties:
+                                      command:
+                                        items:
+                                          type: string
+                                        type: array
+                                    type: object
+                                  httpGet:
+                                    properties:
+                                      path:
+                                        type: string
+                                      scheme:
+                                        type: string
+                                      host:
+                                        type: string
+                                      httpHeaders:
+                                        items:
+                                          properties:
+                                            value:
+                                              type: string
+                                            name:
+                                              type: string
+                                          type: object
+                                        type: array
+                                      port:
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        x-kubernetes-int-or-string: true
+                                    type: object
+                                type: object
+                              terminationMessagePath:
+                                type: string
+                              env:
+                                items:
+                                  properties:
+                                    value:
+                                      type: string
+                                    valueFrom:
+                                      properties:
+                                        configMapKeyRef:
+                                          properties:
+                                            optional:
+                                              type: boolean
+                                            key:
+                                              type: string
+                                            name:
+                                              type: string
+                                          type: object
+                                        fieldRef:
+                                          properties:
+                                            apiVersion:
+                                              type: string
+                                            fieldPath:
+                                              type: string
+                                          type: object
+                                        resourceFieldRef:
+                                          properties:
+                                            containerName:
+                                              type: string
+                                            divisor:
+                                              anyOf:
+                                                - type: integer
+                                                - type: string
+                                              x-kubernetes-int-or-string: true
+                                            resource:
+                                              type: string
+                                          type: object
+                                        secretKeyRef:
+                                          properties:
+                                            optional:
+                                              type: boolean
+                                            key:
+                                              type: string
+                                            name:
+                                              type: string
+                                          type: object
+                                      type: object
+                                    name:
+                                      type: string
+                                  type: object
+                                type: array
+                              tty:
+                                type: boolean
+                              args:
+                                items:
+                                  type: string
+                                type: array
+                              startupProbe:
+                                properties:
+                                  periodSeconds:
+                                    type: integer
+                                  failureThreshold:
+                                    type: integer
+                                  initialDelaySeconds:
+                                    type: integer
+                                  grpc:
+                                    properties:
+                                      port:
+                                        type: integer
+                                      service:
+                                        type: string
+                                    type: object
+                                  successThreshold:
+                                    type: integer
+                                  terminationGracePeriodSeconds:
+                                    type: integer
+                                  tcpSocket:
+                                    properties:
+                                      host:
+                                        type: string
+                                      port:
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        x-kubernetes-int-or-string: true
+                                    type: object
+                                  timeoutSeconds:
+                                    type: integer
+                                  exec:
+                                    properties:
+                                      command:
+                                        items:
+                                          type: string
+                                        type: array
+                                    type: object
+                                  httpGet:
+                                    properties:
+                                      path:
+                                        type: string
+                                      scheme:
+                                        type: string
+                                      host:
+                                        type: string
+                                      httpHeaders:
+                                        items:
+                                          properties:
+                                            value:
+                                              type: string
+                                            name:
+                                              type: string
+                                          type: object
+                                        type: array
+                                      port:
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        x-kubernetes-int-or-string: true
+                                    type: object
+                                type: object
+                              stdinOnce:
+                                type: boolean
+                              ports:
+                                items:
+                                  properties:
+                                    containerPort:
+                                      type: integer
+                                    hostPort:
+                                      type: integer
+                                    name:
+                                      type: string
+                                    protocol:
+                                      type: string
+                                    hostIP:
+                                      type: string
+                                  type: object
+                                type: array
+                              workingDir:
+                                type: string
+                              envFrom:
+                                items:
+                                  properties:
+                                    prefix:
+                                      type: string
+                                    configMapRef:
+                                      properties:
+                                        optional:
+                                          type: boolean
+                                        name:
+                                          type: string
+                                      type: object
+                                    secretRef:
+                                      properties:
+                                        optional:
+                                          type: boolean
+                                        name:
+                                          type: string
+                                      type: object
+                                  type: object
+                                type: array
+                              volumeMounts:
+                                items:
+                                  properties:
+                                    readOnly:
+                                      type: boolean
+                                    subPathExpr:
+                                      type: string
+                                    mountPath:
+                                      type: string
+                                    mountPropagation:
+                                      type: string
+                                    subPath:
+                                      type: string
+                                    name:
+                                      type: string
+                                  type: object
+                                type: array
+                              securityContext:
+                                properties:
+                                  runAsGroup:
+                                    type: integer
+                                  runAsNonRoot:
+                                    type: boolean
+                                  windowsOptions:
+                                    properties:
+                                      gmsaCredentialSpecName:
+                                        type: string
+                                      hostProcess:
+                                        type: boolean
+                                      gmsaCredentialSpec:
+                                        type: string
+                                      runAsUserName:
+                                        type: string
+                                    type: object
+                                  allowPrivilegeEscalation:
+                                    type: boolean
+                                  capabilities:
+                                    properties:
+                                      add:
+                                        items:
+                                          type: string
+                                        type: array
+                                      drop:
+                                        items:
+                                          type: string
+                                        type: array
+                                    type: object
+                                  seLinuxOptions:
+                                    properties:
+                                      role:
+                                        type: string
+                                      type:
+                                        type: string
+                                      user:
+                                        type: string
+                                      level:
+                                        type: string
+                                    type: object
+                                  readOnlyRootFilesystem:
+                                    type: boolean
+                                  privileged:
+                                    type: boolean
+                                  runAsUser:
+                                    type: integer
+                                  procMount:
+                                    type: string
+                                  seccompProfile:
+                                    properties:
+                                      type:
+                                        type: string
+                                      localhostProfile:
+                                        type: string
+                                    type: object
+                                type: object
+                              name:
+                                type: string
+                              resources:
+                                properties:
+                                  limits:
+                                    additionalProperties:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      x-kubernetes-int-or-string: true
+                                    type: object
+                                  requests:
+                                    additionalProperties:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      x-kubernetes-int-or-string: true
+                                    type: object
+                                type: object
+                              imagePullPolicy:
+                                type: string
+                              volumeDevices:
+                                items:
+                                  properties:
+                                    devicePath:
+                                      type: string
+                                    name:
+                                      type: string
+                                  type: object
+                                type: array
+                            type: object
+                          type: array
+                        automountServiceAccountToken:
+                          type: boolean
+                        containers:
+                          items:
+                            properties:
+                              lifecycle:
+                                properties:
+                                  postStart:
+                                    properties:
+                                      tcpSocket:
+                                        properties:
+                                          host:
+                                            type: string
+                                          port:
+                                            anyOf:
+                                              - type: integer
+                                              - type: string
+                                            x-kubernetes-int-or-string: true
+                                        type: object
+                                      exec:
+                                        properties:
+                                          command:
+                                            items:
+                                              type: string
+                                            type: array
+                                        type: object
+                                      httpGet:
+                                        properties:
+                                          path:
+                                            type: string
+                                          scheme:
+                                            type: string
+                                          host:
+                                            type: string
+                                          httpHeaders:
+                                            items:
+                                              properties:
+                                                value:
+                                                  type: string
+                                                name:
+                                                  type: string
+                                              type: object
+                                            type: array
+                                          port:
+                                            anyOf:
+                                              - type: integer
+                                              - type: string
+                                            x-kubernetes-int-or-string: true
+                                        type: object
+                                    type: object
+                                  preStop:
+                                    properties:
+                                      tcpSocket:
+                                        properties:
+                                          host:
+                                            type: string
+                                          port:
+                                            anyOf:
+                                              - type: integer
+                                              - type: string
+                                            x-kubernetes-int-or-string: true
+                                        type: object
+                                      exec:
+                                        properties:
+                                          command:
+                                            items:
+                                              type: string
+                                            type: array
+                                        type: object
+                                      httpGet:
+                                        properties:
+                                          path:
+                                            type: string
+                                          scheme:
+                                            type: string
+                                          host:
+                                            type: string
+                                          httpHeaders:
+                                            items:
+                                              properties:
+                                                value:
+                                                  type: string
+                                                name:
+                                                  type: string
+                                              type: object
+                                            type: array
+                                          port:
+                                            anyOf:
+                                              - type: integer
+                                              - type: string
+                                            x-kubernetes-int-or-string: true
+                                        type: object
+                                    type: object
+                                type: object
+                              command:
+                                items:
+                                  type: string
+                                type: array
+                              livenessProbe:
+                                properties:
+                                  periodSeconds:
+                                    type: integer
+                                  failureThreshold:
+                                    type: integer
+                                  initialDelaySeconds:
+                                    type: integer
+                                  grpc:
+                                    properties:
+                                      port:
+                                        type: integer
+                                      service:
+                                        type: string
+                                    type: object
+                                  successThreshold:
+                                    type: integer
+                                  terminationGracePeriodSeconds:
+                                    type: integer
+                                  tcpSocket:
+                                    properties:
+                                      host:
+                                        type: string
+                                      port:
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        x-kubernetes-int-or-string: true
+                                    type: object
+                                  timeoutSeconds:
+                                    type: integer
+                                  exec:
+                                    properties:
+                                      command:
+                                        items:
+                                          type: string
+                                        type: array
+                                    type: object
+                                  httpGet:
+                                    properties:
+                                      path:
+                                        type: string
+                                      scheme:
+                                        type: string
+                                      host:
+                                        type: string
+                                      httpHeaders:
+                                        items:
+                                          properties:
+                                            value:
+                                              type: string
+                                            name:
+                                              type: string
+                                          type: object
+                                        type: array
+                                      port:
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        x-kubernetes-int-or-string: true
+                                    type: object
+                                type: object
+                              stdin:
+                                type: boolean
+                              image:
+                                type: string
+                              terminationMessagePolicy:
+                                type: string
+                              readinessProbe:
+                                properties:
+                                  periodSeconds:
+                                    type: integer
+                                  failureThreshold:
+                                    type: integer
+                                  initialDelaySeconds:
+                                    type: integer
+                                  grpc:
+                                    properties:
+                                      port:
+                                        type: integer
+                                      service:
+                                        type: string
+                                    type: object
+                                  successThreshold:
+                                    type: integer
+                                  terminationGracePeriodSeconds:
+                                    type: integer
+                                  tcpSocket:
+                                    properties:
+                                      host:
+                                        type: string
+                                      port:
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        x-kubernetes-int-or-string: true
+                                    type: object
+                                  timeoutSeconds:
+                                    type: integer
+                                  exec:
+                                    properties:
+                                      command:
+                                        items:
+                                          type: string
+                                        type: array
+                                    type: object
+                                  httpGet:
+                                    properties:
+                                      path:
+                                        type: string
+                                      scheme:
+                                        type: string
+                                      host:
+                                        type: string
+                                      httpHeaders:
+                                        items:
+                                          properties:
+                                            value:
+                                              type: string
+                                            name:
+                                              type: string
+                                          type: object
+                                        type: array
+                                      port:
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        x-kubernetes-int-or-string: true
+                                    type: object
+                                type: object
+                              terminationMessagePath:
+                                type: string
+                              env:
+                                items:
+                                  properties:
+                                    value:
+                                      type: string
+                                    valueFrom:
+                                      properties:
+                                        configMapKeyRef:
+                                          properties:
+                                            optional:
+                                              type: boolean
+                                            key:
+                                              type: string
+                                            name:
+                                              type: string
+                                          type: object
+                                        fieldRef:
+                                          properties:
+                                            apiVersion:
+                                              type: string
+                                            fieldPath:
+                                              type: string
+                                          type: object
+                                        resourceFieldRef:
+                                          properties:
+                                            containerName:
+                                              type: string
+                                            divisor:
+                                              anyOf:
+                                                - type: integer
+                                                - type: string
+                                              x-kubernetes-int-or-string: true
+                                            resource:
+                                              type: string
+                                          type: object
+                                        secretKeyRef:
+                                          properties:
+                                            optional:
+                                              type: boolean
+                                            key:
+                                              type: string
+                                            name:
+                                              type: string
+                                          type: object
+                                      type: object
+                                    name:
+                                      type: string
+                                  type: object
+                                type: array
+                              tty:
+                                type: boolean
+                              args:
+                                items:
+                                  type: string
+                                type: array
+                              startupProbe:
+                                properties:
+                                  periodSeconds:
+                                    type: integer
+                                  failureThreshold:
+                                    type: integer
+                                  initialDelaySeconds:
+                                    type: integer
+                                  grpc:
+                                    properties:
+                                      port:
+                                        type: integer
+                                      service:
+                                        type: string
+                                    type: object
+                                  successThreshold:
+                                    type: integer
+                                  terminationGracePeriodSeconds:
+                                    type: integer
+                                  tcpSocket:
+                                    properties:
+                                      host:
+                                        type: string
+                                      port:
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        x-kubernetes-int-or-string: true
+                                    type: object
+                                  timeoutSeconds:
+                                    type: integer
+                                  exec:
+                                    properties:
+                                      command:
+                                        items:
+                                          type: string
+                                        type: array
+                                    type: object
+                                  httpGet:
+                                    properties:
+                                      path:
+                                        type: string
+                                      scheme:
+                                        type: string
+                                      host:
+                                        type: string
+                                      httpHeaders:
+                                        items:
+                                          properties:
+                                            value:
+                                              type: string
+                                            name:
+                                              type: string
+                                          type: object
+                                        type: array
+                                      port:
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        x-kubernetes-int-or-string: true
+                                    type: object
+                                type: object
+                              stdinOnce:
+                                type: boolean
+                              ports:
+                                items:
+                                  properties:
+                                    containerPort:
+                                      type: integer
+                                    hostPort:
+                                      type: integer
+                                    name:
+                                      type: string
+                                    protocol:
+                                      type: string
+                                    hostIP:
+                                      type: string
+                                  type: object
+                                type: array
+                              workingDir:
+                                type: string
+                              envFrom:
+                                items:
+                                  properties:
+                                    prefix:
+                                      type: string
+                                    configMapRef:
+                                      properties:
+                                        optional:
+                                          type: boolean
+                                        name:
+                                          type: string
+                                      type: object
+                                    secretRef:
+                                      properties:
+                                        optional:
+                                          type: boolean
+                                        name:
+                                          type: string
+                                      type: object
+                                  type: object
+                                type: array
+                              volumeMounts:
+                                items:
+                                  properties:
+                                    readOnly:
+                                      type: boolean
+                                    subPathExpr:
+                                      type: string
+                                    mountPath:
+                                      type: string
+                                    mountPropagation:
+                                      type: string
+                                    subPath:
+                                      type: string
+                                    name:
+                                      type: string
+                                  type: object
+                                type: array
+                              securityContext:
+                                properties:
+                                  runAsGroup:
+                                    type: integer
+                                  runAsNonRoot:
+                                    type: boolean
+                                  windowsOptions:
+                                    properties:
+                                      gmsaCredentialSpecName:
+                                        type: string
+                                      hostProcess:
+                                        type: boolean
+                                      gmsaCredentialSpec:
+                                        type: string
+                                      runAsUserName:
+                                        type: string
+                                    type: object
+                                  allowPrivilegeEscalation:
+                                    type: boolean
+                                  capabilities:
+                                    properties:
+                                      add:
+                                        items:
+                                          type: string
+                                        type: array
+                                      drop:
+                                        items:
+                                          type: string
+                                        type: array
+                                    type: object
+                                  seLinuxOptions:
+                                    properties:
+                                      role:
+                                        type: string
+                                      type:
+                                        type: string
+                                      user:
+                                        type: string
+                                      level:
+                                        type: string
+                                    type: object
+                                  readOnlyRootFilesystem:
+                                    type: boolean
+                                  privileged:
+                                    type: boolean
+                                  runAsUser:
+                                    type: integer
+                                  procMount:
+                                    type: string
+                                  seccompProfile:
+                                    properties:
+                                      type:
+                                        type: string
+                                      localhostProfile:
+                                        type: string
+                                    type: object
+                                type: object
+                              name:
+                                type: string
+                              resources:
+                                properties:
+                                  limits:
+                                    additionalProperties:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      x-kubernetes-int-or-string: true
+                                    type: object
+                                  requests:
+                                    additionalProperties:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      x-kubernetes-int-or-string: true
+                                    type: object
+                                type: object
+                              imagePullPolicy:
+                                type: string
+                              volumeDevices:
+                                items:
+                                  properties:
+                                    devicePath:
+                                      type: string
+                                    name:
+                                      type: string
+                                  type: object
+                                type: array
+                            type: object
+                          type: array
+                        initContainers:
+                          items:
+                            properties:
+                              lifecycle:
+                                properties:
+                                  postStart:
+                                    properties:
+                                      tcpSocket:
+                                        properties:
+                                          host:
+                                            type: string
+                                          port:
+                                            anyOf:
+                                              - type: integer
+                                              - type: string
+                                            x-kubernetes-int-or-string: true
+                                        type: object
+                                      exec:
+                                        properties:
+                                          command:
+                                            items:
+                                              type: string
+                                            type: array
+                                        type: object
+                                      httpGet:
+                                        properties:
+                                          path:
+                                            type: string
+                                          scheme:
+                                            type: string
+                                          host:
+                                            type: string
+                                          httpHeaders:
+                                            items:
+                                              properties:
+                                                value:
+                                                  type: string
+                                                name:
+                                                  type: string
+                                              type: object
+                                            type: array
+                                          port:
+                                            anyOf:
+                                              - type: integer
+                                              - type: string
+                                            x-kubernetes-int-or-string: true
+                                        type: object
+                                    type: object
+                                  preStop:
+                                    properties:
+                                      tcpSocket:
+                                        properties:
+                                          host:
+                                            type: string
+                                          port:
+                                            anyOf:
+                                              - type: integer
+                                              - type: string
+                                            x-kubernetes-int-or-string: true
+                                        type: object
+                                      exec:
+                                        properties:
+                                          command:
+                                            items:
+                                              type: string
+                                            type: array
+                                        type: object
+                                      httpGet:
+                                        properties:
+                                          path:
+                                            type: string
+                                          scheme:
+                                            type: string
+                                          host:
+                                            type: string
+                                          httpHeaders:
+                                            items:
+                                              properties:
+                                                value:
+                                                  type: string
+                                                name:
+                                                  type: string
+                                              type: object
+                                            type: array
+                                          port:
+                                            anyOf:
+                                              - type: integer
+                                              - type: string
+                                            x-kubernetes-int-or-string: true
+                                        type: object
+                                    type: object
+                                type: object
+                              command:
+                                items:
+                                  type: string
+                                type: array
+                              livenessProbe:
+                                properties:
+                                  periodSeconds:
+                                    type: integer
+                                  failureThreshold:
+                                    type: integer
+                                  initialDelaySeconds:
+                                    type: integer
+                                  grpc:
+                                    properties:
+                                      port:
+                                        type: integer
+                                      service:
+                                        type: string
+                                    type: object
+                                  successThreshold:
+                                    type: integer
+                                  terminationGracePeriodSeconds:
+                                    type: integer
+                                  tcpSocket:
+                                    properties:
+                                      host:
+                                        type: string
+                                      port:
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        x-kubernetes-int-or-string: true
+                                    type: object
+                                  timeoutSeconds:
+                                    type: integer
+                                  exec:
+                                    properties:
+                                      command:
+                                        items:
+                                          type: string
+                                        type: array
+                                    type: object
+                                  httpGet:
+                                    properties:
+                                      path:
+                                        type: string
+                                      scheme:
+                                        type: string
+                                      host:
+                                        type: string
+                                      httpHeaders:
+                                        items:
+                                          properties:
+                                            value:
+                                              type: string
+                                            name:
+                                              type: string
+                                          type: object
+                                        type: array
+                                      port:
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        x-kubernetes-int-or-string: true
+                                    type: object
+                                type: object
+                              stdin:
+                                type: boolean
+                              image:
+                                type: string
+                              terminationMessagePolicy:
+                                type: string
+                              readinessProbe:
+                                properties:
+                                  periodSeconds:
+                                    type: integer
+                                  failureThreshold:
+                                    type: integer
+                                  initialDelaySeconds:
+                                    type: integer
+                                  grpc:
+                                    properties:
+                                      port:
+                                        type: integer
+                                      service:
+                                        type: string
+                                    type: object
+                                  successThreshold:
+                                    type: integer
+                                  terminationGracePeriodSeconds:
+                                    type: integer
+                                  tcpSocket:
+                                    properties:
+                                      host:
+                                        type: string
+                                      port:
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        x-kubernetes-int-or-string: true
+                                    type: object
+                                  timeoutSeconds:
+                                    type: integer
+                                  exec:
+                                    properties:
+                                      command:
+                                        items:
+                                          type: string
+                                        type: array
+                                    type: object
+                                  httpGet:
+                                    properties:
+                                      path:
+                                        type: string
+                                      scheme:
+                                        type: string
+                                      host:
+                                        type: string
+                                      httpHeaders:
+                                        items:
+                                          properties:
+                                            value:
+                                              type: string
+                                            name:
+                                              type: string
+                                          type: object
+                                        type: array
+                                      port:
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        x-kubernetes-int-or-string: true
+                                    type: object
+                                type: object
+                              terminationMessagePath:
+                                type: string
+                              env:
+                                items:
+                                  properties:
+                                    value:
+                                      type: string
+                                    valueFrom:
+                                      properties:
+                                        configMapKeyRef:
+                                          properties:
+                                            optional:
+                                              type: boolean
+                                            key:
+                                              type: string
+                                            name:
+                                              type: string
+                                          type: object
+                                        fieldRef:
+                                          properties:
+                                            apiVersion:
+                                              type: string
+                                            fieldPath:
+                                              type: string
+                                          type: object
+                                        resourceFieldRef:
+                                          properties:
+                                            containerName:
+                                              type: string
+                                            divisor:
+                                              anyOf:
+                                                - type: integer
+                                                - type: string
+                                              x-kubernetes-int-or-string: true
+                                            resource:
+                                              type: string
+                                          type: object
+                                        secretKeyRef:
+                                          properties:
+                                            optional:
+                                              type: boolean
+                                            key:
+                                              type: string
+                                            name:
+                                              type: string
+                                          type: object
+                                      type: object
+                                    name:
+                                      type: string
+                                  type: object
+                                type: array
+                              tty:
+                                type: boolean
+                              args:
+                                items:
+                                  type: string
+                                type: array
+                              startupProbe:
+                                properties:
+                                  periodSeconds:
+                                    type: integer
+                                  failureThreshold:
+                                    type: integer
+                                  initialDelaySeconds:
+                                    type: integer
+                                  grpc:
+                                    properties:
+                                      port:
+                                        type: integer
+                                      service:
+                                        type: string
+                                    type: object
+                                  successThreshold:
+                                    type: integer
+                                  terminationGracePeriodSeconds:
+                                    type: integer
+                                  tcpSocket:
+                                    properties:
+                                      host:
+                                        type: string
+                                      port:
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        x-kubernetes-int-or-string: true
+                                    type: object
+                                  timeoutSeconds:
+                                    type: integer
+                                  exec:
+                                    properties:
+                                      command:
+                                        items:
+                                          type: string
+                                        type: array
+                                    type: object
+                                  httpGet:
+                                    properties:
+                                      path:
+                                        type: string
+                                      scheme:
+                                        type: string
+                                      host:
+                                        type: string
+                                      httpHeaders:
+                                        items:
+                                          properties:
+                                            value:
+                                              type: string
+                                            name:
+                                              type: string
+                                          type: object
+                                        type: array
+                                      port:
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        x-kubernetes-int-or-string: true
+                                    type: object
+                                type: object
+                              stdinOnce:
+                                type: boolean
+                              ports:
+                                items:
+                                  properties:
+                                    containerPort:
+                                      type: integer
+                                    hostPort:
+                                      type: integer
+                                    name:
+                                      type: string
+                                    protocol:
+                                      type: string
+                                    hostIP:
+                                      type: string
+                                  type: object
+                                type: array
+                              workingDir:
+                                type: string
+                              envFrom:
+                                items:
+                                  properties:
+                                    prefix:
+                                      type: string
+                                    configMapRef:
+                                      properties:
+                                        optional:
+                                          type: boolean
+                                        name:
+                                          type: string
+                                      type: object
+                                    secretRef:
+                                      properties:
+                                        optional:
+                                          type: boolean
+                                        name:
+                                          type: string
+                                      type: object
+                                  type: object
+                                type: array
+                              volumeMounts:
+                                items:
+                                  properties:
+                                    readOnly:
+                                      type: boolean
+                                    subPathExpr:
+                                      type: string
+                                    mountPath:
+                                      type: string
+                                    mountPropagation:
+                                      type: string
+                                    subPath:
+                                      type: string
+                                    name:
+                                      type: string
+                                  type: object
+                                type: array
+                              securityContext:
+                                properties:
+                                  runAsGroup:
+                                    type: integer
+                                  runAsNonRoot:
+                                    type: boolean
+                                  windowsOptions:
+                                    properties:
+                                      gmsaCredentialSpecName:
+                                        type: string
+                                      hostProcess:
+                                        type: boolean
+                                      gmsaCredentialSpec:
+                                        type: string
+                                      runAsUserName:
+                                        type: string
+                                    type: object
+                                  allowPrivilegeEscalation:
+                                    type: boolean
+                                  capabilities:
+                                    properties:
+                                      add:
+                                        items:
+                                          type: string
+                                        type: array
+                                      drop:
+                                        items:
+                                          type: string
+                                        type: array
+                                    type: object
+                                  seLinuxOptions:
+                                    properties:
+                                      role:
+                                        type: string
+                                      type:
+                                        type: string
+                                      user:
+                                        type: string
+                                      level:
+                                        type: string
+                                    type: object
+                                  readOnlyRootFilesystem:
+                                    type: boolean
+                                  privileged:
+                                    type: boolean
+                                  runAsUser:
+                                    type: integer
+                                  procMount:
+                                    type: string
+                                  seccompProfile:
+                                    properties:
+                                      type:
+                                        type: string
+                                      localhostProfile:
+                                        type: string
+                                    type: object
+                                type: object
+                              name:
+                                type: string
+                              resources:
+                                properties:
+                                  limits:
+                                    additionalProperties:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      x-kubernetes-int-or-string: true
+                                    type: object
+                                  requests:
+                                    additionalProperties:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      x-kubernetes-int-or-string: true
+                                    type: object
+                                type: object
+                              imagePullPolicy:
+                                type: string
+                              volumeDevices:
+                                items:
+                                  properties:
+                                    devicePath:
+                                      type: string
+                                    name:
+                                      type: string
+                                  type: object
+                                type: array
+                            type: object
+                          type: array
+                        priorityClassName:
+                          type: string
+                        tolerations:
+                          items:
+                            properties:
+                              key:
+                                type: string
+                              operator:
+                                type: string
+                              tolerationSeconds:
+                                type: integer
+                              value:
+                                type: string
+                              effect:
+                                type: string
+                            type: object
+                          type: array
+                        hostPID:
+                          type: boolean
+                        os:
+                          properties:
+                            name:
+                              type: string
+                          type: object
+                        serviceAccountName:
+                          type: string
+                        shareProcessNamespace:
+                          type: boolean
+                        hostNetwork:
+                          type: boolean
+                        hostname:
+                          type: string
+                        nodeSelector:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        enableServiceLinks:
+                          type: boolean
+                        affinity:
+                          properties:
+                            podAntiAffinity:
+                              properties:
+                                requiredDuringSchedulingIgnoredDuringExecution:
+                                  items:
+                                    properties:
+                                      namespaces:
+                                        items:
+                                          type: string
+                                        type: array
+                                      topologyKey:
+                                        type: string
+                                      labelSelector:
+                                        properties:
+                                          matchExpressions:
+                                            items:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                values:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                operator:
+                                                  type: string
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                        type: object
+                                      namespaceSelector:
+                                        properties:
+                                          matchExpressions:
+                                            items:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                values:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                operator:
+                                                  type: string
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                        type: object
+                                    type: object
+                                  type: array
+                                preferredDuringSchedulingIgnoredDuringExecution:
+                                  items:
+                                    properties:
+                                      podAffinityTerm:
+                                        properties:
+                                          namespaces:
+                                            items:
+                                              type: string
+                                            type: array
+                                          topologyKey:
+                                            type: string
+                                          labelSelector:
+                                            properties:
+                                              matchExpressions:
+                                                items:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    values:
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                    operator:
+                                                      type: string
+                                                  type: object
+                                                type: array
+                                              matchLabels:
+                                                additionalProperties:
+                                                  type: string
+                                                type: object
+                                            type: object
+                                          namespaceSelector:
+                                            properties:
+                                              matchExpressions:
+                                                items:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    values:
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                    operator:
+                                                      type: string
+                                                  type: object
+                                                type: array
+                                              matchLabels:
+                                                additionalProperties:
+                                                  type: string
+                                                type: object
+                                            type: object
+                                        type: object
+                                      weight:
+                                        type: integer
+                                    type: object
+                                  type: array
+                              type: object
+                            nodeAffinity:
+                              properties:
+                                preferredDuringSchedulingIgnoredDuringExecution:
+                                  items:
+                                    properties:
+                                      weight:
+                                        type: integer
+                                      preference:
+                                        properties:
+                                          matchFields:
+                                            items:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                values:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                operator:
+                                                  type: string
+                                              type: object
+                                            type: array
+                                          matchExpressions:
+                                            items:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                values:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                operator:
+                                                  type: string
+                                              type: object
+                                            type: array
+                                        type: object
+                                    type: object
+                                  type: array
+                                requiredDuringSchedulingIgnoredDuringExecution:
+                                  properties:
+                                    nodeSelectorTerms:
+                                      items:
+                                        properties:
+                                          matchFields:
+                                            items:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                values:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                operator:
+                                                  type: string
+                                              type: object
+                                            type: array
+                                          matchExpressions:
+                                            items:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                values:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                operator:
+                                                  type: string
+                                              type: object
+                                            type: array
+                                        type: object
+                                      type: array
+                                  type: object
+                              type: object
+                            podAffinity:
+                              properties:
+                                requiredDuringSchedulingIgnoredDuringExecution:
+                                  items:
+                                    properties:
+                                      namespaces:
+                                        items:
+                                          type: string
+                                        type: array
+                                      topologyKey:
+                                        type: string
+                                      labelSelector:
+                                        properties:
+                                          matchExpressions:
+                                            items:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                values:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                operator:
+                                                  type: string
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                        type: object
+                                      namespaceSelector:
+                                        properties:
+                                          matchExpressions:
+                                            items:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                values:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                operator:
+                                                  type: string
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                        type: object
+                                    type: object
+                                  type: array
+                                preferredDuringSchedulingIgnoredDuringExecution:
+                                  items:
+                                    properties:
+                                      podAffinityTerm:
+                                        properties:
+                                          namespaces:
+                                            items:
+                                              type: string
+                                            type: array
+                                          topologyKey:
+                                            type: string
+                                          labelSelector:
+                                            properties:
+                                              matchExpressions:
+                                                items:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    values:
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                    operator:
+                                                      type: string
+                                                  type: object
+                                                type: array
+                                              matchLabels:
+                                                additionalProperties:
+                                                  type: string
+                                                type: object
+                                            type: object
+                                          namespaceSelector:
+                                            properties:
+                                              matchExpressions:
+                                                items:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    values:
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                    operator:
+                                                      type: string
+                                                  type: object
+                                                type: array
+                                              matchLabels:
+                                                additionalProperties:
+                                                  type: string
+                                                type: object
+                                            type: object
+                                        type: object
+                                      weight:
+                                        type: integer
+                                    type: object
+                                  type: array
+                              type: object
+                          type: object
+                        readinessGates:
+                          items:
+                            properties:
+                              conditionType:
+                                type: string
+                            type: object
+                          type: array
+                        dnsPolicy:
+                          type: string
+                        hostIPC:
+                          type: boolean
+                        topologySpreadConstraints:
+                          items:
+                            properties:
+                              topologyKey:
+                                type: string
+                              maxSkew:
+                                type: integer
+                              whenUnsatisfiable:
+                                type: string
+                              labelSelector:
+                                properties:
+                                  matchExpressions:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        values:
+                                          items:
+                                            type: string
+                                          type: array
+                                        operator:
+                                          type: string
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                type: object
+                            type: object
+                          type: array
+                        overhead:
+                          additionalProperties:
+                            anyOf:
+                              - type: integer
+                              - type: string
+                            x-kubernetes-int-or-string: true
+                          type: object
+                        schedulerName:
+                          type: string
+                        nodeName:
+                          type: string
+                        preemptionPolicy:
+                          type: string
+                        hostAliases:
+                          items:
+                            properties:
+                              hostnames:
+                                items:
+                                  type: string
+                                type: array
+                              ip:
+                                type: string
+                            type: object
+                          type: array
+                        runtimeClassName:
+                          type: string
+                      type: object
+                  type: object
+                amqBroker:
+                  properties:
+                    port:
+                      type: integer
+                    managementHost:
+                      type: string
+                    host:
+                      type: string
+                    usernameSecretRef:
+                      properties:
+                        optional:
+                          type: boolean
+                        key:
+                          type: string
+                        name:
+                          type: string
+                      type: object
+                    managementPort:
+                      type: integer
+                    passwordSecretRef:
+                      properties:
+                        optional:
+                          type: boolean
+                        key:
+                          type: string
+                        name:
+                          type: string
+                      type: object
+                    brokerName:
+                      type: string
+                  type: object
+                scaling:
+                  properties:
+                    dynamic:
+                      type: boolean
+                    replicas:
+                      type: integer
+                  type: object
+              type: object
+            status:
+              properties:
+                outputMessageAddress:
+                  type: string
+                inputMessageAddress:
+                  type: string
+                conditions:
+                  items:
                     properties:
-                      optional:
-                        type: boolean
-                      key:
+                      status:
                         type: string
-                      name:
+                      reason:
+                        type: string
+                      lastTransitionTime:
+                        type: string
+                      observedGeneration:
+                        type: integer
+                      type:
+                        type: string
+                      message:
                         type: string
                     type: object
-                  managementPort:
-                    type: integer
-                  passwordSecretRef:
-                    properties:
-                      optional:
-                        type: boolean
-                      key:
-                        type: string
-                      name:
-                        type: string
-                    type: object
-                  brokerName:
-                    type: string
-                type: object
-              solverImage:
-                type: string
-              scaling:
-                properties:
-                  dynamic:
-                    type: boolean
-                  replicas:
-                    type: integer
-                type: object
-            type: object
-          status:
-            properties:
-              outputMessageAddress:
-                type: string
-              inputMessageAddress:
-                type: string
-              errorMessage:
-                type: string
-            type: object
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
+                  type: array
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/optaplanner-operator/src/k8s/school-timetabling-solver.yml
+++ b/optaplanner-operator/src/k8s/school-timetabling-solver.yml
@@ -1,5 +1,5 @@
 # Example solver resource; override as you see fit.
-apiVersion: org.optaplanner.solver/v1beta1
+apiVersion: org.optaplanner.solver/v1alpha1
 kind: Solver
 metadata:
   name: school-timetabling
@@ -14,7 +14,11 @@ spec:
     passwordSecretRef:
       key: AMQ_PASSWORD
       name: ex-aao-credentials-secret
-  solverImage: quay.io/example/school-timetabling:latest
+  template:
+    spec:
+      containers:
+        - name: school-timetabling
+          image: quay.io/example/school-timetabling:latest
   scaling:
     dynamic: true
     replicas: 3

--- a/optaplanner-operator/src/main/java/org/optaplanner/operator/impl/solver/model/OptaPlannerSolver.java
+++ b/optaplanner-operator/src/main/java/org/optaplanner/operator/impl/solver/model/OptaPlannerSolver.java
@@ -8,13 +8,22 @@ import io.fabric8.kubernetes.api.model.Namespaced;
 import io.fabric8.kubernetes.client.CustomResource;
 import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Kind;
+import io.fabric8.kubernetes.model.annotation.Plural;
+import io.fabric8.kubernetes.model.annotation.Singular;
 import io.fabric8.kubernetes.model.annotation.Version;
 
-@Group("org.optaplanner.solver")
-@Kind("Solver")
-@Version("v1beta1")
+@Group(OptaPlannerSolver.GROUP)
+@Plural(OptaPlannerSolver.PLURAL)
+@Singular(OptaPlannerSolver.SINGULAR)
+@Version(OptaPlannerSolver.API_VERSION)
+@Kind(OptaPlannerSolver.KIND)
 public final class OptaPlannerSolver extends CustomResource<OptaPlannerSolverSpec, OptaPlannerSolverStatus>
         implements Namespaced {
+    public static final String GROUP = "org.optaplanner.solver";
+    public static final String PLURAL = "solvers";
+    public static final String SINGULAR = "solver";
+    public static final String API_VERSION = "v1alpha1";
+    public static final String KIND = "Solver";
 
     @Override
     protected OptaPlannerSolverStatus initStatus() {

--- a/optaplanner-operator/src/main/java/org/optaplanner/operator/impl/solver/model/OptaPlannerSolverSpec.java
+++ b/optaplanner-operator/src/main/java/org/optaplanner/operator/impl/solver/model/OptaPlannerSolverSpec.java
@@ -1,18 +1,11 @@
 package org.optaplanner.operator.impl.solver.model;
 
+import io.fabric8.kubernetes.api.model.PodTemplateSpec;
+
 public final class OptaPlannerSolverSpec {
-    private String solverImage;
     private AmqBroker amqBroker;
-
-    private Scaling scaling;
-
-    public String getSolverImage() {
-        return solverImage;
-    }
-
-    public void setSolverImage(String solverImage) {
-        this.solverImage = solverImage;
-    }
+    private Scaling scaling = new Scaling();
+    private PodTemplateSpec template;
 
     public Scaling getScaling() {
         return scaling;
@@ -28,5 +21,13 @@ public final class OptaPlannerSolverSpec {
 
     public void setAmqBroker(AmqBroker amqBroker) {
         this.amqBroker = amqBroker;
+    }
+
+    public PodTemplateSpec getTemplate() {
+        return template;
+    }
+
+    public void setTemplate(PodTemplateSpec template) {
+        this.template = template;
     }
 }


### PR DESCRIPTION
- Enables configuration of the solver deployment by exposing a pod template spec in the CRD
- CRD version changed to alpha in compliance with https://kubernetes.io/docs/reference/using-api/

<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.
-->

### JIRA
https://issues.redhat.com/browse/PLANNER-2765

<!-- Add a JIRA ticket link if it exists. -->
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
- https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
- https://github.com/kiegroup/drools/pull/3000
- https://github.com/kiegroup/optaplanner/pull/899
- etc.
-->

### Checklist
- [ ] Documentation updated if applicable.
- [ ] Release notes updated if applicable.
- [ ] Upgrade recipe provided if applicable.

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request checks</b>  
  Please add comment: <b>Jenkins retest this</b>

- for a <b>specific pull request check</b>  
  please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-vehicle-routing] tests</b>
  
- for a <b>full downstream build</b> 
  - for <b>jenkins</b> job: 
    please add comment: <b>Jenkins run fdb</b>
  - for <b>github actions</b> job: 
    add the label `run_fdb`

- for a <b>compile downstream build</b>  
  please add comment: <b>Jenkins run cdb</b>

- for a <b>full production downstream build</b>  
  please add comment: <b>Jenkins execute product fdb</b>

- for an <b>upstream build</b>  
  please add comment: <b>Jenkins run upstream</b>

- for <b>quarkus branch checks</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins run quarkus-branch</b>

- for a <b>quarkus branch specific check</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-vehicle-routing] quarkus-branch</b>

- for <b>quarkus main checks</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins run quarkus-main</b>

- for a <b>specific quarkus main check</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-vehicle-routing] quarkus-branch</b>

- for <b>native checks</b>  
  Run native checks  
  Please add comment: <b>Jenkins run native</b>

- for a <b>specific native check</b>  
  Run native checks 
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-vehicle-routing] native</b>

- for <b>mandrel checks</b>  
  Run native checks against Mandrel image
  Please add comment: <b>Jenkins run mandrel</b>

- for a <b>specific mandrel check</b>  
  Run native checks against Mandrel image  
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-vehicle-routing] mandrel</b>
</details>

### CI Status

 You can check OptaPlanner repositories CI status from [Chain Status webpage](https://kiegroup.github.io/optaplanner/).
