### PR TITLE
PLANNER-2898 Use PECS principle in Constraint Collectors

### DIFF
--- a/core/optaplanner-core-impl/src/build/revapi-config.json
+++ b/core/optaplanner-core-impl/src/build/revapi-config.json
@@ -332,6 +332,654 @@
           "old": "method org.optaplanner.core.api.score.buildin.simplelong.SimpleLongScore org.optaplanner.core.api.score.buildin.simplelong.SimpleLongScore::negate()",
           "new": "method Score_ org.optaplanner.core.api.score.Score<Score_ extends org.optaplanner.core.api.score.Score<Score_>>::negate() @ org.optaplanner.core.api.score.buildin.simplelong.SimpleLongScore",
           "justification": "Implementation moved to a default method on an interface."
+        },
+        {
+          "ignore": true,
+          "code": "java.method.parameterTypeParameterChanged",
+          "old": "parameter <A> org.optaplanner.core.api.score.stream.uni.UniConstraintCollector<A, ?, A> org.optaplanner.core.api.score.stream.ConstraintCollectors::max(===java.util.Comparator<A>===)",
+          "new": "parameter <A> org.optaplanner.core.api.score.stream.uni.UniConstraintCollector<A, ?, A> org.optaplanner.core.api.score.stream.ConstraintCollectors::max(===java.util.Comparator<? super A>===)",
+          "parameterIndex": "0",
+          "justification": "Apply the PECS principle to support a wider range of types, such as LocalDateTime."
+        },
+        {
+          "ignore": true,
+          "code": "java.method.parameterTypeParameterChanged",
+          "old": "parameter <A, B, Mapped> org.optaplanner.core.api.score.stream.bi.BiConstraintCollector<A, B, ?, Mapped> org.optaplanner.core.api.score.stream.ConstraintCollectors::max(java.util.function.BiFunction<A, B, Mapped>, ===java.util.Comparator<Mapped>===)",
+          "new": "parameter <A, B, Mapped> org.optaplanner.core.api.score.stream.bi.BiConstraintCollector<A, B, ?, Mapped> org.optaplanner.core.api.score.stream.ConstraintCollectors::max(java.util.function.BiFunction<A, B, Mapped>, ===java.util.Comparator<? super Mapped>===)",
+          "parameterIndex": "1",
+          "justification": "Apply the PECS principle to support a wider range of types, such as LocalDateTime."
+        },
+        {
+          "ignore": true,
+          "code": "java.method.parameterTypeParameterChanged",
+          "old": "parameter <A, Mapped> org.optaplanner.core.api.score.stream.uni.UniConstraintCollector<A, ?, Mapped> org.optaplanner.core.api.score.stream.ConstraintCollectors::max(java.util.function.Function<A, Mapped>, ===java.util.Comparator<Mapped>===)",
+          "new": "parameter <A, Mapped> org.optaplanner.core.api.score.stream.uni.UniConstraintCollector<A, ?, Mapped> org.optaplanner.core.api.score.stream.ConstraintCollectors::max(java.util.function.Function<A, Mapped>, ===java.util.Comparator<? super Mapped>===)",
+          "parameterIndex": "1",
+          "justification": "Apply the PECS principle to support a wider range of types, such as LocalDateTime."
+        },
+        {
+          "ignore": true,
+          "code": "java.method.parameterTypeParameterChanged",
+          "old": "parameter <A, B, C, D, Mapped> org.optaplanner.core.api.score.stream.quad.QuadConstraintCollector<A, B, C, D, ?, Mapped> org.optaplanner.core.api.score.stream.ConstraintCollectors::max(org.optaplanner.core.api.function.QuadFunction<A, B, C, D, Mapped>, ===java.util.Comparator<Mapped>===)",
+          "new": "parameter <A, B, C, D, Mapped> org.optaplanner.core.api.score.stream.quad.QuadConstraintCollector<A, B, C, D, ?, Mapped> org.optaplanner.core.api.score.stream.ConstraintCollectors::max(org.optaplanner.core.api.function.QuadFunction<A, B, C, D, Mapped>, ===java.util.Comparator<? super Mapped>===)",
+          "parameterIndex": "1",
+          "justification": "Apply the PECS principle to support a wider range of types, such as LocalDateTime."
+        },
+        {
+          "ignore": true,
+          "code": "java.method.parameterTypeParameterChanged",
+          "old": "parameter <A, B, C, Mapped> org.optaplanner.core.api.score.stream.tri.TriConstraintCollector<A, B, C, ?, Mapped> org.optaplanner.core.api.score.stream.ConstraintCollectors::max(org.optaplanner.core.api.function.TriFunction<A, B, C, Mapped>, ===java.util.Comparator<Mapped>===)",
+          "new": "parameter <A, B, C, Mapped> org.optaplanner.core.api.score.stream.tri.TriConstraintCollector<A, B, C, ?, Mapped> org.optaplanner.core.api.score.stream.ConstraintCollectors::max(org.optaplanner.core.api.function.TriFunction<A, B, C, Mapped>, ===java.util.Comparator<? super Mapped>===)",
+          "parameterIndex": "1",
+          "justification": "Apply the PECS principle to support a wider range of types, such as LocalDateTime."
+        },
+        {
+          "ignore": true,
+          "code": "java.method.parameterTypeParameterChanged",
+          "old": "parameter <A, B, Mapped extends java.lang.Comparable<Mapped>> org.optaplanner.core.api.score.stream.bi.BiConstraintCollector<A, B, ?, Mapped> org.optaplanner.core.api.score.stream.ConstraintCollectors::max(===java.util.function.BiFunction<A, B, Mapped>===)",
+          "new": "parameter <A, B, Mapped extends java.lang.Comparable<? super Mapped>> org.optaplanner.core.api.score.stream.bi.BiConstraintCollector<A, B, ?, Mapped> org.optaplanner.core.api.score.stream.ConstraintCollectors::max(===java.util.function.BiFunction<A, B, Mapped>===)",
+          "parameterIndex": "0",
+          "justification": "Apply the PECS principle to support a wider range of types, such as LocalDateTime."
+        },
+        {
+          "ignore": true,
+          "code": "java.method.returnTypeTypeParametersChanged",
+          "old": "method <A, B, Mapped extends java.lang.Comparable<Mapped>> org.optaplanner.core.api.score.stream.bi.BiConstraintCollector<A, B, ?, Mapped> org.optaplanner.core.api.score.stream.ConstraintCollectors::max(java.util.function.BiFunction<A, B, Mapped>)",
+          "new": "method <A, B, Mapped extends java.lang.Comparable<? super Mapped>> org.optaplanner.core.api.score.stream.bi.BiConstraintCollector<A, B, ?, Mapped> org.optaplanner.core.api.score.stream.ConstraintCollectors::max(java.util.function.BiFunction<A, B, Mapped>)",
+          "justification": "Apply the PECS principle to support a wider range of types, such as LocalDateTime."
+        },
+        {
+          "ignore": true,
+          "code": "java.generics.formalTypeParameterChanged",
+          "old": "method <A, B, Mapped extends java.lang.Comparable<Mapped>> org.optaplanner.core.api.score.stream.bi.BiConstraintCollector<A, B, ?, Mapped> org.optaplanner.core.api.score.stream.ConstraintCollectors::max(java.util.function.BiFunction<A, B, Mapped>)",
+          "new": "method <A, B, Mapped extends java.lang.Comparable<? super Mapped>> org.optaplanner.core.api.score.stream.bi.BiConstraintCollector<A, B, ?, Mapped> org.optaplanner.core.api.score.stream.ConstraintCollectors::max(java.util.function.BiFunction<A, B, Mapped>)",
+          "justification": "Apply the PECS principle to support a wider range of types, such as LocalDateTime."
+        },
+        {
+          "ignore": true,
+          "code": "java.method.parameterTypeParameterChanged",
+          "old": "parameter <A, Mapped extends java.lang.Comparable<Mapped>> org.optaplanner.core.api.score.stream.uni.UniConstraintCollector<A, ?, Mapped> org.optaplanner.core.api.score.stream.ConstraintCollectors::max(===java.util.function.Function<A, Mapped>===)",
+          "new": "parameter <A, Mapped extends java.lang.Comparable<? super Mapped>> org.optaplanner.core.api.score.stream.uni.UniConstraintCollector<A, ?, Mapped> org.optaplanner.core.api.score.stream.ConstraintCollectors::max(===java.util.function.Function<A, Mapped>===)",
+          "parameterIndex": "0",
+          "justification": "Apply the PECS principle to support a wider range of types, such as LocalDateTime."
+        },
+        {
+          "ignore": true,
+          "code": "java.method.returnTypeTypeParametersChanged",
+          "old": "method <A, Mapped extends java.lang.Comparable<Mapped>> org.optaplanner.core.api.score.stream.uni.UniConstraintCollector<A, ?, Mapped> org.optaplanner.core.api.score.stream.ConstraintCollectors::max(java.util.function.Function<A, Mapped>)",
+          "new": "method <A, Mapped extends java.lang.Comparable<? super Mapped>> org.optaplanner.core.api.score.stream.uni.UniConstraintCollector<A, ?, Mapped> org.optaplanner.core.api.score.stream.ConstraintCollectors::max(java.util.function.Function<A, Mapped>)",
+          "justification": "Apply the PECS principle to support a wider range of types, such as LocalDateTime."
+        },
+        {
+          "ignore": true,
+          "code": "java.generics.formalTypeParameterChanged",
+          "old": "method <A, Mapped extends java.lang.Comparable<Mapped>> org.optaplanner.core.api.score.stream.uni.UniConstraintCollector<A, ?, Mapped> org.optaplanner.core.api.score.stream.ConstraintCollectors::max(java.util.function.Function<A, Mapped>)",
+          "new": "method <A, Mapped extends java.lang.Comparable<? super Mapped>> org.optaplanner.core.api.score.stream.uni.UniConstraintCollector<A, ?, Mapped> org.optaplanner.core.api.score.stream.ConstraintCollectors::max(java.util.function.Function<A, Mapped>)",
+          "justification": "Apply the PECS principle to support a wider range of types, such as LocalDateTime."
+        },
+        {
+          "ignore": true,
+          "code": "java.method.parameterTypeParameterChanged",
+          "old": "parameter <A, B, C, D, Mapped extends java.lang.Comparable<Mapped>> org.optaplanner.core.api.score.stream.quad.QuadConstraintCollector<A, B, C, D, ?, Mapped> org.optaplanner.core.api.score.stream.ConstraintCollectors::max(===org.optaplanner.core.api.function.QuadFunction<A, B, C, D, Mapped>===)",
+          "new": "parameter <A, B, C, D, Mapped extends java.lang.Comparable<? super Mapped>> org.optaplanner.core.api.score.stream.quad.QuadConstraintCollector<A, B, C, D, ?, Mapped> org.optaplanner.core.api.score.stream.ConstraintCollectors::max(===org.optaplanner.core.api.function.QuadFunction<A, B, C, D, Mapped>===)",
+          "parameterIndex": "0",
+          "justification": "Apply the PECS principle to support a wider range of types, such as LocalDateTime."
+        },
+        {
+          "ignore": true,
+          "code": "java.method.returnTypeTypeParametersChanged",
+          "old": "method <A, B, C, D, Mapped extends java.lang.Comparable<Mapped>> org.optaplanner.core.api.score.stream.quad.QuadConstraintCollector<A, B, C, D, ?, Mapped> org.optaplanner.core.api.score.stream.ConstraintCollectors::max(org.optaplanner.core.api.function.QuadFunction<A, B, C, D, Mapped>)",
+          "new": "method <A, B, C, D, Mapped extends java.lang.Comparable<? super Mapped>> org.optaplanner.core.api.score.stream.quad.QuadConstraintCollector<A, B, C, D, ?, Mapped> org.optaplanner.core.api.score.stream.ConstraintCollectors::max(org.optaplanner.core.api.function.QuadFunction<A, B, C, D, Mapped>)",
+          "justification": "Apply the PECS principle to support a wider range of types, such as LocalDateTime."
+        },
+        {
+          "ignore": true,
+          "code": "java.generics.formalTypeParameterChanged",
+          "old": "method <A, B, C, D, Mapped extends java.lang.Comparable<Mapped>> org.optaplanner.core.api.score.stream.quad.QuadConstraintCollector<A, B, C, D, ?, Mapped> org.optaplanner.core.api.score.stream.ConstraintCollectors::max(org.optaplanner.core.api.function.QuadFunction<A, B, C, D, Mapped>)",
+          "new": "method <A, B, C, D, Mapped extends java.lang.Comparable<? super Mapped>> org.optaplanner.core.api.score.stream.quad.QuadConstraintCollector<A, B, C, D, ?, Mapped> org.optaplanner.core.api.score.stream.ConstraintCollectors::max(org.optaplanner.core.api.function.QuadFunction<A, B, C, D, Mapped>)",
+          "justification": "Apply the PECS principle to support a wider range of types, such as LocalDateTime."
+        },
+        {
+          "ignore": true,
+          "code": "java.method.parameterTypeParameterChanged",
+          "old": "parameter <A, B, C, Mapped extends java.lang.Comparable<Mapped>> org.optaplanner.core.api.score.stream.tri.TriConstraintCollector<A, B, C, ?, Mapped> org.optaplanner.core.api.score.stream.ConstraintCollectors::max(===org.optaplanner.core.api.function.TriFunction<A, B, C, Mapped>===)",
+          "new": "parameter <A, B, C, Mapped extends java.lang.Comparable<? super Mapped>> org.optaplanner.core.api.score.stream.tri.TriConstraintCollector<A, B, C, ?, Mapped> org.optaplanner.core.api.score.stream.ConstraintCollectors::max(===org.optaplanner.core.api.function.TriFunction<A, B, C, Mapped>===)",
+          "parameterIndex": "0",
+          "justification": "Apply the PECS principle to support a wider range of types, such as LocalDateTime."
+        },
+        {
+          "ignore": true,
+          "code": "java.method.returnTypeTypeParametersChanged",
+          "old": "method <A, B, C, Mapped extends java.lang.Comparable<Mapped>> org.optaplanner.core.api.score.stream.tri.TriConstraintCollector<A, B, C, ?, Mapped> org.optaplanner.core.api.score.stream.ConstraintCollectors::max(org.optaplanner.core.api.function.TriFunction<A, B, C, Mapped>)",
+          "new": "method <A, B, C, Mapped extends java.lang.Comparable<? super Mapped>> org.optaplanner.core.api.score.stream.tri.TriConstraintCollector<A, B, C, ?, Mapped> org.optaplanner.core.api.score.stream.ConstraintCollectors::max(org.optaplanner.core.api.function.TriFunction<A, B, C, Mapped>)",
+          "justification": "Apply the PECS principle to support a wider range of types, such as LocalDateTime."
+        },
+        {
+          "ignore": true,
+          "code": "java.generics.formalTypeParameterChanged",
+          "old": "method <A, B, C, Mapped extends java.lang.Comparable<Mapped>> org.optaplanner.core.api.score.stream.tri.TriConstraintCollector<A, B, C, ?, Mapped> org.optaplanner.core.api.score.stream.ConstraintCollectors::max(org.optaplanner.core.api.function.TriFunction<A, B, C, Mapped>)",
+          "new": "method <A, B, C, Mapped extends java.lang.Comparable<? super Mapped>> org.optaplanner.core.api.score.stream.tri.TriConstraintCollector<A, B, C, ?, Mapped> org.optaplanner.core.api.score.stream.ConstraintCollectors::max(org.optaplanner.core.api.function.TriFunction<A, B, C, Mapped>)",
+          "justification": "Apply the PECS principle to support a wider range of types, such as LocalDateTime."
+        },
+        {
+          "ignore": true,
+          "code": "java.method.parameterTypeParameterChanged",
+          "old": "parameter <A> org.optaplanner.core.api.score.stream.uni.UniConstraintCollector<A, ?, A> org.optaplanner.core.api.score.stream.ConstraintCollectors::min(===java.util.Comparator<A>===)",
+          "new": "parameter <A> org.optaplanner.core.api.score.stream.uni.UniConstraintCollector<A, ?, A> org.optaplanner.core.api.score.stream.ConstraintCollectors::min(===java.util.Comparator<? super A>===)",
+          "parameterIndex": "0",
+          "justification": "Apply the PECS principle to support a wider range of types, such as LocalDateTime."
+        },
+        {
+          "ignore": true,
+          "code": "java.method.parameterTypeParameterChanged",
+          "old": "parameter <A, B, Mapped> org.optaplanner.core.api.score.stream.bi.BiConstraintCollector<A, B, ?, Mapped> org.optaplanner.core.api.score.stream.ConstraintCollectors::min(java.util.function.BiFunction<A, B, Mapped>, ===java.util.Comparator<Mapped>===)",
+          "new": "parameter <A, B, Mapped> org.optaplanner.core.api.score.stream.bi.BiConstraintCollector<A, B, ?, Mapped> org.optaplanner.core.api.score.stream.ConstraintCollectors::min(java.util.function.BiFunction<A, B, Mapped>, ===java.util.Comparator<? super Mapped>===)",
+          "parameterIndex": "1",
+          "justification": "Apply the PECS principle to support a wider range of types, such as LocalDateTime."
+        },
+        {
+          "ignore": true,
+          "code": "java.method.parameterTypeParameterChanged",
+          "old": "parameter <A, Mapped> org.optaplanner.core.api.score.stream.uni.UniConstraintCollector<A, ?, Mapped> org.optaplanner.core.api.score.stream.ConstraintCollectors::min(java.util.function.Function<A, Mapped>, ===java.util.Comparator<Mapped>===)",
+          "new": "parameter <A, Mapped> org.optaplanner.core.api.score.stream.uni.UniConstraintCollector<A, ?, Mapped> org.optaplanner.core.api.score.stream.ConstraintCollectors::min(java.util.function.Function<A, Mapped>, ===java.util.Comparator<? super Mapped>===)",
+          "parameterIndex": "1",
+          "justification": "Apply the PECS principle to support a wider range of types, such as LocalDateTime."
+        },
+        {
+          "ignore": true,
+          "code": "java.method.parameterTypeParameterChanged",
+          "old": "parameter <A, B, C, D, Mapped> org.optaplanner.core.api.score.stream.quad.QuadConstraintCollector<A, B, C, D, ?, Mapped> org.optaplanner.core.api.score.stream.ConstraintCollectors::min(org.optaplanner.core.api.function.QuadFunction<A, B, C, D, Mapped>, ===java.util.Comparator<Mapped>===)",
+          "new": "parameter <A, B, C, D, Mapped> org.optaplanner.core.api.score.stream.quad.QuadConstraintCollector<A, B, C, D, ?, Mapped> org.optaplanner.core.api.score.stream.ConstraintCollectors::min(org.optaplanner.core.api.function.QuadFunction<A, B, C, D, Mapped>, ===java.util.Comparator<? super Mapped>===)",
+          "parameterIndex": "1",
+          "justification": "Apply the PECS principle to support a wider range of types, such as LocalDateTime."
+        },
+        {
+          "ignore": true,
+          "code": "java.method.parameterTypeParameterChanged",
+          "old": "parameter <A, B, C, Mapped> org.optaplanner.core.api.score.stream.tri.TriConstraintCollector<A, B, C, ?, Mapped> org.optaplanner.core.api.score.stream.ConstraintCollectors::min(org.optaplanner.core.api.function.TriFunction<A, B, C, Mapped>, ===java.util.Comparator<Mapped>===)",
+          "new": "parameter <A, B, C, Mapped> org.optaplanner.core.api.score.stream.tri.TriConstraintCollector<A, B, C, ?, Mapped> org.optaplanner.core.api.score.stream.ConstraintCollectors::min(org.optaplanner.core.api.function.TriFunction<A, B, C, Mapped>, ===java.util.Comparator<? super Mapped>===)",
+          "parameterIndex": "1",
+          "justification": "Apply the PECS principle to support a wider range of types, such as LocalDateTime."
+        },
+        {
+          "ignore": true,
+          "code": "java.method.parameterTypeParameterChanged",
+          "old": "parameter <A, B, Mapped extends java.lang.Comparable<Mapped>> org.optaplanner.core.api.score.stream.bi.BiConstraintCollector<A, B, ?, Mapped> org.optaplanner.core.api.score.stream.ConstraintCollectors::min(===java.util.function.BiFunction<A, B, Mapped>===)",
+          "new": "parameter <A, B, Mapped extends java.lang.Comparable<? super Mapped>> org.optaplanner.core.api.score.stream.bi.BiConstraintCollector<A, B, ?, Mapped> org.optaplanner.core.api.score.stream.ConstraintCollectors::min(===java.util.function.BiFunction<A, B, Mapped>===)",
+          "parameterIndex": "0",
+          "justification": "Apply the PECS principle to support a wider range of types, such as LocalDateTime."
+        },
+        {
+          "ignore": true,
+          "code": "java.method.returnTypeTypeParametersChanged",
+          "old": "method <A, B, Mapped extends java.lang.Comparable<Mapped>> org.optaplanner.core.api.score.stream.bi.BiConstraintCollector<A, B, ?, Mapped> org.optaplanner.core.api.score.stream.ConstraintCollectors::min(java.util.function.BiFunction<A, B, Mapped>)",
+          "new": "method <A, B, Mapped extends java.lang.Comparable<? super Mapped>> org.optaplanner.core.api.score.stream.bi.BiConstraintCollector<A, B, ?, Mapped> org.optaplanner.core.api.score.stream.ConstraintCollectors::min(java.util.function.BiFunction<A, B, Mapped>)",
+          "justification": "Apply the PECS principle to support a wider range of types, such as LocalDateTime."
+        },
+        {
+          "ignore": true,
+          "code": "java.generics.formalTypeParameterChanged",
+          "old": "method <A, B, Mapped extends java.lang.Comparable<Mapped>> org.optaplanner.core.api.score.stream.bi.BiConstraintCollector<A, B, ?, Mapped> org.optaplanner.core.api.score.stream.ConstraintCollectors::min(java.util.function.BiFunction<A, B, Mapped>)",
+          "new": "method <A, B, Mapped extends java.lang.Comparable<? super Mapped>> org.optaplanner.core.api.score.stream.bi.BiConstraintCollector<A, B, ?, Mapped> org.optaplanner.core.api.score.stream.ConstraintCollectors::min(java.util.function.BiFunction<A, B, Mapped>)",
+          "justification": "Apply the PECS principle to support a wider range of types, such as LocalDateTime."
+        },
+        {
+          "ignore": true,
+          "code": "java.method.parameterTypeParameterChanged",
+          "old": "parameter <A, Mapped extends java.lang.Comparable<Mapped>> org.optaplanner.core.api.score.stream.uni.UniConstraintCollector<A, ?, Mapped> org.optaplanner.core.api.score.stream.ConstraintCollectors::min(===java.util.function.Function<A, Mapped>===)",
+          "new": "parameter <A, Mapped extends java.lang.Comparable<? super Mapped>> org.optaplanner.core.api.score.stream.uni.UniConstraintCollector<A, ?, Mapped> org.optaplanner.core.api.score.stream.ConstraintCollectors::min(===java.util.function.Function<A, Mapped>===)",
+          "parameterIndex": "0",
+          "justification": "Apply the PECS principle to support a wider range of types, such as LocalDateTime."
+        },
+        {
+          "ignore": true,
+          "code": "java.method.returnTypeTypeParametersChanged",
+          "old": "method <A, Mapped extends java.lang.Comparable<Mapped>> org.optaplanner.core.api.score.stream.uni.UniConstraintCollector<A, ?, Mapped> org.optaplanner.core.api.score.stream.ConstraintCollectors::min(java.util.function.Function<A, Mapped>)",
+          "new": "method <A, Mapped extends java.lang.Comparable<? super Mapped>> org.optaplanner.core.api.score.stream.uni.UniConstraintCollector<A, ?, Mapped> org.optaplanner.core.api.score.stream.ConstraintCollectors::min(java.util.function.Function<A, Mapped>)",
+          "justification": "Apply the PECS principle to support a wider range of types, such as LocalDateTime."
+        },
+        {
+          "ignore": true,
+          "code": "java.generics.formalTypeParameterChanged",
+          "old": "method <A, Mapped extends java.lang.Comparable<Mapped>> org.optaplanner.core.api.score.stream.uni.UniConstraintCollector<A, ?, Mapped> org.optaplanner.core.api.score.stream.ConstraintCollectors::min(java.util.function.Function<A, Mapped>)",
+          "new": "method <A, Mapped extends java.lang.Comparable<? super Mapped>> org.optaplanner.core.api.score.stream.uni.UniConstraintCollector<A, ?, Mapped> org.optaplanner.core.api.score.stream.ConstraintCollectors::min(java.util.function.Function<A, Mapped>)",
+          "justification": "Apply the PECS principle to support a wider range of types, such as LocalDateTime."
+        },
+        {
+          "ignore": true,
+          "code": "java.method.parameterTypeParameterChanged",
+          "old": "parameter <A, B, C, D, Mapped extends java.lang.Comparable<Mapped>> org.optaplanner.core.api.score.stream.quad.QuadConstraintCollector<A, B, C, D, ?, Mapped> org.optaplanner.core.api.score.stream.ConstraintCollectors::min(===org.optaplanner.core.api.function.QuadFunction<A, B, C, D, Mapped>===)",
+          "new": "parameter <A, B, C, D, Mapped extends java.lang.Comparable<? super Mapped>> org.optaplanner.core.api.score.stream.quad.QuadConstraintCollector<A, B, C, D, ?, Mapped> org.optaplanner.core.api.score.stream.ConstraintCollectors::min(===org.optaplanner.core.api.function.QuadFunction<A, B, C, D, Mapped>===)",
+          "parameterIndex": "0",
+          "justification": "Apply the PECS principle to support a wider range of types, such as LocalDateTime."
+        },
+        {
+          "ignore": true,
+          "code": "java.method.returnTypeTypeParametersChanged",
+          "old": "method <A, B, C, D, Mapped extends java.lang.Comparable<Mapped>> org.optaplanner.core.api.score.stream.quad.QuadConstraintCollector<A, B, C, D, ?, Mapped> org.optaplanner.core.api.score.stream.ConstraintCollectors::min(org.optaplanner.core.api.function.QuadFunction<A, B, C, D, Mapped>)",
+          "new": "method <A, B, C, D, Mapped extends java.lang.Comparable<? super Mapped>> org.optaplanner.core.api.score.stream.quad.QuadConstraintCollector<A, B, C, D, ?, Mapped> org.optaplanner.core.api.score.stream.ConstraintCollectors::min(org.optaplanner.core.api.function.QuadFunction<A, B, C, D, Mapped>)",
+          "justification": "Apply the PECS principle to support a wider range of types, such as LocalDateTime."
+        },
+        {
+          "ignore": true,
+          "code": "java.generics.formalTypeParameterChanged",
+          "old": "method <A, B, C, D, Mapped extends java.lang.Comparable<Mapped>> org.optaplanner.core.api.score.stream.quad.QuadConstraintCollector<A, B, C, D, ?, Mapped> org.optaplanner.core.api.score.stream.ConstraintCollectors::min(org.optaplanner.core.api.function.QuadFunction<A, B, C, D, Mapped>)",
+          "new": "method <A, B, C, D, Mapped extends java.lang.Comparable<? super Mapped>> org.optaplanner.core.api.score.stream.quad.QuadConstraintCollector<A, B, C, D, ?, Mapped> org.optaplanner.core.api.score.stream.ConstraintCollectors::min(org.optaplanner.core.api.function.QuadFunction<A, B, C, D, Mapped>)",
+          "justification": "Apply the PECS principle to support a wider range of types, such as LocalDateTime."
+        },
+        {
+          "ignore": true,
+          "code": "java.method.parameterTypeParameterChanged",
+          "old": "parameter <A, B, C, Mapped extends java.lang.Comparable<Mapped>> org.optaplanner.core.api.score.stream.tri.TriConstraintCollector<A, B, C, ?, Mapped> org.optaplanner.core.api.score.stream.ConstraintCollectors::min(===org.optaplanner.core.api.function.TriFunction<A, B, C, Mapped>===)",
+          "new": "parameter <A, B, C, Mapped extends java.lang.Comparable<? super Mapped>> org.optaplanner.core.api.score.stream.tri.TriConstraintCollector<A, B, C, ?, Mapped> org.optaplanner.core.api.score.stream.ConstraintCollectors::min(===org.optaplanner.core.api.function.TriFunction<A, B, C, Mapped>===)",
+          "parameterIndex": "0",
+          "justification": "Apply the PECS principle to support a wider range of types, such as LocalDateTime."
+        },
+        {
+          "ignore": true,
+          "code": "java.method.returnTypeTypeParametersChanged",
+          "old": "method <A, B, C, Mapped extends java.lang.Comparable<Mapped>> org.optaplanner.core.api.score.stream.tri.TriConstraintCollector<A, B, C, ?, Mapped> org.optaplanner.core.api.score.stream.ConstraintCollectors::min(org.optaplanner.core.api.function.TriFunction<A, B, C, Mapped>)",
+          "new": "method <A, B, C, Mapped extends java.lang.Comparable<? super Mapped>> org.optaplanner.core.api.score.stream.tri.TriConstraintCollector<A, B, C, ?, Mapped> org.optaplanner.core.api.score.stream.ConstraintCollectors::min(org.optaplanner.core.api.function.TriFunction<A, B, C, Mapped>)",
+          "justification": "Apply the PECS principle to support a wider range of types, such as LocalDateTime."
+        },
+        {
+          "ignore": true,
+          "code": "java.generics.formalTypeParameterChanged",
+          "old": "method <A, B, C, Mapped extends java.lang.Comparable<Mapped>> org.optaplanner.core.api.score.stream.tri.TriConstraintCollector<A, B, C, ?, Mapped> org.optaplanner.core.api.score.stream.ConstraintCollectors::min(org.optaplanner.core.api.function.TriFunction<A, B, C, Mapped>)",
+          "new": "method <A, B, C, Mapped extends java.lang.Comparable<? super Mapped>> org.optaplanner.core.api.score.stream.tri.TriConstraintCollector<A, B, C, ?, Mapped> org.optaplanner.core.api.score.stream.ConstraintCollectors::min(org.optaplanner.core.api.function.TriFunction<A, B, C, Mapped>)",
+          "justification": "Apply the PECS principle to support a wider range of types, such as LocalDateTime."
+        },
+        {
+          "ignore": true,
+          "code": "java.method.parameterTypeParameterChanged",
+          "old": "parameter <A, B, Key extends java.lang.Comparable<Key>, Value> org.optaplanner.core.api.score.stream.bi.BiConstraintCollector<A, B, ?, java.util.SortedMap<Key, java.util.Set<Value>>> org.optaplanner.core.api.score.stream.ConstraintCollectors::toSortedMap(===java.util.function.BiFunction<? super A, ? super B, ? extends Key>===, java.util.function.BiFunction<? super A, ? super B, ? extends Value>)",
+          "new": "parameter <A, B, Key extends java.lang.Comparable<? super Key>, Value> org.optaplanner.core.api.score.stream.bi.BiConstraintCollector<A, B, ?, java.util.SortedMap<Key, java.util.Set<Value>>> org.optaplanner.core.api.score.stream.ConstraintCollectors::toSortedMap(===java.util.function.BiFunction<? super A, ? super B, ? extends Key>===, java.util.function.BiFunction<? super A, ? super B, ? extends Value>)",
+          "parameterIndex": "0",
+          "justification": "Apply the PECS principle to support a wider range of types, such as LocalDateTime."
+        },
+        {
+          "ignore": true,
+          "code": "java.method.returnTypeTypeParametersChanged",
+          "old": "method <A, B, Key extends java.lang.Comparable<Key>, Value> org.optaplanner.core.api.score.stream.bi.BiConstraintCollector<A, B, ?, java.util.SortedMap<Key, java.util.Set<Value>>> org.optaplanner.core.api.score.stream.ConstraintCollectors::toSortedMap(java.util.function.BiFunction<? super A, ? super B, ? extends Key>, java.util.function.BiFunction<? super A, ? super B, ? extends Value>)",
+          "new": "method <A, B, Key extends java.lang.Comparable<? super Key>, Value> org.optaplanner.core.api.score.stream.bi.BiConstraintCollector<A, B, ?, java.util.SortedMap<Key, java.util.Set<Value>>> org.optaplanner.core.api.score.stream.ConstraintCollectors::toSortedMap(java.util.function.BiFunction<? super A, ? super B, ? extends Key>, java.util.function.BiFunction<? super A, ? super B, ? extends Value>)",
+          "justification": "Apply the PECS principle to support a wider range of types, such as LocalDateTime."
+        },
+        {
+          "ignore": true,
+          "code": "java.generics.formalTypeParameterChanged",
+          "old": "method <A, B, Key extends java.lang.Comparable<Key>, Value> org.optaplanner.core.api.score.stream.bi.BiConstraintCollector<A, B, ?, java.util.SortedMap<Key, java.util.Set<Value>>> org.optaplanner.core.api.score.stream.ConstraintCollectors::toSortedMap(java.util.function.BiFunction<? super A, ? super B, ? extends Key>, java.util.function.BiFunction<? super A, ? super B, ? extends Value>)",
+          "new": "method <A, B, Key extends java.lang.Comparable<? super Key>, Value> org.optaplanner.core.api.score.stream.bi.BiConstraintCollector<A, B, ?, java.util.SortedMap<Key, java.util.Set<Value>>> org.optaplanner.core.api.score.stream.ConstraintCollectors::toSortedMap(java.util.function.BiFunction<? super A, ? super B, ? extends Key>, java.util.function.BiFunction<? super A, ? super B, ? extends Value>)",
+          "justification": "Apply the PECS principle to support a wider range of types, such as LocalDateTime."
+        },
+        {
+          "ignore": true,
+          "code": "java.method.parameterTypeParameterChanged",
+          "old": "parameter <A, Key extends java.lang.Comparable<Key>, Value> org.optaplanner.core.api.score.stream.uni.UniConstraintCollector<A, ?, java.util.SortedMap<Key, java.util.Set<Value>>> org.optaplanner.core.api.score.stream.ConstraintCollectors::toSortedMap(===java.util.function.Function<? super A, ? extends Key>===, java.util.function.Function<? super A, ? extends Value>)",
+          "new": "parameter <A, Key extends java.lang.Comparable<? super Key>, Value> org.optaplanner.core.api.score.stream.uni.UniConstraintCollector<A, ?, java.util.SortedMap<Key, java.util.Set<Value>>> org.optaplanner.core.api.score.stream.ConstraintCollectors::toSortedMap(===java.util.function.Function<? super A, ? extends Key>===, java.util.function.Function<? super A, ? extends Value>)",
+          "parameterIndex": "0",
+          "justification": "Apply the PECS principle to support a wider range of types, such as LocalDateTime."
+        },
+        {
+          "ignore": true,
+          "code": "java.method.returnTypeTypeParametersChanged",
+          "old": "method <A, Key extends java.lang.Comparable<Key>, Value> org.optaplanner.core.api.score.stream.uni.UniConstraintCollector<A, ?, java.util.SortedMap<Key, java.util.Set<Value>>> org.optaplanner.core.api.score.stream.ConstraintCollectors::toSortedMap(java.util.function.Function<? super A, ? extends Key>, java.util.function.Function<? super A, ? extends Value>)",
+          "new": "method <A, Key extends java.lang.Comparable<? super Key>, Value> org.optaplanner.core.api.score.stream.uni.UniConstraintCollector<A, ?, java.util.SortedMap<Key, java.util.Set<Value>>> org.optaplanner.core.api.score.stream.ConstraintCollectors::toSortedMap(java.util.function.Function<? super A, ? extends Key>, java.util.function.Function<? super A, ? extends Value>)",
+          "justification": "Apply the PECS principle to support a wider range of types, such as LocalDateTime."
+        },
+        {
+          "ignore": true,
+          "code": "java.generics.formalTypeParameterChanged",
+          "old": "method <A, Key extends java.lang.Comparable<Key>, Value> org.optaplanner.core.api.score.stream.uni.UniConstraintCollector<A, ?, java.util.SortedMap<Key, java.util.Set<Value>>> org.optaplanner.core.api.score.stream.ConstraintCollectors::toSortedMap(java.util.function.Function<? super A, ? extends Key>, java.util.function.Function<? super A, ? extends Value>)",
+          "new": "method <A, Key extends java.lang.Comparable<? super Key>, Value> org.optaplanner.core.api.score.stream.uni.UniConstraintCollector<A, ?, java.util.SortedMap<Key, java.util.Set<Value>>> org.optaplanner.core.api.score.stream.ConstraintCollectors::toSortedMap(java.util.function.Function<? super A, ? extends Key>, java.util.function.Function<? super A, ? extends Value>)",
+          "justification": "Apply the PECS principle to support a wider range of types, such as LocalDateTime."
+        },
+        {
+          "ignore": true,
+          "code": "java.method.parameterTypeParameterChanged",
+          "old": "parameter <A, B, C, D, Key extends java.lang.Comparable<Key>, Value> org.optaplanner.core.api.score.stream.quad.QuadConstraintCollector<A, B, C, D, ?, java.util.SortedMap<Key, java.util.Set<Value>>> org.optaplanner.core.api.score.stream.ConstraintCollectors::toSortedMap(===org.optaplanner.core.api.function.QuadFunction<? super A, ? super B, ? super C, ? super D, ? extends Key>===, org.optaplanner.core.api.function.QuadFunction<? super A, ? super B, ? super C, ? super D, ? extends Value>)",
+          "new": "parameter <A, B, C, D, Key extends java.lang.Comparable<? super Key>, Value> org.optaplanner.core.api.score.stream.quad.QuadConstraintCollector<A, B, C, D, ?, java.util.SortedMap<Key, java.util.Set<Value>>> org.optaplanner.core.api.score.stream.ConstraintCollectors::toSortedMap(===org.optaplanner.core.api.function.QuadFunction<? super A, ? super B, ? super C, ? super D, ? extends Key>===, org.optaplanner.core.api.function.QuadFunction<? super A, ? super B, ? super C, ? super D, ? extends Value>)",
+          "parameterIndex": "0",
+          "justification": "Apply the PECS principle to support a wider range of types, such as LocalDateTime."
+        },
+        {
+          "ignore": true,
+          "code": "java.method.returnTypeTypeParametersChanged",
+          "old": "method <A, B, C, D, Key extends java.lang.Comparable<Key>, Value> org.optaplanner.core.api.score.stream.quad.QuadConstraintCollector<A, B, C, D, ?, java.util.SortedMap<Key, java.util.Set<Value>>> org.optaplanner.core.api.score.stream.ConstraintCollectors::toSortedMap(org.optaplanner.core.api.function.QuadFunction<? super A, ? super B, ? super C, ? super D, ? extends Key>, org.optaplanner.core.api.function.QuadFunction<? super A, ? super B, ? super C, ? super D, ? extends Value>)",
+          "new": "method <A, B, C, D, Key extends java.lang.Comparable<? super Key>, Value> org.optaplanner.core.api.score.stream.quad.QuadConstraintCollector<A, B, C, D, ?, java.util.SortedMap<Key, java.util.Set<Value>>> org.optaplanner.core.api.score.stream.ConstraintCollectors::toSortedMap(org.optaplanner.core.api.function.QuadFunction<? super A, ? super B, ? super C, ? super D, ? extends Key>, org.optaplanner.core.api.function.QuadFunction<? super A, ? super B, ? super C, ? super D, ? extends Value>)",
+          "justification": "Apply the PECS principle to support a wider range of types, such as LocalDateTime."
+        },
+        {
+          "ignore": true,
+          "code": "java.generics.formalTypeParameterChanged",
+          "old": "method <A, B, C, D, Key extends java.lang.Comparable<Key>, Value> org.optaplanner.core.api.score.stream.quad.QuadConstraintCollector<A, B, C, D, ?, java.util.SortedMap<Key, java.util.Set<Value>>> org.optaplanner.core.api.score.stream.ConstraintCollectors::toSortedMap(org.optaplanner.core.api.function.QuadFunction<? super A, ? super B, ? super C, ? super D, ? extends Key>, org.optaplanner.core.api.function.QuadFunction<? super A, ? super B, ? super C, ? super D, ? extends Value>)",
+          "new": "method <A, B, C, D, Key extends java.lang.Comparable<? super Key>, Value> org.optaplanner.core.api.score.stream.quad.QuadConstraintCollector<A, B, C, D, ?, java.util.SortedMap<Key, java.util.Set<Value>>> org.optaplanner.core.api.score.stream.ConstraintCollectors::toSortedMap(org.optaplanner.core.api.function.QuadFunction<? super A, ? super B, ? super C, ? super D, ? extends Key>, org.optaplanner.core.api.function.QuadFunction<? super A, ? super B, ? super C, ? super D, ? extends Value>)",
+          "justification": "Apply the PECS principle to support a wider range of types, such as LocalDateTime."
+        },
+        {
+          "ignore": true,
+          "code": "java.method.parameterTypeParameterChanged",
+          "old": "parameter <A, B, C, Key extends java.lang.Comparable<Key>, Value> org.optaplanner.core.api.score.stream.tri.TriConstraintCollector<A, B, C, ?, java.util.SortedMap<Key, java.util.Set<Value>>> org.optaplanner.core.api.score.stream.ConstraintCollectors::toSortedMap(===org.optaplanner.core.api.function.TriFunction<? super A, ? super B, ? super C, ? extends Key>===, org.optaplanner.core.api.function.TriFunction<? super A, ? super B, ? super C, ? extends Value>)",
+          "new": "parameter <A, B, C, Key extends java.lang.Comparable<? super Key>, Value> org.optaplanner.core.api.score.stream.tri.TriConstraintCollector<A, B, C, ?, java.util.SortedMap<Key, java.util.Set<Value>>> org.optaplanner.core.api.score.stream.ConstraintCollectors::toSortedMap(===org.optaplanner.core.api.function.TriFunction<? super A, ? super B, ? super C, ? extends Key>===, org.optaplanner.core.api.function.TriFunction<? super A, ? super B, ? super C, ? extends Value>)",
+          "parameterIndex": "0",
+          "justification": "Apply the PECS principle to support a wider range of types, such as LocalDateTime."
+        },
+        {
+          "ignore": true,
+          "code": "java.method.returnTypeTypeParametersChanged",
+          "old": "method <A, B, C, Key extends java.lang.Comparable<Key>, Value> org.optaplanner.core.api.score.stream.tri.TriConstraintCollector<A, B, C, ?, java.util.SortedMap<Key, java.util.Set<Value>>> org.optaplanner.core.api.score.stream.ConstraintCollectors::toSortedMap(org.optaplanner.core.api.function.TriFunction<? super A, ? super B, ? super C, ? extends Key>, org.optaplanner.core.api.function.TriFunction<? super A, ? super B, ? super C, ? extends Value>)",
+          "new": "method <A, B, C, Key extends java.lang.Comparable<? super Key>, Value> org.optaplanner.core.api.score.stream.tri.TriConstraintCollector<A, B, C, ?, java.util.SortedMap<Key, java.util.Set<Value>>> org.optaplanner.core.api.score.stream.ConstraintCollectors::toSortedMap(org.optaplanner.core.api.function.TriFunction<? super A, ? super B, ? super C, ? extends Key>, org.optaplanner.core.api.function.TriFunction<? super A, ? super B, ? super C, ? extends Value>)",
+          "justification": "Apply the PECS principle to support a wider range of types, such as LocalDateTime."
+        },
+        {
+          "ignore": true,
+          "code": "java.generics.formalTypeParameterChanged",
+          "old": "method <A, B, C, Key extends java.lang.Comparable<Key>, Value> org.optaplanner.core.api.score.stream.tri.TriConstraintCollector<A, B, C, ?, java.util.SortedMap<Key, java.util.Set<Value>>> org.optaplanner.core.api.score.stream.ConstraintCollectors::toSortedMap(org.optaplanner.core.api.function.TriFunction<? super A, ? super B, ? super C, ? extends Key>, org.optaplanner.core.api.function.TriFunction<? super A, ? super B, ? super C, ? extends Value>)",
+          "new": "method <A, B, C, Key extends java.lang.Comparable<? super Key>, Value> org.optaplanner.core.api.score.stream.tri.TriConstraintCollector<A, B, C, ?, java.util.SortedMap<Key, java.util.Set<Value>>> org.optaplanner.core.api.score.stream.ConstraintCollectors::toSortedMap(org.optaplanner.core.api.function.TriFunction<? super A, ? super B, ? super C, ? extends Key>, org.optaplanner.core.api.function.TriFunction<? super A, ? super B, ? super C, ? extends Value>)",
+          "justification": "Apply the PECS principle to support a wider range of types, such as LocalDateTime."
+        },
+        {
+          "ignore": true,
+          "code": "java.method.parameterTypeParameterChanged",
+          "old": "parameter <A, B, Key extends java.lang.Comparable<Key>, Value> org.optaplanner.core.api.score.stream.bi.BiConstraintCollector<A, B, ?, java.util.SortedMap<Key, Value>> org.optaplanner.core.api.score.stream.ConstraintCollectors::toSortedMap(===java.util.function.BiFunction<? super A, ? super B, ? extends Key>===, java.util.function.BiFunction<? super A, ? super B, ? extends Value>, java.util.function.BinaryOperator<Value>)",
+          "new": "parameter <A, B, Key extends java.lang.Comparable<? super Key>, Value> org.optaplanner.core.api.score.stream.bi.BiConstraintCollector<A, B, ?, java.util.SortedMap<Key, Value>> org.optaplanner.core.api.score.stream.ConstraintCollectors::toSortedMap(===java.util.function.BiFunction<? super A, ? super B, ? extends Key>===, java.util.function.BiFunction<? super A, ? super B, ? extends Value>, java.util.function.BinaryOperator<Value>)",
+          "parameterIndex": "0",
+          "justification": "Apply the PECS principle to support a wider range of types, such as LocalDateTime."
+        },
+        {
+          "ignore": true,
+          "code": "java.method.returnTypeTypeParametersChanged",
+          "old": "method <A, B, Key extends java.lang.Comparable<Key>, Value> org.optaplanner.core.api.score.stream.bi.BiConstraintCollector<A, B, ?, java.util.SortedMap<Key, Value>> org.optaplanner.core.api.score.stream.ConstraintCollectors::toSortedMap(java.util.function.BiFunction<? super A, ? super B, ? extends Key>, java.util.function.BiFunction<? super A, ? super B, ? extends Value>, java.util.function.BinaryOperator<Value>)",
+          "new": "method <A, B, Key extends java.lang.Comparable<? super Key>, Value> org.optaplanner.core.api.score.stream.bi.BiConstraintCollector<A, B, ?, java.util.SortedMap<Key, Value>> org.optaplanner.core.api.score.stream.ConstraintCollectors::toSortedMap(java.util.function.BiFunction<? super A, ? super B, ? extends Key>, java.util.function.BiFunction<? super A, ? super B, ? extends Value>, java.util.function.BinaryOperator<Value>)",
+          "justification": "Apply the PECS principle to support a wider range of types, such as LocalDateTime."
+        },
+        {
+          "ignore": true,
+          "code": "java.generics.formalTypeParameterChanged",
+          "old": "method <A, B, Key extends java.lang.Comparable<Key>, Value> org.optaplanner.core.api.score.stream.bi.BiConstraintCollector<A, B, ?, java.util.SortedMap<Key, Value>> org.optaplanner.core.api.score.stream.ConstraintCollectors::toSortedMap(java.util.function.BiFunction<? super A, ? super B, ? extends Key>, java.util.function.BiFunction<? super A, ? super B, ? extends Value>, java.util.function.BinaryOperator<Value>)",
+          "new": "method <A, B, Key extends java.lang.Comparable<? super Key>, Value> org.optaplanner.core.api.score.stream.bi.BiConstraintCollector<A, B, ?, java.util.SortedMap<Key, Value>> org.optaplanner.core.api.score.stream.ConstraintCollectors::toSortedMap(java.util.function.BiFunction<? super A, ? super B, ? extends Key>, java.util.function.BiFunction<? super A, ? super B, ? extends Value>, java.util.function.BinaryOperator<Value>)",
+          "justification": "Apply the PECS principle to support a wider range of types, such as LocalDateTime."
+        },
+        {
+          "ignore": true,
+          "code": "java.method.parameterTypeParameterChanged",
+          "old": "parameter <A, B, Key extends java.lang.Comparable<Key>, Value, ValueSet extends java.util.Set<Value>> org.optaplanner.core.api.score.stream.bi.BiConstraintCollector<A, B, ?, java.util.SortedMap<Key, ValueSet>> org.optaplanner.core.api.score.stream.ConstraintCollectors::toSortedMap(===java.util.function.BiFunction<? super A, ? super B, ? extends Key>===, java.util.function.BiFunction<? super A, ? super B, ? extends Value>, java.util.function.IntFunction<ValueSet>)",
+          "new": "parameter <A, B, Key extends java.lang.Comparable<? super Key>, Value, ValueSet extends java.util.Set<Value>> org.optaplanner.core.api.score.stream.bi.BiConstraintCollector<A, B, ?, java.util.SortedMap<Key, ValueSet>> org.optaplanner.core.api.score.stream.ConstraintCollectors::toSortedMap(===java.util.function.BiFunction<? super A, ? super B, ? extends Key>===, java.util.function.BiFunction<? super A, ? super B, ? extends Value>, java.util.function.IntFunction<ValueSet>)",
+          "parameterIndex": "0",
+          "justification": "Apply the PECS principle to support a wider range of types, such as LocalDateTime."
+        },
+        {
+          "ignore": true,
+          "code": "java.method.returnTypeTypeParametersChanged",
+          "old": "method <A, B, Key extends java.lang.Comparable<Key>, Value, ValueSet extends java.util.Set<Value>> org.optaplanner.core.api.score.stream.bi.BiConstraintCollector<A, B, ?, java.util.SortedMap<Key, ValueSet>> org.optaplanner.core.api.score.stream.ConstraintCollectors::toSortedMap(java.util.function.BiFunction<? super A, ? super B, ? extends Key>, java.util.function.BiFunction<? super A, ? super B, ? extends Value>, java.util.function.IntFunction<ValueSet>)",
+          "new": "method <A, B, Key extends java.lang.Comparable<? super Key>, Value, ValueSet extends java.util.Set<Value>> org.optaplanner.core.api.score.stream.bi.BiConstraintCollector<A, B, ?, java.util.SortedMap<Key, ValueSet>> org.optaplanner.core.api.score.stream.ConstraintCollectors::toSortedMap(java.util.function.BiFunction<? super A, ? super B, ? extends Key>, java.util.function.BiFunction<? super A, ? super B, ? extends Value>, java.util.function.IntFunction<ValueSet>)",
+          "justification": "Apply the PECS principle to support a wider range of types, such as LocalDateTime."
+        },
+        {
+          "ignore": true,
+          "code": "java.generics.formalTypeParameterChanged",
+          "old": "method <A, B, Key extends java.lang.Comparable<Key>, Value, ValueSet extends java.util.Set<Value>> org.optaplanner.core.api.score.stream.bi.BiConstraintCollector<A, B, ?, java.util.SortedMap<Key, ValueSet>> org.optaplanner.core.api.score.stream.ConstraintCollectors::toSortedMap(java.util.function.BiFunction<? super A, ? super B, ? extends Key>, java.util.function.BiFunction<? super A, ? super B, ? extends Value>, java.util.function.IntFunction<ValueSet>)",
+          "new": "method <A, B, Key extends java.lang.Comparable<? super Key>, Value, ValueSet extends java.util.Set<Value>> org.optaplanner.core.api.score.stream.bi.BiConstraintCollector<A, B, ?, java.util.SortedMap<Key, ValueSet>> org.optaplanner.core.api.score.stream.ConstraintCollectors::toSortedMap(java.util.function.BiFunction<? super A, ? super B, ? extends Key>, java.util.function.BiFunction<? super A, ? super B, ? extends Value>, java.util.function.IntFunction<ValueSet>)",
+          "justification": "Apply the PECS principle to support a wider range of types, such as LocalDateTime."
+        },
+        {
+          "ignore": true,
+          "code": "java.method.parameterTypeParameterChanged",
+          "old": "parameter <A, Key extends java.lang.Comparable<Key>, Value> org.optaplanner.core.api.score.stream.uni.UniConstraintCollector<A, ?, java.util.SortedMap<Key, Value>> org.optaplanner.core.api.score.stream.ConstraintCollectors::toSortedMap(===java.util.function.Function<? super A, ? extends Key>===, java.util.function.Function<? super A, ? extends Value>, java.util.function.BinaryOperator<Value>)",
+          "new": "parameter <A, Key extends java.lang.Comparable<? super Key>, Value> org.optaplanner.core.api.score.stream.uni.UniConstraintCollector<A, ?, java.util.SortedMap<Key, Value>> org.optaplanner.core.api.score.stream.ConstraintCollectors::toSortedMap(===java.util.function.Function<? super A, ? extends Key>===, java.util.function.Function<? super A, ? extends Value>, java.util.function.BinaryOperator<Value>)",
+          "parameterIndex": "0",
+          "justification": "Apply the PECS principle to support a wider range of types, such as LocalDateTime."
+        },
+        {
+          "ignore": true,
+          "code": "java.method.returnTypeTypeParametersChanged",
+          "old": "method <A, Key extends java.lang.Comparable<Key>, Value> org.optaplanner.core.api.score.stream.uni.UniConstraintCollector<A, ?, java.util.SortedMap<Key, Value>> org.optaplanner.core.api.score.stream.ConstraintCollectors::toSortedMap(java.util.function.Function<? super A, ? extends Key>, java.util.function.Function<? super A, ? extends Value>, java.util.function.BinaryOperator<Value>)",
+          "new": "method <A, Key extends java.lang.Comparable<? super Key>, Value> org.optaplanner.core.api.score.stream.uni.UniConstraintCollector<A, ?, java.util.SortedMap<Key, Value>> org.optaplanner.core.api.score.stream.ConstraintCollectors::toSortedMap(java.util.function.Function<? super A, ? extends Key>, java.util.function.Function<? super A, ? extends Value>, java.util.function.BinaryOperator<Value>)",
+          "justification": "Apply the PECS principle to support a wider range of types, such as LocalDateTime."
+        },
+        {
+          "ignore": true,
+          "code": "java.generics.formalTypeParameterChanged",
+          "old": "method <A, Key extends java.lang.Comparable<Key>, Value> org.optaplanner.core.api.score.stream.uni.UniConstraintCollector<A, ?, java.util.SortedMap<Key, Value>> org.optaplanner.core.api.score.stream.ConstraintCollectors::toSortedMap(java.util.function.Function<? super A, ? extends Key>, java.util.function.Function<? super A, ? extends Value>, java.util.function.BinaryOperator<Value>)",
+          "new": "method <A, Key extends java.lang.Comparable<? super Key>, Value> org.optaplanner.core.api.score.stream.uni.UniConstraintCollector<A, ?, java.util.SortedMap<Key, Value>> org.optaplanner.core.api.score.stream.ConstraintCollectors::toSortedMap(java.util.function.Function<? super A, ? extends Key>, java.util.function.Function<? super A, ? extends Value>, java.util.function.BinaryOperator<Value>)",
+          "justification": "Apply the PECS principle to support a wider range of types, such as LocalDateTime."
+        },
+        {
+          "ignore": true,
+          "code": "java.method.parameterTypeParameterChanged",
+          "old": "parameter <A, Key extends java.lang.Comparable<Key>, Value, ValueSet extends java.util.Set<Value>> org.optaplanner.core.api.score.stream.uni.UniConstraintCollector<A, ?, java.util.SortedMap<Key, ValueSet>> org.optaplanner.core.api.score.stream.ConstraintCollectors::toSortedMap(===java.util.function.Function<? super A, ? extends Key>===, java.util.function.Function<? super A, ? extends Value>, java.util.function.IntFunction<ValueSet>)",
+          "new": "parameter <A, Key extends java.lang.Comparable<? super Key>, Value, ValueSet extends java.util.Set<Value>> org.optaplanner.core.api.score.stream.uni.UniConstraintCollector<A, ?, java.util.SortedMap<Key, ValueSet>> org.optaplanner.core.api.score.stream.ConstraintCollectors::toSortedMap(===java.util.function.Function<? super A, ? extends Key>===, java.util.function.Function<? super A, ? extends Value>, java.util.function.IntFunction<ValueSet>)",
+          "parameterIndex": "0",
+          "justification": "Apply the PECS principle to support a wider range of types, such as LocalDateTime."
+        },
+        {
+          "ignore": true,
+          "code": "java.method.returnTypeTypeParametersChanged",
+          "old": "method <A, Key extends java.lang.Comparable<Key>, Value, ValueSet extends java.util.Set<Value>> org.optaplanner.core.api.score.stream.uni.UniConstraintCollector<A, ?, java.util.SortedMap<Key, ValueSet>> org.optaplanner.core.api.score.stream.ConstraintCollectors::toSortedMap(java.util.function.Function<? super A, ? extends Key>, java.util.function.Function<? super A, ? extends Value>, java.util.function.IntFunction<ValueSet>)",
+          "new": "method <A, Key extends java.lang.Comparable<? super Key>, Value, ValueSet extends java.util.Set<Value>> org.optaplanner.core.api.score.stream.uni.UniConstraintCollector<A, ?, java.util.SortedMap<Key, ValueSet>> org.optaplanner.core.api.score.stream.ConstraintCollectors::toSortedMap(java.util.function.Function<? super A, ? extends Key>, java.util.function.Function<? super A, ? extends Value>, java.util.function.IntFunction<ValueSet>)",
+          "justification": "Apply the PECS principle to support a wider range of types, such as LocalDateTime."
+        },
+        {
+          "ignore": true,
+          "code": "java.generics.formalTypeParameterChanged",
+          "old": "method <A, Key extends java.lang.Comparable<Key>, Value, ValueSet extends java.util.Set<Value>> org.optaplanner.core.api.score.stream.uni.UniConstraintCollector<A, ?, java.util.SortedMap<Key, ValueSet>> org.optaplanner.core.api.score.stream.ConstraintCollectors::toSortedMap(java.util.function.Function<? super A, ? extends Key>, java.util.function.Function<? super A, ? extends Value>, java.util.function.IntFunction<ValueSet>)",
+          "new": "method <A, Key extends java.lang.Comparable<? super Key>, Value, ValueSet extends java.util.Set<Value>> org.optaplanner.core.api.score.stream.uni.UniConstraintCollector<A, ?, java.util.SortedMap<Key, ValueSet>> org.optaplanner.core.api.score.stream.ConstraintCollectors::toSortedMap(java.util.function.Function<? super A, ? extends Key>, java.util.function.Function<? super A, ? extends Value>, java.util.function.IntFunction<ValueSet>)",
+          "justification": "Apply the PECS principle to support a wider range of types, such as LocalDateTime."
+        },
+        {
+          "ignore": true,
+          "code": "java.method.parameterTypeParameterChanged",
+          "old": "parameter <A, B, C, D, Key extends java.lang.Comparable<Key>, Value> org.optaplanner.core.api.score.stream.quad.QuadConstraintCollector<A, B, C, D, ?, java.util.SortedMap<Key, Value>> org.optaplanner.core.api.score.stream.ConstraintCollectors::toSortedMap(===org.optaplanner.core.api.function.QuadFunction<? super A, ? super B, ? super C, ? super D, ? extends Key>===, org.optaplanner.core.api.function.QuadFunction<? super A, ? super B, ? super C, ? super D, ? extends Value>, java.util.function.BinaryOperator<Value>)",
+          "new": "parameter <A, B, C, D, Key extends java.lang.Comparable<? super Key>, Value> org.optaplanner.core.api.score.stream.quad.QuadConstraintCollector<A, B, C, D, ?, java.util.SortedMap<Key, Value>> org.optaplanner.core.api.score.stream.ConstraintCollectors::toSortedMap(===org.optaplanner.core.api.function.QuadFunction<? super A, ? super B, ? super C, ? super D, ? extends Key>===, org.optaplanner.core.api.function.QuadFunction<? super A, ? super B, ? super C, ? super D, ? extends Value>, java.util.function.BinaryOperator<Value>)",
+          "parameterIndex": "0",
+          "justification": "Apply the PECS principle to support a wider range of types, such as LocalDateTime."
+        },
+        {
+          "ignore": true,
+          "code": "java.method.returnTypeTypeParametersChanged",
+          "old": "method <A, B, C, D, Key extends java.lang.Comparable<Key>, Value> org.optaplanner.core.api.score.stream.quad.QuadConstraintCollector<A, B, C, D, ?, java.util.SortedMap<Key, Value>> org.optaplanner.core.api.score.stream.ConstraintCollectors::toSortedMap(org.optaplanner.core.api.function.QuadFunction<? super A, ? super B, ? super C, ? super D, ? extends Key>, org.optaplanner.core.api.function.QuadFunction<? super A, ? super B, ? super C, ? super D, ? extends Value>, java.util.function.BinaryOperator<Value>)",
+          "new": "method <A, B, C, D, Key extends java.lang.Comparable<? super Key>, Value> org.optaplanner.core.api.score.stream.quad.QuadConstraintCollector<A, B, C, D, ?, java.util.SortedMap<Key, Value>> org.optaplanner.core.api.score.stream.ConstraintCollectors::toSortedMap(org.optaplanner.core.api.function.QuadFunction<? super A, ? super B, ? super C, ? super D, ? extends Key>, org.optaplanner.core.api.function.QuadFunction<? super A, ? super B, ? super C, ? super D, ? extends Value>, java.util.function.BinaryOperator<Value>)",
+          "justification": "Apply the PECS principle to support a wider range of types, such as LocalDateTime."
+        },
+        {
+          "ignore": true,
+          "code": "java.generics.formalTypeParameterChanged",
+          "old": "method <A, B, C, D, Key extends java.lang.Comparable<Key>, Value> org.optaplanner.core.api.score.stream.quad.QuadConstraintCollector<A, B, C, D, ?, java.util.SortedMap<Key, Value>> org.optaplanner.core.api.score.stream.ConstraintCollectors::toSortedMap(org.optaplanner.core.api.function.QuadFunction<? super A, ? super B, ? super C, ? super D, ? extends Key>, org.optaplanner.core.api.function.QuadFunction<? super A, ? super B, ? super C, ? super D, ? extends Value>, java.util.function.BinaryOperator<Value>)",
+          "new": "method <A, B, C, D, Key extends java.lang.Comparable<? super Key>, Value> org.optaplanner.core.api.score.stream.quad.QuadConstraintCollector<A, B, C, D, ?, java.util.SortedMap<Key, Value>> org.optaplanner.core.api.score.stream.ConstraintCollectors::toSortedMap(org.optaplanner.core.api.function.QuadFunction<? super A, ? super B, ? super C, ? super D, ? extends Key>, org.optaplanner.core.api.function.QuadFunction<? super A, ? super B, ? super C, ? super D, ? extends Value>, java.util.function.BinaryOperator<Value>)",
+          "justification": "Apply the PECS principle to support a wider range of types, such as LocalDateTime."
+        },
+        {
+          "ignore": true,
+          "code": "java.method.parameterTypeParameterChanged",
+          "old": "parameter <A, B, C, D, Key extends java.lang.Comparable<Key>, Value, ValueSet extends java.util.Set<Value>> org.optaplanner.core.api.score.stream.quad.QuadConstraintCollector<A, B, C, D, ?, java.util.SortedMap<Key, ValueSet>> org.optaplanner.core.api.score.stream.ConstraintCollectors::toSortedMap(===org.optaplanner.core.api.function.QuadFunction<? super A, ? super B, ? super C, ? super D, ? extends Key>===, org.optaplanner.core.api.function.QuadFunction<? super A, ? super B, ? super C, ? super D, ? extends Value>, java.util.function.IntFunction<ValueSet>)",
+          "new": "parameter <A, B, C, D, Key extends java.lang.Comparable<? super Key>, Value, ValueSet extends java.util.Set<Value>> org.optaplanner.core.api.score.stream.quad.QuadConstraintCollector<A, B, C, D, ?, java.util.SortedMap<Key, ValueSet>> org.optaplanner.core.api.score.stream.ConstraintCollectors::toSortedMap(===org.optaplanner.core.api.function.QuadFunction<? super A, ? super B, ? super C, ? super D, ? extends Key>===, org.optaplanner.core.api.function.QuadFunction<? super A, ? super B, ? super C, ? super D, ? extends Value>, java.util.function.IntFunction<ValueSet>)",
+          "parameterIndex": "0",
+          "justification": "Apply the PECS principle to support a wider range of types, such as LocalDateTime."
+        },
+        {
+          "ignore": true,
+          "code": "java.method.returnTypeTypeParametersChanged",
+          "old": "method <A, B, C, D, Key extends java.lang.Comparable<Key>, Value, ValueSet extends java.util.Set<Value>> org.optaplanner.core.api.score.stream.quad.QuadConstraintCollector<A, B, C, D, ?, java.util.SortedMap<Key, ValueSet>> org.optaplanner.core.api.score.stream.ConstraintCollectors::toSortedMap(org.optaplanner.core.api.function.QuadFunction<? super A, ? super B, ? super C, ? super D, ? extends Key>, org.optaplanner.core.api.function.QuadFunction<? super A, ? super B, ? super C, ? super D, ? extends Value>, java.util.function.IntFunction<ValueSet>)",
+          "new": "method <A, B, C, D, Key extends java.lang.Comparable<? super Key>, Value, ValueSet extends java.util.Set<Value>> org.optaplanner.core.api.score.stream.quad.QuadConstraintCollector<A, B, C, D, ?, java.util.SortedMap<Key, ValueSet>> org.optaplanner.core.api.score.stream.ConstraintCollectors::toSortedMap(org.optaplanner.core.api.function.QuadFunction<? super A, ? super B, ? super C, ? super D, ? extends Key>, org.optaplanner.core.api.function.QuadFunction<? super A, ? super B, ? super C, ? super D, ? extends Value>, java.util.function.IntFunction<ValueSet>)",
+          "justification": "Apply the PECS principle to support a wider range of types, such as LocalDateTime."
+        },
+        {
+          "ignore": true,
+          "code": "java.generics.formalTypeParameterChanged",
+          "old": "method <A, B, C, D, Key extends java.lang.Comparable<Key>, Value, ValueSet extends java.util.Set<Value>> org.optaplanner.core.api.score.stream.quad.QuadConstraintCollector<A, B, C, D, ?, java.util.SortedMap<Key, ValueSet>> org.optaplanner.core.api.score.stream.ConstraintCollectors::toSortedMap(org.optaplanner.core.api.function.QuadFunction<? super A, ? super B, ? super C, ? super D, ? extends Key>, org.optaplanner.core.api.function.QuadFunction<? super A, ? super B, ? super C, ? super D, ? extends Value>, java.util.function.IntFunction<ValueSet>)",
+          "new": "method <A, B, C, D, Key extends java.lang.Comparable<? super Key>, Value, ValueSet extends java.util.Set<Value>> org.optaplanner.core.api.score.stream.quad.QuadConstraintCollector<A, B, C, D, ?, java.util.SortedMap<Key, ValueSet>> org.optaplanner.core.api.score.stream.ConstraintCollectors::toSortedMap(org.optaplanner.core.api.function.QuadFunction<? super A, ? super B, ? super C, ? super D, ? extends Key>, org.optaplanner.core.api.function.QuadFunction<? super A, ? super B, ? super C, ? super D, ? extends Value>, java.util.function.IntFunction<ValueSet>)",
+          "justification": "Apply the PECS principle to support a wider range of types, such as LocalDateTime."
+        },
+        {
+          "ignore": true,
+          "code": "java.method.parameterTypeParameterChanged",
+          "old": "parameter <A, B, C, Key extends java.lang.Comparable<Key>, Value> org.optaplanner.core.api.score.stream.tri.TriConstraintCollector<A, B, C, ?, java.util.SortedMap<Key, Value>> org.optaplanner.core.api.score.stream.ConstraintCollectors::toSortedMap(===org.optaplanner.core.api.function.TriFunction<? super A, ? super B, ? super C, ? extends Key>===, org.optaplanner.core.api.function.TriFunction<? super A, ? super B, ? super C, ? extends Value>, java.util.function.BinaryOperator<Value>)",
+          "new": "parameter <A, B, C, Key extends java.lang.Comparable<? super Key>, Value> org.optaplanner.core.api.score.stream.tri.TriConstraintCollector<A, B, C, ?, java.util.SortedMap<Key, Value>> org.optaplanner.core.api.score.stream.ConstraintCollectors::toSortedMap(===org.optaplanner.core.api.function.TriFunction<? super A, ? super B, ? super C, ? extends Key>===, org.optaplanner.core.api.function.TriFunction<? super A, ? super B, ? super C, ? extends Value>, java.util.function.BinaryOperator<Value>)",
+          "parameterIndex": "0",
+          "justification": "Apply the PECS principle to support a wider range of types, such as LocalDateTime."
+        },
+        {
+          "ignore": true,
+          "code": "java.method.returnTypeTypeParametersChanged",
+          "old": "method <A, B, C, Key extends java.lang.Comparable<Key>, Value> org.optaplanner.core.api.score.stream.tri.TriConstraintCollector<A, B, C, ?, java.util.SortedMap<Key, Value>> org.optaplanner.core.api.score.stream.ConstraintCollectors::toSortedMap(org.optaplanner.core.api.function.TriFunction<? super A, ? super B, ? super C, ? extends Key>, org.optaplanner.core.api.function.TriFunction<? super A, ? super B, ? super C, ? extends Value>, java.util.function.BinaryOperator<Value>)",
+          "new": "method <A, B, C, Key extends java.lang.Comparable<? super Key>, Value> org.optaplanner.core.api.score.stream.tri.TriConstraintCollector<A, B, C, ?, java.util.SortedMap<Key, Value>> org.optaplanner.core.api.score.stream.ConstraintCollectors::toSortedMap(org.optaplanner.core.api.function.TriFunction<? super A, ? super B, ? super C, ? extends Key>, org.optaplanner.core.api.function.TriFunction<? super A, ? super B, ? super C, ? extends Value>, java.util.function.BinaryOperator<Value>)",
+          "justification": "Apply the PECS principle to support a wider range of types, such as LocalDateTime."
+        },
+        {
+          "ignore": true,
+          "code": "java.generics.formalTypeParameterChanged",
+          "old": "method <A, B, C, Key extends java.lang.Comparable<Key>, Value> org.optaplanner.core.api.score.stream.tri.TriConstraintCollector<A, B, C, ?, java.util.SortedMap<Key, Value>> org.optaplanner.core.api.score.stream.ConstraintCollectors::toSortedMap(org.optaplanner.core.api.function.TriFunction<? super A, ? super B, ? super C, ? extends Key>, org.optaplanner.core.api.function.TriFunction<? super A, ? super B, ? super C, ? extends Value>, java.util.function.BinaryOperator<Value>)",
+          "new": "method <A, B, C, Key extends java.lang.Comparable<? super Key>, Value> org.optaplanner.core.api.score.stream.tri.TriConstraintCollector<A, B, C, ?, java.util.SortedMap<Key, Value>> org.optaplanner.core.api.score.stream.ConstraintCollectors::toSortedMap(org.optaplanner.core.api.function.TriFunction<? super A, ? super B, ? super C, ? extends Key>, org.optaplanner.core.api.function.TriFunction<? super A, ? super B, ? super C, ? extends Value>, java.util.function.BinaryOperator<Value>)",
+          "justification": "Apply the PECS principle to support a wider range of types, such as LocalDateTime."
+        },
+        {
+          "ignore": true,
+          "code": "java.method.parameterTypeParameterChanged",
+          "old": "parameter <A, B, C, Key extends java.lang.Comparable<Key>, Value, ValueSet extends java.util.Set<Value>> org.optaplanner.core.api.score.stream.tri.TriConstraintCollector<A, B, C, ?, java.util.SortedMap<Key, ValueSet>> org.optaplanner.core.api.score.stream.ConstraintCollectors::toSortedMap(===org.optaplanner.core.api.function.TriFunction<? super A, ? super B, ? super C, ? extends Key>===, org.optaplanner.core.api.function.TriFunction<? super A, ? super B, ? super C, ? extends Value>, java.util.function.IntFunction<ValueSet>)",
+          "new": "parameter <A, B, C, Key extends java.lang.Comparable<? super Key>, Value, ValueSet extends java.util.Set<Value>> org.optaplanner.core.api.score.stream.tri.TriConstraintCollector<A, B, C, ?, java.util.SortedMap<Key, ValueSet>> org.optaplanner.core.api.score.stream.ConstraintCollectors::toSortedMap(===org.optaplanner.core.api.function.TriFunction<? super A, ? super B, ? super C, ? extends Key>===, org.optaplanner.core.api.function.TriFunction<? super A, ? super B, ? super C, ? extends Value>, java.util.function.IntFunction<ValueSet>)",
+          "parameterIndex": "0",
+          "justification": "Apply the PECS principle to support a wider range of types, such as LocalDateTime."
+        },
+        {
+          "ignore": true,
+          "code": "java.method.returnTypeTypeParametersChanged",
+          "old": "method <A, B, C, Key extends java.lang.Comparable<Key>, Value, ValueSet extends java.util.Set<Value>> org.optaplanner.core.api.score.stream.tri.TriConstraintCollector<A, B, C, ?, java.util.SortedMap<Key, ValueSet>> org.optaplanner.core.api.score.stream.ConstraintCollectors::toSortedMap(org.optaplanner.core.api.function.TriFunction<? super A, ? super B, ? super C, ? extends Key>, org.optaplanner.core.api.function.TriFunction<? super A, ? super B, ? super C, ? extends Value>, java.util.function.IntFunction<ValueSet>)",
+          "new": "method <A, B, C, Key extends java.lang.Comparable<? super Key>, Value, ValueSet extends java.util.Set<Value>> org.optaplanner.core.api.score.stream.tri.TriConstraintCollector<A, B, C, ?, java.util.SortedMap<Key, ValueSet>> org.optaplanner.core.api.score.stream.ConstraintCollectors::toSortedMap(org.optaplanner.core.api.function.TriFunction<? super A, ? super B, ? super C, ? extends Key>, org.optaplanner.core.api.function.TriFunction<? super A, ? super B, ? super C, ? extends Value>, java.util.function.IntFunction<ValueSet>)",
+          "justification": "Apply the PECS principle to support a wider range of types, such as LocalDateTime."
+        },
+        {
+          "ignore": true,
+          "code": "java.generics.formalTypeParameterChanged",
+          "old": "method <A, B, C, Key extends java.lang.Comparable<Key>, Value, ValueSet extends java.util.Set<Value>> org.optaplanner.core.api.score.stream.tri.TriConstraintCollector<A, B, C, ?, java.util.SortedMap<Key, ValueSet>> org.optaplanner.core.api.score.stream.ConstraintCollectors::toSortedMap(org.optaplanner.core.api.function.TriFunction<? super A, ? super B, ? super C, ? extends Key>, org.optaplanner.core.api.function.TriFunction<? super A, ? super B, ? super C, ? extends Value>, java.util.function.IntFunction<ValueSet>)",
+          "new": "method <A, B, C, Key extends java.lang.Comparable<? super Key>, Value, ValueSet extends java.util.Set<Value>> org.optaplanner.core.api.score.stream.tri.TriConstraintCollector<A, B, C, ?, java.util.SortedMap<Key, ValueSet>> org.optaplanner.core.api.score.stream.ConstraintCollectors::toSortedMap(org.optaplanner.core.api.function.TriFunction<? super A, ? super B, ? super C, ? extends Key>, org.optaplanner.core.api.function.TriFunction<? super A, ? super B, ? super C, ? extends Value>, java.util.function.IntFunction<ValueSet>)",
+          "justification": "Apply the PECS principle to support a wider range of types, such as LocalDateTime."
+        },
+        {
+          "ignore": true,
+          "code": "java.method.parameterTypeParameterChanged",
+          "old": "parameter <A> org.optaplanner.core.api.score.stream.uni.UniConstraintCollector<A, ?, java.util.SortedSet<A>> org.optaplanner.core.api.score.stream.ConstraintCollectors::toSortedSet(===java.util.Comparator<A>===)",
+          "new": "parameter <A> org.optaplanner.core.api.score.stream.uni.UniConstraintCollector<A, ?, java.util.SortedSet<A>> org.optaplanner.core.api.score.stream.ConstraintCollectors::toSortedSet(===java.util.Comparator<? super A>===)",
+          "parameterIndex": "0",
+          "justification": "Apply the PECS principle to support a wider range of types, such as LocalDateTime."
+        },
+        {
+          "ignore": true,
+          "code": "java.method.parameterTypeParameterChanged",
+          "old": "parameter <A, B, Mapped> org.optaplanner.core.api.score.stream.bi.BiConstraintCollector<A, B, ?, java.util.SortedSet<Mapped>> org.optaplanner.core.api.score.stream.ConstraintCollectors::toSortedSet(java.util.function.BiFunction<A, B, Mapped>, ===java.util.Comparator<Mapped>===)",
+          "new": "parameter <A, B, Mapped> org.optaplanner.core.api.score.stream.bi.BiConstraintCollector<A, B, ?, java.util.SortedSet<Mapped>> org.optaplanner.core.api.score.stream.ConstraintCollectors::toSortedSet(java.util.function.BiFunction<A, B, Mapped>, ===java.util.Comparator<? super Mapped>===)",
+          "parameterIndex": "1",
+          "justification": "Apply the PECS principle to support a wider range of types, such as LocalDateTime."
+        },
+        {
+          "ignore": true,
+          "code": "java.method.parameterTypeParameterChanged",
+          "old": "parameter <A, Mapped> org.optaplanner.core.api.score.stream.uni.UniConstraintCollector<A, ?, java.util.SortedSet<Mapped>> org.optaplanner.core.api.score.stream.ConstraintCollectors::toSortedSet(java.util.function.Function<A, Mapped>, ===java.util.Comparator<Mapped>===)",
+          "new": "parameter <A, Mapped> org.optaplanner.core.api.score.stream.uni.UniConstraintCollector<A, ?, java.util.SortedSet<Mapped>> org.optaplanner.core.api.score.stream.ConstraintCollectors::toSortedSet(java.util.function.Function<A, Mapped>, ===java.util.Comparator<? super Mapped>===)",
+          "parameterIndex": "1",
+          "justification": "Apply the PECS principle to support a wider range of types, such as LocalDateTime."
+        },
+        {
+          "ignore": true,
+          "code": "java.method.parameterTypeParameterChanged",
+          "old": "parameter <A, B, C, D, Mapped> org.optaplanner.core.api.score.stream.quad.QuadConstraintCollector<A, B, C, D, ?, java.util.SortedSet<Mapped>> org.optaplanner.core.api.score.stream.ConstraintCollectors::toSortedSet(org.optaplanner.core.api.function.QuadFunction<A, B, C, D, Mapped>, ===java.util.Comparator<Mapped>===)",
+          "new": "parameter <A, B, C, D, Mapped> org.optaplanner.core.api.score.stream.quad.QuadConstraintCollector<A, B, C, D, ?, java.util.SortedSet<Mapped>> org.optaplanner.core.api.score.stream.ConstraintCollectors::toSortedSet(org.optaplanner.core.api.function.QuadFunction<A, B, C, D, Mapped>, ===java.util.Comparator<? super Mapped>===)",
+          "parameterIndex": "1",
+          "justification": "Apply the PECS principle to support a wider range of types, such as LocalDateTime."
+        },
+        {
+          "ignore": true,
+          "code": "java.method.parameterTypeParameterChanged",
+          "old": "parameter <A, B, C, Mapped> org.optaplanner.core.api.score.stream.tri.TriConstraintCollector<A, B, C, ?, java.util.SortedSet<Mapped>> org.optaplanner.core.api.score.stream.ConstraintCollectors::toSortedSet(org.optaplanner.core.api.function.TriFunction<A, B, C, Mapped>, ===java.util.Comparator<Mapped>===)",
+          "new": "parameter <A, B, C, Mapped> org.optaplanner.core.api.score.stream.tri.TriConstraintCollector<A, B, C, ?, java.util.SortedSet<Mapped>> org.optaplanner.core.api.score.stream.ConstraintCollectors::toSortedSet(org.optaplanner.core.api.function.TriFunction<A, B, C, Mapped>, ===java.util.Comparator<? super Mapped>===)",
+          "parameterIndex": "1",
+          "justification": "Apply the PECS principle to support a wider range of types, such as LocalDateTime."
+        },
+        {
+          "ignore": true,
+          "code": "java.method.parameterTypeParameterChanged",
+          "old": "parameter <A, B, Mapped extends java.lang.Comparable<Mapped>> org.optaplanner.core.api.score.stream.bi.BiConstraintCollector<A, B, ?, java.util.SortedSet<Mapped>> org.optaplanner.core.api.score.stream.ConstraintCollectors::toSortedSet(===java.util.function.BiFunction<A, B, Mapped>===)",
+          "new": "parameter <A, B, Mapped extends java.lang.Comparable<? super Mapped>> org.optaplanner.core.api.score.stream.bi.BiConstraintCollector<A, B, ?, java.util.SortedSet<Mapped>> org.optaplanner.core.api.score.stream.ConstraintCollectors::toSortedSet(===java.util.function.BiFunction<A, B, Mapped>===)",
+          "parameterIndex": "0",
+          "justification": "Apply the PECS principle to support a wider range of types, such as LocalDateTime."
+        },
+        {
+          "ignore": true,
+          "code": "java.method.returnTypeTypeParametersChanged",
+          "old": "method <A, B, Mapped extends java.lang.Comparable<Mapped>> org.optaplanner.core.api.score.stream.bi.BiConstraintCollector<A, B, ?, java.util.SortedSet<Mapped>> org.optaplanner.core.api.score.stream.ConstraintCollectors::toSortedSet(java.util.function.BiFunction<A, B, Mapped>)",
+          "new": "method <A, B, Mapped extends java.lang.Comparable<? super Mapped>> org.optaplanner.core.api.score.stream.bi.BiConstraintCollector<A, B, ?, java.util.SortedSet<Mapped>> org.optaplanner.core.api.score.stream.ConstraintCollectors::toSortedSet(java.util.function.BiFunction<A, B, Mapped>)",
+          "justification": "Apply the PECS principle to support a wider range of types, such as LocalDateTime."
+        },
+        {
+          "ignore": true,
+          "code": "java.generics.formalTypeParameterChanged",
+          "old": "method <A, B, Mapped extends java.lang.Comparable<Mapped>> org.optaplanner.core.api.score.stream.bi.BiConstraintCollector<A, B, ?, java.util.SortedSet<Mapped>> org.optaplanner.core.api.score.stream.ConstraintCollectors::toSortedSet(java.util.function.BiFunction<A, B, Mapped>)",
+          "new": "method <A, B, Mapped extends java.lang.Comparable<? super Mapped>> org.optaplanner.core.api.score.stream.bi.BiConstraintCollector<A, B, ?, java.util.SortedSet<Mapped>> org.optaplanner.core.api.score.stream.ConstraintCollectors::toSortedSet(java.util.function.BiFunction<A, B, Mapped>)",
+          "justification": "Apply the PECS principle to support a wider range of types, such as LocalDateTime."
+        },
+        {
+          "ignore": true,
+          "code": "java.method.parameterTypeParameterChanged",
+          "old": "parameter <A, Mapped extends java.lang.Comparable<Mapped>> org.optaplanner.core.api.score.stream.uni.UniConstraintCollector<A, ?, java.util.SortedSet<Mapped>> org.optaplanner.core.api.score.stream.ConstraintCollectors::toSortedSet(===java.util.function.Function<A, Mapped>===)",
+          "new": "parameter <A, Mapped extends java.lang.Comparable<? super Mapped>> org.optaplanner.core.api.score.stream.uni.UniConstraintCollector<A, ?, java.util.SortedSet<Mapped>> org.optaplanner.core.api.score.stream.ConstraintCollectors::toSortedSet(===java.util.function.Function<A, Mapped>===)",
+          "parameterIndex": "0",
+          "justification": "Apply the PECS principle to support a wider range of types, such as LocalDateTime."
+        },
+        {
+          "ignore": true,
+          "code": "java.method.returnTypeTypeParametersChanged",
+          "old": "method <A, Mapped extends java.lang.Comparable<Mapped>> org.optaplanner.core.api.score.stream.uni.UniConstraintCollector<A, ?, java.util.SortedSet<Mapped>> org.optaplanner.core.api.score.stream.ConstraintCollectors::toSortedSet(java.util.function.Function<A, Mapped>)",
+          "new": "method <A, Mapped extends java.lang.Comparable<? super Mapped>> org.optaplanner.core.api.score.stream.uni.UniConstraintCollector<A, ?, java.util.SortedSet<Mapped>> org.optaplanner.core.api.score.stream.ConstraintCollectors::toSortedSet(java.util.function.Function<A, Mapped>)",
+          "justification": "Apply the PECS principle to support a wider range of types, such as LocalDateTime."
+        },
+        {
+          "ignore": true,
+          "code": "java.generics.formalTypeParameterChanged",
+          "old": "method <A, Mapped extends java.lang.Comparable<Mapped>> org.optaplanner.core.api.score.stream.uni.UniConstraintCollector<A, ?, java.util.SortedSet<Mapped>> org.optaplanner.core.api.score.stream.ConstraintCollectors::toSortedSet(java.util.function.Function<A, Mapped>)",
+          "new": "method <A, Mapped extends java.lang.Comparable<? super Mapped>> org.optaplanner.core.api.score.stream.uni.UniConstraintCollector<A, ?, java.util.SortedSet<Mapped>> org.optaplanner.core.api.score.stream.ConstraintCollectors::toSortedSet(java.util.function.Function<A, Mapped>)",
+          "justification": "Apply the PECS principle to support a wider range of types, such as LocalDateTime."
+        },
+        {
+          "ignore": true,
+          "code": "java.method.parameterTypeParameterChanged",
+          "old": "parameter <A, B, C, D, Mapped extends java.lang.Comparable<Mapped>> org.optaplanner.core.api.score.stream.quad.QuadConstraintCollector<A, B, C, D, ?, java.util.SortedSet<Mapped>> org.optaplanner.core.api.score.stream.ConstraintCollectors::toSortedSet(===org.optaplanner.core.api.function.QuadFunction<A, B, C, D, Mapped>===)",
+          "new": "parameter <A, B, C, D, Mapped extends java.lang.Comparable<? super Mapped>> org.optaplanner.core.api.score.stream.quad.QuadConstraintCollector<A, B, C, D, ?, java.util.SortedSet<Mapped>> org.optaplanner.core.api.score.stream.ConstraintCollectors::toSortedSet(===org.optaplanner.core.api.function.QuadFunction<A, B, C, D, Mapped>===)",
+          "parameterIndex": "0",
+          "justification": "Apply the PECS principle to support a wider range of types, such as LocalDateTime."
+        },
+        {
+          "ignore": true,
+          "code": "java.method.returnTypeTypeParametersChanged",
+          "old": "method <A, B, C, D, Mapped extends java.lang.Comparable<Mapped>> org.optaplanner.core.api.score.stream.quad.QuadConstraintCollector<A, B, C, D, ?, java.util.SortedSet<Mapped>> org.optaplanner.core.api.score.stream.ConstraintCollectors::toSortedSet(org.optaplanner.core.api.function.QuadFunction<A, B, C, D, Mapped>)",
+          "new": "method <A, B, C, D, Mapped extends java.lang.Comparable<? super Mapped>> org.optaplanner.core.api.score.stream.quad.QuadConstraintCollector<A, B, C, D, ?, java.util.SortedSet<Mapped>> org.optaplanner.core.api.score.stream.ConstraintCollectors::toSortedSet(org.optaplanner.core.api.function.QuadFunction<A, B, C, D, Mapped>)",
+          "justification": "Apply the PECS principle to support a wider range of types, such as LocalDateTime."
+        },
+        {
+          "ignore": true,
+          "code": "java.generics.formalTypeParameterChanged",
+          "old": "method <A, B, C, D, Mapped extends java.lang.Comparable<Mapped>> org.optaplanner.core.api.score.stream.quad.QuadConstraintCollector<A, B, C, D, ?, java.util.SortedSet<Mapped>> org.optaplanner.core.api.score.stream.ConstraintCollectors::toSortedSet(org.optaplanner.core.api.function.QuadFunction<A, B, C, D, Mapped>)",
+          "new": "method <A, B, C, D, Mapped extends java.lang.Comparable<? super Mapped>> org.optaplanner.core.api.score.stream.quad.QuadConstraintCollector<A, B, C, D, ?, java.util.SortedSet<Mapped>> org.optaplanner.core.api.score.stream.ConstraintCollectors::toSortedSet(org.optaplanner.core.api.function.QuadFunction<A, B, C, D, Mapped>)",
+          "justification": "Apply the PECS principle to support a wider range of types, such as LocalDateTime."
+        },
+        {
+          "ignore": true,
+          "code": "java.method.parameterTypeParameterChanged",
+          "old": "parameter <A, B, C, Mapped extends java.lang.Comparable<Mapped>> org.optaplanner.core.api.score.stream.tri.TriConstraintCollector<A, B, C, ?, java.util.SortedSet<Mapped>> org.optaplanner.core.api.score.stream.ConstraintCollectors::toSortedSet(===org.optaplanner.core.api.function.TriFunction<A, B, C, Mapped>===)",
+          "new": "parameter <A, B, C, Mapped extends java.lang.Comparable<? super Mapped>> org.optaplanner.core.api.score.stream.tri.TriConstraintCollector<A, B, C, ?, java.util.SortedSet<Mapped>> org.optaplanner.core.api.score.stream.ConstraintCollectors::toSortedSet(===org.optaplanner.core.api.function.TriFunction<A, B, C, Mapped>===)",
+          "parameterIndex": "0",
+          "justification": "Apply the PECS principle to support a wider range of types, such as LocalDateTime."
+        },
+        {
+          "ignore": true,
+          "code": "java.method.returnTypeTypeParametersChanged",
+          "old": "method <A, B, C, Mapped extends java.lang.Comparable<Mapped>> org.optaplanner.core.api.score.stream.tri.TriConstraintCollector<A, B, C, ?, java.util.SortedSet<Mapped>> org.optaplanner.core.api.score.stream.ConstraintCollectors::toSortedSet(org.optaplanner.core.api.function.TriFunction<A, B, C, Mapped>)",
+          "new": "method <A, B, C, Mapped extends java.lang.Comparable<? super Mapped>> org.optaplanner.core.api.score.stream.tri.TriConstraintCollector<A, B, C, ?, java.util.SortedSet<Mapped>> org.optaplanner.core.api.score.stream.ConstraintCollectors::toSortedSet(org.optaplanner.core.api.function.TriFunction<A, B, C, Mapped>)",
+          "justification": "Apply the PECS principle to support a wider range of types, such as LocalDateTime."
+        },
+        {
+          "ignore": true,
+          "code": "java.generics.formalTypeParameterChanged",
+          "old": "method <A, B, C, Mapped extends java.lang.Comparable<Mapped>> org.optaplanner.core.api.score.stream.tri.TriConstraintCollector<A, B, C, ?, java.util.SortedSet<Mapped>> org.optaplanner.core.api.score.stream.ConstraintCollectors::toSortedSet(org.optaplanner.core.api.function.TriFunction<A, B, C, Mapped>)",
+          "new": "method <A, B, C, Mapped extends java.lang.Comparable<? super Mapped>> org.optaplanner.core.api.score.stream.tri.TriConstraintCollector<A, B, C, ?, java.util.SortedSet<Mapped>> org.optaplanner.core.api.score.stream.ConstraintCollectors::toSortedSet(org.optaplanner.core.api.function.TriFunction<A, B, C, Mapped>)",
+          "justification": "Apply the PECS principle to support a wider range of types, such as LocalDateTime."
         }
       ]
     }

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/api/score/stream/ConstraintCollectors.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/api/score/stream/ConstraintCollectors.java
@@ -693,7 +693,7 @@ public final class ConstraintCollectors {
      * @return never null
      */
     public static <A extends Comparable<A>> UniConstraintCollector<A, ?, A> min() {
-        return min(Comparator.<A> naturalOrder());
+        return min(Comparator.naturalOrder());
     }
 
     /**
@@ -715,7 +715,7 @@ public final class ConstraintCollectors {
      * @param groupValueMapping never null, maps facts from the matched type to the result type
      * @return never null
      */
-    public static <A, Mapped extends Comparable<Mapped>> UniConstraintCollector<A, ?, Mapped> min(
+    public static <A, Mapped extends Comparable<? super Mapped>> UniConstraintCollector<A, ?, Mapped> min(
             Function<A, Mapped> groupValueMapping) {
         return min(groupValueMapping, Comparator.naturalOrder());
     }
@@ -723,7 +723,7 @@ public final class ConstraintCollectors {
     /**
      * As defined by {@link #min()}, only with a custom {@link Comparator}.
      */
-    public static <A> UniConstraintCollector<A, ?, A> min(Comparator<A> comparator) {
+    public static <A> UniConstraintCollector<A, ?, A> min(Comparator<? super A> comparator) {
         return min(Function.identity(), comparator);
     }
 
@@ -731,14 +731,14 @@ public final class ConstraintCollectors {
      * As defined by {@link #min(Function)}, only with a custom {@link Comparator}.
      */
     public static <A, Mapped> UniConstraintCollector<A, ?, Mapped> min(Function<A, Mapped> groupValueMapping,
-            Comparator<Mapped> comparator) {
+            Comparator<? super Mapped> comparator) {
         return minOrMax(groupValueMapping, comparator, true);
     }
 
     /**
      * As defined by {@link #min(Function)}.
      */
-    public static <A, B, Mapped extends Comparable<Mapped>> BiConstraintCollector<A, B, ?, Mapped> min(
+    public static <A, B, Mapped extends Comparable<? super Mapped>> BiConstraintCollector<A, B, ?, Mapped> min(
             BiFunction<A, B, Mapped> groupValueMapping) {
         return min(groupValueMapping, Comparator.naturalOrder());
     }
@@ -747,14 +747,14 @@ public final class ConstraintCollectors {
      * As defined by {@link #min(Function)}, only with a custom {@link Comparator}.
      */
     public static <A, B, Mapped> BiConstraintCollector<A, B, ?, Mapped> min(BiFunction<A, B, Mapped> groupValueMapping,
-            Comparator<Mapped> comparator) {
+            Comparator<? super Mapped> comparator) {
         return minOrMax(groupValueMapping, comparator, true);
     }
 
     /**
      * As defined by {@link #min(Function)}.
      */
-    public static <A, B, C, Mapped extends Comparable<Mapped>> TriConstraintCollector<A, B, C, ?, Mapped> min(
+    public static <A, B, C, Mapped extends Comparable<? super Mapped>> TriConstraintCollector<A, B, C, ?, Mapped> min(
             TriFunction<A, B, C, Mapped> groupValueMapping) {
         return min(groupValueMapping, Comparator.naturalOrder());
     }
@@ -763,14 +763,14 @@ public final class ConstraintCollectors {
      * As defined by {@link #min(Function)}, only with a custom {@link Comparator}.
      */
     public static <A, B, C, Mapped> TriConstraintCollector<A, B, C, ?, Mapped> min(
-            TriFunction<A, B, C, Mapped> groupValueMapping, Comparator<Mapped> comparator) {
+            TriFunction<A, B, C, Mapped> groupValueMapping, Comparator<? super Mapped> comparator) {
         return minOrMax(groupValueMapping, comparator, true);
     }
 
     /**
      * As defined by {@link #min(Function)}.
      */
-    public static <A, B, C, D, Mapped extends Comparable<Mapped>> QuadConstraintCollector<A, B, C, D, ?, Mapped> min(
+    public static <A, B, C, D, Mapped extends Comparable<? super Mapped>> QuadConstraintCollector<A, B, C, D, ?, Mapped> min(
             QuadFunction<A, B, C, D, Mapped> groupValueMapping) {
         return min(groupValueMapping, Comparator.naturalOrder());
     }
@@ -779,7 +779,7 @@ public final class ConstraintCollectors {
      * As defined by {@link #min(Function)}, only with a custom {@link Comparator}.
      */
     public static <A, B, C, D, Mapped> QuadConstraintCollector<A, B, C, D, ?, Mapped> min(
-            QuadFunction<A, B, C, D, Mapped> groupValueMapping, Comparator<Mapped> comparator) {
+            QuadFunction<A, B, C, D, Mapped> groupValueMapping, Comparator<? super Mapped> comparator) {
         return minOrMax(groupValueMapping, comparator, true);
     }
 
@@ -808,7 +808,7 @@ public final class ConstraintCollectors {
      * @return never null
      */
     public static <A extends Comparable<A>> UniConstraintCollector<A, ?, A> max() {
-        return max(Comparator.<A> naturalOrder());
+        return max(Comparator.naturalOrder());
     }
 
     /**
@@ -830,7 +830,7 @@ public final class ConstraintCollectors {
      * @param groupValueMapping never null, maps facts from the matched type to the result type
      * @return never null
      */
-    public static <A, Mapped extends Comparable<Mapped>> UniConstraintCollector<A, ?, Mapped> max(
+    public static <A, Mapped extends Comparable<? super Mapped>> UniConstraintCollector<A, ?, Mapped> max(
             Function<A, Mapped> groupValueMapping) {
         return max(groupValueMapping, Comparator.naturalOrder());
     }
@@ -838,7 +838,7 @@ public final class ConstraintCollectors {
     /**
      * As defined by {@link #max()}, only with a custom {@link Comparator}.
      */
-    public static <A> UniConstraintCollector<A, ?, A> max(Comparator<A> comparator) {
+    public static <A> UniConstraintCollector<A, ?, A> max(Comparator<? super A> comparator) {
         return max(Function.identity(), comparator);
     }
 
@@ -846,12 +846,12 @@ public final class ConstraintCollectors {
      * As defined by {@link #max(Function)}, only with a custom {@link Comparator}.
      */
     public static <A, Mapped> UniConstraintCollector<A, ?, Mapped> max(Function<A, Mapped> groupValueMapping,
-            Comparator<Mapped> comparator) {
+            Comparator<? super Mapped> comparator) {
         return minOrMax(groupValueMapping, comparator, false);
     }
 
     private static <A, Mapped> UniConstraintCollector<A, SortedMap<Mapped, MutableLong>, Mapped> minOrMax(
-            Function<A, Mapped> groupValueMapping, Comparator<Mapped> comparator, boolean min) {
+            Function<A, Mapped> groupValueMapping, Comparator<? super Mapped> comparator, boolean min) {
         return new DefaultUniConstraintCollector<>(
                 () -> new TreeMap<>(comparator),
                 (resultContainer, a) -> {
@@ -872,7 +872,7 @@ public final class ConstraintCollectors {
     /**
      * As defined by {@link #max(Function)}.
      */
-    public static <A, B, Mapped extends Comparable<Mapped>> BiConstraintCollector<A, B, ?, Mapped> max(
+    public static <A, B, Mapped extends Comparable<? super Mapped>> BiConstraintCollector<A, B, ?, Mapped> max(
             BiFunction<A, B, Mapped> groupValueMapping) {
         return max(groupValueMapping, Comparator.naturalOrder());
     }
@@ -881,12 +881,12 @@ public final class ConstraintCollectors {
      * As defined by {@link #max(Function)}, only with a custom {@link Comparator}.
      */
     public static <A, B, Mapped> BiConstraintCollector<A, B, ?, Mapped> max(BiFunction<A, B, Mapped> groupValueMapping,
-            Comparator<Mapped> comparator) {
+            Comparator<? super Mapped> comparator) {
         return minOrMax(groupValueMapping, comparator, false);
     }
 
     private static <A, B, Mapped> BiConstraintCollector<A, B, SortedMap<Mapped, MutableLong>, Mapped> minOrMax(
-            BiFunction<A, B, Mapped> groupValueMapping, Comparator<Mapped> comparator, boolean min) {
+            BiFunction<A, B, Mapped> groupValueMapping, Comparator<? super Mapped> comparator, boolean min) {
         return new DefaultBiConstraintCollector<>(
                 () -> new TreeMap<>(comparator),
                 (resultContainer, a, b) -> {
@@ -899,7 +899,7 @@ public final class ConstraintCollectors {
     /**
      * As defined by {@link #max(Function)}.
      */
-    public static <A, B, C, Mapped extends Comparable<Mapped>> TriConstraintCollector<A, B, C, ?, Mapped> max(
+    public static <A, B, C, Mapped extends Comparable<? super Mapped>> TriConstraintCollector<A, B, C, ?, Mapped> max(
             TriFunction<A, B, C, Mapped> groupValueMapping) {
         return max(groupValueMapping, Comparator.naturalOrder());
     }
@@ -908,12 +908,12 @@ public final class ConstraintCollectors {
      * As defined by {@link #max(Function)}, only with a custom {@link Comparator}.
      */
     public static <A, B, C, Mapped> TriConstraintCollector<A, B, C, ?, Mapped> max(
-            TriFunction<A, B, C, Mapped> groupValueMapping, Comparator<Mapped> comparator) {
+            TriFunction<A, B, C, Mapped> groupValueMapping, Comparator<? super Mapped> comparator) {
         return minOrMax(groupValueMapping, comparator, false);
     }
 
     private static <A, B, C, Mapped> TriConstraintCollector<A, B, C, SortedMap<Mapped, MutableLong>, Mapped> minOrMax(
-            TriFunction<A, B, C, Mapped> groupValueMapping, Comparator<Mapped> comparator, boolean min) {
+            TriFunction<A, B, C, Mapped> groupValueMapping, Comparator<? super Mapped> comparator, boolean min) {
         return new DefaultTriConstraintCollector<>(
                 () -> new TreeMap<>(comparator),
                 (resultContainer, a, b, c) -> {
@@ -926,7 +926,7 @@ public final class ConstraintCollectors {
     /**
      * As defined by {@link #max(Function)}.
      */
-    public static <A, B, C, D, Mapped extends Comparable<Mapped>> QuadConstraintCollector<A, B, C, D, ?, Mapped> max(
+    public static <A, B, C, D, Mapped extends Comparable<? super Mapped>> QuadConstraintCollector<A, B, C, D, ?, Mapped> max(
             QuadFunction<A, B, C, D, Mapped> groupValueMapping) {
         return max(groupValueMapping, Comparator.naturalOrder());
     }
@@ -935,12 +935,12 @@ public final class ConstraintCollectors {
      * As defined by {@link #max(Function)}, only with a custom {@link Comparator}.
      */
     public static <A, B, C, D, Mapped> QuadConstraintCollector<A, B, C, D, ?, Mapped> max(
-            QuadFunction<A, B, C, D, Mapped> groupValueMapping, Comparator<Mapped> comparator) {
+            QuadFunction<A, B, C, D, Mapped> groupValueMapping, Comparator<? super Mapped> comparator) {
         return minOrMax(groupValueMapping, comparator, false);
     }
 
     private static <A, B, C, D, Mapped> QuadConstraintCollector<A, B, C, D, SortedMap<Mapped, MutableLong>, Mapped> minOrMax(
-            QuadFunction<A, B, C, D, Mapped> groupValueMapping, Comparator<Mapped> comparator, boolean min) {
+            QuadFunction<A, B, C, D, Mapped> groupValueMapping, Comparator<? super Mapped> comparator, boolean min) {
         return new DefaultQuadConstraintCollector<>(
                 () -> new TreeMap<>(comparator),
                 (resultContainer, a, b, c, d) -> {
@@ -1290,7 +1290,7 @@ public final class ConstraintCollectors {
     /**
      * As defined by {@link #toSortedSet()}, only with a custom {@link Comparator}.
      */
-    public static <A> UniConstraintCollector<A, ?, SortedSet<A>> toSortedSet(Comparator<A> comparator) {
+    public static <A> UniConstraintCollector<A, ?, SortedSet<A>> toSortedSet(Comparator<? super A> comparator) {
         return toSortedSet(a -> a, comparator);
     }
 
@@ -1367,7 +1367,7 @@ public final class ConstraintCollectors {
      * @param <Mapped> type of elements in the resulting set
      * @return never null
      */
-    public static <A, Mapped extends Comparable<Mapped>> UniConstraintCollector<A, ?, SortedSet<Mapped>> toSortedSet(
+    public static <A, Mapped extends Comparable<? super Mapped>> UniConstraintCollector<A, ?, SortedSet<Mapped>> toSortedSet(
             Function<A, Mapped> groupValueMapping) {
         return toSortedSet(groupValueMapping, Comparator.naturalOrder());
     }
@@ -1376,7 +1376,7 @@ public final class ConstraintCollectors {
      * As defined by {@link #toSortedSet(Function)}, only with a custom {@link Comparator}.
      */
     public static <A, Mapped> UniConstraintCollector<A, ?, SortedSet<Mapped>> toSortedSet(
-            Function<A, Mapped> groupValueMapping, Comparator<Mapped> comparator) {
+            Function<A, Mapped> groupValueMapping, Comparator<? super Mapped> comparator) {
         return new DefaultUniConstraintCollector<A, TreeMap<Mapped, MutableLong>, SortedSet<Mapped>>(
                 () -> new TreeMap<>(comparator),
                 (resultContainer, a) -> {
@@ -1443,8 +1443,9 @@ public final class ConstraintCollectors {
     /**
      * As defined by {@link #toSortedSet(Function)}.
      */
-    public static <A, B, Mapped extends Comparable<Mapped>> BiConstraintCollector<A, B, ?, SortedSet<Mapped>> toSortedSet(
-            BiFunction<A, B, Mapped> groupValueMapping) {
+    public static <A, B, Mapped extends Comparable<? super Mapped>> BiConstraintCollector<A, B, ?, SortedSet<Mapped>>
+            toSortedSet(
+                    BiFunction<A, B, Mapped> groupValueMapping) {
         return toSortedSet(groupValueMapping, Comparator.naturalOrder());
     }
 
@@ -1452,7 +1453,7 @@ public final class ConstraintCollectors {
      * As defined by {@link #toSortedSet(Function, Comparator)}.
      */
     public static <A, B, Mapped> BiConstraintCollector<A, B, ?, SortedSet<Mapped>> toSortedSet(
-            BiFunction<A, B, Mapped> groupValueMapping, Comparator<Mapped> comparator) {
+            BiFunction<A, B, Mapped> groupValueMapping, Comparator<? super Mapped> comparator) {
         return new DefaultBiConstraintCollector<A, B, TreeMap<Mapped, MutableLong>, SortedSet<Mapped>>(
                 () -> new TreeMap<>(comparator),
                 (resultContainer, a, b) -> {
@@ -1511,7 +1512,7 @@ public final class ConstraintCollectors {
     /**
      * As defined by {@link #toSortedSet(Function)}.
      */
-    public static <A, B, C, Mapped extends Comparable<Mapped>> TriConstraintCollector<A, B, C, ?, SortedSet<Mapped>>
+    public static <A, B, C, Mapped extends Comparable<? super Mapped>> TriConstraintCollector<A, B, C, ?, SortedSet<Mapped>>
             toSortedSet(TriFunction<A, B, C, Mapped> groupValueMapping) {
         return toSortedSet(groupValueMapping, Comparator.naturalOrder());
     }
@@ -1520,7 +1521,7 @@ public final class ConstraintCollectors {
      * As defined by {@link #toSortedSet(Function, Comparator)}.
      */
     public static <A, B, C, Mapped> TriConstraintCollector<A, B, C, ?, SortedSet<Mapped>> toSortedSet(
-            TriFunction<A, B, C, Mapped> groupValueMapping, Comparator<Mapped> comparator) {
+            TriFunction<A, B, C, Mapped> groupValueMapping, Comparator<? super Mapped> comparator) {
         return new DefaultTriConstraintCollector<A, B, C, TreeMap<Mapped, MutableLong>, SortedSet<Mapped>>(
                 () -> new TreeMap<>(comparator),
                 (resultContainer, a, b, c) -> {
@@ -1579,7 +1580,8 @@ public final class ConstraintCollectors {
     /**
      * As defined by {@link #toSortedSet(Function)}.
      */
-    public static <A, B, C, D, Mapped extends Comparable<Mapped>> QuadConstraintCollector<A, B, C, D, ?, SortedSet<Mapped>>
+    public static <A, B, C, D, Mapped extends Comparable<? super Mapped>>
+            QuadConstraintCollector<A, B, C, D, ?, SortedSet<Mapped>>
             toSortedSet(QuadFunction<A, B, C, D, Mapped> groupValueMapping) {
         return toSortedSet(groupValueMapping, Comparator.naturalOrder());
     }
@@ -1588,7 +1590,7 @@ public final class ConstraintCollectors {
      * As defined by {@link #toSortedSet(Function, Comparator)}.
      */
     public static <A, B, C, D, Mapped> QuadConstraintCollector<A, B, C, D, ?, SortedSet<Mapped>> toSortedSet(
-            QuadFunction<A, B, C, D, Mapped> groupValueMapping, Comparator<Mapped> comparator) {
+            QuadFunction<A, B, C, D, Mapped> groupValueMapping, Comparator<? super Mapped> comparator) {
         return new DefaultQuadConstraintCollector<A, B, C, D, TreeMap<Mapped, MutableLong>, SortedSet<Mapped>>(
                 () -> new TreeMap<>(comparator),
                 (resultContainer, a, b, c, d) -> {
@@ -1883,8 +1885,9 @@ public final class ConstraintCollectors {
      * @param <Value> type of map value
      * @return never null
      */
-    public static <A, Key extends Comparable<Key>, Value> UniConstraintCollector<A, ?, SortedMap<Key, Set<Value>>> toSortedMap(
-            Function<? super A, ? extends Key> keyMapper, Function<? super A, ? extends Value> valueMapper) {
+    public static <A, Key extends Comparable<? super Key>, Value> UniConstraintCollector<A, ?, SortedMap<Key, Set<Value>>>
+            toSortedMap(
+                    Function<? super A, ? extends Key> keyMapper, Function<? super A, ? extends Value> valueMapper) {
         return toSortedMap(keyMapper, valueMapper, (IntFunction<Set<Value>>) LinkedHashSet::new);
     }
 
@@ -1909,7 +1912,7 @@ public final class ConstraintCollectors {
      * @param <ValueSet> type of the value set
      * @return never null
      */
-    public static <A, Key extends Comparable<Key>, Value, ValueSet extends Set<Value>>
+    public static <A, Key extends Comparable<? super Key>, Value, ValueSet extends Set<Value>>
             UniConstraintCollector<A, ?, SortedMap<Key, ValueSet>> toSortedMap(
                     Function<? super A, ? extends Key> keyMapper,
                     Function<? super A, ? extends Value> valueMapper, IntFunction<ValueSet> valueSetFunction) {
@@ -1936,9 +1939,10 @@ public final class ConstraintCollectors {
      * @param <Value> type of map value
      * @return never null
      */
-    public static <A, Key extends Comparable<Key>, Value> UniConstraintCollector<A, ?, SortedMap<Key, Value>> toSortedMap(
-            Function<? super A, ? extends Key> keyMapper, Function<? super A, ? extends Value> valueMapper,
-            BinaryOperator<Value> mergeFunction) {
+    public static <A, Key extends Comparable<? super Key>, Value> UniConstraintCollector<A, ?, SortedMap<Key, Value>>
+            toSortedMap(
+                    Function<? super A, ? extends Key> keyMapper, Function<? super A, ? extends Value> valueMapper,
+                    BinaryOperator<Value> mergeFunction) {
         return new DefaultUniConstraintCollector<>(
                 () -> new ToSimpleMapResultContainer<>((Supplier<TreeMap<Key, Value>>) TreeMap::new, mergeFunction),
                 (resultContainer, a) -> toMapAccumulator(keyMapper, valueMapper, resultContainer, a),
@@ -1990,7 +1994,7 @@ public final class ConstraintCollectors {
     /**
      * As defined by {@link #toSortedMap(Function, Function)}.
      */
-    public static <A, B, Key extends Comparable<Key>, Value> BiConstraintCollector<A, B, ?, SortedMap<Key, Set<Value>>>
+    public static <A, B, Key extends Comparable<? super Key>, Value> BiConstraintCollector<A, B, ?, SortedMap<Key, Set<Value>>>
             toSortedMap(BiFunction<? super A, ? super B, ? extends Key> keyMapper,
                     BiFunction<? super A, ? super B, ? extends Value> valueMapper) {
         return toSortedMap(keyMapper, valueMapper, (IntFunction<Set<Value>>) LinkedHashSet::new);
@@ -1999,7 +2003,7 @@ public final class ConstraintCollectors {
     /**
      * As defined by {@link #toSortedMap(Function, Function, IntFunction)}.
      */
-    public static <A, B, Key extends Comparable<Key>, Value, ValueSet extends Set<Value>>
+    public static <A, B, Key extends Comparable<? super Key>, Value, ValueSet extends Set<Value>>
             BiConstraintCollector<A, B, ?, SortedMap<Key, ValueSet>> toSortedMap(
                     BiFunction<? super A, ? super B, ? extends Key> keyMapper,
                     BiFunction<? super A, ? super B, ? extends Value> valueMapper, IntFunction<ValueSet> valueSetFunction) {
@@ -2012,9 +2016,10 @@ public final class ConstraintCollectors {
     /**
      * As defined by {@link #toSortedMap(Function, Function, BinaryOperator)}.
      */
-    public static <A, B, Key extends Comparable<Key>, Value> BiConstraintCollector<A, B, ?, SortedMap<Key, Value>> toSortedMap(
-            BiFunction<? super A, ? super B, ? extends Key> keyMapper,
-            BiFunction<? super A, ? super B, ? extends Value> valueMapper, BinaryOperator<Value> mergeFunction) {
+    public static <A, B, Key extends Comparable<? super Key>, Value> BiConstraintCollector<A, B, ?, SortedMap<Key, Value>>
+            toSortedMap(
+                    BiFunction<? super A, ? super B, ? extends Key> keyMapper,
+                    BiFunction<? super A, ? super B, ? extends Value> valueMapper, BinaryOperator<Value> mergeFunction) {
         return new DefaultBiConstraintCollector<>(
                 () -> new ToSimpleMapResultContainer<>((Supplier<TreeMap<Key, Value>>) TreeMap::new, mergeFunction),
                 (resultContainer, a, b) -> toMapAccumulator(keyMapper, valueMapper, resultContainer, a, b),
@@ -2068,7 +2073,8 @@ public final class ConstraintCollectors {
     /**
      * As defined by {@link #toSortedMap(Function, Function)}.
      */
-    public static <A, B, C, Key extends Comparable<Key>, Value> TriConstraintCollector<A, B, C, ?, SortedMap<Key, Set<Value>>>
+    public static <A, B, C, Key extends Comparable<? super Key>, Value>
+            TriConstraintCollector<A, B, C, ?, SortedMap<Key, Set<Value>>>
             toSortedMap(TriFunction<? super A, ? super B, ? super C, ? extends Key> keyMapper,
                     TriFunction<? super A, ? super B, ? super C, ? extends Value> valueMapper) {
         return toSortedMap(keyMapper, valueMapper, (IntFunction<Set<Value>>) LinkedHashSet::new);
@@ -2077,7 +2083,7 @@ public final class ConstraintCollectors {
     /**
      * As defined by {@link #toSortedMap(Function, Function, IntFunction)}.
      */
-    public static <A, B, C, Key extends Comparable<Key>, Value, ValueSet extends Set<Value>>
+    public static <A, B, C, Key extends Comparable<? super Key>, Value, ValueSet extends Set<Value>>
             TriConstraintCollector<A, B, C, ?, SortedMap<Key, ValueSet>> toSortedMap(
                     TriFunction<? super A, ? super B, ? super C, ? extends Key> keyMapper,
                     TriFunction<? super A, ? super B, ? super C, ? extends Value> valueMapper,
@@ -2091,7 +2097,8 @@ public final class ConstraintCollectors {
     /**
      * As defined by {@link #toSortedMap(Function, Function, BinaryOperator)}.
      */
-    public static <A, B, C, Key extends Comparable<Key>, Value> TriConstraintCollector<A, B, C, ?, SortedMap<Key, Value>>
+    public static <A, B, C, Key extends Comparable<? super Key>, Value>
+            TriConstraintCollector<A, B, C, ?, SortedMap<Key, Value>>
             toSortedMap(TriFunction<? super A, ? super B, ? super C, ? extends Key> keyMapper,
                     TriFunction<? super A, ? super B, ? super C, ? extends Value> valueMapper,
                     BinaryOperator<Value> mergeFunction) {
@@ -2149,7 +2156,7 @@ public final class ConstraintCollectors {
     /**
      * As defined by {@link #toSortedMap(Function, Function)}.
      */
-    public static <A, B, C, D, Key extends Comparable<Key>, Value>
+    public static <A, B, C, D, Key extends Comparable<? super Key>, Value>
             QuadConstraintCollector<A, B, C, D, ?, SortedMap<Key, Set<Value>>> toSortedMap(
                     QuadFunction<? super A, ? super B, ? super C, ? super D, ? extends Key> keyMapper,
                     QuadFunction<? super A, ? super B, ? super C, ? super D, ? extends Value> valueMapper) {
@@ -2159,7 +2166,7 @@ public final class ConstraintCollectors {
     /**
      * As defined by {@link #toSortedMap(Function, Function, IntFunction)}.
      */
-    public static <A, B, C, D, Key extends Comparable<Key>, Value, ValueSet extends Set<Value>>
+    public static <A, B, C, D, Key extends Comparable<? super Key>, Value, ValueSet extends Set<Value>>
             QuadConstraintCollector<A, B, C, D, ?, SortedMap<Key, ValueSet>> toSortedMap(
                     QuadFunction<? super A, ? super B, ? super C, ? super D, ? extends Key> keyMapper,
                     QuadFunction<? super A, ? super B, ? super C, ? super D, ? extends Value> valueMapper,
@@ -2173,7 +2180,8 @@ public final class ConstraintCollectors {
     /**
      * As defined by {@link #toSortedMap(Function, Function, BinaryOperator)}.
      */
-    public static <A, B, C, D, Key extends Comparable<Key>, Value> QuadConstraintCollector<A, B, C, D, ?, SortedMap<Key, Value>>
+    public static <A, B, C, D, Key extends Comparable<? super Key>, Value>
+            QuadConstraintCollector<A, B, C, D, ?, SortedMap<Key, Value>>
             toSortedMap(QuadFunction<? super A, ? super B, ? super C, ? super D, ? extends Key> keyMapper,
                     QuadFunction<? super A, ? super B, ? super C, ? super D, ? extends Value> valueMapper,
                     BinaryOperator<Value> mergeFunction) {

--- a/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/api/score/stream/ConstraintCollectorsTest.java
+++ b/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/api/score/stream/ConstraintCollectorsTest.java
@@ -23,6 +23,7 @@ import static org.optaplanner.core.impl.testdata.util.PlannerTestUtils.asSortedS
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.time.Duration;
+import java.time.LocalDateTime;
 import java.time.Period;
 import java.util.Comparator;
 import java.util.List;
@@ -1445,29 +1446,35 @@ class ConstraintCollectorsTest {
 
     @Test
     void minComparableBi() {
-        BiConstraintCollector<Integer, Integer, ?, Integer> collector = min(
-                (BiFunction<Integer, Integer, Integer>) Integer::sum);
-        Object container = collector.supplier().get();
+        /*
+         * LocalDateTime is chosen because it doesn't implement Comparable<LocalDateTime>.
+         * Rather it implements Comparable<? super LocalDateTime>,
+         * exercising the PECS principle in our generics
+         * in a way that Integer would not.
+         */
+        var baseLocalDateTime = LocalDateTime.of(2023, 1, 1, 0, 0);
+        var collector = min((Integer a, Integer b) -> baseLocalDateTime.plusMinutes(a + b));
+        var container = collector.supplier().get();
 
         // Default state.
         assertResult(collector, container, null);
         // add first value, which becomes the min
         int firstValueA = 2;
         Runnable firstRetractor = accumulate(collector, container, firstValueA, 0);
-        assertResult(collector, container, 2);
+        assertResult(collector, container, baseLocalDateTime.plusMinutes(2));
         // add second value, lesser than the first, becomes the new min
         int secondValueA = 1;
         Runnable secondRetractor = accumulate(collector, container, secondValueA, 0);
-        assertResult(collector, container, 1);
+        assertResult(collector, container, baseLocalDateTime.plusMinutes(1));
         // add third value, same as the second, result does not change
         Runnable thirdRetractor = accumulate(collector, container, secondValueA, 0);
-        assertResult(collector, container, 1);
+        assertResult(collector, container, baseLocalDateTime.plusMinutes(1));
         // retract one instance of the second value; second value is still the min value, nothing should change
         secondRetractor.run();
-        assertResult(collector, container, 1);
+        assertResult(collector, container, baseLocalDateTime.plusMinutes(1));
         // retract final instance of the second value; first value is now the min value
         thirdRetractor.run();
-        assertResult(collector, container, 2);
+        assertResult(collector, container, baseLocalDateTime.plusMinutes(2));
         // retract last value; there are no values now
         firstRetractor.run();
         assertResult(collector, container, null);
@@ -1504,28 +1511,35 @@ class ConstraintCollectorsTest {
 
     @Test
     void minComparableTri() {
-        TriConstraintCollector<Integer, Integer, Integer, ?, Integer> collector = min((a, b, c) -> a + b + c);
-        Object container = collector.supplier().get();
+        /*
+         * LocalDateTime is chosen because it doesn't implement Comparable<LocalDateTime>.
+         * Rather it implements Comparable<? super LocalDateTime>,
+         * exercising the PECS principle in our generics
+         * in a way that Integer would not.
+         */
+        var baseLocalDateTime = LocalDateTime.of(2023, 1, 1, 0, 0);
+        var collector = min((Integer a, Integer b, Integer c) -> baseLocalDateTime.plusMinutes(a + b + c));
+        var container = collector.supplier().get();
 
         // Default state.
         assertResult(collector, container, null);
         // add first value, which becomes the min
-        int firstValue = 2;
-        Runnable firstRetractor = accumulate(collector, container, firstValue, 0, 0);
-        assertResult(collector, container, 2);
+        int firstValueA = 2;
+        Runnable firstRetractor = accumulate(collector, container, firstValueA, 0, 0);
+        assertResult(collector, container, baseLocalDateTime.plusMinutes(2));
         // add second value, lesser than the first, becomes the new min
-        int secondValue = 1;
-        Runnable secondRetractor = accumulate(collector, container, secondValue, 0, 0);
-        assertResult(collector, container, 1);
+        int secondValueA = 1;
+        Runnable secondRetractor = accumulate(collector, container, secondValueA, 0, 0);
+        assertResult(collector, container, baseLocalDateTime.plusMinutes(1));
         // add third value, same as the second, result does not change
-        Runnable thirdRetractor = accumulate(collector, container, secondValue, 0, 0);
-        assertResult(collector, container, 1);
+        Runnable thirdRetractor = accumulate(collector, container, secondValueA, 0, 0);
+        assertResult(collector, container, baseLocalDateTime.plusMinutes(1));
         // retract one instance of the second value; second value is still the min value, nothing should change
         secondRetractor.run();
-        assertResult(collector, container, 1);
+        assertResult(collector, container, baseLocalDateTime.plusMinutes(1));
         // retract final instance of the second value; first value is now the min value
         thirdRetractor.run();
-        assertResult(collector, container, 2);
+        assertResult(collector, container, baseLocalDateTime.plusMinutes(2));
         // retract last value; there are no values now
         firstRetractor.run();
         assertResult(collector, container, null);
@@ -1563,28 +1577,41 @@ class ConstraintCollectorsTest {
 
     @Test
     void minComparableQuad() {
-        QuadConstraintCollector<Integer, Integer, Integer, Integer, ?, Integer> collector = min((a, b, c, d) -> a + b + c + d);
-        Object container = collector.supplier().get();
+        /*
+         * LocalDateTime is chosen because it doesn't implement Comparable<LocalDateTime>.
+         * Rather it implements Comparable<? super LocalDateTime>,
+         * exercising the PECS principle in our generics
+         * in a way that Integer would not.
+         */
+        /*
+         * LocalDateTime is chosen because it doesn't implement Comparable<LocalDateTime>.
+         * Rather it implements Comparable<? super LocalDateTime>,
+         * exercising the PECS principle in our generics
+         * in a way that Integer would not.
+         */
+        var baseLocalDateTime = LocalDateTime.of(2023, 1, 1, 0, 0);
+        var collector = min((Integer a, Integer b, Integer c, Integer d) -> baseLocalDateTime.plusMinutes(a + b + c + d));
+        var container = collector.supplier().get();
 
         // Default state.
         assertResult(collector, container, null);
         // add first value, which becomes the min
-        int firstValue = 2;
-        Runnable firstRetractor = accumulate(collector, container, firstValue, 0, 0, 0);
-        assertResult(collector, container, 2);
+        int firstValueA = 2;
+        Runnable firstRetractor = accumulate(collector, container, firstValueA, 0, 0, 0);
+        assertResult(collector, container, baseLocalDateTime.plusMinutes(2));
         // add second value, lesser than the first, becomes the new min
-        int secondValue = 1;
-        Runnable secondRetractor = accumulate(collector, container, secondValue, 0, 0, 0);
-        assertResult(collector, container, 1);
+        int secondValueA = 1;
+        Runnable secondRetractor = accumulate(collector, container, secondValueA, 0, 0, 0);
+        assertResult(collector, container, baseLocalDateTime.plusMinutes(1));
         // add third value, same as the second, result does not change
-        Runnable thirdRetractor = accumulate(collector, container, secondValue, 0, 0, 0);
-        assertResult(collector, container, 1);
+        Runnable thirdRetractor = accumulate(collector, container, secondValueA, 0, 0, 0);
+        assertResult(collector, container, baseLocalDateTime.plusMinutes(1));
         // retract one instance of the second value; second value is still the min value, nothing should change
         secondRetractor.run();
-        assertResult(collector, container, 1);
+        assertResult(collector, container, baseLocalDateTime.plusMinutes(1));
         // retract final instance of the second value; first value is now the min value
         thirdRetractor.run();
-        assertResult(collector, container, 2);
+        assertResult(collector, container, baseLocalDateTime.plusMinutes(2));
         // retract last value; there are no values now
         firstRetractor.run();
         assertResult(collector, container, null);
@@ -1684,29 +1711,35 @@ class ConstraintCollectorsTest {
 
     @Test
     void maxComparableBi() {
-        BiConstraintCollector<Integer, Integer, ?, Integer> collector = max(
-                (BiFunction<Integer, Integer, Integer>) Integer::sum);
-        Object container = collector.supplier().get();
+        /*
+         * LocalDateTime is chosen because it doesn't implement Comparable<LocalDateTime>.
+         * Rather it implements Comparable<? super LocalDateTime>,
+         * exercising the PECS principle in our generics
+         * in a way that Integer would not.
+         */
+        var baseLocalDateTime = LocalDateTime.of(2023, 1, 1, 0, 0);
+        var collector = max((Integer a, Integer b) -> baseLocalDateTime.plusMinutes(a + b));
+        var container = collector.supplier().get();
 
         // Default state.
         assertResult(collector, container, null);
         // add first value, which becomes the max
         int firstValue = 2;
         Runnable firstRetractor = accumulate(collector, container, firstValue, 0);
-        assertResult(collector, container, 2);
+        assertResult(collector, container, baseLocalDateTime.plusMinutes(2));
         // add second value, lesser than the first, result does not change
         int secondValue = 1;
         Runnable secondRetractor = accumulate(collector, container, secondValue, 0);
-        assertResult(collector, container, 2);
+        assertResult(collector, container, baseLocalDateTime.plusMinutes(2));
         // add third value, same as the first, result does not change
         Runnable thirdRetractor = accumulate(collector, container, firstValue, 0);
-        assertResult(collector, container, 2);
+        assertResult(collector, container, baseLocalDateTime.plusMinutes(2));
         // retract one instance of the first value; first value is still the max value, nothing should change
         firstRetractor.run();
-        assertResult(collector, container, 2);
+        assertResult(collector, container, baseLocalDateTime.plusMinutes(2));
         // retract final instance of the first value; second value is now the max value
         thirdRetractor.run();
-        assertResult(collector, container, 1);
+        assertResult(collector, container, baseLocalDateTime.plusMinutes(1));
         // retract last value; there are no values now
         secondRetractor.run();
         assertResult(collector, container, null);
@@ -1743,28 +1776,35 @@ class ConstraintCollectorsTest {
 
     @Test
     void maxComparableTri() {
-        TriConstraintCollector<Integer, Integer, Integer, ?, Integer> collector = max((a, b, c) -> a + b + c);
-        Object container = collector.supplier().get();
+        /*
+         * LocalDateTime is chosen because it doesn't implement Comparable<LocalDateTime>.
+         * Rather it implements Comparable<? super LocalDateTime>,
+         * exercising the PECS principle in our generics
+         * in a way that Integer would not.
+         */
+        var baseLocalDateTime = LocalDateTime.of(2023, 1, 1, 0, 0);
+        var collector = max((Integer a, Integer b, Integer c) -> baseLocalDateTime.plusMinutes(a + b + c));
+        var container = collector.supplier().get();
 
         // Default state.
         assertResult(collector, container, null);
         // add first value, which becomes the max
         int firstValue = 2;
         Runnable firstRetractor = accumulate(collector, container, firstValue, 0, 0);
-        assertResult(collector, container, 2);
+        assertResult(collector, container, baseLocalDateTime.plusMinutes(2));
         // add second value, lesser than the first, result does not change
         int secondValue = 1;
         Runnable secondRetractor = accumulate(collector, container, secondValue, 0, 0);
-        assertResult(collector, container, 2);
+        assertResult(collector, container, baseLocalDateTime.plusMinutes(2));
         // add third value, same as the first, result does not change
         Runnable thirdRetractor = accumulate(collector, container, firstValue, 0, 0);
-        assertResult(collector, container, 2);
+        assertResult(collector, container, baseLocalDateTime.plusMinutes(2));
         // retract one instance of the first value; first value is still the max value, nothing should change
         firstRetractor.run();
-        assertResult(collector, container, 2);
+        assertResult(collector, container, baseLocalDateTime.plusMinutes(2));
         // retract final instance of the first value; second value is now the max value
         thirdRetractor.run();
-        assertResult(collector, container, 1);
+        assertResult(collector, container, baseLocalDateTime.plusMinutes(1));
         // retract last value; there are no values now
         secondRetractor.run();
         assertResult(collector, container, null);
@@ -1802,28 +1842,35 @@ class ConstraintCollectorsTest {
 
     @Test
     void maxComparableQuad() {
-        QuadConstraintCollector<Integer, Integer, Integer, Integer, ?, Integer> collector = max((a, b, c, d) -> a + b + c + d);
-        Object container = collector.supplier().get();
+        /*
+         * LocalDateTime is chosen because it doesn't implement Comparable<LocalDateTime>.
+         * Rather it implements Comparable<? super LocalDateTime>,
+         * exercising the PECS principle in our generics
+         * in a way that Integer would not.
+         */
+        var baseLocalDateTime = LocalDateTime.of(2023, 1, 1, 0, 0);
+        var collector = max((Integer a, Integer b, Integer c, Integer d) -> baseLocalDateTime.plusMinutes(a + b + c + d));
+        var container = collector.supplier().get();
 
         // Default state.
         assertResult(collector, container, null);
         // add first value, which becomes the max
         int firstValue = 2;
         Runnable firstRetractor = accumulate(collector, container, firstValue, 0, 0, 0);
-        assertResult(collector, container, 2);
+        assertResult(collector, container, baseLocalDateTime.plusMinutes(2));
         // add second value, lesser than the first, result does not change
         int secondValue = 1;
         Runnable secondRetractor = accumulate(collector, container, secondValue, 0, 0, 0);
-        assertResult(collector, container, 2);
+        assertResult(collector, container, baseLocalDateTime.plusMinutes(2));
         // add third value, same as the first, result does not change
         Runnable thirdRetractor = accumulate(collector, container, firstValue, 0, 0, 0);
-        assertResult(collector, container, 2);
+        assertResult(collector, container, baseLocalDateTime.plusMinutes(2));
         // retract one instance of the first value; first value is still the max value, nothing should change
         firstRetractor.run();
-        assertResult(collector, container, 2);
+        assertResult(collector, container, baseLocalDateTime.plusMinutes(2));
         // retract final instance of the first value; second value is now the max value
         thirdRetractor.run();
-        assertResult(collector, container, 1);
+        assertResult(collector, container, baseLocalDateTime.plusMinutes(1));
         // retract last value; there are no values now
         secondRetractor.run();
         assertResult(collector, container, null);

--- a/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/api/score/stream/ConstraintCollectorsTest.java
+++ b/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/api/score/stream/ConstraintCollectorsTest.java
@@ -1583,12 +1583,6 @@ class ConstraintCollectorsTest {
          * exercising the PECS principle in our generics
          * in a way that Integer would not.
          */
-        /*
-         * LocalDateTime is chosen because it doesn't implement Comparable<LocalDateTime>.
-         * Rather it implements Comparable<? super LocalDateTime>,
-         * exercising the PECS principle in our generics
-         * in a way that Integer would not.
-         */
         var baseLocalDateTime = LocalDateTime.of(2023, 1, 1, 0, 0);
         var collector = min((Integer a, Integer b, Integer c, Integer d) -> baseLocalDateTime.plusMinutes(a + b + c + d));
         var container = collector.supplier().get();


### PR DESCRIPTION
Signed-off-by: Lukáš Petrovický <lukas@petrovicky.net>

<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.
-->

### JIRA

<!-- Add a JIRA ticket link if it exists. -->
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
- https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
- https://github.com/kiegroup/drools/pull/3000
- https://github.com/kiegroup/optaplanner/pull/899
- etc.
-->

### Checklist
- [ ] Documentation updated if applicable.
- [ ] Release notes updated if applicable.
- [ ] Upgrade recipe provided if applicable.

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request checks</b>  
  Please add comment: <b>Jenkins retest this</b>

- for a <b>specific pull request check</b>  
  please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-vehicle-routing] tests</b>
  
- for a <b>full downstream build</b> 
  - for <b>jenkins</b> job: 
    please add comment: <b>Jenkins run fdb</b>
  - for <b>github actions</b> job: 
    add the label `run_fdb`

- for a <b>compile downstream build</b>  
  please add comment: <b>Jenkins run cdb</b>

- for a <b>full production downstream build</b>  
  please add comment: <b>Jenkins execute product fdb</b>

- for an <b>upstream build</b>  
  please add comment: <b>Jenkins run upstream</b>

- for <b>quarkus branch checks</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins run quarkus-branch</b>

- for a <b>quarkus branch specific check</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-vehicle-routing] quarkus-branch</b>

- for <b>quarkus main checks</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins run quarkus-main</b>

- for a <b>specific quarkus main check</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-vehicle-routing] quarkus-branch</b>

- for <b>quarkus lts checks</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins run quarkus-lts</b>

- for a <b>specific quarkus lts check</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-vehicle-routing] quarkus-lts</b>

- for <b>native checks</b>  
  Run native checks  
  Please add comment: <b>Jenkins run native</b>

- for a <b>specific native check</b>  
  Run native checks 
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts] native</b>

- for <b>mandrel checks</b>  
  Run native checks against Mandrel image
  Please add comment: <b>Jenkins run mandrel</b>

- for a <b>specific mandrel check</b>  
  Run native checks against Mandrel image  
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts] mandrel</b>

- for <b>mandrel lts checks</b>  
  Run native checks against Mandrel image and quarkus lts branch
  Please add comment: <b>Jenkins run mandrel-lts</b>

- for a <b>specific mandrel lts check</b>  
  Run native checks against Mandrel image and quarkus lts branch
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts] mandrel-lts</b>

</details>

### CI Status

 You can check OptaPlanner repositories CI status from [Chain Status webpage](https://kiegroup.github.io/optaplanner/).

<details>
<summary>
How to backport a pull request to a different branch?
</summary>

In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-7.67.x` to backport the original PR to the `7.67.x` branch).

> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.

Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.

If something goes wrong, the author will be notified and at this point a manual backporting is needed.

> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
</details>
