### PR TITLE
Reduce memory churn in Demand hashCode

### DIFF
--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/domain/variable/anchor/AnchorVariableDemand.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/domain/variable/anchor/AnchorVariableDemand.java
@@ -1,19 +1,16 @@
 package org.optaplanner.core.impl.domain.variable.anchor;
 
-import java.util.Objects;
-
 import org.optaplanner.core.impl.domain.variable.descriptor.VariableDescriptor;
 import org.optaplanner.core.impl.domain.variable.inverserelation.SingletonInverseVariableDemand;
 import org.optaplanner.core.impl.domain.variable.inverserelation.SingletonInverseVariableSupply;
-import org.optaplanner.core.impl.domain.variable.supply.Demand;
+import org.optaplanner.core.impl.domain.variable.supply.AbstractVariableDescriptorBasedDemand;
 import org.optaplanner.core.impl.domain.variable.supply.SupplyManager;
 
-public class AnchorVariableDemand<Solution_> implements Demand<AnchorVariableSupply> {
-
-    protected final VariableDescriptor<Solution_> sourceVariableDescriptor;
+public final class AnchorVariableDemand<Solution_>
+        extends AbstractVariableDescriptorBasedDemand<Solution_, AnchorVariableSupply> {
 
     public AnchorVariableDemand(VariableDescriptor<Solution_> sourceVariableDescriptor) {
-        this.sourceVariableDescriptor = sourceVariableDescriptor;
+        super(sourceVariableDescriptor);
     }
 
     // ************************************************************************
@@ -23,37 +20,8 @@ public class AnchorVariableDemand<Solution_> implements Demand<AnchorVariableSup
     @Override
     public AnchorVariableSupply createExternalizedSupply(SupplyManager supplyManager) {
         SingletonInverseVariableSupply inverseVariableSupply = supplyManager
-                .demand(new SingletonInverseVariableDemand<>(sourceVariableDescriptor));
-        return new ExternalizedAnchorVariableSupply<>(sourceVariableDescriptor, inverseVariableSupply);
-    }
-
-    // ************************************************************************
-    // Equals/hashCode method
-    // ************************************************************************
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (!(o instanceof AnchorVariableDemand)) {
-            return false;
-        }
-        AnchorVariableDemand<Solution_> other = (AnchorVariableDemand<Solution_>) o;
-        if (!sourceVariableDescriptor.equals(other.sourceVariableDescriptor)) {
-            return false;
-        }
-        return true;
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(AnchorVariableDemand.class.getName(), sourceVariableDescriptor);
-    }
-
-    @Override
-    public String toString() {
-        return getClass().getSimpleName() + "(" + sourceVariableDescriptor.getSimpleEntityAndVariableName() + ")";
+                .demand(new SingletonInverseVariableDemand<>(variableDescriptor));
+        return new ExternalizedAnchorVariableSupply<>(variableDescriptor, inverseVariableSupply);
     }
 
 }

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/domain/variable/index/IndexVariableDemand.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/domain/variable/index/IndexVariableDemand.java
@@ -1,17 +1,14 @@
 package org.optaplanner.core.impl.domain.variable.index;
 
-import java.util.Objects;
-
 import org.optaplanner.core.impl.domain.variable.descriptor.ListVariableDescriptor;
-import org.optaplanner.core.impl.domain.variable.supply.Demand;
+import org.optaplanner.core.impl.domain.variable.supply.AbstractVariableDescriptorBasedDemand;
 import org.optaplanner.core.impl.domain.variable.supply.SupplyManager;
 
