### PR TITLE
PLANNER-2877 Support 9.x in the CI

### DIFF
--- a/.ci/jenkins/Jenkinsfile.deploy
+++ b/.ci/jenkins/Jenkinsfile.deploy
@@ -1,5 +1,6 @@
 import org.jenkinsci.plugins.workflow.libs.Library
-@Library('jenkins-pipeline-shared-libraries')_
+
+@Library('jenkins-pipeline-shared-libraries') _
 
 import org.kie.jenkins.MavenCommand
 import org.kie.jenkins.MavenStagingHelper
@@ -84,20 +85,30 @@ pipeline {
 
         stage('Clone repositories') {
             steps {
-                checkoutRepo(optaplannerRepository)
-                checkoutQuickstarts()
-                checkoutRepo(vehicleRoutingRepository)
+                script {
+                    checkoutRepo(optaplannerRepository)
+                    // TODO: switch to the 9 stream after quickstarts and the optaweb will have been migrated.
+                    if (isStream8()) {
+                        checkoutQuickstarts()
+                        checkoutRepo(vehicleRoutingRepository)
+                    }
+                }
             }
         }
 
         stage('Prepare for PR') {
             when {
-                expression { return isRelease() || isCreatePr()  }
+                expression { return isRelease() || isCreatePr() }
             }
             steps {
-                prepareForPR(optaplannerRepository)
-                prepareForPR(vehicleRoutingRepository)
-                prepareForPR(quickstartsRepository)
+                script {
+                    prepareForPR(optaplannerRepository)
+                    // TODO: switch to the 9 stream after quickstarts and the optaweb will have been migrated.
+                    if (isStream8()) {
+                        prepareForPR(vehicleRoutingRepository)
+                        prepareForPR(quickstartsRepository)
+                    }
+                }
             }
         }
 
@@ -115,9 +126,12 @@ pipeline {
 
                     mavenCleanInstallOptaPlannerParents()
 
-                    maven.mvnVersionsUpdateParentAndChildModules(getOptawebVehicleRoutingMavenCommand(), getProjectVersion(), !isRelease())
+                    // TODO: switch to the 9 stream after quickstarts and the optaweb will have been migrated.
+                    if (isStream8()) {
+                        maven.mvnVersionsUpdateParentAndChildModules(getOptawebVehicleRoutingMavenCommand(), getProjectVersion(), !isRelease())
 
-                    updateQuickstartsVersions()
+                        updateQuickstartsVersions()
+                    }
                 }
             }
         }
