### PR TITLE
CS: Better exception messages at certain points of the constraint stream

### DIFF
--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/bi/BavetAbstractBiConstraintStream.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/bi/BavetAbstractBiConstraintStream.java
@@ -415,12 +415,12 @@ public abstract class BavetAbstractBiConstraintStream<Solution_, A, B> extends B
 
     @Override
     protected final TriFunction<A, B, Score<?>, DefaultConstraintJustification> getDefaultJustificationMapping() {
-        return InnerBiConstraintStream.getDefaultJustificationMapping();
+        return InnerBiConstraintStream.createDefaultJustificationMapping();
     }
 
     @Override
     protected final BiFunction<A, B, Collection<?>> getDefaultIndictedObjectsMapping() {
-        return InnerBiConstraintStream.getDefaultIndictedObjectsMapping();
+        return InnerBiConstraintStream.createDefaultIndictedObjectsMapping();
     }
 
 }

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/bi/BavetScoringBiConstraintStream.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/bi/BavetScoringBiConstraintStream.java
@@ -1,6 +1,6 @@
 package org.optaplanner.constraint.streams.bavet.bi;
 
-import static org.optaplanner.constraint.streams.common.inliner.JustificationsSupplier.ofBi;
+import static org.optaplanner.constraint.streams.common.inliner.JustificationsSupplier.of;
 
 import java.math.BigDecimal;
 import java.util.Collection;
@@ -116,25 +116,25 @@ public final class BavetScoringBiConstraintStream<Solution_, A, B>
                 int matchWeight = intMatchWeigher.applyAsInt(a, b);
                 constraint.assertCorrectImpact(matchWeight);
                 return weightedScoreImpacter.impactScore(matchWeight,
-                        ofBi(constraint, justificationMapping, indictedObjectsMapping, a, b));
+                        of(constraint, justificationMapping, indictedObjectsMapping, a, b));
             };
         } else if (longMatchWeigher != null) {
             scoreImpacter = (a, b) -> {
                 long matchWeight = longMatchWeigher.applyAsLong(a, b);
                 constraint.assertCorrectImpact(matchWeight);
                 return weightedScoreImpacter.impactScore(matchWeight,
-                        ofBi(constraint, justificationMapping, indictedObjectsMapping, a, b));
+                        of(constraint, justificationMapping, indictedObjectsMapping, a, b));
             };
         } else if (bigDecimalMatchWeigher != null) {
             scoreImpacter = (a, b) -> {
                 BigDecimal matchWeight = bigDecimalMatchWeigher.apply(a, b);
                 constraint.assertCorrectImpact(matchWeight);
                 return weightedScoreImpacter.impactScore(matchWeight,
-                        ofBi(constraint, justificationMapping, indictedObjectsMapping, a, b));
+                        of(constraint, justificationMapping, indictedObjectsMapping, a, b));
             };
         } else if (noMatchWeigher) {
             scoreImpacter = (a, b) -> weightedScoreImpacter.impactScore(1,
-                    ofBi(constraint, justificationMapping, indictedObjectsMapping, a, b));
+                    of(constraint, justificationMapping, indictedObjectsMapping, a, b));
         } else {
             throw new IllegalStateException("Impossible state: neither of the supported match weighers provided.");
         }

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/bi/BavetScoringBiConstraintStream.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/bi/BavetScoringBiConstraintStream.java
@@ -1,6 +1,6 @@
 package org.optaplanner.constraint.streams.bavet.bi;
 
-import static org.optaplanner.constraint.streams.common.inliner.JustificationsSupplier.of;
+import static org.optaplanner.constraint.streams.common.inliner.JustificationsSupplier.ofBi;
 
 import java.math.BigDecimal;
 import java.util.Collection;
@@ -116,25 +116,25 @@ public final class BavetScoringBiConstraintStream<Solution_, A, B>
                 int matchWeight = intMatchWeigher.applyAsInt(a, b);
                 constraint.assertCorrectImpact(matchWeight);
                 return weightedScoreImpacter.impactScore(matchWeight,
-                        of(score -> justificationMapping.apply(a, b, score), () -> indictedObjectsMapping.apply(a, b)));
+                        ofBi(constraint, justificationMapping, indictedObjectsMapping, a, b));
             };
         } else if (longMatchWeigher != null) {
             scoreImpacter = (a, b) -> {
                 long matchWeight = longMatchWeigher.applyAsLong(a, b);
                 constraint.assertCorrectImpact(matchWeight);
                 return weightedScoreImpacter.impactScore(matchWeight,
-                        of(score -> justificationMapping.apply(a, b, score), () -> indictedObjectsMapping.apply(a, b)));
+                        ofBi(constraint, justificationMapping, indictedObjectsMapping, a, b));
             };
         } else if (bigDecimalMatchWeigher != null) {
             scoreImpacter = (a, b) -> {
                 BigDecimal matchWeight = bigDecimalMatchWeigher.apply(a, b);
                 constraint.assertCorrectImpact(matchWeight);
                 return weightedScoreImpacter.impactScore(matchWeight,
-                        of(score -> justificationMapping.apply(a, b, score), () -> indictedObjectsMapping.apply(a, b)));
+                        ofBi(constraint, justificationMapping, indictedObjectsMapping, a, b));
             };
         } else if (noMatchWeigher) {
             scoreImpacter = (a, b) -> weightedScoreImpacter.impactScore(1,
-                    of(score -> justificationMapping.apply(a, b, score), () -> indictedObjectsMapping.apply(a, b)));
+                    ofBi(constraint, justificationMapping, indictedObjectsMapping, a, b));
         } else {
             throw new IllegalStateException("Impossible state: neither of the supported match weighers provided.");
         }

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/bi/BiScorer.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/bi/BiScorer.java
@@ -18,6 +18,10 @@ final class BiScorer<A, B> extends AbstractScorer<BiTuple<A, B>> {
 
     @Override
     protected UndoScoreImpacter impact(BiTuple<A, B> tuple) {
-        return scoreImpacter.apply(tuple.getFactA(), tuple.getFactB());
+        try {
+            return scoreImpacter.apply(tuple.getFactA(), tuple.getFactB());
+        } catch (Exception e) {
+            throw createExceptionOnImpact(tuple, e);
+        }
     }
 }

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/common/AbstractIndexedJoinNode.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/common/AbstractIndexedJoinNode.java
@@ -115,7 +115,7 @@ public abstract class AbstractIndexedJoinNode<LeftTuple_ extends Tuple, Right_, 
         }
     }
 