-public class IndexVariableDemand<Solution_> implements Demand<IndexVariableSupply> {
-
-    protected final ListVariableDescriptor<Solution_> sourceVariableDescriptor;
+public final class IndexVariableDemand<Solution_>
+        extends AbstractVariableDescriptorBasedDemand<Solution_, IndexVariableSupply> {
 
     public IndexVariableDemand(ListVariableDescriptor<Solution_> sourceVariableDescriptor) {
-        this.sourceVariableDescriptor = sourceVariableDescriptor;
+        super(sourceVariableDescriptor);
     }
 
     // ************************************************************************
@@ -20,33 +17,7 @@ public class IndexVariableDemand<Solution_> implements Demand<IndexVariableSuppl
 
     @Override
     public IndexVariableSupply createExternalizedSupply(SupplyManager supplyManager) {
-        return new ExternalizedIndexVariableSupply<>(sourceVariableDescriptor);
-    }
-
-    // ************************************************************************
-    // Equals/hashCode method
-    // ************************************************************************
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (!(o instanceof IndexVariableDemand)) {
-            return false;
-        }
-        IndexVariableDemand<Solution_> other = (IndexVariableDemand<Solution_>) o;
-        return sourceVariableDescriptor.equals(other.sourceVariableDescriptor);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(IndexVariableDemand.class.getName(), sourceVariableDescriptor);
-    }
-
-    @Override
-    public String toString() {
-        return getClass().getSimpleName() + "(" + sourceVariableDescriptor.getSimpleEntityAndVariableName() + ")";
+        return new ExternalizedIndexVariableSupply<>((ListVariableDescriptor<Solution_>) variableDescriptor);
     }
 
 }

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/domain/variable/inverserelation/CollectionInverseVariableDemand.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/domain/variable/inverserelation/CollectionInverseVariableDemand.java
@@ -1,21 +1,18 @@
 package org.optaplanner.core.impl.domain.variable.inverserelation;
 
-import java.util.Objects;
-
 import org.optaplanner.core.impl.domain.variable.descriptor.VariableDescriptor;
-import org.optaplanner.core.impl.domain.variable.supply.Demand;
+import org.optaplanner.core.impl.domain.variable.supply.AbstractVariableDescriptorBasedDemand;
 import org.optaplanner.core.impl.domain.variable.supply.SupplyManager;
 import org.optaplanner.core.impl.score.director.InnerScoreDirector;
 
 /**
  * To get an instance, demand a {@link CollectionInverseVariableDemand} from {@link InnerScoreDirector#getSupplyManager()}.
  */
-public class CollectionInverseVariableDemand<Solution_> implements Demand<CollectionInverseVariableSupply> {
-
-    protected final VariableDescriptor<Solution_> sourceVariableDescriptor;
+public final class CollectionInverseVariableDemand<Solution_>
+        extends AbstractVariableDescriptorBasedDemand<Solution_, CollectionInverseVariableSupply> {
 
     public CollectionInverseVariableDemand(VariableDescriptor<Solution_> sourceVariableDescriptor) {
-        this.sourceVariableDescriptor = sourceVariableDescriptor;
+        super(sourceVariableDescriptor);
     }
 
     // ************************************************************************
@@ -24,36 +21,7 @@ public class CollectionInverseVariableDemand<Solution_> implements Demand<Collec
 
     @Override
     public CollectionInverseVariableSupply createExternalizedSupply(SupplyManager supplyManager) {
-        return new ExternalizedCollectionInverseVariableSupply<>(sourceVariableDescriptor);
-    }
-
-    // ************************************************************************
-    // Equals/hashCode method
-    // ************************************************************************
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (!(o instanceof CollectionInverseVariableDemand)) {
-            return false;
-        }
-        CollectionInverseVariableDemand<Solution_> other = (CollectionInverseVariableDemand<Solution_>) o;
-        if (!sourceVariableDescriptor.equals(other.sourceVariableDescriptor)) {
-            return false;
-        }
-        return true;
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(CollectionInverseVariableDemand.class.getName(), sourceVariableDescriptor);
-    }
-
-    @Override
-    public String toString() {
-        return getClass().getSimpleName() + "(" + sourceVariableDescriptor.getSimpleEntityAndVariableName() + ")";
+        return new ExternalizedCollectionInverseVariableSupply<>(variableDescriptor);
     }
 
 }

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/domain/variable/inverserelation/SingletonInverseVariableDemand.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/domain/variable/inverserelation/SingletonInverseVariableDemand.java
@@ -1,17 +1,14 @@
 package org.optaplanner.core.impl.domain.variable.inverserelation;
 
-import java.util.Objects;
-
 import org.optaplanner.core.impl.domain.variable.descriptor.VariableDescriptor;
-import org.optaplanner.core.impl.domain.variable.supply.Demand;
+import org.optaplanner.core.impl.domain.variable.supply.AbstractVariableDescriptorBasedDemand;
 import org.optaplanner.core.impl.domain.variable.supply.SupplyManager;
 
