### PR TITLE
Add list variable to 8.29.0 release notes

### DIFF
--- a/optaplanner-docs/src/modules/ROOT/pages/planner-configuration/planner-configuration.adoc
+++ b/optaplanner-docs/src/modules/ROOT/pages/planner-configuration/planner-configuration.adoc
@@ -870,9 +870,9 @@ For example, none of the `row` variables of any `Queen` may be used to determine
 ==== Planning list variable (VRP, Task assigning, ...)
 
 The planning list variable is a successor to the chained planning variable.
-All problems that have previously been modelled using the <<chainedPlanningVariable, chained planning variable>> can now be modelled using the planning list variable.
+All problems that have previously been modeled using the <<chainedPlanningVariable, chained planning variable>> can now be modeled using the planning list variable.
 
-For example, the Vehicle Routing problem can be modelled as follows:
+For example, the Vehicle Routing problem can be modeled as follows:
 
 image::use-cases-and-examples/vehicle-routing/vehicleRoutingClassDiagram.png[]
 

--- a/optaplanner-docs/src/modules/ROOT/pages/release-notes/release-notes-8.adoc
+++ b/optaplanner-docs/src/modules/ROOT/pages/release-notes/release-notes-8.adoc
@@ -52,6 +52,22 @@ The `@CustomShadowVariable` has been deprecated.
 Read more about xref:shadow-variable/shadow-variable.adoc#customVariableListener[custom shadow variables] in the documentation.
 
 
+=== Planning list variable
+
+OptaPlanner now adds a limited support for planning list variables that can hold multiple planning values.
+The planning list variable provides an alternative approach to modeling planning problems that were previously modeled using the xref:planner-configuration/planner-configuration.adoc#chainedPlanningVariable[chained planning variable].
+
+Both the planning list variable and the chained planning variable should be used with problems where the goal is to distribute a number of workload elements among limited resources in a specific order.
+For example, in vehicle routing, vehicles represent the limited resource and customers represent the workload elements.
+
+The chained planning variable defines a recursive data structure, in which customers form chains ending with vehicles.
+On the other hand, the planning list variable allows for a more intuitive model where each vehicle holds a list of customers it goes to.
+It is defined using the new `@PlaningListVariable` annotation.
+
+WARNING: The planning list variable is a new feature and lacks some advanced features, that are available with the chained planning variable.
+
+See xref:planner-configuration/planner-configuration.adoc#planningListVariable[planning list variable].
+
 [[releaseNotes-8.27.0.Final]]
 === OptaPlanner 8.27.0.Final
 

--- a/optaplanner-docs/src/modules/ROOT/pages/shadow-variable/shadow-variable.adoc
+++ b/optaplanner-docs/src/modules/ROOT/pages/shadow-variable/shadow-variable.adoc
@@ -152,8 +152,8 @@ public class Customer {
 The `sourceVariableName` property is the name of the chained variable on the same entity class.
 
 
-[[listVariableShadows]]
-== List variable shadows
+[[listVariableShadowVariables]]
+== List variable shadow variables
 
 When the planning entity uses a xref:planner-configuration/planner-configuration.adoc#planningListVariable[list variable], its elements can use a number of built-in shadow variables.
 


### PR DESCRIPTION

### Checklist
- [ ] Documentation updated if applicable.
- [ ] Release notes updated if applicable.
- [ ] Upgrade recipe provided if applicable.

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request checks</b>  
  Please add comment: <b>Jenkins retest this</b>

- for a <b>specific pull request check</b>  
  please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-vehicle-routing] tests</b>
  
- for a <b>full downstream build</b> 
  - for <b>jenkins</b> job: 
    please add comment: <b>Jenkins run fdb</b>
  - for <b>github actions</b> job: 
    add the label `run_fdb`

- for a <b>compile downstream build</b>  
  please add comment: <b>Jenkins run cdb</b>

- for a <b>full production downstream build</b>  
  please add comment: <b>Jenkins execute product fdb</b>

- for an <b>upstream build</b>  
  please add comment: <b>Jenkins run upstream</b>

- for <b>quarkus branch checks</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins run quarkus-branch</b>

- for a <b>quarkus branch specific check</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-vehicle-routing] quarkus-branch</b>

- for <b>quarkus main checks</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins run quarkus-main</b>

- for a <b>specific quarkus main check</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-vehicle-routing] quarkus-branch</b>

- for <b>quarkus lts checks</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins run quarkus-lts</b>

- for a <b>specific quarkus lts check</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-vehicle-routing] quarkus-lts</b>

- for <b>native checks</b>  
  Run native checks  
  Please add comment: <b>Jenkins run native</b>

- for a <b>specific native check</b>  
  Run native checks 
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts] native</b>

- for <b>mandrel checks</b>  
  Run native checks against Mandrel image
  Please add comment: <b>Jenkins run mandrel</b>

- for a <b>specific mandrel check</b>  
  Run native checks against Mandrel image  
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts] mandrel</b>

- for <b>mandrel lts checks</b>  
  Run native checks against Mandrel image and quarkus lts branch
  Please add comment: <b>Jenkins run mandrel-lts</b>

- for a <b>specific mandrel lts check</b>  
  Run native checks against Mandrel image and quarkus lts branch
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts] mandrel-lts</b>

</details>

### CI Status

 You can check OptaPlanner repositories CI status from [Chain Status webpage](https://kiegroup.github.io/optaplanner/).
