### PR TITLE
PLANNER-2874: OptaPlanner version should be updated in kie-benchmarks…

### DIFF
--- a/.ci/jenkins/Jenkinsfile.setup-branch
+++ b/.ci/jenkins/Jenkinsfile.setup-branch
@@ -5,7 +5,7 @@ import org.kie.jenkins.MavenCommand
 
 pipeline {
     agent {
-        label 'kie-rhel7 && kie-mem16g && !built-in'
+        label 'kie-rhel8 && kie-mem16g && !built-in'
     }
 
     tools {
@@ -29,6 +29,8 @@ pipeline {
 
         // Keep here for visitibility
         MAVEN_OPTS = '-Xms1024m -Xmx4g'
+    
+        BRANCH_HASH = "${util.generateHash(10)}"
     }
 
     stages {
@@ -40,15 +42,18 @@ pipeline {
                     if (params.DISPLAY_NAME) {
                         currentBuild.displayName = params.DISPLAY_NAME
                     }
-
-                    checkoutRepo(getRepoName(), getBuildBranch())
+                    dir(getRepoName()){
+                        checkoutRepo(getRepoName(), getBuildBranch())
+                    }
                 }
             }
         }
         stage('Update project version') {
             steps {
                 script {
-                    maven.mvnVersionsSet(getMavenCommand(getRepoName()), getOptaPlannerVersion(), true)
+                    dir(getRepoName()){
+                        maven.mvnVersionsSet(getMavenCommand(), getOptaPlannerVersion(), true)
+                    }    
                 }
             }
         }
@@ -58,7 +63,9 @@ pipeline {
             }
             steps {
                 script {
-                    runMavenDeploy(getRepoName())
+                    dir(getRepoName()){
+                        runMavenDeploy()
+                    }    
                 }
             }
         }
@@ -73,7 +80,7 @@ pipeline {
                                 githubscm.findAndStageNotIgnoredFiles('pom.xml')
                                 githubscm.findAndStageNotIgnoredFiles('antora.yml')
                             })
-                            githubscm.pushObject('origin', getBuildBranch(), getGitAuthorCredsID())
+                            githubscm.pushObject('origin', getBuildBranch(), getGitAuthorCredsId())
                         } else {
                             println '[WARN] no changes to commit'
                         }
@@ -81,6 +88,29 @@ pipeline {
                 }
             }
         }
