### PR TITLE
PLANNER-2875 Another pre-migration cleanup

### DIFF
--- a/build/optaplanner-build-parent/pom.xml
+++ b/build/optaplanner-build-parent/pom.xml
@@ -44,17 +44,35 @@
     <!-- Plugins -->
     <!-- ************************************************************************ -->
 
-    <maven.min.version>3.8.1</maven.min.version>
-    <maven.compiler.release>11</maven.compiler.release>
-    <!-- A workaround for https://youtrack.jetbrains.com/issue/IDEA-276403. -->
-    <maven.compiler.target>11</maven.compiler.target>
+    <!-- Plugin version properties -->
+
+    <version.asciidoctor.plugin>2.2.2</version.asciidoctor.plugin>
     <version.assembly.plugin>3.4.2</version.assembly.plugin>
     <!-- jboss suffixed version from jboss-parent which cannot be downloaded due to SNAPSHOT only policy for plugins from JBoss -->
     <version.compiler.plugin>3.8.1</version.compiler.plugin>
     <!-- The first version that supports analysis of classes compiled by Java 11. -->
     <version.dependency.plugin>3.1.2</version.dependency.plugin>
+    <version.formatter.plugin>2.21.0</version.formatter.plugin>
+    <version.impsort.plugin>1.8.0</version.impsort.plugin>
+    <version.jacoco.plugin>0.8.8</version.jacoco.plugin>
+    <!--
+      Do not upgrade unless prepared to deal with JPMS issues.
+      If upgrading, ensure build still passes with the full profile (-Dfull).
+    -->
+    <version.javadoc.plugin>3.0.1</version.javadoc.plugin>
+    <version.jaxb2.plugin>2.5.0</version.jaxb2.plugin>
+    <version.pitest.plugin>1.10.4</version.pitest.plugin>
+    <version.revapi.plugin>0.15.0</version.revapi.plugin>
+    <version.sniffer.plugin>1.22</version.sniffer.plugin>
     <version.surefire.plugin>3.0.0-M7</version.surefire.plugin>
     <version.versions.plugin>2.14.2</version.versions.plugin>
+
+    <!-- Plugin configuration properties -->
+
+    <maven.min.version>3.8.1</maven.min.version>
+    <maven.compiler.release>11</maven.compiler.release>
+    <!-- A workaround for https://youtrack.jetbrains.com/issue/IDEA-276403. -->
+    <maven.compiler.target>11</maven.compiler.target>
     <!-- This property needs to be defined in all modules that use the packaging 'jar'.
          It is used by different plugins to make sure the module/bundle names are consistent. -->
     <java.module.name/>
@@ -62,8 +80,6 @@
     <formatter.goal>format</formatter.goal>
     <!-- TODO name impsort should indicate it's related to formatting -->
     <impsort.goal>sort</impsort.goal>
-    <!-- Jacoco plugin configurations -->
-    <version.jacoco.plugin>0.8.8</version.jacoco.plugin>
     <!-- JaCoCo coverage data file location -->
     <jacoco.exec.file>${project.root.dir}/target/jacoco.exec</jacoco.exec.file>
     <jacoco.agent.argLine/>
@@ -316,7 +332,7 @@
         <plugin>
           <groupId>org.revapi</groupId>
           <artifactId>revapi-maven-plugin</artifactId>
-          <version>0.15.0</version>
+          <version>${version.revapi.plugin}</version>
           <dependencies>
             <dependency>
               <groupId>org.revapi</groupId>
@@ -418,7 +434,7 @@
         <plugin>
           <groupId>org.asciidoctor</groupId>
           <artifactId>asciidoctor-maven-plugin</artifactId>
-          <version>2.2.2</version>
+          <version>${version.asciidoctor.plugin}</version>
           <dependencies>
             <dependency>
               <!-- Required to generate the PDF file -->
@@ -436,11 +452,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-javadoc-plugin</artifactId>
-          <!--
-            Do not upgrade unless prepared to deal with JPMS issues.
-            If upgrading, ensure build still passes with the full profile (-Dfull).
-          -->
-          <version>3.0.1</version>
+          <version>${version.javadoc.plugin}</version>
           <configuration>
             <author>false</author>
             <failOnError>true</failOnError>
@@ -495,7 +507,7 @@
         <plugin>
           <groupId>net.revelc.code.formatter</groupId>
           <artifactId>formatter-maven-plugin</artifactId>
-          <version>2.21.0</version>
+          <version>${version.formatter.plugin}</version>
           <dependencies>
             <dependency>
               <groupId>org.optaplanner</groupId>
@@ -519,7 +531,7 @@
         <plugin>
           <groupId>net.revelc.code</groupId>
           <artifactId>impsort-maven-plugin</artifactId>
