### PR TITLE
PLANNER-2193 Allow anonymous value ranges

### DIFF
--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/api/domain/valuerange/ValueRangeProvider.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/api/domain/valuerange/ValueRangeProvider.java
@@ -25,9 +25,10 @@ public @interface ValueRangeProvider {
     /**
      * Used by {@link PlanningVariable#valueRangeProviderRefs()}
      * to map a {@link PlanningVariable} to a {@link ValueRangeProvider}.
+     * If not provided, an attempt to auto-detect the {@link PlanningVariable} will be made.
      *
-     * @return never null, must be unique across a {@link SolverFactory}
+     * @return if provided, must be unique across a {@link SolverFactory}
      */
-    String id();
+    String id() default "";
 
 }

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/api/domain/valuerange/ValueRangeProvider.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/api/domain/valuerange/ValueRangeProvider.java
@@ -25,7 +25,7 @@ public @interface ValueRangeProvider {
     /**
      * Used by {@link PlanningVariable#valueRangeProviderRefs()}
      * to map a {@link PlanningVariable} to a {@link ValueRangeProvider}.
-     * If not provided, an attempt to auto-detect the {@link PlanningVariable} will be made.
+     * If not provided, an attempt will be made to find a matching {@link PlanningVariable} without a ref.
      *
      * @return if provided, must be unique across a {@link SolverFactory}
      */

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/api/domain/variable/PlanningVariable.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/api/domain/variable/PlanningVariable.java
@@ -26,9 +26,10 @@ public @interface PlanningVariable {
      * Any {@link ValueRangeProvider} annotation on a {@link PlanningSolution} or {@link PlanningEntity}
      * will automatically be registered with its {@link ValueRangeProvider#id()}.
      * <p>
-     * There should be at least 1 element in this array.
+     * If no refs are provided, all {@link ValueRangeProvider}s without an id will be registered,
+     * provided their return types match the type of this variable.
      *
-     * @return 1 (or more) registered {@link ValueRangeProvider#id()}
+     * @return 0 or more registered {@link ValueRangeProvider#id()}
      */
     String[] valueRangeProviderRefs() default {};
 

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/domain/policy/DescriptorPolicy.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/domain/policy/DescriptorPolicy.java
@@ -32,6 +32,11 @@ public class DescriptorPolicy {
         }
     }
 
+    public boolean isFromSolutionValueRangeProvider(MemberAccessor memberAccessor) {
+        return fromSolutionValueRangeProviderMap.containsValue(memberAccessor)
+                || anonymousFromSolutionValueRangeProviderSet.contains(memberAccessor);
+    }
+
     public boolean hasFromSolutionValueRangeProvider(String id) {
         return fromSolutionValueRangeProviderMap.containsKey(id);
     }
@@ -51,6 +56,11 @@ public class DescriptorPolicy {
         } else {
             fromEntityValueRangeProviderMap.put(id, memberAccessor);
         }
+    }
+
+    public boolean isFromEntityValueRangeProvider(MemberAccessor memberAccessor) {
+        return fromEntityValueRangeProviderMap.containsValue(memberAccessor)
+                || anonymousFromEntityValueRangeProviderSet.contains(memberAccessor);
     }
 
     public boolean hasFromEntityValueRangeProvider(String id) {

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/domain/policy/DescriptorPolicy.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/domain/policy/DescriptorPolicy.java
@@ -3,9 +3,10 @@ package org.optaplanner.core.impl.domain.policy;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.UUID;
+import java.util.Set;
 
 import org.optaplanner.core.api.domain.common.DomainAccessType;
 import org.optaplanner.core.api.domain.solution.cloner.SolutionCloner;
@@ -15,14 +16,20 @@ import org.optaplanner.core.impl.domain.common.accessor.MemberAccessorFactory;
 
 public class DescriptorPolicy {
     private Map<String, SolutionCloner> generatedSolutionClonerMap = new LinkedHashMap<>();
-    private Map<String, MemberAccessor> fromSolutionValueRangeProviderMap = new LinkedHashMap<>();
-    private Map<String, MemberAccessor> fromEntityValueRangeProviderMap = new LinkedHashMap<>();
+    private final Map<String, MemberAccessor> fromSolutionValueRangeProviderMap = new LinkedHashMap<>();
+    private final Set<MemberAccessor> anonymousFromSolutionValueRangeProviderSet = new LinkedHashSet<>();
+    private final Map<String, MemberAccessor> fromEntityValueRangeProviderMap = new LinkedHashMap<>();
+    private final Set<MemberAccessor> anonymousFromEntityValueRangeProviderSet = new LinkedHashSet<>();
     private DomainAccessType domainAccessType = DomainAccessType.REFLECTION;
     private MemberAccessorFactory memberAccessorFactory;
 
     public void addFromSolutionValueRangeProvider(MemberAccessor memberAccessor) {
         String id = extractValueRangeProviderId(memberAccessor);
-        fromSolutionValueRangeProviderMap.put(id, memberAccessor);
+        if (id == null) {
+            anonymousFromSolutionValueRangeProviderSet.add(memberAccessor);
+        } else {
+            fromSolutionValueRangeProviderMap.put(id, memberAccessor);
+        }
     }
 
     public boolean hasFromSolutionValueRangeProvider(String id) {
@@ -33,13 +40,25 @@ public class DescriptorPolicy {
         return fromSolutionValueRangeProviderMap.get(id);
     }
 
+    public Set<MemberAccessor> getAnonymousFromSolutionValueRangeProviderSet() {
+        return anonymousFromSolutionValueRangeProviderSet;
+    }
+
     public void addFromEntityValueRangeProvider(MemberAccessor memberAccessor) {
         String id = extractValueRangeProviderId(memberAccessor);
-        fromEntityValueRangeProviderMap.put(id, memberAccessor);
+        if (id == null) {
+            anonymousFromEntityValueRangeProviderSet.add(memberAccessor);
+        } else {
+            fromEntityValueRangeProviderMap.put(id, memberAccessor);
+        }
     }
 
     public boolean hasFromEntityValueRangeProvider(String id) {
         return fromEntityValueRangeProviderMap.containsKey(id);
+    }
+
+    public Set<MemberAccessor> getAnonymousFromEntityValueRangeProviderSet() {
+        return anonymousFromEntityValueRangeProviderSet;
     }
 
     /**
@@ -80,7 +99,7 @@ public class DescriptorPolicy {
         ValueRangeProvider annotation = memberAccessor.getAnnotation(ValueRangeProvider.class);
         String id = annotation.id();
         if (id == null || id.isEmpty()) {
-            id = UUID.randomUUID().toString();
+            return null;
         }
         validateUniqueValueRangeProviderId(id, memberAccessor);
         return id;

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/domain/policy/DescriptorPolicy.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/domain/policy/DescriptorPolicy.java
@@ -5,6 +5,7 @@ import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 
 import org.optaplanner.core.api.domain.common.DomainAccessType;
 import org.optaplanner.core.api.domain.solution.cloner.SolutionCloner;
@@ -79,8 +80,7 @@ public class DescriptorPolicy {
         ValueRangeProvider annotation = memberAccessor.getAnnotation(ValueRangeProvider.class);
         String id = annotation.id();
         if (id == null || id.isEmpty()) {
-            throw new IllegalStateException("The @" + ValueRangeProvider.class.getSimpleName()
-                    + " annotated member (" + memberAccessor + ")'s id (" + id + ") must not be empty.");
+            id = UUID.randomUUID().toString();
         }
         validateUniqueValueRangeProviderId(id, memberAccessor);
         return id;

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/domain/variable/descriptor/BasicVariableDescriptor.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/domain/variable/descriptor/BasicVariableDescriptor.java
@@ -26,14 +26,14 @@ public class BasicVariableDescriptor<Solution_> extends GenuineVariableDescripto
     @Override
     protected void processPropertyAnnotations(DescriptorPolicy descriptorPolicy) {
         PlanningVariable planningVariableAnnotation = variableMemberAccessor.getAnnotation(PlanningVariable.class);
-        processNullable(descriptorPolicy, planningVariableAnnotation);
-        processChained(descriptorPolicy, planningVariableAnnotation);
+        processNullable(planningVariableAnnotation);
+        processChained(planningVariableAnnotation);
         processValueRangeRefs(descriptorPolicy, planningVariableAnnotation.valueRangeProviderRefs());
-        processStrength(descriptorPolicy, planningVariableAnnotation.strengthComparatorClass(),
+        processStrength(planningVariableAnnotation.strengthComparatorClass(),
                 planningVariableAnnotation.strengthWeightFactoryClass());
     }
 
-    private void processNullable(DescriptorPolicy descriptorPolicy, PlanningVariable planningVariableAnnotation) {
+    private void processNullable(PlanningVariable planningVariableAnnotation) {
         nullable = planningVariableAnnotation.nullable();
         if (nullable && variableMemberAccessor.getType().isPrimitive()) {
             throw new IllegalArgumentException("The entityClass (" + entityDescriptor.getEntityClass()
@@ -44,7 +44,7 @@ public class BasicVariableDescriptor<Solution_> extends GenuineVariableDescripto
         }
     }
 
-    private void processChained(DescriptorPolicy descriptorPolicy, PlanningVariable planningVariableAnnotation) {
+    private void processChained(PlanningVariable planningVariableAnnotation) {
         chained = planningVariableAnnotation.graphType() == PlanningVariableGraphType.CHAINED;
         if (!chained) {
             return;

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/domain/variable/descriptor/GenuineVariableDescriptor.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/domain/variable/descriptor/GenuineVariableDescriptor.java
@@ -103,9 +103,7 @@ public abstract class GenuineVariableDescriptor<Solution_> extends VariableDescr
         }
     }
 
-    protected void processStrength(
-            DescriptorPolicy descriptorPolicy,
-            Class<? extends Comparator> strengthComparatorClass,
+    protected void processStrength(Class<? extends Comparator> strengthComparatorClass,
             Class<? extends SelectionSorterWeightFactory> strengthWeightFactoryClass) {
         if (strengthComparatorClass == PlanningVariable.NullStrengthComparator.class) {
             strengthComparatorClass = null;

--- a/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/api/domain/valuerange/AnonymousValueRangeFactoryTest.java
+++ b/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/api/domain/valuerange/AnonymousValueRangeFactoryTest.java
@@ -8,6 +8,8 @@ import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.Test;
 import org.optaplanner.core.api.score.buildin.simple.SimpleScore;
 import org.optaplanner.core.config.solver.SolverConfig;
+import org.optaplanner.core.impl.testdata.domain.valuerange.anonymous.TestdataAnonymousArraySolution;
+import org.optaplanner.core.impl.testdata.domain.valuerange.anonymous.TestdataAnonymousListSolution;
 import org.optaplanner.core.impl.testdata.domain.valuerange.anonymous.TestdataAnonymousValueRangeEntity;
 import org.optaplanner.core.impl.testdata.domain.valuerange.anonymous.TestdataAnonymousValueRangeSolution;
 import org.optaplanner.core.impl.testdata.util.PlannerTestUtils;
@@ -15,7 +17,7 @@ import org.optaplanner.core.impl.testdata.util.PlannerTestUtils;
 class AnonymousValueRangeFactoryTest {
 
     @Test
-    void solve() {
+    void solveValueRange() {
         SolverConfig solverConfig = PlannerTestUtils.buildSolverConfig(
                 TestdataAnonymousValueRangeSolution.class, TestdataAnonymousValueRangeEntity.class);
 
@@ -34,16 +36,52 @@ class AnonymousValueRangeFactoryTest {
         assertThat(solution).isNotNull();
     }
 
+    @Test
+    void solveArray() {
+        SolverConfig solverConfig = PlannerTestUtils.buildSolverConfig(
+                TestdataAnonymousArraySolution.class, TestdataAnonymousValueRangeEntity.class);
+
+        TestdataAnonymousArraySolution solution = new TestdataAnonymousArraySolution("s1");
+        solution.setEntityList(Arrays.asList(new TestdataAnonymousValueRangeEntity("e1"),
+                new TestdataAnonymousValueRangeEntity("e2")));
+
+        TestdataAnonymousArraySolution result = PlannerTestUtils.solve(solverConfig, solution);
+        TestdataAnonymousValueRangeEntity entity1 = result.getEntityList().get(0);
+        TestdataAnonymousValueRangeEntity entity2 = result.getEntityList().get(1);
+        SoftAssertions.assertSoftly(softly -> {
+            softly.assertThat(result.getScore()).isEqualTo(SimpleScore.ZERO);
+            assertEntity(softly, entity1);
+            assertEntity(softly, entity2);
+        });
+        assertThat(solution).isNotNull();
+    }
+
+    @Test
+    void solveList() {
+        SolverConfig solverConfig = PlannerTestUtils.buildSolverConfig(
+                TestdataAnonymousListSolution.class, TestdataAnonymousValueRangeEntity.class);
+
+        TestdataAnonymousListSolution solution = new TestdataAnonymousListSolution("s1");
+        solution.setEntityList(Arrays.asList(new TestdataAnonymousValueRangeEntity("e1"),
+                new TestdataAnonymousValueRangeEntity("e2")));
+
+        TestdataAnonymousListSolution result = PlannerTestUtils.solve(solverConfig, solution);
+        TestdataAnonymousValueRangeEntity entity1 = result.getEntityList().get(0);
+        TestdataAnonymousValueRangeEntity entity2 = result.getEntityList().get(1);
+        SoftAssertions.assertSoftly(softly -> {
+            softly.assertThat(result.getScore()).isEqualTo(SimpleScore.ZERO);
+            assertEntity(softly, entity1);
+            assertEntity(softly, entity2);
+        });
+        assertThat(solution).isNotNull();
+    }
+
     private void assertEntity(SoftAssertions softly, TestdataAnonymousValueRangeEntity entity) {
         softly.assertThat(entity.getNumberValue()).isNotNull();
         softly.assertThat(entity.getIntegerValue()).isNotNull();
         softly.assertThat(entity.getLongValue()).isNotNull();
         softly.assertThat(entity.getBigIntegerValue()).isNotNull();
         softly.assertThat(entity.getBigDecimalValue()).isNotNull();
-        softly.assertThat(entity.getLocalDateValue()).isNotNull();
-        softly.assertThat(entity.getLocalTimeValue()).isNotNull();
-        softly.assertThat(entity.getLocalDateTimeValue()).isNotNull();
-        softly.assertThat(entity.getYearValue()).isNotNull();
     }
 
 }

--- a/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/api/domain/valuerange/AnonymousValueRangeFactoryTest.java
+++ b/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/api/domain/valuerange/AnonymousValueRangeFactoryTest.java
@@ -1,0 +1,49 @@
+package org.optaplanner.core.api.domain.valuerange;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Arrays;
+
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.Test;
+import org.optaplanner.core.api.score.buildin.simple.SimpleScore;
+import org.optaplanner.core.config.solver.SolverConfig;
+import org.optaplanner.core.impl.testdata.domain.valuerange.anonymous.TestdataAnonymousValueRangeEntity;
+import org.optaplanner.core.impl.testdata.domain.valuerange.anonymous.TestdataAnonymousValueRangeSolution;
+import org.optaplanner.core.impl.testdata.util.PlannerTestUtils;
+
+class AnonymousValueRangeFactoryTest {
+
+    @Test
+    void solve() {
+        SolverConfig solverConfig = PlannerTestUtils.buildSolverConfig(
+                TestdataAnonymousValueRangeSolution.class, TestdataAnonymousValueRangeEntity.class);
+
+        TestdataAnonymousValueRangeSolution solution = new TestdataAnonymousValueRangeSolution("s1");
+        solution.setEntityList(Arrays.asList(new TestdataAnonymousValueRangeEntity("e1"),
+                new TestdataAnonymousValueRangeEntity("e2")));
+
+        TestdataAnonymousValueRangeSolution result = PlannerTestUtils.solve(solverConfig, solution);
+        TestdataAnonymousValueRangeEntity entity1 = result.getEntityList().get(0);
+        TestdataAnonymousValueRangeEntity entity2 = result.getEntityList().get(1);
+        SoftAssertions.assertSoftly(softly -> {
+            softly.assertThat(result.getScore()).isEqualTo(SimpleScore.ZERO);
+            assertEntity(softly, entity1);
+            assertEntity(softly, entity2);
+        });
+        assertThat(solution).isNotNull();
+    }
+
+    private void assertEntity(SoftAssertions softly, TestdataAnonymousValueRangeEntity entity) {
+        softly.assertThat(entity.getNumberValue()).isNotNull();
+        softly.assertThat(entity.getIntegerValue()).isNotNull();
+        softly.assertThat(entity.getLongValue()).isNotNull();
+        softly.assertThat(entity.getBigIntegerValue()).isNotNull();
+        softly.assertThat(entity.getBigDecimalValue()).isNotNull();
+        softly.assertThat(entity.getLocalDateValue()).isNotNull();
+        softly.assertThat(entity.getLocalTimeValue()).isNotNull();
+        softly.assertThat(entity.getLocalDateTimeValue()).isNotNull();
+        softly.assertThat(entity.getYearValue()).isNotNull();
+    }
+
+}

--- a/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/testdata/domain/valuerange/anonymous/TestdataAnonymousArraySolution.java
+++ b/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/testdata/domain/valuerange/anonymous/TestdataAnonymousArraySolution.java
@@ -7,18 +7,16 @@ import java.util.List;
 import org.optaplanner.core.api.domain.solution.PlanningEntityCollectionProperty;
 import org.optaplanner.core.api.domain.solution.PlanningScore;
 import org.optaplanner.core.api.domain.solution.PlanningSolution;
-import org.optaplanner.core.api.domain.valuerange.CountableValueRange;
-import org.optaplanner.core.api.domain.valuerange.ValueRangeFactory;
 import org.optaplanner.core.api.domain.valuerange.ValueRangeProvider;
 import org.optaplanner.core.api.score.buildin.simple.SimpleScore;
 import org.optaplanner.core.impl.domain.solution.descriptor.SolutionDescriptor;
 import org.optaplanner.core.impl.testdata.domain.TestdataObject;
 
 @PlanningSolution
-public class TestdataAnonymousValueRangeSolution extends TestdataObject {
+public class TestdataAnonymousArraySolution extends TestdataObject {
 
-    public static SolutionDescriptor<TestdataAnonymousValueRangeSolution> buildSolutionDescriptor() {
-        return SolutionDescriptor.buildSolutionDescriptor(TestdataAnonymousValueRangeSolution.class,
+    public static SolutionDescriptor<TestdataAnonymousArraySolution> buildSolutionDescriptor() {
+        return SolutionDescriptor.buildSolutionDescriptor(TestdataAnonymousArraySolution.class,
                 TestdataAnonymousValueRangeEntity.class);
     }
 
@@ -26,10 +24,10 @@ public class TestdataAnonymousValueRangeSolution extends TestdataObject {
 
     private SimpleScore score;
 
-    public TestdataAnonymousValueRangeSolution() {
+    public TestdataAnonymousArraySolution() {
     }
 
-    public TestdataAnonymousValueRangeSolution(String code) {
+    public TestdataAnonymousArraySolution(String code) {
         super(code);
     }
 
@@ -56,24 +54,28 @@ public class TestdataAnonymousValueRangeSolution extends TestdataObject {
     // ************************************************************************
 
     @ValueRangeProvider
-    public CountableValueRange<Integer> createIntValueRange() {
-        return ValueRangeFactory.createIntValueRange(0, 3);
+    public Integer[] createIntegerArray() {
+        return new Integer[] { 0, 1 };
     }
 
     @ValueRangeProvider
-    public CountableValueRange<Long> createLongValueRange() {
-        return ValueRangeFactory.createLongValueRange(1_000L, 1_003L);
+    public Long[] createLongArray() {
+        return new Long[] { 0L, 1L };
     }
 
     @ValueRangeProvider
-    public CountableValueRange<BigInteger> createBigIntegerValueRange() {
-        return ValueRangeFactory.createBigIntegerValueRange(
-                BigInteger.valueOf(1_000_000L), BigInteger.valueOf(1_000_003L));
+    public Number[] createNumberArray() {
+        return new Number[] { 0L, 1L };
     }
 
     @ValueRangeProvider
-    public CountableValueRange<BigDecimal> createBigDecimalValueRange() {
-        return ValueRangeFactory.createBigDecimalValueRange(new BigDecimal("0.00"), new BigDecimal("0.03"));
+    public BigInteger[] createBigIntegerArray() {
+        return new BigInteger[] { BigInteger.ZERO, BigInteger.TEN };
+    }
+
+    @ValueRangeProvider
+    public BigDecimal[] createBigDecimalArray() {
+        return new BigDecimal[] { BigDecimal.ZERO, BigDecimal.TEN };
     }
 
 }

--- a/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/testdata/domain/valuerange/anonymous/TestdataAnonymousListSolution.java
+++ b/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/testdata/domain/valuerange/anonymous/TestdataAnonymousListSolution.java
@@ -7,18 +7,16 @@ import java.util.List;
 import org.optaplanner.core.api.domain.solution.PlanningEntityCollectionProperty;
 import org.optaplanner.core.api.domain.solution.PlanningScore;
 import org.optaplanner.core.api.domain.solution.PlanningSolution;
-import org.optaplanner.core.api.domain.valuerange.CountableValueRange;
-import org.optaplanner.core.api.domain.valuerange.ValueRangeFactory;
 import org.optaplanner.core.api.domain.valuerange.ValueRangeProvider;
 import org.optaplanner.core.api.score.buildin.simple.SimpleScore;
 import org.optaplanner.core.impl.domain.solution.descriptor.SolutionDescriptor;
 import org.optaplanner.core.impl.testdata.domain.TestdataObject;
 
 @PlanningSolution
-public class TestdataAnonymousValueRangeSolution extends TestdataObject {
+public class TestdataAnonymousListSolution extends TestdataObject {
 
-    public static SolutionDescriptor<TestdataAnonymousValueRangeSolution> buildSolutionDescriptor() {
-        return SolutionDescriptor.buildSolutionDescriptor(TestdataAnonymousValueRangeSolution.class,
+    public static SolutionDescriptor<TestdataAnonymousListSolution> buildSolutionDescriptor() {
+        return SolutionDescriptor.buildSolutionDescriptor(TestdataAnonymousListSolution.class,
                 TestdataAnonymousValueRangeEntity.class);
     }
 
@@ -26,10 +24,10 @@ public class TestdataAnonymousValueRangeSolution extends TestdataObject {
 
     private SimpleScore score;
 
-    public TestdataAnonymousValueRangeSolution() {
+    public TestdataAnonymousListSolution() {
     }
 
-    public TestdataAnonymousValueRangeSolution(String code) {
+    public TestdataAnonymousListSolution(String code) {
         super(code);
     }
 
@@ -56,24 +54,28 @@ public class TestdataAnonymousValueRangeSolution extends TestdataObject {
     // ************************************************************************
 
     @ValueRangeProvider
-    public CountableValueRange<Integer> createIntValueRange() {
-        return ValueRangeFactory.createIntValueRange(0, 3);
+    public List<Integer> createIntegerList() {
+        return List.of(0, 1);
     }
 
     @ValueRangeProvider
-    public CountableValueRange<Long> createLongValueRange() {
-        return ValueRangeFactory.createLongValueRange(1_000L, 1_003L);
+    public List<Long> createLongList() {
+        return List.of(0L, 1L);
     }
 
     @ValueRangeProvider
-    public CountableValueRange<BigInteger> createBigIntegerValueRange() {
-        return ValueRangeFactory.createBigIntegerValueRange(
-                BigInteger.valueOf(1_000_000L), BigInteger.valueOf(1_000_003L));
+    public List<Number> createNumberList() {
+        return List.of(0, BigInteger.TEN);
     }
 
     @ValueRangeProvider
-    public CountableValueRange<BigDecimal> createBigDecimalValueRange() {
-        return ValueRangeFactory.createBigDecimalValueRange(new BigDecimal("0.00"), new BigDecimal("0.03"));
+    public List<BigInteger> createBigIntegerList() {
+        return List.of(BigInteger.ZERO, BigInteger.TEN);
+    }
+
+    @ValueRangeProvider
+    public List<BigDecimal> createBigDecimalList() {
+        return List.of(BigDecimal.ZERO, BigDecimal.TEN);
     }
 
 }

--- a/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/testdata/domain/valuerange/anonymous/TestdataAnonymousValueRangeEntity.java
+++ b/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/testdata/domain/valuerange/anonymous/TestdataAnonymousValueRangeEntity.java
@@ -2,10 +2,6 @@ package org.optaplanner.core.impl.testdata.domain.valuerange.anonymous;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.LocalTime;
-import java.time.Year;
 
 import org.optaplanner.core.api.domain.entity.PlanningEntity;
 import org.optaplanner.core.api.domain.variable.PlanningVariable;
@@ -30,10 +26,6 @@ public class TestdataAnonymousValueRangeEntity extends TestdataObject {
     private Long longValue;
     private BigInteger bigIntegerValue;
     private BigDecimal bigDecimalValue;
-    private LocalDate localDateValue;
-    private LocalTime localTimeValue;
-    private LocalDateTime localDateTimeValue;
-    private Year yearValue;
 
     public TestdataAnonymousValueRangeEntity() {
     }
@@ -85,42 +77,6 @@ public class TestdataAnonymousValueRangeEntity extends TestdataObject {
 
     public void setBigDecimalValue(BigDecimal bigDecimalValue) {
         this.bigDecimalValue = bigDecimalValue;
-    }
-
-    @PlanningVariable
-    public LocalDate getLocalDateValue() {
-        return localDateValue;
-    }
-
-    public void setLocalDateValue(LocalDate localDateValue) {
-        this.localDateValue = localDateValue;
-    }
-
-    @PlanningVariable
-    public LocalTime getLocalTimeValue() {
-        return localTimeValue;
-    }
-
-    public void setLocalTimeValue(LocalTime localTimeValue) {
-        this.localTimeValue = localTimeValue;
-    }
-
-    @PlanningVariable
-    public LocalDateTime getLocalDateTimeValue() {
-        return localDateTimeValue;
-    }
-
-    public void setLocalDateTimeValue(LocalDateTime localDateTimeValue) {
-        this.localDateTimeValue = localDateTimeValue;
-    }
-
-    @PlanningVariable
-    public Year getYearValue() {
-        return yearValue;
-    }
-
-    public void setYearValue(Year yearValue) {
-        this.yearValue = yearValue;
     }
 
     // ************************************************************************

--- a/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/testdata/domain/valuerange/anonymous/TestdataAnonymousValueRangeEntity.java
+++ b/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/testdata/domain/valuerange/anonymous/TestdataAnonymousValueRangeEntity.java
@@ -1,0 +1,130 @@
+package org.optaplanner.core.impl.testdata.domain.valuerange.anonymous;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.Year;
+
+import org.optaplanner.core.api.domain.entity.PlanningEntity;
+import org.optaplanner.core.api.domain.variable.PlanningVariable;
+import org.optaplanner.core.impl.domain.entity.descriptor.EntityDescriptor;
+import org.optaplanner.core.impl.domain.variable.descriptor.GenuineVariableDescriptor;
+import org.optaplanner.core.impl.testdata.domain.TestdataObject;
+
+@PlanningEntity
+public class TestdataAnonymousValueRangeEntity extends TestdataObject {
+
+    public static EntityDescriptor<TestdataAnonymousValueRangeSolution> buildEntityDescriptor() {
+        return TestdataAnonymousValueRangeSolution.buildSolutionDescriptor()
+                .findEntityDescriptorOrFail(TestdataAnonymousValueRangeEntity.class);
+    }
+
+    public static GenuineVariableDescriptor<TestdataAnonymousValueRangeSolution> buildVariableDescriptorForValue() {
+        return buildEntityDescriptor().getGenuineVariableDescriptor("value");
+    }
+
+    private Number numberValue;
+    private Integer integerValue;
+    private Long longValue;
+    private BigInteger bigIntegerValue;
+    private BigDecimal bigDecimalValue;
+    private LocalDate localDateValue;
+    private LocalTime localTimeValue;
+    private LocalDateTime localDateTimeValue;
+    private Year yearValue;
+
+    public TestdataAnonymousValueRangeEntity() {
+    }
+
+    public TestdataAnonymousValueRangeEntity(String code) {
+        super(code);
+    }
+
+    @PlanningVariable
+    public Number getNumberValue() {
+        return numberValue;
+    }
+
+    public void setNumberValue(Number numberValue) {
+        this.numberValue = numberValue;
+    }
+
+    @PlanningVariable
+    public Integer getIntegerValue() {
+        return integerValue;
+    }
+
+    public void setIntegerValue(Integer integerValue) {
+        this.integerValue = integerValue;
+    }
+
+    @PlanningVariable
+    public Long getLongValue() {
+        return longValue;
+    }
+
+    public void setLongValue(Long longValue) {
+        this.longValue = longValue;
+    }
+
+    @PlanningVariable
+    public BigInteger getBigIntegerValue() {
+        return bigIntegerValue;
+    }
+
+    public void setBigIntegerValue(BigInteger bigIntegerValue) {
+        this.bigIntegerValue = bigIntegerValue;
+    }
+
+    @PlanningVariable
+    public BigDecimal getBigDecimalValue() {
+        return bigDecimalValue;
+    }
+
+    public void setBigDecimalValue(BigDecimal bigDecimalValue) {
+        this.bigDecimalValue = bigDecimalValue;
+    }
+
+    @PlanningVariable
+    public LocalDate getLocalDateValue() {
+        return localDateValue;
+    }
+
+    public void setLocalDateValue(LocalDate localDateValue) {
+        this.localDateValue = localDateValue;
+    }
+
+    @PlanningVariable
+    public LocalTime getLocalTimeValue() {
+        return localTimeValue;
+    }
+
+    public void setLocalTimeValue(LocalTime localTimeValue) {
+        this.localTimeValue = localTimeValue;
+    }
+
+    @PlanningVariable
+    public LocalDateTime getLocalDateTimeValue() {
+        return localDateTimeValue;
+    }
+
+    public void setLocalDateTimeValue(LocalDateTime localDateTimeValue) {
+        this.localDateTimeValue = localDateTimeValue;
+    }
+
+    @PlanningVariable
+    public Year getYearValue() {
+        return yearValue;
+    }
+
+    public void setYearValue(Year yearValue) {
+        this.yearValue = yearValue;
+    }
+
+    // ************************************************************************
+    // Complex methods
+    // ************************************************************************
+
+}

--- a/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/testdata/domain/valuerange/anonymous/TestdataAnonymousValueRangeSolution.java
+++ b/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/testdata/domain/valuerange/anonymous/TestdataAnonymousValueRangeSolution.java
@@ -1,0 +1,107 @@
+package org.optaplanner.core.impl.testdata.domain.valuerange.anonymous;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.Year;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+
+import org.optaplanner.core.api.domain.solution.PlanningEntityCollectionProperty;
+import org.optaplanner.core.api.domain.solution.PlanningScore;
+import org.optaplanner.core.api.domain.solution.PlanningSolution;
+import org.optaplanner.core.api.domain.valuerange.CountableValueRange;
+import org.optaplanner.core.api.domain.valuerange.ValueRangeFactory;
+import org.optaplanner.core.api.domain.valuerange.ValueRangeProvider;
+import org.optaplanner.core.api.score.buildin.simple.SimpleScore;
+import org.optaplanner.core.impl.domain.solution.descriptor.SolutionDescriptor;
+import org.optaplanner.core.impl.testdata.domain.TestdataObject;
+
+@PlanningSolution
+public class TestdataAnonymousValueRangeSolution extends TestdataObject {
+
+    public static SolutionDescriptor<TestdataAnonymousValueRangeSolution> buildSolutionDescriptor() {
+        return SolutionDescriptor.buildSolutionDescriptor(TestdataAnonymousValueRangeSolution.class, TestdataAnonymousValueRangeEntity.class);
+    }
+
+    private List<TestdataAnonymousValueRangeEntity> entityList;
+
+    private SimpleScore score;
+
+    public TestdataAnonymousValueRangeSolution() {
+    }
+
+    public TestdataAnonymousValueRangeSolution(String code) {
+        super(code);
+    }
+
+    @PlanningEntityCollectionProperty
+    public List<TestdataAnonymousValueRangeEntity> getEntityList() {
+        return entityList;
+    }
+
+    public void setEntityList(List<TestdataAnonymousValueRangeEntity> entityList) {
+        this.entityList = entityList;
+    }
+
+    @PlanningScore
+    public SimpleScore getScore() {
+        return score;
+    }
+
+    public void setScore(SimpleScore score) {
+        this.score = score;
+    }
+
+    // ************************************************************************
+    // Complex methods
+    // ************************************************************************
+
+    @ValueRangeProvider
+    public CountableValueRange<Integer> createIntValueRange() {
+        return ValueRangeFactory.createIntValueRange(0, 3);
+    }
+
+    @ValueRangeProvider
+    public CountableValueRange<Long> createLongValueRange() {
+        return ValueRangeFactory.createLongValueRange(1_000L, 1_003L);
+    }
+
+    @ValueRangeProvider
+    public CountableValueRange<BigInteger> createBigIntegerValueRange() {
+        return ValueRangeFactory.createBigIntegerValueRange(
+                BigInteger.valueOf(1_000_000L), BigInteger.valueOf(1_000_003L));
+    }
+
+    @ValueRangeProvider
+    public CountableValueRange<BigDecimal> createBigDecimalValueRange() {
+        return ValueRangeFactory.createBigDecimalValueRange(new BigDecimal("0.00"), new BigDecimal("0.03"));
+    }
+
+    @ValueRangeProvider
+    public CountableValueRange<LocalDate> createLocalDateValueRange() {
+        return ValueRangeFactory.createLocalDateValueRange(
+                LocalDate.of(2000, 1, 1), LocalDate.of(2000, 1, 4), 1, ChronoUnit.DAYS);
+    }
+
+    @ValueRangeProvider
+    public CountableValueRange<LocalTime> createLocaleTimeValueRange() {
+        return ValueRangeFactory.createLocalTimeValueRange(
+                LocalTime.of(10, 0), LocalTime.of(10, 3), 1, ChronoUnit.MINUTES);
+    }
+
+    @ValueRangeProvider
+    public CountableValueRange<LocalDateTime> createLocaleDateTimeValueRange() {
+        return ValueRangeFactory.createLocalDateTimeValueRange(
+                LocalDateTime.of(2000, 1, 1, 10, 0), LocalDateTime.of(2000, 1, 1, 10, 3), 1, ChronoUnit.MINUTES);
+    }
+
+    @ValueRangeProvider
+    public CountableValueRange<Year> createYearValueRange() {
+        return ValueRangeFactory.createTemporalValueRange(
+                Year.of(2000), Year.of(2003), 1, ChronoUnit.YEARS);
+    }
+
+}

--- a/optaplanner-docs/src/modules/ROOT/pages/planner-configuration/planner-configuration.adoc
+++ b/optaplanner-docs/src/modules/ROOT/pages/planner-configuration/planner-configuration.adoc
@@ -463,7 +463,7 @@ For example, a ``Queen``'s `row` property is a genuine planning variable.
 Note that even though a ``Queen``'s `row` property changes to another `Row` during planning, no `Row` instance itself is changed.
 Normally planning variables are genuine, but advanced cases can also have xref:shadow-variable/shadow-variable.adoc#shadowVariable[shadows].
 
-A genuine planning variable getter needs to be annotated with the `@PlanningVariable` annotation, which needs a non-empty `valueRangeProviderRefs` property.
+A genuine planning variable getter needs to be annotated with the `@PlanningVariable` annotation, optionally with a non-empty `valueRangeProviderRefs` property.
 
 [source,java,options="nowrap"]
 ----
@@ -473,7 +473,7 @@ public class Queen {
 
     private Row row;
 
-    @PlanningVariable(valueRangeProviderRefs = { "rowRange" })
+    @PlanningVariable
     public Row getRow() {
         return row;
     }
@@ -485,8 +485,9 @@ public class Queen {
 }
 ----
 
-The `valueRangeProviderRefs` property defines what are the possible planning values for this planning variable.
+The optional `valueRangeProviderRefs` property defines what are the possible planning values for this planning variable.
 It references one or more ``@ValueRangeProvider`` ``id``'s.
+If none are provided, OptaPlanner will attempt to auto-detect matching ``@ValueRangeProvider``s.
 
 [NOTE]
 ====
@@ -502,11 +503,16 @@ It is ignored on parent classes or subclasses without that annotation.
 public class Queen {
     ...
 
-    @PlanningVariable(valueRangeProviderRefs = { "rowRange" })
+    @PlanningVariable
     private Row row;
 
 }
 ----
+
+[NOTE]
+====
+For more advanced planning variables used to model precedence relationships, see xref:#planningListVariable[planning list variable] and xref:#chainedPlanningVariable[chained planning variable].
+====
 
 
 [[nullablePlanningVariable]]
@@ -605,7 +611,7 @@ This set can be a countable (for example row ``1``, ``2``, `3` or ``4``) or unco
 ===== Overview
 
 The value range of a planning variable is defined with the `@ValueRangeProvider` annotation.
-A `@ValueRangeProvider` annotation always has a property ``id``, which is referenced by the ``@PlanningVariable``'s property ``valueRangeProviderRefs``.
+A `@ValueRangeProvider` may carry a property ``id``, which is referenced by the ``@PlanningVariable``'s property ``valueRangeProviderRefs``.
 
 This annotation can be located on two types of methods:
 
@@ -625,7 +631,6 @@ The return type of that method can be three types:
 * Array: The value range is defined by an array of its possible values.
 * ``ValueRange``: The value range is defined by its bounds. This is less common.
 
-
 [[valueRangeProviderOnSolution]]
 ===== `ValueRangeProvider` on the solution
 
@@ -637,7 +642,7 @@ Any value from that `Collection` is a possible planning value for this planning 
 
 [source,java,options="nowrap"]
 ----
-    @PlanningVariable(valueRangeProviderRefs = { "rowRange" })
+    @PlanningVariable
     public Row getRow() {
         return row;
     }
@@ -649,7 +654,7 @@ Any value from that `Collection` is a possible planning value for this planning 
 public class NQueens {
     ...
 
-    @ValueRangeProvider(id = "rowRange")
+    @ValueRangeProvider
     public List<Row> getRowList() {
         return rowList;
     }
@@ -670,7 +675,7 @@ That `Collection` (or ``ValueRange``) must not contain the value ``null``, not e
 public class NQueens {
     ...
 
-    @ValueRangeProvider(id = "rowRange")
+    @ValueRangeProvider
     private List<Row> rowList;
 
 }
@@ -685,12 +690,12 @@ For example, if a teacher can *never* teach in a room that does not belong to hi
 
 [source,java,options="nowrap"]
 ----
-    @PlanningVariable(valueRangeProviderRefs = { "departmentRoomRange" })
+    @PlanningVariable
     public Room getRoom() {
         return room;
     }
 
-    @ValueRangeProvider(id = "departmentRoomRange")
+    @ValueRangeProvider
     public List<Room> getPossibleRoomList() {
         return getCourse().getTeacher().getDepartment().getRoomList();
     }
@@ -728,6 +733,123 @@ A `ValueRangeProvider` on the planning entity is not compatible with a <<plannin
 ====
 
 
+[[referencingValueRangeProviders]]
+===== Referencing ``ValueRangeProvider``s
+
+There are two ways how to match a planning variable to a value range provider.
+The simplest way is to have value range provider auto-detected.
+Another way is to explicitly reference the value range provider.
+
+[[anonymousValueRangeProviders]]
+====== Anonymous ``ValueRangeProvider``s
+
+We already described the first approach.
+By not providing any `valueRangeProviderRefs` on the `@PlanningVariable` annotation,
+OptaPlanner will go over every ``@ValueRangeProvider``-annotated method or field which does not have an ``id`` property set,
+and will match planning variables with value ranges where their types match.
+
+In the following example,
+the planning variable ``car`` will be matched to the value range returned by ``getCompanyCarList()``,
+as they both use the ``Car`` type.
+It will not match ``getPersonalCarList()``,
+because that value range provider is not anonymous; it specifies an ``id``.
+
+[source,java,options="nowrap"]
+----
+    @PlanningVariable
+    public Car getCar() {
+        return car;
+    }
+
+    @ValueRangeProvider
+    public List<Car> getCompanyCarList() {
+        return companyCarList;
+    }
+
+    @ValueRangeProvider(id = "personalCarRange")
+    public List<Car> getPersonalCarList() {
+        return personalCarList;
+    }
+----
+
+Automatic matching also accounts for polymorphism.
+In the following example,
+the planning variable ``car`` will be matched to ``getCompanyCarList()`` and ``getPersonalCarList()``,
+as both ``CompanyCar`` and ``PersonalCar`` are ``Car``s.
+It will not match ``getAirplanes()``,
+as an ``Airplane`` is not a ``Car``.
+
+[source,java,options="nowrap"]
+----
+    @PlanningVariable
+    public Car getCar() {
+        return car;
+    }
+
+    @ValueRangeProvider
+    public List<CompanyCar> getCompanyCarList() {
+        return companyCarList;
+    }
+
+    @ValueRangeProvider
+    public List<PersonalCar> getPersonalCarList() {
+        return personalCarList;
+    }
+
+    @ValueRangeProvider
+    public List<Airplane> getAirplanes() {
+        return airplaneList;
+    }
+----
+
+[[referencingValueRangeProviders]]
+====== Explicitly referenced ``ValueRangeProvider``s
+
+In more complicated cases where auto-detection is not sufficient or where clarity is preferred over simplicity,
+value range providers can also be referenced explicitly.
+
+In the following example,
+the ``car`` planning variable will only be matched to value range provided by methods ``getCompanyCarList()``.
+
+[source,java,options="nowrap"]
+----
+    @PlanningVariable(valueRangeProviderRefs = {"companyCarRange"})
+    public Car getCar() {
+        return car;
+    }
+
+    @ValueRangeProvider(id = "companyCarRange")
+    public List<CompanyCar> getCompanyCarList() {
+        return companyCarList;
+    }
+
+    @ValueRangeProvider(id = "personalCarRange")
+    public List<PersonalCar> getPersonalCarList() {
+        return personalCarList;
+    }
+----
+
+Explicitly referenced value range providers can also be combined, for example:
+
+[source,java,options="nowrap"]
+----
+    @PlanningVariable(valueRangeProviderRefs = { "companyCarRange", "personalCarRange" })
+    public Car getCar() {
+        return car;
+    }
+
+    @ValueRangeProvider(id = "companyCarRange")
+    public List<CompanyCar> getCompanyCarList() {
+        return companyCarList;
+    }
+
+    @ValueRangeProvider(id = "personalCarRange")
+    public List<PersonalCar> getPersonalCarList() {
+        return personalCarList;
+    }
+----
+
+
 [[valueRangeFactory]]
 ===== `ValueRangeFactory`
 
@@ -735,7 +857,7 @@ Instead of a ``Collection``, you can also return a `ValueRange` or ``CountableVa
 
 [source,java,options="nowrap"]
 ----
-    @ValueRangeProvider(id = "delayRange")
+    @ValueRangeProvider
     public CountableValueRange<Integer> getDelayRange() {
         return ValueRangeFactory.createIntValueRange(0, 5000);
     }
@@ -748,7 +870,7 @@ Furthermore, an `incrementUnit` can be specified, for example if you have to buy
 
 [source,java,options="nowrap"]
 ----
-    @ValueRangeProvider(id = "stockAmountRange")
+    @ValueRangeProvider
     public CountableValueRange<Integer> getStockAmountRange() {
          // Range: 0, 200, 400, 600, ..., 9999600, 9999800, 10000000
         return ValueRangeFactory.createIntValueRange(0, 10000000, 200);
@@ -769,33 +891,6 @@ The `ValueRangeFactory` has creation methods for several value class types:
 * ``BigInteger``: An arbitrary-precision integer range.
 * ``BigDecimal``: A decimal point range. By default, the increment unit is the lowest non-zero value in the scale of the bounds.
 * `Temporal` (such as ``LocalDate``, ``LocalDateTime``, ...): A time range.
-
-
-[[combineValueRangeProviders]]
-===== Combine `ValueRangeProviders`
-
-Value range providers can be combined, for example:
-
-[source,java,options="nowrap"]
-----
-    @PlanningVariable(valueRangeProviderRefs = { "companyCarRange", "personalCarRange" })
-    public Car getCar() {
-        return car;
-    }
-----
-
-[source,java,options="nowrap"]
-----
-    @ValueRangeProvider(id = "companyCarRange")
-    public List<CompanyCar> getCompanyCarList() {
-        return companyCarList;
-    }
-
-    @ValueRangeProvider(id = "personalCarRange")
-    public List<PersonalCar> getPersonalCarList() {
-        return personalCarList;
-    }
-----
 
 
 [[planningValueStrength]]
@@ -867,7 +962,7 @@ For example, none of the `row` variables of any `Queen` may be used to determine
 
 
 [[planningListVariable]]
-==== Planning list variable (VRP, Task assigning, ...)
+=== Planning list variable (VRP, Task assigning, ...)
 
 Use the planning list variable to model problems where the goal is to distribute a number of workload elements among limited resources in a specific order.
 This includes, for example, vehicle routing, traveling salesman, task assigning, and similar problems, that have previously been modeled using the <<chainedPlanningVariable,chained planning variable>>.
@@ -904,7 +999,7 @@ class Vehicle {
     int capacity;
     Depot depot;
 
-    @PlanningListVariable(valueRangeProviderRefs = "customerRange")
+    @PlanningListVariable
     List<Customer> customers = new ArrayList<>();
 }
 ----
@@ -920,7 +1015,7 @@ No planning value may appear in multiple entities.
 
 
 [[chainedPlanningVariable]]
-==== Chained planning variable (TSP, VRP, ...)
+=== Chained planning variable (TSP, VRP, ...)
 
 Chained planning variable is one way to implement the xref:design-patterns/design-patterns.adoc#chainedThroughTimePattern[Chained Through Time pattern].
 This pattern is used for some use cases, such as TSP and vehicle routing.
@@ -1002,8 +1097,7 @@ public class Visit ... implements Standstill {
 
     public City getCity() {...}
 
-    @PlanningVariable(graphType = PlanningVariableGraphType.CHAINED,
-        valueRangeProviderRefs = { "domicileRange", "visitRange" })
+    @PlanningVariable(graphType = PlanningVariableGraphType.CHAINED)
     public Standstill getPreviousStandstill() {
         return previousStandstill;
     }
@@ -1270,7 +1364,7 @@ For example, on the cloud balancing example:
 public class CloudBalance {
 
     // Auto discovered as @ProblemFactCollectionProperty
-    @ValueRangeProvider(id = "computerRange") // Not (yet) auto discovered
+    @ValueRangeProvider
     private List<CloudComputer> computerList;
 
     // Auto discovered as @PlanningEntityCollectionProperty

--- a/optaplanner-docs/src/modules/ROOT/pages/quickstart/school-timetabling/school-timetabling-model.adoc
+++ b/optaplanner-docs/src/modules/ROOT/pages/quickstart/school-timetabling/school-timetabling-model.adoc
@@ -148,9 +148,9 @@ public class Lesson {
     private String teacher;
     private String studentGroup;
 
-    @PlanningVariable(valueRangeProviderRefs = "timeslotRange")
+    @PlanningVariable
     private Timeslot timeslot;
-    @PlanningVariable(valueRangeProviderRefs = "roomRange")
+    @PlanningVariable
     private Room room;
 
     public Lesson() {
@@ -210,8 +210,8 @@ because it contains one or more planning variables.
 The `timeslot` field has an `@PlanningVariable` annotation,
 so OptaPlanner knows that it can change its value.
 In order to find potential `Timeslot` instances to assign to this field,
-OptaPlanner uses the `valueRangeProviderRefs` property to connect to a value range provider
-(explained later) that provides a `List<Timeslot>` to pick from.
+OptaPlanner uses the variable type to connect to a xref:planner-configuration/planner-configuration.adoc#planningValueRangeProvider[value range provider]
+that provides a `List<Timeslot>` to pick from.
 
 The `room` field also has an `@PlanningVariable` annotation, for the same reasons.
 

--- a/optaplanner-docs/src/modules/ROOT/pages/quickstart/school-timetabling/school-timetabling-solution.adoc
+++ b/optaplanner-docs/src/modules/ROOT/pages/quickstart/school-timetabling/school-timetabling-solution.adoc
@@ -30,10 +30,10 @@ import org.optaplanner.core.api.score.buildin.hardsoft.HardSoftScore;
 @PlanningSolution
 public class TimeTable {
 
-    @ValueRangeProvider(id = "timeslotRange")
+    @ValueRangeProvider
     @ProblemFactCollectionProperty
     private List<Timeslot> timeslotList;
-    @ValueRangeProvider(id = "roomRange")
+    @ValueRangeProvider
     @ProblemFactCollectionProperty
     private List<Room> roomList;
     @PlanningEntityCollectionProperty
@@ -97,7 +97,7 @@ However, this class is also the output of the solution:
 The `timeslotList` field is a value range provider.
 It holds the `Timeslot` instances which OptaPlanner can pick from to assign to the `timeslot` field of `Lesson` instances.
 The `timeslotList` field has an `@ValueRangeProvider` annotation to connect the `@PlanningVariable` with the `@ValueRangeProvider`,
-by matching the value of the `id` property with the value of the `valueRangeProviderRefs` property of the `@PlanningVariable` annotation in the `Lesson` class.
+by matching the type of the planning variable with the type returned by the xref:planner-configuration/planner-configuration.adoc#planningValueRangeProvider[value range provider].
 
 Following the same logic, the `roomList` field also has an `@ValueRangeProvider` annotation.
 

--- a/optaplanner-docs/src/modules/ROOT/pages/release-notes/release-notes-8.adoc
+++ b/optaplanner-docs/src/modules/ROOT/pages/release-notes/release-notes-8.adoc
@@ -1,6 +1,19 @@
 [[releaseNotes-8.x]]
 == OptaPlanner 8.x Release Notes
 
+[[releaseNotes-8.33.0.Final]]
+=== OptaPlanner 8.33.0.Final
+
+==== Value range auto-detection
+
+In most cases, links between planning variables and value ranges can now be auto-detected.
+Therefore, ``@ValueRangeProvider`` no longer needs to provide an ``id`` property.
+Likewise, planning variables no longer need to reference value range providers via ``valueRangeProviderRefs`` property.
+
+No code changes or configuration changes are required.
+Users who prefer clarity over brevity may continue to explicitly reference their value range providers.
+
+
 [[releaseNotes-8.32.0.Final]]
 === OptaPlanner 8.32.0.Final
 

--- a/optaplanner-docs/src/modules/ROOT/pages/shadow-variable/shadow-variable.adoc
+++ b/optaplanner-docs/src/modules/ROOT/pages/shadow-variable/shadow-variable.adoc
@@ -169,7 +169,7 @@ The planning entity side has a genuine list variable:
 @PlanningEntity
 public class Vehicle {
 
-    @PlanningListVariable(valueRangeProviderRefs = "customerRange")
+    @PlanningListVariable
     public List<Customer> getCustomers() {
         return customers;
     }
@@ -216,7 +216,7 @@ The planning entity side has a genuine list variable:
 @PlanningEntity
 public class Vehicle {
 
-    @PlanningListVariable(valueRangeProviderRefs = "customerRange")
+    @PlanningListVariable
     public List<Customer> getCustomers() {
         return customers;
     }

--- a/optaplanner-docs/src/modules/ROOT/pages/use-cases-and-examples/cloud-balancing/cloud-balancing.adoc
+++ b/optaplanner-docs/src/modules/ROOT/pages/use-cases-and-examples/cloud-balancing/cloud-balancing.adoc
@@ -148,7 +148,7 @@ public class CloudProcess ... {
 
     ... // getters
 
-    @PlanningVariable(valueRangeProviderRefs = { "computerRange" })
+    @PlanningVariable
     public CloudComputer getComputer() {
         return computer;
     }
@@ -169,7 +169,7 @@ public class CloudProcess ... {
 
 * OptaPlanner needs to know which values it can choose from to assign to the property ``computer``. Those values are retrieved from the method `CloudBalance.getComputerList()` on the planning solution, which returns a list of all computers in the current data set.
 
-* The ``@PlanningVariable``'s `valueRangeProviderRefs` parameter on `CloudProcess.getComputer()` needs to match with the ``@ValueRangeProvider``'s `id` on `CloudBalance.getComputerList()`.
+* The ``@PlanningVariable`` automatically matches with the ``@ValueRangeProvider`` on `CloudBalance.getComputerList()`.
 
 [NOTE]
 ====
@@ -214,7 +214,7 @@ public class CloudBalance ... {
 
     private HardSoftScore score;
 
-    @ValueRangeProvider(id = "computerRange")
+    @ValueRangeProvider
     @ProblemFactCollectionProperty
     public List<CloudComputer> getComputerList() {
         return computerList;

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/cloudbalancing/domain/CloudBalance.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/cloudbalancing/domain/CloudBalance.java
@@ -28,7 +28,7 @@ public class CloudBalance extends AbstractPersistable {
         this.processList = processList;
     }
 
-    @ValueRangeProvider(id = "computerRange")
+    @ValueRangeProvider
     @ProblemFactCollectionProperty
     public List<CloudComputer> getComputerList() {
         return computerList;

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/cloudbalancing/domain/CloudProcess.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/cloudbalancing/domain/CloudProcess.java
@@ -55,8 +55,7 @@ public class CloudProcess
         this.requiredNetworkBandwidth = requiredNetworkBandwidth;
     }
 
-    @PlanningVariable(valueRangeProviderRefs = {
-            "computerRange" }, strengthComparatorClass = CloudComputerStrengthComparator.class)
+    @PlanningVariable(strengthComparatorClass = CloudComputerStrengthComparator.class)
     public CloudComputer getComputer() {
         return computer;
     }

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/conferencescheduling/domain/Talk.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/conferencescheduling/domain/Talk.java
@@ -40,10 +40,10 @@ public class Talk extends AbstractPersistable {
     @PlanningPin
     private boolean pinnedByUser = false;
 
-    @PlanningVariable(valueRangeProviderRefs = "timeslotRange")
+    @PlanningVariable
     private Timeslot timeslot;
 
-    @PlanningVariable(valueRangeProviderRefs = "roomRange")
+    @PlanningVariable
     private Room room;
 
     public Talk() {
@@ -313,12 +313,12 @@ public class Talk extends AbstractPersistable {
         return code;
     }
 
-    @ValueRangeProvider(id = "timeslotRange")
+    @ValueRangeProvider
     public Set<Timeslot> getTimeslotRange() {
         return talkType.getCompatibleTimeslotSet();
     }
 
-    @ValueRangeProvider(id = "roomRange")
+    @ValueRangeProvider
     public Set<Room> getRoomRange() {
         return talkType.getCompatibleRoomSet();
     }

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/curriculumcourse/domain/CourseSchedule.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/curriculumcourse/domain/CourseSchedule.java
@@ -91,7 +91,7 @@ public class CourseSchedule extends AbstractPersistable {
         this.timeslotList = timeslotList;
     }
 
-    @ValueRangeProvider(id = "periodRange")
+    @ValueRangeProvider
     @ProblemFactCollectionProperty
     public List<Period> getPeriodList() {
         return periodList;
@@ -101,7 +101,7 @@ public class CourseSchedule extends AbstractPersistable {
         this.periodList = periodList;
     }
 
-    @ValueRangeProvider(id = "roomRange")
+    @ValueRangeProvider
     @ProblemFactCollectionProperty
     public List<Room> getRoomList() {
         return roomList;

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/curriculumcourse/domain/Lecture.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/curriculumcourse/domain/Lecture.java
@@ -66,8 +66,7 @@ public class Lecture extends AbstractPersistable implements Labeled {
         this.pinned = pinned;
     }
 
-    @PlanningVariable(valueRangeProviderRefs = {
-            "periodRange" }, strengthWeightFactoryClass = PeriodStrengthWeightFactory.class)
+    @PlanningVariable(strengthWeightFactoryClass = PeriodStrengthWeightFactory.class)
     public Period getPeriod() {
         return period;
     }
@@ -76,7 +75,7 @@ public class Lecture extends AbstractPersistable implements Labeled {
         this.period = period;
     }
 
-    @PlanningVariable(valueRangeProviderRefs = { "roomRange" }, strengthWeightFactoryClass = RoomStrengthWeightFactory.class)
+    @PlanningVariable(strengthWeightFactoryClass = RoomStrengthWeightFactory.class)
     public Room getRoom() {
         return room;
     }

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/examination/domain/Exam.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/examination/domain/Exam.java
@@ -37,7 +37,7 @@ public abstract class Exam extends AbstractPersistable implements Labeled {
         this.topic = topic;
     }
 
-    @PlanningVariable(valueRangeProviderRefs = { "roomRange" }, strengthWeightFactoryClass = RoomStrengthWeightFactory.class)
+    @PlanningVariable(strengthWeightFactoryClass = RoomStrengthWeightFactory.class)
     public Room getRoom() {
         return room;
     }

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/examination/domain/Examination.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/examination/domain/Examination.java
@@ -63,7 +63,7 @@ public class Examination extends AbstractPersistable {
         this.topicList = topicList;
     }
 
-    @ValueRangeProvider(id = "periodRange")
+    @ValueRangeProvider
     @ProblemFactCollectionProperty
     public List<Period> getPeriodList() {
         return periodList;
@@ -73,7 +73,7 @@ public class Examination extends AbstractPersistable {
         this.periodList = periodList;
     }
 
-    @ValueRangeProvider(id = "roomRange")
+    @ValueRangeProvider
     @ProblemFactCollectionProperty
     public List<Room> getRoomList() {
         return roomList;

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/examination/domain/LeadingExam.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/examination/domain/LeadingExam.java
@@ -22,7 +22,7 @@ public class LeadingExam extends Exam {
     }
 
     @Override
-    @PlanningVariable(valueRangeProviderRefs = { "periodRange" })
+    @PlanningVariable
     public Period getPeriod() {
         return period;
     }

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/flightcrewscheduling/domain/FlightAssignment.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/flightcrewscheduling/domain/FlightAssignment.java
@@ -17,7 +17,7 @@ public class FlightAssignment extends AbstractPersistable implements Comparable<
     private int indexInFlight;
     private Skill requiredSkill;
 
-    @PlanningVariable(valueRangeProviderRefs = { "employeeRange" })
+    @PlanningVariable
     private Employee employee;
 
     public FlightAssignment() {

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/flightcrewscheduling/domain/FlightCrewSolution.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/flightcrewscheduling/domain/FlightCrewSolution.java
@@ -28,7 +28,7 @@ public class FlightCrewSolution extends AbstractPersistable {
     private List<Airport> airportList;
 
     @ProblemFactCollectionProperty
-    @ValueRangeProvider(id = "employeeRange")
+    @ValueRangeProvider
     private List<Employee> employeeList;
 
     @ProblemFactCollectionProperty

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/machinereassignment/domain/MachineReassignment.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/machinereassignment/domain/MachineReassignment.java
@@ -75,7 +75,7 @@ public class MachineReassignment extends AbstractPersistable {
         this.locationList = locationList;
     }
 
-    @ValueRangeProvider(id = "machineRange")
+    @ValueRangeProvider
     @ProblemFactCollectionProperty
     public List<MrMachine> getMachineList() {
         return machineList;

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/machinereassignment/domain/MrProcessAssignment.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/machinereassignment/domain/MrProcessAssignment.java
@@ -52,7 +52,7 @@ public class MrProcessAssignment extends AbstractPersistable {
         this.originalMachine = originalMachine;
     }
 
-    @PlanningVariable(valueRangeProviderRefs = { "machineRange" })
+    @PlanningVariable
     public MrMachine getMachine() {
         return machine;
     }

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/meetingscheduling/domain/MeetingAssignment.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/meetingscheduling/domain/MeetingAssignment.java
@@ -51,7 +51,7 @@ public class MeetingAssignment extends AbstractPersistable {
         this.pinned = pinned;
     }
 
-    @PlanningVariable(valueRangeProviderRefs = { "timeGrainRange" })
+    @PlanningVariable
     public TimeGrain getStartingTimeGrain() {
         return startingTimeGrain;
     }
@@ -60,7 +60,7 @@ public class MeetingAssignment extends AbstractPersistable {
         this.startingTimeGrain = startingTimeGrain;
     }
 
-    @PlanningVariable(valueRangeProviderRefs = { "roomRange" })
+    @PlanningVariable
     public Room getRoom() {
         return room;
     }

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/meetingscheduling/domain/MeetingSchedule.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/meetingscheduling/domain/MeetingSchedule.java
@@ -21,10 +21,10 @@ public class MeetingSchedule extends AbstractPersistable {
     private List<Meeting> meetingList;
     @ProblemFactCollectionProperty
     private List<Day> dayList;
-    @ValueRangeProvider(id = "timeGrainRange")
+    @ValueRangeProvider
     @ProblemFactCollectionProperty
     private List<TimeGrain> timeGrainList;
-    @ValueRangeProvider(id = "roomRange")
+    @ValueRangeProvider
     @ProblemFactCollectionProperty
     private List<Room> roomList;
     @ProblemFactCollectionProperty

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/nqueens/domain/NQueens.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/nqueens/domain/NQueens.java
@@ -46,7 +46,7 @@ public class NQueens extends AbstractPersistable {
         this.columnList = columnList;
     }
 
-    @ValueRangeProvider(id = "rowRange")
+    @ValueRangeProvider
     @ProblemFactCollectionProperty
     public List<Row> getRowList() {
         return rowList;

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/nqueens/domain/Queen.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/nqueens/domain/Queen.java
@@ -37,7 +37,7 @@ public class Queen extends AbstractPersistable {
         this.column = column;
     }
 
-    @PlanningVariable(valueRangeProviderRefs = { "rowRange" }, strengthWeightFactoryClass = RowStrengthWeightFactory.class)
+    @PlanningVariable(strengthWeightFactoryClass = RowStrengthWeightFactory.class)
     public Row getRow() {
         return row;
     }

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/nurserostering/domain/NurseRoster.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/nurserostering/domain/NurseRoster.java
@@ -47,7 +47,7 @@ public class NurseRoster extends AbstractPersistable {
     private List<ContractLine> contractLineList;
     @ProblemFactCollectionProperty
     private List<PatternContractLine> patternContractLineList;
-    @ValueRangeProvider(id = "employeeRange")
+    @ValueRangeProvider
     @ProblemFactCollectionProperty
     private List<Employee> employeeList;
     @ProblemFactCollectionProperty

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/nurserostering/domain/ShiftAssignment.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/nurserostering/domain/ShiftAssignment.java
@@ -34,7 +34,7 @@ public class ShiftAssignment extends AbstractPersistable implements Comparable<S
     }
 
     // Planning variables: changes during planning, between score calculations.
-    @PlanningVariable(valueRangeProviderRefs = { "employeeRange" }, strengthComparatorClass = EmployeeStrengthComparator.class)
+    @PlanningVariable(strengthComparatorClass = EmployeeStrengthComparator.class)
     private Employee employee;
 
     public Shift getShift() {

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/pas/domain/BedDesignation.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/pas/domain/BedDesignation.java
@@ -38,8 +38,7 @@ public class BedDesignation extends AbstractPersistable {
         this.admissionPart = admissionPart;
     }
 
-    @PlanningVariable(nullable = true, valueRangeProviderRefs = {
-            "bedRange" }, strengthComparatorClass = BedStrengthComparator.class)
+    @PlanningVariable(nullable = true, strengthComparatorClass = BedStrengthComparator.class)
     public Bed getBed() {
         return bed;
     }

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/pas/domain/PatientAdmissionSchedule.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/pas/domain/PatientAdmissionSchedule.java
@@ -101,7 +101,7 @@ public class PatientAdmissionSchedule extends AbstractPersistable {
         this.roomEquipmentList = roomEquipmentList;
     }
 
-    @ValueRangeProvider(id = "bedRange")
+    @ValueRangeProvider
     @ProblemFactCollectionProperty
     public List<Bed> getBedList() {
         return bedList;

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/projectjobscheduling/domain/Allocation.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/projectjobscheduling/domain/Allocation.java
@@ -85,8 +85,7 @@ public class Allocation extends AbstractPersistable implements Labeled {
         this.successorAllocationList = successorAllocationList;
     }
 
-    @PlanningVariable(valueRangeProviderRefs = {
-            "executionModeRange" }, strengthWeightFactoryClass = ExecutionModeStrengthWeightFactory.class)
+    @PlanningVariable(strengthWeightFactoryClass = ExecutionModeStrengthWeightFactory.class)
     public ExecutionMode getExecutionMode() {
         return executionMode;
     }
@@ -95,7 +94,7 @@ public class Allocation extends AbstractPersistable implements Labeled {
         this.executionMode = executionMode;
     }
 
-    @PlanningVariable(valueRangeProviderRefs = { "delayRange" }, strengthComparatorClass = DelayStrengthComparator.class)
+    @PlanningVariable(strengthComparatorClass = DelayStrengthComparator.class)
     public Integer getDelay() {
         return delay;
     }
@@ -160,13 +159,13 @@ public class Allocation extends AbstractPersistable implements Labeled {
     // Ranges
     // ************************************************************************
 
-    @ValueRangeProvider(id = "executionModeRange")
+    @ValueRangeProvider
     @JsonIgnore
     public List<ExecutionMode> getExecutionModeRange() {
         return job.getExecutionModeList();
     }
 
-    @ValueRangeProvider(id = "delayRange")
+    @ValueRangeProvider
     @JsonIgnore
     public CountableValueRange<Integer> getDelayRange() {
         return ValueRangeFactory.createIntValueRange(0, 500);

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/taskassigning/domain/Employee.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/taskassigning/domain/Employee.java
@@ -28,7 +28,7 @@ public class Employee extends AbstractPersistable implements Labeled {
     private Set<Skill> skillSet;
     private Map<Customer, Affinity> affinityMap;
 
-    @PlanningListVariable(valueRangeProviderRefs = "taskRange")
+    @PlanningListVariable
     private List<Task> tasks;
 
     // TODO pinning: https://issues.redhat.com/browse/PLANNER-2633.

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/taskassigning/domain/TaskAssigningSolution.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/taskassigning/domain/TaskAssigningSolution.java
@@ -19,7 +19,7 @@ public class TaskAssigningSolution extends AbstractPersistable {
     private List<TaskType> taskTypeList;
     @ProblemFactCollectionProperty
     private List<Customer> customerList;
-    @ValueRangeProvider(id = "taskRange")
+    @ValueRangeProvider
     @ProblemFactCollectionProperty
     private List<Task> taskList;
 

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/tennis/domain/TeamAssignment.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/tennis/domain/TeamAssignment.java
@@ -49,7 +49,7 @@ public class TeamAssignment extends AbstractPersistable {
         this.pinned = pinned;
     }
 
-    @PlanningVariable(valueRangeProviderRefs = { "teamRange" })
+    @PlanningVariable
     public Team getTeam() {
         return team;
     }

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/tennis/domain/TennisSolution.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/tennis/domain/TennisSolution.java
@@ -28,7 +28,7 @@ public class TennisSolution extends AbstractPersistable {
         super(id);
     }
 
-    @ValueRangeProvider(id = "teamRange")
+    @ValueRangeProvider
     @ProblemFactCollectionProperty
     public List<Team> getTeamList() {
         return teamList;

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/travelingtournament/domain/Match.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/travelingtournament/domain/Match.java
@@ -37,7 +37,7 @@ public class Match extends AbstractPersistable {
         this.awayTeam = awayTeam;
     }
 
-    @PlanningVariable(valueRangeProviderRefs = { "dayRange" })
+    @PlanningVariable
     public Day getDay() {
         return day;
     }

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/travelingtournament/domain/TravelingTournament.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/travelingtournament/domain/TravelingTournament.java
@@ -29,7 +29,7 @@ public class TravelingTournament extends AbstractPersistable {
         super(id);
     }
 
-    @ValueRangeProvider(id = "dayRange")
+    @ValueRangeProvider
     @ProblemFactCollectionProperty
     public List<Day> getDayList() {
         return dayList;

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/tsp/domain/TspSolution.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/tsp/domain/TspSolution.java
@@ -80,7 +80,7 @@ public class TspSolution extends AbstractPersistable {
     }
 
     @PlanningEntityCollectionProperty
-    @ValueRangeProvider(id = "visitRange")
+    @ValueRangeProvider
     public List<Visit> getVisitList() {
         return visitList;
     }
@@ -102,7 +102,7 @@ public class TspSolution extends AbstractPersistable {
     // Complex methods
     // ************************************************************************
 
-    @ValueRangeProvider(id = "domicileRange")
+    @ValueRangeProvider
     @JsonIgnore
     public List<Domicile> getDomicileRange() {
         return Collections.singletonList(domicile);

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/tsp/domain/Visit.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/tsp/domain/Visit.java
@@ -35,8 +35,7 @@ public class Visit extends AbstractPersistable implements Standstill {
         this.location = location;
     }
 
-    @PlanningVariable(valueRangeProviderRefs = { "domicileRange", "visitRange" },
-            graphType = PlanningVariableGraphType.CHAINED,
+    @PlanningVariable(graphType = PlanningVariableGraphType.CHAINED,
             strengthWeightFactoryClass = DomicileDistanceStandstillStrengthWeightFactory.class)
     public Standstill getPreviousStandstill() {
         return previousStandstill;

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/vehiclerouting/domain/Vehicle.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/vehiclerouting/domain/Vehicle.java
@@ -19,7 +19,7 @@ public class Vehicle extends AbstractPersistable {
     protected int capacity;
     protected Depot depot;
 
-    @PlanningListVariable(valueRangeProviderRefs = "customerRange")
+    @PlanningListVariable
     protected List<Customer> customers = new ArrayList<>();
 
     public Vehicle() {

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/vehiclerouting/domain/VehicleRoutingSolution.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/vehiclerouting/domain/VehicleRoutingSolution.java
@@ -87,7 +87,7 @@ public class VehicleRoutingSolution extends AbstractPersistable {
     }
 
     @ProblemFactCollectionProperty
-    @ValueRangeProvider(id = "customerRange")
+    @ValueRangeProvider
     public List<Customer> getCustomerList() {
         return customerList;
     }


### PR DESCRIPTION
ID on value range and ref on planning variable is now optional.

If the planning variable doesn't provide a ref, we will use the type of the variable and the type of all anonymous value ranges to match them.