+        stage('Update Optaplanner version in kie-benchmarks') {
+            when {
+                expression { isMainBranch() }
+            }    
+            steps {
+                script {
+                    String commitMsg = 'bumped up Optaplanner version to next SNAPSHOT'
+                    String localBranch = "kie-benchmarks-optaplanner-update-${env.BRANCH_HASH}"
+                    String targetBranch = 'main'
+                    String kieBenchmarksRepo = 'kie-benchmarks'
+                    dir(kieBenchmarksRepo){
+                        checkoutRepo(kieBenchmarksRepo, targetBranch)
+                        githubscm.setUserConfigFromCreds()
+                        githubscm.createBranch(localBranch)
+                        maven.mvnSetVersionProperty('version.org.optaplanner', getNextMinorSnapshotVersion(getOptaPlannerVersion()))
+                        String prLink = commitAndCreatePR(commitMsg, localBranch, targetBranch)
+                        sh "git checkout ${targetBranch}"
+                        mergeAndPush(prLink, targetBranch)
+                        githubscm.removeRemoteBranch('origin', localBranch, getGitAuthorCredsId())
+                    }
+                }
+            }
+        }        
     }
     post {
         unsuccessful {
@@ -104,12 +134,9 @@ void sendErrorNotification() {
 }
 
 void checkoutRepo(String repository, String branch) {
-    dir(repository) {
-        deleteDir()
-        checkout(githubscm.resolveRepository(repository, getGitAuthor(), branch, false))
-        // need to manually checkout branch since on a detached branch after checkout command
-        sh "git checkout ${branch}"
-    }
+    checkout(githubscm.resolveRepository(repository, getGitAuthor(), branch, false))
+    // need to manually checkout branch since on a detached branch after checkout command
+    sh "git checkout ${branch}"
 }
 
 boolean shouldDeployToRepository() {
@@ -133,23 +160,44 @@ String getOptaPlannerVersion() {
     return params.OPTAPLANNER_VERSION
 }
 
-String getGitAuthorCredsID() {
+String getGitAuthorCredsId() {
     return env.AUTHOR_CREDS_ID
 }
 
-MavenCommand getMavenCommand(String directory) {
+MavenCommand getMavenCommand() {
     return new MavenCommand(this, ['-fae', '-ntp'])
                 .withSettingsXmlId(env.MAVEN_SETTINGS_CONFIG_FILE_ID)
-                .inDirectory(directory)
                 .withProperty('full')
 }
 
-void runMavenDeploy(String directory) {
-    mvnCmd = getMavenCommand(directory)
+void runMavenDeploy(boolean localDeployment = false) {
+    mvnCmd = getMavenCommand()
 
     if (env.MAVEN_DEPLOY_REPOSITORY) {
         mvnCmd.withDeployRepository(env.MAVEN_DEPLOY_REPOSITORY)
     }
 
     mvnCmd.skipTests(true).run('clean deploy')
+}
+
+boolean isMainBranch() {
+    return env.IS_MAIN_BRANCH ? env.IS_MAIN_BRANCH.toBoolean() : false
+}
+
+String getNextMinorSnapshotVersion(String currentVersion) {
+    return util.getNextVersion(currentVersion, 'minor')
+}
+
+String commitAndCreatePR(String commitMsg, String localBranch, String targetBranch) {
+    def prBody = "Generated by build ${BUILD_TAG}: ${BUILD_URL}"
+    githubscm.commitChanges(commitMsg)
+    githubscm.pushObject('origin', localBranch, getGitAuthorCredsId())
+    return githubscm.createPR(commitMsg, prBody, targetBranch, getGitAuthorCredsId())
+}
+
+void mergeAndPush(String prLink, String targetBranch) {
+    if (prLink?.trim()) {
+        githubscm.mergePR(prLink, getGitAuthorCredsId())
+        githubscm.pushObject('origin', targetBranch, getGitAuthorCredsId())
+    }
 }

--- a/.ci/jenkins/project/Jenkinsfile.post-release
+++ b/.ci/jenkins/project/Jenkinsfile.post-release
@@ -7,11 +7,10 @@ import org.kie.jenkins.MavenCommand
 String optaplannerRepository = 'optaplanner'
 String quickstartsRepository = 'optaplanner-quickstarts'
 String stableBranchName = 'stable'
-String kieBenchmarksRepo = 'kie-benchmarks'
 
 pipeline {
     agent {
-        label 'kie-rhel7 && !built-in'
+        label 'kie-rhel8 && !built-in'
     }
 
     tools {
@@ -113,32 +112,6 @@ pipeline {
                         checkoutRepo(websiteRepository, 'main')
                         mergeAndPush(prLink, 'main')
                         githubscm.removeRemoteBranch('origin', prBranchName, getGitAuthorCredsID())
-                    }
-                }
-            }
-        }
-        stage('update version.org.optaplanner property in kie-benchmarks') {
-            steps {
-                script {
-                    String prLink = null
-                    String commitMsg = 'bumped up kie-version to next SNAPSHOT'
-                    String localBranch = "bump-up-kie-benchmarks-${env.BOT_BRANCH_HASH}"
-                    String targetBranch = 'main'
-                    dir(kieBenchmarksRepo){
-                        checkoutRepo(kieBenchmarksRepo, targetBranch)
-                        githubscm.setUserConfigFromCreds()
-                        githubscm.createBranch(localBranch)
-                        // update version.org.optaplanner property in kie-benchmarks
-                        maven.mvnSetVersionProperty('version.org.optaplanner', getNextMinorSnapshotVersion(getProjectVersion()))
-                        if (githubscm.isThereAnyChanges()) {
-                            // Add changed files, commit, open and merge PR
-                            prLink = commitAndCreatePR(commitMsg, { sh "git add --all" }, localBranch, targetBranch)
-                            sh "git checkout ${targetBranch}"
-                            mergeAndPush(prLink, targetBranch)
-                            githubscm.removeRemoteBranch('origin', localBranch, getGitAuthorCredsID())
-                        } else {
-                            println '[WARN] no changes to commit'
-                        }
                     }
                 }
             }


### PR DESCRIPTION
… when the release branch is created

PLANNER-2874: bump up optaplanner in kie-benchmarks

PLANNER-2874: OptaPlanner version update in kie-benchmarks

Co-authored-by: Tristan Radisson <tristan.radisson@gmail.com>

<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.
-->

### JIRA

<!-- Add a JIRA ticket link if it exists. -->
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
- https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
- https://github.com/kiegroup/drools/pull/3000
- https://github.com/kiegroup/optaplanner/pull/899
- etc.
-->

### Checklist
- [ ] Documentation updated if applicable.
- [ ] Release notes updated if applicable.
- [ ] Upgrade recipe provided if applicable.

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request checks</b>  
  Please add comment: <b>Jenkins retest this</b>

- for a <b>specific pull request check</b>  
  please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-vehicle-routing] tests</b>
  
- for a <b>full downstream build</b> 
  - for <b>jenkins</b> job: 
    please add comment: <b>Jenkins run fdb</b>
  - for <b>github actions</b> job: 
    add the label `run_fdb`

- for a <b>compile downstream build</b>  
  please add comment: <b>Jenkins run cdb</b>

- for a <b>full production downstream build</b>  
  please add comment: <b>Jenkins execute product fdb</b>

- for an <b>upstream build</b>  
  please add comment: <b>Jenkins run upstream</b>

- for <b>quarkus branch checks</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins run quarkus-branch</b>

- for a <b>quarkus branch specific check</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-vehicle-routing] quarkus-branch</b>

- for <b>quarkus main checks</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins run quarkus-main</b>

- for a <b>specific quarkus main check</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-vehicle-routing] quarkus-branch</b>

- for <b>quarkus lts checks</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins run quarkus-lts</b>

- for a <b>specific quarkus lts check</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-vehicle-routing] quarkus-lts</b>

- for <b>native checks</b>  
  Run native checks  
  Please add comment: <b>Jenkins run native</b>

- for a <b>specific native check</b>  
  Run native checks 
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts] native</b>

- for <b>mandrel checks</b>  
  Run native checks against Mandrel image
  Please add comment: <b>Jenkins run mandrel</b>

- for a <b>specific mandrel check</b>  
  Run native checks against Mandrel image  
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts] mandrel</b>

- for <b>mandrel lts checks</b>  
  Run native checks against Mandrel image and quarkus lts branch
  Please add comment: <b>Jenkins run mandrel-lts</b>

- for a <b>specific mandrel lts check</b>  
  Run native checks against Mandrel image and quarkus lts branch
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts] mandrel-lts</b>

</details>

### CI Status

 You can check OptaPlanner repositories CI status from [Chain Status webpage](https://kiegroup.github.io/optaplanner/).

<details>
<summary>
How to backport a pull request to a different branch?
</summary>

In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-7.67.x` to backport the original PR to the `7.67.x` branch).

> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.

Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.

If something goes wrong, the author will be notified and at this point a manual backporting is needed.

> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
</details>
