### PR TITLE
Nearby selection for ListSwapMoveSelector

### DIFF
--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/ListSwapMoveSelectorFactory.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/ListSwapMoveSelectorFactory.java
@@ -68,7 +68,7 @@ public class ListSwapMoveSelectorFactory<Solution_>
         ValueSelector<Solution_> valueSelector = ValueSelectorFactory.<Solution_> create(valueSelectorConfig)
                 .buildValueSelector(configPolicy, entityDescriptor, minimumCacheType, inheritedSelectionOrder);
         if (!(valueSelector instanceof EntityIndependentValueSelector)) {
-            throw new IllegalArgumentException("The swapMoveSelector (" + config
+            throw new IllegalArgumentException("The listSwapMoveSelector (" + config
                     + ") for a list variable needs to be based on an "
                     + EntityIndependentValueSelector.class.getSimpleName() + " (" + valueSelector + ")."
                     + " Check your valueSelectorConfig.");

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/ListValueNearbyDistanceMatrixDemand.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/ListValueNearbyDistanceMatrixDemand.java
@@ -1,0 +1,110 @@
+package org.optaplanner.core.impl.heuristic.selector.move.generic.list;
+
+import java.util.Iterator;
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.function.ToIntFunction;
+
+import org.optaplanner.core.impl.domain.variable.supply.Demand;
+import org.optaplanner.core.impl.domain.variable.supply.SupplyManager;
+import org.optaplanner.core.impl.heuristic.selector.common.nearby.NearbyDistanceMatrix;
+import org.optaplanner.core.impl.heuristic.selector.common.nearby.NearbyDistanceMeter;
+import org.optaplanner.core.impl.heuristic.selector.value.EntityIndependentValueSelector;
+import org.optaplanner.core.impl.heuristic.selector.value.mimic.MimicReplayingValueSelector;
+import org.optaplanner.core.impl.solver.ClassInstanceCache;
+import org.optaplanner.core.impl.util.MemoizingSupply;
+
+/**
+ * Calculating {@link NearbyDistanceMatrix} is very expensive,
+ * therefore we want to reuse it as much as possible.
+ *
+ * <p>
+ * In cases where the demand represents the same nearby selector (as defined by
+ * {@link ListValueNearbyDistanceMatrixDemand#equals(Object)})
+ * the {@link SupplyManager} ensures that the same supply instance is returned
+ * with the pre-computed {@link NearbyDistanceMatrix}.
+ *
+ * @param <Solution_>
+ * @param <Origin_>
+ * @param <Destination_>
+ */
+public final class ListValueNearbyDistanceMatrixDemand<Solution_, Origin_, Destination_>
+        implements Demand<MemoizingSupply<NearbyDistanceMatrix<Origin_, Destination_>>> {
+
+    private final NearbyDistanceMeter<Origin_, Destination_> meter;
+    private final EntityIndependentValueSelector<Solution_> childValueSelector;
+    private final MimicReplayingValueSelector<Solution_> replayingOriginValueSelector;
+    private final ToIntFunction<Origin_> destinationSizeFunction;
+
+    public ListValueNearbyDistanceMatrixDemand(
+            NearbyDistanceMeter<Origin_, Destination_> meter,
+            EntityIndependentValueSelector<Solution_> childValueSelector,
+            MimicReplayingValueSelector<Solution_> replayingOriginValueSelector,
+            ToIntFunction<Origin_> destinationSizeFunction) {
+        this.meter = meter;
+        this.childValueSelector = childValueSelector;
+        this.replayingOriginValueSelector = replayingOriginValueSelector;
+        this.destinationSizeFunction = destinationSizeFunction;
+    }
+
+    @Override
+    public MemoizingSupply<NearbyDistanceMatrix<Origin_, Destination_>> createExternalizedSupply(SupplyManager supplyManager) {
+        Supplier<NearbyDistanceMatrix<Origin_, Destination_>> supplier = () -> {
+            final long childSize = childValueSelector.getSize();
+            if (childSize > Integer.MAX_VALUE) {
+                throw new IllegalStateException("The childSize (" + childSize + ") is higher than Integer.MAX_VALUE.");
+            }
+
+            long originSize = replayingOriginValueSelector.getSize();
+            if (originSize > Integer.MAX_VALUE) {
+                throw new IllegalStateException("The originValueSelector (" + replayingOriginValueSelector
+                        + ") has a valueSize (" + originSize
+                        + ") which is higher than Integer.MAX_VALUE.");
+            }
+            // List variables use entity independent value selectors, so we can pass null to the ending iterator.
+            Function<Origin_, Iterator<Destination_>> destinationIteratorProvider =
+                    origin -> (Iterator<Destination_>) childValueSelector.endingIterator(null);
+            NearbyDistanceMatrix<Origin_, Destination_> nearbyDistanceMatrix =
+                    new NearbyDistanceMatrix<>(meter, (int) originSize, destinationIteratorProvider, destinationSizeFunction);
+            // Replaying selector's ending iterator uses the recording selector's ending iterator. So, again, null is OK here.
+            replayingOriginValueSelector.endingIterator(null)
+                    .forEachRemaining(origin -> nearbyDistanceMatrix.addAllDestinations((Origin_) origin));
+
+            return nearbyDistanceMatrix;
+        };
+        return new MemoizingSupply<>(supplier);
+    }
+
+    /**
+     * Two instances of this class are considered equal if and only if:
+     *
+     * <ul>
+     * <li>Their meter instances are equal.</li>
+     * <li>Their child selectors are equal.</li>
+     * <li>Their replaying origin entity selectors are equal.</li>
+     * </ul>
+     *
+     * Otherwise as defined by {@link Object#equals(Object)}.
+     *
+     * @see ClassInstanceCache for how we ensure equality for meter instances in particular and selectors in general.
+     */
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ListValueNearbyDistanceMatrixDemand<?, ?, ?> that = (ListValueNearbyDistanceMatrixDemand<?, ?, ?>) o;
+        return Objects.equals(meter, that.meter)
+                && Objects.equals(childValueSelector, that.childValueSelector)
+                && Objects.equals(replayingOriginValueSelector, that.replayingOriginValueSelector);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(meter, childValueSelector, replayingOriginValueSelector);
+    }
+}

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/NearValueNearbyValueSelector.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/NearValueNearbyValueSelector.java
@@ -1,0 +1,261 @@
+package org.optaplanner.core.impl.heuristic.selector.move.generic.list;
+
+import java.util.Iterator;
+import java.util.Objects;
+
+import org.optaplanner.core.impl.domain.variable.descriptor.GenuineVariableDescriptor;
+import org.optaplanner.core.impl.heuristic.selector.common.iterator.SelectionIterator;
+import org.optaplanner.core.impl.heuristic.selector.common.nearby.NearbyDistanceMatrix;
+import org.optaplanner.core.impl.heuristic.selector.common.nearby.NearbyDistanceMeter;
+import org.optaplanner.core.impl.heuristic.selector.common.nearby.NearbyRandom;
+import org.optaplanner.core.impl.heuristic.selector.value.AbstractValueSelector;
+import org.optaplanner.core.impl.heuristic.selector.value.EntityIndependentValueSelector;
+import org.optaplanner.core.impl.heuristic.selector.value.mimic.MimicReplayingValueSelector;
+import org.optaplanner.core.impl.phase.scope.AbstractPhaseScope;
+import org.optaplanner.core.impl.solver.scope.SolverScope;
+import org.optaplanner.core.impl.util.MemoizingSupply;
+
+public final class NearValueNearbyValueSelector<Solution_> extends AbstractValueSelector<Solution_>
+        implements EntityIndependentValueSelector<Solution_> {
+
+    private final EntityIndependentValueSelector<Solution_> childValueSelector;
+    private final MimicReplayingValueSelector<Solution_> replayingOriginValueSelector;
+    private final NearbyDistanceMeter<?, ?> nearbyDistanceMeter;
+    private final NearbyRandom nearbyRandom;
+    private final boolean randomSelection;
+    private final ListValueNearbyDistanceMatrixDemand<Solution_, ?, ?> nearbyDistanceMatrixDemand;
+
+    private MemoizingSupply<NearbyDistanceMatrix<Object, Object>> nearbyDistanceMatrixSupply = null;
+
+    public NearValueNearbyValueSelector(
+            EntityIndependentValueSelector<Solution_> childValueSelector,
+            EntityIndependentValueSelector<Solution_> originValueSelector,
+            NearbyDistanceMeter<?, ?> nearbyDistanceMeter,
+            NearbyRandom nearbyRandom, boolean randomSelection) {
+        this.childValueSelector = childValueSelector;
+        if (!(originValueSelector instanceof MimicReplayingValueSelector)) {
+            // In order to select a nearby value, we must first have something to be near by.
+            throw new IllegalStateException("Impossible state: Nearby value selector (" + this +
+                    ") did not receive a replaying value selector (" + originValueSelector + ").");
+        }
+        this.replayingOriginValueSelector = (MimicReplayingValueSelector<Solution_>) originValueSelector;
+        this.nearbyDistanceMeter = nearbyDistanceMeter;
+        this.nearbyRandom = nearbyRandom;
+        this.randomSelection = randomSelection;
+        if (randomSelection && nearbyRandom == null) {
+            throw new IllegalArgumentException("The entitySelector (" + this
+                    + ") with randomSelection (" + randomSelection + ") has no nearbyRandom (" + nearbyRandom + ").");
+        }
+        this.nearbyDistanceMatrixDemand = new ListValueNearbyDistanceMatrixDemand<>(
+                nearbyDistanceMeter,
+                childValueSelector,
+                replayingOriginValueSelector,
+                this::computeDestinationSize);
+
+        phaseLifecycleSupport.addEventListener(childValueSelector);
+        phaseLifecycleSupport.addEventListener(originValueSelector);
+    }
+
+    @Override
+    public void solvingStarted(SolverScope<Solution_> solverScope) {
+        super.solvingStarted(solverScope);
+        /*
+         * Supply will ask questions of the child selector.
+         * However, child selector will only be initialized during phase start.
+         * Yet we still want the very expensive nearby distance matrix to be reused across phases.
+         * Therefore we request the supply here, but actually lazily initialize it during phase start.
+         */
+        nearbyDistanceMatrixSupply = (MemoizingSupply) solverScope.getScoreDirector().getSupplyManager()
+                .demand(nearbyDistanceMatrixDemand);
+    }
+
+    @Override
+    public void phaseStarted(AbstractPhaseScope<Solution_> phaseScope) {
+        super.phaseStarted(phaseScope);
+        // Lazily initialize the supply, so that steps can then have uniform performance.
+        nearbyDistanceMatrixSupply.read();
+    }
+
+    private int computeDestinationSize(Object origin) {
+        long childSize = childValueSelector.getSize();
+        if (childSize > Integer.MAX_VALUE) {
+            throw new IllegalStateException("The childValueSelector (" + childValueSelector
+                    + ") has a valueSize (" + childSize
+                    + ") which is higher than Integer.MAX_VALUE.");
+        }
+
+        int destinationSize = (int) childSize;
+        if (randomSelection) {
+            // Reduce RAM memory usage by reducing destinationSize if nearbyRandom will never select a higher value
+            int overallSizeMaximum = nearbyRandom.getOverallSizeMaximum();
+            if (destinationSize > overallSizeMaximum) {
+                destinationSize = overallSizeMaximum;
+            }
+        }
+        return destinationSize;
+    }
+
+    @Override
+    public void solvingEnded(SolverScope<Solution_> solverScope) {
+        super.solvingEnded(solverScope);
+        solverScope.getScoreDirector().getSupplyManager().cancel(nearbyDistanceMatrixDemand);
+        nearbyDistanceMatrixSupply = null;
+    }
+
+    @Override
+    public GenuineVariableDescriptor<Solution_> getVariableDescriptor() {
+        return childValueSelector.getVariableDescriptor();
+    }
+
+    @Override
+    public boolean isCountable() {
+        return true;
+    }
+
+    @Override
+    public boolean isNeverEnding() {
+        return randomSelection;
+    }
+
+    @Override
+    public long getSize(Object entity) {
+        return getSize();
+    }
+
+    @Override
+    public long getSize() {
+        return childValueSelector.getSize();
+    }
+
+    @Override
+    public Iterator<Object> iterator(Object entity) {
+        return iterator();
+    }
+
+    @Override
+    public Iterator<Object> iterator() {
+        Iterator<Object> replayingOriginValueIterator = replayingOriginValueSelector.iterator();
+        if (!randomSelection) {
+            return new OriginalNearbyValueIterator(replayingOriginValueIterator, childValueSelector.getSize());
+        } else {
+            return new RandomNearbyValueIterator(replayingOriginValueIterator, childValueSelector.getSize());
+        }
+    }
+
+    @Override
+    public Iterator<Object> endingIterator(Object entity) {
+        // TODO It should probably use nearby order
+        // It must include the origin entity too
+        return childValueSelector.endingIterator(entity);
+    }
+
+    private final class OriginalNearbyValueIterator extends SelectionIterator<Object> {
+
+        private final Iterator<Object> replayingOriginValueIterator;
+        private final long childSize;
+
+        private boolean originSelected = false;
+        private boolean originIsNotEmpty;
+        private Object origin;
+
+        private int nextNearbyIndex;
+
+        public OriginalNearbyValueIterator(Iterator<Object> replayingOriginValueIterator, long childSize) {
+            this.replayingOriginValueIterator = replayingOriginValueIterator;
+            this.childSize = childSize;
+            nextNearbyIndex = 0;
+        }
+
+        private void selectOrigin() {
+            if (originSelected) {
+                return;
+            }
+            /*
+             * The origin iterator is guaranteed to be a replaying iterator.
+             * Therefore next() will point to whatever that the related recording iterator was pointing to at the time
+             * when its next() was called.
+             * As a result, origin here will be constant unless next() on the original recording iterator is called
+             * first.
+             */
+            originIsNotEmpty = replayingOriginValueIterator.hasNext();
+            origin = replayingOriginValueIterator.next();
+            originSelected = true;
+        }
+
+        @Override
+        public boolean hasNext() {
+            selectOrigin();
+            return originIsNotEmpty && nextNearbyIndex < childSize;
+        }
+
+        @Override
+        public Object next() {
+            selectOrigin();
+            Object next = nearbyDistanceMatrixSupply.read().getDestination(origin, nextNearbyIndex);
+            nextNearbyIndex++;
+            return next;
+        }
+
+    }
+
+    private final class RandomNearbyValueIterator extends SelectionIterator<Object> {
+
+        private final Iterator<Object> replayingOriginValueIterator;
+        private final int nearbySize;
+
+        public RandomNearbyValueIterator(Iterator<Object> replayingOriginValueIterator, long childSize) {
+            this.replayingOriginValueIterator = replayingOriginValueIterator;
+            if (childSize > Integer.MAX_VALUE) {
+                throw new IllegalStateException("The destinationSelector (" + this
+                        + ") has a destinationSize (" + childSize
+                        + ") which is higher than Integer.MAX_VALUE.");
+            }
+            nearbySize = (int) childSize;
+        }
+
+        @Override
+        public boolean hasNext() {
+            return replayingOriginValueIterator.hasNext() && nearbySize > 0;
+        }
+
+        @Override
+        public Object next() {
+            /*
+             * The origin iterator is guaranteed to be a replaying iterator.
+             * Therefore next() will point to whatever that the related recording iterator was pointing to at the time
+             * when its next() was called.
+             * As a result, origin here will be constant unless next() on the original recording iterator is called
+             * first.
+             */
+            Object origin = replayingOriginValueIterator.next();
+            int nearbyIndex = nearbyRandom.nextInt(workingRandom, nearbySize);
+            return nearbyDistanceMatrixSupply.read().getDestination(origin, nearbyIndex);
+        }
+
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (this == other)
+            return true;
+        if (other == null || getClass() != other.getClass())
+            return false;
+        NearValueNearbyValueSelector<?> that = (NearValueNearbyValueSelector<?>) other;
+        return randomSelection == that.randomSelection
+                && Objects.equals(childValueSelector, that.childValueSelector)
+                && Objects.equals(replayingOriginValueSelector, that.replayingOriginValueSelector)
+                && Objects.equals(nearbyDistanceMeter, that.nearbyDistanceMeter)
+                && Objects.equals(nearbyRandom, that.nearbyRandom);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(childValueSelector, replayingOriginValueSelector, nearbyDistanceMeter, nearbyRandom,
+                randomSelection);
+    }
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName() + "(" + replayingOriginValueSelector + ", " + childValueSelector + ")";
+    }
+}

