### PR TITLE
PLANNER-2889 Allow to set Drools version in release

### DIFF
--- a/.ci/jenkins/Jenkinsfile.deploy
+++ b/.ci/jenkins/Jenkinsfile.deploy
@@ -107,6 +107,10 @@ pipeline {
             }
             steps {
                 script {
+                    if (getDroolsVersion()) {
+                        maven.mvnSetVersionProperty(getOptaplannerMavenCommand(), 'version.org.drools', getDroolsVersion())
+                    }
+
                     maven.mvnVersionsSet(getOptaplannerMavenCommand(), getProjectVersion(), !isRelease())
 
                     mavenCleanInstallOptaPlannerParents()
@@ -517,6 +521,10 @@ String getBuildBranch() {
 
 String getProjectVersion() {
     return params.PROJECT_VERSION
+}
+
+String getDroolsVersion() {
+    return params.DROOLS_VERSION
 }
 
 String getBotBranch() {

--- a/.ci/jenkins/dsl/jobs.groovy
+++ b/.ci/jenkins/dsl/jobs.groovy
@@ -37,7 +37,7 @@ if (Utils.isMainBranch(this)) {
 
 // Tools
 KogitoJobUtils.createQuarkusPlatformUpdateToolsJob(this, 'optaplanner')
-KogitoJobUtils.createMainQuarkusUpdateToolsJob(this, 
+KogitoJobUtils.createMainQuarkusUpdateToolsJob(this,
         [ 'optaplanner', 'optaplanner-quickstarts' ],
         [ 'rsynek', 'triceo']
 )
@@ -112,6 +112,8 @@ void setupProjectReleaseJob() {
 
             stringParam('OPTAPLANNER_VERSION', '', 'Project version of OptaPlanner and its examples to release as Major.minor.micro')
             stringParam('OPTAPLANNER_RELEASE_BRANCH', '', '(optional) Use to override the release branch name deduced from the OPTAPLANNER_VERSION')
+
+            stringParam('DROOLS_VERSION', '', '(optional) Drools version to be set to the project before releasing the artifacts.')
 
             booleanParam('SKIP_TESTS', false, 'Skip all tests')
         }
@@ -317,6 +319,8 @@ void setupDeployJob(Folder jobFolder) {
 
             booleanParam('CREATE_PR', false, 'Should we create a PR with the changes ?')
             stringParam('PROJECT_VERSION', '', 'Optional if not RELEASE. If RELEASE, cannot be empty.')
+
+            stringParam('DROOLS_VERSION', '', '(optional) Drools version to be set to the project before releasing the artifacts.')
 
             if (jobFolder.isPullRequest()) {
                 stringParam('PR_TARGET_BRANCH', '', 'What is the target branch of the PR?')

--- a/.ci/jenkins/project/Jenkinsfile.release
+++ b/.ci/jenkins/project/Jenkinsfile.release
@@ -58,6 +58,7 @@ pipeline {
                 always {
                     setReleasePropertyIfneeded('optaplanner.version', getOptaPlannerVersion())
                     setReleasePropertyIfneeded('optaplanner.branch', getOptaPlannerReleaseBranch())
+                    setReleasePropertyIfneeded('drools.version', getDroolsVersion())
                 }
             }
         }
@@ -65,7 +66,7 @@ pipeline {
         stage('Build & Deploy OptaPlanner') {
             steps {
                 script {
-                    def buildParams = getDefaultBuildParams(getOptaPlannerVersion())
+                    def buildParams = getDefaultBuildParams()
                     addSkipTestsParam(buildParams)
                     addSkipIntegrationTestsParam(buildParams)
                     addStringParam(buildParams, 'QUICKSTARTS_BUILD_BRANCH_NAME', getOptaPlannerReleaseBranch())
@@ -109,7 +110,7 @@ pipeline {
             }
             steps {
                 script {
-                    def buildParams = getDefaultBuildParams(getOptaPlannerVersion())
+                    def buildParams = getDefaultBuildParams()
                     addDeployBuildUrlParam(buildParams, OPTAPLANNER_DEPLOY)
 
                     buildJob(OPTAPLANNER_PROMOTE, buildParams)
@@ -273,10 +274,11 @@ def readPropertiesFromUrl(String url, String propsFilename) {
     return props
 }
 
-List getDefaultBuildParams(String version) {
+List getDefaultBuildParams() {
     List buildParams = []
-    addDisplayNameParam(buildParams, getDisplayName(version))
-    addStringParam(buildParams, 'PROJECT_VERSION', version)
+    addDisplayNameParam(buildParams, getDisplayName(getOptaPlannerVersion()))
+    addStringParam(buildParams, 'PROJECT_VERSION', getOptaPlannerVersion())
+    addStringParam(buildParams, 'DROOLS_VERSION', getDroolsVersion())
     return buildParams
 }
 
@@ -325,6 +327,10 @@ String getDisplayName(version = '') {
 
 String getOptaPlannerVersion() {
     return params.OPTAPLANNER_VERSION ?: getReleaseProperty('optaplanner.version')
+}
+
+String getDroolsVersion() {
+    return params.DROOLS_VERSION ?: getReleaseProperty('drools.version')
 }
 
 String getGitAuthor() {


### PR DESCRIPTION
https://issues.redhat.com/browse/PLANNER-2889

This will help to release OptaPlanner at the same time as Kogito and Drools in case we don't have the time to release one after the other.
All artifacts will so be staged to JBoss Nexus and then release altogether.

NOTE: This remains an optional parameter