### PR TITLE
PLANNER-2814 ElementDestinationSelector

### DIFF
--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/config/heuristic/selector/move/generic/list/SubListChangeMoveSelectorConfig.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/config/heuristic/selector/move/generic/list/SubListChangeMoveSelectorConfig.java
@@ -12,7 +12,8 @@ import org.optaplanner.core.config.util.ConfigUtils;
         "maximumSubListSize",
         "selectReversingMoveToo"
 })
-public class SubListChangeMoveSelectorConfig extends MoveSelectorConfig<SubListChangeMoveSelectorConfig> {
+public class SubListChangeMoveSelectorConfig extends MoveSelectorConfig<SubListChangeMoveSelectorConfig>
+        implements SubListSelectorConfig {
 
     public static final String XML_ELEMENT_NAME = "subListChangeMoveSelector";
 
@@ -20,6 +21,7 @@ public class SubListChangeMoveSelectorConfig extends MoveSelectorConfig<SubListC
     protected Integer maximumSubListSize = null;
     private Boolean selectReversingMoveToo = null;
 
+    @Override
     public Integer getMinimumSubListSize() {
         return minimumSubListSize;
     }
@@ -28,6 +30,7 @@ public class SubListChangeMoveSelectorConfig extends MoveSelectorConfig<SubListC
         this.minimumSubListSize = minimumSubListSize;
     }
 
+    @Override
     public Integer getMaximumSubListSize() {
         return maximumSubListSize;
     }

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/config/heuristic/selector/move/generic/list/SubListSelectorConfig.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/config/heuristic/selector/move/generic/list/SubListSelectorConfig.java
@@ -1,0 +1,12 @@
+package org.optaplanner.core.config.heuristic.selector.move.generic.list;
+
+/**
+ * Defines subList properties implemented by various subList move selector configs.
+ */
+public interface SubListSelectorConfig {
+
+    Integer getMinimumSubListSize();
+
+    Integer getMaximumSubListSize();
+
+}

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/config/heuristic/selector/move/generic/list/SubListSwapMoveSelectorConfig.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/config/heuristic/selector/move/generic/list/SubListSwapMoveSelectorConfig.java
@@ -12,7 +12,8 @@ import org.optaplanner.core.config.util.ConfigUtils;
         "maximumSubListSize",
         "selectReversingMoveToo"
 })
-public class SubListSwapMoveSelectorConfig extends MoveSelectorConfig<SubListSwapMoveSelectorConfig> {
+public class SubListSwapMoveSelectorConfig extends MoveSelectorConfig<SubListSwapMoveSelectorConfig>
+        implements SubListSelectorConfig {
 
     public static final String XML_ELEMENT_NAME = "subListSwapMoveSelector";
 
@@ -20,6 +21,7 @@ public class SubListSwapMoveSelectorConfig extends MoveSelectorConfig<SubListSwa
     protected Integer maximumSubListSize = null;
     private Boolean selectReversingMoveToo = null;
 
+    @Override
     public Integer getMinimumSubListSize() {
         return minimumSubListSize;
     }
@@ -28,6 +30,7 @@ public class SubListSwapMoveSelectorConfig extends MoveSelectorConfig<SubListSwa
         this.minimumSubListSize = minimumSubListSize;
     }
 
+    @Override
     public Integer getMaximumSubListSize() {
         return maximumSubListSize;
     }

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/constructionheuristic/DefaultConstructionHeuristicPhaseFactory.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/constructionheuristic/DefaultConstructionHeuristicPhaseFactory.java
@@ -62,6 +62,7 @@ public class DefaultConstructionHeuristicPhaseFactory<Solution_>
         HeuristicConfigPolicy<Solution_> phaseConfigPolicy = solverConfigPolicy.cloneBuilder()
                 .withReinitializeVariableFilterEnabled(true)
                 .withInitializedChainedValueFilterEnabled(true)
+                .withUnassignedValuesAllowed(true)
                 .withEntitySorterManner(entitySorterManner)
                 .withValueSorterManner(valueSorterManner)
                 .build();

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/constructionheuristic/placer/QueuedValuePlacerFactory.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/constructionheuristic/placer/QueuedValuePlacerFactory.java
@@ -36,9 +36,10 @@ public class QueuedValuePlacerFactory<Solution_>
         // TODO improve the ValueSelectorFactory API (avoid the boolean flags).
         ValueSelector<Solution_> valueSelector = ValueSelectorFactory.<Solution_> create(valueSelectorConfig_)
                 .buildValueSelector(configPolicy, entityDescriptor, SelectionCacheType.PHASE, SelectionOrder.ORIGINAL,
-                        false, true);
+                        false, // override applyReinitializeVariableFiltering
+                        ValueSelectorFactory.ListValueFilteringType.ACCEPT_UNASSIGNED);
 