--- a/optaplanner-examples/src/main/resources/org/optaplanner/examples/vehiclerouting/vehicleRoutingSolverConfig.xml
+++ b/optaplanner-examples/src/main/resources/org/optaplanner/examples/vehiclerouting/vehicleRoutingSolverConfig.xml
@@ -36,14 +36,24 @@
           </nearbySelection>
         </destinationSelector>
       </listChangeMoveSelector>
-      <listSwapMoveSelector/>
+      <listSwapMoveSelector>
+        <valueSelector id="2"/>
+        <secondaryValueSelector>
+          <nearbySelection>
+            <originValueSelector mimicSelectorRef="2"/>
+            <nearbyDistanceMeterClass>org.optaplanner.examples.vehiclerouting.domain.solver.nearby.CustomerNearbyDistanceMeter</nearbyDistanceMeterClass>
+            <nearbySelectionDistributionType>PARABOLIC_DISTRIBUTION</nearbySelectionDistributionType>
+            <parabolicDistributionSizeMaximum>40</parabolicDistributionSizeMaximum>
+          </nearbySelection>
+        </secondaryValueSelector>
+      </listSwapMoveSelector>
       <subListChangeMoveSelector>
         <selectReversingMoveToo>true</selectReversingMoveToo>
       </subListChangeMoveSelector>
       <subListSwapMoveSelector>
         <selectReversingMoveToo>true</selectReversingMoveToo>
       </subListSwapMoveSelector>