-    private final void indexAndPropagateLeft(LeftTuple_ leftTuple, IndexProperties indexProperties) {
+    private void indexAndPropagateLeft(LeftTuple_ leftTuple, IndexProperties indexProperties) {
         leftTuple.setStore(inputStoreIndexLeftProperties, indexProperties);
         TupleListEntry<LeftTuple_> leftEntry = indexerLeft.put(indexProperties, leftTuple);
         leftTuple.setStore(inputStoreIndexLeftEntry, leftEntry);

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/common/AbstractJoinNode.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/common/AbstractJoinNode.java
@@ -74,7 +74,7 @@ public abstract class AbstractJoinNode<LeftTuple_ extends Tuple, Right_, OutTupl
         doUpdateOutTuple(outTuple);
     }
 
-    private final void doUpdateOutTuple(OutTuple_ outTuple) {
+    private void doUpdateOutTuple(OutTuple_ outTuple) {
         switch (outTuple.getState()) {
             case CREATING:
             case UPDATING:

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/common/AbstractScorer.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/common/AbstractScorer.java
@@ -38,6 +38,19 @@ public abstract class AbstractScorer<Tuple_ extends Tuple> implements TupleLifec
 
     protected abstract UndoScoreImpacter impact(Tuple_ tuple);
 
+    /**
+     * Helps with debugging exceptions thrown by user code during impact calls.
+     *
+     * @param tuple never null
+     * @param cause never null
+     * @return never null, exception to be thrown.
+     */
+    protected RuntimeException createExceptionOnImpact(Tuple_ tuple, Exception cause) {
+        return new IllegalStateException(
+                "Consequence of a constraint (" + constraintId + ") threw an exception processing a tuple (" + tuple + ").",
+                cause);
+    }
+
     @Override
     public final void retract(Tuple_ tuple) {
         UndoScoreImpacter undoScoreImpacter = tuple.getStore(inputStoreIndex);

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/quad/BavetAbstractQuadConstraintStream.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/quad/BavetAbstractQuadConstraintStream.java
@@ -397,12 +397,12 @@ public abstract class BavetAbstractQuadConstraintStream<Solution_, A, B, C, D>
 
     @Override
     protected final PentaFunction<A, B, C, D, Score<?>, DefaultConstraintJustification> getDefaultJustificationMapping() {
-        return InnerQuadConstraintStream.getDefaultJustificationMapping();
+        return InnerQuadConstraintStream.createDefaultJustificationMapping();
     }
 
     @Override
     protected final QuadFunction<A, B, C, D, Collection<?>> getDefaultIndictedObjectsMapping() {
-        return InnerQuadConstraintStream.getDefaultIndictedObjectsMapping();
+        return InnerQuadConstraintStream.createDefaultIndictedObjectsMapping();
     }
 
 }

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/quad/BavetScoringQuadConstraintStream.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/quad/BavetScoringQuadConstraintStream.java
@@ -1,6 +1,6 @@
 package org.optaplanner.constraint.streams.bavet.quad;
 
-import static org.optaplanner.constraint.streams.common.inliner.JustificationsSupplier.ofQuad;
+import static org.optaplanner.constraint.streams.common.inliner.JustificationsSupplier.of;
 
 import java.math.BigDecimal;
 import java.util.Collection;
@@ -117,25 +117,25 @@ public final class BavetScoringQuadConstraintStream<Solution_, A, B, C, D>
                 int matchWeight = intMatchWeigher.applyAsInt(a, b, c, d);
                 constraint.assertCorrectImpact(matchWeight);
                 return weightedScoreImpacter.impactScore(matchWeight,
-                        ofQuad(constraint, justificationMapping, indictedObjectsMapping, a, b, c, d));
+                        of(constraint, justificationMapping, indictedObjectsMapping, a, b, c, d));
             };
         } else if (longMatchWeigher != null) {
             scoreImpacter = (a, b, c, d) -> {
                 long matchWeight = longMatchWeigher.applyAsLong(a, b, c, d);
                 constraint.assertCorrectImpact(matchWeight);
                 return weightedScoreImpacter.impactScore(matchWeight,
-                        ofQuad(constraint, justificationMapping, indictedObjectsMapping, a, b, c, d));
+                        of(constraint, justificationMapping, indictedObjectsMapping, a, b, c, d));
             };
         } else if (bigDecimalMatchWeigher != null) {
             scoreImpacter = (a, b, c, d) -> {
                 BigDecimal matchWeight = bigDecimalMatchWeigher.apply(a, b, c, d);
                 constraint.assertCorrectImpact(matchWeight);
                 return weightedScoreImpacter.impactScore(matchWeight,
-                        ofQuad(constraint, justificationMapping, indictedObjectsMapping, a, b, c, d));
+                        of(constraint, justificationMapping, indictedObjectsMapping, a, b, c, d));
             };
         } else if (noMatchWeigher) {
             scoreImpacter = (a, b, c, d) -> weightedScoreImpacter.impactScore(1,
-                    ofQuad(constraint, justificationMapping, indictedObjectsMapping, a, b, c, d));
+                    of(constraint, justificationMapping, indictedObjectsMapping, a, b, c, d));
         } else {
             throw new IllegalStateException("Impossible state: neither of the supported match weighers provided.");
         }

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/quad/BavetScoringQuadConstraintStream.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/quad/BavetScoringQuadConstraintStream.java
@@ -1,6 +1,6 @@
 package org.optaplanner.constraint.streams.bavet.quad;
 
-import static org.optaplanner.constraint.streams.common.inliner.JustificationsSupplier.of;
+import static org.optaplanner.constraint.streams.common.inliner.JustificationsSupplier.ofQuad;
 
 import java.math.BigDecimal;
 import java.util.Collection;
@@ -117,29 +117,25 @@ public final class BavetScoringQuadConstraintStream<Solution_, A, B, C, D>
                 int matchWeight = intMatchWeigher.applyAsInt(a, b, c, d);
                 constraint.assertCorrectImpact(matchWeight);
                 return weightedScoreImpacter.impactScore(matchWeight,
-                        of(score -> justificationMapping.apply(a, b, c, d, score),
-                                () -> indictedObjectsMapping.apply(a, b, c, d)));
+                        ofQuad(constraint, justificationMapping, indictedObjectsMapping, a, b, c, d));
             };
         } else if (longMatchWeigher != null) {
             scoreImpacter = (a, b, c, d) -> {
                 long matchWeight = longMatchWeigher.applyAsLong(a, b, c, d);
                 constraint.assertCorrectImpact(matchWeight);
                 return weightedScoreImpacter.impactScore(matchWeight,
-                        of(score -> justificationMapping.apply(a, b, c, d, score),
-                                () -> indictedObjectsMapping.apply(a, b, c, d)));
+                        ofQuad(constraint, justificationMapping, indictedObjectsMapping, a, b, c, d));
             };
         } else if (bigDecimalMatchWeigher != null) {
             scoreImpacter = (a, b, c, d) -> {
                 BigDecimal matchWeight = bigDecimalMatchWeigher.apply(a, b, c, d);
                 constraint.assertCorrectImpact(matchWeight);
                 return weightedScoreImpacter.impactScore(matchWeight,
-                        of(score -> justificationMapping.apply(a, b, c, d, score),
-                                () -> indictedObjectsMapping.apply(a, b, c, d)));
+                        ofQuad(constraint, justificationMapping, indictedObjectsMapping, a, b, c, d));
             };
         } else if (noMatchWeigher) {
             scoreImpacter = (a, b, c, d) -> weightedScoreImpacter.impactScore(1,
-                    of(score -> justificationMapping.apply(a, b, c, d, score),
-                            () -> indictedObjectsMapping.apply(a, b, c, d)));
+                    ofQuad(constraint, justificationMapping, indictedObjectsMapping, a, b, c, d));
         } else {
             throw new IllegalStateException("Impossible state: neither of the supported match weighers provided.");
         }

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/quad/QuadScorer.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/quad/QuadScorer.java
@@ -17,6 +17,10 @@ final class QuadScorer<A, B, C, D> extends AbstractScorer<QuadTuple<A, B, C, D>>
 
     @Override
     protected UndoScoreImpacter impact(QuadTuple<A, B, C, D> tuple) {
-        return scoreImpacter.apply(tuple.getFactA(), tuple.getFactB(), tuple.getFactC(), tuple.getFactD());
+        try {
+            return scoreImpacter.apply(tuple.getFactA(), tuple.getFactB(), tuple.getFactC(), tuple.getFactD());
+        } catch (Exception e) {
+            throw createExceptionOnImpact(tuple, e);
+        }
     }
 }

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/tri/BavetAbstractTriConstraintStream.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/tri/BavetAbstractTriConstraintStream.java
@@ -426,12 +426,12 @@ public abstract class BavetAbstractTriConstraintStream<Solution_, A, B, C> exten
 
     @Override
     protected final QuadFunction<A, B, C, Score<?>, DefaultConstraintJustification> getDefaultJustificationMapping() {
-        return InnerTriConstraintStream.getDefaultJustificationMapping();
+        return InnerTriConstraintStream.createDefaultJustificationMapping();
     }
 
     @Override
     protected final TriFunction<A, B, C, Collection<?>> getDefaultIndictedObjectsMapping() {
-        return InnerTriConstraintStream.getDefaultIndictedObjectsMapping();
+        return InnerTriConstraintStream.createDefaultIndictedObjectsMapping();
     }
 
 }

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/tri/BavetScoringTriConstraintStream.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/tri/BavetScoringTriConstraintStream.java
@@ -1,6 +1,6 @@
 package org.optaplanner.constraint.streams.bavet.tri;
 
-import static org.optaplanner.constraint.streams.common.inliner.JustificationsSupplier.ofTri;
+import static org.optaplanner.constraint.streams.common.inliner.JustificationsSupplier.of;
 
 import java.math.BigDecimal;
 import java.util.Collection;
@@ -116,25 +116,25 @@ public final class BavetScoringTriConstraintStream<Solution_, A, B, C>
                 int matchWeight = intMatchWeigher.applyAsInt(a, b, c);
                 constraint.assertCorrectImpact(matchWeight);
                 return weightedScoreImpacter.impactScore(matchWeight,
-                        ofTri(constraint, justificationMapping, indictedObjectsMapping, a, b, c));
+                        of(constraint, justificationMapping, indictedObjectsMapping, a, b, c));
             };
         } else if (longMatchWeigher != null) {
             scoreImpacter = (a, b, c) -> {
                 long matchWeight = longMatchWeigher.applyAsLong(a, b, c);
                 constraint.assertCorrectImpact(matchWeight);
                 return weightedScoreImpacter.impactScore(matchWeight,
-                        ofTri(constraint, justificationMapping, indictedObjectsMapping, a, b, c));
+                        of(constraint, justificationMapping, indictedObjectsMapping, a, b, c));
             };
         } else if (bigDecimalMatchWeigher != null) {
             scoreImpacter = (a, b, c) -> {
                 BigDecimal matchWeight = bigDecimalMatchWeigher.apply(a, b, c);
                 constraint.assertCorrectImpact(matchWeight);
                 return weightedScoreImpacter.impactScore(matchWeight,
-                        ofTri(constraint, justificationMapping, indictedObjectsMapping, a, b, c));
+                        of(constraint, justificationMapping, indictedObjectsMapping, a, b, c));
             };
         } else if (noMatchWeigher) {
             scoreImpacter = (a, b, c) -> weightedScoreImpacter.impactScore(1,
-                    ofTri(constraint, justificationMapping, indictedObjectsMapping, a, b, c));
+                    of(constraint, justificationMapping, indictedObjectsMapping, a, b, c));
         } else {
             throw new IllegalStateException("Impossible state: neither of the supported match weighers provided.");
         }

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/tri/BavetScoringTriConstraintStream.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/tri/BavetScoringTriConstraintStream.java
@@ -1,6 +1,6 @@
 package org.optaplanner.constraint.streams.bavet.tri;
 