-public class SingletonInverseVariableDemand<Solution_> implements Demand<SingletonInverseVariableSupply> {
-
-    protected final VariableDescriptor<Solution_> sourceVariableDescriptor;
+public final class SingletonInverseVariableDemand<Solution_>
+        extends AbstractVariableDescriptorBasedDemand<Solution_, SingletonInverseVariableSupply> {
 
     public SingletonInverseVariableDemand(VariableDescriptor<Solution_> sourceVariableDescriptor) {
-        this.sourceVariableDescriptor = sourceVariableDescriptor;
+        super(sourceVariableDescriptor);
     }
 
     // ************************************************************************
@@ -20,36 +17,7 @@ public class SingletonInverseVariableDemand<Solution_> implements Demand<Singlet
 
     @Override
     public SingletonInverseVariableSupply createExternalizedSupply(SupplyManager supplyManager) {
-        return new ExternalizedSingletonInverseVariableSupply<>(sourceVariableDescriptor);
-    }
-
-    // ************************************************************************
-    // Equals/hashCode method
-    // ************************************************************************
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (!(o instanceof SingletonInverseVariableDemand)) {
-            return false;
-        }
-        SingletonInverseVariableDemand<Solution_> other = (SingletonInverseVariableDemand<Solution_>) o;
-        if (!sourceVariableDescriptor.equals(other.sourceVariableDescriptor)) {
-            return false;
-        }
-        return true;
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(SingletonInverseVariableDemand.class.getName(), sourceVariableDescriptor);
-    }
-
-    @Override
-    public String toString() {
-        return getClass().getSimpleName() + "(" + sourceVariableDescriptor.getSimpleEntityAndVariableName() + ")";
+        return new ExternalizedSingletonInverseVariableSupply<>(variableDescriptor);
     }
 
 }

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/domain/variable/inverserelation/SingletonListInverseVariableDemand.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/domain/variable/inverserelation/SingletonListInverseVariableDemand.java
@@ -1,17 +1,14 @@
 package org.optaplanner.core.impl.domain.variable.inverserelation;
 
-import java.util.Objects;
-
 import org.optaplanner.core.impl.domain.variable.descriptor.ListVariableDescriptor;
-import org.optaplanner.core.impl.domain.variable.supply.Demand;
+import org.optaplanner.core.impl.domain.variable.supply.AbstractVariableDescriptorBasedDemand;
 import org.optaplanner.core.impl.domain.variable.supply.SupplyManager;
 
