### PR TITLE
PLANNER-2002: Add Substitute_LambdaBeanPropertyMemberAccessor

### DIFF
--- a/optaplanner-quarkus-integration/optaplanner-quarkus/pom.xml
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/pom.xml
@@ -17,6 +17,7 @@
     <module>runtime</module>
     <module>deployment</module>
     <module>integration-test</module>
+    <module>reflection-integration-test</module>
     <module>devui-integration-test</module>
     <module>drl-integration-test</module>
   </modules>

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/reflection-integration-test/.gitignore
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/reflection-integration-test/.gitignore
@@ -1,0 +1,10 @@
+/target
+/local
+
+# Eclipse, Netbeans and IntelliJ files
+/.*
+!.gitignore
+/nbproject
+/*.ipr
+/*.iws
+/*.iml

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/reflection-integration-test/pom.xml
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/reflection-integration-test/pom.xml
@@ -1,0 +1,118 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.optaplanner</groupId>
+    <artifactId>optaplanner-quarkus-parent</artifactId>
+    <version>8.32.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>optaplanner-quarkus-reflection-integration-test</artifactId>
+  <name>OptaPlanner Quarkus - Reflection Integration tests</name>
+  <description>Quarkus reflection integration tests for OptaPlanner</description>
+
+  <properties>
+    <java.module.name>org.optaplanner.quarkus</java.module.name>
+    <!-- Code of integration tests should not be a part of test coverage reports. -->
+    <sonar.coverage.exclusions>**/*</sonar.coverage.exclusions>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-arc</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-resteasy</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.optaplanner</groupId>
+      <artifactId>optaplanner-quarkus</artifactId>
+    </dependency>
+
+    <!-- test dependencies -->
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-junit5</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.rest-assured</groupId>
+      <artifactId>rest-assured</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>io.quarkus</groupId>
+        <artifactId>quarkus-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <goals>
+              <goal>build</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <executions>
+          <execution>
+            <!-- Transitive dependencies through quarkus are expected in this module. -->
+            <id>analyze-only</id>
+            <phase>none</phase>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <artifactId>maven-failsafe-plugin</artifactId>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+  <profiles>
+    <profile>
+      <id>native</id>
+      <activation>
+        <property>
+          <name>native</name>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-failsafe-plugin</artifactId>
+            <configuration>
+              <skip>false</skip>
+            </configuration>
+            <executions>
+              <execution>
+                <goals>
+                  <goal>integration-test</goal>
+                  <goal>verify</goal>
+                </goals>
+                <configuration>
+                  <systemPropertyVariables>
+                    <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
+                  </systemPropertyVariables>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+      <properties>
+        <quarkus.package.type>native</quarkus.package.type>
+      </properties>
+    </profile>
+  </profiles>
+</project>

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/reflection-integration-test/src/main/java/org/optaplanner/quarkus/it/reflection/OptaPlannerTestResource.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/reflection-integration-test/src/main/java/org/optaplanner/quarkus/it/reflection/OptaPlannerTestResource.java
@@ -1,0 +1,43 @@
+package org.optaplanner.quarkus.it.reflection;
+
+import java.util.Arrays;
+import java.util.concurrent.ExecutionException;
+
+import javax.inject.Inject;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import org.optaplanner.core.api.solver.SolverJob;
+import org.optaplanner.core.api.solver.SolverManager;
+import org.optaplanner.quarkus.it.reflection.domain.TestdataReflectionEntity;
+import org.optaplanner.quarkus.it.reflection.domain.TestdataReflectionSolution;
+
+@Path("/optaplanner/test")
+public class OptaPlannerTestResource {
+
+    @Inject
+    SolverManager<TestdataReflectionSolution, Long> solverManager;
+
+    @POST
+    @Path("/solver-factory")
+    @Produces(MediaType.TEXT_PLAIN)
+    public String solveWithSolverFactory() {
+        TestdataReflectionSolution planningProblem = new TestdataReflectionSolution();
+        planningProblem.setEntityList(Arrays.asList(
+                new TestdataReflectionEntity(),
+                new TestdataReflectionEntity()));
+        planningProblem.setFieldValueList(Arrays.asList("a", "bb", "ccc"));
+        planningProblem.setMethodValueList(Arrays.asList("a", "bb", "ccc", "ddd"));
+        SolverJob<TestdataReflectionSolution, Long> solverJob = solverManager.solve(1L, planningProblem);
+        try {
+            return solverJob.getFinalBestSolution().getScore().toString();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException("Solving was interrupted.", e);
+        } catch (ExecutionException e) {
+            throw new IllegalStateException("Solving failed.", e);
+        }
+    }
+}

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/reflection-integration-test/src/main/java/org/optaplanner/quarkus/it/reflection/domain/TestdataReflectionEntity.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/reflection-integration-test/src/main/java/org/optaplanner/quarkus/it/reflection/domain/TestdataReflectionEntity.java
@@ -1,0 +1,27 @@
+package org.optaplanner.quarkus.it.reflection.domain;
+
+import org.optaplanner.core.api.domain.entity.PlanningEntity;
+import org.optaplanner.core.api.domain.variable.PlanningVariable;
+
+@PlanningEntity
+public class TestdataReflectionEntity {
+
+    @PlanningVariable(valueRangeProviderRefs = "fieldValueRange")
+    public String fieldValue;
+
+    private String methodValueField;
+
+    // ************************************************************************
+    // Getters/setters
+    // ************************************************************************
+
+    @PlanningVariable(valueRangeProviderRefs = "methodValueRange")
+    public String getMethodValue() {
+        return methodValueField;
+    }
+
+    public void setMethodValue(String methodValueField) {
+        this.methodValueField = methodValueField;
+    }
+
+}

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/reflection-integration-test/src/main/java/org/optaplanner/quarkus/it/reflection/domain/TestdataReflectionSolution.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/reflection-integration-test/src/main/java/org/optaplanner/quarkus/it/reflection/domain/TestdataReflectionSolution.java
@@ -1,0 +1,65 @@
+package org.optaplanner.quarkus.it.reflection.domain;
+
+import java.util.List;
+
+import org.optaplanner.core.api.domain.solution.PlanningEntityCollectionProperty;
+import org.optaplanner.core.api.domain.solution.PlanningScore;
+import org.optaplanner.core.api.domain.solution.PlanningSolution;
+import org.optaplanner.core.api.domain.valuerange.ValueRangeProvider;
+import org.optaplanner.core.api.score.buildin.hardsoft.HardSoftScore;
+
+@PlanningSolution
+public class TestdataReflectionSolution {
+
+    @ValueRangeProvider(id = "fieldValueRange")
+    private List<String> fieldValueList;
+
+    private List<String> methodValueList;
+
+    @PlanningEntityCollectionProperty
+    private List<TestdataReflectionEntity> entityList;
+
+    @PlanningScore
+    private HardSoftScore score;
+
+    // ************************************************************************
+    // Getters/setters
+    // ************************************************************************
+
+    public List<String> getFieldValueList() {
+        return fieldValueList;
+    }
+
+    public void setFieldValueList(List<String> fieldValueList) {
+        this.fieldValueList = fieldValueList;
+    }
+
+    public List<String> getMethodValueList() {
+        return methodValueList;
+    }
+
+    public void setMethodValueList(List<String> methodValueList) {
+        this.methodValueList = methodValueList;
+    }
+
+    @ValueRangeProvider(id = "methodValueRange")
+    public List<String> readMethodValueList() {
+        return methodValueList;
+    }
+
+    public List<TestdataReflectionEntity> getEntityList() {
+        return entityList;
+    }
+
+    public void setEntityList(List<TestdataReflectionEntity> entityList) {
+        this.entityList = entityList;
+    }
+
+    public HardSoftScore getScore() {
+        return score;
+    }
+
+    public void setScore(HardSoftScore score) {
+        this.score = score;
+    }
+}

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/reflection-integration-test/src/main/java/org/optaplanner/quarkus/it/reflection/solver/TestdataStringLengthConstraintProvider.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/reflection-integration-test/src/main/java/org/optaplanner/quarkus/it/reflection/solver/TestdataStringLengthConstraintProvider.java
@@ -1,0 +1,26 @@
+package org.optaplanner.quarkus.it.reflection.solver;
+
+import org.optaplanner.core.api.score.buildin.hardsoft.HardSoftScore;
+import org.optaplanner.core.api.score.stream.Constraint;
+import org.optaplanner.core.api.score.stream.ConstraintFactory;
+import org.optaplanner.core.api.score.stream.ConstraintProvider;
+import org.optaplanner.core.api.score.stream.Joiners;
+import org.optaplanner.quarkus.it.reflection.domain.TestdataReflectionEntity;
+
+public class TestdataStringLengthConstraintProvider implements ConstraintProvider {
+
+    @Override
+    public Constraint[] defineConstraints(ConstraintFactory factory) {
+        return new Constraint[] {
+                factory.forEach(TestdataReflectionEntity.class)
+                        .join(TestdataReflectionEntity.class, Joiners.equal(TestdataReflectionEntity::getMethodValue))
+                        .filter((a, b) -> !a.fieldValue.equals(b.fieldValue))
+                        .penalize(HardSoftScore.ONE_HARD)
+                        .asConstraint("Entities with equal method values should have equal field values"),
+                factory.forEach(TestdataReflectionEntity.class)
+                        .reward(HardSoftScore.ONE_SOFT, entity -> entity.getMethodValue().length())
+                        .asConstraint("Maximize method value length")
+        };
+    }
+
+}

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/reflection-integration-test/src/main/resources/application.properties
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/reflection-integration-test/src/main/resources/application.properties
@@ -1,0 +1,3 @@
+# The solver runs only for few milliseconds to avoid a HTTP timeout in this simple implementation.
+quarkus.optaplanner.solver.domain-access-type=REFLECTION
+quarkus.optaplanner.solver.termination.best-score-limit=0hard/6soft

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/reflection-integration-test/src/test/java/org/optaplanner/quarkus/it/reflection/OptaPlannerTestResourceIT.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/reflection-integration-test/src/test/java/org/optaplanner/quarkus/it/reflection/OptaPlannerTestResourceIT.java
@@ -1,0 +1,11 @@
+package org.optaplanner.quarkus.it.reflection;
+
+import io.quarkus.test.junit.NativeImageTest;
+
+/**
+ * Test various OptaPlanner operations running in native mode
+ */
+@NativeImageTest
+public class OptaPlannerTestResourceIT extends OptaPlannerTestResourceTest {
+
+}

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/reflection-integration-test/src/test/java/org/optaplanner/quarkus/it/reflection/OptaPlannerTestResourceTest.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/reflection-integration-test/src/test/java/org/optaplanner/quarkus/it/reflection/OptaPlannerTestResourceTest.java
@@ -1,0 +1,30 @@
+package org.optaplanner.quarkus.it.reflection;
+
+import static org.hamcrest.Matchers.is;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.RestAssured;
+
+/**
+ * Test various OptaPlanner operations running in Quarkus
+ */
+
+@QuarkusTest
+class OptaPlannerTestResourceTest {
+
+    @Test
+    @Timeout(600)
+    void solveWithSolverFactory() throws Exception {
+        RestAssured.given()
+                .header("Content-Type", "application/json")
+                .when()
+                .post("/optaplanner/test/solver-factory")
+                .then()
+                .body(is(
+                        "0hard/6soft"));
+    }
+
+}

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/runtime/src/main/java/org/optaplanner/quarkus/nativeimage/Substitute_LambdaBeanPropertyMemberAccessor.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/runtime/src/main/java/org/optaplanner/quarkus/nativeimage/Substitute_LambdaBeanPropertyMemberAccessor.java
@@ -25,23 +25,23 @@ public final class Substitute_LambdaBeanPropertyMemberAccessor {
     Method setterMethod;
 
     @Substitute
-    private Function createGetterFunction(MethodHandles.Lookup lookup) {
-        return new GetterFunctionDelegator(getterMethod);
+    private Function<Object, Object> createGetterFunction(MethodHandles.Lookup lookup) {
+        return new GetterDelegationFunction(getterMethod);
     }
 
     @Substitute
-    private BiConsumer createSetterFunction(MethodHandles.Lookup lookup) {
+    private BiConsumer<Object, Object> createSetterFunction(MethodHandles.Lookup lookup) {
         if (setterMethod == null) {
             return null;
         }
 
-        return new SetterFunctionDelegator(setterMethod);
+        return new SetterDelegationBiConsumer(setterMethod);
     }
 
-    private static final class GetterFunctionDelegator implements Function {
+    private static final class GetterDelegationFunction implements Function<Object, Object> {
         private final Method method;
 
-        public GetterFunctionDelegator(Method method) {
+        public GetterDelegationFunction(Method method) {
             this.method = method;
         }
 
@@ -55,10 +55,10 @@ public final class Substitute_LambdaBeanPropertyMemberAccessor {
         }
     }
 
-    private static final class SetterFunctionDelegator implements BiConsumer {
+    private static final class SetterDelegationBiConsumer implements BiConsumer<Object, Object> {
         private final Method method;
 
-        public SetterFunctionDelegator(Method method) {
+        public SetterDelegationBiConsumer(Method method) {
             this.method = method;
         }
 

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/runtime/src/main/java/org/optaplanner/quarkus/nativeimage/Substitute_LambdaBeanPropertyMemberAccessor.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/runtime/src/main/java/org/optaplanner/quarkus/nativeimage/Substitute_LambdaBeanPropertyMemberAccessor.java
@@ -1,0 +1,74 @@
+package org.optaplanner.quarkus.nativeimage;
+
+import java.lang.invoke.MethodHandles;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.function.BiConsumer;
+import java.util.function.Function;
+
+import com.oracle.svm.core.annotate.Alias;
+import com.oracle.svm.core.annotate.Substitute;
+import com.oracle.svm.core.annotate.TargetClass;
+
+/**
+ * LambdaBeanPropertyMemberAccessor works by creating a new class during runtime (via LambdaMetafactory) to delegate to
+ * the provided getter/setter methods. This is not supported in GraalVM, so we need to use Method reflection
+ * (i.e. {@link Method#invoke(Object, Object...)}) instead.
+ */
+@TargetClass(className = "org.optaplanner.core.impl.domain.common.accessor.LambdaBeanPropertyMemberAccessor")
+public final class Substitute_LambdaBeanPropertyMemberAccessor {
+
+    @Alias
+    Method getterMethod;
+
+    @Alias
+    Method setterMethod;
+
+    @Substitute
+    private Function createGetterFunction(MethodHandles.Lookup lookup) {
+        return new GetterFunctionDelegator(getterMethod);
+    }
+
+    @Substitute
+    private BiConsumer createSetterFunction(MethodHandles.Lookup lookup) {
+        if (setterMethod == null) {
+            return null;
+        }
+
+        return new SetterFunctionDelegator(setterMethod);
+    }
+
+    private static final class GetterFunctionDelegator implements Function {
+        private final Method method;
+
+        public GetterFunctionDelegator(Method method) {
+            this.method = method;
+        }
+
+        @Override
+        public Object apply(Object object) {
+            try {
+                return method.invoke(object);
+            } catch (IllegalAccessException | InvocationTargetException e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
+    private static final class SetterFunctionDelegator implements BiConsumer {
+        private final Method method;
+
+        public SetterFunctionDelegator(Method method) {
+            this.method = method;
+        }
+
+        @Override
+        public void accept(Object object, Object value) {
+            try {
+                method.invoke(object, value);
+            } catch (IllegalAccessException | InvocationTargetException e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+}


### PR DESCRIPTION
The missing context for why Substitute_MemberAccessorFactory was created: LambdaBeanPropertyMemberAccessor generate classes at runtime (via LambdaMetafactory), which is not supported by GraalVM. Thus, if a getter method is annotated for member access, a
LambdaBeanPropertyMemberAccessor is created, which will try to create a new class, and GraalVM will throw an unsupported feature exception at runtime when run in native mode.

The Substitute_MemberAccessorFactory "fixed" it by removing the code path that leads to LambdaBeanPropertyMemberAccessor. However, that is more work to maintain and requires knowledge of why LambdaBeanPropertyMemberAccessor should not be used. What this commit does instead, is substitute LambdaBeanPropertyMemberAccessor, keeping the original MemberAccessorFactory implementation. The methods that create the new classes now return a delegator class, which use reflection to invoke the method. This allows
LambdaBeanPropertyMemberAccessor to be safely used in MemberAccessorFactory and elsewhere in the code.

<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.
-->

### JIRA

<!-- Add a JIRA ticket link if it exists. -->
https://issues.redhat.com/browse/PLANNER-2002

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
- https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
- https://github.com/kiegroup/drools/pull/3000
- https://github.com/kiegroup/optaplanner/pull/899
- etc.
-->

### Checklist
- [ ] Documentation updated if applicable.
- [ ] Release notes updated if applicable.
- [ ] Upgrade recipe provided if applicable.

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request checks</b>  
  Please add comment: <b>Jenkins retest this</b>

- for a <b>specific pull request check</b>  
  please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-vehicle-routing] tests</b>
  
- for a <b>full downstream build</b> 
  - for <b>jenkins</b> job: 
    please add comment: <b>Jenkins run fdb</b>
  - for <b>github actions</b> job: 
    add the label `run_fdb`

- for a <b>compile downstream build</b>  
  please add comment: <b>Jenkins run cdb</b>

- for a <b>full production downstream build</b>  
  please add comment: <b>Jenkins execute product fdb</b>

- for an <b>upstream build</b>  
  please add comment: <b>Jenkins run upstream</b>

- for <b>quarkus branch checks</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins run quarkus-branch</b>

- for a <b>quarkus branch specific check</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-vehicle-routing] quarkus-branch</b>

- for <b>quarkus main checks</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins run quarkus-main</b>

- for a <b>specific quarkus main check</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-vehicle-routing] quarkus-branch</b>

- for <b>quarkus lts checks</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins run quarkus-lts</b>

- for a <b>specific quarkus lts check</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-vehicle-routing] quarkus-lts</b>

- for <b>native checks</b>  
  Run native checks  
  Please add comment: <b>Jenkins run native</b>

- for a <b>specific native check</b>  
  Run native checks 
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts] native</b>

- for <b>mandrel checks</b>  
  Run native checks against Mandrel image
  Please add comment: <b>Jenkins run mandrel</b>

- for a <b>specific mandrel check</b>  
  Run native checks against Mandrel image  
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts] mandrel</b>

- for <b>mandrel lts checks</b>  
  Run native checks against Mandrel image and quarkus lts branch
  Please add comment: <b>Jenkins run mandrel-lts</b>

- for a <b>specific mandrel lts check</b>  
  Run native checks against Mandrel image and quarkus lts branch
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts] mandrel-lts</b>

</details>

### CI Status

 You can check OptaPlanner repositories CI status from [Chain Status webpage](https://kiegroup.github.io/optaplanner/).
