### PR TITLE
Clean up parts of the KOpt related code

### DIFF
--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/config/heuristic/selector/move/generic/list/kopt/KOptListMoveSelectorConfig.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/config/heuristic/selector/move/generic/list/kopt/KOptListMoveSelectorConfig.java
@@ -55,10 +55,8 @@ public class KOptListMoveSelectorConfig extends MoveSelectorConfig<KOptListMoveS
     @Override
     public KOptListMoveSelectorConfig inherit(KOptListMoveSelectorConfig inheritedConfig) {
         super.inherit(inheritedConfig);
-        this.minimumK =
-                ConfigUtils.inheritOverwritableProperty(minimumK, inheritedConfig.minimumK);
-        this.maximumK =
-                ConfigUtils.inheritOverwritableProperty(maximumK, inheritedConfig.maximumK);
+        this.minimumK = ConfigUtils.inheritOverwritableProperty(minimumK, inheritedConfig.minimumK);
+        this.maximumK = ConfigUtils.inheritOverwritableProperty(maximumK, inheritedConfig.maximumK);
         return this;
     }
 

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/kopt/KOptListMoveIterator.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/kopt/KOptListMoveIterator.java
@@ -123,11 +123,11 @@ final class KOptListMoveIterator<Solution_, Node_> extends UpcomingSelectionIter
 
     private KOptDescriptor<Solution_, Node_> pickKOptMoveRec(Iterator<Node_> valueIterator, Node_[] pickedValues,
             int pickedSoFar,
-            int K) {
+            int k) {
         Node_ previousRemovedEdgeEndpoint = pickedValues[2 * pickedSoFar - 2];
         Node_ nextRemovedEdgePoint, nextRemovedEdgeOppositePoint;
 
-        int remainingAttempts = (K - pickedSoFar + 3) * 2;
+        int remainingAttempts = (k - pickedSoFar + 3) * 2;
         while (remainingAttempts > 0) {
             nextRemovedEdgePoint = valueIterator.next();
             while (nextRemovedEdgePoint == getNodePredecessor(previousRemovedEdgeEndpoint) ||
@@ -158,8 +158,8 @@ final class KOptListMoveIterator<Solution_, Node_> extends UpcomingSelectionIter
             }
             pickedValues[2 * pickedSoFar] = nextRemovedEdgeOppositePoint;
 
-            if (pickedSoFar < K) {
-                KOptDescriptor<Solution_, Node_> descriptor = pickKOptMoveRec(valueIterator, pickedValues, pickedSoFar + 1, K);
+            if (pickedSoFar < k) {
+                KOptDescriptor<Solution_, Node_> descriptor = pickKOptMoveRec(valueIterator, pickedValues, pickedSoFar + 1, k);
                 if (descriptor != null && descriptor.isFeasible()) {
                     return descriptor;
                 }

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/kopt/KOptListMoveSelector.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/kopt/KOptListMoveSelector.java
@@ -71,14 +71,6 @@ final class KOptListMoveSelector<Solution_> extends GenericMoveSelector<Solution
         return total;
     }
 
-    private long factorialUpToCount(long toMultiply, int count) {
-        long total = toMultiply;
-        for (int i = 1; i < count; i++) {
-            total *= (toMultiply - i);
-        }
-        return total;
-    }
-
     @Override
     public Iterator<Move<Solution_>> iterator() {
         return new KOptListMoveIterator<>(workingRandom, listVariableDescriptor, inverseVariableSupply, indexVariableSupply,

--- a/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/kopt/KOptListMoveTest.java
+++ b/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/kopt/KOptListMoveTest.java
@@ -10,10 +10,8 @@ import java.util.List;
 import java.util.function.Function;
 
 import org.junit.jupiter.api.Test;
-import org.optaplanner.core.impl.domain.solution.descriptor.SolutionDescriptor;
 import org.optaplanner.core.impl.domain.variable.descriptor.ListVariableDescriptor;
 import org.optaplanner.core.impl.domain.variable.index.IndexVariableDemand;
-import org.optaplanner.core.impl.domain.variable.index.IndexVariableListener;
 import org.optaplanner.core.impl.domain.variable.index.IndexVariableSupply;
 import org.optaplanner.core.impl.heuristic.move.AbstractMove;
 import org.optaplanner.core.impl.score.director.InnerScoreDirector;
@@ -23,11 +21,12 @@ import org.optaplanner.core.impl.testdata.domain.list.TestdataListValue;
 import org.optaplanner.core.impl.testdata.util.PlannerTestUtils;
 
 class KOptListMoveTest {
-    private final SolutionDescriptor<TestdataListSolution> solutionDescriptor = TestdataListSolution.buildSolutionDescriptor();
-    private final InnerScoreDirector<TestdataListSolution, ?> scoreDirector =
-            PlannerTestUtils.mockScoreDirector(solutionDescriptor);
+
     private final ListVariableDescriptor<TestdataListSolution> variableDescriptor =
-            solutionDescriptor.getListVariableDescriptors().get(0);
+            TestdataListEntity.buildVariableDescriptorForValueList();
+
+    private final InnerScoreDirector<TestdataListSolution, ?> scoreDirector =
+            PlannerTestUtils.mockScoreDirector(variableDescriptor.getEntityDescriptor().getSolutionDescriptor());
 
     private final TestdataListValue v1 = new TestdataListValue("1");
     private final TestdataListValue v2 = new TestdataListValue("2");
@@ -44,13 +43,10 @@ class KOptListMoveTest {
 
     @Test
     void test3Opt() {
-        IndexVariableSupply indexVariableSupply =
-                scoreDirector.getSupplyManager().demand(new IndexVariableDemand<>(variableDescriptor));
-        IndexVariableListener indexVariableListener = (IndexVariableListener) indexVariableSupply;
-        TestdataListEntity e1 = new TestdataListEntity("e1", v1, v2, v3, v4, v5, v6);
-        indexVariableListener.afterListVariableChanged(scoreDirector, e1, 0, 6);
-        KOptListMove<TestdataListSolution, TestdataListValue> kOptListMove = fromRemovedAndAddedEdges(variableDescriptor,
-                indexVariableSupply,
+        TestdataListEntity e1 = TestdataListEntity.createWithValues("e1", v1, v2, v3, v4, v5, v6);
+
+        KOptListMove<TestdataListSolution, TestdataListValue> kOptListMove = fromRemovedAndAddedEdges(scoreDirector,
+                variableDescriptor,
                 e1,
                 List.of(v6, v1,
                         v2, v3,
@@ -74,13 +70,10 @@ class KOptListMoveTest {
 
     @Test
     void test3OptLong() {
-        IndexVariableSupply indexVariableSupply =
-                scoreDirector.getSupplyManager().demand(new IndexVariableDemand<>(variableDescriptor));
-        IndexVariableListener indexVariableListener = (IndexVariableListener) indexVariableSupply;
-        TestdataListEntity e1 = new TestdataListEntity("e1", v1, v2, v3, v4, v5, v6, v7, v8, v9, v10);
-        indexVariableListener.afterListVariableChanged(scoreDirector, e1, 0, 6);
-        KOptListMove<TestdataListSolution, TestdataListValue> kOptListMove = fromRemovedAndAddedEdges(variableDescriptor,
-                indexVariableSupply,
+        TestdataListEntity e1 = TestdataListEntity.createWithValues("e1", v1, v2, v3, v4, v5, v6, v7, v8, v9, v10);
+
+        KOptListMove<TestdataListSolution, TestdataListValue> kOptListMove = fromRemovedAndAddedEdges(scoreDirector,
+                variableDescriptor,
                 e1,
                 List.of(v10, v1,
                         v3, v4,
@@ -104,15 +97,10 @@ class KOptListMoveTest {
 
     @Test
     void test4Opt() {
-        IndexVariableSupply indexVariableSupply =
-                scoreDirector.getSupplyManager().demand(new IndexVariableDemand<>(variableDescriptor));
-        IndexVariableListener indexVariableListener = (IndexVariableListener) indexVariableSupply;
-        TestdataListEntity e1 = new TestdataListEntity("e1", v1, v2, v3, v4, v5, v6, v7, v8);
+        TestdataListEntity e1 = TestdataListEntity.createWithValues("e1", v1, v2, v3, v4, v5, v6, v7, v8);
 
-        indexVariableListener.afterListVariableChanged(scoreDirector, e1, 0, 8);
-
-        KOptListMove<TestdataListSolution, TestdataListValue> kOptListMove = fromRemovedAndAddedEdges(variableDescriptor,
-                indexVariableSupply,
+        KOptListMove<TestdataListSolution, TestdataListValue> kOptListMove = fromRemovedAndAddedEdges(scoreDirector,
+                variableDescriptor,
                 e1,
                 List.of(
                         v1, v2,
@@ -142,14 +130,10 @@ class KOptListMoveTest {
 
     @Test
     void test4OptLong() {
-        IndexVariableSupply indexVariableSupply =
-                scoreDirector.getSupplyManager().demand(new IndexVariableDemand<>(variableDescriptor));
-        IndexVariableListener indexVariableListener = (IndexVariableListener) indexVariableSupply;
-        TestdataListEntity e1 = new TestdataListEntity("e1", v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12);
+        TestdataListEntity e1 = TestdataListEntity.createWithValues("e1", v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12);
 
-        indexVariableListener.afterListVariableChanged(scoreDirector, e1, 0, 8);
-        KOptListMove<TestdataListSolution, TestdataListValue> kOptListMove = fromRemovedAndAddedEdges(variableDescriptor,
-                indexVariableSupply,
+        KOptListMove<TestdataListSolution, TestdataListValue> kOptListMove = fromRemovedAndAddedEdges(scoreDirector,
+                variableDescriptor,
                 e1,
                 List.of(v1, v12,
                         v2, v3,
@@ -178,16 +162,11 @@ class KOptListMoveTest {
 
     @Test
     void testInverted4OptLong() {
-        IndexVariableSupply indexVariableSupply =
-                scoreDirector.getSupplyManager().demand(new IndexVariableDemand<>(variableDescriptor));
-        IndexVariableListener indexVariableListener = (IndexVariableListener) indexVariableSupply;
-        TestdataListEntity e1 = new TestdataListEntity("e1", v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12);
-
-        indexVariableListener.afterListVariableChanged(scoreDirector, e1, 0, 8);
+        TestdataListEntity e1 = TestdataListEntity.createWithValues("e1", v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12);
 
         // Note: using only endpoints work (removing v4, v7, v8, v11) from the above list works
-        KOptListMove<TestdataListSolution, TestdataListValue> kOptListMove = fromRemovedAndAddedEdges(variableDescriptor,
-                indexVariableSupply,
+        KOptListMove<TestdataListSolution, TestdataListValue> kOptListMove = fromRemovedAndAddedEdges(scoreDirector,
+                variableDescriptor,
                 e1,
                 List.of(
                         v2, v3,
@@ -225,15 +204,10 @@ class KOptListMoveTest {
 
     @Test
     void testDoubleBridge4Opt() {
-        IndexVariableSupply indexVariableSupply =
-                scoreDirector.getSupplyManager().demand(new IndexVariableDemand<>(variableDescriptor));
-        IndexVariableListener indexVariableListener = (IndexVariableListener) indexVariableSupply;
-        TestdataListEntity e1 = new TestdataListEntity("e1", v1, v2, v3, v4, v5, v6, v7, v8);
+        TestdataListEntity e1 = TestdataListEntity.createWithValues("e1", v1, v2, v3, v4, v5, v6, v7, v8);
 
-        indexVariableListener.afterListVariableChanged(scoreDirector, e1, 0, 8);
-
-        KOptListMove<TestdataListSolution, TestdataListValue> kOptListMove = fromRemovedAndAddedEdges(variableDescriptor,
-                indexVariableSupply,
+        KOptListMove<TestdataListSolution, TestdataListValue> kOptListMove = fromRemovedAndAddedEdges(scoreDirector,
+                variableDescriptor,
                 e1,
                 List.of(v8, v1,
                         v4, v5,
@@ -262,15 +236,10 @@ class KOptListMoveTest {
 
     @Test
     void testDoubleBridge4OptLong() {
-        IndexVariableSupply indexVariableSupply =
-                scoreDirector.getSupplyManager().demand(new IndexVariableDemand<>(variableDescriptor));
-        IndexVariableListener indexVariableListener = (IndexVariableListener) indexVariableSupply;
-        TestdataListEntity e1 = new TestdataListEntity("e1", v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12);
+        TestdataListEntity e1 = TestdataListEntity.createWithValues("e1", v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12);
 
-        indexVariableListener.afterListVariableChanged(scoreDirector, e1, 0, 8);
-
-        KOptListMove<TestdataListSolution, TestdataListValue> kOptListMove = fromRemovedAndAddedEdges(variableDescriptor,
-                indexVariableSupply,
+        KOptListMove<TestdataListSolution, TestdataListValue> kOptListMove = fromRemovedAndAddedEdges(scoreDirector,
+                variableDescriptor,
                 e1,
                 List.of(v12, v1,
                         v5, v6,
@@ -301,15 +270,10 @@ class KOptListMoveTest {
 
     @Test
     void testIsFeasible() {
-        IndexVariableSupply indexVariableSupply =
-                scoreDirector.getSupplyManager().demand(new IndexVariableDemand<>(variableDescriptor));
-        IndexVariableListener indexVariableListener = (IndexVariableListener) indexVariableSupply;
-        TestdataListEntity e1 = new TestdataListEntity("e1", v1, v2, v3, v4, v5, v6, v7, v8);
+        TestdataListEntity e1 = TestdataListEntity.createWithValues("e1", v1, v2, v3, v4, v5, v6, v7, v8);
 
-        indexVariableListener.afterListVariableChanged(scoreDirector, e1, 0, 8);
-
-        KOptListMove<TestdataListSolution, TestdataListValue> kOptListMove = fromRemovedAndAddedEdges(variableDescriptor,
-                indexVariableSupply,
+        KOptListMove<TestdataListSolution, TestdataListValue> kOptListMove = fromRemovedAndAddedEdges(scoreDirector,
+                variableDescriptor,
                 e1,
                 List.of(
                         v1, v2,
@@ -324,12 +288,9 @@ class KOptListMoveTest {
         // this move create 1 cycle (v1 -> v5 -> v4 -> v2 -> v3 -> v7 -> v6 -> v8 -> v1 -> ...)
         assertThat(kOptListMove.isMoveDoable(scoreDirector)).isTrue();
 
-        e1 = new TestdataListEntity("e1", v1, v2, v3, v4, v8, v7, v5, v6);
+        e1 = TestdataListEntity.createWithValues("e1", v1, v2, v3, v4, v8, v7, v5, v6);
 
-        indexVariableListener.afterListVariableChanged(scoreDirector, e1, 0, 8);
-
-        kOptListMove = fromRemovedAndAddedEdges(variableDescriptor,
-                indexVariableSupply,
+        kOptListMove = fromRemovedAndAddedEdges(scoreDirector, variableDescriptor,
                 e1,
                 List.of(
                         v1, v2,
@@ -348,8 +309,9 @@ class KOptListMoveTest {
     /**
      * Create a sequential or non-sequential k-opt from the supplied pairs of undirected removed and added edges.
      *
+     * @param <Solution_>
+     * @param scoreDirector
      * @param listVariableDescriptor
-     * @param indexVariableSupply
      * @param entity The entity
      * @param removedEdgeList The edges to remove. For each pair {@code (edgePairs[2*i], edgePairs[2*i+1])},
      *        it must be the case {@code edgePairs[2*i+1]} is either the successor or predecessor of
@@ -357,11 +319,10 @@ class KOptListMoveTest {
      *        list variable.
      * @param addedEdgeList The edges to add. Must contain only endpoints specified in the removedEdgeList.
      * @return A new sequential or non-sequential k-opt move with the specified undirected edges removed and added.
-     * @param <Solution_>
      */
     private static <Solution_> KOptListMove<Solution_, TestdataListValue> fromRemovedAndAddedEdges(
+            InnerScoreDirector<Solution_, ?> scoreDirector,
             ListVariableDescriptor<Solution_> listVariableDescriptor,
-            IndexVariableSupply indexVariableSupply,
             Object entity,
             List<TestdataListValue> removedEdgeList,
             List<TestdataListValue> addedEdgeList) {
@@ -380,6 +341,9 @@ class KOptListMoveTest {
             throw new IllegalArgumentException("addedEdgeList (" + addedEdgeList + ") is invalid; it contains endpoints "
                     + "that are not included in the removedEdgeList (" + removedEdgeList + ").");
         }
+
+        IndexVariableSupply indexVariableSupply =
+                scoreDirector.getSupplyManager().demand(new IndexVariableDemand<>(listVariableDescriptor));
 
         Function<TestdataListValue, TestdataListValue> successorFunction =
                 getSuccessorFunction(listVariableDescriptor, ignored -> entity, indexVariableSupply);

--- a/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/kopt/KOptListMoveTest.java
+++ b/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/kopt/KOptListMoveTest.java
@@ -6,7 +6,6 @@ import static org.mockito.Mockito.verify;
 import static org.optaplanner.core.impl.heuristic.selector.move.generic.list.kopt.KOptUtils.getBetweenPredicate;
 import static org.optaplanner.core.impl.heuristic.selector.move.generic.list.kopt.KOptUtils.getSuccessorFunction;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Function;
 
@@ -48,7 +47,7 @@ class KOptListMoveTest {
         IndexVariableSupply indexVariableSupply =
                 scoreDirector.getSupplyManager().demand(new IndexVariableDemand<>(variableDescriptor));
         IndexVariableListener indexVariableListener = (IndexVariableListener) indexVariableSupply;
-        TestdataListEntity e1 = new TestdataListEntity("e1", new ArrayList<>(List.of(v1, v2, v3, v4, v5, v6)));
+        TestdataListEntity e1 = new TestdataListEntity("e1", v1, v2, v3, v4, v5, v6);
         indexVariableListener.afterListVariableChanged(scoreDirector, e1, 0, 6);
         KOptListMove<TestdataListSolution, TestdataListValue> kOptListMove = fromRemovedAndAddedEdges(variableDescriptor,
                 indexVariableSupply,
@@ -78,7 +77,7 @@ class KOptListMoveTest {
         IndexVariableSupply indexVariableSupply =
                 scoreDirector.getSupplyManager().demand(new IndexVariableDemand<>(variableDescriptor));
         IndexVariableListener indexVariableListener = (IndexVariableListener) indexVariableSupply;
-        TestdataListEntity e1 = new TestdataListEntity("e1", new ArrayList<>(List.of(v1, v2, v3, v4, v5, v6, v7, v8, v9, v10)));
+        TestdataListEntity e1 = new TestdataListEntity("e1", v1, v2, v3, v4, v5, v6, v7, v8, v9, v10);
         indexVariableListener.afterListVariableChanged(scoreDirector, e1, 0, 6);
         KOptListMove<TestdataListSolution, TestdataListValue> kOptListMove = fromRemovedAndAddedEdges(variableDescriptor,
                 indexVariableSupply,
@@ -108,8 +107,7 @@ class KOptListMoveTest {
         IndexVariableSupply indexVariableSupply =
                 scoreDirector.getSupplyManager().demand(new IndexVariableDemand<>(variableDescriptor));
         IndexVariableListener indexVariableListener = (IndexVariableListener) indexVariableSupply;
-        TestdataListEntity e1 = new TestdataListEntity("e1", new ArrayList<>(
-                List.of(v1, v2, v3, v4, v5, v6, v7, v8)));
+        TestdataListEntity e1 = new TestdataListEntity("e1", v1, v2, v3, v4, v5, v6, v7, v8);
 
         indexVariableListener.afterListVariableChanged(scoreDirector, e1, 0, 8);
 
@@ -147,8 +145,7 @@ class KOptListMoveTest {
         IndexVariableSupply indexVariableSupply =
                 scoreDirector.getSupplyManager().demand(new IndexVariableDemand<>(variableDescriptor));
         IndexVariableListener indexVariableListener = (IndexVariableListener) indexVariableSupply;
-        TestdataListEntity e1 = new TestdataListEntity("e1", new ArrayList<>(
-                List.of(v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12)));
+        TestdataListEntity e1 = new TestdataListEntity("e1", v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12);
 
         indexVariableListener.afterListVariableChanged(scoreDirector, e1, 0, 8);
         KOptListMove<TestdataListSolution, TestdataListValue> kOptListMove = fromRemovedAndAddedEdges(variableDescriptor,
@@ -184,8 +181,7 @@ class KOptListMoveTest {
         IndexVariableSupply indexVariableSupply =
                 scoreDirector.getSupplyManager().demand(new IndexVariableDemand<>(variableDescriptor));
         IndexVariableListener indexVariableListener = (IndexVariableListener) indexVariableSupply;
-        TestdataListEntity e1 = new TestdataListEntity("e1", new ArrayList<>(
-                List.of(v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12)));
+        TestdataListEntity e1 = new TestdataListEntity("e1", v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12);
 
         indexVariableListener.afterListVariableChanged(scoreDirector, e1, 0, 8);
 
@@ -232,8 +228,7 @@ class KOptListMoveTest {
         IndexVariableSupply indexVariableSupply =
                 scoreDirector.getSupplyManager().demand(new IndexVariableDemand<>(variableDescriptor));
         IndexVariableListener indexVariableListener = (IndexVariableListener) indexVariableSupply;
-        TestdataListEntity e1 = new TestdataListEntity("e1", new ArrayList<>(
-                List.of(v1, v2, v3, v4, v5, v6, v7, v8)));
+        TestdataListEntity e1 = new TestdataListEntity("e1", v1, v2, v3, v4, v5, v6, v7, v8);
 
         indexVariableListener.afterListVariableChanged(scoreDirector, e1, 0, 8);
 
@@ -270,8 +265,7 @@ class KOptListMoveTest {
         IndexVariableSupply indexVariableSupply =
                 scoreDirector.getSupplyManager().demand(new IndexVariableDemand<>(variableDescriptor));
         IndexVariableListener indexVariableListener = (IndexVariableListener) indexVariableSupply;
-        TestdataListEntity e1 = new TestdataListEntity("e1", new ArrayList<>(
-                List.of(v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12)));
+        TestdataListEntity e1 = new TestdataListEntity("e1", v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12);
 
         indexVariableListener.afterListVariableChanged(scoreDirector, e1, 0, 8);
 
@@ -310,8 +304,7 @@ class KOptListMoveTest {
         IndexVariableSupply indexVariableSupply =
                 scoreDirector.getSupplyManager().demand(new IndexVariableDemand<>(variableDescriptor));
         IndexVariableListener indexVariableListener = (IndexVariableListener) indexVariableSupply;
-        TestdataListEntity e1 = new TestdataListEntity("e1", new ArrayList<>(
-                List.of(v1, v2, v3, v4, v5, v6, v7, v8)));
+        TestdataListEntity e1 = new TestdataListEntity("e1", v1, v2, v3, v4, v5, v6, v7, v8);
 
         indexVariableListener.afterListVariableChanged(scoreDirector, e1, 0, 8);
 
@@ -331,8 +324,7 @@ class KOptListMoveTest {
         // this move create 1 cycle (v1 -> v5 -> v4 -> v2 -> v3 -> v7 -> v6 -> v8 -> v1 -> ...)
         assertThat(kOptListMove.isMoveDoable(scoreDirector)).isTrue();
 
-        e1 = new TestdataListEntity("e1", new ArrayList<>(
-                List.of(v1, v2, v3, v4, v8, v7, v5, v6)));
+        e1 = new TestdataListEntity("e1", v1, v2, v3, v4, v8, v7, v5, v6);
 
         indexVariableListener.afterListVariableChanged(scoreDirector, e1, 0, 8);
 

--- a/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/kopt/TwoOptListMoveTest.java
+++ b/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/kopt/TwoOptListMoveTest.java
@@ -5,9 +5,6 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.verify;
 import static org.optaplanner.core.impl.testdata.util.PlannerTestUtils.mockRebasingScoreDirector;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import org.junit.jupiter.api.Test;
 import org.optaplanner.core.api.score.buildin.simple.SimpleScore;
 import org.optaplanner.core.impl.domain.solution.descriptor.SolutionDescriptor;
@@ -42,8 +39,7 @@ class TwoOptListMoveTest {
         TestdataListValue v6 = new TestdataListValue("6");
         TestdataListValue v7 = new TestdataListValue("7");
         TestdataListValue v8 = new TestdataListValue("8");
-        TestdataListEntity e1 = new TestdataListEntity("e1", new ArrayList<>(
-                List.of(v1, v2, v5, v4, v3, v6, v7, v8)));
+        TestdataListEntity e1 = new TestdataListEntity("e1", v1, v2, v5, v4, v3, v6, v7, v8);
 
         indexVariableListener.afterListVariableChanged(scoreDirector, e1, 0, 8);
 
@@ -74,8 +70,7 @@ class TwoOptListMoveTest {
         TestdataListValue v6 = new TestdataListValue("6");
         TestdataListValue v7 = new TestdataListValue("7");
         TestdataListValue v8 = new TestdataListValue("8");
-        TestdataListEntity e1 = new TestdataListEntity("e1", new ArrayList<>(
-                List.of(v8, v7, v3, v4, v5, v6, v2, v1)));
+        TestdataListEntity e1 = new TestdataListEntity("e1", v8, v7, v3, v4, v5, v6, v2, v1);
 
         indexVariableListener.afterListVariableChanged(scoreDirector, e1, 0, 8);
 
@@ -105,8 +100,7 @@ class TwoOptListMoveTest {
         TestdataListValue v5 = new TestdataListValue("5");
         TestdataListValue v6 = new TestdataListValue("6");
         TestdataListValue v7 = new TestdataListValue("7");
-        TestdataListEntity e1 = new TestdataListEntity("e1", new ArrayList<>(
-                List.of(v5, v2, v3, v4, v1, v7, v6)));
+        TestdataListEntity e1 = new TestdataListEntity("e1", v5, v2, v3, v4, v1, v7, v6);
 
         indexVariableListener.afterListVariableChanged(scoreDirector, e1, 0, 8);
 
@@ -136,8 +130,7 @@ class TwoOptListMoveTest {
         TestdataListValue v5 = new TestdataListValue("5");
         TestdataListValue v6 = new TestdataListValue("6");
         TestdataListValue v7 = new TestdataListValue("7");
-        TestdataListEntity e1 = new TestdataListEntity("e1", new ArrayList<>(
-                List.of(v2, v1, v7, v4, v5, v6, v3)));
+        TestdataListEntity e1 = new TestdataListEntity("e1", v2, v1, v7, v4, v5, v6, v3);
 
         indexVariableListener.afterListVariableChanged(scoreDirector, e1, 0, 8);
 

--- a/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/kopt/TwoOptListMoveTest.java
+++ b/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/kopt/TwoOptListMoveTest.java
@@ -7,10 +7,8 @@ import static org.optaplanner.core.impl.testdata.util.PlannerTestUtils.mockRebas
 
 import org.junit.jupiter.api.Test;
 import org.optaplanner.core.api.score.buildin.simple.SimpleScore;
-import org.optaplanner.core.impl.domain.solution.descriptor.SolutionDescriptor;
 import org.optaplanner.core.impl.domain.variable.descriptor.ListVariableDescriptor;
 import org.optaplanner.core.impl.domain.variable.index.IndexVariableDemand;
-import org.optaplanner.core.impl.domain.variable.index.IndexVariableListener;
 import org.optaplanner.core.impl.domain.variable.index.IndexVariableSupply;
 import org.optaplanner.core.impl.heuristic.move.AbstractMove;
 import org.optaplanner.core.impl.score.director.InnerScoreDirector;
@@ -20,17 +18,15 @@ import org.optaplanner.core.impl.testdata.domain.list.TestdataListValue;
 import org.optaplanner.core.impl.testdata.util.PlannerTestUtils;
 
 class TwoOptListMoveTest {
-    private final SolutionDescriptor<TestdataListSolution> solutionDescriptor = TestdataListSolution.buildSolutionDescriptor();
-    private final InnerScoreDirector<TestdataListSolution, ?> scoreDirector =
-            PlannerTestUtils.mockScoreDirector(solutionDescriptor);
+
     private final ListVariableDescriptor<TestdataListSolution> variableDescriptor =
-            solutionDescriptor.getListVariableDescriptors().get(0);
+            TestdataListEntity.buildVariableDescriptorForValueList();
+
+    private final InnerScoreDirector<TestdataListSolution, ?> scoreDirector =
+            PlannerTestUtils.mockScoreDirector(variableDescriptor.getEntityDescriptor().getSolutionDescriptor());
 
     @Test
     void doMove() {
-        IndexVariableSupply indexVariableSupply =
-                scoreDirector.getSupplyManager().demand(new IndexVariableDemand<>(variableDescriptor));
-        IndexVariableListener indexVariableListener = (IndexVariableListener) indexVariableSupply;
         TestdataListValue v1 = new TestdataListValue("1");
         TestdataListValue v2 = new TestdataListValue("2");
         TestdataListValue v3 = new TestdataListValue("3");
@@ -39,12 +35,11 @@ class TwoOptListMoveTest {
         TestdataListValue v6 = new TestdataListValue("6");
         TestdataListValue v7 = new TestdataListValue("7");
         TestdataListValue v8 = new TestdataListValue("8");
-        TestdataListEntity e1 = new TestdataListEntity("e1", v1, v2, v5, v4, v3, v6, v7, v8);
-
-        indexVariableListener.afterListVariableChanged(scoreDirector, e1, 0, 8);
+        TestdataListEntity e1 = TestdataListEntity.createWithValues("e1", v1, v2, v5, v4, v3, v6, v7, v8);
 
         // 2-Opt((v2, v5), (v3, v6))
-        TwoOptListMove<TestdataListSolution> move = new TwoOptListMove<>(variableDescriptor, indexVariableSupply,
+        TwoOptListMove<TestdataListSolution> move = new TwoOptListMove<>(variableDescriptor,
+                scoreDirector.getSupplyManager().demand(new IndexVariableDemand<>(variableDescriptor)),
                 e1, v5, v6);
         AbstractMove<TestdataListSolution> undoMove = move.doMove(scoreDirector);
         assertThat(e1.getValueList()).containsExactly(v1, v2, v3, v4, v5, v6, v7, v8);
@@ -59,9 +54,6 @@ class TwoOptListMoveTest {
 
     @Test
     void doMoveSecondEndsBeforeFirst() {
-        IndexVariableSupply indexVariableSupply =
-                scoreDirector.getSupplyManager().demand(new IndexVariableDemand<>(variableDescriptor));
-        IndexVariableListener indexVariableListener = (IndexVariableListener) indexVariableSupply;
         TestdataListValue v1 = new TestdataListValue("1");
         TestdataListValue v2 = new TestdataListValue("2");
         TestdataListValue v3 = new TestdataListValue("3");
@@ -70,12 +62,11 @@ class TwoOptListMoveTest {
         TestdataListValue v6 = new TestdataListValue("6");
         TestdataListValue v7 = new TestdataListValue("7");
         TestdataListValue v8 = new TestdataListValue("8");
-        TestdataListEntity e1 = new TestdataListEntity("e1", v8, v7, v3, v4, v5, v6, v2, v1);
-
-        indexVariableListener.afterListVariableChanged(scoreDirector, e1, 0, 8);
+        TestdataListEntity e1 = TestdataListEntity.createWithValues("e1", v8, v7, v3, v4, v5, v6, v2, v1);
 
         // 2-Opt((v6, v2), (v7, v3))
-        TwoOptListMove<TestdataListSolution> move = new TwoOptListMove<>(variableDescriptor, indexVariableSupply,
+        TwoOptListMove<TestdataListSolution> move = new TwoOptListMove<>(variableDescriptor,
+                scoreDirector.getSupplyManager().demand(new IndexVariableDemand<>(variableDescriptor)),
                 e1, v2, v3);
         AbstractMove<TestdataListSolution> undoMove = move.doMove(scoreDirector);
         assertThat(e1.getValueList()).containsExactly(v8, v1, v2, v3, v4, v5, v6, v7);
@@ -90,9 +81,6 @@ class TwoOptListMoveTest {
 
     @Test
     void doMoveSecondEndsBeforeFirstUnbalanced() {
-        IndexVariableSupply indexVariableSupply =
-                scoreDirector.getSupplyManager().demand(new IndexVariableDemand<>(variableDescriptor));
-        IndexVariableListener indexVariableListener = (IndexVariableListener) indexVariableSupply;
         TestdataListValue v1 = new TestdataListValue("1");
         TestdataListValue v2 = new TestdataListValue("2");
         TestdataListValue v3 = new TestdataListValue("3");
@@ -100,12 +88,11 @@ class TwoOptListMoveTest {
         TestdataListValue v5 = new TestdataListValue("5");
         TestdataListValue v6 = new TestdataListValue("6");
         TestdataListValue v7 = new TestdataListValue("7");
-        TestdataListEntity e1 = new TestdataListEntity("e1", v5, v2, v3, v4, v1, v7, v6);
-
-        indexVariableListener.afterListVariableChanged(scoreDirector, e1, 0, 8);
+        TestdataListEntity e1 = TestdataListEntity.createWithValues("e1", v5, v2, v3, v4, v1, v7, v6);
 
         // 2-Opt((v4, v1), (v5, v2))
-        TwoOptListMove<TestdataListSolution> move = new TwoOptListMove<>(variableDescriptor, indexVariableSupply,
+        TwoOptListMove<TestdataListSolution> move = new TwoOptListMove<>(variableDescriptor,
+                scoreDirector.getSupplyManager().demand(new IndexVariableDemand<>(variableDescriptor)),
                 e1, v1, v2);
         AbstractMove<TestdataListSolution> undoMove = move.doMove(scoreDirector);
         assertThat(e1.getValueList()).containsExactly(v5, v6, v7, v1, v2, v3, v4);
@@ -120,9 +107,6 @@ class TwoOptListMoveTest {
 
     @Test
     void doMoveFirstEndsBeforeSecondUnbalanced() {
-        IndexVariableSupply indexVariableSupply =
-                scoreDirector.getSupplyManager().demand(new IndexVariableDemand<>(variableDescriptor));
-        IndexVariableListener indexVariableListener = (IndexVariableListener) indexVariableSupply;
         TestdataListValue v1 = new TestdataListValue("1");
         TestdataListValue v2 = new TestdataListValue("2");
         TestdataListValue v3 = new TestdataListValue("3");
@@ -130,12 +114,11 @@ class TwoOptListMoveTest {
         TestdataListValue v5 = new TestdataListValue("5");
         TestdataListValue v6 = new TestdataListValue("6");
         TestdataListValue v7 = new TestdataListValue("7");
-        TestdataListEntity e1 = new TestdataListEntity("e1", v2, v1, v7, v4, v5, v6, v3);
-
-        indexVariableListener.afterListVariableChanged(scoreDirector, e1, 0, 8);
+        TestdataListEntity e1 = TestdataListEntity.createWithValues("e1", v2, v1, v7, v4, v5, v6, v3);
 
         // 2-Opt((v4, v1), (v5, v2))
-        TwoOptListMove<TestdataListSolution> move = new TwoOptListMove<>(variableDescriptor, indexVariableSupply,
+        TwoOptListMove<TestdataListSolution> move = new TwoOptListMove<>(variableDescriptor,
+                scoreDirector.getSupplyManager().demand(new IndexVariableDemand<>(variableDescriptor)),
                 e1, v3, v4);
         AbstractMove<TestdataListSolution> undoMove = move.doMove(scoreDirector);
         assertThat(e1.getValueList()).containsExactly(v2, v3, v4, v5, v6, v7, v1);


### PR DESCRIPTION
Most of the PR eliminates the boilerplate test code that calls index variable listener just to initialize the index shadow variables. The `TestdataListEntity.createWithValues()` already does that in a way that does not depend on internal API.

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request checks</b>  
  Please add comment: <b>Jenkins retest this</b>

- for a <b>specific pull request check</b>  
  please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-vehicle-routing] tests</b>
  
- for a <b>full downstream build</b> 
  - for <b>jenkins</b> job: 
    please add comment: <b>Jenkins run fdb</b>
  - for <b>github actions</b> job: 
    add the label `run_fdb`

- for a <b>compile downstream build</b>  
  please add comment: <b>Jenkins run cdb</b>

- for a <b>full production downstream build</b>  
  please add comment: <b>Jenkins execute product fdb</b>

- for an <b>upstream build</b>  
  please add comment: <b>Jenkins run upstream</b>

- for <b>quarkus branch checks</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins run quarkus-branch</b>

- for a <b>quarkus branch specific check</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-vehicle-routing] quarkus-branch</b>

- for <b>quarkus main checks</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins run quarkus-main</b>

- for a <b>specific quarkus main check</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-vehicle-routing] quarkus-branch</b>

- for <b>quarkus lts checks</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins run quarkus-lts</b>

- for a <b>specific quarkus lts check</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-vehicle-routing] quarkus-lts</b>

- for <b>native checks</b>  
  Run native checks  
  Please add comment: <b>Jenkins run native</b>

- for a <b>specific native check</b>  
  Run native checks 
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts] native</b>

- for <b>native lts checks</b>  
  Run native checks against quarkus lts branch
  Please add comment: <b>Jenkins run native-lts</b>

- for a <b>specific native lts check</b>  
  Run native checks against quarkus lts branch
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts] native-lts</b>

</details>

### CI Status

 You can check OptaPlanner repositories CI status from [Chain Status webpage](https://kiegroup.github.io/optaplanner/).

<details>
<summary>
How to backport a pull request to a different branch?
</summary>

In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-7.67.x` to backport the original PR to the `7.67.x` branch).

> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.

Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.

If something goes wrong, the author will be notified and at this point a manual backporting is needed.

> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
</details>
