### PR TITLE
Bump quarkus-operator-sdk from 4.0.5 to 5.0.0

### DIFF
--- a/build/optaplanner-build-parent/pom.xml
+++ b/build/optaplanner-build-parent/pom.xml
@@ -26,7 +26,7 @@
     <version.ch.qos.logback>1.2.9</version.ch.qos.logback>
     <version.org.apache.logging.log4j>2.19.0</version.org.apache.logging.log4j>
     <version.com.thoughtworks.xstream>1.4.20</version.com.thoughtworks.xstream>
-    <version.io.quarkiverse.operatorsdk>4.0.5</version.io.quarkiverse.operatorsdk>
+    <version.io.quarkiverse.operatorsdk>5.0.0</version.io.quarkiverse.operatorsdk>
     <version.io.quarkus>2.15.0.Final</version.io.quarkus>
     <version.org.apache.commons.math3>3.6.1</version.org.apache.commons.math3>
     <version.org.apache.commons.text>1.10.0</version.org.apache.commons.text>

--- a/optaplanner-operator/pom.xml
+++ b/optaplanner-operator/pom.xml
@@ -24,19 +24,12 @@
   <properties>
     <java.module.name>org.optaplanner.operator</java.module.name>
     <!-- Quarkus Ecosystem CI (and other CI possibly too) updates the version.io.quarkus property. -->
-    <version.io.quarkus.override>2.13.0.Final</version.io.quarkus.override>
+    <version.io.quarkus.override>2.15.0.Final</version.io.quarkus.override>
   </properties>
 
-  <!-- TODO: Remove when upgrading to Quarkus Operator SDK compatible with latest Quarkus versions. -->
+  <!-- TODO: Remove when OptaPlanner no longer supports Quarkus 2.13 -->
   <dependencyManagement>
     <dependencies>
-      <dependency>
-        <groupId>io.fabric8</groupId>
-        <artifactId>kubernetes-client-bom</artifactId>
-        <version>5.12.4</version>
-        <scope>import</scope>
-        <type>pom</type>
-      </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-bom</artifactId>

--- a/optaplanner-operator/src/main/java/org/optaplanner/operator/impl/solver/model/messaging/ArtemisQueueDependentResource.java
+++ b/optaplanner-operator/src/main/java/org/optaplanner/operator/impl/solver/model/messaging/ArtemisQueueDependentResource.java
@@ -1,7 +1,5 @@
 package org.optaplanner.operator.impl.solver.model.messaging;
 
-import java.util.Map;
-
 import org.optaplanner.operator.impl.solver.model.OptaPlannerSolver;
 
 import io.fabric8.kubernetes.api.model.ObjectMeta;
@@ -20,21 +18,15 @@ public final class ArtemisQueueDependentResource extends CRUDKubernetesDependent
         setKubernetesClient(kubernetesClient);
     }
 
-    public static final String MESSAGE_ADDRESS_LABEL = "message-address";
-
     private final MessageAddress messageAddress;
 
     @Override
     protected ArtemisQueue desired(OptaPlannerSolver solver, Context<OptaPlannerSolver> context) {
         final String queueName = solver.getMessageAddressName(messageAddress);
 
-        // The two dependent resource of the same type need to be differentiated by a label.
-        Map<String, String> labels = Map.of(MESSAGE_ADDRESS_LABEL, messageAddress.getName());
-
         ObjectMeta objectMeta = new ObjectMetaBuilder()
                 .withName(queueName)
                 .withNamespace(solver.getNamespace())
-                .withLabels(labels)
                 .build();
 
         ArtemisQueueSpec spec = new ArtemisQueueSpec();

--- a/optaplanner-operator/src/test/java/org/optaplanner/operator/impl/solver/OptaPlannerSolverReconcilerTest.java
+++ b/optaplanner-operator/src/test/java/org/optaplanner/operator/impl/solver/OptaPlannerSolverReconcilerTest.java
@@ -122,6 +122,7 @@ public class OptaPlannerSolverReconcilerTest extends AbstractKubernetesTest {
 
         final OptaPlannerSolver solver = new OptaPlannerSolver();
         solver.getMetadata().setName(solverName);
+        solver.getMetadata().setNamespace(namespace);
         solver.setSpec(new OptaPlannerSolverSpec());
         solver.getSpec().setTemplate(createPodTemplateSpec("solver-project-image"));
         solver.getSpec().setAmqBroker(amqBroker);


### PR DESCRIPTION
Replaces https://github.com/kiegroup/optaplanner/pull/2463.

Bumps quarkus-operator-sdk from 4.0.5 to 5.0.0.

---
updated-dependencies:
- dependency-name: io.quarkiverse.operatorsdk:quarkus-operator-sdk dependency-type: direct:production update-type: version-update:semver-major ...

Signed-off-by: dependabot[bot] <support@github.com>

<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.
-->

### JIRA

<!-- Add a JIRA ticket link if it exists. -->
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
- https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
- https://github.com/kiegroup/drools/pull/3000
- https://github.com/kiegroup/optaplanner/pull/899
- etc.
-->

### Checklist
- [ ] Documentation updated if applicable.
- [ ] Release notes updated if applicable.
- [ ] Upgrade recipe provided if applicable.

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request checks</b>  
  Please add comment: <b>Jenkins retest this</b>

- for a <b>specific pull request check</b>  
  please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-vehicle-routing] tests</b>
  
- for a <b>full downstream build</b> 
  - for <b>jenkins</b> job: 
    please add comment: <b>Jenkins run fdb</b>
  - for <b>github actions</b> job: 
    add the label `run_fdb`

- for a <b>compile downstream build</b>  
  please add comment: <b>Jenkins run cdb</b>

- for a <b>full production downstream build</b>  
  please add comment: <b>Jenkins execute product fdb</b>

- for an <b>upstream build</b>  
  please add comment: <b>Jenkins run upstream</b>

- for <b>quarkus branch checks</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins run quarkus-branch</b>

- for a <b>quarkus branch specific check</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-vehicle-routing] quarkus-branch</b>

- for <b>quarkus main checks</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins run quarkus-main</b>

- for a <b>specific quarkus main check</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-vehicle-routing] quarkus-branch</b>

- for <b>quarkus lts checks</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins run quarkus-lts</b>

- for a <b>specific quarkus lts check</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-vehicle-routing] quarkus-lts</b>

- for <b>native checks</b>  
  Run native checks  
  Please add comment: <b>Jenkins run native</b>

- for a <b>specific native check</b>  
  Run native checks 
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts] native</b>

- for <b>mandrel checks</b>  
  Run native checks against Mandrel image
  Please add comment: <b>Jenkins run mandrel</b>

- for a <b>specific mandrel check</b>  
  Run native checks against Mandrel image  
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts] mandrel</b>

- for <b>mandrel lts checks</b>  
  Run native checks against Mandrel image and quarkus lts branch
  Please add comment: <b>Jenkins run mandrel-lts</b>

- for a <b>specific mandrel lts check</b>  
  Run native checks against Mandrel image and quarkus lts branch
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts] mandrel-lts</b>

</details>

### CI Status

 You can check OptaPlanner repositories CI status from [Chain Status webpage](https://kiegroup.github.io/optaplanner/).

<details>
<summary>
How to backport a pull request to a different branch?
</summary>

In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-7.67.x` to backport the original PR to the `7.67.x` branch).

> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.

Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.

If something goes wrong, the author will be notified and at this point a manual backporting is needed.

> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
</details>
