### PR TITLE
Use AssertJ assertions instead of JUnit

### DIFF
--- a/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/testutil/TestRandom.java
+++ b/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/testutil/TestRandom.java
@@ -1,15 +1,14 @@
 package org.optaplanner.core.impl.testutil;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.math.BigDecimal;
 import java.util.Arrays;
-import java.util.Objects;
 import java.util.Random;
 import java.util.stream.DoubleStream;
 import java.util.stream.IntStream;
 import java.util.stream.LongStream;
 import java.util.stream.Stream;
-
-import org.junit.jupiter.api.Assertions;
 
 /**
  * On the later JDKs, it is no longer possible to mock {@link Random} to return custom sequences.
@@ -211,12 +210,10 @@ public final class TestRandom extends Random {
      * @throws org.opentest4j.AssertionFailedError when bound not matching
      */
     public void assertIntBoundJustRequested(int bound) {
-        if (Objects.equals(bound, lastRequestedIntBound)) {
-            lastRequestedIntBound = null;
-            return;
-        }
-        Assertions.fail("Expected bound (" + bound + ") to have just been requested, " +
-                "but was (" + lastRequestedIntBound + ").");
+        assertThat(lastRequestedIntBound)
+                .as("Expected bound (%s) to have just been requested, but was (%s).", bound, lastRequestedIntBound)
+                .isEqualTo(bound);
+        lastRequestedIntBound = null;
     }
 
 }

--- a/optaplanner-benchmark/src/test/java/org/optaplanner/benchmark/config/PlannerBenchmarkConfigTest.java
+++ b/optaplanner-benchmark/src/test/java/org/optaplanner/benchmark/config/PlannerBenchmarkConfigTest.java
@@ -2,7 +2,6 @@ package org.optaplanner.benchmark.config;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.IOException;
 import java.io.InputStreamReader;
@@ -91,7 +90,7 @@ class PlannerBenchmarkConfigTest {
         pbc.setSolutionFileIOClass(RigidTestdataSolutionFileIO.class);
 
         Class<? extends SolutionFileIO<?>> configured = pbc.getSolutionFileIOClass();
-        assertNotNull(configured);
+        assertThat(configured).isNotNull();
     }
 
     private static class TestdataSolutionFileIO extends JacksonSolutionFileIO<TestdataSolution> {

--- a/optaplanner-benchmark/src/test/java/org/optaplanner/benchmark/impl/statistic/AbstractSubSingleStatisticTest.java
+++ b/optaplanner-benchmark/src/test/java/org/optaplanner/benchmark/impl/statistic/AbstractSubSingleStatisticTest.java
@@ -1,6 +1,7 @@
 package org.optaplanner.benchmark.impl.statistic;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 import java.io.File;
@@ -23,7 +24,6 @@ import javax.xml.namespace.QName;
 import javax.xml.transform.stream.StreamSource;
 
 import org.assertj.core.api.SoftAssertions;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.api.parallel.Execution;
@@ -74,7 +74,7 @@ public abstract class AbstractSubSingleStatisticTest<Point_ extends StatisticPoi
             Marshaller marshaller = context.createMarshaller();
             marshaller.marshal(root, writer);
         } catch (Exception e) {
-            Assertions.fail("Failed serializing statistic.", e);
+            fail("Failed serializing statistic.", e);
         }
 
         // Deserialize from XML.
@@ -82,7 +82,7 @@ public abstract class AbstractSubSingleStatisticTest<Point_ extends StatisticPoi
         try {
             root = unmarshaller.unmarshal(new StreamSource(tempFile.toFile()), clz);
         } catch (Exception e) {
-            Assertions.fail("Failed deserializing statistic.", e);
+            fail("Failed deserializing statistic.", e);
         }
 
         SubSingleStatistic_ deserialized = root.getValue();


### PR DESCRIPTION


<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request checks</b>  
  Please add comment: <b>Jenkins retest this</b>

- for a <b>specific pull request check</b>  
  please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-vehicle-routing] tests</b>
  
- for a <b>full downstream build</b> 
  - for <b>jenkins</b> job: 
    please add comment: <b>Jenkins run fdb</b>
  - for <b>github actions</b> job: 
    add the label `run_fdb`

- for a <b>compile downstream build</b>  
  please add comment: <b>Jenkins run cdb</b>

- for a <b>full production downstream build</b>  
  please add comment: <b>Jenkins execute product fdb</b>

- for an <b>upstream build</b>  
  please add comment: <b>Jenkins run upstream</b>

- for <b>quarkus branch checks</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins run quarkus-branch</b>

- for a <b>quarkus branch specific check</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-vehicle-routing] quarkus-branch</b>

- for <b>quarkus main checks</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins run quarkus-main</b>

- for a <b>specific quarkus main check</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-vehicle-routing] quarkus-branch</b>

- for <b>quarkus lts checks</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins run quarkus-lts</b>

- for a <b>specific quarkus lts check</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-vehicle-routing] quarkus-lts</b>

- for <b>native checks</b>  
  Run native checks  
  Please add comment: <b>Jenkins run native</b>

- for a <b>specific native check</b>  
  Run native checks 
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts] native</b>

- for <b>mandrel checks</b>  
  Run native checks against Mandrel image
  Please add comment: <b>Jenkins run mandrel</b>

- for a <b>specific mandrel check</b>  
  Run native checks against Mandrel image  
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts] mandrel</b>

- for <b>mandrel lts checks</b>  
  Run native checks against Mandrel image and quarkus lts branch
  Please add comment: <b>Jenkins run mandrel-lts</b>

- for a <b>specific mandrel lts check</b>  
  Run native checks against Mandrel image and quarkus lts branch
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts] mandrel-lts</b>

</details>

### CI Status

 You can check OptaPlanner repositories CI status from [Chain Status webpage](https://kiegroup.github.io/optaplanner/).

<details>
<summary>
How to backport a pull request to a different branch?
</summary>

In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-7.67.x` to backport the original PR to the `7.67.x` branch).

> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.

Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.

If something goes wrong, the author will be notified and at this point a manual backporting is needed.

> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
</details>