-public class SingletonListInverseVariableDemand<Solution_> implements Demand<SingletonInverseVariableSupply> {
-
-    protected final ListVariableDescriptor<Solution_> sourceVariableDescriptor;
+public final class SingletonListInverseVariableDemand<Solution_>
+        extends AbstractVariableDescriptorBasedDemand<Solution_, SingletonInverseVariableSupply> {
 
     public SingletonListInverseVariableDemand(ListVariableDescriptor<Solution_> sourceVariableDescriptor) {
-        this.sourceVariableDescriptor = sourceVariableDescriptor;
+        super(sourceVariableDescriptor);
     }
 
     // ************************************************************************
@@ -20,33 +17,7 @@ public class SingletonListInverseVariableDemand<Solution_> implements Demand<Sin
 
     @Override
     public SingletonInverseVariableSupply createExternalizedSupply(SupplyManager supplyManager) {
-        return new ExternalizedSingletonListInverseVariableSupply<>(sourceVariableDescriptor);
-    }
-
-    // ************************************************************************
-    // Equals/hashCode method
-    // ************************************************************************
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (!(o instanceof SingletonListInverseVariableDemand)) {
-            return false;
-        }
-        SingletonListInverseVariableDemand<Solution_> other = (SingletonListInverseVariableDemand<Solution_>) o;
-        return sourceVariableDescriptor.equals(other.sourceVariableDescriptor);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(SingletonListInverseVariableDemand.class.getName(), sourceVariableDescriptor);
-    }
-
-    @Override
-    public String toString() {
-        return getClass().getSimpleName() + "(" + sourceVariableDescriptor.getSimpleEntityAndVariableName() + ")";
+        return new ExternalizedSingletonListInverseVariableSupply<>((ListVariableDescriptor<Solution_>) variableDescriptor);
     }
 
 }

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/domain/variable/supply/AbstractVariableDescriptorBasedDemand.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/domain/variable/supply/AbstractVariableDescriptorBasedDemand.java
@@ -6,10 +6,8 @@ import org.optaplanner.core.impl.domain.variable.descriptor.VariableDescriptor;
 
 /**
  * Some {@link Demand} implementation classes are defined by their {@link VariableDescriptor} and nothing else.
- * However, they still must not have the same {@link #hashCode()} as other {@link Demand} implementation classes
- * defined by the same {@link VariableDescriptor}.
- * Otherwise these different {@link Demand} implementations would be considered identical in hash maps
- * and the same supply would be used for them.
+ * However, they still must not equal (and therefore have the same {@link #hashCode()})
+ * as other {@link Demand} implementation classes defined by the same {@link VariableDescriptor}.
  * This helper abstraction exists so that this logic can be shared across all such {@link Demand} implementations.
  *
  * @param <Solution_>

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/domain/variable/supply/AbstractVariableDescriptorBasedDemand.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/domain/variable/supply/AbstractVariableDescriptorBasedDemand.java
@@ -1,0 +1,49 @@
+package org.optaplanner.core.impl.domain.variable.supply;
+
+import java.util.Objects;
+
+import org.optaplanner.core.impl.domain.variable.descriptor.VariableDescriptor;
+
+/**
+ * Some {@link Demand} implementation classes are defined by their {@link VariableDescriptor} and nothing else.
+ * However, they still must not have the same {@link #hashCode()} as other {@link Demand} implementation classes
+ * defined by the same {@link VariableDescriptor}.
+ * Otherwise these different {@link Demand} implementations would be considered identical in hash maps
+ * and the same supply would be used for them.
+ * This helper abstraction exists so that this logic can be shared across all such {@link Demand} implementations.
+ *
+ * @param <Solution_>
+ * @param <Supply_>
+ */
+public abstract class AbstractVariableDescriptorBasedDemand<Solution_, Supply_ extends Supply>
+        implements Demand<Supply_> {
+
+    protected final VariableDescriptor<Solution_> variableDescriptor;
+
+    protected AbstractVariableDescriptorBasedDemand(VariableDescriptor<Solution_> variableDescriptor) {
+        this.variableDescriptor = Objects.requireNonNull(variableDescriptor);
+    }
+
+    @Override
+    public final boolean equals(Object other) {
+        if (this == other)
+            return true;
+        if (other == null || getClass() != other.getClass())
+            return false;
+        AbstractVariableDescriptorBasedDemand<?, ?> that = (AbstractVariableDescriptorBasedDemand<?, ?>) other;
+        return Objects.equals(variableDescriptor, that.variableDescriptor);
+    }
+
+    @Override
+    public final int hashCode() { // Don't use Objects.hashCode(...) as that would create varargs array on the hot path.
+        int result = this.getClass().getName().hashCode();
+        result = 31 * result + variableDescriptor.hashCode();
+        return result;
+    }
+
+    @Override
+    public final String toString() {
+        return getClass().getSimpleName() + "(" + variableDescriptor.getSimpleEntityAndVariableName() + ")";
+    }
+
+}

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/common/nearby/NearbyDistanceMatrixDemand.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/common/nearby/NearbyDistanceMatrixDemand.java
@@ -19,7 +19,7 @@ import org.optaplanner.core.impl.util.MemoizingSupply;
  * <p>
  * In cases where the demand represents the same nearby selector (as defined by
  * {@link NearbyDistanceMatrixDemand#equals(Object)})
- * the {@link SupplyManager} ensures that the same {@link NearbyDistanceMatrixSupply} instance is returned
+ * the {@link SupplyManager} ensures that the same supply instance is returned
  * with the pre-computed {@link NearbyDistanceMatrix}.
  *
  * @param <Solution_>

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/PillarDemand.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/PillarDemand.java
@@ -20,7 +20,7 @@ import org.optaplanner.core.impl.domain.variable.supply.SupplyManager;
 import org.optaplanner.core.impl.heuristic.selector.entity.EntitySelector;
 import org.optaplanner.core.impl.util.MemoizingSupply;
 
-public class PillarDemand<Solution_> implements Demand<MemoizingSupply<List<List<Object>>>> {
+public final class PillarDemand<Solution_> implements Demand<MemoizingSupply<List<List<Object>>>> {
 
     private final EntitySelector<Solution_> entitySelector;
     private final List<GenuineVariableDescriptor<Solution_>> variableDescriptors;


### PR DESCRIPTION
`Objects.hashCode(...)` is a varargs method, which means it creates an array of arguments every time it is called. 
This is typically not a problem, but in the case of `Demand` implementations, this actually shows up on the hot path.
This change significantly reduces the number of `Object[]` arrays getting allocated.