-        MoveSelectorConfig moveSelectorConfig_ = config.getMoveSelectorConfig() == null
+        MoveSelectorConfig<?> moveSelectorConfig_ = config.getMoveSelectorConfig() == null
                 ? buildChangeMoveSelectorConfig(configPolicy, valueSelectorConfig_.getId(),
                         valueSelector.getVariableDescriptor())
                 : config.getMoveSelectorConfig();

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/HeuristicConfigPolicy.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/HeuristicConfigPolicy.java
@@ -33,6 +33,7 @@ public class HeuristicConfigPolicy<Solution_> {
     private final ClassInstanceCache classInstanceCache;
     private final boolean reinitializeVariableFilterEnabled;
     private final boolean initializedChainedValueFilterEnabled;
+    private final boolean unassignedValuesAllowed;
 
     private final Map<String, EntityMimicRecorder<Solution_>> entityMimicRecorderMap = new HashMap<>();
     private final Map<String, ValueMimicRecorder<Solution_>> valueMimicRecorderMap = new HashMap<>();
@@ -50,6 +51,7 @@ public class HeuristicConfigPolicy<Solution_> {
         this.classInstanceCache = builder.classInstanceCache;
         this.reinitializeVariableFilterEnabled = builder.reinitializeVariableFilterEnabled;
         this.initializedChainedValueFilterEnabled = builder.initializedChainedValueFilterEnabled;
+        this.unassignedValuesAllowed = builder.unassignedValuesAllowed;
     }
 
     public EnvironmentMode getEnvironmentMode() {
@@ -98,6 +100,10 @@ public class HeuristicConfigPolicy<Solution_> {
 
     public boolean isInitializedChainedValueFilterEnabled() {
         return initializedChainedValueFilterEnabled;
+    }
+
+    public boolean isUnassignedValuesAllowed() {
+        return unassignedValuesAllowed;
     }
 
     // ************************************************************************
@@ -188,6 +194,7 @@ public class HeuristicConfigPolicy<Solution_> {
 
         private boolean reinitializeVariableFilterEnabled = false;
         private boolean initializedChainedValueFilterEnabled = false;
+        private boolean unassignedValuesAllowed = false;
 
         public Builder(EnvironmentMode environmentMode, Integer moveThreadCount, Integer moveThreadBufferSize,
                 Class<? extends ThreadFactory> threadFactoryClass, InitializingScoreTrend initializingScoreTrend,
@@ -223,6 +230,11 @@ public class HeuristicConfigPolicy<Solution_> {
 
         public Builder<Solution_> withInitializedChainedValueFilterEnabled(boolean initializedChainedValueFilterEnabled) {
             this.initializedChainedValueFilterEnabled = initializedChainedValueFilterEnabled;
+            return this;
+        }
+
+        public Builder<Solution_> withUnassignedValuesAllowed(boolean unassignedValuesAllowed) {
+            this.unassignedValuesAllowed = unassignedValuesAllowed;
             return this;
         }
 

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/ChangeMoveSelectorFactory.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/ChangeMoveSelectorFactory.java
@@ -61,7 +61,23 @@ public class ChangeMoveSelectorFactory<Solution_>
             }
             ValueSelector<Solution_> destinationValueSelector = ValueSelectorFactory
                     .<Solution_> create(new ValueSelectorConfig())
-                    .buildValueSelector(configPolicy, entitySelector.getEntityDescriptor(), minimumCacheType, selectionOrder);
+                    .buildValueSelector(configPolicy, entitySelector.getEntityDescriptor(), minimumCacheType, selectionOrder,
+                            // Do not override reinitializeVariableFilterEnabled.
+                            configPolicy.isReinitializeVariableFilterEnabled(),
+                            /*
+                             * Filter assigned values (but only if this filtering type is allowed by the configPolicy).
+                             *
+                             * The destination selector requires the child value selector to only select assign values.
+                             * To guarantee this during CH where not all values are assigned, the UnassignedValueSelector filter
+                             * must be applied.
+                             *
+                             * In the LS phase, not only is the filter redundant because there are no unassigned values,
+                             * but it would also crash if the base value selector inherits random selection order,
+                             * because the filter cannot work on a never-ending child value selector.
+                             * Therefore, it must not be applied even though it is requested here. This is accomplished by
+                             * the configPolicy that only allows this filtering type in the CH phase.
+                             */
+                            ValueSelectorFactory.ListValueFilteringType.ACCEPT_ASSIGNED);
 
             ListVariableDescriptor<Solution_> listVariableDescriptor =
                     (ListVariableDescriptor<Solution_>) sourceValueSelector.getVariableDescriptor();

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/ElementDestinationSelector.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/ElementDestinationSelector.java
@@ -1,0 +1,143 @@
+package org.optaplanner.core.impl.heuristic.selector.move.generic.list;
+
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+import org.optaplanner.core.api.domain.solution.PlanningSolution;
+import org.optaplanner.core.impl.domain.variable.descriptor.ListVariableDescriptor;
+import org.optaplanner.core.impl.domain.variable.index.IndexVariableDemand;
+import org.optaplanner.core.impl.domain.variable.index.IndexVariableSupply;
+import org.optaplanner.core.impl.domain.variable.inverserelation.SingletonInverseVariableSupply;
+import org.optaplanner.core.impl.domain.variable.inverserelation.SingletonListInverseVariableDemand;
+import org.optaplanner.core.impl.domain.variable.supply.SupplyManager;
+import org.optaplanner.core.impl.heuristic.selector.AbstractSelector;
+import org.optaplanner.core.impl.heuristic.selector.IterableSelector;
+import org.optaplanner.core.impl.heuristic.selector.entity.EntitySelector;
+import org.optaplanner.core.impl.heuristic.selector.value.EntityIndependentValueSelector;
+import org.optaplanner.core.impl.solver.random.RandomUtils;
+import org.optaplanner.core.impl.solver.scope.SolverScope;
+
+/**
+ * Selects destinations for list variable change moves. The destination specifies a future position in a list variable,
+ * expressed as an {@link ElementRef}, where a moved element or subList can be inserted.
+ * <p>
+ * Destination completeness is achieved by using both entity and value child selectors.
+ * When an entity <em>A</em> is selected, the destination becomes <em>A[0]</em>.
+ * When a value <em>x</em> is selected, its current position <em>A[i]</em> is determined using inverse and index supplies and
+ * the destination becomes <em>A[i + 1]</em>.
+ * <p>
+ * Fairness in random selection is achieved by first deciding between entity and value selector with a probability that is
+ * proportional to the entity/value ratio. The child entity and value selectors are assumed to be fair.
+ *
+ * @param <Solution_> the solution type, the class with the {@link PlanningSolution} annotation
+ */
+public class ElementDestinationSelector<Solution_> extends AbstractSelector<Solution_>
+        implements IterableSelector<Solution_, ElementRef> {
+
+    private final ListVariableDescriptor<Solution_> listVariableDescriptor;
+    private final EntitySelector<Solution_> entitySelector;
+    private final EntityIndependentValueSelector<Solution_> valueSelector;
+    private final boolean randomSelection;
+
+    private SingletonInverseVariableSupply inverseVariableSupply;
+    private IndexVariableSupply indexVariableSupply;
+
+    public ElementDestinationSelector(
+            ListVariableDescriptor<Solution_> listVariableDescriptor,
+            EntitySelector<Solution_> entitySelector,
+            EntityIndependentValueSelector<Solution_> valueSelector,
+            boolean randomSelection) {
+        this.listVariableDescriptor = listVariableDescriptor;
+        this.entitySelector = entitySelector;
+        this.valueSelector = valueSelector;
+        this.randomSelection = randomSelection;
+
+        phaseLifecycleSupport.addEventListener(entitySelector);
+        phaseLifecycleSupport.addEventListener(valueSelector);
+    }
+
+    @Override
+    public void solvingStarted(SolverScope<Solution_> solverScope) {
+        super.solvingStarted(solverScope);
+        SupplyManager supplyManager = solverScope.getScoreDirector().getSupplyManager();
+        inverseVariableSupply = supplyManager.demand(new SingletonListInverseVariableDemand<>(listVariableDescriptor));
+        indexVariableSupply = supplyManager.demand(new IndexVariableDemand<>(listVariableDescriptor));
+    }
+
+    @Override
+    public void solvingEnded(SolverScope<Solution_> solverScope) {
+        super.solvingEnded(solverScope);
+        inverseVariableSupply = null;
+        indexVariableSupply = null;
+    }
+
+    @Override
+    public long getSize() {
+        if (entitySelector.getSize() == 0) {
+            return 0;
+        }
+        // FIXME do not count unassigned values (use AssignedValueSelector)
+        return entitySelector.getSize() + valueSelector.getSize();
+    }
+
+    @Override
+    public Iterator<ElementRef> iterator() {
+        if (randomSelection) {
+            long totalSize = Math.addExact(entitySelector.getSize(), valueSelector.getSize());
+            Iterator<Object> entityIterator = entitySelector.iterator();
+            Iterator<Object> valueIterator = valueSelector.iterator();
+
+            return new Iterator<>() {
+                @Override
+                public boolean hasNext() {
+                    // The valueSelector's hasNext() is insignificant. The next random destination exists if and only if
+                    // there is a next entity.
+                    return entityIterator.hasNext();
+                }
+
+                @Override
+                public ElementRef next() {
+                    long size = entitySelector.getSize();
+                    if (RandomUtils.nextLong(workingRandom, totalSize) < size) {
+                        return ElementRef.of(entityIterator.next(), 0);
+                    }
+                    Object value = valueIterator.next();
+                    return ElementRef.of(
+                            inverseVariableSupply.getInverseSingleton(value),
+                            indexVariableSupply.getIndex(value) + 1);
+                }
+            };
+        } else {
+            if (entitySelector.getSize() == 0) {
+                return Collections.emptyIterator();
+            }
+            return Stream.concat(
+                    StreamSupport.stream(entitySelector.spliterator(), false)
+                            .map(entity -> ElementRef.of(entity, 0)),
+                    StreamSupport.stream(valueSelector.spliterator(), false)
+                            // TODO do not filter here, leave it up to the AssignedValueSelector
+                            .filter(value -> inverseVariableSupply.getInverseSingleton(value) != null)
+                            .map(value -> ElementRef.of(
+                                    inverseVariableSupply.getInverseSingleton(value),
+                                    indexVariableSupply.getIndex(value) + 1)))
+                    .iterator();
+        }
+    }
+
+    @Override
+    public boolean isCountable() {
+        return entitySelector.isCountable() && valueSelector.isCountable();
+    }
+
+    @Override
+    public boolean isNeverEnding() {
+        return randomSelection || entitySelector.isNeverEnding() || valueSelector.isNeverEnding();
+    }
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName() + "(" + entitySelector + ", " + valueSelector + ")";
+    }
+}

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/ElementDestinationSelector.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/ElementDestinationSelector.java
@@ -78,7 +78,6 @@ public class ElementDestinationSelector<Solution_> extends AbstractSelector<Solu
         if (entitySelector.getSize() == 0) {
             return 0;
         }
-        // FIXME do not count unassigned values (use AssignedValueSelector)
         return entitySelector.getSize() + valueSelector.getSize();
     }
 
@@ -117,8 +116,6 @@ public class ElementDestinationSelector<Solution_> extends AbstractSelector<Solu
                     StreamSupport.stream(entitySelector.spliterator(), false)
                             .map(entity -> ElementRef.of(entity, 0)),
                     StreamSupport.stream(valueSelector.spliterator(), false)
-                            // TODO do not filter here, leave it up to the AssignedValueSelector
-                            .filter(value -> inverseVariableSupply.getInverseSingleton(value) != null)
                             .map(value -> ElementRef.of(
                                     inverseVariableSupply.getInverseSingleton(value),
                                     indexVariableSupply.getIndex(value) + 1)))

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/ElementRef.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/ElementRef.java
@@ -1,0 +1,36 @@
+package org.optaplanner.core.impl.heuristic.selector.move.generic.list;
+
+/**
+ * Points to a list variable position specified by an entity and an index.
+ */
+public final class ElementRef {
+
+    private final Object entity;
+    private final int index;
+
+    private ElementRef(Object entity, int index) {
+        this.entity = entity;
+        this.index = index;
+    }
+
+    public static ElementRef of(Object entity, int index) {
+        return new ElementRef(entity, index);
+    }
+
+    public static ElementRef elementRef(Object entity, int index) {
+        return new ElementRef(entity, index);
+    }
+
+    public Object getEntity() {
+        return entity;
+    }
+
+    public int getIndex() {
+        return index;
+    }
+
+    @Override
+    public String toString() {
+        return entity + "[" + index + "]";
+    }
+}

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/RandomListChangeIterator.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/RandomListChangeIterator.java
@@ -1,10 +1,6 @@
 package org.optaplanner.core.impl.heuristic.selector.move.generic.list;
 
 import java.util.Iterator;
-import java.util.Map;
-import java.util.NavigableMap;
-import java.util.Random;
-import java.util.TreeMap;
 
 import org.optaplanner.core.api.domain.solution.PlanningSolution;
 import org.optaplanner.core.impl.domain.variable.descriptor.ListVariableDescriptor;
@@ -12,9 +8,7 @@ import org.optaplanner.core.impl.domain.variable.index.IndexVariableSupply;
 import org.optaplanner.core.impl.domain.variable.inverserelation.SingletonInverseVariableSupply;
 import org.optaplanner.core.impl.heuristic.move.Move;
 import org.optaplanner.core.impl.heuristic.selector.common.iterator.UpcomingSelectionIterator;
-import org.optaplanner.core.impl.heuristic.selector.entity.EntitySelector;
 import org.optaplanner.core.impl.heuristic.selector.value.EntityIndependentValueSelector;
-import org.optaplanner.core.impl.util.Pair;
 
 /**
  * @param <Solution_> the solution type, the class with the {@link PlanningSolution} annotation
@@ -25,53 +19,35 @@ public class RandomListChangeIterator<Solution_> extends UpcomingSelectionIterat
     private final SingletonInverseVariableSupply inverseVariableSupply;
     private final IndexVariableSupply indexVariableSupply;
     private final Iterator<Object> valueIterator;
-    private final Random workingRandom;
-    private final NavigableMap<Integer, Object> indexToDestinationEntityMap;
-    private final int destinationIndexRange;
+    private final Iterator<ElementRef> destinationIterator;
 
     public RandomListChangeIterator(
             ListVariableDescriptor<Solution_> listVariableDescriptor,
             SingletonInverseVariableSupply inverseVariableSupply,
             IndexVariableSupply indexVariableSupply,
             EntityIndependentValueSelector<Solution_> valueSelector,
-            EntitySelector<Solution_> entitySelector,
-            Random workingRandom) {
+            ElementDestinationSelector<Solution_> destinationSelector) {
         this.listVariableDescriptor = listVariableDescriptor;
         this.inverseVariableSupply = inverseVariableSupply;
         this.indexVariableSupply = indexVariableSupply;
         this.valueIterator = valueSelector.iterator();
-        this.workingRandom = workingRandom;
-
-        // TODO optimize this (don't rebuild the whole map at the beginning of each step).
-        //  https://issues.redhat.com/browse/PLANNER-2507
-        indexToDestinationEntityMap = new TreeMap<>();
-        int cumulativeDestinationListSize = 0;
-        for (Object entity : ((Iterable<Object>) entitySelector::endingIterator)) {
-            indexToDestinationEntityMap.put(cumulativeDestinationListSize, entity);
-            cumulativeDestinationListSize += (listVariableDescriptor.getListSize(entity) + 1);
-        }
-        this.destinationIndexRange = cumulativeDestinationListSize;
+        this.destinationIterator = destinationSelector.iterator();
     }
 
     @Override
     protected Move<Solution_> createUpcomingSelection() {
-        if (!valueIterator.hasNext() || destinationIndexRange == 0) {
+        if (!valueIterator.hasNext() || !destinationIterator.hasNext()) {
             return noUpcomingSelection();
         }
 
         Object upcomingValue = valueIterator.next();
-        Pair<Object, Integer> destination = entityAndIndexFromGlobalIndex(workingRandom.nextInt(destinationIndexRange));
+        ElementRef destination = destinationIterator.next();
 
         return new ListChangeMove<>(
                 listVariableDescriptor,
                 inverseVariableSupply.getInverseSingleton(upcomingValue),
                 indexVariableSupply.getIndex(upcomingValue),
-                destination.getKey(),
-                destination.getValue());
-    }
-
-    Pair<Object, Integer> entityAndIndexFromGlobalIndex(int index) {
-        Map.Entry<Integer, Object> entry = indexToDestinationEntityMap.floorEntry(index);
-        return Pair.of(entry.getValue(), index - entry.getKey());
+                destination.getEntity(),
+                destination.getIndex());
     }
 }

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/RandomSubListChangeMoveIterator.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/RandomSubListChangeMoveIterator.java
@@ -1,63 +1,48 @@
 package org.optaplanner.core.impl.heuristic.selector.move.generic.list;
 
 import java.util.Iterator;
-import java.util.Map;
-import java.util.NavigableMap;
 import java.util.Random;
-import java.util.TreeMap;
 
 import org.optaplanner.core.impl.domain.variable.descriptor.ListVariableDescriptor;
 import org.optaplanner.core.impl.heuristic.move.Move;
 import org.optaplanner.core.impl.heuristic.selector.common.iterator.UpcomingSelectionIterator;
-import org.optaplanner.core.impl.heuristic.selector.entity.EntitySelector;
-import org.optaplanner.core.impl.util.Pair;
 
 class RandomSubListChangeMoveIterator<Solution_> extends UpcomingSelectionIterator<Move<Solution_>> {
 
     private final ListVariableDescriptor<Solution_> listVariableDescriptor;
     private final Iterator<SubList> subListIterator;
+    private final Iterator<ElementRef> destinationIterator;
     private final Random workingRandom;
     private final boolean selectReversingMoveToo;
-    private final NavigableMap<Integer, Object> indexToDestinationEntityMap;
-    private final int destinationIndexRange;
 
     RandomSubListChangeMoveIterator(
             ListVariableDescriptor<Solution_> listVariableDescriptor,
             RandomSubListSelector<Solution_> subListSelector,
-            EntitySelector<Solution_> entitySelector,
+            ElementDestinationSelector<Solution_> destinationSelector,
             Random workingRandom,
             boolean selectReversingMoveToo) {
         this.listVariableDescriptor = listVariableDescriptor;
-        subListIterator = subListSelector.iterator();
+        this.subListIterator = subListSelector.iterator();
+        this.destinationIterator = destinationSelector.iterator();
         this.workingRandom = workingRandom;
         this.selectReversingMoveToo = selectReversingMoveToo;
-
-        // TODO optimize this (don't rebuild the whole map at the beginning of each step).
-        //  https://issues.redhat.com/browse/PLANNER-2507
-        indexToDestinationEntityMap = new TreeMap<>();
-        int cumulativeDestinationListSize = 0;
-        for (Object entity : ((Iterable<Object>) entitySelector::endingIterator)) {
-            indexToDestinationEntityMap.put(cumulativeDestinationListSize, entity);
-            cumulativeDestinationListSize += (listVariableDescriptor.getListSize(entity) + 1);
-        }
-        this.destinationIndexRange = cumulativeDestinationListSize;
     }
 
     @Override
     protected Move<Solution_> createUpcomingSelection() {
-        if (!subListIterator.hasNext() || destinationIndexRange == 0) {
+        if (!subListIterator.hasNext() || !destinationIterator.hasNext()) {
             return noUpcomingSelection();
         }
-        SubList subList = subListIterator.next();
-        // TODO maybe destinationSelector
-        Pair<Object, Integer> destination = entityAndIndexFromGlobalIndex(workingRandom.nextInt(destinationIndexRange));
-        boolean reversing = selectReversingMoveToo && workingRandom.nextBoolean();
-        return new SubListChangeMove<>(listVariableDescriptor, subList, destination.getKey(), destination.getValue(),
-                reversing);
-    }
 
-    Pair<Object, Integer> entityAndIndexFromGlobalIndex(int index) {
-        Map.Entry<Integer, Object> entry = indexToDestinationEntityMap.floorEntry(index);
-        return Pair.of(entry.getValue(), index - entry.getKey());
+        SubList subList = subListIterator.next();
+        ElementRef destination = destinationIterator.next();
+        boolean reversing = selectReversingMoveToo && workingRandom.nextBoolean();
+
+        return new SubListChangeMove<>(
+                listVariableDescriptor,
+                subList,
+                destination.getEntity(),
+                destination.getIndex(),
+                reversing);
     }
 }

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/RandomSubListSelector.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/RandomSubListSelector.java
@@ -73,17 +73,19 @@ public class RandomSubListSelector<Solution_> extends AbstractSelector<Solution_
 
     @Override
     public long getSize() {
-        long size = 0;
+        long subListCount = 0;
         for (Object entity : ((Iterable<Object>) entitySelector::endingIterator)) {
             int listSize = listVariableDescriptor.getListSize(entity);
+            // Add subLists bigger than minimum subList size.
             if (listSize >= minimumSubListSize) {
-                size += TriangularNumbers.nthTriangle(listSize - minimumSubListSize + 1);
+                subListCount += TriangularNumbers.nthTriangle(listSize - minimumSubListSize + 1);
+                // Subtract moves with subLists bigger than maximum subList size.
                 if (listSize > maximumSubListSize) {
-                    size -= TriangularNumbers.nthTriangle(listSize - maximumSubListSize);
+                    subListCount -= TriangularNumbers.nthTriangle(listSize - maximumSubListSize);
                 }
             }
         }
-        return size;
+        return subListCount;
     }
 
     @Override
@@ -134,6 +136,14 @@ public class RandomSubListSelector<Solution_> extends AbstractSelector<Solution_
 
             return new SubList(sourceEntity, sourceIndex, subListLength);
         }
+    }
+
+    public int getMinimumSubListSize() {
+        return minimumSubListSize;
+    }
+
+    public int getMaximumSubListSize() {
+        return maximumSubListSize;
     }
 
     @Override

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/RandomSubListSwapMoveSelector.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/RandomSubListSwapMoveSelector.java
@@ -1,44 +1,29 @@
 package org.optaplanner.core.impl.heuristic.selector.move.generic.list;
 
-import static org.optaplanner.core.impl.heuristic.selector.move.generic.list.TriangularNumbers.nthTriangle;
-
 import java.util.Iterator;
 
 import org.optaplanner.core.impl.domain.variable.descriptor.ListVariableDescriptor;
 import org.optaplanner.core.impl.heuristic.move.Move;
 import org.optaplanner.core.impl.heuristic.selector.common.iterator.AbstractRandomSwapIterator;
-import org.optaplanner.core.impl.heuristic.selector.entity.EntitySelector;
 import org.optaplanner.core.impl.heuristic.selector.move.generic.GenericMoveSelector;
-import org.optaplanner.core.impl.heuristic.selector.value.EntityIndependentValueSelector;
 
 public class RandomSubListSwapMoveSelector<Solution_> extends GenericMoveSelector<Solution_> {
 
     private final ListVariableDescriptor<Solution_> listVariableDescriptor;
-    private final EntitySelector<Solution_> entitySelector;
-    private final int minimumSubListSize;
-    private final int maximumSubListSize;
     private final RandomSubListSelector<Solution_> leftSubListSelector;
     private final RandomSubListSelector<Solution_> rightSubListSelector;
     private final boolean selectReversingMoveToo;
 
     public RandomSubListSwapMoveSelector(
             ListVariableDescriptor<Solution_> listVariableDescriptor,
-            EntitySelector<Solution_> entitySelector,
-            EntityIndependentValueSelector<Solution_> leftValueSelector,
-            EntityIndependentValueSelector<Solution_> rightValueSelector,
-            int minimumSubListSize, int maximumSubListSize,
+            RandomSubListSelector<Solution_> leftSubListSelector,
+            RandomSubListSelector<Solution_> rightSubListSelector,
             boolean selectReversingMoveToo) {
         this.listVariableDescriptor = listVariableDescriptor;
-        this.entitySelector = entitySelector;
-        this.minimumSubListSize = minimumSubListSize;
-        this.maximumSubListSize = maximumSubListSize;
+        this.leftSubListSelector = leftSubListSelector;
+        this.rightSubListSelector = rightSubListSelector;
         this.selectReversingMoveToo = selectReversingMoveToo;
-        leftSubListSelector = new RandomSubListSelector<>(listVariableDescriptor, entitySelector, leftValueSelector,
-                minimumSubListSize, maximumSubListSize);
-        rightSubListSelector = new RandomSubListSelector<>(listVariableDescriptor, entitySelector, rightValueSelector,
-                minimumSubListSize, maximumSubListSize);
-        phaseLifecycleSupport.addEventListener(entitySelector);
-        phaseLifecycleSupport.addEventListener(leftValueSelector);
+
         phaseLifecycleSupport.addEventListener(leftSubListSelector);
         phaseLifecycleSupport.addEventListener(rightSubListSelector);
     }
@@ -66,20 +51,9 @@ public class RandomSubListSwapMoveSelector<Solution_> extends GenericMoveSelecto
 
     @Override
     public long getSize() {
-        long subListCount = 0;
-        for (Object entity : (Iterable<?>) entitySelector::endingIterator) {
-            int listSize = listVariableDescriptor.getListSize(entity);
-            if (listSize < minimumSubListSize) {
-                continue;
-            }
-            // Add moves with subLists bigger than minimum subList size.
-            subListCount += nthTriangle(listSize - minimumSubListSize + 1);
-            if (listSize > maximumSubListSize) {
-                // Subtract moves with subLists bigger than maximum subList size.
-                subListCount -= nthTriangle(listSize - maximumSubListSize);
-            }
-        }
-        return subListCount * subListCount;
+        long leftSubListCount = leftSubListSelector.getSize();
+        long rightSubListCount = rightSubListSelector.getSize();
+        return leftSubListCount * rightSubListCount * (selectReversingMoveToo ? 2 : 1);
     }
 
     boolean isSelectReversingMoveToo() {

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/SubListChangeMoveSelectorFactory.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/SubListChangeMoveSelectorFactory.java
@@ -25,9 +25,6 @@ import org.optaplanner.core.impl.heuristic.selector.value.ValueSelectorFactory;
 public class SubListChangeMoveSelectorFactory<Solution_>
         extends AbstractMoveSelectorFactory<Solution_, SubListChangeMoveSelectorConfig> {
 
-    private static final int DEFAULT_MINIMUM_SUB_LIST_SIZE = 1;
-    private static final int DEFAULT_MAXIMUM_SUB_LIST_SIZE = Integer.MAX_VALUE;
-
     public SubListChangeMoveSelectorFactory(SubListChangeMoveSelectorConfig moveSelectorConfig) {
         super(moveSelectorConfig);
     }
@@ -49,13 +46,21 @@ public class SubListChangeMoveSelectorFactory<Solution_>
                     + " and make sure it has a @" + PlanningListVariable.class.getSimpleName() + ".");
         }
 
+        ListVariableDescriptor<Solution_> listVariableDescriptor = (ListVariableDescriptor<Solution_>) variableDescriptor;
+
+        RandomSubListSelector<Solution_> subListSelector = SubListSelectorFactory.<Solution_> create(config)
+                .buildSubListSelector(configPolicy, listVariableDescriptor, entitySelector, minimumCacheType, selectionOrder);
+
         EntityIndependentValueSelector<Solution_> valueSelector = buildEntityIndependentValueSelector(configPolicy,
                 entitySelector.getEntityDescriptor(), minimumCacheType, selectionOrder);
-        int minimumSubListSize = Objects.requireNonNullElse(config.getMinimumSubListSize(), DEFAULT_MINIMUM_SUB_LIST_SIZE);
-        int maximumSubListSize = Objects.requireNonNullElse(config.getMaximumSubListSize(), DEFAULT_MAXIMUM_SUB_LIST_SIZE);
+
+        ElementDestinationSelector<Solution_> destinationSelector =
+                new ElementDestinationSelector<>(listVariableDescriptor, entitySelector, valueSelector, true);
+
         boolean selectReversingMoveToo = Objects.requireNonNullElse(config.getSelectReversingMoveToo(), true);
-        return new RandomSubListChangeMoveSelector<>(((ListVariableDescriptor<Solution_>) variableDescriptor), entitySelector,
-                valueSelector, minimumSubListSize, maximumSubListSize, selectReversingMoveToo);
+
+        return new RandomSubListChangeMoveSelector<>(listVariableDescriptor, subListSelector, destinationSelector,
+                selectReversingMoveToo);
     }
 
     private EntityIndependentValueSelector<Solution_> buildEntityIndependentValueSelector(

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/SubListSelectorFactory.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/SubListSelectorFactory.java
@@ -1,0 +1,61 @@
+package org.optaplanner.core.impl.heuristic.selector.move.generic.list;
+
+import java.util.Objects;
+
+import org.optaplanner.core.api.domain.valuerange.ValueRangeProvider;
+import org.optaplanner.core.config.heuristic.selector.common.SelectionCacheType;
+import org.optaplanner.core.config.heuristic.selector.common.SelectionOrder;
+import org.optaplanner.core.config.heuristic.selector.move.generic.list.SubListSelectorConfig;
+import org.optaplanner.core.config.heuristic.selector.value.ValueSelectorConfig;
+import org.optaplanner.core.impl.domain.entity.descriptor.EntityDescriptor;
+import org.optaplanner.core.impl.domain.variable.descriptor.ListVariableDescriptor;
+import org.optaplanner.core.impl.heuristic.HeuristicConfigPolicy;
+import org.optaplanner.core.impl.heuristic.selector.entity.EntitySelector;
+import org.optaplanner.core.impl.heuristic.selector.value.EntityIndependentValueSelector;
+import org.optaplanner.core.impl.heuristic.selector.value.ValueSelector;
+import org.optaplanner.core.impl.heuristic.selector.value.ValueSelectorFactory;
+
+public class SubListSelectorFactory<Solution_> {
+
+    private static final int DEFAULT_MINIMUM_SUB_LIST_SIZE = 1;
+    private static final int DEFAULT_MAXIMUM_SUB_LIST_SIZE = Integer.MAX_VALUE;
+
+    public SubListSelectorFactory(SubListSelectorConfig config) {
+        this.config = config;
+    }
+
+    public static <Solution_> SubListSelectorFactory<Solution_> create(SubListSelectorConfig subListSelectorConfig) {
+        return new SubListSelectorFactory<>(subListSelectorConfig);
+    }
+
+    private final SubListSelectorConfig config;
+
+    public RandomSubListSelector<Solution_> buildSubListSelector(
+            HeuristicConfigPolicy<Solution_> configPolicy,
+            ListVariableDescriptor<Solution_> listVariableDescriptor,
+            EntitySelector<Solution_> entitySelector,
+            SelectionCacheType minimumCacheType,
+            SelectionOrder inheritedSelectionOrder) {
+        EntityIndependentValueSelector<Solution_> valueSelector = buildEntityIndependentValueSelector(configPolicy,
+                entitySelector.getEntityDescriptor(), minimumCacheType, inheritedSelectionOrder);
+        int minimumSubListSize = Objects.requireNonNullElse(config.getMinimumSubListSize(), DEFAULT_MINIMUM_SUB_LIST_SIZE);
+        int maximumSubListSize = Objects.requireNonNullElse(config.getMaximumSubListSize(), DEFAULT_MAXIMUM_SUB_LIST_SIZE);
+        return new RandomSubListSelector<>(listVariableDescriptor, entitySelector, valueSelector,
+                minimumSubListSize, maximumSubListSize);
+    }
+
+    private EntityIndependentValueSelector<Solution_> buildEntityIndependentValueSelector(
+            HeuristicConfigPolicy<Solution_> configPolicy, EntityDescriptor<Solution_> entityDescriptor,
+            SelectionCacheType minimumCacheType, SelectionOrder inheritedSelectionOrder) {
+        ValueSelector<Solution_> valueSelector = ValueSelectorFactory.<Solution_> create(new ValueSelectorConfig())
+                .buildValueSelector(configPolicy, entityDescriptor, minimumCacheType, inheritedSelectionOrder);
+        if (!(valueSelector instanceof EntityIndependentValueSelector)) {
+            throw new IllegalArgumentException("The subListChangeMoveSelector or subListSwapMoveSelector (" + config
+                    + ") for a list variable needs to be based on an "
+                    + EntityIndependentValueSelector.class.getSimpleName() + " (" + valueSelector + ")."
+                    + " Check your @" + ValueRangeProvider.class.getSimpleName() + " annotations.");
+
+        }
+        return (EntityIndependentValueSelector<Solution_>) valueSelector;
+    }
+}

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/SubListSwapMoveSelectorFactory.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/SubListSwapMoveSelectorFactory.java
@@ -3,14 +3,11 @@ package org.optaplanner.core.impl.heuristic.selector.move.generic.list;
 import java.util.Objects;
 
 import org.optaplanner.core.api.domain.entity.PlanningEntity;
-import org.optaplanner.core.api.domain.valuerange.ValueRangeProvider;
 import org.optaplanner.core.api.domain.variable.PlanningListVariable;
 import org.optaplanner.core.config.heuristic.selector.common.SelectionCacheType;
 import org.optaplanner.core.config.heuristic.selector.common.SelectionOrder;
 import org.optaplanner.core.config.heuristic.selector.entity.EntitySelectorConfig;
 import org.optaplanner.core.config.heuristic.selector.move.generic.list.SubListSwapMoveSelectorConfig;
-import org.optaplanner.core.config.heuristic.selector.value.ValueSelectorConfig;
-import org.optaplanner.core.impl.domain.entity.descriptor.EntityDescriptor;
 import org.optaplanner.core.impl.domain.variable.descriptor.GenuineVariableDescriptor;
 import org.optaplanner.core.impl.domain.variable.descriptor.ListVariableDescriptor;
 import org.optaplanner.core.impl.heuristic.HeuristicConfigPolicy;
@@ -18,15 +15,9 @@ import org.optaplanner.core.impl.heuristic.selector.entity.EntitySelector;
 import org.optaplanner.core.impl.heuristic.selector.entity.EntitySelectorFactory;
 import org.optaplanner.core.impl.heuristic.selector.move.AbstractMoveSelectorFactory;
 import org.optaplanner.core.impl.heuristic.selector.move.MoveSelector;
-import org.optaplanner.core.impl.heuristic.selector.value.EntityIndependentValueSelector;
-import org.optaplanner.core.impl.heuristic.selector.value.ValueSelector;
-import org.optaplanner.core.impl.heuristic.selector.value.ValueSelectorFactory;
 
 public class SubListSwapMoveSelectorFactory<Solution_>
         extends AbstractMoveSelectorFactory<Solution_, SubListSwapMoveSelectorConfig> {
-
-    private static final int DEFAULT_MINIMUM_SUB_LIST_SIZE = 1;
-    private static final int DEFAULT_MAXIMUM_SUB_LIST_SIZE = Integer.MAX_VALUE;
 
     public SubListSwapMoveSelectorFactory(SubListSwapMoveSelectorConfig moveSelectorConfig) {
         super(moveSelectorConfig);
@@ -49,30 +40,17 @@ public class SubListSwapMoveSelectorFactory<Solution_>
                     + " and make sure it has a @" + PlanningListVariable.class.getSimpleName() + ".");
         }
 
-        EntityIndependentValueSelector<Solution_> leftValueSelector = buildEntityIndependentValueSelector(configPolicy,
-                entitySelector.getEntityDescriptor(), minimumCacheType, selectionOrder);
-        EntityIndependentValueSelector<Solution_> rightValueSelector = buildEntityIndependentValueSelector(configPolicy,
-                entitySelector.getEntityDescriptor(), minimumCacheType, selectionOrder);
-        int minimumSubListSize = Objects.requireNonNullElse(config.getMinimumSubListSize(), DEFAULT_MINIMUM_SUB_LIST_SIZE);
-        int maximumSubListSize = Objects.requireNonNullElse(config.getMaximumSubListSize(), DEFAULT_MAXIMUM_SUB_LIST_SIZE);
+        ListVariableDescriptor<Solution_> listVariableDescriptor = (ListVariableDescriptor<Solution_>) variableDescriptor;
+
+        SubListSelectorFactory<Solution_> subListSelectorFactory = SubListSelectorFactory.create(config);
+        RandomSubListSelector<Solution_> leftSubListSelector = subListSelectorFactory
+                .buildSubListSelector(configPolicy, listVariableDescriptor, entitySelector, minimumCacheType, selectionOrder);
+        RandomSubListSelector<Solution_> rightSubListSelector = subListSelectorFactory
+                .buildSubListSelector(configPolicy, listVariableDescriptor, entitySelector, minimumCacheType, selectionOrder);
+
         boolean selectReversingMoveToo = Objects.requireNonNullElse(config.getSelectReversingMoveToo(), true);
-        return new RandomSubListSwapMoveSelector<>(((ListVariableDescriptor<Solution_>) variableDescriptor), entitySelector,
-                leftValueSelector, rightValueSelector, minimumSubListSize, maximumSubListSize, selectReversingMoveToo);
-    }
 
-    private EntityIndependentValueSelector<Solution_> buildEntityIndependentValueSelector(
-            HeuristicConfigPolicy<Solution_> configPolicy, EntityDescriptor<Solution_> entityDescriptor,
-            SelectionCacheType minimumCacheType, SelectionOrder inheritedSelectionOrder) {
-        ValueSelector<Solution_> valueSelector =
-                ValueSelectorFactory.<Solution_> create(new ValueSelectorConfig())
-                        .buildValueSelector(configPolicy, entityDescriptor, minimumCacheType, inheritedSelectionOrder);
-        if (!(valueSelector instanceof EntityIndependentValueSelector)) {
-            throw new IllegalArgumentException("The subListSwapMoveSelector (" + config
-                    + ") for a list variable needs to be based on an "
-                    + EntityIndependentValueSelector.class.getSimpleName() + " (" + valueSelector + ")."
-                    + " Check your @" + ValueRangeProvider.class.getSimpleName() + " annotations.");
-
-        }
-        return (EntityIndependentValueSelector<Solution_>) valueSelector;
+        return new RandomSubListSwapMoveSelector<>(listVariableDescriptor, leftSubListSelector, rightSubListSelector,
+                selectReversingMoveToo);
     }
 }

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/value/decorator/AbstractInverseEntityFilteringValueSelector.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/value/decorator/AbstractInverseEntityFilteringValueSelector.java
@@ -1,0 +1,128 @@
+package org.optaplanner.core.impl.heuristic.selector.value.decorator;
+
+import java.util.Iterator;
+import java.util.Objects;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+import org.optaplanner.core.impl.domain.variable.descriptor.GenuineVariableDescriptor;
+import org.optaplanner.core.impl.domain.variable.descriptor.ListVariableDescriptor;
+import org.optaplanner.core.impl.domain.variable.inverserelation.SingletonInverseVariableSupply;
+import org.optaplanner.core.impl.domain.variable.inverserelation.SingletonListInverseVariableDemand;
+import org.optaplanner.core.impl.heuristic.selector.value.AbstractValueSelector;
+import org.optaplanner.core.impl.heuristic.selector.value.EntityIndependentValueSelector;
+import org.optaplanner.core.impl.phase.scope.AbstractPhaseScope;
+
+/**
+ * Filters planning values based on their assigned status. The assigned status is determined using the inverse supply.
+ * If the inverse entity is not null, the value is assigned, otherwise it is unassigned.
+ * A subclass must implement the {@link #valueFilter(Object)} to decide whether assigned or unassigned values will be selected.
+ * <p>
+ * Does implement {@link EntityIndependentValueSelector} because the question whether a value is assigned or not does not depend
+ * on a specific entity.
+ */
+abstract class AbstractInverseEntityFilteringValueSelector<Solution_>
+        extends AbstractValueSelector<Solution_>
+        implements EntityIndependentValueSelector<Solution_> {
+
+    protected final EntityIndependentValueSelector<Solution_> childValueSelector;
+
+    protected SingletonInverseVariableSupply inverseVariableSupply;
+
+    protected AbstractInverseEntityFilteringValueSelector(EntityIndependentValueSelector<Solution_> childValueSelector) {
+        if (childValueSelector.isNeverEnding()) {
+            throw new IllegalArgumentException("The selector (" + this
+                    + ") has a childValueSelector (" + childValueSelector
+                    + ") with neverEnding (" + childValueSelector.isNeverEnding() + ").\n"
+                    + "This is not allowed because " + AbstractInverseEntityFilteringValueSelector.class.getSimpleName()
+                    + " cannot decorate a never-ending child value selector.\n"
+                    + "This could be a result of using random selection order (which is often the default).");
+        }
+        this.childValueSelector = childValueSelector;
+        phaseLifecycleSupport.addEventListener(childValueSelector);
+    }
+
+    protected abstract boolean valueFilter(Object value);
+
+    // ************************************************************************
+    // Worker methods
+    // ************************************************************************
+
+    @Override
+    public void phaseStarted(AbstractPhaseScope<Solution_> phaseScope) {
+        super.phaseStarted(phaseScope);
+        ListVariableDescriptor<Solution_> variableDescriptor =
+                (ListVariableDescriptor<Solution_>) childValueSelector.getVariableDescriptor();
+        inverseVariableSupply = phaseScope.getScoreDirector().getSupplyManager()
+                .demand(new SingletonListInverseVariableDemand<>(variableDescriptor));
+    }
+
+    @Override
+    public void phaseEnded(AbstractPhaseScope<Solution_> phaseScope) {
+        super.phaseEnded(phaseScope);
+        inverseVariableSupply = null;
+    }
+
+    @Override
+    public GenuineVariableDescriptor<Solution_> getVariableDescriptor() {
+        return childValueSelector.getVariableDescriptor();
+    }
+
+    @Override
+    public boolean isCountable() {
+        // Because !neverEnding => countable.
+        return true;
+    }
+
+    @Override
+    public boolean isNeverEnding() {
+        // Because the childValueSelector is not never-ending.
+        return false;
+    }
+
+    @Override
+    public long getSize(Object entity) {
+        return getSize();
+    }
+
+    @Override
+    public long getSize() {
+        return streamUnassignedValues().count();
+    }
+
+    @Override
+    public Iterator<Object> iterator(Object entity) {
+        return iterator();
+    }
+
+    @Override
+    public Iterator<Object> iterator() {
+        return streamUnassignedValues().iterator();
+    }
+
+    @Override
+    public Iterator<Object> endingIterator(Object entity) {
+        return iterator();
+    }
+
+    private Stream<Object> streamUnassignedValues() {
+        return StreamSupport.stream(childValueSelector.spliterator(), false)
+                // Accept either assigned or unassigned values.
+                .filter(this::valueFilter);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (this == other)
+            return true;
+        if (other == null || getClass() != other.getClass())
+            return false;
+        AbstractInverseEntityFilteringValueSelector<?> that = (AbstractInverseEntityFilteringValueSelector<?>) other;
+        return Objects.equals(childValueSelector, that.childValueSelector);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(childValueSelector);
+    }
+}

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/value/decorator/AssignedValueSelector.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/value/decorator/AssignedValueSelector.java
@@ -1,0 +1,27 @@
+package org.optaplanner.core.impl.heuristic.selector.value.decorator;
+
+import org.optaplanner.core.impl.heuristic.selector.move.generic.list.ElementDestinationSelector;
+import org.optaplanner.core.impl.heuristic.selector.move.generic.list.ElementRef;
+import org.optaplanner.core.impl.heuristic.selector.value.EntityIndependentValueSelector;
+
+/**
+ * Only selects values from the child value selector that are assigned.
+ * This is used for {@link ElementDestinationSelector}’s child value selector during Construction Heuristic phase
+ * to filter out unassigned values, which cannot be used to build a destination {@link ElementRef}.
+ */
+public final class AssignedValueSelector<Solution_> extends AbstractInverseEntityFilteringValueSelector<Solution_> {
+
+    public AssignedValueSelector(EntityIndependentValueSelector<Solution_> childValueSelector) {
+        super(childValueSelector);
+    }
+
+    @Override
+    protected boolean valueFilter(Object value) {
+        return inverseVariableSupply.getInverseSingleton(value) != null;
+    }
+
+    @Override
+    public String toString() {
+        return "Assigned(" + childValueSelector + ")";
+    }
+}

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/value/decorator/UnassignedValueSelector.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/value/decorator/UnassignedValueSelector.java
@@ -2,7 +2,6 @@ package org.optaplanner.core.impl.heuristic.selector.value.decorator;
 
 import java.util.Iterator;
 import java.util.Objects;
-import java.util.Spliterators;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
@@ -106,8 +105,7 @@ public final class UnassignedValueSelector<Solution_>
     }
 
     private Stream<Object> streamUnassignedValues() {
-        return StreamSupport
-                .stream(Spliterators.spliterator(childValueSelector.iterator(), childValueSelector.getSize(), 0), false)
+        return StreamSupport.stream(childValueSelector.spliterator(), false)
                 // Skip assigned values.
                 .filter(value -> inverseVariableSupply.getInverseSingleton(value) == null);
     }

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/value/decorator/UnassignedValueSelector.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/value/decorator/UnassignedValueSelector.java
@@ -1,128 +1,22 @@
 package org.optaplanner.core.impl.heuristic.selector.value.decorator;
 
-import java.util.Iterator;
-import java.util.Objects;
-import java.util.stream.Stream;
-import java.util.stream.StreamSupport;
-
-import org.optaplanner.core.impl.domain.variable.descriptor.GenuineVariableDescriptor;
-import org.optaplanner.core.impl.domain.variable.descriptor.ListVariableDescriptor;
-import org.optaplanner.core.impl.domain.variable.inverserelation.SingletonInverseVariableSupply;
-import org.optaplanner.core.impl.domain.variable.inverserelation.SingletonListInverseVariableDemand;
-import org.optaplanner.core.impl.heuristic.selector.value.AbstractValueSelector;
+import org.optaplanner.core.impl.constructionheuristic.placer.QueuedValuePlacer;
 import org.optaplanner.core.impl.heuristic.selector.value.EntityIndependentValueSelector;
-import org.optaplanner.core.impl.phase.scope.AbstractPhaseScope;
 
 /**
- * Discards planning values that are already assigned to a list variable.
- * <p>
- * Only returns values from the child value selector that are unassigned.
- * This prevents reassigning of values that are already assigned to a list variable during Construction Heuristics.
- * <p>
- * Does implement {@link EntityIndependentValueSelector} because the question whether a value is assigned or not does not depend
- * on a specific entity.
+ * Only selects values from the child value selector that are unassigned.
+ * This used for {@link QueuedValuePlacer}’s recording value selector during Construction Heuristic phase
+ * to prevent reassigning of values that are already assigned to a list variable.
  */
-public final class UnassignedValueSelector<Solution_>
-        extends AbstractValueSelector<Solution_>
-        implements EntityIndependentValueSelector<Solution_> {
-
-    private final EntityIndependentValueSelector<Solution_> childValueSelector;
-
-    private SingletonInverseVariableSupply inverseVariableSupply;
+public final class UnassignedValueSelector<Solution_> extends AbstractInverseEntityFilteringValueSelector<Solution_> {
 
     public UnassignedValueSelector(EntityIndependentValueSelector<Solution_> childValueSelector) {
-        if (childValueSelector.isNeverEnding()) {
-            throw new IllegalArgumentException("The selector (" + this
-                    + ") has a childValueSelector (" + childValueSelector
-                    + ") with neverEnding (" + childValueSelector.isNeverEnding() + ").\n"
-                    + "This is not allowed because " + UnassignedValueSelector.class.getSimpleName()
-                    + " cannot decorate a never-ending child value selector.\n"
-                    + "This could be a result of using random selection order (which is often the default).");
-        }
-        this.childValueSelector = childValueSelector;
-        phaseLifecycleSupport.addEventListener(childValueSelector);
-    }
-
-    // ************************************************************************
-    // Worker methods
-    // ************************************************************************
-
-    @Override
-    public void phaseStarted(AbstractPhaseScope<Solution_> phaseScope) {
-        super.phaseStarted(phaseScope);
-        ListVariableDescriptor<Solution_> variableDescriptor =
-                (ListVariableDescriptor<Solution_>) childValueSelector.getVariableDescriptor();
-        inverseVariableSupply = phaseScope.getScoreDirector().getSupplyManager()
-                .demand(new SingletonListInverseVariableDemand<>(variableDescriptor));
+        super(childValueSelector);
     }
 
     @Override
-    public void phaseEnded(AbstractPhaseScope<Solution_> phaseScope) {
-        super.phaseEnded(phaseScope);
-        inverseVariableSupply = null;
-    }
-
-    @Override
-    public GenuineVariableDescriptor<Solution_> getVariableDescriptor() {
-        return childValueSelector.getVariableDescriptor();
-    }
-
-    @Override
-    public boolean isCountable() {
-        // Because !neverEnding => countable.
-        return true;
-    }
-
-    @Override
-    public boolean isNeverEnding() {
-        // Because the childValueSelector is not never-ending.
-        return false;
-    }
-
-    @Override
-    public long getSize(Object entity) {
-        return getSize();
-    }
-
-    @Override
-    public long getSize() {
-        return streamUnassignedValues().count();
-    }
-
-    @Override
-    public Iterator<Object> iterator(Object entity) {
-        return iterator();
-    }
-
-    @Override
-    public Iterator<Object> iterator() {
-        return streamUnassignedValues().iterator();
-    }
-
-    @Override
-    public Iterator<Object> endingIterator(Object entity) {
-        return iterator();
-    }
-
-    private Stream<Object> streamUnassignedValues() {
-        return StreamSupport.stream(childValueSelector.spliterator(), false)
-                // Skip assigned values.
-                .filter(value -> inverseVariableSupply.getInverseSingleton(value) == null);
-    }
-
-    @Override
-    public boolean equals(Object other) {
-        if (this == other)
-            return true;
-        if (other == null || getClass() != other.getClass())
-            return false;
-        UnassignedValueSelector<?> that = (UnassignedValueSelector<?>) other;
-        return Objects.equals(childValueSelector, that.childValueSelector);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(childValueSelector);
+    protected boolean valueFilter(Object value) {
+        return inverseVariableSupply.getInverseSingleton(value) == null;
     }
 
     @Override

--- a/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/heuristic/selector/SelectorTestUtils.java
+++ b/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/heuristic/selector/SelectorTestUtils.java
@@ -138,6 +138,7 @@ public class SelectorTestUtils {
         when(valueSelector.iterator(any())).thenAnswer(invocation -> valueList.iterator());
         when(valueSelector.endingIterator(any())).thenAnswer(invocation -> valueList.iterator());
         when(valueSelector.iterator()).thenAnswer(invocation -> valueList.iterator());
+        when(valueSelector.spliterator()).thenAnswer(invocation -> valueList.spliterator());
         when(valueSelector.isCountable()).thenReturn(true);
         when(valueSelector.isNeverEnding()).thenReturn(false);
         when(valueSelector.getSize(any())).thenReturn((long) valueList.size());
@@ -192,9 +193,12 @@ public class SelectorTestUtils {
     // ************************************************************************
 
     public static <Solution_> SolverScope<Solution_> solvingStarted(PhaseLifecycleListener<Solution_> listener) {
-        SolverScope<Solution_> solverScope = mock(SolverScope.class);
-        listener.solvingStarted(solverScope);
-        return solverScope;
+        return solvingStarted(listener, null, null);
+    }
+
+    public static <Solution_, Score_ extends Score<Score_>> SolverScope<Solution_> solvingStarted(
+            PhaseLifecycleListener<Solution_> listener, InnerScoreDirector<Solution_, Score_> scoreDirector) {
+        return solvingStarted(listener, scoreDirector, null);
     }
 
     public static <Solution_, Score_ extends Score<Score_>> SolverScope<Solution_> solvingStarted(

--- a/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/heuristic/selector/move/generic/ChangeMoveSelectorTest.java
+++ b/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/heuristic/selector/move/generic/ChangeMoveSelectorTest.java
@@ -85,7 +85,7 @@ class ChangeMoveSelectorTest {
 
         ChangeMoveSelector<TestdataSolution> moveSelector = new ChangeMoveSelector<>(entitySelector, valueSelector, false);
 
-        SolverScope<TestdataSolution> solverScope = solvingStarted(moveSelector, null, null);
+        SolverScope<TestdataSolution> solverScope = solvingStarted(moveSelector);
         AbstractPhaseScope<TestdataSolution> phaseScopeA = phaseStarted(moveSelector, solverScope);
 
         doInsideStep(moveSelector, phaseScopeA, PlannerAssert::assertAllCodesOfMoveSelector);

--- a/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/ElementDestinationSelectorTest.java
+++ b/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/ElementDestinationSelectorTest.java
@@ -1,0 +1,234 @@
+package org.optaplanner.core.impl.heuristic.selector.move.generic.list;
+
+import static org.optaplanner.core.impl.heuristic.selector.SelectorTestUtils.phaseStarted;
+import static org.optaplanner.core.impl.heuristic.selector.SelectorTestUtils.solvingStarted;
+import static org.optaplanner.core.impl.heuristic.selector.SelectorTestUtils.stepStarted;
+import static org.optaplanner.core.impl.testdata.domain.list.TestdataListUtils.getListVariableDescriptor;
+import static org.optaplanner.core.impl.testdata.domain.list.TestdataListUtils.mockEntityIndependentValueSelector;
+import static org.optaplanner.core.impl.testdata.domain.list.TestdataListUtils.mockEntitySelector;
+import static org.optaplanner.core.impl.testdata.domain.list.TestdataListUtils.mockNeverEndingEntityIndependentValueSelector;
+import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertAllCodesOfIterableSelector;
+import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertCodesOfNeverEndingIterableSelector;
+import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertEmptyNeverEndingIterableSelector;
+import static org.optaplanner.core.impl.testdata.util.PlannerAssert.verifyPhaseLifecycle;
+
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.optaplanner.core.api.score.buildin.simple.SimpleScore;
+import org.optaplanner.core.impl.domain.variable.descriptor.ListVariableDescriptor;
+import org.optaplanner.core.impl.heuristic.selector.entity.EntitySelector;
+import org.optaplanner.core.impl.heuristic.selector.value.EntityIndependentValueSelector;
+import org.optaplanner.core.impl.phase.scope.AbstractPhaseScope;
+import org.optaplanner.core.impl.phase.scope.AbstractStepScope;
+import org.optaplanner.core.impl.score.director.InnerScoreDirector;
+import org.optaplanner.core.impl.solver.scope.SolverScope;
+import org.optaplanner.core.impl.testdata.domain.list.TestdataListEntity;
+import org.optaplanner.core.impl.testdata.domain.list.TestdataListSolution;
+import org.optaplanner.core.impl.testdata.domain.list.TestdataListValue;
+import org.optaplanner.core.impl.testdata.util.PlannerTestUtils;
+import org.optaplanner.core.impl.testutil.TestRandom;
+
+class ElementDestinationSelectorTest {
+
+    @Test
+    void original() {
+        TestdataListValue v1 = new TestdataListValue("1");
+        TestdataListValue v2 = new TestdataListValue("2");
+        TestdataListValue v3 = new TestdataListValue("3");
+        TestdataListEntity a = TestdataListEntity.createWithValues("A", v2, v1);
+        TestdataListEntity b = TestdataListEntity.createWithValues("B");
+        TestdataListEntity c = TestdataListEntity.createWithValues("C", v3);
+
+        InnerScoreDirector<TestdataListSolution, SimpleScore> scoreDirector =
+                PlannerTestUtils.mockScoreDirector(TestdataListSolution.buildSolutionDescriptor());
+
+        ListVariableDescriptor<TestdataListSolution> listVariableDescriptor = getListVariableDescriptor(scoreDirector);
+        EntitySelector<TestdataListSolution> entitySelector = mockEntitySelector(a, b, c);
+        EntityIndependentValueSelector<TestdataListSolution> valueSelector = mockEntityIndependentValueSelector(v3, v1, v2);
+        long destinationSize = entitySelector.getSize() + valueSelector.getSize();
+
+        ElementDestinationSelector<TestdataListSolution> selector = new ElementDestinationSelector<>(
+                listVariableDescriptor,
+                entitySelector,
+                valueSelector,
+                false);
+
+        solvingStarted(selector, scoreDirector);
+
+        // Entity order: [A, B, C]
+        // Value order: [3, 1, 2]
+        // Initial state:
+        // - A [2, 1]
+        // - B []
+        // - C [3]
+
+        assertAllCodesOfIterableSelector(selector, destinationSize,
+                "A[0]",
+                "B[0]",
+                "C[0]",
+                "C[1]",
+                "A[2]",
+                "A[1]");
+    }
+
+    @Test
+    void random() {
+        TestdataListValue v1 = new TestdataListValue("1");
+        TestdataListValue v2 = new TestdataListValue("2");
+        TestdataListValue v3 = new TestdataListValue("3");
+        TestdataListEntity a = TestdataListEntity.createWithValues("A", v1, v2);
+        TestdataListEntity b = TestdataListEntity.createWithValues("B");
+        TestdataListEntity c = TestdataListEntity.createWithValues("C", v3);
+
+        InnerScoreDirector<TestdataListSolution, SimpleScore> scoreDirector =
+                PlannerTestUtils.mockScoreDirector(TestdataListSolution.buildSolutionDescriptor());
+
+        ListVariableDescriptor<TestdataListSolution> listVariableDescriptor = getListVariableDescriptor(scoreDirector);
+        EntitySelector<TestdataListSolution> entitySelector = mockEntitySelector(a, b, c, c);
+        EntityIndependentValueSelector<TestdataListSolution> valueSelector =
+                mockNeverEndingEntityIndependentValueSelector(v3, v2, v1);
+        long destinationSize = entitySelector.getSize() + valueSelector.getSize();
+
+        ElementDestinationSelector<TestdataListSolution> selector = new ElementDestinationSelector<>(
+                listVariableDescriptor,
+                entitySelector,
+                valueSelector,
+                true);
+
+        // <4 => entity selector; >=4 => value selector
+        TestRandom random = new TestRandom(
+                0, // => A[0]
+                4, // => v3 => C[1]
+                1, // => B[0]
+                5, // => v2 => A[2]
+                6, // => v1 => A[1]
+                2, // => C[0]
+                -1); // (not tested)
+
+        solvingStarted(selector, scoreDirector, random);
+
+        // Initial state:
+        // - A [1, 2]
+        // - B []
+        // - C [3]
+
+        // The destinations (A[0], C[1], ...) depend on the random number, which decides whether entitySelector or valueSelector
+        // will be used; and then on the order of entities and values in the mocked selectors.
+        assertCodesOfNeverEndingIterableSelector(selector, destinationSize,
+                "A[0]",
+                "C[1]",
+                "B[0]",
+                "A[2]",
+                "A[1]",
+                "C[0]");
+
+        random.assertIntBoundJustRequested((int) destinationSize);
+    }
+
+    @Test
+    void emptyIfThereAreNoEntities() {
+        TestdataListValue v1 = new TestdataListValue("1");
+        TestdataListValue v2 = new TestdataListValue("2");
+        TestdataListValue v3 = new TestdataListValue("3");
+
+        InnerScoreDirector<TestdataListSolution, SimpleScore> scoreDirector =
+                PlannerTestUtils.mockScoreDirector(TestdataListSolution.buildSolutionDescriptor());
+
+        ListVariableDescriptor<TestdataListSolution> listVariableDescriptor = getListVariableDescriptor(scoreDirector);
+        EntitySelector<TestdataListSolution> entitySelector = mockEntitySelector();
+        EntityIndependentValueSelector<TestdataListSolution> valueSelector = mockEntityIndependentValueSelector(v1, v2, v3);
+
+        ElementDestinationSelector<TestdataListSolution> randomSelector = new ElementDestinationSelector<>(
+                listVariableDescriptor, entitySelector, valueSelector, true);
+        assertEmptyNeverEndingIterableSelector(randomSelector, 0);
+
+        ElementDestinationSelector<TestdataListSolution> originalSelector = new ElementDestinationSelector<>(
+                listVariableDescriptor, entitySelector, valueSelector, false);
+        assertAllCodesOfIterableSelector(originalSelector, 0);
+    }
+
+    @Test
+    void notEmptyIfThereAreEntities() {
+        TestdataListEntity a = TestdataListEntity.createWithValues("A");
+        TestdataListEntity b = TestdataListEntity.createWithValues("B");
+
+        InnerScoreDirector<TestdataListSolution, SimpleScore> scoreDirector =
+                PlannerTestUtils.mockScoreDirector(TestdataListSolution.buildSolutionDescriptor());
+
+        ListVariableDescriptor<TestdataListSolution> listVariableDescriptor = getListVariableDescriptor(scoreDirector);
+        EntitySelector<TestdataListSolution> entitySelector = mockEntitySelector(a, b);
+        EntityIndependentValueSelector<TestdataListSolution> valueSelector = mockEntityIndependentValueSelector();
+
+        ElementDestinationSelector<TestdataListSolution> originalSelector = new ElementDestinationSelector<>(
+                listVariableDescriptor, entitySelector, valueSelector, false);
+        assertAllCodesOfIterableSelector(originalSelector, 2, "A[0]", "B[0]");
+
+        ElementDestinationSelector<TestdataListSolution> randomSelector = new ElementDestinationSelector<>(
+                listVariableDescriptor, entitySelector, valueSelector, true);
+        TestRandom random = new TestRandom(0, 1);
+
+        solvingStarted(randomSelector, scoreDirector, random);
+        // Do not assert all codes to prevent exhausting the iterator.
+        assertCodesOfNeverEndingIterableSelector(randomSelector, 2, "A[0]");
+    }
+
+    @Test
+    void phaseLifecycle() {
+        InnerScoreDirector<TestdataListSolution, SimpleScore> scoreDirector =
+                PlannerTestUtils.mockScoreDirector(TestdataListSolution.buildSolutionDescriptor());
+
+        EntitySelector<TestdataListSolution> entitySelector = mockEntitySelector();
+        EntityIndependentValueSelector<TestdataListSolution> valueSelector = mockEntityIndependentValueSelector();
+
+        ElementDestinationSelector<TestdataListSolution> selector = new ElementDestinationSelector<>(
+                getListVariableDescriptor(scoreDirector),
+                entitySelector,
+                valueSelector,
+                false);
+
+        SolverScope<TestdataListSolution> solverScope = solvingStarted(selector, scoreDirector);
+        AbstractPhaseScope<TestdataListSolution> phaseScope = phaseStarted(selector, solverScope);
+
+        AbstractStepScope<TestdataListSolution> stepScope1 = stepStarted(selector, phaseScope);
+        selector.stepEnded(stepScope1);
+
+        AbstractStepScope<TestdataListSolution> stepScope2 = stepStarted(selector, phaseScope);
+        selector.stepEnded(stepScope2);
+
+        selector.phaseEnded(phaseScope);
+        selector.solvingEnded(solverScope);
+
+        verifyPhaseLifecycle(entitySelector, 1, 1, 2);
+        verifyPhaseLifecycle(valueSelector, 1, 1, 2);
+    }
+
+    @Test
+    @Disabled
+    void constructionHeuristic() {
+        TestdataListValue v1 = new TestdataListValue("1");
+        TestdataListValue v2 = new TestdataListValue("2");
+        TestdataListValue v3 = new TestdataListValue("3");
+        TestdataListValue v4 = new TestdataListValue("4");
+        TestdataListValue v5 = new TestdataListValue("5");
+        TestdataListEntity a = new TestdataListEntity("A");
+        TestdataListEntity b = new TestdataListEntity("B");
+        TestdataListEntity c = TestdataListEntity.createWithValues("C", v5);
+
+        InnerScoreDirector<TestdataListSolution, SimpleScore> scoreDirector =
+                PlannerTestUtils.mockScoreDirector(TestdataListSolution.buildSolutionDescriptor());
+
+        ElementDestinationSelector<TestdataListSolution> selector = new ElementDestinationSelector<>(
+                getListVariableDescriptor(scoreDirector),
+                mockEntitySelector(a, b, c),
+                mockEntityIndependentValueSelector(v3, v1, v4, v2, v5),
+                false);
+
+        solvingStarted(selector, scoreDirector);
+
+        assertAllCodesOfIterableSelector(selector, 4,
+                "A[0]",
+                "B[0]",
+                "C[0]",
+                "C[1]");
+    }
+}

--- a/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/ElementDestinationSelectorTest.java
+++ b/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/ElementDestinationSelectorTest.java
@@ -12,7 +12,6 @@ import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertCodesO
 import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertEmptyNeverEndingIterableSelector;
 import static org.optaplanner.core.impl.testdata.util.PlannerAssert.verifyPhaseLifecycle;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.optaplanner.core.api.score.buildin.simple.SimpleScore;
 import org.optaplanner.core.impl.domain.variable.descriptor.ListVariableDescriptor;
@@ -200,35 +199,5 @@ class ElementDestinationSelectorTest {
 
         verifyPhaseLifecycle(entitySelector, 1, 1, 2);
         verifyPhaseLifecycle(valueSelector, 1, 1, 2);
-    }
-
-    @Test
-    @Disabled
-    void constructionHeuristic() {
-        TestdataListValue v1 = new TestdataListValue("1");
-        TestdataListValue v2 = new TestdataListValue("2");
-        TestdataListValue v3 = new TestdataListValue("3");
-        TestdataListValue v4 = new TestdataListValue("4");
-        TestdataListValue v5 = new TestdataListValue("5");
-        TestdataListEntity a = new TestdataListEntity("A");
-        TestdataListEntity b = new TestdataListEntity("B");
-        TestdataListEntity c = TestdataListEntity.createWithValues("C", v5);
-
-        InnerScoreDirector<TestdataListSolution, SimpleScore> scoreDirector =
-                PlannerTestUtils.mockScoreDirector(TestdataListSolution.buildSolutionDescriptor());
-
-        ElementDestinationSelector<TestdataListSolution> selector = new ElementDestinationSelector<>(
-                getListVariableDescriptor(scoreDirector),
-                mockEntitySelector(a, b, c),
-                mockEntityIndependentValueSelector(v3, v1, v4, v2, v5),
-                false);
-
-        solvingStarted(selector, scoreDirector);
-
-        assertAllCodesOfIterableSelector(selector, 4,
-                "A[0]",
-                "B[0]",
-                "C[0]",
-                "C[1]");
     }
 }

--- a/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/ListSwapMoveSelectorTest.java
+++ b/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/ListSwapMoveSelectorTest.java
@@ -1,7 +1,6 @@
 package org.optaplanner.core.impl.heuristic.selector.move.generic.list;
 
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import static org.optaplanner.core.impl.heuristic.selector.SelectorTestUtils.solvingStarted;
 import static org.optaplanner.core.impl.testdata.domain.list.TestdataListUtils.getListVariableDescriptor;
 import static org.optaplanner.core.impl.testdata.domain.list.TestdataListUtils.mockEntityIndependentValueSelector;
 import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertAllCodesOfMoveSelector;
@@ -11,7 +10,6 @@ import static org.optaplanner.core.impl.testdata.util.PlannerTestUtils.mockScore
 import org.junit.jupiter.api.Test;
 import org.optaplanner.core.api.score.buildin.simple.SimpleScore;
 import org.optaplanner.core.impl.score.director.InnerScoreDirector;
-import org.optaplanner.core.impl.solver.scope.SolverScope;
 import org.optaplanner.core.impl.testdata.domain.list.TestdataListEntity;
 import org.optaplanner.core.impl.testdata.domain.list.TestdataListSolution;
 import org.optaplanner.core.impl.testdata.domain.list.TestdataListValue;
@@ -36,9 +34,7 @@ class ListSwapMoveSelectorTest {
                 mockEntityIndependentValueSelector(v3, v1, v2),
                 false);
 
-        SolverScope<TestdataListSolution> solverScope = mock(SolverScope.class);
-        when(solverScope.<SimpleScore> getScoreDirector()).thenReturn(scoreDirector);
-        moveSelector.solvingStarted(solverScope);
+        solvingStarted(moveSelector, scoreDirector);
 
         // Value order: [3, 1, 2]
         // Entity order: [A, B, C]
@@ -80,9 +76,7 @@ class ListSwapMoveSelectorTest {
                 mockEntityIndependentValueSelector(v1, v2, v3, v1, v2, v3, v1, v2, v3, v1),
                 true);
 
-        SolverScope<TestdataListSolution> solverScope = mock(SolverScope.class);
-        when(solverScope.<SimpleScore> getScoreDirector()).thenReturn(scoreDirector);
-        moveSelector.solvingStarted(solverScope);
+        solvingStarted(moveSelector, scoreDirector);
 
         assertCodesOfNeverEndingMoveSelector(moveSelector,
                 "2 {A[1]} <-> 1 {A[0]}",

--- a/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/OriginalListChangeIteratorTest.java
+++ b/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/OriginalListChangeIteratorTest.java
@@ -15,6 +15,7 @@ import org.optaplanner.core.api.score.buildin.simple.SimpleScore;
 import org.optaplanner.core.impl.domain.variable.descriptor.ListVariableDescriptor;
 import org.optaplanner.core.impl.domain.variable.index.IndexVariableDemand;
 import org.optaplanner.core.impl.domain.variable.inverserelation.SingletonListInverseVariableDemand;
+import org.optaplanner.core.impl.heuristic.selector.value.EntityIndependentValueSelector;
 import org.optaplanner.core.impl.score.director.InnerScoreDirector;
 import org.optaplanner.core.impl.testdata.domain.list.TestdataListEntity;
 import org.optaplanner.core.impl.testdata.domain.list.TestdataListSolution;
@@ -36,13 +37,19 @@ class OriginalListChangeIteratorTest {
         InnerScoreDirector<TestdataListSolution, SimpleScore> scoreDirector =
                 mockScoreDirector(TestdataListSolution.buildSolutionDescriptor());
         ListVariableDescriptor<TestdataListSolution> listVariableDescriptor = getListVariableDescriptor(scoreDirector);
-        OriginalListChangeIterator<TestdataListSolution> listSwapIterator = new OriginalListChangeIterator<>(
+        EntityIndependentValueSelector<TestdataListSolution> valueSelector =
+                mockEntityIndependentValueSelector(values.toArray());
+        OriginalListChangeIterator<TestdataListSolution> listChangeIterator = new OriginalListChangeIterator<>(
                 listVariableDescriptor,
                 scoreDirector.getSupplyManager().demand(new SingletonListInverseVariableDemand<>(listVariableDescriptor)),
                 scoreDirector.getSupplyManager().demand(new IndexVariableDemand<>(listVariableDescriptor)),
-                mockEntityIndependentValueSelector(values.toArray()),
-                mockEntitySelector(entities.toArray()));
+                valueSelector,
+                new ElementDestinationSelector<>(
+                        listVariableDescriptor,
+                        mockEntitySelector(entities.toArray()),
+                        valueSelector,
+                        false));
 
-        assertThat(listSwapIterator).isExhausted();
+        assertThat(listChangeIterator).isExhausted();
     }
 }

--- a/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/RandomListChangeIteratorTest.java
+++ b/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/RandomListChangeIteratorTest.java
@@ -1,6 +1,6 @@
 package org.optaplanner.core.impl.heuristic.selector.move.generic.list;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.optaplanner.core.impl.heuristic.selector.SelectorTestUtils.solvingStarted;
 import static org.optaplanner.core.impl.testdata.domain.list.TestdataListUtils.getListVariableDescriptor;
 import static org.optaplanner.core.impl.testdata.domain.list.TestdataListUtils.mockEntityIndependentValueSelector;
 import static org.optaplanner.core.impl.testdata.domain.list.TestdataListUtils.mockEntitySelector;
@@ -12,12 +12,13 @@ import org.optaplanner.core.api.score.buildin.simple.SimpleScore;
 import org.optaplanner.core.impl.domain.variable.descriptor.ListVariableDescriptor;
 import org.optaplanner.core.impl.domain.variable.index.IndexVariableDemand;
 import org.optaplanner.core.impl.domain.variable.inverserelation.SingletonListInverseVariableDemand;
+import org.optaplanner.core.impl.heuristic.selector.entity.EntitySelector;
+import org.optaplanner.core.impl.heuristic.selector.value.EntityIndependentValueSelector;
 import org.optaplanner.core.impl.score.director.InnerScoreDirector;
 import org.optaplanner.core.impl.testdata.domain.list.TestdataListEntity;
 import org.optaplanner.core.impl.testdata.domain.list.TestdataListSolution;
 import org.optaplanner.core.impl.testdata.domain.list.TestdataListValue;
 import org.optaplanner.core.impl.testutil.TestRandom;
-import org.optaplanner.core.impl.util.Pair;
 
 class RandomListChangeIteratorTest {
 
@@ -30,29 +31,29 @@ class RandomListChangeIteratorTest {
         TestdataListEntity b = TestdataListEntity.createWithValues("B");
         TestdataListEntity c = TestdataListEntity.createWithValues("C", v3);
 
-        TestRandom random = new TestRandom(2, 3, 0); // global destination indexes
-        final int destinationIndexRange = 6; // value count + entity count
-
         InnerScoreDirector<TestdataListSolution, SimpleScore> scoreDirector =
                 mockScoreDirector(TestdataListSolution.buildSolutionDescriptor());
         ListVariableDescriptor<TestdataListSolution> listVariableDescriptor = getListVariableDescriptor(scoreDirector);
-
+        // Iterates over values in this given order.
+        EntityIndependentValueSelector<TestdataListSolution> sourceValueSelector =
+                mockEntityIndependentValueSelector(v1, v2, v3);
+        EntityIndependentValueSelector<TestdataListSolution> destinationValueSelector =
+                mockEntityIndependentValueSelector(v2, v3);
+        EntitySelector<TestdataListSolution> entitySelector = mockEntitySelector(b, a, c);
+        ElementDestinationSelector<TestdataListSolution> destinationSelector =
+                new ElementDestinationSelector<>(listVariableDescriptor, entitySelector, destinationValueSelector, true);
         RandomListChangeIterator<TestdataListSolution> randomListChangeIterator = new RandomListChangeIterator<>(
                 listVariableDescriptor,
                 scoreDirector.getSupplyManager().demand(new SingletonListInverseVariableDemand<>(listVariableDescriptor)),
                 scoreDirector.getSupplyManager().demand(new IndexVariableDemand<>(listVariableDescriptor)),
-                mockEntityIndependentValueSelector(v1, v2, v3), // Iterates over values in this given order.
-                mockEntitySelector(a, b, c), // Entity selector is only used to discover the destination index range.
-                random);
+                sourceValueSelector,
+                destinationSelector);
 
-        // 0 points at A[0]
-        assertEntityAndIndex(randomListChangeIterator, 0, a, 0);
-        // 1 points at A[1]
-        assertEntityAndIndex(randomListChangeIterator, 1, a, 1);
-        // 2 points at A[2]
-        assertEntityAndIndex(randomListChangeIterator, 2, a, 2);
-        // 3 points at B[0]
-        assertEntityAndIndex(randomListChangeIterator, 3, b, 0);
+        // <3 => entity selector; >=3 => value selector
+        TestRandom random = new TestRandom(3, 0, 1);
+        final long destinationRange = entitySelector.getSize() + destinationValueSelector.getSize();
+
+        solvingStarted(destinationSelector, scoreDirector, random);
 
         // The moved values (1, 2, 3) and their source positions are supplied by the mocked value selector.
         // The test is focused on the destinations (A[2], B[0], A[0]), which reflect the numbers supplied by the test random.
@@ -61,16 +62,7 @@ class RandomListChangeIteratorTest {
                 "2 {A[1]->B[0]}",
                 "3 {C[0]->A[0]}");
 
-        random.assertIntBoundJustRequested(destinationIndexRange);
+        random.assertIntBoundJustRequested((int) destinationRange);
     }
 
-    static void assertEntityAndIndex(
-            RandomListChangeIterator<TestdataListSolution> randomListChangeIterator,
-            int globalIndex,
-            Object expectedEntity,
-            int expectedListIndex) {
-        Pair<Object, Integer> pair = randomListChangeIterator.entityAndIndexFromGlobalIndex(globalIndex);
-        assertThat(pair.getKey()).isEqualTo(expectedEntity);
-        assertThat(pair.getValue()).isEqualTo(expectedListIndex);
-    }
 }

--- a/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/RandomSubListSelectorTest.java
+++ b/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/RandomSubListSelectorTest.java
@@ -6,9 +6,11 @@ import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.optaplanner.core.impl.heuristic.selector.SelectorTestUtils.phaseStarted;
 import static org.optaplanner.core.impl.heuristic.selector.SelectorTestUtils.solvingStarted;
 import static org.optaplanner.core.impl.heuristic.selector.SelectorTestUtils.stepStarted;
+import static org.optaplanner.core.impl.heuristic.selector.move.generic.list.TriangularNumbers.nthTriangle;
 import static org.optaplanner.core.impl.testdata.domain.list.TestdataListUtils.getListVariableDescriptor;
-import static org.optaplanner.core.impl.testdata.domain.list.TestdataListUtils.mockEntityIndependentValueSelector;
+import static org.optaplanner.core.impl.testdata.domain.list.TestdataListUtils.listSize;
 import static org.optaplanner.core.impl.testdata.domain.list.TestdataListUtils.mockEntitySelector;
+import static org.optaplanner.core.impl.testdata.domain.list.TestdataListUtils.mockNeverEndingEntityIndependentValueSelector;
 import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertCodesOfNeverEndingIterableSelector;
 import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertEmptyNeverEndingIterableSelector;
 import static org.optaplanner.core.impl.testdata.util.PlannerAssert.verifyPhaseLifecycle;
@@ -47,14 +49,12 @@ class RandomSubListSelectorTest {
         int subListCount = 10;
 
         // The number of subLists of [1, 2, 3, 4] is the 4th triangular number (10).
-        assertThat(TriangularNumbers.nthTriangle(a.getValueList().size())).isEqualTo(subListCount);
+        assertThat(subListCount).isEqualTo(nthTriangle(listSize(a)) + nthTriangle(listSize(b)));
 
         RandomSubListSelector<TestdataListSolution> selector = new RandomSubListSelector<>(
                 getListVariableDescriptor(scoreDirector),
                 mockEntitySelector(a, b),
-                // The value selector is longer than the number of expected codes because it is expected
-                // to be never ending, so it must not be exhausted after the last asserted code.
-                mockEntityIndependentValueSelector(v1, v1, v1, v1, v1, v1, v1, v1, v1, v1, v1),
+                mockNeverEndingEntityIndependentValueSelector(v1),
                 minimumSubListSize,
                 maximumSubListSize);
 
@@ -91,9 +91,7 @@ class RandomSubListSelectorTest {
         RandomSubListSelector<TestdataListSolution> selector = new RandomSubListSelector<>(
                 getListVariableDescriptor(scoreDirector),
                 mockEntitySelector(a, b),
-                // The value selector is longer than the number of expected codes because it is expected
-                // to be never ending, so it must not be exhausted after the last asserted code.
-                mockEntityIndependentValueSelector(v1, v1, v1, v1, v1, v1, v1, v1),
+                mockNeverEndingEntityIndependentValueSelector(v1),
                 minimumSubListSize,
                 maximumSubListSize);
 
@@ -124,13 +122,11 @@ class RandomSubListSelectorTest {
         RandomSubListSelector<TestdataListSolution> selector = new RandomSubListSelector<>(
                 getListVariableDescriptor(scoreDirector),
                 mockEntitySelector(a),
-                mockEntityIndependentValueSelector(),
+                mockNeverEndingEntityIndependentValueSelector(),
                 minimumSubListSize,
                 maximumSubListSize);
 
-        TestRandom random = new TestRandom(new int[] {});
-
-        solvingStarted(selector, scoreDirector, random);
+        solvingStarted(selector, scoreDirector);
 
         assertEmptyNeverEndingIterableSelector(selector, 0);
     }
@@ -141,7 +137,7 @@ class RandomSubListSelectorTest {
                 PlannerTestUtils.mockScoreDirector(TestdataListSolution.buildSolutionDescriptor());
 
         EntitySelector<TestdataListSolution> entitySelector = mockEntitySelector();
-        EntityIndependentValueSelector<TestdataListSolution> valueSelector = mockEntityIndependentValueSelector();
+        EntityIndependentValueSelector<TestdataListSolution> valueSelector = mockNeverEndingEntityIndependentValueSelector();
 
         int minimumSubListSize = 1;
         int maximumSubListSize = Integer.MAX_VALUE;
@@ -153,9 +149,7 @@ class RandomSubListSelectorTest {
                 minimumSubListSize,
                 maximumSubListSize);
 
-        TestRandom random = new TestRandom(new int[] {});
-
-        SolverScope<TestdataListSolution> solverScope = solvingStarted(selector, scoreDirector, random);
+        SolverScope<TestdataListSolution> solverScope = solvingStarted(selector, scoreDirector);
         AbstractPhaseScope<TestdataListSolution> phaseScope = phaseStarted(selector, solverScope);
 
         AbstractStepScope<TestdataListSolution> stepScope1 = stepStarted(selector, phaseScope);
@@ -176,7 +170,7 @@ class RandomSubListSelectorTest {
         ListVariableDescriptor<TestdataListSolution> listVariableDescriptor =
                 TestdataListEntity.buildVariableDescriptorForValueList();
         EntitySelector<TestdataListSolution> entitySelector = mockEntitySelector();
-        EntityIndependentValueSelector<TestdataListSolution> valueSelector = mockEntityIndependentValueSelector();
+        EntityIndependentValueSelector<TestdataListSolution> valueSelector = mockNeverEndingEntityIndependentValueSelector();
 
         assertThatIllegalArgumentException().isThrownBy(() -> new RandomSubListSelector<>(
                 listVariableDescriptor, entitySelector, valueSelector, 0, 5))

--- a/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/SubListSelectorFactoryTest.java
+++ b/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/SubListSelectorFactoryTest.java
@@ -1,0 +1,44 @@
+package org.optaplanner.core.impl.heuristic.selector.move.generic.list;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.when;
+import static org.optaplanner.core.impl.heuristic.HeuristicConfigPolicyTestUtils.buildHeuristicConfigPolicy;
+
+import org.junit.jupiter.api.Test;
+import org.optaplanner.core.config.heuristic.selector.common.SelectionCacheType;
+import org.optaplanner.core.config.heuristic.selector.common.SelectionOrder;
+import org.optaplanner.core.config.heuristic.selector.move.generic.list.SubListChangeMoveSelectorConfig;
+import org.optaplanner.core.impl.domain.variable.descriptor.ListVariableDescriptor;
+import org.optaplanner.core.impl.heuristic.HeuristicConfigPolicy;
+import org.optaplanner.core.impl.heuristic.selector.entity.EntitySelector;
+import org.optaplanner.core.impl.testdata.domain.list.TestdataListEntity;
+import org.optaplanner.core.impl.testdata.domain.list.TestdataListSolution;
+import org.optaplanner.core.impl.testdata.domain.list.TestdataListUtils;
+
+class SubListSelectorFactoryTest {
+
+    @Test
+    void buildSubListSelector() {
+        SubListChangeMoveSelectorConfig config = new SubListChangeMoveSelectorConfig();
+
+        config.setMinimumSubListSize(2);
+        config.setMaximumSubListSize(3);
+
+        SubListSelectorFactory<TestdataListSolution> factory = new SubListSelectorFactory<>(config);
+
+        HeuristicConfigPolicy<TestdataListSolution> heuristicConfigPolicy =
+                buildHeuristicConfigPolicy(TestdataListSolution.buildSolutionDescriptor());
+
+        ListVariableDescriptor<TestdataListSolution> listVariableDescriptor =
+                TestdataListEntity.buildVariableDescriptorForValueList();
+        EntitySelector<TestdataListSolution> entitySelector = TestdataListUtils.mockEntitySelector();
+        when(entitySelector.getEntityDescriptor()).thenReturn(listVariableDescriptor.getEntityDescriptor());
+        RandomSubListSelector<TestdataListSolution> subListSelector =
+                factory.buildSubListSelector(heuristicConfigPolicy, listVariableDescriptor,
+                        entitySelector, SelectionCacheType.JUST_IN_TIME, SelectionOrder.RANDOM);
+
+        assertThat(subListSelector.getMinimumSubListSize()).isEqualTo(config.getMinimumSubListSize());
+        assertThat(subListSelector.getMaximumSubListSize()).isEqualTo(config.getMaximumSubListSize());
+    }
+}

--- a/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/SubListSwapMoveSelectorFactoryTest.java
+++ b/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/SubListSwapMoveSelectorFactoryTest.java
@@ -29,6 +29,7 @@ class SubListSwapMoveSelectorFactoryTest {
 
         assertThat(selector.isCountable()).isTrue();
         assertThat(selector.isNeverEnding()).isTrue();
+        assertThat(selector.isSelectReversingMoveToo()).isTrue();
     }
 
     @Test

--- a/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/testdata/domain/list/TestdataListUtils.java
+++ b/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/testdata/domain/list/TestdataListUtils.java
@@ -1,14 +1,28 @@
 package org.optaplanner.core.impl.testdata.domain.list;
 
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+
 import org.optaplanner.core.impl.domain.variable.descriptor.ListVariableDescriptor;
 import org.optaplanner.core.impl.heuristic.selector.SelectorTestUtils;
 import org.optaplanner.core.impl.heuristic.selector.entity.EntitySelector;
+import org.optaplanner.core.impl.heuristic.selector.move.generic.list.ElementDestinationSelector;
+import org.optaplanner.core.impl.heuristic.selector.move.generic.list.ElementRef;
 import org.optaplanner.core.impl.heuristic.selector.value.EntityIndependentValueSelector;
 import org.optaplanner.core.impl.score.director.InnerScoreDirector;
 
 public class TestdataListUtils {
 
     private TestdataListUtils() {
+    }
+
+    public static int listSize(TestdataListEntity entity) {
+        return entity.getValueList().size();
     }
 
     public static EntitySelector<TestdataListSolution> mockEntitySelector(Object... entities) {
@@ -19,11 +33,82 @@ public class TestdataListUtils {
         return SelectorTestUtils.mockEntityIndependentValueSelector(TestdataListEntity.class, "valueList", values);
     }
 
+    public static EntityIndependentValueSelector<TestdataListSolution>
+            mockNeverEndingEntityIndependentValueSelector(Object... values) {
+        EntityIndependentValueSelector<TestdataListSolution> valueSelector =
+                SelectorTestUtils.mockEntityIndependentValueSelector(TestdataListEntity.class, "valueList", values);
+        when(valueSelector.isNeverEnding()).thenReturn(true);
+        when(valueSelector.iterator()).thenAnswer(invocation -> cyclicIterator(Arrays.asList(values)));
+        return valueSelector;
+    }
+
+    public static ElementDestinationSelector<TestdataListSolution> mockNeverEndingDestinationSelector(
+            ElementRef... elementRefs) {
+        return mockNeverEndingDestinationSelector(elementRefs.length, elementRefs);
+    }
+
+    public static ElementDestinationSelector<TestdataListSolution> mockNeverEndingDestinationSelector(long size,
+            ElementRef... elementRefs) {
+        ElementDestinationSelector<TestdataListSolution> destinationSelector = mock(ElementDestinationSelector.class);
+        when(destinationSelector.isCountable()).thenReturn(true);
+        when(destinationSelector.isNeverEnding()).thenReturn(true);
+        when(destinationSelector.getSize()).thenReturn(size);
+        when(destinationSelector.iterator()).thenAnswer(invocation -> cyclicIterator(Arrays.asList(elementRefs)));
+        return destinationSelector;
+    }
+
+    public static ElementDestinationSelector<TestdataListSolution> mockDestinationSelector(ElementRef... elementRefs) {
+        ElementDestinationSelector<TestdataListSolution> destinationSelector = mock(ElementDestinationSelector.class);
+        List<ElementRef> refList = Arrays.asList(elementRefs);
+        when(destinationSelector.isCountable()).thenReturn(true);
+        when(destinationSelector.isNeverEnding()).thenReturn(false);
+        when(destinationSelector.getSize()).thenReturn((long) refList.size());
+        when(destinationSelector.iterator()).thenAnswer(invocation -> refList.iterator());
+        return destinationSelector;
+    }
+
     public static ListVariableDescriptor<TestdataListSolution> getListVariableDescriptor(
             InnerScoreDirector<TestdataListSolution, ?> scoreDirector) {
         return (ListVariableDescriptor<TestdataListSolution>) scoreDirector
                 .getSolutionDescriptor()
                 .getEntityDescriptorStrict(TestdataListEntity.class)
                 .getGenuineVariableDescriptor("valueList");
+    }
+
+    private static <T> Iterator<T> cyclicIterator(List<T> elements) {
+        if (elements.isEmpty()) {
+            return Collections.emptyIterator();
+        }
+        if (elements.size() == 1) {
+            return new Iterator<>() {
+
+                private final T element = elements.get(0);
+
+                @Override
+                public boolean hasNext() {
+                    return true;
+                }
+
+                @Override
+                public T next() {
+                    return element;
+                }
+            };
+        }
+        return new Iterator<>() {
+            private int i = 0;
+
+            @Override
+            public boolean hasNext() {
+                return true;
+            }
+
+            @Override
+            public T next() {
+                T element = elements.get(i % elements.size());
+                i++;
+                return element;
+            }
+        };
     }
 }

--- a/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/testdata/util/CodeAssertable.java
+++ b/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/testdata/util/CodeAssertable.java
@@ -7,6 +7,7 @@ import org.optaplanner.core.impl.heuristic.move.CompositeMove;
 import org.optaplanner.core.impl.heuristic.move.Move;
 import org.optaplanner.core.impl.heuristic.selector.move.generic.ChangeMove;
 import org.optaplanner.core.impl.heuristic.selector.move.generic.SwapMove;
+import org.optaplanner.core.impl.heuristic.selector.move.generic.list.ElementRef;
 import org.optaplanner.core.impl.heuristic.selector.move.generic.list.ListAssignMove;
 import org.optaplanner.core.impl.heuristic.selector.move.generic.list.ListChangeMove;
 import org.optaplanner.core.impl.heuristic.selector.move.generic.list.ListSwapMove;
@@ -94,6 +95,9 @@ public interface CodeAssertable {
         } else if (o instanceof SubList) {
             SubList subList = (SubList) o;
             return () -> convert(subList.getEntity()) + "[" + subList.getFromIndex() + "+" + subList.getLength() + "]";
+        } else if (o instanceof ElementRef) {
+            ElementRef elementRef = (ElementRef) o;
+            return () -> convert(elementRef.getEntity()) + "[" + elementRef.getIndex() + "]";
         } else if (o instanceof SubChain) {
             SubChain subChain = (SubChain) o;
             final String code = convert(subChain.getEntityList()).getCode();


### PR DESCRIPTION
### Step 1: Destination selector

This step changes the way how the destination entity and index for list change moves are selected. Previously a `NavigableMap<Integer, Object>` was constructed at the beginning of each step when the change move iterator was created. A global index (original or random) was used to look up a corresponding destination entity, the remainder represented the index in the selected entity's list variable.

This was fair and complete but the map needed to be reconstructed after each step. More importantly, this approach is not compatible with the existing nearby distance matrix, which stores indexes of entities and values sorted by distance from the key entity. The matrix is static; it doesn't change during solving. Although we could store global indexes from the previous approach in it, it wouldn't work because a value or an entity represented by a given global index changes as the elements of list variables move during solving.

The new destination selection approach is built on the plain old entity and value selectors. See `ElementDestinationSelector` Javadoc. This hopefully makes it possible to apply the existing nearby selection mechanism on the child entity and value selectors.

Note: (sub)list swap moves are unaffected because they can be done and undone without knowing where (*entity[index]*) the swapped elements are. In other words, swap moves do not select a destination, they select left and right value or subList.

### Step 2: List value filtering

The destination selector is not only used for list change moves in the LS phase, but also for list assign moves in the CH phase. However, in CH phase, the unassigned values that would be returned by the child value selector are worthless to the destination selector so we need to get rid of them somehow.

In step 1, I simply filtered out unassigned values inside the destination selector when building the iterator. Step 2 introduces a filtering value selector (`AssignedValueSelector`) to do this job.

The benefits of using the selector layering approach instead of ad-hoc filtering are:
1. The destination selector doesn't have to care about it. Its child value selector only returns assigned values at all times.
2. The assigned value filtering is only applied in CH. In LS, it's completely bypassed because the `AssignedValueSelector` is not applied at all.

### JIRA

- Contributes to https://issues.redhat.com/browse/PLANNER-2814.
- Closes https://issues.redhat.com/browse/PLANNER-2507.

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
- https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
- https://github.com/kiegroup/drools/pull/3000
- https://github.com/kiegroup/optaplanner/pull/899
- etc.
-->

### Checklist
- [ ] Documentation updated if applicable.
- [ ] Release notes updated if applicable.
- [ ] Upgrade recipe provided if applicable.

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request checks</b>  
  Please add comment: <b>Jenkins retest this</b>

- for a <b>specific pull request check</b>  
  please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-vehicle-routing] tests</b>
  
- for a <b>full downstream build</b> 
  - for <b>jenkins</b> job: 
    please add comment: <b>Jenkins run fdb</b>
  - for <b>github actions</b> job: 
    add the label `run_fdb`

- for a <b>compile downstream build</b>  
  please add comment: <b>Jenkins run cdb</b>

- for a <b>full production downstream build</b>  
  please add comment: <b>Jenkins execute product fdb</b>

- for an <b>upstream build</b>  
  please add comment: <b>Jenkins run upstream</b>

- for <b>quarkus branch checks</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins run quarkus-branch</b>

- for a <b>quarkus branch specific check</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-vehicle-routing] quarkus-branch</b>

- for <b>quarkus main checks</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins run quarkus-main</b>

- for a <b>specific quarkus main check</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-vehicle-routing] quarkus-branch</b>

- for <b>quarkus lts checks</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins run quarkus-lts</b>

- for a <b>specific quarkus lts check</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-vehicle-routing] quarkus-lts</b>

- for <b>native checks</b>  
  Run native checks  
  Please add comment: <b>Jenkins run native</b>

- for a <b>specific native check</b>  
  Run native checks 
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts] native</b>

- for <b>mandrel checks</b>  
  Run native checks against Mandrel image
  Please add comment: <b>Jenkins run mandrel</b>

- for a <b>specific mandrel check</b>  
  Run native checks against Mandrel image  
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts] mandrel</b>

- for <b>mandrel lts checks</b>  
  Run native checks against Mandrel image and quarkus lts branch
  Please add comment: <b>Jenkins run mandrel-lts</b>

- for a <b>specific mandrel lts check</b>  
  Run native checks against Mandrel image and quarkus lts branch
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts] mandrel-lts</b>

</details>

### CI Status

 You can check OptaPlanner repositories CI status from [Chain Status webpage](https://kiegroup.github.io/optaplanner/).

<details>
<summary>
How to backport a pull request to a different branch?
</summary>

In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-7.67.x` to backport the original PR to the `7.67.x` branch).

> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.

Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.

If something goes wrong, the author will be notified and at this point a manual backporting is needed.

> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
</details>
