### PR TITLE
[9.x] Backport the CI changes

### DIFF
--- a/.ci/jenkins/Jenkinsfile.deploy
+++ b/.ci/jenkins/Jenkinsfile.deploy
@@ -1,5 +1,6 @@
 import org.jenkinsci.plugins.workflow.libs.Library
-@Library('jenkins-pipeline-shared-libraries')_
+
+@Library('jenkins-pipeline-shared-libraries') _
 
 import org.kie.jenkins.MavenCommand
 import org.kie.jenkins.MavenStagingHelper
@@ -84,20 +85,30 @@ pipeline {
 
         stage('Clone repositories') {
             steps {
-                checkoutRepo(optaplannerRepository)
-                checkoutQuickstarts()
-                checkoutRepo(vehicleRoutingRepository)
+                script {
+                    checkoutRepo(optaplannerRepository)
+                    // TODO: switch to the 9 stream after quickstarts and the optaweb will have been migrated.
+                    if (isStream8()) {
+                        checkoutQuickstarts()
+                        checkoutRepo(vehicleRoutingRepository)
+                    }
+                }
             }
         }
 
         stage('Prepare for PR') {
             when {
-                expression { return isRelease() || isCreatePr()  }
+                expression { return isRelease() || isCreatePr() }
             }
             steps {
-                prepareForPR(optaplannerRepository)
-                prepareForPR(vehicleRoutingRepository)
-                prepareForPR(quickstartsRepository)
+                script {
+                    prepareForPR(optaplannerRepository)
+                    // TODO: switch to the 9 stream after quickstarts and the optaweb will have been migrated.
+                    if (isStream8()) {
+                        prepareForPR(vehicleRoutingRepository)
+                        prepareForPR(quickstartsRepository)
+                    }
+                }
             }
         }
 
@@ -111,9 +122,12 @@ pipeline {
 
                     mavenCleanInstallOptaPlannerParents()
 
-                    maven.mvnVersionsUpdateParentAndChildModules(getOptawebVehicleRoutingMavenCommand(), getProjectVersion(), !isRelease())
+                    // TODO: switch to the 9 stream after quickstarts and the optaweb will have been migrated.
+                    if (isStream8()) {
+                        maven.mvnVersionsUpdateParentAndChildModules(getOptawebVehicleRoutingMavenCommand(), getProjectVersion(), !isRelease())
 
-                    updateQuickstartsVersions()
+                        updateQuickstartsVersions()
+                    }
                 }
             }
         }
