### PR TITLE
[9.x-dsl-config] PLANNER-2870 Environments should be configurable via branch config

### DIFF
--- a/.ci/jenkins/config/branch.yaml
+++ b/.ci/jenkins/config/branch.yaml
@@ -1,81 +1,56 @@
-environment:
-  quarkus:
-    main:
-      enabled: false
-    branch:
-      enabled: true
-      version: '3.0'
-    lts:
-      enabled: false
-      # TODO: upgrade with Quarkus 3
-      version: '2.13'
+environments:
   native:
-    enabled: true
+    env_vars:
+      NATIVE: true
+      BUILD_MVN_OPTS_CURRENT: -Dnative -Dquarkus.native.container-build=true
+      ADDITIONAL_TIMEOUT: 720
+    ids:
+    - native
   mandrel:
     enabled: false
-    # TODO: upgrade with Quarkus 3
-    builder_image: quay.io/quarkus/ubi-quarkus-mandrel:22.3-java17
-  mandrel_lts:
+    env_vars:
+      NATIVE: true
+      BUILD_MVN_OPTS_CURRENT: -Dnative -Dquarkus.native.container-build=true
+      QUARKUS_NATIVE_BUILDER_IMAGE: mandrel
+      ADDITIONAL_TIMEOUT: 720
+    ids:
+    - native
+    - prod
+  quarkus-main:
     enabled: false
-    builder_image: quay.io/quarkus/ubi-quarkus-mandrel:22.3-java17
-    quarkus_version: 2.13
-  runtimes_bdd:
-    enabled: true
-productized_branch: true
-disable:
-  triggers: false
-repositories:
-- name: optaplanner
-  branch: 9.x
-- name: optaweb-vehicle-routing
-  branch: main
-- name: optaplanner-quickstarts
-  branch: development
-- name: optaplanner-website
-  branch: main
-git:
-  author:
-    name: kiegroup
-    credentials_id: kie-ci
-    token_credentials_id: kie-ci3-token
-  bot_author:
-    name: bsig-gh-bot
-    credentials_id: bsig-gh-bot
-  fork_author:
-    name: kie-ci
-    credentials_id: kie-ci
-  quarkus:
-    author:
-      name: quarkusio
-      credentials_id: kie-ci
-    branch: main
-  jenkins_config_path: .ci/jenkins
-buildchain_config:
-  git:
-    repository: optaplanner
-    branch: main
-    file_path: .ci/buildchain-config.yaml
-maven:
-  settings_file_id: kogito_release_settings
-  nexus:
-    release_url: https://repository.jboss.org/nexus
-    release_repository: jboss-releases-repository
-    staging_profile_url: https://repository.jboss.org/nexus/content/groups/kogito-public/
-    staging_profile_id: 2161b7b8da0080
-    build_promotion_profile_id: ea49ccd6f174
-  artifacts_repository: ''
-  pr_checks:
-    repository:
-      url: https://bxms-qe.rhev-ci-vms.eng.rdu2.redhat.com:8443/nexus/content/repositories/kogito-runtimes-pr-full-testing/
-      creds_id: unpacks-zip-on-qa-nexus
-cloud:
-  image:
-    registry_credentials: optaplanner-quay-token
-    registry: quay.io
-    namespace: optaplanner
-    latest_git_branch: main
-jenkins:
-  email_creds_id: OPTAPLANNER_CI_EMAIL
-  default_tools:
-    jdk: kie-jdk17
-    maven: kie-maven-3.8.7
+    env_vars:
+      QUARKUS_BRANCH: main
+    ids:
+    - quarkus
+  quarkus-branch:
+    env_vars:
+      QUARKUS_BRANCH: '3.0'
+    ids:
+    - quarkus
+  quarkus-lts:
+    # TODO: upgrade with Quarkus 3
+    enabled: false
+    env_vars:
+      BUILD_MVN_OPTS: -Dproductized
+      QUARKUS_BRANCH: '2.13'
+    ids:
+    - quarkus
+    - lts
+    - prod
+  mandrel-lts:
+    enabled: false
+    env_vars:
+      NATIVE: true
+      BUILD_MVN_OPTS: -Dproductized
+      BUILD_MVN_OPTS_CURRENT: -Dnative -Dquarkus.native.container-build=true
+      QUARKUS_BRANCH: '2.13'
+      QUARKUS_NATIVE_BUILDER_IMAGE: mandrel
+      ADDITIONAL_TIMEOUT: 720
+    ids:
+    - native
+    - prod
+    - lts
+  ecosystem:
+    auto_generation: false
+    ids:
+    - ecosystem

--- a/.ci/jenkins/config/branch.yaml
+++ b/.ci/jenkins/config/branch.yaml
@@ -54,3 +54,61 @@ environments:
     auto_generation: false
     ids:
     - ecosystem
+productized_branch: true
+disable:
+  triggers: false
+repositories:
+- name: optaplanner
+  branch: 9.x
+- name: optaweb-vehicle-routing
+  branch: main
+- name: optaplanner-quickstarts
+  branch: development
+- name: optaplanner-website
+  branch: main
+git:
+  author:
+    name: kiegroup
+    credentials_id: kie-ci
+    token_credentials_id: kie-ci3-token
+  bot_author:
+    name: bsig-gh-bot
+    credentials_id: bsig-gh-bot
+  fork_author:
+    name: kie-ci
+    credentials_id: kie-ci
+  quarkus:
+    author:
+      name: quarkusio
+      credentials_id: kie-ci
+    branch: main
+  jenkins_config_path: .ci/jenkins
+buildchain_config:
+  git:
+    repository: optaplanner
+    branch: main
+    file_path: .ci/buildchain-config.yaml
+maven:
+  settings_file_id: kogito_release_settings
+  nexus:
+    release_url: https://repository.jboss.org/nexus
+    release_repository: jboss-releases-repository
+    staging_profile_url: https://repository.jboss.org/nexus/content/groups/kogito-public/
+    staging_profile_id: 2161b7b8da0080
+    build_promotion_profile_id: ea49ccd6f174
+  artifacts_repository: ''
+  pr_checks:
+    repository:
+      url: https://bxms-qe.rhev-ci-vms.eng.rdu2.redhat.com:8443/nexus/content/repositories/kogito-runtimes-pr-full-testing/
+      creds_id: unpacks-zip-on-qa-nexus
+cloud:
+  image:
+    registry_credentials: optaplanner-quay-token
+    registry: quay.io
+    namespace: optaplanner
+    latest_git_branch: main
+jenkins:
+  email_creds_id: OPTAPLANNER_CI_EMAIL
+  default_tools:
+    jdk: kie-jdk17
+    maven: kie-maven-3.8.7


### PR DESCRIPTION
https://issues.redhat.com/browse/PLANNER-2870

Related:
- https://github.com/kiegroup/kogito-pipelines/pull/801
- https://github.com/kiegroup/optaplanner/pull/2550
- https://github.com/kiegroup/optaweb-vehicle-routing/pull/842
- https://github.com/kiegroup/optaplanner-quickstarts/pull/505
- https://github.com/kiegroup/optaplanner-website/pull/569
- [9.x] https://github.com/kiegroup/optaplanner/pull/2558