@@ -146,9 +160,16 @@ pipeline {
         }
 
         stage('Build Quickstarts') {
+            when {
+                // TODO: switch to the 9 stream after quickstarts and the optaweb will have been migrated.
+                expression { return isStream8() }
+            }
             steps {
                 script {
-                    getOptaplannerQuickstartsMavenCommand().withProperty('maven.test.failure.ignore', true).skipTests(params.SKIP_TESTS).run('clean install')
+                    getOptaplannerQuickstartsMavenCommand()
+                            .withProperty('maven.test.failure.ignore', true)
+                            .skipTests(params.SKIP_TESTS)
+                            .run('clean install')
                 }
             }
             post {
@@ -162,6 +183,10 @@ pipeline {
         }
 
         stage('Build Vehicle Routing') {
+            when {
+                // TODO: switch to the 9 stream after quickstarts and the optaweb will have been migrated.
+                expression { return isStream8() }
+            }
             steps {
                 script {
                     buildOptaweb(getOptawebVehicleRoutingMavenCommand())
@@ -185,8 +210,11 @@ pipeline {
             steps {
                 script {
                     runMavenDeploy(getOptaplannerMavenCommand())
-                    runMavenDeploy(getOptaplannerQuickstartsMavenCommand().withOptions(['-pl', ':optaplanner-distribution']))
-                    runMavenDeploy(getOptawebVehicleRoutingMavenCommand())
+                    // TODO: switch to the 9 stream after quickstarts and the optaweb will have been migrated.
+                    if (isStream8()) {
+                        runMavenDeploy(getOptaplannerQuickstartsMavenCommand().withOptions(['-pl', ':optaplanner-distribution']))
+                        runMavenDeploy(getOptawebVehicleRoutingMavenCommand())
+                    }
                 }
             }
         }
@@ -197,7 +225,10 @@ pipeline {
             steps {
                 script {
                     runMavenDeploy(getOptaplannerMavenCommand(), optaplannerRepository)
-                    runMavenDeploy(getOptawebVehicleRoutingMavenCommand(), vehicleRoutingRepository)
+                    // TODO: switch to the 9 stream after quickstarts and the optaweb will have been migrated.
+                    if (isStream8()) {
+                        runMavenDeploy(getOptawebVehicleRoutingMavenCommand(), vehicleRoutingRepository)
+                    }
                 }
             }
         }
@@ -209,7 +240,10 @@ pipeline {
                 script {
                     // Deploy to specific repository with credentials
                     maven.uploadLocalArtifacts(env.MAVEN_REPO_CREDS_ID, getLocalDeploymentFolder(optaplannerRepository), getMavenRepoZipUrl())
-                    maven.uploadLocalArtifacts(env.MAVEN_REPO_CREDS_ID, getLocalDeploymentFolder(vehicleRoutingRepository), getMavenRepoZipUrl())
+                    // TODO: switch to the 9 stream after quickstarts and the optaweb will have been migrated.
+                    if (isStream8()) {
+                        maven.uploadLocalArtifacts(env.MAVEN_REPO_CREDS_ID, getLocalDeploymentFolder(vehicleRoutingRepository), getMavenRepoZipUrl())
+                    }
                 }
             }
         }
@@ -221,7 +255,10 @@ pipeline {
                 script {
                     // Stage release artifacts
                     runMavenStage(getOptaplannerMavenCommand(), optaplannerRepository)
-                    runMavenStage(getOptawebVehicleRoutingMavenCommand(), vehicleRoutingRepository)
+                    // TODO: switch to the 9 stream after quickstarts and the optaweb will have been migrated.
+                    if (isStream8()) {
+                        runMavenStage(getOptawebVehicleRoutingMavenCommand(), vehicleRoutingRepository)
+                    }
                 }
             }
         }
@@ -231,9 +268,14 @@ pipeline {
                 expression { return isRelease() || isCreatePr() }
             }
             steps {
-                commitAndCreatePR(optaplannerRepository, getBuildBranch())
-                commitAndCreatePRIgnoringNpmRegistry(vehicleRoutingRepository, getBuildBranch())
-                commitAndCreatePR(quickstartsRepository, getQuickStartsBranch())
+                script {
+                    commitAndCreatePR(optaplannerRepository, getBuildBranch())
+                    // TODO: switch to the 9 stream after quickstarts and the optaweb will have been migrated.
+                    if (isStream8()) {
+                        commitAndCreatePRIgnoringNpmRegistry(vehicleRoutingRepository, getBuildBranch())
+                        commitAndCreatePR(quickstartsRepository, getQuickStartsBranch())
+                    }
+                }
             }
             post {
                 success {
@@ -254,7 +296,7 @@ pipeline {
 
         stage('Push a temporary operator image to a registry') {
             when {
-                expression { return isRelease() }
+                expression { return isRelease() && isStream8() }
             }
             steps {
                 script {
@@ -589,4 +631,12 @@ void pushOperatorTemporaryImage() {
             getOperatorImageNamespace(), getOperatorImageName(), temporaryImageTag)
     imageUtils.tagImage(localImage, temporaryImageFullName)
     imageUtils.pushImage(temporaryImageFullName)
+}
+
+boolean isStream8() {
+    return env.OPTAPLANNER_LATEST_STREAM == '8'
+}
+
+boolean isStream9() {
+    return env.OPTAPLANNER_LATEST_STREAM == '9'
 }

--- a/.ci/jenkins/Jenkinsfile.promote
+++ b/.ci/jenkins/Jenkinsfile.promote
@@ -82,7 +82,8 @@ pipeline {
 
         stage('Merge Optaweb Vehicle Routing deploy PR and tag') {
             when {
-                expression { return isRelease() }
+                // TODO: switch to the 9 stream after optaweb will have been migrated.
+                expression { return isRelease() && isStream8() }
             }
             steps {
                 script {
@@ -97,7 +98,8 @@ pipeline {
 
         stage('Merge OptaPlanner Quickstarts PR and tag') {
             when {
-                expression { return isRelease() }
+                // TODO: switch to the 9 stream after quickstarts and the optaweb will have been migrated.
+                expression { return isRelease() && isStream8() }
             }
             steps {
                 script {
@@ -112,11 +114,16 @@ pipeline {
 
         stage('Upload OptaPlanner documentation') {
             when {
-                expression { return isRelease() }
+                // TODO: switch to the 9 stream after quickstarts and the optaweb will have been migrated.
+                expression { return isRelease() && isStream8() }
             }
             steps {
                 script {
-                    getMavenCommand().inDirectory(optaplannerRepository).skipTests(true).withProperty('full').run('clean install')
+                    getMavenCommand()
+                            .inDirectory(optaplannerRepository)
+                            .skipTests(true)
+                            .withProperty('full')
+                            .run('clean install')
                     uploadDistribution(optaplannerRepository)
                 }
             }
@@ -124,11 +131,15 @@ pipeline {
 
         stage('Upload Vehicle Routing documentation and distribution') {
             when {
-                expression { return isRelease() }
+                // TODO: switch to the 9 stream after quickstarts and the optaweb will have been migrated.
+                expression { return isRelease() && isStream8() }
             }
             steps {
                 script {
-                    getMavenCommand().inDirectory(vehicleRoutingRepository).skipTests(true).run('clean install')
+                    getMavenCommand()
+                            .inDirectory(vehicleRoutingRepository)
+                            .skipTests(true)
+                            .run('clean install')
                     uploadDistribution(vehicleRoutingRepository)
                 }
             }
@@ -162,7 +173,8 @@ pipeline {
 
         stage('Set Optaweb Vehicle Routing next snapshot version') {
             when {
-                expression { return isRelease() }
+                // TODO: switch to the 9 stream after quickstarts and the optaweb will have been migrated.
+                expression { return isRelease() && isStream8()  }
             }
             steps {
                 script {
@@ -185,7 +197,8 @@ pipeline {
 
         stage('Set Quickstarts next snapshot version') {
             when {
-                expression { return isRelease() }
+                // TODO: switch to the 9 stream after quickstarts and the optaweb will have been migrated.
+                expression { return isRelease() && isStream8() }
             }
             steps {
                 script {
@@ -208,7 +221,7 @@ pipeline {
 
         stage('Push the final OptaPlanner operator image') {
             when {
-                expression { return isRelease() }
+                expression { return isRelease() && isStream8() }
             }
             steps {
                 script {
@@ -497,4 +510,12 @@ void removeOperatorImageTemporaryTag() {
         error "Cannot remove the OptaPlanner Operator temporary image tag (${temporaryImageName}) from quay.io. "
                 + "The tag should be removed manually."
     }
+}
+
+boolean isStream8() {
+    return env.OPTAPLANNER_LATEST_STREAM == '8'
+}
+
+boolean isStream9() {
+    return env.OPTAPLANNER_LATEST_STREAM == '9'
 }

--- a/.ci/jenkins/dsl/jobs.groovy
+++ b/.ci/jenkins/dsl/jobs.groovy
@@ -67,7 +67,8 @@ void createProjectSetupBranchJob() {
         GIT_BRANCH_NAME: "${GIT_BRANCH}",
         GIT_AUTHOR: "${GIT_AUTHOR_NAME}",
 
-        IS_MAIN_BRANCH: "${Utils.isMainBranch(this)}"
+        IS_MAIN_BRANCH: "${Utils.isMainBranch(this)}",
+        OPTAPLANNER_LATEST_STREAM: getOptaPlannerLatestStream()
     ])
     KogitoJobTemplate.createPipelineJob(this, jobParams)?.with {
         parameters {
@@ -84,9 +85,11 @@ void setupProjectNightlyJob() {
 
         GIT_BRANCH_NAME: "${GIT_BRANCH}",
         GIT_AUTHOR: "${GIT_AUTHOR_NAME}",
+        AUTHOR_CREDS_ID: "${GIT_AUTHOR_CREDENTIALS_ID}",
 
         MAVEN_SETTINGS_CONFIG_FILE_ID: "${MAVEN_SETTINGS_FILE_ID}",
         ARTIFACTS_REPOSITORY: "${MAVEN_ARTIFACTS_REPOSITORY}",
+        OPTAPLANNER_LATEST_STREAM: getOptaPlannerLatestStream()
     ])
     KogitoJobTemplate.createPipelineJob(this, jobParams)?.with {
         parameters {
@@ -105,6 +108,7 @@ void setupProjectReleaseJob() {
 
         DEFAULT_STAGING_REPOSITORY: "${MAVEN_NEXUS_STAGING_PROFILE_URL}",
         ARTIFACTS_REPOSITORY: "${MAVEN_ARTIFACTS_REPOSITORY}",
+        OPTAPLANNER_LATEST_STREAM: getOptaPlannerLatestStream()
     ])
     KogitoJobTemplate.createPipelineJob(this, jobParams)?.with {
         parameters {
@@ -135,6 +139,7 @@ void setupProjectPostReleaseJob() {
         MAVEN_DEPENDENCIES_REPOSITORY: "${MAVEN_ARTIFACTS_REPOSITORY}",
 
         GITHUB_CLI_VERSION: '0.11.1',
+        OPTAPLANNER_LATEST_STREAM: getOptaPlannerLatestStream()
     ])
     KogitoJobTemplate.createPipelineJob(this, jobParams)?.with {
         parameters {
@@ -245,7 +250,8 @@ void createSetupBranchJob() {
         MAVEN_DEPENDENCIES_REPOSITORY: "${MAVEN_ARTIFACTS_REPOSITORY}",
         MAVEN_DEPLOY_REPOSITORY: "${MAVEN_ARTIFACTS_REPOSITORY}",
 
-        IS_MAIN_BRANCH: "${Utils.isMainBranch(this)}"
+        IS_MAIN_BRANCH: "${Utils.isMainBranch(this)}",
+        OPTAPLANNER_LATEST_STREAM: getOptaPlannerLatestStream()
     ])
     KogitoJobTemplate.createPipelineJob(this, jobParams)?.with {
         parameters {
@@ -273,6 +279,7 @@ void setupDeployJob(Folder jobFolder) {
 
         JENKINS_EMAIL_CREDS_ID: "${JENKINS_EMAIL_CREDS_ID}",
         MAVEN_SETTINGS_CONFIG_FILE_ID: "${MAVEN_SETTINGS_FILE_ID}",
+        OPTAPLANNER_LATEST_STREAM: getOptaPlannerLatestStream()
     ])
     if (jobFolder.isPullRequest()) {
         jobParams.env.putAll([
@@ -358,6 +365,7 @@ void setupPromoteJob(Folder jobFolder) {
 
         PROPERTIES_FILE_NAME: 'deployment.properties',
         GITHUB_CLI_VERSION: '0.11.1',
+        OPTAPLANNER_LATEST_STREAM: getOptaPlannerLatestStream()
     ])
     KogitoJobTemplate.createPipelineJob(this, jobParams)?.with {
         parameters {
@@ -396,5 +404,17 @@ void setupOptaPlannerTurtleTestsJob(String constraintStreamImplType) {
             stringParam('BUILD_BRANCH_NAME', "${GIT_BRANCH}", 'Git branch to checkout')
             stringParam('GIT_AUTHOR', "${GIT_AUTHOR_NAME}", 'Git author or an organization.')
         }
+    }
+}
+
+String getOptaPlannerLatestStream() {
+    String gitMainBranch = "${GIT_MAIN_BRANCH}"
+
+    if (gitMainBranch == 'main') {
+        return '8'
+    } else if (gitMainBranch == '9.x') {
+        return '9'
+    } else {
+        return gitMainBranch
     }
 }

--- a/.ci/jenkins/project/Jenkinsfile.nightly
+++ b/.ci/jenkins/project/Jenkinsfile.nightly
@@ -1,6 +1,10 @@
 import org.jenkinsci.plugins.workflow.libs.Library
 @Library('jenkins-pipeline-shared-libraries')_
 
+String optaPlannerRepository = 'optaplanner'
+String optaPlannerMainBranch = 'main'
+String optaPlanner9xBranch = '9.x'
+
 // Deploy jobs
 OPTAPLANNER_DEPLOY = 'optaplanner-deploy'
 
@@ -49,13 +53,28 @@ pipeline {
             }
         }
 
+        // Applies only to the 9.x branch build. The 9.?.x release branches must remain intact.
+        stage('Migrate to 9') {
+            when {
+                expression { return getBuildBranch() == optaPlanner9xBranch }
+            }
+            steps {
+                script {
+                    checkoutNewBranch(optaPlannerRepository, optaPlannerMainBranch, optaPlanner9xBranch)
+                    callMigrationScript(optaPlannerRepository)
+                    forcePushBranch(optaPlannerRepository, optaPlanner9xBranch)
+                }
+            }
+        }
+
         stage('Build & Deploy OptaPlanner') {
             steps {
                 script {
                     def buildParams = getDefaultBuildParams(getBuildBranch())
                     addSkipTestsParam(buildParams)
                     addSkipIntegrationTestsParam(buildParams)
-                    def quickstartsBranch = getBuildBranch() == 'main' ? 'development' : getBuildBranch()
+                    def quickstartsBranch = getBuildBranch() == 'main' || getBuildBranch() == '9.x'
+                            ? 'development' : getBuildBranch()
                     addStringParam(buildParams, 'QUICKSTARTS_BUILD_BRANCH_NAME', quickstartsBranch)
 
                     buildJob(OPTAPLANNER_DEPLOY, buildParams)
@@ -168,4 +187,34 @@ String getBuildBranch() {
 
 String getGitAuthor() {
     return env.GIT_AUTHOR
+}
+
+String getGitAuthorCredsID() {
+    return env.AUTHOR_CREDS_ID
+}
+
+void checkoutNewBranch(String repo, String originBranch, String newBranch, String dirName = repo) {
+    dir(dirName) {
+        deleteDir()
+        checkout(githubscm.resolveRepository(repo, getGitAuthor(), originBranch, false))
+        sh "git checkout -b ${newBranch}"
+    }
+}
+
+void forcePushBranch(String dirName, String branch) {
+    dir(dirName) {
+        withCredentials([usernamePassword(credentialsId: getGitAuthorCredsID(), usernameVariable: 'GIT_USERNAME', passwordVariable: 'GIT_PASSWORD')]) {
+            // Please leave the double-quote here. They are mandatory for the shell command to work correctly.
+            sh """
+            git config --local credential.helper \"!f() { echo username=\\$GIT_USERNAME; echo password=\\$GIT_PASSWORD; }; f\"
+            git push origin ${branch} --force
+        """
+        }
+    }
+}
+
+void callMigrationScript(String dirName) {
+    dir(dirName) {
+        sh "./build/8-to-9-migration/migrate.sh"
+    }
 }

--- a/.ci/jenkins/project/Jenkinsfile.nightly
+++ b/.ci/jenkins/project/Jenkinsfile.nightly
@@ -196,7 +196,7 @@ String getGitAuthorCredsID() {
 void checkoutNewBranch(String repo, String originBranch, String newBranch, String dirName = repo) {
     dir(dirName) {
         deleteDir()
-        checkout(githubscm.resolveRepository(repo, getGitAuthor(), originBranch, false))
+        checkoutRepo(optaPlannerRepository, originBranch)
         sh "git checkout -b ${newBranch}"
     }
 }

--- a/.ci/jenkins/project/Jenkinsfile.post-release
+++ b/.ci/jenkins/project/Jenkinsfile.post-release
@@ -57,6 +57,10 @@ pipeline {
         }
 
         stage('Reset Quickstarts stable branch') {
+            when {
+                // TODO: switch to the 9 stream after quickstarts and the optaweb will have been migrated.
+                expression { return isStream8() }
+            }
             steps {
                 script {
                     dir(quickstartsRepository) {
@@ -69,6 +73,10 @@ pipeline {
         }
 
         stage('Upload OptaPlanner distribution from Quickstarts') {
+            when {
+                // TODO: switch to the 9 stream after quickstarts and the optaweb will have been migrated.
+                expression { return isStream8() }
+            }
             steps {
                 script {
                     dir(optaplannerRepository) {
@@ -83,6 +91,10 @@ pipeline {
         }
 
         stage('Update OptaPlanner website') {
+            when {
+                // TODO: switch to the 9 stream after quickstarts and the optaweb will have been migrated.
+                expression { return isStream8() }
+            }
             steps {
                 script {
                     final String websiteRepository = 'optaplanner-website'
@@ -363,4 +375,12 @@ void assertGithubCLI(String ghPath) {
     else {
         error "gh not found at $ghPath"
     }
+}
+
+boolean isStream8() {
+    return env.OPTAPLANNER_LATEST_STREAM == '8'
+}
+
+boolean isStream9() {
+    return env.OPTAPLANNER_LATEST_STREAM == '9'
 }

--- a/build/8-to-9-migration/migrate.sh
+++ b/build/8-to-9-migration/migrate.sh
@@ -13,7 +13,7 @@ project_version=$(${mvn_cmd} help:evaluate -Dexpression=project.version -q -Dfor
 ${mvn_cmd} rewrite:run \
   -Drewrite.configLocation="${optaplanner_file}" \
   -Drewrite.recipeArtifactCoordinates=org.optaplanner:optaplanner-migration:"$project_version" \
-  -Drewrite.exclusions=optaplanner-operator/** \
+  -Drewrite.exclusions=optaplanner-operator/**,optaplanner-examples/data/** \
   -Drewrite.activeRecipes=org.optaplanner.openrewrite.Quarkus3 \
   -Dfull \
   -Dquickly \

--- a/build/8-to-9-migration/migrate.sh
+++ b/build/8-to-9-migration/migrate.sh
@@ -30,6 +30,8 @@ ${mvn_cmd} versions:set \
   -DgenerateBackupPoms=false \
   -DnewVersion="${new_project_version}" \
 
+${mvn_cmd} process-test-sources
+
 # Commit the changes.
 git status
 git add -u


### PR DESCRIPTION
OptaPlanner will release the "8" stream from the `main` branch and the "9" stream from the `9.x` branch.

Optaweb vehicle routing and quickstarts exist only in the "9" stream; the `main`, resp. `development` branch of these repositories depend on OptaPlanner 9.

<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.
-->

### JIRA
https://issues.redhat.com/browse/PLANNER-2877

<!-- Add a JIRA ticket link if it exists. -->
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->

### Referenced pull requests
Depends on https://github.com/kiegroup/optaplanner/pull/2542 if the next build of 9.x should not fail.

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
- https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
- https://github.com/kiegroup/drools/pull/3000
- https://github.com/kiegroup/optaplanner/pull/899
- etc.
-->

### Checklist
- [ ] Documentation updated if applicable.
- [ ] Release notes updated if applicable.
- [ ] Upgrade recipe provided if applicable.

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request checks</b>  
  Please add comment: <b>Jenkins retest this</b>

- for a <b>specific pull request check</b>  
  please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-vehicle-routing] tests</b>
  
- for a <b>full downstream build</b> 
  - for <b>jenkins</b> job: 
    please add comment: <b>Jenkins run fdb</b>
  - for <b>github actions</b> job: 
    add the label `run_fdb`

- for a <b>compile downstream build</b>  
  please add comment: <b>Jenkins run cdb</b>

- for a <b>full production downstream build</b>  
  please add comment: <b>Jenkins execute product fdb</b>

- for an <b>upstream build</b>  
  please add comment: <b>Jenkins run upstream</b>

- for <b>quarkus branch checks</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins run quarkus-branch</b>

- for a <b>quarkus branch specific check</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-vehicle-routing] quarkus-branch</b>

- for <b>quarkus main checks</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins run quarkus-main</b>

- for a <b>specific quarkus main check</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-vehicle-routing] quarkus-branch</b>

- for <b>quarkus lts checks</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins run quarkus-lts</b>

- for a <b>specific quarkus lts check</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-vehicle-routing] quarkus-lts</b>

- for <b>native checks</b>  
  Run native checks  
  Please add comment: <b>Jenkins run native</b>

- for a <b>specific native check</b>  
  Run native checks 
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts] native</b>

- for <b>mandrel checks</b>  
  Run native checks against Mandrel image
  Please add comment: <b>Jenkins run mandrel</b>

- for a <b>specific mandrel check</b>  
  Run native checks against Mandrel image  
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts] mandrel</b>

- for <b>mandrel lts checks</b>  
  Run native checks against Mandrel image and quarkus lts branch
  Please add comment: <b>Jenkins run mandrel-lts</b>

- for a <b>specific mandrel lts check</b>  
  Run native checks against Mandrel image and quarkus lts branch
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts] mandrel-lts</b>

</details>

### CI Status

 You can check OptaPlanner repositories CI status from [Chain Status webpage](https://kiegroup.github.io/optaplanner/).

<details>
<summary>
How to backport a pull request to a different branch?
</summary>

In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-7.67.x` to backport the original PR to the `7.67.x` branch).

> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.

Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.

If something goes wrong, the author will be notified and at this point a manual backporting is needed.

> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
</details>
