### PR TITLE
Enable optaplanner-operator in the release pipeline

### DIFF
--- a/.ci/jenkins/Jenkinsfile.deploy
+++ b/.ci/jenkins/Jenkinsfile.deploy
@@ -248,8 +248,7 @@ pipeline {
             }
         }
 
-        // TODO: enable after the 8.29.x branch is created.
-        /*stage('Push a temporary operator image to a registry') {
+        stage('Push a temporary operator image to a registry') {
             when {
                 expression { return isRelease() }
             }
@@ -263,7 +262,7 @@ pipeline {
                     setDeployPropertyIfNeeded('operator.image.temporary_tag', getOperatorImageTemporaryTag())
                 }
             }
-        }*/
+        }
     }
     post {
         always {

--- a/.ci/jenkins/Jenkinsfile.promote
+++ b/.ci/jenkins/Jenkinsfile.promote
@@ -206,8 +206,7 @@ pipeline {
             }
         }
 
-// TODO: enable after the 8.29.x branch is created.
-        /*stage('Push the final OptaPlanner operator image') {
+        stage('Push the final OptaPlanner operator image') {
             when {
                 expression { return isRelease() }
             }
@@ -217,7 +216,7 @@ pipeline {
                     removeOperatorImageTemporaryTag()
                 }
             }
-        }*/
+        }
     }
     post {
         unsuccessful {

--- a/build/optaplanner-distribution-internal/pom.xml
+++ b/build/optaplanner-distribution-internal/pom.xml
@@ -92,11 +92,10 @@
       <groupId>org.optaplanner</groupId>
       <artifactId>optaplanner-test</artifactId>
     </dependency>
-    <!-- TODO: enable the module by default after the 8.29.x branch is created. -->
-    <!--<dependency>
+    <dependency>
       <groupId>org.optaplanner</groupId>
       <artifactId>optaplanner-operator</artifactId>
-    </dependency>-->
+    </dependency>
 
     <!-- Examples -->
     <dependency>

--- a/build/optaplanner-distribution-internal/src/main/assembly/assembly-optaplanner.xml
+++ b/build/optaplanner-distribution-internal/src/main/assembly/assembly-optaplanner.xml
@@ -54,11 +54,10 @@
       </excludes>
     </fileSet>
     <!-- OptaPlanner Operator distribution. -->
-    <!-- TODO: enable the module by default after the 8.29.x branch is created. -->
-    <!--<fileSet>
+    <fileSet>
       <directory>../../optaplanner-operator/target/install</directory>
       <outputDirectory>extra/optaplanner-operator</outputDirectory>
-    </fileSet>-->
+    </fileSet>
   </fileSets>
 
   <dependencySets>
@@ -66,11 +65,10 @@
       <includes>
         <include>org.optaplanner:*:jar</include>
       </includes>
-      <!-- TODO: enable the module by default after the 8.29.x branch is created. -->
-      <!--<excludes>
+      <excludes>
         <exclude>org.optaplanner:optaplanner-operator:jar</exclude>
         <exclude>*:sources</exclude>
-      </excludes>-->
+      </excludes>
       <useProjectArtifact>false</useProjectArtifact>
       <outputDirectory>examples/binaries</outputDirectory>
       <useStrictFiltering>true</useStrictFiltering>

--- a/optaplanner-docs/src/modules/ROOT/pages/release-notes/release-notes-8.adoc
+++ b/optaplanner-docs/src/modules/ROOT/pages/release-notes/release-notes-8.adoc
@@ -1,8 +1,6 @@
 [[releaseNotes-8.x]]
 == OptaPlanner 8.x Release Notes
 
-////
-TODO: enable after the 8.29.x branch is created.
 [[releaseNotes-8.30.0.Final]]
 === OptaPlanner 8.30.0.Final
 
@@ -11,7 +9,6 @@ TODO: enable after the 8.29.x branch is created.
 While the OptaPlanner operator remains experimental, it has now become a part of the https://download.jboss.org/optaplanner/release/latestFinal[OptaPlanner distribution].
 
 If you want to learn more about the operator, follow the https://github.com/kiegroup/optaplanner-quickstarts/tree/development/technology/kubernetes[Kubernetes demo]
-////
 
 [[releaseNotes-8.29.0.Final]]
 === OptaPlanner 8.29.0.Final


### PR DESCRIPTION
This is a leftover from https://github.com/kiegroup/optaplanner/pull/2246.

<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.
-->

### JIRA

<!-- Add a JIRA ticket link if it exists. -->
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
- https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
- https://github.com/kiegroup/drools/pull/3000
- https://github.com/kiegroup/optaplanner/pull/899
- etc.
-->

### Checklist
- [x] Documentation updated if applicable.
- [x] Release notes updated if applicable.
- [x] Upgrade recipe provided if applicable.

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request checks</b>  
  Please add comment: <b>Jenkins retest this</b>

- for a <b>specific pull request check</b>  
  please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-vehicle-routing] tests</b>
  
- for a <b>full downstream build</b> 
  - for <b>jenkins</b> job: 
    please add comment: <b>Jenkins run fdb</b>
  - for <b>github actions</b> job: 
    add the label `run_fdb`

- for a <b>compile downstream build</b>  
  please add comment: <b>Jenkins run cdb</b>

- for a <b>full production downstream build</b>  
  please add comment: <b>Jenkins execute product fdb</b>

- for an <b>upstream build</b>  
  please add comment: <b>Jenkins run upstream</b>

- for <b>quarkus branch checks</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins run quarkus-branch</b>

- for a <b>quarkus branch specific check</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-vehicle-routing] quarkus-branch</b>

- for <b>quarkus main checks</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins run quarkus-main</b>

- for a <b>specific quarkus main check</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-vehicle-routing] quarkus-branch</b>

- for <b>quarkus lts checks</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins run quarkus-lts</b>

- for a <b>specific quarkus lts check</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-vehicle-routing] quarkus-lts</b>

- for <b>native checks</b>  
  Run native checks  
  Please add comment: <b>Jenkins run native</b>

- for a <b>specific native check</b>  
  Run native checks 
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts] native</b>

- for <b>mandrel checks</b>  
  Run native checks against Mandrel image
  Please add comment: <b>Jenkins run mandrel</b>

- for a <b>specific mandrel check</b>  
  Run native checks against Mandrel image  
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts] mandrel</b>

- for <b>mandrel lts checks</b>  
  Run native checks against Mandrel image and quarkus lts branch
  Please add comment: <b>Jenkins run mandrel-lts</b>

- for a <b>specific mandrel lts check</b>  
  Run native checks against Mandrel image and quarkus lts branch
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts] mandrel-lts</b>

</details>

### CI Status

 You can check OptaPlanner repositories CI status from [Chain Status webpage](https://kiegroup.github.io/optaplanner/).