@@ -142,9 +156,16 @@ pipeline {
         }
 
         stage('Build Quickstarts') {
+            when {
+                // TODO: switch to the 9 stream after quickstarts and the optaweb will have been migrated.
+                expression { return isStream8() }
+            }
             steps {
                 script {
-                    getOptaplannerQuickstartsMavenCommand().withProperty('maven.test.failure.ignore', true).skipTests(params.SKIP_TESTS).run('clean install')
+                    getOptaplannerQuickstartsMavenCommand()
+                            .withProperty('maven.test.failure.ignore', true)
+                            .skipTests(params.SKIP_TESTS)
+                            .run('clean install')
                 }
             }
             post {
@@ -158,6 +179,10 @@ pipeline {
         }
 
         stage('Build Vehicle Routing') {
+            when {
+                // TODO: switch to the 9 stream after quickstarts and the optaweb will have been migrated.
+                expression { return isStream8() }
+            }
             steps {
                 script {
                     buildOptaweb(getOptawebVehicleRoutingMavenCommand())
@@ -181,8 +206,11 @@ pipeline {
             steps {
                 script {
                     runMavenDeploy(getOptaplannerMavenCommand())
-                    runMavenDeploy(getOptaplannerQuickstartsMavenCommand().withOptions(['-pl', ':optaplanner-distribution']))
-                    runMavenDeploy(getOptawebVehicleRoutingMavenCommand())
+                    // TODO: switch to the 9 stream after quickstarts and the optaweb will have been migrated.
+                    if (isStream8()) {
+                        runMavenDeploy(getOptaplannerQuickstartsMavenCommand().withOptions(['-pl', ':optaplanner-distribution']))
+                        runMavenDeploy(getOptawebVehicleRoutingMavenCommand())
+                    }
                 }
             }
         }
@@ -193,7 +221,10 @@ pipeline {
             steps {
                 script {
                     runMavenDeploy(getOptaplannerMavenCommand(), optaplannerRepository)
-                    runMavenDeploy(getOptawebVehicleRoutingMavenCommand(), vehicleRoutingRepository)
+                    // TODO: switch to the 9 stream after quickstarts and the optaweb will have been migrated.
+                    if (isStream8()) {
+                        runMavenDeploy(getOptawebVehicleRoutingMavenCommand(), vehicleRoutingRepository)
+                    }
                 }
             }
         }
@@ -205,7 +236,10 @@ pipeline {
                 script {
                     // Deploy to specific repository with credentials
                     maven.uploadLocalArtifacts(env.MAVEN_REPO_CREDS_ID, getLocalDeploymentFolder(optaplannerRepository), getMavenRepoZipUrl())
-                    maven.uploadLocalArtifacts(env.MAVEN_REPO_CREDS_ID, getLocalDeploymentFolder(vehicleRoutingRepository), getMavenRepoZipUrl())
+                    // TODO: switch to the 9 stream after quickstarts and the optaweb will have been migrated.
+                    if (isStream8()) {
+                        maven.uploadLocalArtifacts(env.MAVEN_REPO_CREDS_ID, getLocalDeploymentFolder(vehicleRoutingRepository), getMavenRepoZipUrl())
+                    }
                 }
             }
         }
@@ -217,7 +251,10 @@ pipeline {
                 script {
                     // Stage release artifacts
                     runMavenStage(getOptaplannerMavenCommand(), optaplannerRepository)
-                    runMavenStage(getOptawebVehicleRoutingMavenCommand(), vehicleRoutingRepository)
+                    // TODO: switch to the 9 stream after quickstarts and the optaweb will have been migrated.
+                    if (isStream8()) {
+                        runMavenStage(getOptawebVehicleRoutingMavenCommand(), vehicleRoutingRepository)
+                    }
                 }
             }
         }
@@ -227,9 +264,14 @@ pipeline {
                 expression { return isRelease() || isCreatePr() }
             }
             steps {
-                commitAndCreatePR(optaplannerRepository, getBuildBranch())
-                commitAndCreatePRIgnoringNpmRegistry(vehicleRoutingRepository, getBuildBranch())
-                commitAndCreatePR(quickstartsRepository, getQuickStartsBranch())
+                script {
+                    commitAndCreatePR(optaplannerRepository, getBuildBranch())
+                    // TODO: switch to the 9 stream after quickstarts and the optaweb will have been migrated.
+                    if (isStream8()) {
+                        commitAndCreatePRIgnoringNpmRegistry(vehicleRoutingRepository, getBuildBranch())
+                        commitAndCreatePR(quickstartsRepository, getQuickStartsBranch())
+                    }
+                }
             }
             post {
                 success {
@@ -250,7 +292,7 @@ pipeline {
 
         stage('Push a temporary operator image to a registry') {
             when {
-                expression { return isRelease() }
+                expression { return isRelease() && isStream8() }
             }
             steps {
                 script {
@@ -581,4 +623,12 @@ void pushOperatorTemporaryImage() {
             getOperatorImageNamespace(), getOperatorImageName(), temporaryImageTag)
     imageUtils.tagImage(localImage, temporaryImageFullName)
     imageUtils.pushImage(temporaryImageFullName)
+}
+
+boolean isStream8() {
+    return env.OPTAPLANNER_LATEST_STREAM == '8'
+}
+
+boolean isStream9() {
+    return env.OPTAPLANNER_LATEST_STREAM == '9'
 }

--- a/.ci/jenkins/Jenkinsfile.promote
+++ b/.ci/jenkins/Jenkinsfile.promote
@@ -82,7 +82,8 @@ pipeline {
 
         stage('Merge Optaweb Vehicle Routing deploy PR and tag') {
             when {
-                expression { return isRelease() }
+                // TODO: switch to the 9 stream after optaweb will have been migrated.
+                expression { return isRelease() && isStream8() }
             }
             steps {
                 script {
@@ -97,7 +98,8 @@ pipeline {
 
         stage('Merge OptaPlanner Quickstarts PR and tag') {
             when {
-                expression { return isRelease() }
+                // TODO: switch to the 9 stream after quickstarts and the optaweb will have been migrated.
+                expression { return isRelease() && isStream8() }
             }
             steps {
                 script {
@@ -112,11 +114,16 @@ pipeline {
 
         stage('Upload OptaPlanner documentation') {
             when {
-                expression { return isRelease() }
+                // TODO: switch to the 9 stream after quickstarts and the optaweb will have been migrated.
+                expression { return isRelease() && isStream8() }
             }
             steps {
                 script {
-                    getMavenCommand().inDirectory(optaplannerRepository).skipTests(true).withProperty('full').run('clean install')
+                    getMavenCommand()
+                            .inDirectory(optaplannerRepository)
+                            .skipTests(true)
+                            .withProperty('full')
+                            .run('clean install')
                     uploadDistribution(optaplannerRepository)
                 }
             }
@@ -124,11 +131,15 @@ pipeline {
 
         stage('Upload Vehicle Routing documentation and distribution') {
             when {
-                expression { return isRelease() }
+                // TODO: switch to the 9 stream after quickstarts and the optaweb will have been migrated.
+                expression { return isRelease() && isStream8() }
             }
             steps {
                 script {
-                    getMavenCommand().inDirectory(vehicleRoutingRepository).skipTests(true).run('clean install')
+                    getMavenCommand()
+                            .inDirectory(vehicleRoutingRepository)
+                            .skipTests(true)
+                            .run('clean install')
                     uploadDistribution(vehicleRoutingRepository)
                 }
             }
@@ -162,7 +173,8 @@ pipeline {
 
         stage('Set Optaweb Vehicle Routing next snapshot version') {
             when {
-                expression { return isRelease() }
+                // TODO: switch to the 9 stream after quickstarts and the optaweb will have been migrated.
+                expression { return isRelease() && isStream8()  }
             }
             steps {
                 script {
@@ -185,7 +197,8 @@ pipeline {
 
         stage('Set Quickstarts next snapshot version') {
             when {
-                expression { return isRelease() }
+                // TODO: switch to the 9 stream after quickstarts and the optaweb will have been migrated.
+                expression { return isRelease() && isStream8() }
             }
             steps {
                 script {
@@ -208,7 +221,7 @@ pipeline {
 
         stage('Push the final OptaPlanner operator image') {
             when {
-                expression { return isRelease() }
+                expression { return isRelease() && isStream8() }
             }
             steps {
                 script {
@@ -497,4 +510,12 @@ void removeOperatorImageTemporaryTag() {
         error "Cannot remove the OptaPlanner Operator temporary image tag (${temporaryImageName}) from quay.io. "
                 + "The tag should be removed manually."
     }
+}
+
+boolean isStream8() {
+    return env.OPTAPLANNER_LATEST_STREAM == '8'
+}
+
+boolean isStream9() {
+    return env.OPTAPLANNER_LATEST_STREAM == '9'
 }

--- a/.ci/jenkins/config/branch.yaml
+++ b/.ci/jenkins/config/branch.yaml
@@ -1,24 +1,55 @@
-environment:
-  quarkus:
-    main:
-      enabled: true
-    branch:
-      enabled: true
-      version: '2.15'
-    lts:
-      enabled: true
-      version: '2.13'
+environments:
   native:
-    enabled: true
+    env_vars:
+      NATIVE: true
+      BUILD_MVN_OPTS_CURRENT: -Dnative -Dquarkus.native.container-build=true
+      ADDITIONAL_TIMEOUT: 720
+    ids:
+    - native
   mandrel:
-    enabled: true
-    builder_image: quay.io/quarkus/ubi-quarkus-mandrel:22.3-java17
-  mandrel_lts:
-    enabled: true
-    builder_image: quay.io/quarkus/ubi-quarkus-mandrel:22.3-java17
-    quarkus_version: 2.13
-  runtimes_bdd:
-    enabled: true
+    env_vars:
+      NATIVE: true
+      BUILD_MVN_OPTS_CURRENT: -Dnative -Dquarkus.native.container-build=true
+      QUARKUS_NATIVE_BUILDER_IMAGE: mandrel
+      ADDITIONAL_TIMEOUT: 720
+    ids:
+    - native
+    - prod
+  quarkus-main:
+    env_vars:
+      QUARKUS_BRANCH: main
+    ids:
+    - quarkus
+  quarkus-branch:
+    env_vars:
+      QUARKUS_BRANCH: '2.16'
+    ids:
+    - quarkus
+  quarkus-lts:
+    env_vars:
+      BUILD_MVN_OPTS: -Dproductized
+      QUARKUS_BRANCH: '2.13'
+    ids:
+    - quarkus
+    - lts
+    - prod
+  mandrel-lts:
+    env_vars:
+      NATIVE: true
+      BUILD_MVN_OPTS: -Dproductized
+      BUILD_MVN_OPTS_CURRENT: -Dnative -Dquarkus.native.container-build=true
+      QUARKUS_BRANCH: '2.13'
+      QUARKUS_NATIVE_BUILDER_IMAGE: mandrel
+      ADDITIONAL_TIMEOUT: 720
+    ids:
+    - native
+    - prod
+    - lts
+  ecosystem:
+    auto_generation: false
+    ids:
+    - ecosystem
+
 productized_branch: true
 disable:
   triggers: false
@@ -74,5 +105,5 @@ cloud:
 jenkins:
   email_creds_id: OPTAPLANNER_CI_EMAIL
   default_tools:
-    jdk: kie-jdk11
-    maven: kie-maven-3.8.6
+    jdk: kie-jdk17
+    maven: kie-maven-3.8.7

--- a/.ci/jenkins/dsl/jobs.groovy
+++ b/.ci/jenkins/dsl/jobs.groovy
@@ -8,7 +8,10 @@
 * https://github.com/kiegroup/kogito-pipelines/tree/main/dsl/seed/src/main/groovy/org/kie/jenkins/jobdsl.
 */
 
-import org.kie.jenkins.jobdsl.model.Folder
+import org.kie.jenkins.jobdsl.model.JenkinsFolder
+import org.kie.jenkins.jobdsl.model.JobType
+import org.kie.jenkins.jobdsl.utils.EnvUtils
+import org.kie.jenkins.jobdsl.utils.JobParamsUtils
 import org.kie.jenkins.jobdsl.KogitoJobTemplate
 import org.kie.jenkins.jobdsl.KogitoJobUtils
 import org.kie.jenkins.jobdsl.Utils
@@ -37,14 +40,14 @@ if (Utils.isMainBranch(this)) {
 
 // Tools
 KogitoJobUtils.createQuarkusPlatformUpdateToolsJob(this, 'optaplanner')
-KogitoJobUtils.createMainQuarkusUpdateToolsJob(this, 
+KogitoJobUtils.createMainQuarkusUpdateToolsJob(this,
         [ 'optaplanner', 'optaplanner-quickstarts' ],
         [ 'rsynek', 'triceo']
 )
 
 void setupProjectDroolsJob(String droolsBranch) {
-    def jobParams = KogitoJobUtils.getBasicJobParams(this, 'optaplanner-drools-snapshot', Folder.NIGHTLY_ECOSYSTEM, "${jenkins_path_project}/Jenkinsfile.drools", 'Optaplanner testing against Drools snapshot')
-    KogitoJobUtils.setupJobParamsDefaultMavenConfiguration(this, jobParams)
+    def jobParams = JobParamsUtils.getBasicJobParamsWithEnv(this, 'optaplanner-drools-snapshot', JobType.NIGHTLY, 'ecosystem', "${jenkins_path_project}/Jenkinsfile.drools", 'Optaplanner testing against Drools snapshot')
+    JobParamsUtils.setupJobParamsDefaultMavenConfiguration(this, jobParams)
     jobParams.triggers = [ cron : 'H 2 * * *' ]
     jobParams.env.putAll([
         JENKINS_EMAIL_CREDS_ID: "${JENKINS_EMAIL_CREDS_ID}",
@@ -60,7 +63,7 @@ void setupProjectDroolsJob(String droolsBranch) {
 }
 
 void createProjectSetupBranchJob() {
-    def jobParams = KogitoJobUtils.getBasicJobParams(this, '0-setup-branch', Folder.SETUP_BRANCH, "${jenkins_path_project}/Jenkinsfile.setup-branch", 'Optaplanner Project Setup Branch')
+    def jobParams = JobParamsUtils.getBasicJobParams(this, '0-setup-branch', JobType.SETUP_BRANCH, "${jenkins_path_project}/Jenkinsfile.setup-branch", 'Optaplanner Project Setup Branch')
     jobParams.env.putAll([
         JENKINS_EMAIL_CREDS_ID: "${JENKINS_EMAIL_CREDS_ID}",
 
@@ -78,7 +81,7 @@ void createProjectSetupBranchJob() {
 }
 
 void setupProjectNightlyJob() {
-    def jobParams = KogitoJobUtils.getBasicJobParams(this, 'optaplanner-nightly', Folder.NIGHTLY, "${jenkins_path_project}/Jenkinsfile.nightly", 'Optaplanner Nightly')
+    def jobParams = JobParamsUtils.getBasicJobParams(this, 'optaplanner-nightly', JobType.NIGHTLY, "${jenkins_path_project}/Jenkinsfile.nightly", 'Optaplanner Nightly')
     jobParams.triggers = [cron : '@midnight']
     jobParams.env.putAll([
         JENKINS_EMAIL_CREDS_ID: "${JENKINS_EMAIL_CREDS_ID}",
@@ -99,7 +102,7 @@ void setupProjectNightlyJob() {
 }
 
 void setupProjectReleaseJob() {
-    def jobParams = KogitoJobUtils.getBasicJobParams(this, 'optaplanner-release', Folder.RELEASE, "${jenkins_path_project}/Jenkinsfile.release", 'Optaplanner Release')
+    def jobParams = JobParamsUtils.getBasicJobParams(this, 'optaplanner-release', JobType.RELEASE, "${jenkins_path_project}/Jenkinsfile.release", 'Optaplanner Release')
     jobParams.env.putAll([
         JENKINS_EMAIL_CREDS_ID: "${JENKINS_EMAIL_CREDS_ID}",
 
@@ -117,14 +120,16 @@ void setupProjectReleaseJob() {
             stringParam('OPTAPLANNER_VERSION', '', 'Project version of OptaPlanner and its examples to release as Major.minor.micro')
             stringParam('OPTAPLANNER_RELEASE_BRANCH', '', '(optional) Use to override the release branch name deduced from the OPTAPLANNER_VERSION')
 
+            stringParam('DROOLS_VERSION', '', '(optional) Drools version to be set to the project before releasing the artifacts.')
+
             booleanParam('SKIP_TESTS', false, 'Skip all tests')
         }
     }
 }
 
 void setupProjectPostReleaseJob() {
-    def jobParams = KogitoJobUtils.getBasicJobParams(this, 'optaplanner-post-release', Folder.RELEASE, "${jenkins_path_project}/Jenkinsfile.post-release", 'Optaplanner Post Release')
-    KogitoJobUtils.setupJobParamsDefaultMavenConfiguration(this, jobParams)
+    def jobParams = JobParamsUtils.getBasicJobParams(this, 'optaplanner-post-release', JobType.RELEASE, "${jenkins_path_project}/Jenkinsfile.post-release", 'Optaplanner Post Release')
+    JobParamsUtils.setupJobParamsDefaultMavenConfiguration(this, jobParams)
     jobParams.env.putAll([
         JENKINS_EMAIL_CREDS_ID: "${JENKINS_EMAIL_CREDS_ID}",
 
@@ -157,7 +162,7 @@ void setupProjectPostReleaseJob() {
 // Optaplanner repository only project jobs
 ///////////////////////////////////////////////////////////////////////////////////////////
 
-Map getMultijobPRConfig(Folder jobFolder) {
+Map getMultijobPRConfig(JenkinsFolder jobFolder) {
     def jobConfig = [
         parallel: true,
         buildchain: true,
@@ -184,33 +189,30 @@ Map getMultijobPRConfig(Folder jobFolder) {
             ]
         ]
     ]
-    if (jobFolder.isNative() || jobFolder.isMandrel()  || jobFolder.isMandrelLTS()) { // Optaweb should not be built in native.
+    if (EnvUtils.hasEnvironmentId(this, jobFolder.getEnvironmentName(), 'native')) {
         jobConfig.jobs.retainAll { !it.id.startsWith('optaweb') }
     }
     return jobConfig
 }
 
 // Optaplanner PR checks
-KogitoJobUtils.createAllEnvsPerRepoPRJobs(this) { jobFolder -> getMultijobPRConfig(jobFolder) }
-setupDeployJob(Folder.PULLREQUEST_RUNTIMES_BDD)
+KogitoJobUtils.createAllEnvironmentsPerRepoPRJobs(this) { jobFolder -> getMultijobPRConfig(jobFolder) }
 
 // Setup branch branch
 createSetupBranchJob()
 
 // Nightly jobs
-setupDeployJob(Folder.NIGHTLY)
-setupSpecificBuildChainNightlyJob(Folder.NIGHTLY_NATIVE)
-
-setupSpecificBuildChainNightlyJob(Folder.NIGHTLY_QUARKUS_MAIN)
-setupSpecificBuildChainNightlyJob(Folder.NIGHTLY_QUARKUS_BRANCH)
-
-setupSpecificBuildChainNightlyJob(Folder.NIGHTLY_MANDREL)
-setupSpecificBuildChainNightlyJob(Folder.NIGHTLY_MANDREL_LTS)
-setupSpecificBuildChainNightlyJob(Folder.NIGHTLY_QUARKUS_LTS)
+setupDeployJob(JobType.NIGHTLY)
+setupSpecificBuildChainNightlyJob('native')
+setupSpecificBuildChainNightlyJob('quarkus-main')
+setupSpecificBuildChainNightlyJob('quarkus-branch')
+setupSpecificBuildChainNightlyJob('mandrel')
+setupSpecificBuildChainNightlyJob('quarkus-lts')
+setupSpecificBuildChainNightlyJob('mandrel-lts')
 
 // Release jobs
-setupDeployJob(Folder.RELEASE)
-setupPromoteJob(Folder.RELEASE)
+setupDeployJob(JobType.RELEASE)
+setupPromoteJob(JobType.RELEASE)
 
 if (Utils.isMainBranch(this)) {
     setupOptaPlannerTurtleTestsJob('drools')
@@ -229,14 +231,13 @@ KogitoJobUtils.createVersionUpdateToolsJob(this, 'optaplanner', 'Drools', [
   properties: [ 'version.org.drools' ],
 ])
 
-void setupSpecificBuildChainNightlyJob(Folder specificNightlyFolder) {
-    String envName = specificNightlyFolder.environment.toName()
-    KogitoJobUtils.createNightlyBuildChainBuildAndTestJobForCurrentRepo(this, specificNightlyFolder, true, envName)
+void setupSpecificBuildChainNightlyJob(String envName) {
+    KogitoJobUtils.createNightlyBuildChainBuildAndTestJobForCurrentRepo(this, envName, true)
 }
 
 void createSetupBranchJob() {
-    def jobParams = KogitoJobUtils.getBasicJobParams(this, 'optaplanner', Folder.SETUP_BRANCH, "${jenkins_path}/Jenkinsfile.setup-branch", 'OptaPlanner Setup Branch')
-    KogitoJobUtils.setupJobParamsDefaultMavenConfiguration(this, jobParams)
+    def jobParams = JobParamsUtils.getBasicJobParams(this, 'optaplanner', JobType.SETUP_BRANCH, "${jenkins_path}/Jenkinsfile.setup-branch", 'OptaPlanner Setup Branch')
+    JobParamsUtils.setupJobParamsDefaultMavenConfiguration(this, jobParams)
     jobParams.env.putAll([
         REPO_NAME: 'optaplanner',
         JENKINS_EMAIL_CREDS_ID: "${JENKINS_EMAIL_CREDS_ID}",
@@ -264,10 +265,10 @@ void createSetupBranchJob() {
     }
 }
 
-void setupDeployJob(Folder jobFolder) {
-    def jobParams = KogitoJobUtils.getBasicJobParams(this, 'optaplanner-deploy', jobFolder, "${jenkins_path}/Jenkinsfile.deploy", 'Optaplanner Deploy')
-    KogitoJobUtils.setupJobParamsDefaultMavenConfiguration(this, jobParams)
-    if (jobFolder.isPullRequest()) {
+void setupDeployJob(JobType jobType, String envName = '') {
+    def jobParams = JobParamsUtils.getBasicJobParamsWithEnv(this, 'optaplanner-deploy', jobType, envName, "${jenkins_path}/Jenkinsfile.deploy", 'Optaplanner Deploy')
+    JobParamsUtils.setupJobParamsDefaultMavenConfiguration(this, jobParams)
+    if (jobType == JobType.PULL_REQUEST) {
         jobParams.git.branch = '${BUILD_BRANCH_NAME}'
         jobParams.git.author = '${GIT_AUTHOR}'
         jobParams.git.project_url = Utils.createProjectUrl("${GIT_AUTHOR_NAME}", jobParams.git.repository)
@@ -279,7 +280,7 @@ void setupDeployJob(Folder jobFolder) {
         MAVEN_SETTINGS_CONFIG_FILE_ID: "${MAVEN_SETTINGS_FILE_ID}",
         OPTAPLANNER_LATEST_STREAM: getOptaPlannerLatestStream()
     ])
-    if (jobFolder.isPullRequest()) {
+    if (jobType == JobType.PULL_REQUEST) {
         jobParams.env.putAll([
             MAVEN_DEPENDENCIES_REPOSITORY: "${MAVEN_PR_CHECKS_REPOSITORY_URL}",
             MAVEN_DEPLOY_REPOSITORY: "${MAVEN_PR_CHECKS_REPOSITORY_URL}",
@@ -300,7 +301,7 @@ void setupDeployJob(Folder jobFolder) {
             OPERATOR_IMAGE_NAME: 'optaplanner-operator',
             MAX_REGISTRY_RETRIES: 3,
         ])
-        if (jobFolder.isRelease()) {
+        if (jobType == JobType.RELEASE) {
             jobParams.env.putAll([
                 NEXUS_RELEASE_URL: "${MAVEN_NEXUS_RELEASE_URL}",
                 NEXUS_RELEASE_REPOSITORY_ID: "${MAVEN_NEXUS_RELEASE_REPOSITORY}",
@@ -314,7 +315,7 @@ void setupDeployJob(Folder jobFolder) {
             stringParam('DISPLAY_NAME', '', 'Setup a specific build display name')
 
             stringParam('BUILD_BRANCH_NAME', "${GIT_BRANCH}", 'Set the Git branch to checkout')
-            if (jobFolder.isPullRequest()) {
+            if (jobType == JobType.PULL_REQUEST) {
                 // author can be changed as param only for PR behavior, due to source branch/target, else it is considered as an env
                 stringParam('GIT_AUTHOR', "${GIT_AUTHOR_NAME}", 'Set the Git author to checkout')
             }
@@ -325,7 +326,9 @@ void setupDeployJob(Folder jobFolder) {
             booleanParam('CREATE_PR', false, 'Should we create a PR with the changes ?')
             stringParam('PROJECT_VERSION', '', 'Optional if not RELEASE. If RELEASE, cannot be empty.')
 
-            if (jobFolder.isPullRequest()) {
+            stringParam('DROOLS_VERSION', '', '(optional) Drools version to be set to the project before releasing the artifacts.')
+
+            if (jobType == JobType.PULL_REQUEST) {
                 stringParam('PR_TARGET_BRANCH', '', 'What is the target branch of the PR?')
             }
 
@@ -342,9 +345,9 @@ void setupDeployJob(Folder jobFolder) {
     }
 }
 
-void setupPromoteJob(Folder jobFolder) {
-    def jobParams = KogitoJobUtils.getBasicJobParams(this, 'optaplanner-promote', jobFolder, "${jenkins_path}/Jenkinsfile.promote", 'Optaplanner Promote')
-    KogitoJobUtils.setupJobParamsDefaultMavenConfiguration(this, jobParams)
+void setupPromoteJob(JobType jobType) {
+    def jobParams = JobParamsUtils.getBasicJobParams(this, 'optaplanner-promote', jobType, "${jenkins_path}/Jenkinsfile.promote", 'Optaplanner Promote')
+    JobParamsUtils.setupJobParamsDefaultMavenConfiguration(this, jobParams)
     jobParams.env.putAll([
         JENKINS_EMAIL_CREDS_ID: "${JENKINS_EMAIL_CREDS_ID}",
 
@@ -387,9 +390,9 @@ void setupPromoteJob(Folder jobFolder) {
 }
 
 void setupOptaPlannerTurtleTestsJob(String constraintStreamImplType) {
-    def jobParams = KogitoJobUtils.getBasicJobParams(this, "optaplanner-turtle-tests-${constraintStreamImplType}", Folder.OTHER, "${jenkins_path}/Jenkinsfile.turtle",
+    def jobParams = JobParamsUtils.getBasicJobParams(this, "optaplanner-turtle-tests-${constraintStreamImplType}", JobType.OTHER, "${jenkins_path}/Jenkinsfile.turtle",
             "Run OptaPlanner turtle tests with CS-${constraintStreamImplType} on a weekly basis.")
-    KogitoJobUtils.setupJobParamsDefaultMavenConfiguration(this, jobParams)
+    JobParamsUtils.setupJobParamsDefaultMavenConfiguration(this, jobParams)
     jobParams.env.putAll([
             CONSTRAINT_STREAM_IMPL_TYPE: "${constraintStreamImplType}",
             JENKINS_EMAIL_CREDS_ID: "${JENKINS_EMAIL_CREDS_ID}"

--- a/.ci/jenkins/dsl/jobs.groovy
+++ b/.ci/jenkins/dsl/jobs.groovy
@@ -67,7 +67,8 @@ void createProjectSetupBranchJob() {
         GIT_BRANCH_NAME: "${GIT_BRANCH}",
         GIT_AUTHOR: "${GIT_AUTHOR_NAME}",
 
-        IS_MAIN_BRANCH: "${Utils.isMainBranch(this)}"
+        IS_MAIN_BRANCH: "${Utils.isMainBranch(this)}",
+        OPTAPLANNER_LATEST_STREAM: getOptaPlannerLatestStream()
     ])
     KogitoJobTemplate.createPipelineJob(this, jobParams)?.with {
         parameters {
@@ -84,9 +85,11 @@ void setupProjectNightlyJob() {
 
         GIT_BRANCH_NAME: "${GIT_BRANCH}",
         GIT_AUTHOR: "${GIT_AUTHOR_NAME}",
+        AUTHOR_CREDS_ID: "${GIT_AUTHOR_CREDENTIALS_ID}",
 
         MAVEN_SETTINGS_CONFIG_FILE_ID: "${MAVEN_SETTINGS_FILE_ID}",
         ARTIFACTS_REPOSITORY: "${MAVEN_ARTIFACTS_REPOSITORY}",
+        OPTAPLANNER_LATEST_STREAM: getOptaPlannerLatestStream()
     ])
     KogitoJobTemplate.createPipelineJob(this, jobParams)?.with {
         parameters {
@@ -105,6 +108,7 @@ void setupProjectReleaseJob() {
 
         DEFAULT_STAGING_REPOSITORY: "${MAVEN_NEXUS_STAGING_PROFILE_URL}",
         ARTIFACTS_REPOSITORY: "${MAVEN_ARTIFACTS_REPOSITORY}",
+        OPTAPLANNER_LATEST_STREAM: getOptaPlannerLatestStream()
     ])
     KogitoJobTemplate.createPipelineJob(this, jobParams)?.with {
         parameters {
@@ -133,6 +137,7 @@ void setupProjectPostReleaseJob() {
         MAVEN_DEPENDENCIES_REPOSITORY: "${MAVEN_ARTIFACTS_REPOSITORY}",
 
         GITHUB_CLI_VERSION: '0.11.1',
+        OPTAPLANNER_LATEST_STREAM: getOptaPlannerLatestStream()
     ])
     KogitoJobTemplate.createPipelineJob(this, jobParams)?.with {
         parameters {
@@ -243,7 +248,8 @@ void createSetupBranchJob() {
         MAVEN_DEPENDENCIES_REPOSITORY: "${MAVEN_ARTIFACTS_REPOSITORY}",
         MAVEN_DEPLOY_REPOSITORY: "${MAVEN_ARTIFACTS_REPOSITORY}",
 
-        IS_MAIN_BRANCH: "${Utils.isMainBranch(this)}"
+        IS_MAIN_BRANCH: "${Utils.isMainBranch(this)}",
+        OPTAPLANNER_LATEST_STREAM: getOptaPlannerLatestStream()
     ])
     KogitoJobTemplate.createPipelineJob(this, jobParams)?.with {
         parameters {
@@ -271,6 +277,7 @@ void setupDeployJob(Folder jobFolder) {
 
         JENKINS_EMAIL_CREDS_ID: "${JENKINS_EMAIL_CREDS_ID}",
         MAVEN_SETTINGS_CONFIG_FILE_ID: "${MAVEN_SETTINGS_FILE_ID}",
+        OPTAPLANNER_LATEST_STREAM: getOptaPlannerLatestStream()
     ])
     if (jobFolder.isPullRequest()) {
         jobParams.env.putAll([
@@ -354,6 +361,7 @@ void setupPromoteJob(Folder jobFolder) {
 
         PROPERTIES_FILE_NAME: 'deployment.properties',
         GITHUB_CLI_VERSION: '0.11.1',
+        OPTAPLANNER_LATEST_STREAM: getOptaPlannerLatestStream()
     ])
     KogitoJobTemplate.createPipelineJob(this, jobParams)?.with {
         parameters {
@@ -392,5 +400,17 @@ void setupOptaPlannerTurtleTestsJob(String constraintStreamImplType) {
             stringParam('BUILD_BRANCH_NAME', "${GIT_BRANCH}", 'Git branch to checkout')
             stringParam('GIT_AUTHOR', "${GIT_AUTHOR_NAME}", 'Git author or an organization.')
         }
+    }
+}
+
+String getOptaPlannerLatestStream() {
+    String gitMainBranch = "${GIT_MAIN_BRANCH}"
+
+    if (gitMainBranch == 'main') {
+        return '8'
+    } else if (gitMainBranch == '9.x') {
+        return '9'
+    } else {
+        return gitMainBranch
     }
 }

--- a/.ci/jenkins/project/Jenkinsfile.nightly
+++ b/.ci/jenkins/project/Jenkinsfile.nightly
@@ -1,6 +1,10 @@
 import org.jenkinsci.plugins.workflow.libs.Library
 @Library('jenkins-pipeline-shared-libraries')_
 
+String optaPlannerRepository = 'optaplanner'
+String optaPlannerMainBranch = 'main'
+String optaPlanner9xBranch = '9.x'
+
 // Deploy jobs
 OPTAPLANNER_DEPLOY = 'optaplanner-deploy'
 
@@ -49,13 +53,28 @@ pipeline {
             }
         }
 
+        // Applies only to the 9.x branch build. The 9.?.x release branches must remain intact.
+        stage('Migrate to 9') {
+            when {
+                expression { return getBuildBranch() == optaPlanner9xBranch }
+            }
+            steps {
+                script {
+                    checkoutNewBranch(optaPlannerRepository, optaPlannerMainBranch, optaPlanner9xBranch)
+                    callMigrationScript(optaPlannerRepository)
+                    forcePushBranch(optaPlannerRepository, optaPlanner9xBranch)
+                }
+            }
+        }
+
         stage('Build & Deploy OptaPlanner') {
             steps {
                 script {
                     def buildParams = getDefaultBuildParams(getBuildBranch())
                     addSkipTestsParam(buildParams)
                     addSkipIntegrationTestsParam(buildParams)
-                    def quickstartsBranch = getBuildBranch() == 'main' ? 'development' : getBuildBranch()
+                    def quickstartsBranch = getBuildBranch() == 'main' || getBuildBranch() == '9.x'
+                            ? 'development' : getBuildBranch()
                     addStringParam(buildParams, 'QUICKSTARTS_BUILD_BRANCH_NAME', quickstartsBranch)
 
                     buildJob(OPTAPLANNER_DEPLOY, buildParams)
@@ -168,4 +187,34 @@ String getBuildBranch() {
 
 String getGitAuthor() {
     return env.GIT_AUTHOR
+}
+
+String getGitAuthorCredsID() {
+    return env.AUTHOR_CREDS_ID
+}
+
+void checkoutNewBranch(String repo, String originBranch, String newBranch, String dirName = repo) {
+    dir(dirName) {
+        deleteDir()
+        checkoutRepo(optaPlannerRepository, originBranch)
+        sh "git checkout -b ${newBranch}"
+    }
+}
+
+void forcePushBranch(String dirName, String branch) {
+    dir(dirName) {
+        withCredentials([usernamePassword(credentialsId: getGitAuthorCredsID(), usernameVariable: 'GIT_USERNAME', passwordVariable: 'GIT_PASSWORD')]) {
+            // Please leave the double-quote here. They are mandatory for the shell command to work correctly.
+            sh """
+            git config --local credential.helper \"!f() { echo username=\\$GIT_USERNAME; echo password=\\$GIT_PASSWORD; }; f\"
+            git push origin ${branch} --force
+        """
+        }
+    }
+}
+
+void callMigrationScript(String dirName) {
+    dir(dirName) {
+        sh "./build/8-to-9-migration/migrate.sh"
+    }
 }

--- a/.ci/jenkins/project/Jenkinsfile.post-release
+++ b/.ci/jenkins/project/Jenkinsfile.post-release
@@ -58,6 +58,10 @@ pipeline {
         }
 
         stage('Reset Quickstarts stable branch') {
+            when {
+                // TODO: switch to the 9 stream after quickstarts and the optaweb will have been migrated.
+                expression { return isStream8() }
+            }
             steps {
                 script {
                     dir(quickstartsRepository) {
@@ -70,6 +74,10 @@ pipeline {
         }
 
         stage('Upload OptaPlanner distribution from Quickstarts') {
+            when {
+                // TODO: switch to the 9 stream after quickstarts and the optaweb will have been migrated.
+                expression { return isStream8() }
+            }
             steps {
                 script {
                     dir(optaplannerRepository) {
@@ -84,6 +92,10 @@ pipeline {
         }
 
         stage('Update OptaPlanner website') {
+            when {
+                // TODO: switch to the 9 stream after quickstarts and the optaweb will have been migrated.
+                expression { return isStream8() }
+            }
             steps {
                 script {
                     final String websiteRepository = 'optaplanner-website'
@@ -390,4 +402,12 @@ void assertGithubCLI(String ghPath) {
     else {
         error "gh not found at $ghPath"
     }
+}
+
+boolean isStream8() {
+    return env.OPTAPLANNER_LATEST_STREAM == '8'
+}
+
+boolean isStream9() {
+    return env.OPTAPLANNER_LATEST_STREAM == '9'
 }

--- a/build/8-to-9-migration/migrate.sh
+++ b/build/8-to-9-migration/migrate.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+script_dir_path=$(cd "$(dirname "${BASH_SOURCE[0]}")" || exit; pwd -P)
+
+mvn_cmd="mvn ${BUILD_MVN_OPTS:-}"
+optaplanner_file="${script_dir_path}/optaplanner-quarkus3.yaml"
+
+# Install artifacts locally.
+${mvn_cmd} clean install -Dquickly
+project_version=$(${mvn_cmd} help:evaluate -Dexpression=project.version -q -DforceStdout)
+
+# Run the recipe.
+${mvn_cmd} rewrite:run \
+  -Drewrite.configLocation="${optaplanner_file}" \
+  -Drewrite.recipeArtifactCoordinates=org.optaplanner:optaplanner-migration:"$project_version" \
+  -Drewrite.exclusions=optaplanner-operator/**,optaplanner-examples/data/** \
+  -Drewrite.activeRecipes=org.optaplanner.openrewrite.Quarkus3 \
+  -Dfull \
+  -Dquickly \
+  -Dmigration \
+
+# Remove obsolete spring.factories
+find "${script_dir_path}/../../optaplanner-spring-integration" -type f -name "spring.factories" -exec rm {} \;
+
+# 8.x.y(-SNAPSHOT|.Final) -> 9.x.y(-SNAPSHOT|.Final)
+new_project_version="9${project_version:1}"
+${mvn_cmd} versions:set \
+  -Dfull \
+  -DallowSnapshots=true \
+  -DgenerateBackupPoms=false \
+  -DnewVersion="${new_project_version}" \
+
+${mvn_cmd} process-test-sources
+
+# Commit the changes.
+git status
+git add -u
+git commit -m "Migrate to OptaPlanner 9"


### PR DESCRIPTION
<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.
-->

### JIRA

<!-- Add a JIRA ticket link if it exists. -->
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->

### Referenced pull requests
https://github.com/kiegroup/optaplanner/pull/2523
https://github.com/kiegroup/optaplanner/pull/2550

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
- https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
- https://github.com/kiegroup/drools/pull/3000
- https://github.com/kiegroup/optaplanner/pull/899
- etc.
-->

### Checklist
- [ ] Documentation updated if applicable.
- [ ] Release notes updated if applicable.
- [ ] Upgrade recipe provided if applicable.

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request checks</b>  
  Please add comment: <b>Jenkins retest this</b>

- for a <b>specific pull request check</b>  
  please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-vehicle-routing] tests</b>
  
- for a <b>full downstream build</b> 
  - for <b>jenkins</b> job: 
    please add comment: <b>Jenkins run fdb</b>
  - for <b>github actions</b> job: 
    add the label `run_fdb`

- for a <b>compile downstream build</b>  
  please add comment: <b>Jenkins run cdb</b>

- for a <b>full production downstream build</b>  
  please add comment: <b>Jenkins execute product fdb</b>

- for an <b>upstream build</b>  
  please add comment: <b>Jenkins run upstream</b>

- for <b>quarkus branch checks</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins run quarkus-branch</b>

- for a <b>quarkus branch specific check</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-vehicle-routing] quarkus-branch</b>

- for <b>quarkus main checks</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins run quarkus-main</b>

- for a <b>specific quarkus main check</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-vehicle-routing] quarkus-branch</b>

- for <b>quarkus lts checks</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins run quarkus-lts</b>

- for a <b>specific quarkus lts check</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-vehicle-routing] quarkus-lts</b>

- for <b>native checks</b>  
  Run native checks  
  Please add comment: <b>Jenkins run native</b>

- for a <b>specific native check</b>  
  Run native checks 
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts] native</b>

- for <b>mandrel checks</b>  
  Run native checks against Mandrel image
  Please add comment: <b>Jenkins run mandrel</b>

- for a <b>specific mandrel check</b>  
  Run native checks against Mandrel image  
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts] mandrel</b>

- for <b>mandrel lts checks</b>  
  Run native checks against Mandrel image and quarkus lts branch
  Please add comment: <b>Jenkins run mandrel-lts</b>

- for a <b>specific mandrel lts check</b>  
  Run native checks against Mandrel image and quarkus lts branch
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts] mandrel-lts</b>

</details>

### CI Status

 You can check OptaPlanner repositories CI status from [Chain Status webpage](https://kiegroup.github.io/optaplanner/).

<details>
<summary>
How to backport a pull request to a different branch?
</summary>

In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-7.67.x` to backport the original PR to the `7.67.x` branch).

> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.

Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.

If something goes wrong, the author will be notified and at this point a manual backporting is needed.

> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
</details>