-import static org.optaplanner.constraint.streams.common.inliner.JustificationsSupplier.of;
+import static org.optaplanner.constraint.streams.common.inliner.JustificationsSupplier.ofTri;
 
 import java.math.BigDecimal;
 import java.util.Collection;
@@ -116,29 +116,25 @@ public final class BavetScoringTriConstraintStream<Solution_, A, B, C>
                 int matchWeight = intMatchWeigher.applyAsInt(a, b, c);
                 constraint.assertCorrectImpact(matchWeight);
                 return weightedScoreImpacter.impactScore(matchWeight,
-                        of(score -> justificationMapping.apply(a, b, c, score),
-                                () -> indictedObjectsMapping.apply(a, b, c)));
+                        ofTri(constraint, justificationMapping, indictedObjectsMapping, a, b, c));
             };
         } else if (longMatchWeigher != null) {
             scoreImpacter = (a, b, c) -> {
                 long matchWeight = longMatchWeigher.applyAsLong(a, b, c);
                 constraint.assertCorrectImpact(matchWeight);
                 return weightedScoreImpacter.impactScore(matchWeight,
-                        of(score -> justificationMapping.apply(a, b, c, score),
-                                () -> indictedObjectsMapping.apply(a, b, c)));
+                        ofTri(constraint, justificationMapping, indictedObjectsMapping, a, b, c));
             };
         } else if (bigDecimalMatchWeigher != null) {
             scoreImpacter = (a, b, c) -> {
                 BigDecimal matchWeight = bigDecimalMatchWeigher.apply(a, b, c);
                 constraint.assertCorrectImpact(matchWeight);
                 return weightedScoreImpacter.impactScore(matchWeight,
-                        of(score -> justificationMapping.apply(a, b, c, score),
-                                () -> indictedObjectsMapping.apply(a, b, c)));
+                        ofTri(constraint, justificationMapping, indictedObjectsMapping, a, b, c));
             };
         } else if (noMatchWeigher) {
             scoreImpacter = (a, b, c) -> weightedScoreImpacter.impactScore(1,
-                    of(score -> justificationMapping.apply(a, b, c, score),
-                            () -> indictedObjectsMapping.apply(a, b, c)));
+                    ofTri(constraint, justificationMapping, indictedObjectsMapping, a, b, c));
         } else {
             throw new IllegalStateException("Impossible state: neither of the supported match weighers provided.");
         }

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/tri/TriScorer.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/tri/TriScorer.java
@@ -17,6 +17,10 @@ final class TriScorer<A, B, C> extends AbstractScorer<TriTuple<A, B, C>> {
 
     @Override
     protected UndoScoreImpacter impact(TriTuple<A, B, C> tuple) {
-        return scoreImpacter.apply(tuple.getFactA(), tuple.getFactB(), tuple.getFactC());
+        try {
+            return scoreImpacter.apply(tuple.getFactA(), tuple.getFactB(), tuple.getFactC());
+        } catch (Exception e) {
+            throw createExceptionOnImpact(tuple, e);
+        }
     }
 }

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/uni/BavetAbstractUniConstraintStream.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/uni/BavetAbstractUniConstraintStream.java
@@ -416,12 +416,12 @@ public abstract class BavetAbstractUniConstraintStream<Solution_, A> extends Bav
 
     @Override
     protected final BiFunction<A, Score<?>, DefaultConstraintJustification> getDefaultJustificationMapping() {
-        return InnerUniConstraintStream.getDefaultJustificationMapping();
+        return InnerUniConstraintStream.createDefaultJustificationMapping();
     }
 
     @Override
     protected final Function<A, Collection<?>> getDefaultIndictedObjectsMapping() {
-        return InnerUniConstraintStream.getDefaultIndictedObjectsMapping();
+        return InnerUniConstraintStream.createDefaultIndictedObjectsMapping();
     }
 
 }

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/uni/BavetScoringUniConstraintStream.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/uni/BavetScoringUniConstraintStream.java
@@ -1,6 +1,6 @@
 package org.optaplanner.constraint.streams.bavet.uni;
 
-import static org.optaplanner.constraint.streams.common.inliner.JustificationsSupplier.ofUni;
+import static org.optaplanner.constraint.streams.common.inliner.JustificationsSupplier.of;
 
 import java.math.BigDecimal;
 import java.util.Collection;
@@ -119,25 +119,25 @@ public final class BavetScoringUniConstraintStream<Solution_, A>
                 int matchWeight = intMatchWeigher.applyAsInt(a);
                 constraint.assertCorrectImpact(matchWeight);
                 return weightedScoreImpacter.impactScore(matchWeight,
-                        ofUni(constraint, justificationMapping, indictedObjectsMapping, a));
+                        of(constraint, justificationMapping, indictedObjectsMapping, a));
             };
         } else if (longMatchWeigher != null) {
             scoreImpacter = a -> {
                 long matchWeight = longMatchWeigher.applyAsLong(a);
                 constraint.assertCorrectImpact(matchWeight);
                 return weightedScoreImpacter.impactScore(matchWeight,
-                        ofUni(constraint, justificationMapping, indictedObjectsMapping, a));
+                        of(constraint, justificationMapping, indictedObjectsMapping, a));
             };
         } else if (bigDecimalMatchWeigher != null) {
             scoreImpacter = a -> {
                 BigDecimal matchWeight = bigDecimalMatchWeigher.apply(a);
                 constraint.assertCorrectImpact(matchWeight);
                 return weightedScoreImpacter.impactScore(matchWeight,
-                        ofUni(constraint, justificationMapping, indictedObjectsMapping, a));
+                        of(constraint, justificationMapping, indictedObjectsMapping, a));
             };
         } else if (noMatchWeigher) {
             scoreImpacter = a -> weightedScoreImpacter.impactScore(1,
-                    ofUni(constraint, justificationMapping, indictedObjectsMapping, a));
+                    of(constraint, justificationMapping, indictedObjectsMapping, a));
         } else {
             throw new IllegalStateException("Impossible state: neither of the supported match weighers provided.");
         }

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/uni/BavetScoringUniConstraintStream.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/uni/BavetScoringUniConstraintStream.java
@@ -1,6 +1,6 @@
 package org.optaplanner.constraint.streams.bavet.uni;
 
-import static org.optaplanner.constraint.streams.common.inliner.JustificationsSupplier.of;
+import static org.optaplanner.constraint.streams.common.inliner.JustificationsSupplier.ofUni;
 
 import java.math.BigDecimal;
 import java.util.Collection;
@@ -119,25 +119,25 @@ public final class BavetScoringUniConstraintStream<Solution_, A>
                 int matchWeight = intMatchWeigher.applyAsInt(a);
                 constraint.assertCorrectImpact(matchWeight);
                 return weightedScoreImpacter.impactScore(matchWeight,
-                        of(score -> justificationMapping.apply(a, score), () -> indictedObjectsMapping.apply(a)));
+                        ofUni(constraint, justificationMapping, indictedObjectsMapping, a));
             };
         } else if (longMatchWeigher != null) {
             scoreImpacter = a -> {
                 long matchWeight = longMatchWeigher.applyAsLong(a);
                 constraint.assertCorrectImpact(matchWeight);
                 return weightedScoreImpacter.impactScore(matchWeight,
-                        of(score -> justificationMapping.apply(a, score), () -> indictedObjectsMapping.apply(a)));
+                        ofUni(constraint, justificationMapping, indictedObjectsMapping, a));
             };
         } else if (bigDecimalMatchWeigher != null) {
             scoreImpacter = a -> {
                 BigDecimal matchWeight = bigDecimalMatchWeigher.apply(a);
                 constraint.assertCorrectImpact(matchWeight);
                 return weightedScoreImpacter.impactScore(matchWeight,
-                        of(score -> justificationMapping.apply(a, score), () -> indictedObjectsMapping.apply(a)));
+                        ofUni(constraint, justificationMapping, indictedObjectsMapping, a));
             };
         } else if (noMatchWeigher) {
             scoreImpacter = a -> weightedScoreImpacter.impactScore(1,
-                    of(score -> justificationMapping.apply(a, score), () -> indictedObjectsMapping.apply(a)));
+                    ofUni(constraint, justificationMapping, indictedObjectsMapping, a));
         } else {
             throw new IllegalStateException("Impossible state: neither of the supported match weighers provided.");
         }

--- a/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/uni/UniScorer.java
+++ b/core/optaplanner-constraint-streams-bavet/src/main/java/org/optaplanner/constraint/streams/bavet/uni/UniScorer.java
@@ -18,6 +18,10 @@ final class UniScorer<A> extends AbstractScorer<UniTuple<A>> {
 
     @Override
     protected UndoScoreImpacter impact(UniTuple<A> tuple) {
-        return scoreImpacter.apply(tuple.getFactA());
+        try {
+            return scoreImpacter.apply(tuple.getFactA());
+        } catch (Exception e) {
+            throw createExceptionOnImpact(tuple, e);
+        }
     }
 }

