### PR TITLE
Prepare JAXB for Jakarta migration

### DIFF
--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/api/domain/common/package-info.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/api/domain/common/package-info.java
@@ -1,8 +1,9 @@
-@javax.xml.bind.annotation.XmlSchema(
+@XmlSchema(
         namespace = SolverConfig.XML_NAMESPACE,
         elementFormDefault = XmlNsForm.QUALIFIED)
 package org.optaplanner.core.api.domain.common;
 
 import javax.xml.bind.annotation.XmlNsForm;
+import javax.xml.bind.annotation.XmlSchema;
 
 import org.optaplanner.core.config.solver.SolverConfig;

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/api/score/stream/package-info.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/api/score/stream/package-info.java
@@ -1,5 +1,5 @@
 
-@javax.xml.bind.annotation.XmlSchema(namespace = SolverConfig.XML_NAMESPACE)
+@XmlSchema(namespace = SolverConfig.XML_NAMESPACE)
 package org.optaplanner.core.api.score.stream;
 
 import org.optaplanner.core.config.solver.SolverConfig;

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/api/score/stream/package-info.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/api/score/stream/package-info.java
@@ -2,4 +2,6 @@
 @XmlSchema(namespace = SolverConfig.XML_NAMESPACE)
 package org.optaplanner.core.api.score.stream;
 
+import javax.xml.bind.annotation.XmlSchema;
+
 import org.optaplanner.core.config.solver.SolverConfig;

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/config/constructionheuristic/decider/forager/package-info.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/config/constructionheuristic/decider/forager/package-info.java
@@ -1,8 +1,9 @@
-@javax.xml.bind.annotation.XmlSchema(
+@XmlSchema(
         namespace = SolverConfig.XML_NAMESPACE,
         elementFormDefault = XmlNsForm.QUALIFIED)
 package org.optaplanner.core.config.constructionheuristic.decider.forager;
 
 import javax.xml.bind.annotation.XmlNsForm;
+import javax.xml.bind.annotation.XmlSchema;
 
 import org.optaplanner.core.config.solver.SolverConfig;

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/config/constructionheuristic/package-info.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/config/constructionheuristic/package-info.java
@@ -1,8 +1,9 @@
-@javax.xml.bind.annotation.XmlSchema(
+@XmlSchema(
         namespace = SolverConfig.XML_NAMESPACE,
         elementFormDefault = XmlNsForm.QUALIFIED)
 package org.optaplanner.core.config.constructionheuristic;
 
 import javax.xml.bind.annotation.XmlNsForm;
+import javax.xml.bind.annotation.XmlSchema;
 
 import org.optaplanner.core.config.solver.SolverConfig;

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/config/constructionheuristic/placer/package-info.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/config/constructionheuristic/placer/package-info.java
@@ -1,8 +1,9 @@
-@javax.xml.bind.annotation.XmlSchema(
+@XmlSchema(
         namespace = SolverConfig.XML_NAMESPACE,
         elementFormDefault = XmlNsForm.QUALIFIED)
 package org.optaplanner.core.config.constructionheuristic.placer;
 
 import javax.xml.bind.annotation.XmlNsForm;
+import javax.xml.bind.annotation.XmlSchema;
 
 import org.optaplanner.core.config.solver.SolverConfig;

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/config/exhaustivesearch/package-info.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/config/exhaustivesearch/package-info.java
@@ -1,8 +1,9 @@
-@javax.xml.bind.annotation.XmlSchema(
+@XmlSchema(
         namespace = SolverConfig.XML_NAMESPACE,
         elementFormDefault = XmlNsForm.QUALIFIED)
 package org.optaplanner.core.config.exhaustivesearch;
 
 import javax.xml.bind.annotation.XmlNsForm;
+import javax.xml.bind.annotation.XmlSchema;
 
 import org.optaplanner.core.config.solver.SolverConfig;

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/config/heuristic/selector/common/decorator/package-info.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/config/heuristic/selector/common/decorator/package-info.java
@@ -1,8 +1,9 @@
-@javax.xml.bind.annotation.XmlSchema(
+@XmlSchema(
         namespace = SolverConfig.XML_NAMESPACE,
         elementFormDefault = XmlNsForm.QUALIFIED)
 package org.optaplanner.core.config.heuristic.selector.common.decorator;
 
 import javax.xml.bind.annotation.XmlNsForm;
+import javax.xml.bind.annotation.XmlSchema;
 
 import org.optaplanner.core.config.solver.SolverConfig;

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/config/heuristic/selector/common/nearby/package-info.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/config/heuristic/selector/common/nearby/package-info.java
@@ -1,8 +1,9 @@
-@javax.xml.bind.annotation.XmlSchema(
+@XmlSchema(
         namespace = SolverConfig.XML_NAMESPACE,
         elementFormDefault = XmlNsForm.QUALIFIED)
 package org.optaplanner.core.config.heuristic.selector.common.nearby;
 
 import javax.xml.bind.annotation.XmlNsForm;
+import javax.xml.bind.annotation.XmlSchema;
 
 import org.optaplanner.core.config.solver.SolverConfig;

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/config/heuristic/selector/common/package-info.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/config/heuristic/selector/common/package-info.java
@@ -1,8 +1,9 @@
-@javax.xml.bind.annotation.XmlSchema(
+@XmlSchema(
         namespace = SolverConfig.XML_NAMESPACE,
         elementFormDefault = XmlNsForm.QUALIFIED)
 package org.optaplanner.core.config.heuristic.selector.common;
 
 import javax.xml.bind.annotation.XmlNsForm;
+import javax.xml.bind.annotation.XmlSchema;
 
 import org.optaplanner.core.config.solver.SolverConfig;

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/config/heuristic/selector/entity/package-info.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/config/heuristic/selector/entity/package-info.java
@@ -1,8 +1,9 @@
-@javax.xml.bind.annotation.XmlSchema(
+@XmlSchema(
         namespace = SolverConfig.XML_NAMESPACE,
         elementFormDefault = XmlNsForm.QUALIFIED)
 package org.optaplanner.core.config.heuristic.selector.entity;
 
 import javax.xml.bind.annotation.XmlNsForm;
+import javax.xml.bind.annotation.XmlSchema;
 
 import org.optaplanner.core.config.solver.SolverConfig;

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/config/heuristic/selector/entity/pillar/package-info.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/config/heuristic/selector/entity/pillar/package-info.java
@@ -1,8 +1,9 @@
-@javax.xml.bind.annotation.XmlSchema(
+@XmlSchema(
         namespace = SolverConfig.XML_NAMESPACE,
         elementFormDefault = XmlNsForm.QUALIFIED)
 package org.optaplanner.core.config.heuristic.selector.entity.pillar;
 
 import javax.xml.bind.annotation.XmlNsForm;
+import javax.xml.bind.annotation.XmlSchema;
 
 import org.optaplanner.core.config.solver.SolverConfig;

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/config/heuristic/selector/move/composite/package-info.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/config/heuristic/selector/move/composite/package-info.java
@@ -1,8 +1,9 @@
-@javax.xml.bind.annotation.XmlSchema(
+@XmlSchema(
         namespace = SolverConfig.XML_NAMESPACE,
         elementFormDefault = XmlNsForm.QUALIFIED)
 package org.optaplanner.core.config.heuristic.selector.move.composite;
 
 import javax.xml.bind.annotation.XmlNsForm;
+import javax.xml.bind.annotation.XmlSchema;
 
 import org.optaplanner.core.config.solver.SolverConfig;

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/config/heuristic/selector/move/factory/package-info.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/config/heuristic/selector/move/factory/package-info.java
@@ -1,8 +1,9 @@
-@javax.xml.bind.annotation.XmlSchema(
+@XmlSchema(
         namespace = SolverConfig.XML_NAMESPACE,
         elementFormDefault = XmlNsForm.QUALIFIED)
 package org.optaplanner.core.config.heuristic.selector.move.factory;
 
 import javax.xml.bind.annotation.XmlNsForm;
+import javax.xml.bind.annotation.XmlSchema;
 
 import org.optaplanner.core.config.solver.SolverConfig;

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/config/heuristic/selector/move/generic/chained/package-info.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/config/heuristic/selector/move/generic/chained/package-info.java
@@ -1,8 +1,9 @@
-@javax.xml.bind.annotation.XmlSchema(
+@XmlSchema(
         namespace = SolverConfig.XML_NAMESPACE,
         elementFormDefault = XmlNsForm.QUALIFIED)
 package org.optaplanner.core.config.heuristic.selector.move.generic.chained;
 
 import javax.xml.bind.annotation.XmlNsForm;
+import javax.xml.bind.annotation.XmlSchema;
 
 import org.optaplanner.core.config.solver.SolverConfig;

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/config/heuristic/selector/move/generic/list/package-info.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/config/heuristic/selector/move/generic/list/package-info.java
@@ -1,8 +1,9 @@
-@javax.xml.bind.annotation.XmlSchema(
+@XmlSchema(
         namespace = SolverConfig.XML_NAMESPACE,
         elementFormDefault = XmlNsForm.QUALIFIED)
 package org.optaplanner.core.config.heuristic.selector.move.generic.list;
 
 import javax.xml.bind.annotation.XmlNsForm;
+import javax.xml.bind.annotation.XmlSchema;
 
 import org.optaplanner.core.config.solver.SolverConfig;

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/config/heuristic/selector/move/generic/package-info.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/config/heuristic/selector/move/generic/package-info.java
@@ -1,8 +1,9 @@
-@javax.xml.bind.annotation.XmlSchema(
+@XmlSchema(
         namespace = SolverConfig.XML_NAMESPACE,
         elementFormDefault = XmlNsForm.QUALIFIED)
 package org.optaplanner.core.config.heuristic.selector.move.generic;
 
 import javax.xml.bind.annotation.XmlNsForm;
+import javax.xml.bind.annotation.XmlSchema;
 
 import org.optaplanner.core.config.solver.SolverConfig;

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/config/heuristic/selector/move/package-info.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/config/heuristic/selector/move/package-info.java
@@ -1,8 +1,9 @@
-@javax.xml.bind.annotation.XmlSchema(
+@XmlSchema(
         namespace = SolverConfig.XML_NAMESPACE,
         elementFormDefault = XmlNsForm.QUALIFIED)
 package org.optaplanner.core.config.heuristic.selector.move;
 
 import javax.xml.bind.annotation.XmlNsForm;
+import javax.xml.bind.annotation.XmlSchema;
 
 import org.optaplanner.core.config.solver.SolverConfig;

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/config/heuristic/selector/package-info.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/config/heuristic/selector/package-info.java
@@ -1,8 +1,9 @@
-@javax.xml.bind.annotation.XmlSchema(
+@XmlSchema(
         namespace = SolverConfig.XML_NAMESPACE,
         elementFormDefault = XmlNsForm.QUALIFIED)
 package org.optaplanner.core.config.heuristic.selector;
 
 import javax.xml.bind.annotation.XmlNsForm;
+import javax.xml.bind.annotation.XmlSchema;
 
 import org.optaplanner.core.config.solver.SolverConfig;

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/config/heuristic/selector/value/chained/package-info.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/config/heuristic/selector/value/chained/package-info.java
@@ -1,8 +1,9 @@
-@javax.xml.bind.annotation.XmlSchema(
+@XmlSchema(
         namespace = SolverConfig.XML_NAMESPACE,
         elementFormDefault = XmlNsForm.QUALIFIED)
 package org.optaplanner.core.config.heuristic.selector.value.chained;
 
 import javax.xml.bind.annotation.XmlNsForm;
+import javax.xml.bind.annotation.XmlSchema;
 
 import org.optaplanner.core.config.solver.SolverConfig;

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/config/heuristic/selector/value/package-info.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/config/heuristic/selector/value/package-info.java
@@ -1,8 +1,9 @@
-@javax.xml.bind.annotation.XmlSchema(
+@XmlSchema(
         namespace = SolverConfig.XML_NAMESPACE,
         elementFormDefault = XmlNsForm.QUALIFIED)
 package org.optaplanner.core.config.heuristic.selector.value;
 
 import javax.xml.bind.annotation.XmlNsForm;
+import javax.xml.bind.annotation.XmlSchema;
 
 import org.optaplanner.core.config.solver.SolverConfig;

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/config/localsearch/decider/acceptor/package-info.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/config/localsearch/decider/acceptor/package-info.java
@@ -1,8 +1,9 @@
-@javax.xml.bind.annotation.XmlSchema(
+@XmlSchema(
         namespace = SolverConfig.XML_NAMESPACE,
         elementFormDefault = XmlNsForm.QUALIFIED)
 package org.optaplanner.core.config.localsearch.decider.acceptor;
 
 import javax.xml.bind.annotation.XmlNsForm;
+import javax.xml.bind.annotation.XmlSchema;
 
 import org.optaplanner.core.config.solver.SolverConfig;

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/config/localsearch/decider/acceptor/stepcountinghillclimbing/package-info.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/config/localsearch/decider/acceptor/stepcountinghillclimbing/package-info.java
@@ -1,8 +1,9 @@
-@javax.xml.bind.annotation.XmlSchema(
+@XmlSchema(
         namespace = SolverConfig.XML_NAMESPACE,
         elementFormDefault = XmlNsForm.QUALIFIED)
 package org.optaplanner.core.config.localsearch.decider.acceptor.stepcountinghillclimbing;
 
 import javax.xml.bind.annotation.XmlNsForm;
+import javax.xml.bind.annotation.XmlSchema;
 
 import org.optaplanner.core.config.solver.SolverConfig;

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/config/localsearch/decider/forager/package-info.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/config/localsearch/decider/forager/package-info.java
@@ -1,8 +1,9 @@
-@javax.xml.bind.annotation.XmlSchema(
+@XmlSchema(
         namespace = SolverConfig.XML_NAMESPACE,
         elementFormDefault = XmlNsForm.QUALIFIED)
 package org.optaplanner.core.config.localsearch.decider.forager;
 
 import javax.xml.bind.annotation.XmlNsForm;
+import javax.xml.bind.annotation.XmlSchema;
 
 import org.optaplanner.core.config.solver.SolverConfig;

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/config/localsearch/package-info.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/config/localsearch/package-info.java
@@ -1,8 +1,9 @@
-@javax.xml.bind.annotation.XmlSchema(
+@XmlSchema(
         namespace = SolverConfig.XML_NAMESPACE,
         elementFormDefault = XmlNsForm.QUALIFIED)
 package org.optaplanner.core.config.localsearch;
 
 import javax.xml.bind.annotation.XmlNsForm;
+import javax.xml.bind.annotation.XmlSchema;
 
 import org.optaplanner.core.config.solver.SolverConfig;

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/config/package-info.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/config/package-info.java
@@ -2,13 +2,14 @@
  * Classes which represent the XML Solver configuration of OptaPlanner.
  * <p>
  * The XML Solver configuration is backwards compatible for all elements,
- * except for elements that require the use of non public API classes.
+ * except for elements that require the use of non-public API classes.
  */
-@javax.xml.bind.annotation.XmlSchema(
+@XmlSchema(
         namespace = SolverConfig.XML_NAMESPACE,
         elementFormDefault = XmlNsForm.QUALIFIED)
 package org.optaplanner.core.config;
 
 import javax.xml.bind.annotation.XmlNsForm;
+import javax.xml.bind.annotation.XmlSchema;
 
 import org.optaplanner.core.config.solver.SolverConfig;

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/config/partitionedsearch/package-info.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/config/partitionedsearch/package-info.java
@@ -1,8 +1,9 @@
-@javax.xml.bind.annotation.XmlSchema(
+@XmlSchema(
         namespace = SolverConfig.XML_NAMESPACE,
         elementFormDefault = XmlNsForm.QUALIFIED)
 package org.optaplanner.core.config.partitionedsearch;
 
 import javax.xml.bind.annotation.XmlNsForm;
+import javax.xml.bind.annotation.XmlSchema;
 
 import org.optaplanner.core.config.solver.SolverConfig;

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/config/phase/custom/package-info.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/config/phase/custom/package-info.java
@@ -1,8 +1,9 @@
-@javax.xml.bind.annotation.XmlSchema(
+@XmlSchema(
         namespace = SolverConfig.XML_NAMESPACE,
         elementFormDefault = XmlNsForm.QUALIFIED)
 package org.optaplanner.core.config.phase.custom;
 
 import javax.xml.bind.annotation.XmlNsForm;
+import javax.xml.bind.annotation.XmlSchema;
 
 import org.optaplanner.core.config.solver.SolverConfig;

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/config/phase/package-info.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/config/phase/package-info.java
@@ -1,8 +1,9 @@
-@javax.xml.bind.annotation.XmlSchema(
+@XmlSchema(
         namespace = SolverConfig.XML_NAMESPACE,
         elementFormDefault = XmlNsForm.QUALIFIED)
 package org.optaplanner.core.config.phase;
 
 import javax.xml.bind.annotation.XmlNsForm;
+import javax.xml.bind.annotation.XmlSchema;
 
 import org.optaplanner.core.config.solver.SolverConfig;

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/config/score/definition/package-info.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/config/score/definition/package-info.java
@@ -1,8 +1,9 @@
-@javax.xml.bind.annotation.XmlSchema(
+@XmlSchema(
         namespace = SolverConfig.XML_NAMESPACE,
         elementFormDefault = XmlNsForm.QUALIFIED)
 package org.optaplanner.core.config.score.definition;
 
 import javax.xml.bind.annotation.XmlNsForm;
+import javax.xml.bind.annotation.XmlSchema;
 
 import org.optaplanner.core.config.solver.SolverConfig;

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/config/score/director/package-info.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/config/score/director/package-info.java
@@ -1,8 +1,9 @@
-@javax.xml.bind.annotation.XmlSchema(
+@XmlSchema(
         namespace = SolverConfig.XML_NAMESPACE,
         elementFormDefault = XmlNsForm.QUALIFIED)
 package org.optaplanner.core.config.score.director;
 
 import javax.xml.bind.annotation.XmlNsForm;
+import javax.xml.bind.annotation.XmlSchema;
 
 import org.optaplanner.core.config.solver.SolverConfig;

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/config/score/trend/package-info.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/config/score/trend/package-info.java
@@ -1,8 +1,9 @@
-@javax.xml.bind.annotation.XmlSchema(
+@XmlSchema(
         namespace = SolverConfig.XML_NAMESPACE,
         elementFormDefault = XmlNsForm.QUALIFIED)
 package org.optaplanner.core.config.score.trend;
 
 import javax.xml.bind.annotation.XmlNsForm;
+import javax.xml.bind.annotation.XmlSchema;
 
 import org.optaplanner.core.config.solver.SolverConfig;

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/config/solver/monitoring/package-info.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/config/solver/monitoring/package-info.java
@@ -1,8 +1,9 @@
-@javax.xml.bind.annotation.XmlSchema(
+@XmlSchema(
         namespace = SolverConfig.XML_NAMESPACE,
         elementFormDefault = XmlNsForm.QUALIFIED)
 package org.optaplanner.core.config.solver.monitoring;
 
 import javax.xml.bind.annotation.XmlNsForm;
+import javax.xml.bind.annotation.XmlSchema;
 
 import org.optaplanner.core.config.solver.SolverConfig;

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/config/solver/package-info.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/config/solver/package-info.java
@@ -1,6 +1,7 @@
-@javax.xml.bind.annotation.XmlSchema(
+@XmlSchema(
         namespace = SolverConfig.XML_NAMESPACE,
         elementFormDefault = XmlNsForm.QUALIFIED)
 package org.optaplanner.core.config.solver;
 
 import javax.xml.bind.annotation.XmlNsForm;
+import javax.xml.bind.annotation.XmlSchema;

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/config/solver/random/package-info.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/config/solver/random/package-info.java
@@ -1,8 +1,9 @@
-@javax.xml.bind.annotation.XmlSchema(
+@XmlSchema(
         namespace = SolverConfig.XML_NAMESPACE,
         elementFormDefault = XmlNsForm.QUALIFIED)
 package org.optaplanner.core.config.solver.random;
 
 import javax.xml.bind.annotation.XmlNsForm;
+import javax.xml.bind.annotation.XmlSchema;
 
 import org.optaplanner.core.config.solver.SolverConfig;

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/config/solver/termination/package-info.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/config/solver/termination/package-info.java
@@ -1,8 +1,9 @@
-@javax.xml.bind.annotation.XmlSchema(
+@XmlSchema(
         namespace = SolverConfig.XML_NAMESPACE,
         elementFormDefault = XmlNsForm.QUALIFIED)
 package org.optaplanner.core.config.solver.termination;
 
 import javax.xml.bind.annotation.XmlNsForm;
+import javax.xml.bind.annotation.XmlSchema;
 
 import org.optaplanner.core.config.solver.SolverConfig;

--- a/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/config/blueprint/package-info.java
+++ b/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/config/blueprint/package-info.java
@@ -1,9 +1,10 @@
 
-@javax.xml.bind.annotation.XmlSchema(
+@XmlSchema(
         namespace = PlannerBenchmarkConfig.XML_NAMESPACE,
         elementFormDefault = XmlNsForm.QUALIFIED)
 package org.optaplanner.benchmark.config.blueprint;
 
 import javax.xml.bind.annotation.XmlNsForm;
+import javax.xml.bind.annotation.XmlSchema;
 
 import org.optaplanner.benchmark.config.PlannerBenchmarkConfig;

--- a/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/config/package-info.java
+++ b/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/config/package-info.java
@@ -2,9 +2,9 @@
  * Classes which represent the XML Benchmark configuration of OptaPlanner Benchmark.
  * <p>
  * The XML Benchmark configuration is backwards compatible for all elements,
- * except for elements that require the use of non public API classes.
+ * except for elements that require the use of non-public API classes.
  */
-@javax.xml.bind.annotation.XmlSchema(
+@XmlSchema(
         namespace = PlannerBenchmarkConfig.XML_NAMESPACE,
         elementFormDefault = XmlNsForm.QUALIFIED,
         xmlns = {
@@ -14,5 +14,6 @@ package org.optaplanner.benchmark.config;
 
 import javax.xml.bind.annotation.XmlNs;
 import javax.xml.bind.annotation.XmlNsForm;
+import javax.xml.bind.annotation.XmlSchema;
 
 import org.optaplanner.core.config.solver.SolverConfig;

--- a/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/config/ranking/package-info.java
+++ b/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/config/ranking/package-info.java
@@ -1,9 +1,10 @@
 
-@javax.xml.bind.annotation.XmlSchema(
+@XmlSchema(
         namespace = PlannerBenchmarkConfig.XML_NAMESPACE,
         elementFormDefault = XmlNsForm.QUALIFIED)
 package org.optaplanner.benchmark.config.ranking;
 
 import javax.xml.bind.annotation.XmlNsForm;
+import javax.xml.bind.annotation.XmlSchema;
 
 import org.optaplanner.benchmark.config.PlannerBenchmarkConfig;

--- a/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/config/report/package-info.java
+++ b/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/config/report/package-info.java
@@ -1,9 +1,10 @@
 
-@javax.xml.bind.annotation.XmlSchema(
+@XmlSchema(
         namespace = PlannerBenchmarkConfig.XML_NAMESPACE,
         elementFormDefault = XmlNsForm.QUALIFIED)
 package org.optaplanner.benchmark.config.report;
 
 import javax.xml.bind.annotation.XmlNsForm;
+import javax.xml.bind.annotation.XmlSchema;
 
 import org.optaplanner.benchmark.config.PlannerBenchmarkConfig;

--- a/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/config/statistic/package-info.java
+++ b/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/config/statistic/package-info.java
@@ -1,9 +1,10 @@
 
-@javax.xml.bind.annotation.XmlSchema(
+@XmlSchema(
         namespace = PlannerBenchmarkConfig.XML_NAMESPACE,
         elementFormDefault = XmlNsForm.QUALIFIED)
 package org.optaplanner.benchmark.config.statistic;
 
 import javax.xml.bind.annotation.XmlNsForm;
+import javax.xml.bind.annotation.XmlSchema;
 
 import org.optaplanner.benchmark.config.PlannerBenchmarkConfig;


### PR DESCRIPTION
- refactors imports in `package-info.java` so that these files can be migrated via the Q3 OpenRewrite recipe
- add a classpath check for the right `JAXBContextFactory`

<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.
-->

### JIRA

<!-- Add a JIRA ticket link if it exists. -->
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
- https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
- https://github.com/kiegroup/drools/pull/3000
- https://github.com/kiegroup/optaplanner/pull/899
- etc.
-->

### Checklist
- [ ] Documentation updated if applicable.
- [ ] Release notes updated if applicable.
- [ ] Upgrade recipe provided if applicable.

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request checks</b>  
  Please add comment: <b>Jenkins retest this</b>

- for a <b>specific pull request check</b>  
  please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-vehicle-routing] tests</b>
  
- for a <b>full downstream build</b> 
  - for <b>jenkins</b> job: 
    please add comment: <b>Jenkins run fdb</b>
  - for <b>github actions</b> job: 
    add the label `run_fdb`

- for a <b>compile downstream build</b>  
  please add comment: <b>Jenkins run cdb</b>

- for a <b>full production downstream build</b>  
  please add comment: <b>Jenkins execute product fdb</b>

- for an <b>upstream build</b>  
  please add comment: <b>Jenkins run upstream</b>

- for <b>quarkus branch checks</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins run quarkus-branch</b>

- for a <b>quarkus branch specific check</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-vehicle-routing] quarkus-branch</b>

- for <b>quarkus main checks</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins run quarkus-main</b>

- for a <b>specific quarkus main check</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-vehicle-routing] quarkus-branch</b>

- for <b>quarkus lts checks</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins run quarkus-lts</b>

- for a <b>specific quarkus lts check</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-vehicle-routing] quarkus-lts</b>

- for <b>native checks</b>  
  Run native checks  
  Please add comment: <b>Jenkins run native</b>

- for a <b>specific native check</b>  
  Run native checks 
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts] native</b>

- for <b>mandrel checks</b>  
  Run native checks against Mandrel image
  Please add comment: <b>Jenkins run mandrel</b>

- for a <b>specific mandrel check</b>  
  Run native checks against Mandrel image  
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts] mandrel</b>

- for <b>mandrel lts checks</b>  
  Run native checks against Mandrel image and quarkus lts branch
  Please add comment: <b>Jenkins run mandrel-lts</b>

- for a <b>specific mandrel lts check</b>  
  Run native checks against Mandrel image and quarkus lts branch
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts] mandrel-lts</b>

</details>

### CI Status

 You can check OptaPlanner repositories CI status from [Chain Status webpage](https://kiegroup.github.io/optaplanner/).

<details>
<summary>
How to backport a pull request to a different branch?
</summary>

In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-7.67.x` to backport the original PR to the `7.67.x` branch).

> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.

Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.

If something goes wrong, the author will be notified and at this point a manual backporting is needed.

> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
</details>