-          <version>1.8.0</version>
+          <version>${version.impsort.plugin}</version>
           <configuration>
             <groups>java.,jakarta.,javax.,org.,com.</groups>
             <staticGroups>*</staticGroups>
@@ -538,7 +550,7 @@
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>jaxb2-maven-plugin</artifactId>
-          <version>2.5.0</version>
+          <version>${version.jaxb2.plugin}</version>
           <executions>
             <execution>
               <id>schemagen</id>
@@ -566,7 +578,7 @@
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>animal-sniffer-maven-plugin</artifactId>
-          <version>1.22</version>
+          <version>${version.sniffer.plugin}</version>
           <configuration>
             <signature>
               <groupId>net.sf.androidscents.signature</groupId>
@@ -691,7 +703,7 @@
             <plugin>
               <groupId>org.pitest</groupId>
               <artifactId>pitest-maven</artifactId>
-              <version>1.10.4</version>
+              <version>${version.pitest.plugin}</version>
             </plugin>
           </plugins>
         </pluginManagement>

--- a/optaplanner-persistence/optaplanner-persistence-jaxb/pom.xml
+++ b/optaplanner-persistence/optaplanner-persistence-jaxb/pom.xml
@@ -25,17 +25,6 @@
     <java.module.name>org.optaplanner.persistence.jaxb</java.module.name>
   </properties>
 
-  <!-- TODO: Move to optaplanner-build-parent once https://github.com/quarkusio/quarkus-platform-bom-generator/issues/64 is solved.  -->
-  <dependencyManagement>
-    <dependencies>
-      <dependency>
-        <groupId>org.eclipse.persistence</groupId>
-        <artifactId>org.eclipse.persistence.moxy</artifactId>
-        <version>2.7.11</version>
-      </dependency>
-    </dependencies>
-  </dependencyManagement>
-
   <dependencies>
     <!-- Internal dependencies -->
     <dependency>
@@ -72,12 +61,6 @@
     <dependency>
       <groupId>org.glassfish</groupId>
       <artifactId>jakarta.json</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <!-- MOXy needed as JAXB JSON provider -->
-    <dependency>
-      <groupId>org.eclipse.persistence</groupId>
-      <artifactId>org.eclipse.persistence.moxy</artifactId>
       <scope>test</scope>
     </dependency>
     <!-- Testing -->

--- a/optaplanner-persistence/optaplanner-persistence-jaxb/pom.xml
+++ b/optaplanner-persistence/optaplanner-persistence-jaxb/pom.xml
@@ -28,7 +28,6 @@
   <!-- TODO: Move to optaplanner-build-parent once https://github.com/quarkusio/quarkus-platform-bom-generator/issues/64 is solved.  -->
   <dependencyManagement>
     <dependencies>
-      <!-- TODO Dependencies that should maybe be removed/replaced in 8 https://issues.redhat.com/browse/PLANNER-2262 -->
       <dependency>
         <groupId>org.eclipse.persistence</groupId>
         <artifactId>org.eclipse.persistence.moxy</artifactId>

--- a/optaplanner-persistence/optaplanner-persistence-jaxb/pom.xml
+++ b/optaplanner-persistence/optaplanner-persistence-jaxb/pom.xml
@@ -25,6 +25,18 @@
     <java.module.name>org.optaplanner.persistence.jaxb</java.module.name>
   </properties>
 
+  <!-- TODO: Move to optaplanner-build-parent once https://github.com/quarkusio/quarkus-platform-bom-generator/issues/64 is solved.  -->
+  <dependencyManagement>
+    <dependencies>
+      <!-- TODO Dependencies that should maybe be removed/replaced in 8 https://issues.redhat.com/browse/PLANNER-2262 -->
+      <dependency>
+        <groupId>org.eclipse.persistence</groupId>
+        <artifactId>org.eclipse.persistence.moxy</artifactId>
+        <version>2.7.11</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <dependencies>
     <!-- Internal dependencies -->
     <dependency>

--- a/optaplanner-persistence/optaplanner-persistence-jaxb/src/test/java/org/optaplanner/persistence/jaxb/api/score/AbstractScoreJaxbAdapterTest.java
+++ b/optaplanner-persistence/optaplanner-persistence-jaxb/src/test/java/org/optaplanner/persistence/jaxb/api/score/AbstractScoreJaxbAdapterTest.java
@@ -119,7 +119,7 @@ public abstract class AbstractScoreJaxbAdapterTest {
         try {
             Class.forName("jakarta.xml.bind.JAXBContext", false, AbstractScoreJaxbAdapterTest.class.getClassLoader());
             return true;
-        } catch (ClassNotFoundException classNotFoundException) {
+        } catch (ClassNotFoundException | NoClassDefFoundError classNotFound) {
             return false;
         }
     }

