### PR TITLE
Enable nearby selection for ListChangeMove

### DIFF
--- a/core/optaplanner-core-impl/src/build/revapi-config.json
+++ b/core/optaplanner-core-impl/src/build/revapi-config.json
@@ -1019,6 +1019,15 @@
           "annotationType": "javax.xml.bind.annotation.XmlSeeAlso",
           "attribute": "value",
           "justification": "Introduce ListChangeMoveSelectorConfig and ListSwapMoveSelectorConfig."
+        },
+        {
+          "ignore": true,
+          "code": "java.annotation.attributeValueChanged",
+          "old": "class org.optaplanner.core.config.heuristic.selector.common.nearby.NearbySelectionConfig",
+          "new": "class org.optaplanner.core.config.heuristic.selector.common.nearby.NearbySelectionConfig",
+          "annotationType": "javax.xml.bind.annotation.XmlType",
+          "attribute": "propOrder",
+          "justification": "TODO: ADD YOUR EXPLANATION FOR THE NECESSITY OF THIS CHANGE"
         }
       ]
     }

--- a/core/optaplanner-core-impl/src/build/revapi-config.json
+++ b/core/optaplanner-core-impl/src/build/revapi-config.json
@@ -1027,7 +1027,7 @@
           "new": "class org.optaplanner.core.config.heuristic.selector.common.nearby.NearbySelectionConfig",
           "annotationType": "javax.xml.bind.annotation.XmlType",
           "attribute": "propOrder",
-          "justification": "TODO: ADD YOUR EXPLANATION FOR THE NECESSITY OF THIS CHANGE"
+          "justification": "Add new origin selector attributes to support nearby selection for list move selectors."
         }
       ]
     }

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/config/heuristic/selector/common/nearby/NearbySelectionConfig.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/config/heuristic/selector/common/nearby/NearbySelectionConfig.java
@@ -9,11 +9,13 @@ import org.optaplanner.core.config.heuristic.selector.SelectorConfig;
 import org.optaplanner.core.config.heuristic.selector.common.SelectionCacheType;
 import org.optaplanner.core.config.heuristic.selector.common.SelectionOrder;
 import org.optaplanner.core.config.heuristic.selector.entity.EntitySelectorConfig;