-      <kOptListMoveSelector />
+      <kOptListMoveSelector/>
       <!-- TODO use nearby selection to scale out -->
     </unionMoveSelector>
     <acceptor>


### PR DESCRIPTION
The nearby selector and demand are copies of the existing variants for the list change move. These two new classes need:
- better names
- tests
- deduplication

but all of that will be addressed in the last step when there are all four variants for list change, swap, sublist change and swap move selectors when it's clear what parts of the code are common and what the differences are.

Another significant change is the value selector factory, which now has to handle two different cases when applying nearby selection config.

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request checks</b>  
  Please add comment: <b>Jenkins retest this</b>

- for a <b>specific pull request check</b>  
  please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-vehicle-routing] tests</b>
  
- for a <b>full downstream build</b> 
  - for <b>jenkins</b> job: 
    please add comment: <b>Jenkins run fdb</b>
  - for <b>github actions</b> job: 
    add the label `run_fdb`

- for a <b>compile downstream build</b>  
  please add comment: <b>Jenkins run cdb</b>

- for a <b>full production downstream build</b>  
  please add comment: <b>Jenkins execute product fdb</b>

- for an <b>upstream build</b>  
  please add comment: <b>Jenkins run upstream</b>

- for <b>quarkus branch checks</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins run quarkus-branch</b>

- for a <b>quarkus branch specific check</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-vehicle-routing] quarkus-branch</b>

- for <b>quarkus main checks</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins run quarkus-main</b>

- for a <b>specific quarkus main check</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-vehicle-routing] quarkus-branch</b>

- for <b>quarkus lts checks</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins run quarkus-lts</b>

- for a <b>specific quarkus lts check</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-vehicle-routing] quarkus-lts</b>

- for <b>native checks</b>  
  Run native checks  
  Please add comment: <b>Jenkins run native</b>

- for a <b>specific native check</b>  
  Run native checks 
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts] native</b>

- for <b>native lts checks</b>  
  Run native checks against quarkus lts branch
  Please add comment: <b>Jenkins run native-lts</b>

- for a <b>specific native lts check</b>  
  Run native checks against quarkus lts branch
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts] native-lts</b>

</details>

### CI Status

 You can check OptaPlanner repositories CI status from [Chain Status webpage](https://kiegroup.github.io/optaplanner/).

<details>
<summary>
How to backport a pull request to a different branch?
</summary>

In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-7.67.x` to backport the original PR to the `7.67.x` branch).

> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.

Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.

If something goes wrong, the author will be notified and at this point a manual backporting is needed.

> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
</details>
