### PR TITLE
PLANNER-2892 Update default Maven to 3.8.7

### DIFF
--- a/.ci/jenkins/Jenkinsfile.prod.nightly
+++ b/.ci/jenkins/Jenkinsfile.prod.nightly
@@ -5,7 +5,7 @@ pipeline {
         label 'kie-rhel7 && kie-mem8g && !built-in'
     }
     tools {
-        maven 'kie-maven-3.8.6'
+        maven 'kie-maven-3.8.7'
         jdk 'kie-jdk11'
     }
     parameters {

--- a/.ci/jenkins/config/branch.yaml
+++ b/.ci/jenkins/config/branch.yaml
@@ -75,4 +75,4 @@ jenkins:
   email_creds_id: OPTAPLANNER_CI_EMAIL
   default_tools:
     jdk: kie-jdk11
-    maven: kie-maven-3.8.6
+    maven: kie-maven-3.8.7

--- a/.github/workflows/full-downstream.yml
+++ b/.github/workflows/full-downstream.yml
@@ -23,7 +23,7 @@ jobs:
       matrix:
         os: [ ubuntu-latest ]
         java-version: [ 11 ]
-        maven-version: [ '3.8.6' ]
+        maven-version: [ '3.8.7' ]
       fail-fast: false
     runs-on: ${{ matrix.os }}
     name: ${{ matrix.os }} - Java ${{ matrix.java-version }} - Maven

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -28,7 +28,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
         java-version: [ 11, 17, 19 ]
-        maven-version: [ '3.8.6' ]
+        maven-version: [ '3.8.7' ]
       fail-fast: false
     runs-on: ${{ matrix.os }}
     name: ${{ matrix.os }} - Java ${{ matrix.java-version }} - Maven

--- a/.github/workflows/quarkus-snapshot.yml
+++ b/.github/workflows/quarkus-snapshot.yml
@@ -22,7 +22,7 @@ jobs:
       matrix:
         os: [ ubuntu-latest ]
         java-version: [ 11 ]
-        maven-version: [ '3.8.6' ]
+        maven-version: [ '3.8.7' ]
       fail-fast: false
     runs-on: ${{ matrix.os }}
     if: github.actor == 'quarkusbot'

--- a/.github/workflows/rhbop_productized_pull_request.yml
+++ b/.github/workflows/rhbop_productized_pull_request.yml
@@ -29,7 +29,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         java-version: [11]
-        maven-version: ['3.8.6']
+        maven-version: ['3.8.7']
       fail-fast: false
     runs-on: ${{ matrix.os }}
     name: ${{ matrix.os }} - Java ${{ matrix.java-version }} - Maven

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -23,7 +23,7 @@ jobs:
       matrix:
         os: [ ubuntu-latest ]
         java-version: [ 11 ]
-        maven-version: [ '3.8.6' ]
+        maven-version: [ '3.8.7' ]
       fail-fast: false
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
https://issues.redhat.com/browse/PLANNER-2892

Related:
- https://github.com/kiegroup/optaplanner/pull/2530
- https://github.com/kiegroup/optaweb-vehicle-routing/pull/840
- https://github.com/kiegroup/optaplanner-quickstarts/pull/497