--- a/optaplanner-persistence/optaplanner-persistence-jaxb/src/test/java/org/optaplanner/persistence/jaxb/api/score/AbstractScoreJaxbAdapterTest.java
+++ b/optaplanner-persistence/optaplanner-persistence-jaxb/src/test/java/org/optaplanner/persistence/jaxb/api/score/AbstractScoreJaxbAdapterTest.java
@@ -11,8 +11,6 @@ import javax.xml.bind.JAXBException;
 import javax.xml.bind.Marshaller;
 import javax.xml.bind.Unmarshaller;
 
-import org.eclipse.persistence.jaxb.MarshallerProperties;
-import org.eclipse.persistence.jaxb.UnmarshallerProperties;
 import org.optaplanner.core.api.score.Score;
 
 public abstract class AbstractScoreJaxbAdapterTest {
@@ -27,7 +25,6 @@ public abstract class AbstractScoreJaxbAdapterTest {
     protected <Score_ extends Score<Score_>, W extends TestScoreWrapper<Score_>> void
             assertSerializeAndDeserialize(Score_ expectedScore, W input) {
         assertSerializeAndDeserializeXML(expectedScore, input);
-        assertSerializeAndDeserializeJson(expectedScore, input);
     }
 
     protected <Score_ extends Score<Score_>, W extends TestScoreWrapper<Score_>> void
@@ -63,69 +60,6 @@ public abstract class AbstractScoreJaxbAdapterTest {
             fail(String.format("Regular expression match failed.%nExpected regular expression: %s%n" +
                     "Actual string: %s", regex, xmlString));
         }
-    }
-
-    protected <Score_ extends Score<Score_>, W extends TestScoreWrapper<Score_>> void assertSerializeAndDeserializeJson(
-            Score_ expectedScore,
-            W input) {
-        final String xmlBindContextFactoryProperty = getJaxbContextFactoryProperty();
-        System.setProperty(xmlBindContextFactoryProperty, "org.eclipse.persistence.jaxb.JAXBContextFactory");
-        String jsonString;
-        W output;
-        try {
-            JAXBContext jaxbContext = JAXBContext.newInstance(input.getClass());
-
-            Marshaller jaxbMarshaller = jaxbContext.createMarshaller();
-            jaxbMarshaller.setProperty(MarshallerProperties.MEDIA_TYPE, "application/json");
-            jaxbMarshaller.setProperty(MarshallerProperties.JSON_INCLUDE_ROOT, true);
-            jaxbMarshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, true);
-            StringWriter writer = new StringWriter();
-            jaxbMarshaller.marshal(input, writer);
-            jsonString = writer.toString();
-
-            Unmarshaller unmarshaller = jaxbContext.createUnmarshaller();
-            unmarshaller.setProperty(UnmarshallerProperties.MEDIA_TYPE, "application/json");
-            unmarshaller.setProperty(UnmarshallerProperties.JSON_INCLUDE_ROOT, true);
-
-            StringReader reader = new StringReader(jsonString);
-            output = (W) unmarshaller.unmarshal(reader);
-        } catch (JAXBException e) {
-            throw new IllegalStateException("Marshalling or unmarshalling for input (" + input + ") failed.", e);
-        } finally {
-            System.clearProperty(xmlBindContextFactoryProperty);
-        }
-        assertThat(output.getScore()).isEqualTo(expectedScore);
-        String regex;
-        if (expectedScore != null) {
-            regex = "\\{\\R" // Opening bracket
-                    + "\\s*\"([\\w]+)\"\\s:\\s\\{\\R" // Start of element
-                    + "\\s*\"score\"\\s:\\s\"" // Start of element
-                    + expectedScore.toString().replaceAll("\\[", "\\\\[").replaceAll("\\]", "\\\\]") // Score
-                    + "\"\\s*\\}\\R" // End of element
-                    + "\\}"; // Closing bracket
-        } else {
-            regex = "\\{\\R" // Opening bracket
-                    + "\\s*\"([\\w]+)\"\\s:\\s\\{\\R" // Start of element
-                    + "\\s*\\}\\R" // End of element
-                    + "\\}"; // Closing bracket
-        }
-        if (!jsonString.matches(regex)) {
-            fail(String.format("Regular expression match failed.%nExpected regular expression: %s%n" +
-                    "Actual string: %s", regex, jsonString));
-        }
-    }
-
-    private static boolean isJakarta() {
-        try {
-            Class.forName("jakarta.xml.bind.JAXBContext", false, AbstractScoreJaxbAdapterTest.class.getClassLoader());
-            return true;
-        } catch (ClassNotFoundException | NoClassDefFoundError classNotFound) {
-            return false;
-        }
-    }
-
-    private static String getJaxbContextFactoryProperty() {
-        return isJakarta() ? JAKARTA_XML_BIND_CONTEXT_FACTORY_PROPERTY : JAVAX_XML_BIND_CONTEXT_FACTORY_PROPERTY;
     }
 
     public static abstract class TestScoreWrapper<Score_ extends Score<Score_>> {

--- a/optaplanner-persistence/optaplanner-persistence-jpa/pom.xml
+++ b/optaplanner-persistence/optaplanner-persistence-jpa/pom.xml
@@ -67,12 +67,6 @@
       <!-- Used at compile time by *ScoreHibernateType -->
       <optional>true</optional>
     </dependency>
-    <dependency>
-      <groupId>jakarta.transaction</groupId>
-      <artifactId>jakarta.transaction-api</artifactId>
-      <scope>runtime</scope>
-      <optional>true</optional>
-    </dependency>
 
     <!-- Testing -->
     <dependency>

--- a/optaplanner-persistence/pom.xml
+++ b/optaplanner-persistence/pom.xml
@@ -32,18 +32,6 @@
     <module>optaplanner-persistence-jsonb</module>
   </modules>
 
-  <!-- TODO: Move to optaplanner-build-parent once https://github.com/quarkusio/quarkus-platform-bom-generator/issues/64 is solved.  -->
-  <dependencyManagement>
-    <dependencies>
-      <!-- TODO Dependencies that should maybe be removed/replaced in 8 https://issues.redhat.com/browse/PLANNER-2262 -->
-      <dependency>
-        <groupId>org.eclipse.persistence</groupId>
-        <artifactId>org.eclipse.persistence.moxy</artifactId>
-        <version>2.7.11</version>
-      </dependency>
-    </dependencies>
-  </dependencyManagement>
-
   <build>
     <plugins>
       <plugin>


### PR DESCRIPTION
Related to https://issues.redhat.com/browse/PLANNER-2875.

<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.
-->

### JIRA

<!-- Add a JIRA ticket link if it exists. -->
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
- https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
- https://github.com/kiegroup/drools/pull/3000
- https://github.com/kiegroup/optaplanner/pull/899
- etc.
-->

### Checklist
- [ ] Documentation updated if applicable.
- [ ] Release notes updated if applicable.
- [ ] Upgrade recipe provided if applicable.

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request checks</b>  
  Please add comment: <b>Jenkins retest this</b>

- for a <b>specific pull request check</b>  
  please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-vehicle-routing] tests</b>
  