+import org.optaplanner.core.config.heuristic.selector.value.ValueSelectorConfig;
 import org.optaplanner.core.config.util.ConfigUtils;
 import org.optaplanner.core.impl.heuristic.selector.common.nearby.NearbyDistanceMeter;
 
 @XmlType(propOrder = {
         "originEntitySelectorConfig",
+        "originValueSelectorConfig",
         "nearbyDistanceMeterClass",
         "nearbySelectionDistributionType",
         "blockDistributionSizeMinimum",
@@ -29,6 +31,8 @@ public class NearbySelectionConfig extends SelectorConfig<NearbySelectionConfig>
 
     @XmlElement(name = "originEntitySelector")
     protected EntitySelectorConfig originEntitySelectorConfig = null;
+    @XmlElement(name = "originValueSelector")
+    protected ValueSelectorConfig originValueSelectorConfig = null;
     protected Class<? extends NearbyDistanceMeter> nearbyDistanceMeterClass = null;
 
     protected NearbySelectionDistributionType nearbySelectionDistributionType = null;
@@ -51,6 +55,14 @@ public class NearbySelectionConfig extends SelectorConfig<NearbySelectionConfig>
 
     public void setOriginEntitySelectorConfig(EntitySelectorConfig originEntitySelectorConfig) {
         this.originEntitySelectorConfig = originEntitySelectorConfig;
+    }
+
+    public ValueSelectorConfig getOriginValueSelectorConfig() {
+        return originValueSelectorConfig;
+    }
+
+    public void setOriginValueSelectorConfig(ValueSelectorConfig originValueSelectorConfig) {
+        this.originValueSelectorConfig = originValueSelectorConfig;
     }
 
     public Class<? extends NearbyDistanceMeter> getNearbyDistanceMeterClass() {
@@ -134,16 +146,26 @@ public class NearbySelectionConfig extends SelectorConfig<NearbySelectionConfig>
     }
 
     public void validateNearby(SelectionCacheType resolvedCacheType, SelectionOrder resolvedSelectionOrder) {
-        if (originEntitySelectorConfig == null) {
+        // TODO must use exactly one origin selector config
+        if (originEntitySelectorConfig == null && originValueSelectorConfig == null) {
             throw new IllegalArgumentException("The nearbySelectorConfig (" + this
                     + ") is nearby selection"
-                    + " but lacks an originEntitySelectorConfig (" + originEntitySelectorConfig + ").");
+                    + " but lacks an originEntitySelectorConfig (" + originEntitySelectorConfig
+                    + ") or an originValueSelectorConfig (" + originValueSelectorConfig + ").");
         }
-        if (originEntitySelectorConfig.getMimicSelectorRef() == null) {
+        if (originEntitySelectorConfig != null &&
+                originEntitySelectorConfig.getMimicSelectorRef() == null) {
             throw new IllegalArgumentException("The nearbySelectorConfig (" + this
                     + ") has an originEntitySelectorConfig (" + originEntitySelectorConfig
                     + ") which has no MimicSelectorRef (" + originEntitySelectorConfig.getMimicSelectorRef() + "). "
                     + "A nearby's original entity should always be the same as an entity selected earlier in the move.");
+        }
+        if (originValueSelectorConfig != null &&
+                originValueSelectorConfig.getMimicSelectorRef() == null) {
+            throw new IllegalArgumentException("The nearbySelectorConfig (" + this
+                    + ") has an originValueSelectorConfig (" + originValueSelectorConfig
+                    + ") which has no MimicSelectorRef (" + originValueSelectorConfig.getMimicSelectorRef() + "). "
+                    + "A nearby's original value should always be the same as a value selected earlier in the move.");
         }
         if (nearbyDistanceMeterClass == null) {
             throw new IllegalArgumentException("The nearbySelectorConfig (" + this
@@ -153,6 +175,7 @@ public class NearbySelectionConfig extends SelectorConfig<NearbySelectionConfig>
         if (resolvedSelectionOrder != SelectionOrder.ORIGINAL && resolvedSelectionOrder != SelectionOrder.RANDOM) {
             throw new IllegalArgumentException("The nearbySelectorConfig (" + this
                     + ") with nearbyOriginEntitySelector (" + originEntitySelectorConfig
+                    + ") and nearbyOriginValueSelector (" + originValueSelectorConfig
                     + ") and nearbyDistanceMeterClass (" + nearbyDistanceMeterClass
                     + ") has a resolvedSelectionOrder (" + resolvedSelectionOrder
                     + ") that is not " + SelectionOrder.ORIGINAL + " or " + SelectionOrder.RANDOM + ".");
@@ -160,6 +183,7 @@ public class NearbySelectionConfig extends SelectorConfig<NearbySelectionConfig>
         if (resolvedCacheType.isCached()) {
             throw new IllegalArgumentException("The nearbySelectorConfig (" + this
                     + ") with nearbyOriginEntitySelector (" + originEntitySelectorConfig
+                    + ") and nearbyOriginValueSelector (" + originValueSelectorConfig
                     + ") and nearbyDistanceMeterClass (" + nearbyDistanceMeterClass
                     + ") has a resolvedCacheType (" + resolvedCacheType
                     + ") that is cached.");
@@ -170,6 +194,8 @@ public class NearbySelectionConfig extends SelectorConfig<NearbySelectionConfig>
     public NearbySelectionConfig inherit(NearbySelectionConfig inheritedConfig) {
         originEntitySelectorConfig = ConfigUtils.inheritConfig(originEntitySelectorConfig,
                 inheritedConfig.getOriginEntitySelectorConfig());
+        originValueSelectorConfig = ConfigUtils.inheritConfig(originValueSelectorConfig,
+                inheritedConfig.getOriginValueSelectorConfig());
         nearbyDistanceMeterClass = ConfigUtils.inheritOverwritableProperty(nearbyDistanceMeterClass,
                 inheritedConfig.getNearbyDistanceMeterClass());
         nearbySelectionDistributionType = ConfigUtils.inheritOverwritableProperty(nearbySelectionDistributionType,

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/config/heuristic/selector/common/nearby/NearbySelectionConfig.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/config/heuristic/selector/common/nearby/NearbySelectionConfig.java
@@ -1,6 +1,8 @@
 package org.optaplanner.core.config.heuristic.selector.common.nearby;
 
+import java.util.Objects;
 import java.util.function.Consumer;
+import java.util.stream.Stream;
 
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlType;
@@ -145,13 +147,87 @@ public class NearbySelectionConfig extends SelectorConfig<NearbySelectionConfig>
         this.betaDistributionBeta = betaDistributionBeta;
     }
 
+    // ************************************************************************
+    // With methods
+    // ************************************************************************
+
+    public NearbySelectionConfig withOriginEntitySelectorConfig(EntitySelectorConfig originEntitySelectorConfig) {
+        this.setOriginEntitySelectorConfig(originEntitySelectorConfig);
+        return this;
+    }
+
+    public NearbySelectionConfig withOriginValueSelectorConfig(ValueSelectorConfig originValueSelectorConfig) {
+        this.setOriginValueSelectorConfig(originValueSelectorConfig);
+        return this;
+    }
+
+    public NearbySelectionConfig withNearbyDistanceMeterClass(Class<? extends NearbyDistanceMeter> nearbyDistanceMeterClass) {
+        this.setNearbyDistanceMeterClass(nearbyDistanceMeterClass);
+        return this;
+    }
+
+    public NearbySelectionConfig
+            withNearbySelectionDistributionType(NearbySelectionDistributionType nearbySelectionDistributionType) {
+        this.setNearbySelectionDistributionType(nearbySelectionDistributionType);
+        return this;
+    }
+
+    public NearbySelectionConfig withBlockDistributionSizeMinimum(Integer blockDistributionSizeMinimum) {
+        this.setBlockDistributionSizeMinimum(blockDistributionSizeMinimum);
+        return this;
+    }
+
+    public NearbySelectionConfig withBlockDistributionSizeMaximum(Integer blockDistributionSizeMaximum) {
+        this.setBlockDistributionSizeMaximum(blockDistributionSizeMaximum);
+        return this;
+    }
+
+    public NearbySelectionConfig withBlockDistributionSizeRatio(Double blockDistributionSizeRatio) {
+        this.setBlockDistributionSizeRatio(blockDistributionSizeRatio);
+        return this;
+    }
+
+    public NearbySelectionConfig
+            withBlockDistributionUniformDistributionProbability(Double blockDistributionUniformDistributionProbability) {
+        this.setBlockDistributionUniformDistributionProbability(blockDistributionUniformDistributionProbability);
+        return this;
+    }
+
+    public NearbySelectionConfig withLinearDistributionSizeMaximum(Integer linearDistributionSizeMaximum) {
+        this.setLinearDistributionSizeMaximum(linearDistributionSizeMaximum);
+        return this;
+    }
+
+    public NearbySelectionConfig withParabolicDistributionSizeMaximum(Integer parabolicDistributionSizeMaximum) {
+        this.setParabolicDistributionSizeMaximum(parabolicDistributionSizeMaximum);
+        return this;
+    }
+
+    public NearbySelectionConfig withBetaDistributionAlpha(Double betaDistributionAlpha) {
+        this.setBetaDistributionAlpha(betaDistributionAlpha);
+        return this;
+    }
+
+    public NearbySelectionConfig withBetaDistributionBeta(Double betaDistributionBeta) {
+        this.setBetaDistributionBeta(betaDistributionBeta);
+        return this;
+    }
+
+    // ************************************************************************
+    // Builder methods
+    // ************************************************************************
+
     public void validateNearby(SelectionCacheType resolvedCacheType, SelectionOrder resolvedSelectionOrder) {
-        // TODO must use exactly one origin selector config
-        if (originEntitySelectorConfig == null && originValueSelectorConfig == null) {
+        long originSelectorCount = Stream.of(originEntitySelectorConfig, originValueSelectorConfig)
+                .filter(Objects::nonNull)
+                .count();
+        if (originSelectorCount == 0) {
             throw new IllegalArgumentException("The nearbySelectorConfig (" + this
-                    + ") is nearby selection"
-                    + " but lacks an originEntitySelectorConfig (" + originEntitySelectorConfig
-                    + ") or an originValueSelectorConfig (" + originValueSelectorConfig + ").");
+                    + ") is nearby selection but lacks an origin selector config."
+                    + " Set one of originEntitySelectorConfig or originValueSelectorConfig.");
+        } else if (originSelectorCount > 1) {
+            throw new IllegalArgumentException("The nearbySelectorConfig (" + this + ") has multiple origin selector configs"
+                    + " but exactly one of originEntitySelectorConfig or originValueSelectorConfig is expected.");
         }
         if (originEntitySelectorConfig != null &&
                 originEntitySelectorConfig.getMimicSelectorRef() == null) {
@@ -229,6 +305,9 @@ public class NearbySelectionConfig extends SelectorConfig<NearbySelectionConfig>
     public void visitReferencedClasses(Consumer<Class<?>> classVisitor) {
         if (originEntitySelectorConfig != null) {
             originEntitySelectorConfig.visitReferencedClasses(classVisitor);
+        }
+        if (originValueSelectorConfig != null) {
+            originValueSelectorConfig.visitReferencedClasses(classVisitor);
         }
         classVisitor.accept(nearbyDistanceMeterClass);
     }

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/config/heuristic/selector/move/generic/list/DestinationSelectorConfig.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/config/heuristic/selector/move/generic/list/DestinationSelectorConfig.java
@@ -62,15 +62,24 @@ public class DestinationSelectorConfig extends SelectorConfig<DestinationSelecto
     // With methods
     // ************************************************************************
 
+    public DestinationSelectorConfig withEntitySelectorConfig(EntitySelectorConfig entitySelectorConfig) {
+        this.setEntitySelectorConfig(entitySelectorConfig);
+        return this;
+    }
+
     public DestinationSelectorConfig withValueSelectorConfig(ValueSelectorConfig valueSelectorConfig) {
         this.setValueSelectorConfig(valueSelectorConfig);
         return this;
     }
 
-    public DestinationSelectorConfig withEntitySelectorConfig(EntitySelectorConfig entitySelectorConfig) {
-        this.setEntitySelectorConfig(entitySelectorConfig);
+    public DestinationSelectorConfig withNearbySelectionConfig(NearbySelectionConfig nearbySelectionConfig) {
+        this.setNearbySelectionConfig(nearbySelectionConfig);
         return this;
     }
+
+    // ************************************************************************
+    // Builder methods
+    // ************************************************************************
 
     @Override
     public DestinationSelectorConfig inherit(DestinationSelectorConfig inheritedConfig) {

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/config/heuristic/selector/move/generic/list/DestinationSelectorConfig.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/config/heuristic/selector/move/generic/list/DestinationSelectorConfig.java
@@ -1,0 +1,99 @@
+package org.optaplanner.core.config.heuristic.selector.move.generic.list;
+
+import java.util.function.Consumer;
+
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlType;
+
+import org.optaplanner.core.config.heuristic.selector.SelectorConfig;
+import org.optaplanner.core.config.heuristic.selector.common.nearby.NearbySelectionConfig;
+import org.optaplanner.core.config.heuristic.selector.entity.EntitySelectorConfig;
+import org.optaplanner.core.config.heuristic.selector.value.ValueSelectorConfig;
+import org.optaplanner.core.config.util.ConfigUtils;
+
+@XmlType(propOrder = {
+        "entitySelectorConfig",
+        "valueSelectorConfig",
+        "nearbySelectionConfig",
+})
+public class DestinationSelectorConfig extends SelectorConfig<DestinationSelectorConfig> {
+
+    @XmlElement(name = "entitySelector")
+    private EntitySelectorConfig entitySelectorConfig;
+    @XmlElement(name = "valueSelector")
+    private ValueSelectorConfig valueSelectorConfig;
+    @XmlElement(name = "nearbySelection")
+    private NearbySelectionConfig nearbySelectionConfig;
+
+    public DestinationSelectorConfig() {
+    }
+
+    public DestinationSelectorConfig(DestinationSelectorConfig inheritedConfig) {
+        if (inheritedConfig != null) {
+            inherit(inheritedConfig);
+        }
+    }
+
+    public EntitySelectorConfig getEntitySelectorConfig() {
+        return entitySelectorConfig;
+    }
+
+    public void setEntitySelectorConfig(EntitySelectorConfig entitySelectorConfig) {
+        this.entitySelectorConfig = entitySelectorConfig;
+    }
+
+    public ValueSelectorConfig getValueSelectorConfig() {
+        return valueSelectorConfig;
+    }
+
+    public void setValueSelectorConfig(ValueSelectorConfig valueSelectorConfig) {
+        this.valueSelectorConfig = valueSelectorConfig;
+    }
+
+    public NearbySelectionConfig getNearbySelectionConfig() {
+        return nearbySelectionConfig;
+    }
+
+    public void setNearbySelectionConfig(NearbySelectionConfig nearbySelectionConfig) {
+        this.nearbySelectionConfig = nearbySelectionConfig;
+    }
+
+    // ************************************************************************
+    // With methods
+    // ************************************************************************
+
+    public DestinationSelectorConfig withValueSelectorConfig(ValueSelectorConfig valueSelectorConfig) {
+        this.setValueSelectorConfig(valueSelectorConfig);
+        return this;
+    }
+
+    public DestinationSelectorConfig withEntitySelectorConfig(EntitySelectorConfig entitySelectorConfig) {
+        this.setEntitySelectorConfig(entitySelectorConfig);
+        return this;
+    }
+
+    @Override
+    public DestinationSelectorConfig inherit(DestinationSelectorConfig inheritedConfig) {
+        entitySelectorConfig = ConfigUtils.inheritConfig(entitySelectorConfig, inheritedConfig.getEntitySelectorConfig());
+        valueSelectorConfig = ConfigUtils.inheritConfig(valueSelectorConfig, inheritedConfig.getValueSelectorConfig());
+        nearbySelectionConfig = ConfigUtils.inheritConfig(nearbySelectionConfig, inheritedConfig.getNearbySelectionConfig());
+        return this;
+    }
+
+    @Override
+    public DestinationSelectorConfig copyConfig() {
+        return new DestinationSelectorConfig().inherit(this);
+    }
+
+    @Override
+    public void visitReferencedClasses(Consumer<Class<?>> classVisitor) {
+        if (nearbySelectionConfig != null) {
+            nearbySelectionConfig.visitReferencedClasses(classVisitor);
+        }
+    }
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName() + "(" + entitySelectorConfig + ", " + valueSelectorConfig + ")";
+    }
+}

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/config/heuristic/selector/move/generic/list/DestinationSelectorConfig.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/config/heuristic/selector/move/generic/list/DestinationSelectorConfig.java
@@ -96,6 +96,12 @@ public class DestinationSelectorConfig extends SelectorConfig<DestinationSelecto
 
     @Override
     public void visitReferencedClasses(Consumer<Class<?>> classVisitor) {
+        if (entitySelectorConfig != null) {
+            entitySelectorConfig.visitReferencedClasses(classVisitor);
+        }
+        if (valueSelectorConfig != null) {
+            valueSelectorConfig.visitReferencedClasses(classVisitor);
+        }
         if (nearbySelectionConfig != null) {
             nearbySelectionConfig.visitReferencedClasses(classVisitor);
         }

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/config/heuristic/selector/move/generic/list/ListChangeMoveSelectorConfig.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/config/heuristic/selector/move/generic/list/ListChangeMoveSelectorConfig.java
@@ -5,14 +5,13 @@ import java.util.function.Consumer;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlType;
 
-import org.optaplanner.core.config.heuristic.selector.entity.EntitySelectorConfig;
 import org.optaplanner.core.config.heuristic.selector.move.MoveSelectorConfig;
 import org.optaplanner.core.config.heuristic.selector.value.ValueSelectorConfig;
 import org.optaplanner.core.config.util.ConfigUtils;
 
 @XmlType(propOrder = {
         "valueSelectorConfig",
-        "entitySelectorConfig"
+        "destinationSelectorConfig"
 })
 public class ListChangeMoveSelectorConfig extends MoveSelectorConfig<ListChangeMoveSelectorConfig> {
 
@@ -21,8 +20,8 @@ public class ListChangeMoveSelectorConfig extends MoveSelectorConfig<ListChangeM
     @XmlElement(name = "valueSelector")
     private ValueSelectorConfig valueSelectorConfig = null;
 
-    @XmlElement(name = "entitySelector")
-    private EntitySelectorConfig entitySelectorConfig = null;
+    @XmlElement(name = "destinationSelector")
+    private DestinationSelectorConfig destinationSelectorConfig = null;
 
     public ValueSelectorConfig getValueSelectorConfig() {
         return valueSelectorConfig;
@@ -32,12 +31,12 @@ public class ListChangeMoveSelectorConfig extends MoveSelectorConfig<ListChangeM
         this.valueSelectorConfig = valueSelectorConfig;
     }
 
-    public EntitySelectorConfig getEntitySelectorConfig() {
-        return entitySelectorConfig;
+    public DestinationSelectorConfig getDestinationSelectorConfig() {
+        return destinationSelectorConfig;
     }
 
-    public void setEntitySelectorConfig(EntitySelectorConfig entitySelectorConfig) {
-        this.entitySelectorConfig = entitySelectorConfig;
+    public void setDestinationSelectorConfig(DestinationSelectorConfig destinationSelectorConfig) {
+        this.destinationSelectorConfig = destinationSelectorConfig;
     }
 
     // ************************************************************************
@@ -49,8 +48,8 @@ public class ListChangeMoveSelectorConfig extends MoveSelectorConfig<ListChangeM
         return this;
     }
 
-    public ListChangeMoveSelectorConfig withEntitySelectorConfig(EntitySelectorConfig entitySelectorConfig) {
-        this.setEntitySelectorConfig(entitySelectorConfig);
+    public ListChangeMoveSelectorConfig withDestinationSelectorConfig(DestinationSelectorConfig destinationSelectorConfig) {
+        this.setDestinationSelectorConfig(destinationSelectorConfig);
         return this;
     }
 
@@ -62,7 +61,8 @@ public class ListChangeMoveSelectorConfig extends MoveSelectorConfig<ListChangeM
     public ListChangeMoveSelectorConfig inherit(ListChangeMoveSelectorConfig inheritedConfig) {
         super.inherit(inheritedConfig);
         valueSelectorConfig = ConfigUtils.inheritConfig(valueSelectorConfig, inheritedConfig.getValueSelectorConfig());
-        entitySelectorConfig = ConfigUtils.inheritConfig(entitySelectorConfig, inheritedConfig.getEntitySelectorConfig());
+        destinationSelectorConfig =
+                ConfigUtils.inheritConfig(destinationSelectorConfig, inheritedConfig.getDestinationSelectorConfig());
         return this;
     }
 
@@ -77,14 +77,13 @@ public class ListChangeMoveSelectorConfig extends MoveSelectorConfig<ListChangeM
         if (valueSelectorConfig != null) {
             valueSelectorConfig.visitReferencedClasses(classVisitor);
         }
-        if (entitySelectorConfig != null) {
-            entitySelectorConfig.visitReferencedClasses(classVisitor);
+        if (destinationSelectorConfig != null) {
+            destinationSelectorConfig.visitReferencedClasses(classVisitor);
         }
     }
 
     @Override
     public String toString() {
-        return getClass().getSimpleName() + "(" + valueSelectorConfig + ", " + entitySelectorConfig + ")";
+        return getClass().getSimpleName() + "(" + valueSelectorConfig + ", " + destinationSelectorConfig + ")";
     }
-
 }

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/common/nearby/NearbyDistanceMatrix.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/common/nearby/NearbyDistanceMatrix.java
@@ -8,9 +8,6 @@ import java.util.Map;
 import java.util.function.Function;
 import java.util.function.ToIntFunction;
 
-import org.optaplanner.core.impl.heuristic.selector.entity.EntitySelector;
-import org.optaplanner.core.impl.heuristic.selector.value.ValueSelector;
-
 public final class NearbyDistanceMatrix<Origin, Destination> {
 
     private final NearbyDistanceMeter<Origin, Destination> nearbyDistanceMeter;
@@ -18,24 +15,12 @@ public final class NearbyDistanceMatrix<Origin, Destination> {
     private final Function<Origin, Iterator<Destination>> destinationIteratorProvider;
     private final ToIntFunction<Origin> destinationSizeFunction;
 
-    public <Solution_> NearbyDistanceMatrix(NearbyDistanceMeter<Origin, Destination> nearbyDistanceMeter, int originSize,
-            ValueSelector<Solution_> destinationSelector, ToIntFunction<Origin> destinationSizeFunction) {
-        this(nearbyDistanceMeter, originSize, origin -> (Iterator<Destination>) destinationSelector.endingIterator(origin),
-                destinationSizeFunction);
-    }
-
-    public <Solution_> NearbyDistanceMatrix(NearbyDistanceMeter<Origin, Destination> nearbyDistanceMeter, int originSize,
-            EntitySelector<Solution_> destinationSelector, ToIntFunction<Origin> destinationSizeFunction) {
-        this(nearbyDistanceMeter, originSize, origin -> (Iterator<Destination>) destinationSelector.endingIterator(),
-                destinationSizeFunction);
-    }
-
     NearbyDistanceMatrix(NearbyDistanceMeter<Origin, Destination> nearbyDistanceMeter, int originSize,
             List<Destination> destinationSelector, ToIntFunction<Origin> destinationSizeFunction) {
         this(nearbyDistanceMeter, originSize, origin -> destinationSelector.iterator(), destinationSizeFunction);
     }
 
-    private NearbyDistanceMatrix(NearbyDistanceMeter<Origin, Destination> nearbyDistanceMeter, int originSize,
+    public NearbyDistanceMatrix(NearbyDistanceMeter<Origin, Destination> nearbyDistanceMeter, int originSize,
             Function<Origin, Iterator<Destination>> destinationIteratorProvider,
             ToIntFunction<Origin> destinationSizeFunction) {
         this.nearbyDistanceMeter = nearbyDistanceMeter;

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/common/nearby/NearbyDistanceMatrixDemand.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/common/nearby/NearbyDistanceMatrixDemand.java
@@ -74,7 +74,7 @@ public final class NearbyDistanceMatrixDemand<Solution_, Origin_, Destination_>
     }
 
     /**
-     * Two instances of this class are consider equal if and only if:
+     * Two instances of this class are considered equal if and only if:
      *
      * <ul>
      * <li>Their meter instances are equal.</li>

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/common/nearby/NearbyDistanceMatrixDemand.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/common/nearby/NearbyDistanceMatrixDemand.java
@@ -1,6 +1,8 @@
 package org.optaplanner.core.impl.heuristic.selector.common.nearby;
 
+import java.util.Iterator;
 import java.util.Objects;
+import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.function.ToIntFunction;
 
@@ -59,11 +61,11 @@ public final class NearbyDistanceMatrixDemand<Solution_, Origin_, Destination_>
                         + ") has an entitySize (" + originSize
                         + ") which is higher than Integer.MAX_VALUE.");
             }
-            NearbyDistanceMatrix<Origin_, Destination_> nearbyDistanceMatrix = childSelector instanceof EntitySelector
-                    ? new NearbyDistanceMatrix<>(meter, (int) originSize, (EntitySelector<?>) childSelector,
-                            destinationSizeFunction)
-                    : new NearbyDistanceMatrix<>(meter, (int) originSize, (ValueSelector<?>) childSelector,
-                            destinationSizeFunction);
+            Function<Origin_, Iterator<Destination_>> destinationIteratorProvider = childSelector instanceof EntitySelector
+                    ? origin -> (Iterator<Destination_>) ((EntitySelector<Solution_>) childSelector).endingIterator()
+                    : origin -> (Iterator<Destination_>) ((ValueSelector<Solution_>) childSelector).endingIterator(origin);
+            NearbyDistanceMatrix<Origin_, Destination_> nearbyDistanceMatrix =
+                    new NearbyDistanceMatrix<>(meter, (int) originSize, destinationIteratorProvider, destinationSizeFunction);
             replayingOriginEntitySelector.endingIterator()
                     .forEachRemaining(origin -> nearbyDistanceMatrix.addAllDestinations((Origin_) origin));
             return nearbyDistanceMatrix;

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/entity/nearby/NearEntityNearbyEntitySelector.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/entity/nearby/NearEntityNearbyEntitySelector.java
@@ -56,9 +56,11 @@ public final class NearEntityNearbyEntitySelector<Solution_> extends AbstractEnt
                     + ") which is not a superclass of the originEntitySelector's entityClass ("
                     + originEntitySelector.getEntityDescriptor().getEntityClass() + ").");
         }
-        this.nearbyDistanceMatrixDemand =
-                new NearbyDistanceMatrixDemand<>(nearbyDistanceMeter, childEntitySelector, replayingOriginEntitySelector,
-                        origin -> computeDestinationSize(childEntitySelector.getSize()));
+        this.nearbyDistanceMatrixDemand = new NearbyDistanceMatrixDemand<>(
+                nearbyDistanceMeter,
+                childEntitySelector,
+                replayingOriginEntitySelector,
+                origin -> computeDestinationSize(childEntitySelector.getSize()));
 
         phaseLifecycleSupport.addEventListener(childEntitySelector);
         phaseLifecycleSupport.addEventListener(originEntitySelector);
@@ -238,7 +240,8 @@ public final class NearEntityNearbyEntitySelector<Solution_> extends AbstractEnt
         if (other == null || getClass() != other.getClass())
             return false;
         NearEntityNearbyEntitySelector<?> that = (NearEntityNearbyEntitySelector<?>) other;
-        return randomSelection == that.randomSelection && Objects.equals(childEntitySelector, that.childEntitySelector)
+        return randomSelection == that.randomSelection
+                && Objects.equals(childEntitySelector, that.childEntitySelector)
                 && Objects.equals(replayingOriginEntitySelector, that.replayingOriginEntitySelector)
                 && Objects.equals(nearbyDistanceMeter, that.nearbyDistanceMeter)
                 && Objects.equals(nearbyRandom, that.nearbyRandom);
@@ -250,4 +253,8 @@ public final class NearEntityNearbyEntitySelector<Solution_> extends AbstractEnt
                 randomSelection);
     }
 
+    @Override
+    public String toString() {
+        return getClass().getSimpleName() + "(" + replayingOriginEntitySelector + ", " + childEntitySelector + ")";
+    }
 }

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/AbstractMoveSelectorFactory.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/AbstractMoveSelectorFactory.java
@@ -90,6 +90,13 @@ public abstract class AbstractMoveSelectorFactory<Solution_, MoveSelectorConfig_
         return null;
     }
 
+    protected static void checkUnfolded(String configPropertyName, Object configProperty) {
+        if (configProperty == null) {
+            throw new IllegalStateException("The " + configPropertyName + " (" + configProperty
+                    + ") should haven been initialized during unfolding.");
+        }
+    }
+
     private void validateResolvedCacheType(SelectionCacheType resolvedCacheType, MoveSelector<Solution_> moveSelector) {
         if (!moveSelector.supportsPhaseAndSolverCaching() && resolvedCacheType.compareTo(SelectionCacheType.PHASE) >= 0) {
             throw new IllegalArgumentException("The moveSelectorConfig (" + config

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/ChangeMoveSelectorFactory.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/ChangeMoveSelectorFactory.java
@@ -11,6 +11,7 @@ import org.optaplanner.core.config.heuristic.selector.entity.EntitySelectorConfi
 import org.optaplanner.core.config.heuristic.selector.move.MoveSelectorConfig;
 import org.optaplanner.core.config.heuristic.selector.move.composite.UnionMoveSelectorConfig;
 import org.optaplanner.core.config.heuristic.selector.move.generic.ChangeMoveSelectorConfig;
+import org.optaplanner.core.config.heuristic.selector.move.generic.list.DestinationSelectorConfig;
 import org.optaplanner.core.config.heuristic.selector.move.generic.list.ListChangeMoveSelectorConfig;
 import org.optaplanner.core.config.heuristic.selector.value.ValueSelectorConfig;
 import org.optaplanner.core.impl.domain.entity.descriptor.EntityDescriptor;
@@ -39,14 +40,8 @@ public class ChangeMoveSelectorFactory<Solution_>
     @Override
     protected MoveSelector<Solution_> buildBaseMoveSelector(HeuristicConfigPolicy<Solution_> configPolicy,
             SelectionCacheType minimumCacheType, boolean randomSelection) {
-        if (config.getEntitySelectorConfig() == null) {
-            throw new IllegalStateException("The entitySelectorConfig (" + config.getEntitySelectorConfig()
-                    + ") should haven been initialized during unfolding.");
-        }
-        if (config.getValueSelectorConfig() == null) {
-            throw new IllegalStateException("The valueSelectorConfig (" + config.getValueSelectorConfig()
-                    + ") should haven been initialized during unfolding.");
-        }
+        checkUnfolded("entitySelectorConfig", config.getEntitySelectorConfig());
+        checkUnfolded("valueSelectorConfig", config.getValueSelectorConfig());
         SelectionOrder selectionOrder = SelectionOrder.fromRandomSelectionBoolean(randomSelection);
         EntitySelector<Solution_> entitySelector = EntitySelectorFactory
                 .<Solution_> create(config.getEntitySelectorConfig())
@@ -134,7 +129,10 @@ public class ChangeMoveSelectorFactory<Solution_>
                 + " but it will be removed in the next major release.\n"
                 + "Please update your solver config to use ListChangeMoveSelectorConfig now.");
         ListChangeMoveSelectorConfig listChangeMoveSelectorConfig = ListChangeMoveSelectorFactory.buildChildMoveSelectorConfig(
-                variableDescriptor, config.getEntitySelectorConfig(), config.getValueSelectorConfig());
+                variableDescriptor, config.getValueSelectorConfig(),
+                new DestinationSelectorConfig()
+                        .withEntitySelectorConfig(config.getEntitySelectorConfig())
+                        .withValueSelectorConfig(config.getValueSelectorConfig()));
         if (inheritFoldedConfig) {
             listChangeMoveSelectorConfig.inheritFolded(config);
         }

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/DestinationSelector.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/DestinationSelector.java
@@ -1,0 +1,6 @@
+package org.optaplanner.core.impl.heuristic.selector.move.generic.list;
+
+import org.optaplanner.core.impl.heuristic.selector.IterableSelector;
+
+public interface DestinationSelector<Solution_> extends IterableSelector<Solution_, ElementRef> {
+}

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/DestinationSelectorFactory.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/DestinationSelectorFactory.java
@@ -1,0 +1,95 @@
+package org.optaplanner.core.impl.heuristic.selector.move.generic.list;
+
+import org.optaplanner.core.config.heuristic.selector.common.SelectionCacheType;
+import org.optaplanner.core.config.heuristic.selector.common.SelectionOrder;
+import org.optaplanner.core.config.heuristic.selector.common.nearby.NearbySelectionConfig;
+import org.optaplanner.core.config.heuristic.selector.move.generic.list.DestinationSelectorConfig;
+import org.optaplanner.core.config.heuristic.selector.value.ValueSelectorConfig;
+import org.optaplanner.core.impl.domain.variable.descriptor.ListVariableDescriptor;
+import org.optaplanner.core.impl.heuristic.HeuristicConfigPolicy;
+import org.optaplanner.core.impl.heuristic.selector.AbstractSelectorFactory;
+import org.optaplanner.core.impl.heuristic.selector.common.nearby.NearbyDistanceMeter;
+import org.optaplanner.core.impl.heuristic.selector.common.nearby.NearbyRandom;
+import org.optaplanner.core.impl.heuristic.selector.common.nearby.NearbyRandomFactory;
+import org.optaplanner.core.impl.heuristic.selector.entity.EntitySelector;
+import org.optaplanner.core.impl.heuristic.selector.entity.EntitySelectorFactory;
+import org.optaplanner.core.impl.heuristic.selector.value.EntityIndependentValueSelector;
+import org.optaplanner.core.impl.heuristic.selector.value.ValueSelector;
+import org.optaplanner.core.impl.heuristic.selector.value.ValueSelectorFactory;
+
+public final class DestinationSelectorFactory<Solution_> extends AbstractSelectorFactory<Solution_, DestinationSelectorConfig> {
+
+    public static <Solution_> DestinationSelectorFactory<Solution_>
+            create(DestinationSelectorConfig destinationSelectorConfig) {
+        return new DestinationSelectorFactory<>(destinationSelectorConfig);
+    }
+
+    private DestinationSelectorFactory(DestinationSelectorConfig destinationSelectorConfig) {
+        super(destinationSelectorConfig);
+    }
+
+    public DestinationSelector<Solution_> buildDestinationSelector(
+            HeuristicConfigPolicy<Solution_> configPolicy,
+            SelectionCacheType minimumCacheType,
+            boolean randomSelection) {
+        SelectionOrder selectionOrder = SelectionOrder.fromRandomSelectionBoolean(randomSelection);
+
+        EntitySelector<Solution_> entitySelector = EntitySelectorFactory
+                .<Solution_> create(config.getEntitySelectorConfig())
+                .buildEntitySelector(configPolicy, minimumCacheType, selectionOrder);
+
+        ValueSelector<Solution_> valueSelector = ValueSelectorFactory
+                .<Solution_> create(config.getValueSelectorConfig())
+                .buildValueSelector(configPolicy, entitySelector.getEntityDescriptor(), minimumCacheType, selectionOrder,
+                        // Do not override reinitializeVariableFilterEnabled.
+                        configPolicy.isReinitializeVariableFilterEnabled(),
+                        /*
+                         * Filter assigned values (but only if this filtering type is allowed by the configPolicy).
+                         *
+                         * The destination selector requires the child value selector to only select assigned values.
+                         * To guarantee this during CH, where not all values are assigned, the UnassignedValueSelector filter
+                         * must be applied.
+                         *
+                         * In the LS phase, not only is the filter redundant because there are no unassigned values,
+                         * but it would also crash if the base value selector inherits random selection order,
+                         * because the filter cannot work on a never-ending child value selector.
+                         * Therefore, it must not be applied even though it is requested here. This is accomplished by
+                         * the configPolicy that only allows this filtering type in the CH phase.
+                         */
+                        ValueSelectorFactory.ListValueFilteringType.ACCEPT_ASSIGNED);
+
+        if (config.getNearbySelectionConfig() != null) {
+            NearbySelectionConfig nearbySelectionConfig = config.getNearbySelectionConfig();
+
+            ValueSelectorConfig valueSelectorConfig = new ValueSelectorConfig()
+                    .withMimicSelectorRef(nearbySelectionConfig.getOriginValueSelectorConfig().getMimicSelectorRef());
+
+            ValueSelector<Solution_> originValueSelector = ValueSelectorFactory.<Solution_> create(valueSelectorConfig)
+                    .buildValueSelector(configPolicy, entitySelector.getEntityDescriptor(), minimumCacheType, selectionOrder);
+
+            NearbyDistanceMeter<?, ?> nearbyDistanceMeter =
+                    configPolicy.getClassInstanceCache().newInstance(nearbySelectionConfig,
+                            "nearbyDistanceMeterClass", nearbySelectionConfig.getNearbyDistanceMeterClass());
+            // TODO Check nearbyDistanceMeterClass.getGenericInterfaces() to confirm generic type S is an entityClass
+            NearbyRandom nearbyRandom =
+                    NearbyRandomFactory.create(nearbySelectionConfig).buildNearbyRandom(randomSelection);
+            return new NearValueNearbyDestinationSelector<>(
+                    entitySelector,
+                    ((EntityIndependentValueSelector<Solution_>) valueSelector),
+                    ((EntityIndependentValueSelector<Solution_>) originValueSelector),
+                    nearbyDistanceMeter,
+                    nearbyRandom,
+                    randomSelection);
+        }
+
+        // TODO move this to constructor (all list move selectors)
+        ListVariableDescriptor<Solution_> listVariableDescriptor =
+                (ListVariableDescriptor<Solution_>) valueSelector.getVariableDescriptor();
+
+        return new ElementDestinationSelector<>(
+                listVariableDescriptor,
+                entitySelector,
+                ((EntityIndependentValueSelector<Solution_>) valueSelector),
+                randomSelection);
+    }
+}

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/ElementDestinationSelector.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/ElementDestinationSelector.java
@@ -13,7 +13,6 @@ import org.optaplanner.core.impl.domain.variable.inverserelation.SingletonInvers
 import org.optaplanner.core.impl.domain.variable.inverserelation.SingletonListInverseVariableDemand;
 import org.optaplanner.core.impl.domain.variable.supply.SupplyManager;
 import org.optaplanner.core.impl.heuristic.selector.AbstractSelector;
-import org.optaplanner.core.impl.heuristic.selector.IterableSelector;
 import org.optaplanner.core.impl.heuristic.selector.entity.EntitySelector;
 import org.optaplanner.core.impl.heuristic.selector.value.EntityIndependentValueSelector;
 import org.optaplanner.core.impl.solver.random.RandomUtils;
@@ -34,7 +33,7 @@ import org.optaplanner.core.impl.solver.scope.SolverScope;
  * @param <Solution_> the solution type, the class with the {@link PlanningSolution} annotation
  */
 public class ElementDestinationSelector<Solution_> extends AbstractSelector<Solution_>
-        implements IterableSelector<Solution_, ElementRef> {
+        implements DestinationSelector<Solution_> {
 
     private final ListVariableDescriptor<Solution_> listVariableDescriptor;
     private final EntitySelector<Solution_> entitySelector;

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/ListChangeMoveSelector.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/ListChangeMoveSelector.java
@@ -17,7 +17,7 @@ public class ListChangeMoveSelector<Solution_> extends GenericMoveSelector<Solut
 
     private final ListVariableDescriptor<Solution_> listVariableDescriptor;
     private final EntityIndependentValueSelector<Solution_> sourceValueSelector;
-    private final ElementDestinationSelector<Solution_> destinationSelector;
+    private final DestinationSelector<Solution_> destinationSelector;
     private final boolean randomSelection;
 
     private SingletonInverseVariableSupply inverseVariableSupply;
@@ -26,7 +26,7 @@ public class ListChangeMoveSelector<Solution_> extends GenericMoveSelector<Solut
     public ListChangeMoveSelector(
             ListVariableDescriptor<Solution_> listVariableDescriptor,
             EntityIndependentValueSelector<Solution_> sourceValueSelector,
-            ElementDestinationSelector<Solution_> destinationSelector,
+            DestinationSelector<Solution_> destinationSelector,
             boolean randomSelection) {
         this.listVariableDescriptor = listVariableDescriptor;
         this.sourceValueSelector = sourceValueSelector;

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/ListChangeMoveSelectorFactory.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/ListChangeMoveSelectorFactory.java
@@ -4,22 +4,21 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
-import org.optaplanner.core.api.domain.entity.PlanningEntity;
 import org.optaplanner.core.api.domain.variable.PlanningListVariable;
 import org.optaplanner.core.config.heuristic.selector.common.SelectionCacheType;
 import org.optaplanner.core.config.heuristic.selector.common.SelectionOrder;
 import org.optaplanner.core.config.heuristic.selector.entity.EntitySelectorConfig;
 import org.optaplanner.core.config.heuristic.selector.move.MoveSelectorConfig;
-import org.optaplanner.core.config.heuristic.selector.move.composite.UnionMoveSelectorConfig;
+import org.optaplanner.core.config.heuristic.selector.move.generic.list.DestinationSelectorConfig;
 import org.optaplanner.core.config.heuristic.selector.move.generic.list.ListChangeMoveSelectorConfig;
 import org.optaplanner.core.config.heuristic.selector.value.ValueSelectorConfig;
 import org.optaplanner.core.impl.domain.entity.descriptor.EntityDescriptor;
 import org.optaplanner.core.impl.domain.variable.descriptor.GenuineVariableDescriptor;
 import org.optaplanner.core.impl.domain.variable.descriptor.ListVariableDescriptor;
 import org.optaplanner.core.impl.heuristic.HeuristicConfigPolicy;
-import org.optaplanner.core.impl.heuristic.selector.entity.EntitySelector;
 import org.optaplanner.core.impl.heuristic.selector.entity.EntitySelectorFactory;
 import org.optaplanner.core.impl.heuristic.selector.move.AbstractMoveSelectorFactory;
 import org.optaplanner.core.impl.heuristic.selector.move.MoveSelector;
@@ -37,28 +36,21 @@ public class ListChangeMoveSelectorFactory<Solution_>
     @Override
     protected MoveSelector<Solution_> buildBaseMoveSelector(HeuristicConfigPolicy<Solution_> configPolicy,
             SelectionCacheType minimumCacheType, boolean randomSelection) {
-        if (config.getEntitySelectorConfig() == null) {
-            throw new IllegalStateException("The entitySelectorConfig (" + config.getEntitySelectorConfig()
-                    + ") should haven been initialized during unfolding.");
-        }
-        if (config.getValueSelectorConfig() == null) {
-            throw new IllegalStateException("The valueSelectorConfig (" + config.getValueSelectorConfig()
-                    + ") should haven been initialized during unfolding.");
-        }
+        checkUnfolded("valueSelectorConfig", config.getValueSelectorConfig());
+        checkUnfolded("destinationSelectorConfig", config.getDestinationSelectorConfig());
+        checkUnfolded("destinationEntitySelectorConfig", config.getDestinationSelectorConfig().getEntitySelectorConfig());
+        checkUnfolded("destinationValueSelectorConfig", config.getDestinationSelectorConfig().getValueSelectorConfig());
+
         SelectionOrder selectionOrder = SelectionOrder.fromRandomSelectionBoolean(randomSelection);
-        EntitySelector<Solution_> entitySelector = EntitySelectorFactory
-                .<Solution_> create(config.getEntitySelectorConfig())
-                .buildEntitySelector(configPolicy, minimumCacheType, selectionOrder);
+
+        EntityDescriptor<Solution_> entityDescriptor = EntitySelectorFactory
+                .<Solution_> create(config.getDestinationSelectorConfig().getEntitySelectorConfig())
+                .extractEntityDescriptor(configPolicy);
+
         ValueSelector<Solution_> sourceValueSelector = ValueSelectorFactory
                 .<Solution_> create(config.getValueSelectorConfig())
-                .buildValueSelector(configPolicy, entitySelector.getEntityDescriptor(), minimumCacheType, selectionOrder);
-        // TODO review on all list move selectors (should be impossible because it *should* be checked during unfolding.
-        if (!sourceValueSelector.getVariableDescriptor().isListVariable()) {
-            throw new IllegalArgumentException("The listChangeMoveSelector (" + config
-                    + ") can only be used when the domain model has a list variable."
-                    + " Check your @" + PlanningEntity.class.getSimpleName()
-                    + " and make sure it has a @" + PlanningListVariable.class.getSimpleName() + ".");
-        }
+                .buildValueSelector(configPolicy, entityDescriptor, minimumCacheType, selectionOrder);
+
         if (!(sourceValueSelector instanceof EntityIndependentValueSelector)) {
             throw new IllegalArgumentException("The listChangeMoveSelector (" + config
                     + ") for a list variable needs to be based on an "
@@ -66,37 +58,12 @@ public class ListChangeMoveSelectorFactory<Solution_>
                     + " Check your valueSelectorConfig.");
         }
 
-        ValueSelector<Solution_> destinationValueSelector = ValueSelectorFactory
-                // This must not be the config.valueSelector because that is the source value selector, which, in CH,
-                // is the replaying value selector. But we're building the destination selector here. That must not be replaying.
-                // FIXME maybe find a better way to avoid the mistake. Unfolding? DestinationSelectorConfig/Factory?
-                .<Solution_> create(new ValueSelectorConfig(config.getValueSelectorConfig().getVariableName()))
-                .buildValueSelector(configPolicy, entitySelector.getEntityDescriptor(), minimumCacheType, selectionOrder,
-                        // Do not override reinitializeVariableFilterEnabled.
-                        configPolicy.isReinitializeVariableFilterEnabled(),
-                        /*
-                         * Filter assigned values (but only if this filtering type is allowed by the configPolicy).
-                         *
-                         * The destination selector requires the child value selector to only select assign values.
-                         * To guarantee this during CH where not all values are assigned, the UnassignedValueSelector filter
-                         * must be applied.
-                         *
-                         * In the LS phase, not only is the filter redundant because there are no unassigned values,
-                         * but it would also crash if the base value selector inherits random selection order,
-                         * because the filter cannot work on a never-ending child value selector.
-                         * Therefore, it must not be applied even though it is requested here. This is accomplished by
-                         * the configPolicy that only allows this filtering type in the CH phase.
-                         */
-                        ValueSelectorFactory.ListValueFilteringType.ACCEPT_ASSIGNED);
+        DestinationSelector<Solution_> destinationSelector = DestinationSelectorFactory
+                .<Solution_> create(config.getDestinationSelectorConfig())
+                .buildDestinationSelector(configPolicy, minimumCacheType, randomSelection);
 
         ListVariableDescriptor<Solution_> listVariableDescriptor =
                 (ListVariableDescriptor<Solution_>) sourceValueSelector.getVariableDescriptor();
-
-        ElementDestinationSelector<Solution_> destinationSelector = new ElementDestinationSelector<>(
-                listVariableDescriptor,
-                entitySelector,
-                ((EntityIndependentValueSelector<Solution_>) destinationValueSelector),
-                randomSelection);
 
         return new ListChangeMoveSelector<>(
                 listVariableDescriptor,
@@ -108,85 +75,104 @@ public class ListChangeMoveSelectorFactory<Solution_>
     @Override
     protected MoveSelectorConfig<?> buildUnfoldedMoveSelectorConfig(HeuristicConfigPolicy<Solution_> configPolicy) {
         Collection<EntityDescriptor<Solution_>> entityDescriptors;
-        EntityDescriptor<Solution_> onlyEntityDescriptor = config.getEntitySelectorConfig() == null ? null
-                : EntitySelectorFactory.<Solution_> create(config.getEntitySelectorConfig())
-                        .extractEntityDescriptor(configPolicy);
+        EntityDescriptor<Solution_> onlyEntityDescriptor = config.getDestinationSelectorConfig() == null ? null
+                : config.getDestinationSelectorConfig().getEntitySelectorConfig() == null ? null
+                        : EntitySelectorFactory
+                                .<Solution_> create(config.getDestinationSelectorConfig().getEntitySelectorConfig())
+                                .extractEntityDescriptor(configPolicy);
         if (onlyEntityDescriptor != null) {
             entityDescriptors = Collections.singletonList(onlyEntityDescriptor);
         } else {
             entityDescriptors = configPolicy.getSolutionDescriptor().getGenuineEntityDescriptors();
         }
         List<ListVariableDescriptor<Solution_>> variableDescriptorList = new ArrayList<>();
-        for (EntityDescriptor<Solution_> entityDescriptor : entityDescriptors) {
-            GenuineVariableDescriptor<Solution_> onlyVariableDescriptor = config.getValueSelectorConfig() == null ? null
-                    : ValueSelectorFactory.<Solution_> create(config.getValueSelectorConfig())
-                            .extractVariableDescriptor(configPolicy, entityDescriptor);
-            if (onlyVariableDescriptor != null) {
-                if (!onlyVariableDescriptor.isListVariable()) {
-                    throw new IllegalArgumentException("The listChangeMoveSelector (" + config
-                            + ") is configured to use a planning variable (" + onlyVariableDescriptor
-                            + "), which is not a list planning variable."
-                            + " Either fix your annotations and use a @" + PlanningListVariable.class.getSimpleName()
-                            + " on the variable to make it work with listChangeMoveSelector"
-                            + " or use a changeMoveSelector instead.");
-                }
-                if (onlyEntityDescriptor != null) {
-                    // No need for unfolding or deducing
-                    return null;
-                }
-                variableDescriptorList.add((ListVariableDescriptor<Solution_>) onlyVariableDescriptor);
-            } else {
-                variableDescriptorList.addAll(
-                        entityDescriptor.getGenuineVariableDescriptorList().stream()
-                                .filter(GenuineVariableDescriptor::isListVariable)
-                                .map(variableDescriptor -> ((ListVariableDescriptor<Solution_>) variableDescriptor))
-                                .collect(Collectors.toList()));
 
-                if (variableDescriptorList.isEmpty()) {
-                    throw new IllegalArgumentException("The listChangeMoveSelector (" + config
-                            + ") cannot unfold because there are no list planning variables for the entitySelector ("
-                            + config.getEntitySelectorConfig()
-                            + ") or no list planning variables at all.");
-                }
+        if (entityDescriptors.size() > 1) {
+            throw new IllegalArgumentException("The listChangeMoveSelector (" + config
+                    + ") cannot unfold when there are multiple entities (" + entityDescriptors + ")."
+                    + " Please use one listChangeMoveSelector per each list planning variable.");
+        }
+        EntityDescriptor<Solution_> entityDescriptor = entityDescriptors.iterator().next();
+
+        GenuineVariableDescriptor<Solution_> onlyVariableDescriptor = config.getValueSelectorConfig() == null ? null
+                : ValueSelectorFactory.<Solution_> create(config.getValueSelectorConfig())
+                        .extractVariableDescriptor(configPolicy, entityDescriptor);
+        GenuineVariableDescriptor<Solution_> onlyDestinationVariableDescriptor =
+                config.getDestinationSelectorConfig() == null ? null
+                        : config.getDestinationSelectorConfig().getValueSelectorConfig() == null ? null
+                                : ValueSelectorFactory
+                                        .<Solution_> create(config.getDestinationSelectorConfig().getValueSelectorConfig())
+                                        .extractVariableDescriptor(configPolicy, entityDescriptor);
+        if (onlyVariableDescriptor != null && onlyDestinationVariableDescriptor != null) {
+            if (!onlyVariableDescriptor.isListVariable()) {
+                throw new IllegalArgumentException("The listChangeMoveSelector (" + config
+                        + ") is configured to use a planning variable (" + onlyVariableDescriptor
+                        + "), which is not a list planning variable."
+                        + " Either fix your annotations and use a @" + PlanningListVariable.class.getSimpleName()
+                        + " on the variable to make it work with listChangeMoveSelector"
+                        + " or use a changeMoveSelector instead.");
             }
-        }
-        return buildUnfoldedMoveSelectorConfig(variableDescriptorList);
-    }
-
-    protected MoveSelectorConfig<?> buildUnfoldedMoveSelectorConfig(
-            List<ListVariableDescriptor<Solution_>> variableDescriptorList) {
-        List<MoveSelectorConfig> moveSelectorConfigList = variableDescriptorList.stream()
-                .map(variableDescriptor -> buildChildMoveSelectorConfig(
-                        variableDescriptor, config.getEntitySelectorConfig(), config.getValueSelectorConfig()))
-                .collect(Collectors.toList());
-
-        MoveSelectorConfig<?> unfoldedMoveSelectorConfig;
-        if (moveSelectorConfigList.size() == 1) {
-            unfoldedMoveSelectorConfig = moveSelectorConfigList.get(0);
+            if (!onlyDestinationVariableDescriptor.isListVariable()) {
+                throw new IllegalArgumentException("The destinationSelector (" + config.getDestinationSelectorConfig()
+                        + ") is configured to use a planning variable (" + onlyDestinationVariableDescriptor
+                        + "), which is not a list planning variable.");
+            }
+            if (onlyVariableDescriptor != onlyDestinationVariableDescriptor) {
+                throw new IllegalArgumentException("The listChangeMoveSelector's valueSelector ("
+                        + config.getValueSelectorConfig()
+                        + ") and destinationValueSelector (" + config.getDestinationSelectorConfig().getValueSelectorConfig()
+                        + ") must be configured for the same planning variable.");
+            }
+            if (onlyEntityDescriptor != null) {
+                // No need for unfolding or deducing
+                return null;
+            }
+            variableDescriptorList.add((ListVariableDescriptor<Solution_>) onlyVariableDescriptor);
         } else {
-            unfoldedMoveSelectorConfig = new UnionMoveSelectorConfig(moveSelectorConfigList);
+            variableDescriptorList.addAll(
+                    entityDescriptor.getGenuineVariableDescriptorList().stream()
+                            .filter(GenuineVariableDescriptor::isListVariable)
+                            .map(variableDescriptor -> ((ListVariableDescriptor<Solution_>) variableDescriptor))
+                            .collect(Collectors.toList()));
         }
-        unfoldedMoveSelectorConfig.inheritFolded(config);
-        return unfoldedMoveSelectorConfig;
+        if (variableDescriptorList.isEmpty()) {
+            throw new IllegalArgumentException("The listChangeMoveSelector (" + config
+                    + ") cannot unfold because there are no list planning variables.");
+        }
+        if (variableDescriptorList.size() > 1) {
+            throw new IllegalArgumentException("The listChangeMoveSelector (" + config
+                    + ") cannot unfold because there are multiple list planning variables.");
+        }
+        return buildChildMoveSelectorConfig(variableDescriptorList.get(0), config.getValueSelectorConfig(),
+                config.getDestinationSelectorConfig());
     }
 
     public static ListChangeMoveSelectorConfig buildChildMoveSelectorConfig(
             ListVariableDescriptor<?> variableDescriptor,
-            EntitySelectorConfig inheritedEntitySelectorConfig,
-            ValueSelectorConfig inheritedValueSelectorConfig) {
-        // No childMoveSelectorConfig.inherit() because of unfoldedMoveSelectorConfig.inheritFolded()
-        ListChangeMoveSelectorConfig childMoveSelectorConfig = new ListChangeMoveSelectorConfig();
-        // Different EntitySelector per child because it is a union
-        EntitySelectorConfig childEntitySelectorConfig = new EntitySelectorConfig(inheritedEntitySelectorConfig);
-        if (childEntitySelectorConfig.getMimicSelectorRef() == null) {
-            childEntitySelectorConfig.setEntityClass(variableDescriptor.getEntityDescriptor().getEntityClass());
-        }
-        childMoveSelectorConfig.setEntitySelectorConfig(childEntitySelectorConfig);
+            ValueSelectorConfig inheritedValueSelectorConfig,
+            DestinationSelectorConfig inheritedDestinationSelectorConfig) {
+
         ValueSelectorConfig childValueSelectorConfig = new ValueSelectorConfig(inheritedValueSelectorConfig);
         if (childValueSelectorConfig.getMimicSelectorRef() == null) {
             childValueSelectorConfig.setVariableName(variableDescriptor.getVariableName());
         }
-        childMoveSelectorConfig.setValueSelectorConfig(childValueSelectorConfig);
-        return childMoveSelectorConfig;
+
+        return new ListChangeMoveSelectorConfig()
+                .withValueSelectorConfig(childValueSelectorConfig)
+                .withDestinationSelectorConfig(new DestinationSelectorConfig(inheritedDestinationSelectorConfig)
+                        .withEntitySelectorConfig(
+                                Optional.ofNullable(inheritedDestinationSelectorConfig)
+                                        .map(DestinationSelectorConfig::getEntitySelectorConfig)
+                                        .map(EntitySelectorConfig::new) // use copy constructor if inherited not null
+                                        .orElseGet(EntitySelectorConfig::new) // otherwise create new instance
+                                        // override entity class (destination entity selector is never replaying)
+                                        .withEntityClass(variableDescriptor.getEntityDescriptor().getEntityClass()))
+                        .withValueSelectorConfig(
+                                Optional.ofNullable(inheritedDestinationSelectorConfig)
+                                        .map(DestinationSelectorConfig::getValueSelectorConfig)
+                                        .map(ValueSelectorConfig::new) // use copy constructor if inherited not null
+                                        .orElseGet(ValueSelectorConfig::new) // otherwise create new instance
+                                        // override variable name (destination value selector is never replaying)
+                                        .withVariableName(variableDescriptor.getVariableName())));
     }
 }

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/ListNearbyDistanceMatrixDemand.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/ListNearbyDistanceMatrixDemand.java
@@ -1,0 +1,128 @@
+package org.optaplanner.core.impl.heuristic.selector.move.generic.list;
+
+import java.util.Iterator;
+import java.util.Objects;
+import java.util.Spliterators;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.function.ToIntFunction;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+import org.optaplanner.core.impl.domain.variable.supply.Demand;
+import org.optaplanner.core.impl.domain.variable.supply.SupplyManager;
+import org.optaplanner.core.impl.heuristic.selector.common.nearby.NearbyDistanceMatrix;
+import org.optaplanner.core.impl.heuristic.selector.common.nearby.NearbyDistanceMeter;
+import org.optaplanner.core.impl.heuristic.selector.entity.EntitySelector;
+import org.optaplanner.core.impl.heuristic.selector.value.FromSolutionPropertyValueSelector;
+import org.optaplanner.core.impl.heuristic.selector.value.mimic.MimicReplayingValueSelector;
+import org.optaplanner.core.impl.solver.ClassInstanceCache;
+import org.optaplanner.core.impl.util.MemoizingSupply;
+
+/**
+ * Calculating {@link NearbyDistanceMatrix} is very expensive,
+ * therefore we want to reuse it as much as possible.
+ *
+ * <p>
+ * In cases where the demand represents the same nearby selector (as defined by
+ * {@link ListNearbyDistanceMatrixDemand#equals(Object)})
+ * the {@link SupplyManager} ensures that the same supply instance is returned
+ * with the pre-computed {@link NearbyDistanceMatrix}.
+ *
+ * @param <Solution_>
+ * @param <Origin_>
+ * @param <Destination_>
+ */
+public final class ListNearbyDistanceMatrixDemand<Solution_, Origin_, Destination_>
+        implements Demand<MemoizingSupply<NearbyDistanceMatrix<Origin_, Destination_>>> {
+
+    private final NearbyDistanceMeter<Origin_, Destination_> meter;
+    private final MimicReplayingValueSelector<Solution_> replayingOriginValueSelector;
+    private final EntitySelector<Solution_> childEntitySelector;
+    private final FromSolutionPropertyValueSelector<Solution_> childValueSelector;
+    private final ToIntFunction<Origin_> destinationSizeFunction;
+
+    public ListNearbyDistanceMatrixDemand(
+            NearbyDistanceMeter<Origin_, Destination_> meter,
+            MimicReplayingValueSelector<Solution_> replayingOriginValueSelector,
+            EntitySelector<Solution_> childEntitySelector,
+            FromSolutionPropertyValueSelector<Solution_> childValueSelector,
+            ToIntFunction<Origin_> destinationSizeFunction) {
+        this.meter = meter;
+        this.replayingOriginValueSelector = replayingOriginValueSelector;
+        this.childEntitySelector = childEntitySelector;
+        this.childValueSelector = childValueSelector;
+        this.destinationSizeFunction = destinationSizeFunction;
+    }
+
+    @Override
+    public MemoizingSupply<NearbyDistanceMatrix<Origin_, Destination_>> createExternalizedSupply(SupplyManager supplyManager) {
+        Supplier<NearbyDistanceMatrix<Origin_, Destination_>> supplier = () -> {
+            final long childSize = childEntitySelector.getSize() + childValueSelector.getSize();
+            if (childSize > Integer.MAX_VALUE) {
+                throw new IllegalStateException("The childSize (" + childSize
+                        + ") which is the sum of the childEntitySelector (" + childEntitySelector
+                        + ") and the childValueSelector (" + childValueSelector
+                        + ") sizes is higher than Integer.MAX_VALUE.");
+            }
+
+            long originSize = replayingOriginValueSelector.getSize();
+            if (originSize > Integer.MAX_VALUE) {
+                throw new IllegalStateException("The originEntitySelector (" + replayingOriginValueSelector
+                        + ") has an entitySize (" + originSize
+                        + ") which is higher than Integer.MAX_VALUE.");
+            }
+            // Destinations in the "matrix" need to be entities and values (not ElementRefs!) because that's what
+            // the NearbyDistanceMeter is able to measure.
+            Function<Origin_, Iterator<Destination_>> destinationIteratorProvider =
+                    origin -> (Iterator<Destination_>) Stream.concat(
+                            StreamSupport.stream(Spliterators.spliterator(childEntitySelector.endingIterator(),
+                                    childEntitySelector.getSize(), 0), false),
+                            StreamSupport.stream(Spliterators.spliterator(childValueSelector.endingIterator(),
+                                    childValueSelector.getSize(), 0), false))
+                            .iterator();
+            NearbyDistanceMatrix<Origin_, Destination_> nearbyDistanceMatrix =
+                    new NearbyDistanceMatrix<>(meter, (int) originSize, destinationIteratorProvider, destinationSizeFunction);
+            // Replaying selector's ending iterator will use the recording selector's ending iterator. Since list variables
+            // use entity independent value selectors, we can pass null here.
+            replayingOriginValueSelector.endingIterator(null)
+                    .forEachRemaining(origin -> nearbyDistanceMatrix.addAllDestinations((Origin_) origin));
+
+            return nearbyDistanceMatrix;
+        };
+        return new MemoizingSupply<>(supplier);
+    }
+
+    /**
+     * Two instances of this class are consider equal if and only if:
+     *
+     * <ul>
+     * <li>Their meter instances are equal.</li>
+     * <li>Their child selectors are equal.</li>
+     * <li>Their replaying origin entity selectors are equal.</li>
+     * </ul>
+     *
+     * Otherwise as defined by {@link Object#equals(Object)}.
+     *
+     * @see ClassInstanceCache for how we ensure equality for meter instances in particular and selectors in general.
+     */
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ListNearbyDistanceMatrixDemand<?, ?, ?> that = (ListNearbyDistanceMatrixDemand<?, ?, ?>) o;
+        return Objects.equals(meter, that.meter)
+                && Objects.equals(replayingOriginValueSelector, that.replayingOriginValueSelector)
+                && Objects.equals(childEntitySelector, that.childEntitySelector)
+                && Objects.equals(childValueSelector, that.childValueSelector);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(meter, replayingOriginValueSelector, childEntitySelector, childValueSelector);
+    }
+}

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/ListNearbyDistanceMatrixDemand.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/ListNearbyDistanceMatrixDemand.java
@@ -78,7 +78,7 @@ public final class ListNearbyDistanceMatrixDemand<Solution_, Origin_, Destinatio
     }
 
     /**
-     * Two instances of this class are consider equal if and only if:
+     * Two instances of this class are considered equal if and only if:
      *
      * <ul>
      * <li>Their meter instances are equal.</li>

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/NearValueNearbyDestinationSelector.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/NearValueNearbyDestinationSelector.java
@@ -1,0 +1,294 @@
+package org.optaplanner.core.impl.heuristic.selector.move.generic.list;
+
+import java.util.Iterator;
+import java.util.Objects;
+
+import org.optaplanner.core.impl.domain.variable.descriptor.ListVariableDescriptor;
+import org.optaplanner.core.impl.domain.variable.index.IndexVariableDemand;
+import org.optaplanner.core.impl.domain.variable.index.IndexVariableSupply;
+import org.optaplanner.core.impl.domain.variable.inverserelation.SingletonInverseVariableSupply;
+import org.optaplanner.core.impl.domain.variable.inverserelation.SingletonListInverseVariableDemand;
+import org.optaplanner.core.impl.domain.variable.supply.SupplyManager;
+import org.optaplanner.core.impl.heuristic.selector.AbstractSelector;
+import org.optaplanner.core.impl.heuristic.selector.common.iterator.SelectionIterator;
+import org.optaplanner.core.impl.heuristic.selector.common.nearby.NearbyDistanceMatrix;
+import org.optaplanner.core.impl.heuristic.selector.common.nearby.NearbyDistanceMeter;
+import org.optaplanner.core.impl.heuristic.selector.common.nearby.NearbyRandom;
+import org.optaplanner.core.impl.heuristic.selector.entity.EntitySelector;
+import org.optaplanner.core.impl.heuristic.selector.value.EntityIndependentValueSelector;
+import org.optaplanner.core.impl.heuristic.selector.value.FromSolutionPropertyValueSelector;
+import org.optaplanner.core.impl.heuristic.selector.value.mimic.MimicReplayingValueSelector;
+import org.optaplanner.core.impl.phase.scope.AbstractPhaseScope;
+import org.optaplanner.core.impl.solver.scope.SolverScope;
+import org.optaplanner.core.impl.util.MemoizingSupply;
+
+// TODO extends abstract destination selector!
+public final class NearValueNearbyDestinationSelector<Solution_> extends AbstractSelector<Solution_>
+        implements DestinationSelector<Solution_> {
+
+    private final EntitySelector<Solution_> childEntitySelector;
+    private final EntityIndependentValueSelector<Solution_> childValueSelector;
+    private final MimicReplayingValueSelector<Solution_> replayingOriginValueSelector;
+    private final NearbyDistanceMeter<?, ?> nearbyDistanceMeter;
+    private final NearbyRandom nearbyRandom;
+    private final boolean randomSelection;
+    private final ListNearbyDistanceMatrixDemand<Solution_, ?, ?> nearbyDistanceMatrixDemand;
+
+    private MemoizingSupply<NearbyDistanceMatrix<Object, Object>> nearbyDistanceMatrixSupply = null;
+    private SingletonInverseVariableSupply inverseVariableSupply;
+    private IndexVariableSupply indexVariableSupply;
+
+    public NearValueNearbyDestinationSelector(
+            EntitySelector<Solution_> childEntitySelector,
+            EntityIndependentValueSelector<Solution_> childValueSelector,
+            EntityIndependentValueSelector<Solution_> originValueSelector,
+            NearbyDistanceMeter<?, ?> nearbyDistanceMeter,
+            NearbyRandom nearbyRandom, boolean randomSelection) {
+        this.childEntitySelector = childEntitySelector;
+        this.childValueSelector = childValueSelector;
+        if (!(originValueSelector instanceof MimicReplayingValueSelector)) {
+            // In order to select a nearby destination, we must first have something to be near by.
+            throw new IllegalStateException("Impossible state: Nearby destination selector (" + this +
+                    ") did not receive a replaying value selector (" + originValueSelector + ").");
+        }
+        this.replayingOriginValueSelector = (MimicReplayingValueSelector<Solution_>) originValueSelector;
+        this.nearbyDistanceMeter = nearbyDistanceMeter;
+        this.nearbyRandom = nearbyRandom;
+        this.randomSelection = randomSelection;
+        if (randomSelection && nearbyRandom == null) {
+            throw new IllegalArgumentException("The valueSelector (" + this
+                    + ") with randomSelection (" + randomSelection + ") has no nearbyRandom (" + nearbyRandom + ").");
+        }
+        this.nearbyDistanceMatrixDemand =
+                new ListNearbyDistanceMatrixDemand<>(
+                        nearbyDistanceMeter,
+                        ((MimicReplayingValueSelector<Solution_>) originValueSelector),
+                        childEntitySelector,
+                        ((FromSolutionPropertyValueSelector<Solution_>) childValueSelector),
+                        this::computeDestinationSize);
+        phaseLifecycleSupport.addEventListener(childEntitySelector);
+        phaseLifecycleSupport.addEventListener(originValueSelector);
+        phaseLifecycleSupport.addEventListener(childValueSelector);
+    }
+
+    @Override
+    public void solvingStarted(SolverScope<Solution_> solverScope) {
+        super.solvingStarted(solverScope);
+        SupplyManager supplyManager = solverScope.getScoreDirector().getSupplyManager();
+        ListVariableDescriptor<Solution_> listVariableDescriptor =
+                (ListVariableDescriptor<Solution_>) childValueSelector.getVariableDescriptor();
+        /*
+         * Supply will ask questions of the child selector.
+         * However, child selector will only be initialized during phase start.
+         * Yet we still want the very expensive nearby distance matrix to be reused across phases.
+         * Therefore we request the supply here, but actually lazily initialize it during phase start.
+         */
+        nearbyDistanceMatrixSupply = (MemoizingSupply) supplyManager.demand(nearbyDistanceMatrixDemand);
+        inverseVariableSupply = supplyManager.demand(new SingletonListInverseVariableDemand<>(listVariableDescriptor));
+        indexVariableSupply = supplyManager.demand(new IndexVariableDemand<>(listVariableDescriptor));
+    }
+
+    @Override
+    public void phaseStarted(AbstractPhaseScope<Solution_> phaseScope) {
+        super.phaseStarted(phaseScope);
+        // Lazily initialize the supply, so that steps can then have uniform performance.
+        nearbyDistanceMatrixSupply.read();
+    }
+
+    private int computeDestinationSize(Object origin) {
+        long entitySelectorSize = childEntitySelector.getSize();
+        if (entitySelectorSize > Integer.MAX_VALUE) {
+            throw new IllegalStateException("The childEntitySelector (" + childEntitySelector
+                    + ") has size (" + entitySelectorSize + ") which is higher than Integer.MAX_VALUE.");
+        }
+        long valueSelectorSize = childValueSelector.getSize();
+        if (valueSelectorSize > Integer.MAX_VALUE) {
+            throw new IllegalStateException("The childValueSelector (" + childValueSelector
+                    + ") has size (" + valueSelectorSize + ") which is higher than Integer.MAX_VALUE.");
+        }
+
+        long childSize = entitySelectorSize + valueSelectorSize;
+        if (childSize > Integer.MAX_VALUE) {
+            throw new IllegalStateException("The sum of the childEntitySelector (" + entitySelectorSize
+                    + ") and the childValueSelector (" + valueSelectorSize
+                    + ") sizes is higher than Integer.MAX_VALUE.");
+        }
+
+        int destinationSize = (int) childSize;
+        if (randomSelection) {
+            // Reduce RAM memory usage by reducing destinationSize if nearbyRandom will never select a higher value
+            int overallSizeMaximum = nearbyRandom.getOverallSizeMaximum();
+            if (destinationSize > overallSizeMaximum) {
+                destinationSize = overallSizeMaximum;
+            }
+        }
+        return destinationSize;
+    }
+
+    @Override
+    public void solvingEnded(SolverScope<Solution_> solverScope) {
+        super.solvingEnded(solverScope);
+        solverScope.getScoreDirector().getSupplyManager().cancel(nearbyDistanceMatrixDemand);
+        nearbyDistanceMatrixSupply = null;
+        inverseVariableSupply = null;
+        indexVariableSupply = null;
+    }
+
+    // ************************************************************************
+    // Worker methods
+    // ************************************************************************
+
+    @Override
+    public boolean isCountable() {
+        return childEntitySelector.isCountable() && childValueSelector.isCountable();
+    }
+
+    @Override
+    public boolean isNeverEnding() {
+        return randomSelection || !isCountable();
+    }
+
+    @Override
+    public long getSize() {
+        return childEntitySelector.getSize() + childValueSelector.getSize();
+    }
+
+    @Override
+    public Iterator<ElementRef> iterator() {
+        Iterator<Object> replayingOriginValueIterator = replayingOriginValueSelector.iterator();
+        if (!randomSelection) {
+            return new OriginalValueNearbyDestinationIterator(replayingOriginValueIterator, childValueSelector.getSize());
+        } else {
+            return new RandomValueNearbyDestinationIterator(replayingOriginValueIterator, childValueSelector.getSize());
+        }
+    }
+
+    private final class OriginalValueNearbyDestinationIterator extends SelectionIterator<ElementRef> {
+
+        private final Iterator<Object> replayingOriginValueIterator;
+        private final long childSize;
+
+        private boolean originSelected = false;
+        private boolean originIsNotEmpty;
+        private Object origin;
+
+        private int nextNearbyIndex;
+
+        public OriginalValueNearbyDestinationIterator(Iterator<Object> replayingOriginValueIterator, long childSize) {
+            this.replayingOriginValueIterator = replayingOriginValueIterator;
+            this.childSize = childSize;
+            nextNearbyIndex = 0;
+        }
+
+        private void selectOrigin() {
+            if (originSelected) {
+                return;
+            }
+            /*
+             * The origin iterator is guaranteed to be a replaying iterator.
+             * Therefore next() will point to whatever that the related recording iterator was pointing to at the time
+             * when its next() was called.
+             * As a result, origin here will be constant unless next() on the original recording iterator is called
+             * first.
+             */
+            originIsNotEmpty = replayingOriginValueIterator.hasNext();
+            origin = replayingOriginValueIterator.next();
+            originSelected = true;
+        }
+
+        @Override
+        public boolean hasNext() {
+            selectOrigin();
+            return originIsNotEmpty && nextNearbyIndex < childSize;
+        }
+
+        @Override
+        public ElementRef next() {
+            selectOrigin();
+            Object next = nearbyDistanceMatrixSupply.read().getDestination(origin, nextNearbyIndex);
+            nextNearbyIndex++;
+
+            if (childEntitySelector.getEntityDescriptor().matchesEntity(next)) {
+                return ElementRef.of(next, 0);
+            }
+
+            return ElementRef.of(
+                    inverseVariableSupply.getInverseSingleton(next),
+                    indexVariableSupply.getIndex(next) + 1);
+        }
+
+    }
+
+    private final class RandomValueNearbyDestinationIterator extends SelectionIterator<ElementRef> {
+
+        private final Iterator<Object> replayingOriginValueIterator;
+        private final int nearbySize;
+
+        public RandomValueNearbyDestinationIterator(Iterator<Object> replayingOriginValueIterator, long childSize) {
+            this.replayingOriginValueIterator = replayingOriginValueIterator;
+            if (childSize > Integer.MAX_VALUE) {
+                throw new IllegalStateException("The valueSelector (" + this
+                        + ") has an entitySize (" + childSize
+                        + ") which is higher than Integer.MAX_VALUE.");
+            }
+            nearbySize = (int) childSize;
+        }
+
+        @Override
+        public boolean hasNext() {
+            return replayingOriginValueIterator.hasNext() && nearbySize > 0;
+        }
+
+        @Override
+        public ElementRef next() {
+            /*
+             * The originValue iterator is guaranteed to be a replaying iterator.
+             * Therefore next() will point to whatever that the related recording iterator was pointing to at the time
+             * when its next() was called.
+             * As a result, originValue here will be constant unless next() on the original recording iterator is called
+             * first.
+             */
+            Object originValue = replayingOriginValueIterator.next();
+            int nearbyIndex = nearbyRandom.nextInt(workingRandom, nearbySize);
+            Object destinationAnchor = nearbyDistanceMatrixSupply.read().getDestination(originValue, nearbyIndex);
+
+            if (childEntitySelector.getEntityDescriptor().matchesEntity(destinationAnchor)) {
+                return ElementRef.of(destinationAnchor, 0);
+            }
+
+            return ElementRef.of(
+                    inverseVariableSupply.getInverseSingleton(destinationAnchor),
+                    indexVariableSupply.getIndex(destinationAnchor) + 1);
+        }
+
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (this == other) {
+            return true;
+        }
+        if (other == null || getClass() != other.getClass()) {
+            return false;
+        }
+        NearValueNearbyDestinationSelector<?> that = (NearValueNearbyDestinationSelector<?>) other;
+        return randomSelection == that.randomSelection
+                && Objects.equals(childEntitySelector, that.childEntitySelector)
+                && Objects.equals(childValueSelector, that.childValueSelector)
+                && Objects.equals(replayingOriginValueSelector, that.replayingOriginValueSelector)
+                && Objects.equals(nearbyDistanceMeter, that.nearbyDistanceMeter)
+                && Objects.equals(nearbyRandom, that.nearbyRandom);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(childEntitySelector, childValueSelector, replayingOriginValueSelector, nearbyDistanceMeter,
+                nearbyRandom, randomSelection);
+    }
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName() + "(" + replayingOriginValueSelector + ", " + childEntitySelector + ", "
+                + childValueSelector + ")";
+    }
+}

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/OriginalListChangeIterator.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/OriginalListChangeIterator.java
@@ -21,7 +21,7 @@ public class OriginalListChangeIterator<Solution_> extends UpcomingSelectionIter
     private final SingletonInverseVariableSupply inverseVariableSupply;
     private final IndexVariableSupply indexVariableSupply;
     private final Iterator<Object> valueIterator;
-    private final ElementDestinationSelector<Solution_> destinationSelector;
+    private final DestinationSelector<Solution_> destinationSelector;
     private Iterator<ElementRef> destinationIterator;
 
     private Object upcomingSourceEntity;
@@ -33,7 +33,7 @@ public class OriginalListChangeIterator<Solution_> extends UpcomingSelectionIter
             SingletonInverseVariableSupply inverseVariableSupply,
             IndexVariableSupply indexVariableSupply,
             EntityIndependentValueSelector<Solution_> valueSelector,
-            ElementDestinationSelector<Solution_> destinationSelector) {
+            DestinationSelector<Solution_> destinationSelector) {
         this.listVariableDescriptor = listVariableDescriptor;
         this.inverseVariableSupply = inverseVariableSupply;
         this.indexVariableSupply = indexVariableSupply;

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/RandomListChangeIterator.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/RandomListChangeIterator.java
@@ -26,7 +26,7 @@ public class RandomListChangeIterator<Solution_> extends UpcomingSelectionIterat
             SingletonInverseVariableSupply inverseVariableSupply,
             IndexVariableSupply indexVariableSupply,
             EntityIndependentValueSelector<Solution_> valueSelector,
-            ElementDestinationSelector<Solution_> destinationSelector) {
+            DestinationSelector<Solution_> destinationSelector) {
         this.listVariableDescriptor = listVariableDescriptor;
         this.inverseVariableSupply = inverseVariableSupply;
         this.indexVariableSupply = indexVariableSupply;

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/RandomSubListChangeMoveIterator.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/RandomSubListChangeMoveIterator.java
@@ -18,7 +18,7 @@ class RandomSubListChangeMoveIterator<Solution_> extends UpcomingSelectionIterat
     RandomSubListChangeMoveIterator(
             ListVariableDescriptor<Solution_> listVariableDescriptor,
             RandomSubListSelector<Solution_> subListSelector,
-            ElementDestinationSelector<Solution_> destinationSelector,
+            DestinationSelector<Solution_> destinationSelector,
             Random workingRandom,
             boolean selectReversingMoveToo) {
         this.listVariableDescriptor = listVariableDescriptor;

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/RandomSubListChangeMoveSelector.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/RandomSubListChangeMoveSelector.java
@@ -10,13 +10,13 @@ public class RandomSubListChangeMoveSelector<Solution_> extends GenericMoveSelec
 
     private final ListVariableDescriptor<Solution_> listVariableDescriptor;
     private final RandomSubListSelector<Solution_> subListSelector;
-    private final ElementDestinationSelector<Solution_> destinationSelector;
+    private final DestinationSelector<Solution_> destinationSelector;
     private final boolean selectReversingMoveToo;
 
     public RandomSubListChangeMoveSelector(
             ListVariableDescriptor<Solution_> listVariableDescriptor,
             RandomSubListSelector<Solution_> subListSelector,
-            ElementDestinationSelector<Solution_> destinationSelector,
+            DestinationSelector<Solution_> destinationSelector,
             boolean selectReversingMoveToo) {
         this.listVariableDescriptor = listVariableDescriptor;
         this.subListSelector = subListSelector;
@@ -49,8 +49,8 @@ public class RandomSubListChangeMoveSelector<Solution_> extends GenericMoveSelec
 
     @Override
     public long getSize() {
-        long destinationCount = destinationSelector.getSize();
         long subListCount = subListSelector.getSize();
+        long destinationCount = destinationSelector.getSize();
         return subListCount * destinationCount * (selectReversingMoveToo ? 2 : 1);
     }
 

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/RandomSubListSelector.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/RandomSubListSelector.java
@@ -138,11 +138,11 @@ public class RandomSubListSelector<Solution_> extends AbstractSelector<Solution_
         }
     }
 
-    public int getMinimumSubListSize() {
+    int getMinimumSubListSize() {
         return minimumSubListSize;
     }
 
-    public int getMaximumSubListSize() {
+    int getMaximumSubListSize() {
         return maximumSubListSize;
     }
 

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/value/nearby/NearEntityNearbyValueSelector.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/value/nearby/NearEntityNearbyValueSelector.java
@@ -27,7 +27,7 @@ public final class NearEntityNearbyValueSelector<Solution_> extends AbstractValu
     private final boolean discardNearbyIndexZero;
     private final NearbyDistanceMatrixDemand<Solution_, ?, ?> nearbyDistanceMatrixDemand;
 
-    private MemoizingSupply<NearbyDistanceMatrix> nearbyDistanceMatrixSupply = null;
+    private MemoizingSupply<NearbyDistanceMatrix<Object, Object>> nearbyDistanceMatrixSupply = null;
 
     public NearEntityNearbyValueSelector(ValueSelector<Solution_> childValueSelector,
             EntitySelector<Solution_> originEntitySelector, NearbyDistanceMeter<?, ?> nearbyDistanceMeter,

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/value/nearby/NearEntityNearbyValueSelector.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/value/nearby/NearEntityNearbyValueSelector.java
@@ -48,9 +48,12 @@ public final class NearEntityNearbyValueSelector<Solution_> extends AbstractValu
         }
         this.discardNearbyIndexZero = childValueSelector.getVariableDescriptor().getVariablePropertyType().isAssignableFrom(
                 originEntitySelector.getEntityDescriptor().getEntityClass());
-        this.nearbyDistanceMatrixDemand =
-                new NearbyDistanceMatrixDemand<>(nearbyDistanceMeter, childValueSelector, replayingOriginEntitySelector,
-                        this::computeDestinationSize);
+        this.nearbyDistanceMatrixDemand = new NearbyDistanceMatrixDemand<>(
+                nearbyDistanceMeter,
+                childValueSelector,
+                replayingOriginEntitySelector,
+                this::computeDestinationSize);
+
         phaseLifecycleSupport.addEventListener(childValueSelector);
         phaseLifecycleSupport.addEventListener(originEntitySelector);
     }
@@ -83,8 +86,8 @@ public final class NearEntityNearbyValueSelector<Solution_> extends AbstractValu
     private int computeDestinationSize(Object origin) {
         long childSize = childValueSelector.getSize(origin);
         if (childSize > Integer.MAX_VALUE) {
-            throw new IllegalStateException("The childEntitySelector (" + childValueSelector
-                    + ") has an entitySize (" + childSize
+            throw new IllegalStateException("The childValueSelector (" + childValueSelector
+                    + ") has a valueSize (" + childSize
                     + ") which is higher than Integer.MAX_VALUE.");
         }
         int destinationSize = (int) childSize;
@@ -202,7 +205,7 @@ public final class NearEntityNearbyValueSelector<Solution_> extends AbstractValu
             this.replayingOriginEntityIterator = replayingOriginEntityIterator;
             if (childSize > Integer.MAX_VALUE) {
                 throw new IllegalStateException("The valueSelector (" + this
-                        + ") has an entitySize (" + childSize
+                        + ") has a valueSize (" + childSize
                         + ") which is higher than Integer.MAX_VALUE.");
             }
             nearbySize = (int) childSize - (discardNearbyIndexZero ? 1 : 0);
@@ -239,7 +242,8 @@ public final class NearEntityNearbyValueSelector<Solution_> extends AbstractValu
         if (other == null || getClass() != other.getClass())
             return false;
         NearEntityNearbyValueSelector<?> that = (NearEntityNearbyValueSelector<?>) other;
-        return Objects.equals(childValueSelector, that.childValueSelector)
+        return randomSelection == that.randomSelection
+                && Objects.equals(childValueSelector, that.childValueSelector)
                 && Objects.equals(replayingOriginEntitySelector, that.replayingOriginEntitySelector)
                 && Objects.equals(nearbyDistanceMeter, that.nearbyDistanceMeter)
                 && Objects.equals(nearbyRandom, that.nearbyRandom);
@@ -247,12 +251,12 @@ public final class NearEntityNearbyValueSelector<Solution_> extends AbstractValu
 
     @Override
     public int hashCode() {
-        return Objects.hash(childValueSelector, replayingOriginEntitySelector, nearbyDistanceMeter, nearbyRandom);
+        return Objects.hash(childValueSelector, replayingOriginEntitySelector, nearbyDistanceMeter, nearbyRandom,
+                randomSelection);
     }
 
     @Override
     public String toString() {
         return getClass().getSimpleName() + "(" + replayingOriginEntitySelector + ", " + childValueSelector + ")";
     }
-
 }

--- a/core/optaplanner-core-impl/src/main/resources/solver.xsd
+++ b/core/optaplanner-core-impl/src/main/resources/solver.xsd
@@ -411,6 +411,8 @@
                     
           <xs:element minOccurs="0" name="originEntitySelector" type="tns:entitySelectorConfig"/>
                     
+          <xs:element minOccurs="0" name="originValueSelector" type="tns:valueSelectorConfig"/>
+                    
           <xs:element minOccurs="0" name="nearbyDistanceMeterClass" type="xs:string"/>
                     
           <xs:element minOccurs="0" name="nearbySelectionDistributionType" type="tns:nearbySelectionDistributionType"/>
@@ -432,6 +434,52 @@
           <xs:element minOccurs="0" name="betaDistributionBeta" type="xs:double"/>
                   
         </xs:sequence>
+              
+      </xs:extension>
+          
+    </xs:complexContent>
+      
+  </xs:complexType>
+    
+  <xs:complexType name="valueSelectorConfig">
+        
+    <xs:complexContent>
+            
+      <xs:extension base="tns:selectorConfig">
+                
+        <xs:sequence>
+                    
+          <xs:element minOccurs="0" name="downcastEntityClass" type="xs:string"/>
+                    
+          <xs:element minOccurs="0" name="cacheType" type="tns:selectionCacheType"/>
+                    
+          <xs:element minOccurs="0" name="selectionOrder" type="tns:selectionOrder"/>
+                    
+          <xs:element minOccurs="0" name="nearbySelection" type="tns:nearbySelectionConfig"/>
+                    
+          <xs:element minOccurs="0" name="filterClass" type="xs:string"/>
+                    
+          <xs:element minOccurs="0" name="sorterManner" type="tns:valueSorterManner"/>
+                    
+          <xs:element minOccurs="0" name="sorterComparatorClass" type="xs:string"/>
+                    
+          <xs:element minOccurs="0" name="sorterWeightFactoryClass" type="xs:string"/>
+                    
+          <xs:element minOccurs="0" name="sorterOrder" type="tns:selectionSorterOrder"/>
+                    
+          <xs:element minOccurs="0" name="sorterClass" type="xs:string"/>
+                    
+          <xs:element minOccurs="0" name="probabilityWeightFactoryClass" type="xs:string"/>
+                    
+          <xs:element minOccurs="0" name="selectedCountLimit" type="xs:long"/>
+                  
+        </xs:sequence>
+                
+        <xs:attribute name="id" type="xs:string"/>
+                
+        <xs:attribute name="mimicSelectorRef" type="xs:string"/>
+                
+        <xs:attribute name="variableName" type="xs:string"/>
               
       </xs:extension>
           
@@ -549,52 +597,6 @@
       
   </xs:complexType>
     
-  <xs:complexType name="valueSelectorConfig">
-        
-    <xs:complexContent>
-            
-      <xs:extension base="tns:selectorConfig">
-                
-        <xs:sequence>
-                    
-          <xs:element minOccurs="0" name="downcastEntityClass" type="xs:string"/>
-                    
-          <xs:element minOccurs="0" name="cacheType" type="tns:selectionCacheType"/>
-                    
-          <xs:element minOccurs="0" name="selectionOrder" type="tns:selectionOrder"/>
-                    
-          <xs:element minOccurs="0" name="nearbySelection" type="tns:nearbySelectionConfig"/>
-                    
-          <xs:element minOccurs="0" name="filterClass" type="xs:string"/>
-                    
-          <xs:element minOccurs="0" name="sorterManner" type="tns:valueSorterManner"/>
-                    
-          <xs:element minOccurs="0" name="sorterComparatorClass" type="xs:string"/>
-                    
-          <xs:element minOccurs="0" name="sorterWeightFactoryClass" type="xs:string"/>
-                    
-          <xs:element minOccurs="0" name="sorterOrder" type="tns:selectionSorterOrder"/>
-                    
-          <xs:element minOccurs="0" name="sorterClass" type="xs:string"/>
-                    
-          <xs:element minOccurs="0" name="probabilityWeightFactoryClass" type="xs:string"/>
-                    
-          <xs:element minOccurs="0" name="selectedCountLimit" type="xs:long"/>
-                  
-        </xs:sequence>
-                
-        <xs:attribute name="id" type="xs:string"/>
-                
-        <xs:attribute name="mimicSelectorRef" type="xs:string"/>
-                
-        <xs:attribute name="variableName" type="xs:string"/>
-              
-      </xs:extension>
-          
-    </xs:complexContent>
-      
-  </xs:complexType>
-    
   <xs:complexType name="kOptListMoveSelectorConfig">
         
     <xs:complexContent>
@@ -625,7 +627,29 @@
                     
           <xs:element minOccurs="0" name="valueSelector" type="tns:valueSelectorConfig"/>
                     
+          <xs:element minOccurs="0" name="destinationSelector" type="tns:destinationSelectorConfig"/>
+                  
+        </xs:sequence>
+              
+      </xs:extension>
+          
+    </xs:complexContent>
+      
+  </xs:complexType>
+    
+  <xs:complexType name="destinationSelectorConfig">
+        
+    <xs:complexContent>
+            
+      <xs:extension base="tns:selectorConfig">
+                
+        <xs:sequence>
+                    
           <xs:element minOccurs="0" name="entitySelector" type="tns:entitySelectorConfig"/>
+                    
+          <xs:element minOccurs="0" name="valueSelector" type="tns:valueSelectorConfig"/>
+                    
+          <xs:element minOccurs="0" name="nearbySelection" type="tns:nearbySelectionConfig"/>
                   
         </xs:sequence>
               
@@ -1601,6 +1625,18 @@
       
   </xs:simpleType>
     
+  <xs:simpleType name="selectionSorterOrder">
+        
+    <xs:restriction base="xs:string">
+            
+      <xs:enumeration value="ASCENDING"/>
+            
+      <xs:enumeration value="DESCENDING"/>
+          
+    </xs:restriction>
+      
+  </xs:simpleType>
+    
   <xs:simpleType name="nearbySelectionDistributionType">
         
     <xs:restriction base="xs:string">
@@ -1612,18 +1648,6 @@
       <xs:enumeration value="PARABOLIC_DISTRIBUTION"/>
             
       <xs:enumeration value="BETA_DISTRIBUTION"/>
-          
-    </xs:restriction>
-      
-  </xs:simpleType>
-    
-  <xs:simpleType name="selectionSorterOrder">
-        
-    <xs:restriction base="xs:string">
-            
-      <xs:enumeration value="ASCENDING"/>
-            
-      <xs:enumeration value="DESCENDING"/>
           
     </xs:restriction>
       

--- a/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/config/heuristic/selector/common/nearby/NearbySelectionConfigTest.java
+++ b/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/config/heuristic/selector/common/nearby/NearbySelectionConfigTest.java
@@ -26,10 +26,11 @@ class NearbySelectionConfigTest {
     private static final String ENTITY_SELECTOR_ID = "entitySelector";
 
     @Test
-    void withNoOriginEntitySelectorConfig() {
+    void withNoOriginSelectorConfig() {
         NearbySelectionConfig nearbySelectionConfig = new NearbySelectionConfig();
         assertThatIllegalArgumentException().isThrownBy(() -> nearbySelectionConfig.validateNearby(JUST_IN_TIME, ORIGINAL))
-                .withMessageContaining("originEntitySelectorConfig");
+                .withMessageContaining("originEntitySelectorConfig")
+                .withMessageContaining("originValueSelectorConfig");
     }
 
     @Test

--- a/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/heuristic/selector/common/nearby/NearbyDistanceMatrixTest.java
+++ b/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/heuristic/selector/common/nearby/NearbyDistanceMatrixTest.java
@@ -16,11 +16,12 @@ class NearbyDistanceMatrixTest {
         final MatrixTestdataObject b = new MatrixTestdataObject("b", 1, new double[] { 4.0, 0.0, 5.0, 10.0 });
         final MatrixTestdataObject c = new MatrixTestdataObject("c", 2, new double[] { 2.0, 5.0, 0.0, 7.0 });
         final MatrixTestdataObject d = new MatrixTestdataObject("d", 3, new double[] { 6.0, 10.0, 7.0, 0.0 });
-        List<Object> entityList = Arrays.asList(a, b, c, d);
-        NearbyDistanceMeter<MatrixTestdataObject, MatrixTestdataObject> meter = (origin,
-                destination) -> origin.distances[destination.index];
+        List<MatrixTestdataObject> entityList = Arrays.asList(a, b, c, d);
+        NearbyDistanceMeter<MatrixTestdataObject, MatrixTestdataObject> meter =
+                (origin, destination) -> origin.distances[destination.index];
 
-        NearbyDistanceMatrix nearbyDistanceMatrix = new NearbyDistanceMatrix(meter, 4, entityList, origin -> 4);
+        NearbyDistanceMatrix<MatrixTestdataObject, MatrixTestdataObject> nearbyDistanceMatrix =
+                new NearbyDistanceMatrix<>(meter, 4, entityList, origin -> 4);
         nearbyDistanceMatrix.addAllDestinations(a);
         nearbyDistanceMatrix.addAllDestinations(b);
         nearbyDistanceMatrix.addAllDestinations(c);
@@ -50,11 +51,12 @@ class NearbyDistanceMatrixTest {
         final MatrixTestdataObject b = new MatrixTestdataObject("b", 1, new double[] { 1.0, 0.0, 2.0, 1.0 });
         final MatrixTestdataObject c = new MatrixTestdataObject("c", 2, new double[] { 1.0, 2.0, 0.0, 3.0 });
         final MatrixTestdataObject d = new MatrixTestdataObject("d", 3, new double[] { 1.0, 1.0, 3.0, 0.0 });
-        List<Object> entityList = Arrays.asList(a, b, c, d);
-        NearbyDistanceMeter<MatrixTestdataObject, MatrixTestdataObject> meter = (origin,
-                destination) -> origin.distances[destination.index];
+        List<MatrixTestdataObject> entityList = Arrays.asList(a, b, c, d);
+        NearbyDistanceMeter<MatrixTestdataObject, MatrixTestdataObject> meter =
+                (origin, destination) -> origin.distances[destination.index];
 
-        NearbyDistanceMatrix nearbyDistanceMatrix = new NearbyDistanceMatrix(meter, 4, entityList, origin -> 4);
+        NearbyDistanceMatrix<MatrixTestdataObject, MatrixTestdataObject> nearbyDistanceMatrix =
+                new NearbyDistanceMatrix<>(meter, 4, entityList, origin -> 4);
         nearbyDistanceMatrix.addAllDestinations(a);
         nearbyDistanceMatrix.addAllDestinations(b);
         nearbyDistanceMatrix.addAllDestinations(c);
@@ -85,11 +87,12 @@ class NearbyDistanceMatrixTest {
 
         final MatrixTestdataObject destination1 = new MatrixTestdataObject("1", 0, new double[] {});
         final MatrixTestdataObject destination2 = new MatrixTestdataObject("2", 0, new double[] {});
-        List<Object> valueList = Arrays.asList(destination1, destination2);
+        List<MatrixTestdataObject> valueList = Arrays.asList(destination1, destination2);
 
         NearbyDistanceMeter<MatrixTestdataObject, MatrixTestdataObject> meter =
                 (origin, destination) -> origin.distances[destination.index];
-        NearbyDistanceMatrix nearbyDistanceMatrix = new NearbyDistanceMatrix(meter, 1, valueList, origin -> valueList.size());
+        NearbyDistanceMatrix<MatrixTestdataObject, MatrixTestdataObject> nearbyDistanceMatrix =
+                new NearbyDistanceMatrix<>(meter, 1, valueList, origin -> valueList.size());
 
         // Add destinations for a. Destinations of b will be added when nearbyDistanceMatrix.getDestination() is called.
         nearbyDistanceMatrix.addAllDestinations(a);
@@ -101,8 +104,8 @@ class NearbyDistanceMatrixTest {
     }
 
     private static class MatrixTestdataObject extends TestdataObject {
-        private int index;
-        private double[] distances;
+        private final int index;
+        private final double[] distances;
 
         public MatrixTestdataObject(String code, int index, double[] distances) {
             super(code);

--- a/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/heuristic/selector/move/generic/ChangeMoveSelectorFactoryTest.java
+++ b/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/heuristic/selector/move/generic/ChangeMoveSelectorFactoryTest.java
@@ -12,6 +12,7 @@ import org.optaplanner.core.config.heuristic.selector.common.SelectionOrder;
 import org.optaplanner.core.config.heuristic.selector.entity.EntitySelectorConfig;
 import org.optaplanner.core.config.heuristic.selector.move.MoveSelectorConfig;
 import org.optaplanner.core.config.heuristic.selector.move.generic.ChangeMoveSelectorConfig;
+import org.optaplanner.core.config.heuristic.selector.move.generic.list.DestinationSelectorConfig;
 import org.optaplanner.core.config.heuristic.selector.move.generic.list.ListChangeMoveSelectorConfig;
 import org.optaplanner.core.config.heuristic.selector.value.ValueSelectorConfig;
 import org.optaplanner.core.impl.domain.solution.descriptor.SolutionDescriptor;
@@ -140,9 +141,12 @@ class ChangeMoveSelectorFactoryTest {
         assertThat(listChangeMoveSelectorConfig.getCacheType()).isEqualTo(moveSelectorCacheType);
         assertThat(listChangeMoveSelectorConfig.getSelectedCountLimit()).isEqualTo(selectedCountLimit);
 
-        EntitySelectorConfig entitySelectorConfig = listChangeMoveSelectorConfig.getEntitySelectorConfig();
+        DestinationSelectorConfig destinationSelectorConfig = listChangeMoveSelectorConfig.getDestinationSelectorConfig();
+        EntitySelectorConfig entitySelectorConfig = destinationSelectorConfig.getEntitySelectorConfig();
         assertThat(entitySelectorConfig.getEntityClass()).isEqualTo(TestdataListEntity.class);
         assertThat(entitySelectorConfig.getSorterComparatorClass()).isEqualTo(DummyEntityComparator.class);
+        ValueSelectorConfig valueSelectorConfig = destinationSelectorConfig.getValueSelectorConfig();
+        assertThat(valueSelectorConfig.getVariableName()).isEqualTo("valueList");
     }
 
     static class DummyEntityComparator implements Comparator<TestdataListEntity> {

--- a/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/ListChangeMoveSelectorFactoryTest.java
+++ b/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/ListChangeMoveSelectorFactoryTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.Test;
 import org.optaplanner.core.config.heuristic.selector.common.SelectionCacheType;
 import org.optaplanner.core.config.heuristic.selector.common.SelectionOrder;
 import org.optaplanner.core.config.heuristic.selector.entity.EntitySelectorConfig;
+import org.optaplanner.core.config.heuristic.selector.move.generic.list.DestinationSelectorConfig;
 import org.optaplanner.core.config.heuristic.selector.move.generic.list.ListChangeMoveSelectorConfig;
 import org.optaplanner.core.config.heuristic.selector.value.ValueSelectorConfig;
 import org.optaplanner.core.impl.domain.solution.descriptor.SolutionDescriptor;
@@ -27,7 +28,9 @@ class ListChangeMoveSelectorFactoryTest {
         SolutionDescriptor<TestdataListSolution> solutionDescriptor = TestdataListSolution.buildSolutionDescriptor();
         ListChangeMoveSelectorConfig moveSelectorConfig = new ListChangeMoveSelectorConfig()
                 .withValueSelectorConfig(new ValueSelectorConfig("valueList"))
-                .withEntitySelectorConfig(new EntitySelectorConfig(TestdataListEntity.class));
+                .withDestinationSelectorConfig(new DestinationSelectorConfig()
+                        .withEntitySelectorConfig(new EntitySelectorConfig(TestdataListEntity.class))
+                        .withValueSelectorConfig(new ValueSelectorConfig("valueList")));
         MoveSelector<TestdataListSolution> moveSelector =
                 MoveSelectorFactory.<TestdataListSolution> create(moveSelectorConfig).buildMoveSelector(
                         buildHeuristicConfigPolicy(solutionDescriptor), SelectionCacheType.JUST_IN_TIME, SelectionOrder.RANDOM);
@@ -74,7 +77,9 @@ class ListChangeMoveSelectorFactoryTest {
     void explicitConfigMustUseListVariable() {
         ListChangeMoveSelectorConfig config = new ListChangeMoveSelectorConfig()
                 .withValueSelectorConfig(new ValueSelectorConfig("value"))
-                .withEntitySelectorConfig(new EntitySelectorConfig(TestdataMixedVariablesEntity.class));
+                .withDestinationSelectorConfig(new DestinationSelectorConfig()
+                        .withEntitySelectorConfig(new EntitySelectorConfig(TestdataMixedVariablesEntity.class))
+                        .withValueSelectorConfig(new ValueSelectorConfig("value")));
 
         ListChangeMoveSelectorFactory<TestdataMixedVariablesSolution> moveSelectorFactory =
                 new ListChangeMoveSelectorFactory<>(config);

--- a/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/testdata/domain/list/TestdataListUtils.java
+++ b/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/testdata/domain/list/TestdataListUtils.java
@@ -11,7 +11,7 @@ import java.util.List;
 import org.optaplanner.core.impl.domain.variable.descriptor.ListVariableDescriptor;
 import org.optaplanner.core.impl.heuristic.selector.SelectorTestUtils;
 import org.optaplanner.core.impl.heuristic.selector.entity.EntitySelector;
-import org.optaplanner.core.impl.heuristic.selector.move.generic.list.ElementDestinationSelector;
+import org.optaplanner.core.impl.heuristic.selector.move.generic.list.DestinationSelector;
 import org.optaplanner.core.impl.heuristic.selector.move.generic.list.ElementRef;
 import org.optaplanner.core.impl.heuristic.selector.value.EntityIndependentValueSelector;
 import org.optaplanner.core.impl.score.director.InnerScoreDirector;
@@ -42,14 +42,14 @@ public class TestdataListUtils {
         return valueSelector;
     }
 
-    public static ElementDestinationSelector<TestdataListSolution> mockNeverEndingDestinationSelector(
+    public static DestinationSelector<TestdataListSolution> mockNeverEndingDestinationSelector(
             ElementRef... elementRefs) {
         return mockNeverEndingDestinationSelector(elementRefs.length, elementRefs);
     }
 
-    public static ElementDestinationSelector<TestdataListSolution> mockNeverEndingDestinationSelector(long size,
+    public static DestinationSelector<TestdataListSolution> mockNeverEndingDestinationSelector(long size,
             ElementRef... elementRefs) {
-        ElementDestinationSelector<TestdataListSolution> destinationSelector = mock(ElementDestinationSelector.class);
+        DestinationSelector<TestdataListSolution> destinationSelector = mock(DestinationSelector.class);
         when(destinationSelector.isCountable()).thenReturn(true);
         when(destinationSelector.isNeverEnding()).thenReturn(true);
         when(destinationSelector.getSize()).thenReturn(size);
@@ -57,8 +57,8 @@ public class TestdataListUtils {
         return destinationSelector;
     }
 
-    public static ElementDestinationSelector<TestdataListSolution> mockDestinationSelector(ElementRef... elementRefs) {
-        ElementDestinationSelector<TestdataListSolution> destinationSelector = mock(ElementDestinationSelector.class);
+    public static DestinationSelector<TestdataListSolution> mockDestinationSelector(ElementRef... elementRefs) {
+        DestinationSelector<TestdataListSolution> destinationSelector = mock(DestinationSelector.class);
         List<ElementRef> refList = Arrays.asList(elementRefs);
         when(destinationSelector.isCountable()).thenReturn(true);
         when(destinationSelector.isNeverEnding()).thenReturn(false);

--- a/optaplanner-benchmark/src/main/resources/benchmark.xsd
+++ b/optaplanner-benchmark/src/main/resources/benchmark.xsd
@@ -902,6 +902,9 @@
           <xs:element minOccurs="0" name="originEntitySelector" type="tns:entitySelectorConfig"/>
                               
           
+          <xs:element minOccurs="0" name="originValueSelector" type="tns:valueSelectorConfig"/>
+                              
+          
           <xs:element minOccurs="0" name="nearbyDistanceMeterClass" type="xs:string"/>
                               
           
@@ -933,6 +936,75 @@
                             
         
         </xs:sequence>
+                      
+      
+      </xs:extension>
+                
+    
+    </xs:complexContent>
+          
+  
+  </xs:complexType>
+      
+  
+  <xs:complexType name="valueSelectorConfig">
+            
+    
+    <xs:complexContent>
+                  
+      
+      <xs:extension base="tns:selectorConfig">
+                        
+        
+        <xs:sequence>
+                              
+          
+          <xs:element minOccurs="0" name="downcastEntityClass" type="xs:string"/>
+                              
+          
+          <xs:element minOccurs="0" name="cacheType" type="tns:selectionCacheType"/>
+                              
+          
+          <xs:element minOccurs="0" name="selectionOrder" type="tns:selectionOrder"/>
+                              
+          
+          <xs:element minOccurs="0" name="nearbySelection" type="tns:nearbySelectionConfig"/>
+                              
+          
+          <xs:element minOccurs="0" name="filterClass" type="xs:string"/>
+                              
+          
+          <xs:element minOccurs="0" name="sorterManner" type="tns:valueSorterManner"/>
+                              
+          
+          <xs:element minOccurs="0" name="sorterComparatorClass" type="xs:string"/>
+                              
+          
+          <xs:element minOccurs="0" name="sorterWeightFactoryClass" type="xs:string"/>
+                              
+          
+          <xs:element minOccurs="0" name="sorterOrder" type="tns:selectionSorterOrder"/>
+                              
+          
+          <xs:element minOccurs="0" name="sorterClass" type="xs:string"/>
+                              
+          
+          <xs:element minOccurs="0" name="probabilityWeightFactoryClass" type="xs:string"/>
+                              
+          
+          <xs:element minOccurs="0" name="selectedCountLimit" type="xs:long"/>
+                            
+        
+        </xs:sequence>
+                        
+        
+        <xs:attribute name="id" type="xs:string"/>
+                        
+        
+        <xs:attribute name="mimicSelectorRef" type="xs:string"/>
+                        
+        
+        <xs:attribute name="variableName" type="xs:string"/>
                       
       
       </xs:extension>
@@ -1109,75 +1181,6 @@
   </xs:complexType>
       
   
-  <xs:complexType name="valueSelectorConfig">
-            
-    
-    <xs:complexContent>
-                  
-      
-      <xs:extension base="tns:selectorConfig">
-                        
-        
-        <xs:sequence>
-                              
-          
-          <xs:element minOccurs="0" name="downcastEntityClass" type="xs:string"/>
-                              
-          
-          <xs:element minOccurs="0" name="cacheType" type="tns:selectionCacheType"/>
-                              
-          
-          <xs:element minOccurs="0" name="selectionOrder" type="tns:selectionOrder"/>
-                              
-          
-          <xs:element minOccurs="0" name="nearbySelection" type="tns:nearbySelectionConfig"/>
-                              
-          
-          <xs:element minOccurs="0" name="filterClass" type="xs:string"/>
-                              
-          
-          <xs:element minOccurs="0" name="sorterManner" type="tns:valueSorterManner"/>
-                              
-          
-          <xs:element minOccurs="0" name="sorterComparatorClass" type="xs:string"/>
-                              
-          
-          <xs:element minOccurs="0" name="sorterWeightFactoryClass" type="xs:string"/>
-                              
-          
-          <xs:element minOccurs="0" name="sorterOrder" type="tns:selectionSorterOrder"/>
-                              
-          
-          <xs:element minOccurs="0" name="sorterClass" type="xs:string"/>
-                              
-          
-          <xs:element minOccurs="0" name="probabilityWeightFactoryClass" type="xs:string"/>
-                              
-          
-          <xs:element minOccurs="0" name="selectedCountLimit" type="xs:long"/>
-                            
-        
-        </xs:sequence>
-                        
-        
-        <xs:attribute name="id" type="xs:string"/>
-                        
-        
-        <xs:attribute name="mimicSelectorRef" type="xs:string"/>
-                        
-        
-        <xs:attribute name="variableName" type="xs:string"/>
-                      
-      
-      </xs:extension>
-                
-    
-    </xs:complexContent>
-          
-  
-  </xs:complexType>
-      
-  
   <xs:complexType name="kOptListMoveSelectorConfig">
             
     
@@ -1223,7 +1226,40 @@
           <xs:element minOccurs="0" name="valueSelector" type="tns:valueSelectorConfig"/>
                               
           
+          <xs:element minOccurs="0" name="destinationSelector" type="tns:destinationSelectorConfig"/>
+                            
+        
+        </xs:sequence>
+                      
+      
+      </xs:extension>
+                
+    
+    </xs:complexContent>
+          
+  
+  </xs:complexType>
+      
+  
+  <xs:complexType name="destinationSelectorConfig">
+            
+    
+    <xs:complexContent>
+                  
+      
+      <xs:extension base="tns:selectorConfig">
+                        
+        
+        <xs:sequence>
+                              
+          
           <xs:element minOccurs="0" name="entitySelector" type="tns:entitySelectorConfig"/>
+                              
+          
+          <xs:element minOccurs="0" name="valueSelector" type="tns:valueSelectorConfig"/>
+                              
+          
+          <xs:element minOccurs="0" name="nearbySelection" type="tns:nearbySelectionConfig"/>
                             
         
         </xs:sequence>
@@ -2657,6 +2693,24 @@
   </xs:simpleType>
       
   
+  <xs:simpleType name="selectionSorterOrder">
+            
+    
+    <xs:restriction base="xs:string">
+                  
+      
+      <xs:enumeration value="ASCENDING"/>
+                  
+      
+      <xs:enumeration value="DESCENDING"/>
+                
+    
+    </xs:restriction>
+          
+  
+  </xs:simpleType>
+      
+  
   <xs:simpleType name="nearbySelectionDistributionType">
             
     
@@ -2673,24 +2727,6 @@
                   
       
       <xs:enumeration value="BETA_DISTRIBUTION"/>
-                
-    
-    </xs:restriction>
-          
-  
-  </xs:simpleType>
-      
-  
-  <xs:simpleType name="selectionSorterOrder">
-            
-    
-    <xs:restriction base="xs:string">
-                  
-      
-      <xs:enumeration value="ASCENDING"/>
-                  
-      
-      <xs:enumeration value="DESCENDING"/>
                 
     
     </xs:restriction>

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/vehiclerouting/domain/Customer.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/vehiclerouting/domain/Customer.java
@@ -23,7 +23,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 })
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonIdentityInfo(generator = JacksonUniqueIdGenerator.class)
-public class Customer extends AbstractPersistable implements CustomerOrVehicle {
+public class Customer extends AbstractPersistable implements LocationAware {
 
     protected Location location;
     protected int demand;

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/vehiclerouting/domain/Customer.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/vehiclerouting/domain/Customer.java
@@ -23,7 +23,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 })
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonIdentityInfo(generator = JacksonUniqueIdGenerator.class)
-public class Customer extends AbstractPersistable {
+public class Customer extends AbstractPersistable implements CustomerOrVehicle {
 
     protected Location location;
     protected int demand;
@@ -42,6 +42,7 @@ public class Customer extends AbstractPersistable {
         this.demand = demand;
     }
 
+    @Override
     public Location getLocation() {
         return location;
     }

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/vehiclerouting/domain/CustomerOrVehicle.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/vehiclerouting/domain/CustomerOrVehicle.java
@@ -1,0 +1,7 @@
+package org.optaplanner.examples.vehiclerouting.domain;
+
+import org.optaplanner.examples.vehiclerouting.domain.location.Location;
+
+public interface CustomerOrVehicle {
+    Location getLocation();
+}

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/vehiclerouting/domain/LocationAware.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/vehiclerouting/domain/LocationAware.java
@@ -2,6 +2,6 @@ package org.optaplanner.examples.vehiclerouting.domain;
 
 import org.optaplanner.examples.vehiclerouting.domain.location.Location;
 
-public interface CustomerOrVehicle {
+public interface LocationAware {
     Location getLocation();
 }

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/vehiclerouting/domain/Vehicle.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/vehiclerouting/domain/Vehicle.java
@@ -14,7 +14,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 
 @PlanningEntity
 @JsonIdentityInfo(generator = JacksonUniqueIdGenerator.class)
-public class Vehicle extends AbstractPersistable {
+public class Vehicle extends AbstractPersistable implements CustomerOrVehicle {
 
     protected int capacity;
     protected Depot depot;
@@ -59,6 +59,7 @@ public class Vehicle extends AbstractPersistable {
     // Complex methods
     // ************************************************************************
 
+    @Override
     @JsonIgnore
     public Location getLocation() {
         return depot.getLocation();

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/vehiclerouting/domain/Vehicle.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/vehiclerouting/domain/Vehicle.java
@@ -14,7 +14,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 
 @PlanningEntity
 @JsonIdentityInfo(generator = JacksonUniqueIdGenerator.class)
-public class Vehicle extends AbstractPersistable implements CustomerOrVehicle {
+public class Vehicle extends AbstractPersistable implements LocationAware {
 
     protected int capacity;
     protected Depot depot;

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/vehiclerouting/domain/solver/nearby/CustomerNearbyDistanceMeter.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/vehiclerouting/domain/solver/nearby/CustomerNearbyDistanceMeter.java
@@ -2,12 +2,12 @@ package org.optaplanner.examples.vehiclerouting.domain.solver.nearby;
 
 import org.optaplanner.core.impl.heuristic.selector.common.nearby.NearbyDistanceMeter;
 import org.optaplanner.examples.vehiclerouting.domain.Customer;
-import org.optaplanner.examples.vehiclerouting.domain.CustomerOrVehicle;
+import org.optaplanner.examples.vehiclerouting.domain.LocationAware;
 
-public class CustomerNearbyDistanceMeter implements NearbyDistanceMeter<Customer, CustomerOrVehicle> {
+public class CustomerNearbyDistanceMeter implements NearbyDistanceMeter<Customer, LocationAware> {
 
     @Override
-    public double getNearbyDistance(Customer origin, CustomerOrVehicle destination) {
+    public double getNearbyDistance(Customer origin, LocationAware destination) {
         long distance = origin.getLocation().getDistanceTo(destination.getLocation());
         // If arriving early also inflicts a cost (more than just not using the vehicle more), such as the driver's wage, use this:
         //        if (origin instanceof TimeWindowedCustomer && destination instanceof TimeWindowedCustomer) {

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/vehiclerouting/domain/solver/nearby/CustomerNearbyDistanceMeter.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/vehiclerouting/domain/solver/nearby/CustomerNearbyDistanceMeter.java
@@ -1,13 +1,14 @@
 package org.optaplanner.examples.vehiclerouting.domain.solver.nearby;
 
 import org.optaplanner.core.impl.heuristic.selector.common.nearby.NearbyDistanceMeter;
-import org.optaplanner.examples.vehiclerouting.domain.location.Location;
+import org.optaplanner.examples.vehiclerouting.domain.Customer;
+import org.optaplanner.examples.vehiclerouting.domain.CustomerOrVehicle;
 
-public class CustomerNearbyDistanceMeter implements NearbyDistanceMeter<Location, Location> {
+public class CustomerNearbyDistanceMeter implements NearbyDistanceMeter<Customer, CustomerOrVehicle> {
 
     @Override
-    public double getNearbyDistance(Location origin, Location destination) {
-        long distance = origin.getDistanceTo(destination);
+    public double getNearbyDistance(Customer origin, CustomerOrVehicle destination) {
+        long distance = origin.getLocation().getDistanceTo(destination.getLocation());
         // If arriving early also inflicts a cost (more than just not using the vehicle more), such as the driver's wage, use this:
         //        if (origin instanceof TimeWindowedCustomer && destination instanceof TimeWindowedCustomer) {
         //            distance += ((TimeWindowedCustomer) origin).getTimeWindowGapTo((TimeWindowedCustomer) destination);

--- a/optaplanner-examples/src/main/resources/org/optaplanner/examples/vehiclerouting/optional/benchmark/vehicleRoutingBenchmarkConfig.xml
+++ b/optaplanner-examples/src/main/resources/org/optaplanner/examples/vehiclerouting/optional/benchmark/vehicleRoutingBenchmarkConfig.xml
@@ -169,7 +169,17 @@
       </constructionHeuristic>
       <localSearch>
         <unionMoveSelector>
-          <listChangeMoveSelector/>
+          <listChangeMoveSelector>
+            <valueSelector id="1"/>
+            <destinationSelector>
+              <nearbySelection>
+                <originValueSelector mimicSelectorRef="1"/>
+                <nearbyDistanceMeterClass>org.optaplanner.examples.vehiclerouting.domain.solver.nearby.CustomerNearbyDistanceMeter</nearbyDistanceMeterClass>
+                <nearbySelectionDistributionType>PARABOLIC_DISTRIBUTION</nearbySelectionDistributionType>
+                <parabolicDistributionSizeMaximum>40</parabolicDistributionSizeMaximum>
+              </nearbySelection>
+            </destinationSelector>
+          </listChangeMoveSelector>
           <listSwapMoveSelector/>
           <subListChangeMoveSelector>
             <selectReversingMoveToo>true</selectReversingMoveToo>

--- a/optaplanner-examples/src/main/resources/org/optaplanner/examples/vehiclerouting/vehicleRoutingSolverConfig.xml
+++ b/optaplanner-examples/src/main/resources/org/optaplanner/examples/vehiclerouting/vehicleRoutingSolverConfig.xml
@@ -25,7 +25,17 @@
   </constructionHeuristic>
   <localSearch>
     <unionMoveSelector>
-      <listChangeMoveSelector/>
+      <listChangeMoveSelector>
+        <valueSelector id="1"/>
+        <destinationSelector>
+          <nearbySelection>
+            <originValueSelector mimicSelectorRef="1"/>
+            <nearbyDistanceMeterClass>org.optaplanner.examples.vehiclerouting.domain.solver.nearby.CustomerNearbyDistanceMeter</nearbyDistanceMeterClass>
+            <nearbySelectionDistributionType>PARABOLIC_DISTRIBUTION</nearbySelectionDistributionType>
+            <parabolicDistributionSizeMaximum>40</parabolicDistributionSizeMaximum>
+          </nearbySelection>
+        </destinationSelector>
+      </listChangeMoveSelector>
       <listSwapMoveSelector/>
       <subListChangeMoveSelector>
         <selectReversingMoveToo>true</selectReversingMoveToo>


### PR DESCRIPTION
Follows up on #2619.

This PR has two main parts: the list change move selector configuration updates and the nearby selector for list change moves.

### Config

The destination selector has now its own config element, which 1) allows to configure destination value selector separately from the source value selector and 2) allows to apply nearby selection.

Before:
```xml
<listChangeMoveSelector>
  <valueSelector/> <!-- same config for source and destination value selector -->
  <entitySelector/>
</listChangeMoveSelector>
```
After:
```xml
<listChangeMoveSelector>
  <valueSelector id="1"/>
  <destinationSelector>
    <valueSelector/>
    <entitySelector/>
    <nearbySelection>
      <originValueSelector mimicSelectorRef="1"/>
    </nearbySelection>
  </destinationSelector>
</listChangeMoveSelector>
```

The destination selector config reuses the existing nearby selection config and adds the new `originValueSelectorConfig` property.

Pros:
- Fewer configuration classes.

Cons:
- More possibilities to create invalid configurations.

This can be improved by introducing a dedicated `DestinationNearbySelectionConfig` class and a class hierarchy to avoid code duplication.

`<changeMoveSelector/>` unfolding into a `<listChangeMoveSelector/>` still works and it seems like it should work for multiple list variables/entities while the `<listChangeMoveSelector/>` config does not support unfolding for multiple list variables/entities. This may need to be addressed.

### Nearby selector

Is the old POC from a few weeks ago. What needs attention:
- [x] Replacing child entity + value selector combo with a child destination selector.
- [ ] Review the endingIterator "hacks".
- [ ] Every time a destination is retrieved from the "matrix" it is checked whether it's an entity or a value. Possible performance impact.
- [ ] Reduce duplicated code. But that can wait until the other nearby selectors for swap and sublist moves are introduced.

The nearby distance meter needs to accept elements of the nearby matrix, which are entities and values. Therefore, a common interface is needed through which the location is accessed.

New tests are probably needed for the added list change move selector factory complexity and for the new nearby selection code.

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
- https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
- https://github.com/kiegroup/drools/pull/3000
- https://github.com/kiegroup/optaplanner/pull/899
- etc.
-->

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request checks</b>  
  Please add comment: <b>Jenkins retest this</b>

- for a <b>specific pull request check</b>  
  please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-vehicle-routing] tests</b>
  
- for a <b>full downstream build</b> 
  - for <b>jenkins</b> job: 
    please add comment: <b>Jenkins run fdb</b>
  - for <b>github actions</b> job: 
    add the label `run_fdb`

- for a <b>compile downstream build</b>  
  please add comment: <b>Jenkins run cdb</b>

- for a <b>full production downstream build</b>  
  please add comment: <b>Jenkins execute product fdb</b>

- for an <b>upstream build</b>  
  please add comment: <b>Jenkins run upstream</b>

- for <b>quarkus branch checks</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins run quarkus-branch</b>

- for a <b>quarkus branch specific check</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-vehicle-routing] quarkus-branch</b>

- for <b>quarkus main checks</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins run quarkus-main</b>

- for a <b>specific quarkus main check</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-vehicle-routing] quarkus-branch</b>

- for <b>quarkus lts checks</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins run quarkus-lts</b>

- for a <b>specific quarkus lts check</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-vehicle-routing] quarkus-lts</b>

- for <b>native checks</b>  
  Run native checks  
  Please add comment: <b>Jenkins run native</b>

- for a <b>specific native check</b>  
  Run native checks 
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts] native</b>

- for <b>native lts checks</b>  
  Run native checks against quarkus lts branch
  Please add comment: <b>Jenkins run native-lts</b>

- for a <b>specific native lts check</b>  
  Run native checks against quarkus lts branch
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts] native-lts</b>

</details>

### CI Status

 You can check OptaPlanner repositories CI status from [Chain Status webpage](https://kiegroup.github.io/optaplanner/).

<details>
<summary>
How to backport a pull request to a different branch?
</summary>

In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-7.67.x` to backport the original PR to the `7.67.x` branch).

> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.

Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.

If something goes wrong, the author will be notified and at this point a manual backporting is needed.

> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
</details>