--- a/core/optaplanner-constraint-streams-common/src/main/java/org/optaplanner/constraint/streams/common/bi/InnerBiConstraintStream.java
+++ b/core/optaplanner-constraint-streams-common/src/main/java/org/optaplanner/constraint/streams/common/bi/InnerBiConstraintStream.java
@@ -22,11 +22,11 @@ import org.optaplanner.core.api.score.stream.tri.TriJoiner;
 
 public interface InnerBiConstraintStream<A, B> extends BiConstraintStream<A, B> {
 
-    static <A, B> TriFunction<A, B, Score<?>, DefaultConstraintJustification> getDefaultJustificationMapping() {
+    static <A, B> TriFunction<A, B, Score<?>, DefaultConstraintJustification> createDefaultJustificationMapping() {
         return (a, b, score) -> DefaultConstraintJustification.of(score, a, b);
     }
 
-    static <A, B> BiFunction<A, B, Collection<?>> getDefaultIndictedObjectsMapping() {
+    static <A, B> BiFunction<A, B, Collection<?>> createDefaultIndictedObjectsMapping() {
         return List::of;
     }
 

--- a/core/optaplanner-constraint-streams-common/src/main/java/org/optaplanner/constraint/streams/common/inliner/AbstractScoreInliner.java
+++ b/core/optaplanner-constraint-streams-common/src/main/java/org/optaplanner/constraint/streams/common/inliner/AbstractScoreInliner.java
@@ -123,9 +123,9 @@ public abstract class AbstractScoreInliner<Score_ extends Score<Score_>> {
         DefaultConstraintMatchTotal<Score_> constraintMatchTotal = constraintMatchTotalMap.computeIfAbsent(
                 constraint.getConstraintId(),
                 key -> new DefaultConstraintMatchTotal<>(constraintPackage, constraintName, constraintWeight));
-        ConstraintMatch<Score_> constraintMatch =
-                constraintMatchTotal.addConstraintMatch(justificationsSupplier.createConstraintJustification(score),
-                        justificationsSupplier.createIndictedObjects(), score);
+        ConstraintMatch<Score_> constraintMatch = constraintMatchTotal.addConstraintMatch(
+                justificationsSupplier.createConstraintJustification(score),
+                justificationsSupplier.createIndictedObjects(), score);
         List<DefaultIndictment<Score_>> indictments = constraintMatch.getIndictedObjectList()
                 .stream()
                 .distinct() // One match might have the same justification twice

--- a/core/optaplanner-constraint-streams-common/src/main/java/org/optaplanner/constraint/streams/common/inliner/JustificationsSupplier.java
+++ b/core/optaplanner-constraint-streams-common/src/main/java/org/optaplanner/constraint/streams/common/inliner/JustificationsSupplier.java
@@ -1,12 +1,19 @@
 package org.optaplanner.constraint.streams.common.inliner;
 
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Objects;
+import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
 
+import org.optaplanner.core.api.function.PentaFunction;
+import org.optaplanner.core.api.function.QuadFunction;
+import org.optaplanner.core.api.function.TriFunction;
 import org.optaplanner.core.api.score.Score;
+import org.optaplanner.core.api.score.stream.Constraint;
 import org.optaplanner.core.api.score.stream.ConstraintJustification;
 import org.optaplanner.core.api.score.stream.DefaultConstraintJustification;
 
@@ -22,9 +29,104 @@ public final class JustificationsSupplier {
         return new JustificationsSupplier(DefaultConstraintJustification::of, Collections::emptyList);
     }
 
-    public static JustificationsSupplier of(Function<Score<?>, ConstraintJustification> constraintJustificationSupplier,
-            Supplier<Collection<Object>> indictedObjectsSupplier) {
-        return new JustificationsSupplier(constraintJustificationSupplier, indictedObjectsSupplier);
+    public static <A> JustificationsSupplier ofUni(Constraint constraint,
+            BiFunction<A, Score<?>, ConstraintJustification> justificationMapping,
+            Function<A, Collection<Object>> indictedObjectsMapping,
+            A a) {
+        Function<Score<?>, ConstraintJustification> explainingJustificationMapping = impact -> {
+            try {
+                return justificationMapping.apply(a, impact);
+            } catch (Exception e) {
+                throw createJustificationException(constraint, e, a);
+            }
+        };
+        Supplier<Collection<Object>> explainingIndictedObjectsSupplier = () -> {
+            try {
+                return indictedObjectsMapping.apply(a);
+            } catch (Exception e) {
+                throw createIndictmentException(constraint, e, a);
+            }
+        };
+        return new JustificationsSupplier(explainingJustificationMapping, explainingIndictedObjectsSupplier);
+    }
+
+    private static RuntimeException createJustificationException(Constraint constraint, Exception cause, Object... facts) {
+        throw new IllegalStateException("Consequence of a constraint (" + constraint.getConstraintId()
+                + ") threw an exception creating constraint justification from a tuple (" + factsToString(facts) + ").", cause);
+    }
+
+    private static String factsToString(Object... facts) {
+        return Arrays.stream(facts)
+                .map(Object::toString)
+                .collect(Collectors.joining(", ", "{", "}"));
+    }
+
+    private static RuntimeException createIndictmentException(Constraint constraint, Exception cause, Object... facts) {
+        throw new IllegalStateException("Consequence of a constraint (" + constraint.getConstraintId()
+                + ") threw an exception collecting indicted objects from a tuple (" + factsToString(facts) + ").", cause);
+    }
+
+    public static <A, B> JustificationsSupplier ofBi(Constraint constraint,
+            TriFunction<A, B, Score<?>, ConstraintJustification> justificationMapping,
+            BiFunction<A, B, Collection<Object>> indictedObjectsMapping,
+            A a, B b) {
+        Function<Score<?>, ConstraintJustification> explainingJustificationMapping = impact -> {
+            try {
+                return justificationMapping.apply(a, b, impact);
+            } catch (Exception e) {
+                throw createJustificationException(constraint, e, a, b);
+            }
+        };
+        Supplier<Collection<Object>> explainingIndictedObjectsSupplier = () -> {
+            try {
+                return indictedObjectsMapping.apply(a, b);
+            } catch (Exception e) {
+                throw createIndictmentException(constraint, e, a, b);
+            }
+        };
+        return new JustificationsSupplier(explainingJustificationMapping, explainingIndictedObjectsSupplier);
+    }
+
+    public static <A, B, C> JustificationsSupplier ofTri(Constraint constraint,
+            QuadFunction<A, B, C, Score<?>, ConstraintJustification> justificationMapping,
+            TriFunction<A, B, C, Collection<Object>> indictedObjectsMapping,
+            A a, B b, C c) {
+        Function<Score<?>, ConstraintJustification> explainingJustificationMapping = impact -> {
+            try {
+                return justificationMapping.apply(a, b, c, impact);
+            } catch (Exception e) {
+                throw createJustificationException(constraint, e, a, b, c);
+            }
+        };
+        Supplier<Collection<Object>> explainingIndictedObjectsSupplier = () -> {
+            try {
+                return indictedObjectsMapping.apply(a, b, c);
+            } catch (Exception e) {
+                throw createIndictmentException(constraint, e, a, b, c);
+            }
+        };
+        return new JustificationsSupplier(explainingJustificationMapping, explainingIndictedObjectsSupplier);
+    }
+
+    public static <A, B, C, D> JustificationsSupplier ofQuad(Constraint constraint,
+            PentaFunction<A, B, C, D, Score<?>, ConstraintJustification> justificationMapping,
+            QuadFunction<A, B, C, D, Collection<Object>> indictedObjectsMapping,
+            A a, B b, C c, D d) {
+        Function<Score<?>, ConstraintJustification> explainingJustificationMapping = impact -> {
+            try {
+                return justificationMapping.apply(a, b, c, d, impact);
+            } catch (Exception e) {
+                throw createJustificationException(constraint, e, a, b, c, d);
+            }
+        };
+        Supplier<Collection<Object>> explainingIndictedObjectsSupplier = () -> {
+            try {
+                return indictedObjectsMapping.apply(a, b, c, d);
+            } catch (Exception e) {
+                throw createIndictmentException(constraint, e, a, b, c, d);
+            }
+        };
+        return new JustificationsSupplier(explainingJustificationMapping, explainingIndictedObjectsSupplier);
     }
 
     private final Function<Score<?>, ConstraintJustification> constraintJustificationSupplier;

--- a/core/optaplanner-constraint-streams-common/src/main/java/org/optaplanner/constraint/streams/common/inliner/JustificationsSupplier.java
+++ b/core/optaplanner-constraint-streams-common/src/main/java/org/optaplanner/constraint/streams/common/inliner/JustificationsSupplier.java
@@ -29,7 +29,7 @@ public final class JustificationsSupplier {
         return new JustificationsSupplier(DefaultConstraintJustification::of, Collections::emptyList);
     }
 
-    public static <A> JustificationsSupplier ofUni(Constraint constraint,
+    public static <A> JustificationsSupplier of(Constraint constraint,
             BiFunction<A, Score<?>, ConstraintJustification> justificationMapping,
             Function<A, Collection<Object>> indictedObjectsMapping,
             A a) {
@@ -66,7 +66,7 @@ public final class JustificationsSupplier {
                 + ") threw an exception collecting indicted objects from a tuple (" + factsToString(facts) + ").", cause);
     }
 
-    public static <A, B> JustificationsSupplier ofBi(Constraint constraint,
+    public static <A, B> JustificationsSupplier of(Constraint constraint,
             TriFunction<A, B, Score<?>, ConstraintJustification> justificationMapping,
             BiFunction<A, B, Collection<Object>> indictedObjectsMapping,
             A a, B b) {
@@ -87,7 +87,7 @@ public final class JustificationsSupplier {
         return new JustificationsSupplier(explainingJustificationMapping, explainingIndictedObjectsSupplier);
     }
 
-    public static <A, B, C> JustificationsSupplier ofTri(Constraint constraint,
+    public static <A, B, C> JustificationsSupplier of(Constraint constraint,
             QuadFunction<A, B, C, Score<?>, ConstraintJustification> justificationMapping,
             TriFunction<A, B, C, Collection<Object>> indictedObjectsMapping,
             A a, B b, C c) {
@@ -108,7 +108,7 @@ public final class JustificationsSupplier {
         return new JustificationsSupplier(explainingJustificationMapping, explainingIndictedObjectsSupplier);
     }
 
-    public static <A, B, C, D> JustificationsSupplier ofQuad(Constraint constraint,
+    public static <A, B, C, D> JustificationsSupplier of(Constraint constraint,
             PentaFunction<A, B, C, D, Score<?>, ConstraintJustification> justificationMapping,
             QuadFunction<A, B, C, D, Collection<Object>> indictedObjectsMapping,
             A a, B b, C c, D d) {

--- a/core/optaplanner-constraint-streams-common/src/main/java/org/optaplanner/constraint/streams/common/quad/InnerQuadConstraintStream.java
+++ b/core/optaplanner-constraint-streams-common/src/main/java/org/optaplanner/constraint/streams/common/quad/InnerQuadConstraintStream.java
@@ -17,11 +17,12 @@ import org.optaplanner.core.api.score.stream.quad.QuadConstraintStream;
 
 public interface InnerQuadConstraintStream<A, B, C, D> extends QuadConstraintStream<A, B, C, D> {
 
-    static <A, B, C, D> PentaFunction<A, B, C, D, Score<?>, DefaultConstraintJustification> getDefaultJustificationMapping() {
+    static <A, B, C, D> PentaFunction<A, B, C, D, Score<?>, DefaultConstraintJustification>
+            createDefaultJustificationMapping() {
         return (a, b, c, d, score) -> DefaultConstraintJustification.of(score, a, b, c, d);
     }
 
-    static <A, B, C, D> QuadFunction<A, B, C, D, Collection<?>> getDefaultIndictedObjectsMapping() {
+    static <A, B, C, D> QuadFunction<A, B, C, D, Collection<?>> createDefaultIndictedObjectsMapping() {
         return List::of;
     }
 

--- a/core/optaplanner-constraint-streams-common/src/main/java/org/optaplanner/constraint/streams/common/tri/InnerTriConstraintStream.java
+++ b/core/optaplanner-constraint-streams-common/src/main/java/org/optaplanner/constraint/streams/common/tri/InnerTriConstraintStream.java
@@ -20,11 +20,11 @@ import org.optaplanner.core.api.score.stream.tri.TriConstraintStream;
 
 public interface InnerTriConstraintStream<A, B, C> extends TriConstraintStream<A, B, C> {
 
-    static <A, B, C> QuadFunction<A, B, C, Score<?>, DefaultConstraintJustification> getDefaultJustificationMapping() {
+    static <A, B, C> QuadFunction<A, B, C, Score<?>, DefaultConstraintJustification> createDefaultJustificationMapping() {
         return (a, b, c, score) -> DefaultConstraintJustification.of(score, a, b, c);
     }
 
-    static <A, B, C> TriFunction<A, B, C, Collection<?>> getDefaultIndictedObjectsMapping() {
+    static <A, B, C> TriFunction<A, B, C, Collection<?>> createDefaultIndictedObjectsMapping() {
         return List::of;
     }
 

--- a/core/optaplanner-constraint-streams-common/src/main/java/org/optaplanner/constraint/streams/common/uni/InnerUniConstraintStream.java
+++ b/core/optaplanner-constraint-streams-common/src/main/java/org/optaplanner/constraint/streams/common/uni/InnerUniConstraintStream.java
@@ -22,11 +22,11 @@ import org.optaplanner.core.api.score.stream.uni.UniConstraintStream;
 
 public interface InnerUniConstraintStream<A> extends UniConstraintStream<A> {
 
-    static <A> BiFunction<A, Score<?>, DefaultConstraintJustification> getDefaultJustificationMapping() {
+    static <A> BiFunction<A, Score<?>, DefaultConstraintJustification> createDefaultJustificationMapping() {
         return (a, score) -> DefaultConstraintJustification.of(score, a);
     }
 
-    static <A> Function<A, Collection<?>> getDefaultIndictedObjectsMapping() {
+    static <A> Function<A, Collection<?>> createDefaultIndictedObjectsMapping() {
         return List::of;
     }
 

--- a/core/optaplanner-constraint-streams-drools/src/main/java/org/optaplanner/constraint/streams/drools/bi/DroolsAbstractBiConstraintStream.java
+++ b/core/optaplanner-constraint-streams-drools/src/main/java/org/optaplanner/constraint/streams/drools/bi/DroolsAbstractBiConstraintStream.java
@@ -308,12 +308,12 @@ public abstract class DroolsAbstractBiConstraintStream<Solution_, A, B>
 
     @Override
     protected final TriFunction<A, B, Score<?>, DefaultConstraintJustification> getDefaultJustificationMapping() {
-        return InnerBiConstraintStream.getDefaultJustificationMapping();
+        return InnerBiConstraintStream.createDefaultJustificationMapping();
     }
 
     @Override
     protected final BiFunction<A, B, Collection<?>> getDefaultIndictedObjectsMapping() {
-        return InnerBiConstraintStream.getDefaultIndictedObjectsMapping();
+        return InnerBiConstraintStream.createDefaultIndictedObjectsMapping();
     }
 
     public abstract BiLeftHandSide<A, B> getLeftHandSide();

--- a/core/optaplanner-constraint-streams-drools/src/main/java/org/optaplanner/constraint/streams/drools/common/AbstractRuleContext.java
+++ b/core/optaplanner-constraint-streams-drools/src/main/java/org/optaplanner/constraint/streams/drools/common/AbstractRuleContext.java
@@ -31,28 +31,45 @@ abstract class AbstractRuleContext {
 
     protected static void runConsequence(DroolsConstraint<?> constraint, Drools drools,
             WeightedScoreImpacter scoreImpacter, int impact, JustificationsSupplier justificationsSupplier) {
-        constraint.assertCorrectImpact(impact);
-        UndoScoreImpacter undoImpact = scoreImpacter.impactScore(impact, justificationsSupplier);
-        addUndo(drools, undoImpact);
-    }
-
-    protected static void runConsequence(DroolsConstraint<?> constraint, Drools drools,
-            WeightedScoreImpacter scoreImpacter, long impact, JustificationsSupplier justificationsSupplier) {
-        constraint.assertCorrectImpact(impact);
-        UndoScoreImpacter undoImpact = scoreImpacter.impactScore(impact, justificationsSupplier);
-        addUndo(drools, undoImpact);
-    }
-
-    protected static void runConsequence(DroolsConstraint<?> constraint, Drools drools,
-            WeightedScoreImpacter scoreImpacter, BigDecimal impact, JustificationsSupplier justificationsSupplier) {
-        constraint.assertCorrectImpact(impact);
-        UndoScoreImpacter undoImpact = scoreImpacter.impactScore(impact, justificationsSupplier);
-        addUndo(drools, undoImpact);
+        try {
+            constraint.assertCorrectImpact(impact);
+            UndoScoreImpacter undoImpact = scoreImpacter.impactScore(impact, justificationsSupplier);
+            addUndo(drools, undoImpact);
+        } catch (Exception e) {
+            throw createExceptionOnImpact(constraint, e);
+        }
     }
 
     private static void addUndo(Drools drools, UndoScoreImpacter undoImpact) {
         AgendaItem agendaItem = (AgendaItem) ((RuleContext) drools).getMatch();
         agendaItem.setCallback(undoImpact);
+    }
+
+    private static RuntimeException createExceptionOnImpact(DroolsConstraint<?> constraint, Exception cause) {
+        return new IllegalStateException(
+                "Consequence of a constraint (" + constraint.getConstraintId() + ") threw an exception.", cause);
+    }
+
+    protected static void runConsequence(DroolsConstraint<?> constraint, Drools drools,
+            WeightedScoreImpacter scoreImpacter, long impact, JustificationsSupplier justificationsSupplier) {
+        try {
+            constraint.assertCorrectImpact(impact);
+            UndoScoreImpacter undoImpact = scoreImpacter.impactScore(impact, justificationsSupplier);
+            addUndo(drools, undoImpact);
+        } catch (Exception e) {
+            throw createExceptionOnImpact(constraint, e);
+        }
+    }
+
+    protected static void runConsequence(DroolsConstraint<?> constraint, Drools drools,
+            WeightedScoreImpacter scoreImpacter, BigDecimal impact, JustificationsSupplier justificationsSupplier) {
+        try {
+            constraint.assertCorrectImpact(impact);
+            UndoScoreImpacter undoImpact = scoreImpacter.impactScore(impact, justificationsSupplier);
+            addUndo(drools, undoImpact);
+        } catch (Exception e) {
+            throw createExceptionOnImpact(constraint, e);
+        }
     }
 
     protected <Solution_> RuleBuilder<Solution_> assemble(ConsequenceBuilder<Solution_> consequenceBuilder) {

--- a/core/optaplanner-constraint-streams-drools/src/main/java/org/optaplanner/constraint/streams/drools/common/BiLeftHandSide.java
+++ b/core/optaplanner-constraint-streams-drools/src/main/java/org/optaplanner/constraint/streams/drools/common/BiLeftHandSide.java
@@ -472,10 +472,6 @@ public final class BiLeftHandSide<A, B> extends AbstractLeftHandSide {
         return new BiLeftHandSide<>(patternVariableA.getPrimaryVariable(), newPatternVariableB, variableFactory);
     }
 
-    public <Solution_> RuleBuilder<Solution_> andTerminate() {
-        return ruleContext.newRuleBuilder();
-    }
-
     public <Solution_> RuleBuilder<Solution_> andTerminate(ToIntBiFunction<A, B> matchWeigher) {
         return ruleContext.newRuleBuilder(matchWeigher);
     }

--- a/core/optaplanner-constraint-streams-drools/src/main/java/org/optaplanner/constraint/streams/drools/common/BiRuleContext.java
+++ b/core/optaplanner-constraint-streams-drools/src/main/java/org/optaplanner/constraint/streams/drools/common/BiRuleContext.java
@@ -1,6 +1,6 @@
 package org.optaplanner.constraint.streams.drools.common;
 
-import static org.optaplanner.constraint.streams.common.inliner.JustificationsSupplier.ofBi;
+import static org.optaplanner.constraint.streams.common.inliner.JustificationsSupplier.of;
 
 import java.math.BigDecimal;
 import java.util.Collection;
@@ -37,7 +37,7 @@ final class BiRuleContext<A, B> extends AbstractRuleContext {
                     return DSL.on(scoreImpacterGlobal, variableA, variableB)
                             .execute((drools, scoreImpacter, a, b) -> {
                                 JustificationsSupplier justificationsSupplier =
-                                        ofBi(constraint, justificationMapping, indictedObjectsMapping, a, b);
+                                        of(constraint, justificationMapping, indictedObjectsMapping, a, b);
                                 runConsequence(constraint, drools, scoreImpacter, matchWeigher.applyAsInt(a, b),
                                         justificationsSupplier);
                             });
@@ -54,7 +54,7 @@ final class BiRuleContext<A, B> extends AbstractRuleContext {
                     return DSL.on(scoreImpacterGlobal, variableA, variableB)
                             .execute((drools, scoreImpacter, a, b) -> {
                                 JustificationsSupplier justificationsSupplier =
-                                        ofBi(constraint, justificationMapping, indictedObjectsMapping, a, b);
+                                        of(constraint, justificationMapping, indictedObjectsMapping, a, b);
                                 runConsequence(constraint, drools, scoreImpacter, matchWeigher.applyAsLong(a, b),
                                         justificationsSupplier);
                             });
@@ -71,7 +71,7 @@ final class BiRuleContext<A, B> extends AbstractRuleContext {
                     return DSL.on(scoreImpacterGlobal, variableA, variableB)
                             .execute((drools, scoreImpacter, a, b) -> {
                                 JustificationsSupplier justificationsSupplier =
-                                        ofBi(constraint, justificationMapping, indictedObjectsMapping, a, b);
+                                        of(constraint, justificationMapping, indictedObjectsMapping, a, b);
                                 runConsequence(constraint, drools, scoreImpacter, matchWeigher.apply(a, b),
                                         justificationsSupplier);
                             });

--- a/core/optaplanner-constraint-streams-drools/src/main/java/org/optaplanner/constraint/streams/drools/common/BiRuleContext.java
+++ b/core/optaplanner-constraint-streams-drools/src/main/java/org/optaplanner/constraint/streams/drools/common/BiRuleContext.java
@@ -1,6 +1,6 @@
 package org.optaplanner.constraint.streams.drools.common;
 
-import static org.optaplanner.constraint.streams.common.inliner.JustificationsSupplier.of;
+import static org.optaplanner.constraint.streams.common.inliner.JustificationsSupplier.ofBi;
 
 import java.math.BigDecimal;
 import java.util.Collection;
@@ -37,8 +37,7 @@ final class BiRuleContext<A, B> extends AbstractRuleContext {
                     return DSL.on(scoreImpacterGlobal, variableA, variableB)
                             .execute((drools, scoreImpacter, a, b) -> {
                                 JustificationsSupplier justificationsSupplier =
-                                        of(score -> justificationMapping.apply(a, b, score),
-                                                () -> indictedObjectsMapping.apply(a, b));
+                                        ofBi(constraint, justificationMapping, indictedObjectsMapping, a, b);
                                 runConsequence(constraint, drools, scoreImpacter, matchWeigher.applyAsInt(a, b),
                                         justificationsSupplier);
                             });
@@ -55,8 +54,7 @@ final class BiRuleContext<A, B> extends AbstractRuleContext {
                     return DSL.on(scoreImpacterGlobal, variableA, variableB)
                             .execute((drools, scoreImpacter, a, b) -> {
                                 JustificationsSupplier justificationsSupplier =
-                                        of(score -> justificationMapping.apply(a, b, score),
-                                                () -> indictedObjectsMapping.apply(a, b));
+                                        ofBi(constraint, justificationMapping, indictedObjectsMapping, a, b);
                                 runConsequence(constraint, drools, scoreImpacter, matchWeigher.applyAsLong(a, b),
                                         justificationsSupplier);
                             });
@@ -73,17 +71,12 @@ final class BiRuleContext<A, B> extends AbstractRuleContext {
                     return DSL.on(scoreImpacterGlobal, variableA, variableB)
                             .execute((drools, scoreImpacter, a, b) -> {
                                 JustificationsSupplier justificationsSupplier =
-                                        of(score -> justificationMapping.apply(a, b, score),
-                                                () -> indictedObjectsMapping.apply(a, b));
+                                        ofBi(constraint, justificationMapping, indictedObjectsMapping, a, b);
                                 runConsequence(constraint, drools, scoreImpacter, matchWeigher.apply(a, b),
                                         justificationsSupplier);
                             });
                 };
         return assemble(consequenceBuilder);
-    }
-
-    public <Solution_> RuleBuilder<Solution_> newRuleBuilder() {
-        return newRuleBuilder((ToIntBiFunction<A, B>) (a, b) -> 1);
     }
 
 }

--- a/core/optaplanner-constraint-streams-drools/src/main/java/org/optaplanner/constraint/streams/drools/common/QuadRuleContext.java
+++ b/core/optaplanner-constraint-streams-drools/src/main/java/org/optaplanner/constraint/streams/drools/common/QuadRuleContext.java
@@ -1,6 +1,6 @@
 package org.optaplanner.constraint.streams.drools.common;
 
-import static org.optaplanner.constraint.streams.common.inliner.JustificationsSupplier.ofQuad;
+import static org.optaplanner.constraint.streams.common.inliner.JustificationsSupplier.of;
 
 import java.math.BigDecimal;
 import java.util.Collection;
@@ -43,7 +43,7 @@ final class QuadRuleContext<A, B, C, D> extends AbstractRuleContext {
                     return DSL.on(scoreImpacterGlobal, variableA, variableB, variableC, variableD)
                             .execute((drools, scoreImpacter, a, b, c, d) -> {
                                 JustificationsSupplier justificationsSupplier =
-                                        ofQuad(constraint, justificationMapping, indictedObjectsMapping, a, b, c, d);
+                                        of(constraint, justificationMapping, indictedObjectsMapping, a, b, c, d);
                                 runConsequence(constraint, drools, scoreImpacter, matchWeigher.applyAsInt(a, b, c, d),
                                         justificationsSupplier);
                             });
@@ -61,7 +61,7 @@ final class QuadRuleContext<A, B, C, D> extends AbstractRuleContext {
                     return DSL.on(scoreImpacterGlobal, variableA, variableB, variableC, variableD)
                             .execute((drools, scoreImpacter, a, b, c, d) -> {
                                 JustificationsSupplier justificationsSupplier =
-                                        ofQuad(constraint, justificationMapping, indictedObjectsMapping, a, b, c, d);
+                                        of(constraint, justificationMapping, indictedObjectsMapping, a, b, c, d);
                                 runConsequence(constraint, drools, scoreImpacter, matchWeigher.applyAsLong(a, b, c, d),
                                         justificationsSupplier);
                             });
@@ -79,7 +79,7 @@ final class QuadRuleContext<A, B, C, D> extends AbstractRuleContext {
                     return DSL.on(scoreImpacterGlobal, variableA, variableB, variableC, variableD)
                             .execute((drools, scoreImpacter, a, b, c, d) -> {
                                 JustificationsSupplier justificationsSupplier =
-                                        ofQuad(constraint, justificationMapping, indictedObjectsMapping, a, b, c, d);
+                                        of(constraint, justificationMapping, indictedObjectsMapping, a, b, c, d);
                                 runConsequence(constraint, drools, scoreImpacter, matchWeigher.apply(a, b, c, d),
                                         justificationsSupplier);
                             });

--- a/core/optaplanner-constraint-streams-drools/src/main/java/org/optaplanner/constraint/streams/drools/common/QuadRuleContext.java
+++ b/core/optaplanner-constraint-streams-drools/src/main/java/org/optaplanner/constraint/streams/drools/common/QuadRuleContext.java
@@ -1,6 +1,6 @@
 package org.optaplanner.constraint.streams.drools.common;
 
-import static org.optaplanner.constraint.streams.common.inliner.JustificationsSupplier.of;
+import static org.optaplanner.constraint.streams.common.inliner.JustificationsSupplier.ofQuad;
 
 import java.math.BigDecimal;
 import java.util.Collection;
@@ -43,8 +43,7 @@ final class QuadRuleContext<A, B, C, D> extends AbstractRuleContext {
                     return DSL.on(scoreImpacterGlobal, variableA, variableB, variableC, variableD)
                             .execute((drools, scoreImpacter, a, b, c, d) -> {
                                 JustificationsSupplier justificationsSupplier =
-                                        of(score -> justificationMapping.apply(a, b, c, d, score),
-                                                () -> indictedObjectsMapping.apply(a, b, c, d));
+                                        ofQuad(constraint, justificationMapping, indictedObjectsMapping, a, b, c, d);
                                 runConsequence(constraint, drools, scoreImpacter, matchWeigher.applyAsInt(a, b, c, d),
                                         justificationsSupplier);
                             });
@@ -62,8 +61,7 @@ final class QuadRuleContext<A, B, C, D> extends AbstractRuleContext {
                     return DSL.on(scoreImpacterGlobal, variableA, variableB, variableC, variableD)
                             .execute((drools, scoreImpacter, a, b, c, d) -> {
                                 JustificationsSupplier justificationsSupplier =
-                                        of(score -> justificationMapping.apply(a, b, c, d, score),
-                                                () -> indictedObjectsMapping.apply(a, b, c, d));
+                                        ofQuad(constraint, justificationMapping, indictedObjectsMapping, a, b, c, d);
                                 runConsequence(constraint, drools, scoreImpacter, matchWeigher.applyAsLong(a, b, c, d),
                                         justificationsSupplier);
                             });
@@ -81,8 +79,7 @@ final class QuadRuleContext<A, B, C, D> extends AbstractRuleContext {
                     return DSL.on(scoreImpacterGlobal, variableA, variableB, variableC, variableD)
                             .execute((drools, scoreImpacter, a, b, c, d) -> {
                                 JustificationsSupplier justificationsSupplier =
-                                        of(score -> justificationMapping.apply(a, b, c, d, score),
-                                                () -> indictedObjectsMapping.apply(a, b, c, d));
+                                        ofQuad(constraint, justificationMapping, indictedObjectsMapping, a, b, c, d);
                                 runConsequence(constraint, drools, scoreImpacter, matchWeigher.apply(a, b, c, d),
                                         justificationsSupplier);
                             });

--- a/core/optaplanner-constraint-streams-drools/src/main/java/org/optaplanner/constraint/streams/drools/common/TriRuleContext.java
+++ b/core/optaplanner-constraint-streams-drools/src/main/java/org/optaplanner/constraint/streams/drools/common/TriRuleContext.java
@@ -1,6 +1,6 @@
 package org.optaplanner.constraint.streams.drools.common;
 
-import static org.optaplanner.constraint.streams.common.inliner.JustificationsSupplier.of;
+import static org.optaplanner.constraint.streams.common.inliner.JustificationsSupplier.ofTri;
 
 import java.math.BigDecimal;
 import java.util.Collection;
@@ -40,8 +40,7 @@ final class TriRuleContext<A, B, C> extends AbstractRuleContext {
                     return DSL.on(scoreImpacterGlobal, variableA, variableB, variableC)
                             .execute((drools, scoreImpacter, a, b, c) -> {
                                 JustificationsSupplier justificationsSupplier =
-                                        of(score -> justificationMapping.apply(a, b, c, score),
-                                                () -> indictedObjectsMapping.apply(a, b, c));
+                                        ofTri(constraint, justificationMapping, indictedObjectsMapping, a, b, c);
                                 runConsequence(constraint, drools, scoreImpacter, matchWeigher.applyAsInt(a, b, c),
                                         justificationsSupplier);
                             });
@@ -58,8 +57,7 @@ final class TriRuleContext<A, B, C> extends AbstractRuleContext {
                     return DSL.on(scoreImpacterGlobal, variableA, variableB, variableC)
                             .execute((drools, scoreImpacter, a, b, c) -> {
                                 JustificationsSupplier justificationsSupplier =
-                                        of(score -> justificationMapping.apply(a, b, c, score),
-                                                () -> indictedObjectsMapping.apply(a, b, c));
+                                        ofTri(constraint, justificationMapping, indictedObjectsMapping, a, b, c);
                                 runConsequence(constraint, drools, scoreImpacter, matchWeigher.applyAsLong(a, b, c),
                                         justificationsSupplier);
                             });
@@ -76,8 +74,7 @@ final class TriRuleContext<A, B, C> extends AbstractRuleContext {
                     return DSL.on(scoreImpacterGlobal, variableA, variableB, variableC)
                             .execute((drools, scoreImpacter, a, b, c) -> {
                                 JustificationsSupplier justificationsSupplier =
-                                        of(score -> justificationMapping.apply(a, b, c, score),
-                                                () -> indictedObjectsMapping.apply(a, b, c));
+                                        ofTri(constraint, justificationMapping, indictedObjectsMapping, a, b, c);
                                 runConsequence(constraint, drools, scoreImpacter, matchWeigher.apply(a, b, c),
                                         justificationsSupplier);
                             });

--- a/core/optaplanner-constraint-streams-drools/src/main/java/org/optaplanner/constraint/streams/drools/common/TriRuleContext.java
+++ b/core/optaplanner-constraint-streams-drools/src/main/java/org/optaplanner/constraint/streams/drools/common/TriRuleContext.java
@@ -1,6 +1,6 @@
 package org.optaplanner.constraint.streams.drools.common;
 
-import static org.optaplanner.constraint.streams.common.inliner.JustificationsSupplier.ofTri;
+import static org.optaplanner.constraint.streams.common.inliner.JustificationsSupplier.of;
 
 import java.math.BigDecimal;
 import java.util.Collection;
@@ -40,7 +40,7 @@ final class TriRuleContext<A, B, C> extends AbstractRuleContext {
                     return DSL.on(scoreImpacterGlobal, variableA, variableB, variableC)
                             .execute((drools, scoreImpacter, a, b, c) -> {
                                 JustificationsSupplier justificationsSupplier =
-                                        ofTri(constraint, justificationMapping, indictedObjectsMapping, a, b, c);
+                                        of(constraint, justificationMapping, indictedObjectsMapping, a, b, c);
                                 runConsequence(constraint, drools, scoreImpacter, matchWeigher.applyAsInt(a, b, c),
                                         justificationsSupplier);
                             });
@@ -57,7 +57,7 @@ final class TriRuleContext<A, B, C> extends AbstractRuleContext {
                     return DSL.on(scoreImpacterGlobal, variableA, variableB, variableC)
                             .execute((drools, scoreImpacter, a, b, c) -> {
                                 JustificationsSupplier justificationsSupplier =
-                                        ofTri(constraint, justificationMapping, indictedObjectsMapping, a, b, c);
+                                        of(constraint, justificationMapping, indictedObjectsMapping, a, b, c);
                                 runConsequence(constraint, drools, scoreImpacter, matchWeigher.applyAsLong(a, b, c),
                                         justificationsSupplier);
                             });
@@ -74,7 +74,7 @@ final class TriRuleContext<A, B, C> extends AbstractRuleContext {
                     return DSL.on(scoreImpacterGlobal, variableA, variableB, variableC)
                             .execute((drools, scoreImpacter, a, b, c) -> {
                                 JustificationsSupplier justificationsSupplier =
-                                        ofTri(constraint, justificationMapping, indictedObjectsMapping, a, b, c);
+                                        of(constraint, justificationMapping, indictedObjectsMapping, a, b, c);
                                 runConsequence(constraint, drools, scoreImpacter, matchWeigher.apply(a, b, c),
                                         justificationsSupplier);
                             });

--- a/core/optaplanner-constraint-streams-drools/src/main/java/org/optaplanner/constraint/streams/drools/common/UniRuleContext.java
+++ b/core/optaplanner-constraint-streams-drools/src/main/java/org/optaplanner/constraint/streams/drools/common/UniRuleContext.java
@@ -1,6 +1,6 @@
 package org.optaplanner.constraint.streams.drools.common;
 
-import static org.optaplanner.constraint.streams.common.inliner.JustificationsSupplier.of;
+import static org.optaplanner.constraint.streams.common.inliner.JustificationsSupplier.ofUni;
 
 import java.math.BigDecimal;
 import java.util.Collection;
@@ -35,8 +35,7 @@ final class UniRuleContext<A> extends AbstractRuleContext {
                     return DSL.on(scoreImpacterGlobal, variable)
                             .execute((drools, scoreImpacter, a) -> {
                                 JustificationsSupplier justificationsSupplier =
-                                        of(score -> justificationMapping.apply(a, score),
-                                                () -> indictedObjectsMapping.apply(a));
+                                        ofUni(constraint, justificationMapping, indictedObjectsMapping, a);
                                 runConsequence(constraint, drools, scoreImpacter, matchWeigher.applyAsInt(a),
                                         justificationsSupplier);
                             });
@@ -53,8 +52,7 @@ final class UniRuleContext<A> extends AbstractRuleContext {
                     return DSL.on(scoreImpacterGlobal, variable)
                             .execute((drools, scoreImpacter, a) -> {
                                 JustificationsSupplier justificationsSupplier =
-                                        of(score -> justificationMapping.apply(a, score),
-                                                () -> indictedObjectsMapping.apply(a));
+                                        ofUni(constraint, justificationMapping, indictedObjectsMapping, a);
                                 runConsequence(constraint, drools, scoreImpacter, matchWeigher.applyAsLong(a),
                                         justificationsSupplier);
                             });
@@ -71,8 +69,7 @@ final class UniRuleContext<A> extends AbstractRuleContext {
                     return DSL.on(scoreImpacterGlobal, variable)
                             .execute((drools, scoreImpacter, a) -> {
                                 JustificationsSupplier justificationsSupplier =
-                                        of(score -> justificationMapping.apply(a, score),
-                                                () -> indictedObjectsMapping.apply(a));
+                                        ofUni(constraint, justificationMapping, indictedObjectsMapping, a);
                                 runConsequence(constraint, drools, scoreImpacter, matchWeigher.apply(a),
                                         justificationsSupplier);
                             });

--- a/core/optaplanner-constraint-streams-drools/src/main/java/org/optaplanner/constraint/streams/drools/common/UniRuleContext.java
+++ b/core/optaplanner-constraint-streams-drools/src/main/java/org/optaplanner/constraint/streams/drools/common/UniRuleContext.java
@@ -1,6 +1,6 @@
 package org.optaplanner.constraint.streams.drools.common;
 
-import static org.optaplanner.constraint.streams.common.inliner.JustificationsSupplier.ofUni;
+import static org.optaplanner.constraint.streams.common.inliner.JustificationsSupplier.of;
 
 import java.math.BigDecimal;
 import java.util.Collection;
@@ -35,7 +35,7 @@ final class UniRuleContext<A> extends AbstractRuleContext {
                     return DSL.on(scoreImpacterGlobal, variable)
                             .execute((drools, scoreImpacter, a) -> {
                                 JustificationsSupplier justificationsSupplier =
-                                        ofUni(constraint, justificationMapping, indictedObjectsMapping, a);
+                                        of(constraint, justificationMapping, indictedObjectsMapping, a);
                                 runConsequence(constraint, drools, scoreImpacter, matchWeigher.applyAsInt(a),
                                         justificationsSupplier);
                             });
@@ -52,7 +52,7 @@ final class UniRuleContext<A> extends AbstractRuleContext {
                     return DSL.on(scoreImpacterGlobal, variable)
                             .execute((drools, scoreImpacter, a) -> {
                                 JustificationsSupplier justificationsSupplier =
-                                        ofUni(constraint, justificationMapping, indictedObjectsMapping, a);
+                                        of(constraint, justificationMapping, indictedObjectsMapping, a);
                                 runConsequence(constraint, drools, scoreImpacter, matchWeigher.applyAsLong(a),
                                         justificationsSupplier);
                             });
@@ -69,7 +69,7 @@ final class UniRuleContext<A> extends AbstractRuleContext {
                     return DSL.on(scoreImpacterGlobal, variable)
                             .execute((drools, scoreImpacter, a) -> {
                                 JustificationsSupplier justificationsSupplier =
-                                        ofUni(constraint, justificationMapping, indictedObjectsMapping, a);
+                                        of(constraint, justificationMapping, indictedObjectsMapping, a);
                                 runConsequence(constraint, drools, scoreImpacter, matchWeigher.apply(a),
                                         justificationsSupplier);
                             });

--- a/core/optaplanner-constraint-streams-drools/src/main/java/org/optaplanner/constraint/streams/drools/quad/DroolsAbstractQuadConstraintStream.java
+++ b/core/optaplanner-constraint-streams-drools/src/main/java/org/optaplanner/constraint/streams/drools/quad/DroolsAbstractQuadConstraintStream.java
@@ -298,12 +298,12 @@ public abstract class DroolsAbstractQuadConstraintStream<Solution_, A, B, C, D>
 
     @Override
     protected final PentaFunction<A, B, C, D, Score<?>, DefaultConstraintJustification> getDefaultJustificationMapping() {
-        return InnerQuadConstraintStream.getDefaultJustificationMapping();
+        return InnerQuadConstraintStream.createDefaultJustificationMapping();
     }
 
     @Override
     protected final QuadFunction<A, B, C, D, Collection<?>> getDefaultIndictedObjectsMapping() {
-        return InnerQuadConstraintStream.getDefaultIndictedObjectsMapping();
+        return InnerQuadConstraintStream.createDefaultIndictedObjectsMapping();
     }
 
     public abstract QuadLeftHandSide<A, B, C, D> getLeftHandSide();

--- a/core/optaplanner-constraint-streams-drools/src/main/java/org/optaplanner/constraint/streams/drools/tri/DroolsAbstractTriConstraintStream.java
+++ b/core/optaplanner-constraint-streams-drools/src/main/java/org/optaplanner/constraint/streams/drools/tri/DroolsAbstractTriConstraintStream.java
@@ -312,12 +312,12 @@ public abstract class DroolsAbstractTriConstraintStream<Solution_, A, B, C>
 
     @Override
     protected final QuadFunction<A, B, C, Score<?>, DefaultConstraintJustification> getDefaultJustificationMapping() {
-        return InnerTriConstraintStream.getDefaultJustificationMapping();
+        return InnerTriConstraintStream.createDefaultJustificationMapping();
     }
 
     @Override
     protected final TriFunction<A, B, C, Collection<?>> getDefaultIndictedObjectsMapping() {
-        return InnerTriConstraintStream.getDefaultIndictedObjectsMapping();
+        return InnerTriConstraintStream.createDefaultIndictedObjectsMapping();
     }
 
     public abstract TriLeftHandSide<A, B, C> getLeftHandSide();

--- a/core/optaplanner-constraint-streams-drools/src/main/java/org/optaplanner/constraint/streams/drools/uni/DroolsAbstractUniConstraintStream.java
+++ b/core/optaplanner-constraint-streams-drools/src/main/java/org/optaplanner/constraint/streams/drools/uni/DroolsAbstractUniConstraintStream.java
@@ -315,12 +315,12 @@ public abstract class DroolsAbstractUniConstraintStream<Solution_, A> extends Dr
 
     @Override
     protected final BiFunction<A, Score<?>, DefaultConstraintJustification> getDefaultJustificationMapping() {
-        return InnerUniConstraintStream.getDefaultJustificationMapping();
+        return InnerUniConstraintStream.createDefaultJustificationMapping();
     }
 
     @Override
     protected final Function<A, Collection<?>> getDefaultIndictedObjectsMapping() {
-        return InnerUniConstraintStream.getDefaultIndictedObjectsMapping();
+        return InnerUniConstraintStream.createDefaultIndictedObjectsMapping();
     }
 
     public abstract UniLeftHandSide<A> getLeftHandSide();

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/score/stream/JoinerType.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/score/stream/JoinerType.java
@@ -36,7 +36,13 @@ public enum JoinerType {
     }
 
     public boolean matches(Object left, Object right) {
-        return matcher.test(left, right);
+        try {
+            return matcher.test(left, right);
+        } catch (Exception e) { // For easier debugging, in the absence of pointing to a specific constraint.
+            throw new IllegalStateException(
+                    "Joiner (" + this + ") threw an exception matching left (" + left + ") and right (" + right + ") objects.",
+                    e);
+        }
     }
 
     private static boolean disjoint(Collection leftCollection, Collection rightCollection) {


### PR DESCRIPTION
Exceptions in the following places now give as much context as they can:

- Joiners show which joiner failed, and on which facts.
- Penalties/rewards include constraint name and the tuple.

This should significantly help with debugging of CS.
Performance benchmarks did not show any statistically significant changes.