- for a <b>full downstream build</b> 
  - for <b>jenkins</b> job: 
    please add comment: <b>Jenkins run fdb</b>
  - for <b>github actions</b> job: 
    add the label `run_fdb`

- for a <b>compile downstream build</b>  
  please add comment: <b>Jenkins run cdb</b>

- for a <b>full production downstream build</b>  
  please add comment: <b>Jenkins execute product fdb</b>

- for an <b>upstream build</b>  
  please add comment: <b>Jenkins run upstream</b>

- for <b>quarkus branch checks</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins run quarkus-branch</b>

- for a <b>quarkus branch specific check</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-vehicle-routing] quarkus-branch</b>

- for <b>quarkus main checks</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins run quarkus-main</b>

- for a <b>specific quarkus main check</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-vehicle-routing] quarkus-branch</b>

- for <b>quarkus lts checks</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins run quarkus-lts</b>

- for a <b>specific quarkus lts check</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-vehicle-routing] quarkus-lts</b>

- for <b>native checks</b>  
  Run native checks  
  Please add comment: <b>Jenkins run native</b>

- for a <b>specific native check</b>  
  Run native checks 
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts] native</b>

- for <b>mandrel checks</b>  
  Run native checks against Mandrel image
  Please add comment: <b>Jenkins run mandrel</b>

- for a <b>specific mandrel check</b>  
  Run native checks against Mandrel image  
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts] mandrel</b>

- for <b>mandrel lts checks</b>  
  Run native checks against Mandrel image and quarkus lts branch
  Please add comment: <b>Jenkins run mandrel-lts</b>

- for a <b>specific mandrel lts check</b>  
  Run native checks against Mandrel image and quarkus lts branch
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts] mandrel-lts</b>

</details>

### CI Status

 You can check OptaPlanner repositories CI status from [Chain Status webpage](https://kiegroup.github.io/optaplanner/).

<details>
<summary>
How to backport a pull request to a different branch?
</summary>

In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-7.67.x` to backport the original PR to the `7.67.x` branch).

> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.

Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.

If something goes wrong, the author will be notified and at this point a manual backporting is needed.

> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
</details>
