### PR TITLE
PLANNER-2161 Add missing with methods

### DIFF
--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/config/AbstractConfig.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/config/AbstractConfig.java
@@ -51,4 +51,11 @@ public abstract class AbstractConfig<Config_ extends AbstractConfig<Config_>> {
         return getClass().getSimpleName() + "()";
     }
 
+    /**
+     * Used as a return value of the with() methods on Config classes to ensure the correct type
+     * in the hierarchical builder pattern.
+     */
+    protected Config_ self() {
+        return (Config_) this;
+    }
 }

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/config/AbstractConfig.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/config/AbstractConfig.java
@@ -50,12 +50,4 @@ public abstract class AbstractConfig<Config_ extends AbstractConfig<Config_>> {
     public String toString() {
         return getClass().getSimpleName() + "()";
     }
-
-    /**
-     * Used as a return value of the with() methods on Config classes to ensure the correct type
-     * in the hierarchical builder pattern.
-     */
-    protected Config_ self() {
-        return (Config_) this;
-    }
 }

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/config/constructionheuristic/decider/forager/ConstructionHeuristicForagerConfig.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/config/constructionheuristic/decider/forager/ConstructionHeuristicForagerConfig.java
@@ -22,6 +22,15 @@ public class ConstructionHeuristicForagerConfig extends AbstractConfig<Construct
         this.pickEarlyType = pickEarlyType;
     }
 
+    // ************************************************************************
+    // With methods
+    // ************************************************************************
+
+    public ConstructionHeuristicForagerConfig withPickEarlyType(ConstructionHeuristicPickEarlyType pickEarlyType) {
+        this.setPickEarlyType(pickEarlyType);
+        return this;
+    }
+
     @Override
     public ConstructionHeuristicForagerConfig inherit(ConstructionHeuristicForagerConfig inheritedConfig) {
         pickEarlyType = ConfigUtils.inheritOverwritableProperty(pickEarlyType, inheritedConfig.getPickEarlyType());

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/config/constructionheuristic/placer/PooledEntityPlacerConfig.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/config/constructionheuristic/placer/PooledEntityPlacerConfig.java
@@ -53,6 +53,15 @@ public class PooledEntityPlacerConfig extends EntityPlacerConfig<PooledEntityPla
         this.moveSelectorConfig = moveSelectorConfig;
     }
 
+    // ************************************************************************
+    // With methods
+    // ************************************************************************
+
+    public PooledEntityPlacerConfig withMoveSelectorConfig(MoveSelectorConfig moveSelectorConfig) {
+        this.setMoveSelectorConfig(moveSelectorConfig);
+        return this;
+    }
+
     @Override
     public PooledEntityPlacerConfig inherit(PooledEntityPlacerConfig inheritedConfig) {
         setMoveSelectorConfig(ConfigUtils.inheritOverwritableProperty(getMoveSelectorConfig(),

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/config/exhaustivesearch/ExhaustiveSearchPhaseConfig.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/config/exhaustivesearch/ExhaustiveSearchPhaseConfig.java
@@ -115,6 +115,40 @@ public class ExhaustiveSearchPhaseConfig extends PhaseConfig<ExhaustiveSearchPha
         this.moveSelectorConfig = moveSelectorConfig;
     }
 
+    // ************************************************************************
+    // With methods
+    // ************************************************************************
+
+    public ExhaustiveSearchPhaseConfig withExhaustiveSearchType(ExhaustiveSearchType exhaustiveSearchType) {
+        this.setExhaustiveSearchType(exhaustiveSearchType);
+        return this;
+    }
+
+    public ExhaustiveSearchPhaseConfig withNodeExplorationType(NodeExplorationType nodeExplorationType) {
+        this.setNodeExplorationType(nodeExplorationType);
+        return this;
+    }
+
+    public ExhaustiveSearchPhaseConfig withEntitySorterManner(EntitySorterManner entitySorterManner) {
+        this.setEntitySorterManner(entitySorterManner);
+        return this;
+    }
+
+    public ExhaustiveSearchPhaseConfig withValueSorterManner(ValueSorterManner valueSorterManner) {
+        this.setValueSorterManner(valueSorterManner);
+        return this;
+    }
+
+    public ExhaustiveSearchPhaseConfig withEntitySelectorConfig(EntitySelectorConfig entitySelectorConfig) {
+        this.setEntitySelectorConfig(entitySelectorConfig);
+        return this;
+    }
+
+    public ExhaustiveSearchPhaseConfig withMoveSelectorConfig(MoveSelectorConfig moveSelectorConfig) {
+        this.setMoveSelectorConfig(moveSelectorConfig);
+        return this;
+    }
+
     @Override
     public ExhaustiveSearchPhaseConfig inherit(ExhaustiveSearchPhaseConfig inheritedConfig) {
         super.inherit(inheritedConfig);

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/config/heuristic/selector/entity/pillar/PillarSelectorConfig.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/config/heuristic/selector/entity/pillar/PillarSelectorConfig.java
@@ -46,6 +46,25 @@ public class PillarSelectorConfig extends SelectorConfig<PillarSelectorConfig> {
         this.maximumSubPillarSize = maximumSubPillarSize;
     }
 
+    // ************************************************************************
+    // With methods
+    // ************************************************************************
+
+    public PillarSelectorConfig withEntitySelectorConfig(EntitySelectorConfig entitySelectorConfig) {
+        this.setEntitySelectorConfig(entitySelectorConfig);
+        return this;
+    }
+
+    public PillarSelectorConfig withMinimumSubPillarSize(Integer minimumSubPillarSize) {
+        this.setMinimumSubPillarSize(minimumSubPillarSize);
+        return this;
+    }
+
+    public PillarSelectorConfig withMaximumSubPillarSize(Integer maximumSubPillarSize) {
+        this.setMaximumSubPillarSize(maximumSubPillarSize);
+        return this;
+    }
+
     @Override
     public PillarSelectorConfig inherit(PillarSelectorConfig inheritedConfig) {
         entitySelectorConfig = ConfigUtils.inheritConfig(entitySelectorConfig, inheritedConfig.getEntitySelectorConfig());

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/config/heuristic/selector/move/MoveSelectorConfig.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/config/heuristic/selector/move/MoveSelectorConfig.java
@@ -170,56 +170,56 @@ public abstract class MoveSelectorConfig<Config_ extends MoveSelectorConfig<Conf
     // With methods
     // ************************************************************************
 
-    public MoveSelectorConfig<Config_> withCacheType(SelectionCacheType cacheType) {
+    public Config_ withCacheType(SelectionCacheType cacheType) {
         this.cacheType = cacheType;
-        return this;
+        return self();
     }
 
-    public MoveSelectorConfig<Config_> withSelectionOrder(SelectionOrder selectionOrder) {
+    public Config_ withSelectionOrder(SelectionOrder selectionOrder) {
         this.selectionOrder = selectionOrder;
-        return this;
+        return self();
     }
 
-    public MoveSelectorConfig<Config_> withFilterClass(Class<? extends SelectionFilter> filterClass) {
+    public Config_ withFilterClass(Class<? extends SelectionFilter> filterClass) {
         this.filterClass = filterClass;
-        return this;
+        return self();
     }
 
-    public MoveSelectorConfig<Config_> withSorterComparatorClass(Class<? extends Comparator> sorterComparatorClass) {
+    public Config_ withSorterComparatorClass(Class<? extends Comparator> sorterComparatorClass) {
         this.sorterComparatorClass = sorterComparatorClass;
-        return this;
+        return self();
     }
 
-    public MoveSelectorConfig<Config_> withSorterWeightFactoryClass(
+    public Config_ withSorterWeightFactoryClass(
             Class<? extends SelectionSorterWeightFactory> sorterWeightFactoryClass) {
         this.sorterWeightFactoryClass = sorterWeightFactoryClass;
-        return this;
+        return self();
     }
 
-    public MoveSelectorConfig<Config_> withSorterOrder(SelectionSorterOrder sorterOrder) {
+    public Config_ withSorterOrder(SelectionSorterOrder sorterOrder) {
         this.sorterOrder = sorterOrder;
-        return this;
+        return self();
     }
 
-    public MoveSelectorConfig<Config_> withSorterClass(Class<? extends SelectionSorter> sorterClass) {
+    public Config_ withSorterClass(Class<? extends SelectionSorter> sorterClass) {
         this.sorterClass = sorterClass;
-        return this;
+        return self();
     }
 
-    public MoveSelectorConfig<Config_> withProbabilityWeightFactoryClass(
+    public Config_ withProbabilityWeightFactoryClass(
             Class<? extends SelectionProbabilityWeightFactory> probabilityWeightFactoryClass) {
         this.probabilityWeightFactoryClass = probabilityWeightFactoryClass;
-        return this;
+        return self();
     }
 
-    public MoveSelectorConfig<Config_> withSelectedCountLimit(Long selectedCountLimit) {
+    public Config_ withSelectedCountLimit(Long selectedCountLimit) {
         this.selectedCountLimit = selectedCountLimit;
-        return this;
+        return self();
     }
 
-    public MoveSelectorConfig<Config_> withFixedProbabilityWeight(Double fixedProbabilityWeight) {
+    public Config_ withFixedProbabilityWeight(Double fixedProbabilityWeight) {
         this.fixedProbabilityWeight = fixedProbabilityWeight;
-        return this;
+        return self();
     }
 
     /**
@@ -235,7 +235,7 @@ public abstract class MoveSelectorConfig<Config_ extends MoveSelectorConfig<Conf
     @Override
     public Config_ inherit(Config_ inheritedConfig) {
         inheritCommon(inheritedConfig);
-        return (Config_) this;
+        return self();
     }
 
     /**

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/config/heuristic/selector/move/MoveSelectorConfig.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/config/heuristic/selector/move/MoveSelectorConfig.java
@@ -172,54 +172,54 @@ public abstract class MoveSelectorConfig<Config_ extends MoveSelectorConfig<Conf
 
     public Config_ withCacheType(SelectionCacheType cacheType) {
         this.cacheType = cacheType;
-        return self();
+        return (Config_) this;
     }
 
     public Config_ withSelectionOrder(SelectionOrder selectionOrder) {
         this.selectionOrder = selectionOrder;
-        return self();
+        return (Config_) this;
     }
 
     public Config_ withFilterClass(Class<? extends SelectionFilter> filterClass) {
         this.filterClass = filterClass;
-        return self();
+        return (Config_) this;
     }
 
     public Config_ withSorterComparatorClass(Class<? extends Comparator> sorterComparatorClass) {
         this.sorterComparatorClass = sorterComparatorClass;
-        return self();
+        return (Config_) this;
     }
 
     public Config_ withSorterWeightFactoryClass(
             Class<? extends SelectionSorterWeightFactory> sorterWeightFactoryClass) {
         this.sorterWeightFactoryClass = sorterWeightFactoryClass;
-        return self();
+        return (Config_) this;
     }
 
     public Config_ withSorterOrder(SelectionSorterOrder sorterOrder) {
         this.sorterOrder = sorterOrder;
-        return self();
+        return (Config_) this;
     }
 
     public Config_ withSorterClass(Class<? extends SelectionSorter> sorterClass) {
         this.sorterClass = sorterClass;
-        return self();
+        return (Config_) this;
     }
 
     public Config_ withProbabilityWeightFactoryClass(
             Class<? extends SelectionProbabilityWeightFactory> probabilityWeightFactoryClass) {
         this.probabilityWeightFactoryClass = probabilityWeightFactoryClass;
-        return self();
+        return (Config_) this;
     }
 
     public Config_ withSelectedCountLimit(Long selectedCountLimit) {
         this.selectedCountLimit = selectedCountLimit;
-        return self();
+        return (Config_) this;
     }
 
     public Config_ withFixedProbabilityWeight(Double fixedProbabilityWeight) {
         this.fixedProbabilityWeight = fixedProbabilityWeight;
-        return self();
+        return (Config_) this;
     }
 
     /**
@@ -235,7 +235,7 @@ public abstract class MoveSelectorConfig<Config_ extends MoveSelectorConfig<Conf
     @Override
     public Config_ inherit(Config_ inheritedConfig) {
         inheritCommon(inheritedConfig);
-        return self();
+        return (Config_) this;
     }
 
     /**

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/config/heuristic/selector/move/factory/MoveIteratorFactoryConfig.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/config/heuristic/selector/move/factory/MoveIteratorFactoryConfig.java
@@ -40,6 +40,22 @@ public class MoveIteratorFactoryConfig extends MoveSelectorConfig<MoveIteratorFa
         this.moveIteratorFactoryCustomProperties = moveIteratorFactoryCustomProperties;
     }
 
+    // ************************************************************************
+    // With methods
+    // ************************************************************************
+
+    public MoveIteratorFactoryConfig
+            withMoveIteratorFactoryClass(Class<? extends MoveIteratorFactory> moveIteratorFactoryClass) {
+        this.setMoveIteratorFactoryClass(moveIteratorFactoryClass);
+        return this;
+    }
+
+    public MoveIteratorFactoryConfig
+            withMoveIteratorFactoryCustomProperties(Map<String, String> moveIteratorFactoryCustomProperties) {
+        this.setMoveIteratorFactoryCustomProperties(moveIteratorFactoryCustomProperties);
+        return this;
+    }
+
     @Override
     public MoveIteratorFactoryConfig inherit(MoveIteratorFactoryConfig inheritedConfig) {
         super.inherit(inheritedConfig);

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/config/heuristic/selector/move/factory/MoveListFactoryConfig.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/config/heuristic/selector/move/factory/MoveListFactoryConfig.java
@@ -41,6 +41,20 @@ public class MoveListFactoryConfig extends MoveSelectorConfig<MoveListFactoryCon
     }
 
     // ************************************************************************
+    // With methods
+    // ************************************************************************
+
+    public MoveListFactoryConfig withMoveListFactoryClass(Class<? extends MoveListFactory> moveListFactoryClass) {
+        this.setMoveListFactoryClass(moveListFactoryClass);
+        return this;
+    }
+
+    public MoveListFactoryConfig withMoveListFactoryCustomProperties(Map<String, String> moveListFactoryCustomProperties) {
+        this.setMoveListFactoryCustomProperties(moveListFactoryCustomProperties);
+        return this;
+    }
+
+    // ************************************************************************
     // Builder methods
     // ************************************************************************
 

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/config/heuristic/selector/move/generic/AbstractPillarMoveSelectorConfig.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/config/heuristic/selector/move/generic/AbstractPillarMoveSelectorConfig.java
@@ -47,6 +47,25 @@ public abstract class AbstractPillarMoveSelectorConfig<Config_ extends AbstractP
         this.pillarSelectorConfig = pillarSelectorConfig;
     }
 
+    // ************************************************************************
+    // With methods
+    // ************************************************************************
+
+    public Config_ withSubPillarType(SubPillarType subPillarType) {
+        this.setSubPillarType(subPillarType);
+        return self();
+    }
+
+    public Config_ withSubPillarSequenceComparatorClass(Class<? extends Comparator> subPillarSequenceComparatorClass) {
+        this.setSubPillarSequenceComparatorClass(subPillarSequenceComparatorClass);
+        return self();
+    }
+
+    public Config_ withPillarSelectorConfig(PillarSelectorConfig pillarSelectorConfig) {
+        this.setPillarSelectorConfig(pillarSelectorConfig);
+        return self();
+    }
+
     @Override
     public Config_ inherit(Config_ inheritedConfig) {
         super.inherit(inheritedConfig);
@@ -54,7 +73,7 @@ public abstract class AbstractPillarMoveSelectorConfig<Config_ extends AbstractP
         subPillarSequenceComparatorClass = ConfigUtils.inheritOverwritableProperty(subPillarSequenceComparatorClass,
                 inheritedConfig.getSubPillarSequenceComparatorClass());
         pillarSelectorConfig = ConfigUtils.inheritConfig(pillarSelectorConfig, inheritedConfig.getPillarSelectorConfig());
-        return (Config_) this;
+        return self();
     }
 
     @Override

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/config/heuristic/selector/move/generic/AbstractPillarMoveSelectorConfig.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/config/heuristic/selector/move/generic/AbstractPillarMoveSelectorConfig.java
@@ -53,17 +53,17 @@ public abstract class AbstractPillarMoveSelectorConfig<Config_ extends AbstractP
 
     public Config_ withSubPillarType(SubPillarType subPillarType) {
         this.setSubPillarType(subPillarType);
-        return self();
+        return (Config_) this;
     }
 
     public Config_ withSubPillarSequenceComparatorClass(Class<? extends Comparator> subPillarSequenceComparatorClass) {
         this.setSubPillarSequenceComparatorClass(subPillarSequenceComparatorClass);
-        return self();
+        return (Config_) this;
     }
 
     public Config_ withPillarSelectorConfig(PillarSelectorConfig pillarSelectorConfig) {
         this.setPillarSelectorConfig(pillarSelectorConfig);
-        return self();
+        return (Config_) this;
     }
 
     @Override
@@ -73,7 +73,7 @@ public abstract class AbstractPillarMoveSelectorConfig<Config_ extends AbstractP
         subPillarSequenceComparatorClass = ConfigUtils.inheritOverwritableProperty(subPillarSequenceComparatorClass,
                 inheritedConfig.getSubPillarSequenceComparatorClass());
         pillarSelectorConfig = ConfigUtils.inheritConfig(pillarSelectorConfig, inheritedConfig.getPillarSelectorConfig());
-        return self();
+        return (Config_) this;
     }
 
     @Override

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/config/heuristic/selector/move/generic/PillarChangeMoveSelectorConfig.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/config/heuristic/selector/move/generic/PillarChangeMoveSelectorConfig.java
@@ -26,6 +26,15 @@ public class PillarChangeMoveSelectorConfig extends AbstractPillarMoveSelectorCo
         this.valueSelectorConfig = valueSelectorConfig;
     }
 
+    // ************************************************************************
+    // With methods
+    // ************************************************************************
+
+    public PillarChangeMoveSelectorConfig withValueSelectorConfig(ValueSelectorConfig valueSelectorConfig) {
+        this.setValueSelectorConfig(valueSelectorConfig);
+        return this;
+    }
+
     @Override
     public PillarChangeMoveSelectorConfig inherit(PillarChangeMoveSelectorConfig inheritedConfig) {
         super.inherit(inheritedConfig);

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/config/heuristic/selector/move/generic/PillarSwapMoveSelectorConfig.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/config/heuristic/selector/move/generic/PillarSwapMoveSelectorConfig.java
@@ -41,6 +41,25 @@ public class PillarSwapMoveSelectorConfig extends AbstractPillarMoveSelectorConf
         this.variableNameIncludeList = variableNameIncludeList;
     }
 
+    // ************************************************************************
+    // With methods
+    // ************************************************************************
+
+    public PillarSwapMoveSelectorConfig withSecondaryPillarSelectorConfig(PillarSelectorConfig pillarSelectorConfig) {
+        this.setSecondaryPillarSelectorConfig(pillarSelectorConfig);
+        return this;
+    }
+
+    public PillarSwapMoveSelectorConfig withVariableNameIncludeList(List<String> variableNameIncludeList) {
+        this.setVariableNameIncludeList(variableNameIncludeList);
+        return this;
+    }
+
+    public PillarSwapMoveSelectorConfig withVariableNameIncludes(String... variableNameIncludes) {
+        this.setVariableNameIncludeList(List.of(variableNameIncludes));
+        return this;
+    }
+
     @Override
     public PillarSwapMoveSelectorConfig inherit(PillarSwapMoveSelectorConfig inheritedConfig) {
         super.inherit(inheritedConfig);

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/config/heuristic/selector/move/generic/chained/KOptMoveSelectorConfig.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/config/heuristic/selector/move/generic/chained/KOptMoveSelectorConfig.java
@@ -51,6 +51,20 @@ public class KOptMoveSelectorConfig extends MoveSelectorConfig<KOptMoveSelectorC
         this.valueSelectorConfig = valueSelectorConfig;
     }
 
+    // ************************************************************************
+    // With methods
+    // ************************************************************************
+
+    public KOptMoveSelectorConfig withEntitySelectorConfig(EntitySelectorConfig entitySelectorConfig) {
+        this.setEntitySelectorConfig(entitySelectorConfig);
+        return this;
+    }
+
+    public KOptMoveSelectorConfig withValueSelectorConfig(ValueSelectorConfig valueSelectorConfig) {
+        this.setValueSelectorConfig(valueSelectorConfig);
+        return this;
+    }
+
     @Override
     public KOptMoveSelectorConfig inherit(KOptMoveSelectorConfig inheritedConfig) {
         super.inherit(inheritedConfig);

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/config/heuristic/selector/move/generic/chained/SubChainChangeMoveSelectorConfig.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/config/heuristic/selector/move/generic/chained/SubChainChangeMoveSelectorConfig.java
@@ -60,6 +60,30 @@ public class SubChainChangeMoveSelectorConfig extends MoveSelectorConfig<SubChai
         this.selectReversingMoveToo = selectReversingMoveToo;
     }
 
+    // ************************************************************************
+    // With methods
+    // ************************************************************************
+
+    public SubChainChangeMoveSelectorConfig withEntityClass(Class<?> entityClass) {
+        this.setEntityClass(entityClass);
+        return this;
+    }
+
+    public SubChainChangeMoveSelectorConfig withSubChainSelectorConfig(SubChainSelectorConfig subChainSelectorConfig) {
+        this.setSubChainSelectorConfig(subChainSelectorConfig);
+        return this;
+    }
+
+    public SubChainChangeMoveSelectorConfig withValueSelectorConfig(ValueSelectorConfig valueSelectorConfig) {
+        this.setValueSelectorConfig(valueSelectorConfig);
+        return this;
+    }
+
+    public SubChainChangeMoveSelectorConfig withSelectReversingMoveToo(Boolean selectReversingMoveToo) {
+        this.setSelectReversingMoveToo(selectReversingMoveToo);
+        return this;
+    }
+
     @Override
     public SubChainChangeMoveSelectorConfig inherit(SubChainChangeMoveSelectorConfig inheritedConfig) {
         super.inherit(inheritedConfig);

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/config/heuristic/selector/move/generic/chained/SubChainSwapMoveSelectorConfig.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/config/heuristic/selector/move/generic/chained/SubChainSwapMoveSelectorConfig.java
@@ -59,6 +59,31 @@ public class SubChainSwapMoveSelectorConfig extends MoveSelectorConfig<SubChainS
         this.selectReversingMoveToo = selectReversingMoveToo;
     }
 
+    // ************************************************************************
+    // With methods
+    // ************************************************************************
+
+    public SubChainSwapMoveSelectorConfig withEntityClass(Class<?> entityClass) {
+        this.setEntityClass(entityClass);
+        return this;
+    }
+
+    public SubChainSwapMoveSelectorConfig withSubChainSelectorConfig(SubChainSelectorConfig subChainSelectorConfig) {
+        this.setSubChainSelectorConfig(subChainSelectorConfig);
+        return this;
+    }
+
+    public SubChainSwapMoveSelectorConfig
+            withSecondarySubChainSelectorConfig(SubChainSelectorConfig secondarySubChainSelectorConfig) {
+        this.setSecondarySubChainSelectorConfig(secondarySubChainSelectorConfig);
+        return this;
+    }
+
+    public SubChainSwapMoveSelectorConfig withSelectReversingMoveToo(Boolean selectReversingMoveToo) {
+        this.setSelectReversingMoveToo(selectReversingMoveToo);
+        return this;
+    }
+
     @Override
     public SubChainSwapMoveSelectorConfig inherit(SubChainSwapMoveSelectorConfig inheritedConfig) {
         super.inherit(inheritedConfig);

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/config/heuristic/selector/move/generic/list/SubListChangeMoveSelectorConfig.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/config/heuristic/selector/move/generic/list/SubListChangeMoveSelectorConfig.java
@@ -47,6 +47,25 @@ public class SubListChangeMoveSelectorConfig extends MoveSelectorConfig<SubListC
         this.selectReversingMoveToo = selectReversingMoveToo;
     }
 
+    // ************************************************************************
+    // With methods
+    // ************************************************************************
+
+    public SubListChangeMoveSelectorConfig withMinimumSubListSize(Integer minimumSubListSize) {
+        this.setMinimumSubListSize(minimumSubListSize);
+        return this;
+    }
+
+    public SubListChangeMoveSelectorConfig withMaximumSubListSize(Integer maximumSubListSize) {
+        this.setMaximumSubListSize(maximumSubListSize);
+        return this;
+    }
+
+    public SubListChangeMoveSelectorConfig withSelectReversingMoveToo(Boolean selectReversingMoveToo) {
+        this.setSelectReversingMoveToo(selectReversingMoveToo);
+        return this;
+    }
+
     @Override
     public SubListChangeMoveSelectorConfig inherit(SubListChangeMoveSelectorConfig inheritedConfig) {
         super.inherit(inheritedConfig);

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/config/heuristic/selector/move/generic/list/SubListSwapMoveSelectorConfig.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/config/heuristic/selector/move/generic/list/SubListSwapMoveSelectorConfig.java
@@ -47,6 +47,25 @@ public class SubListSwapMoveSelectorConfig extends MoveSelectorConfig<SubListSwa
         this.selectReversingMoveToo = selectReversingMoveToo;
     }
 
+    // ************************************************************************
+    // With methods
+    // ************************************************************************
+
+    public SubListSwapMoveSelectorConfig withMinimumSubListSize(Integer minimumSubListSize) {
+        this.setMinimumSubListSize(minimumSubListSize);
+        return this;
+    }
+
+    public SubListSwapMoveSelectorConfig withMaximumSubListSize(Integer maximumSubListSize) {
+        this.setMaximumSubListSize(maximumSubListSize);
+        return this;
+    }
+
+    public SubListSwapMoveSelectorConfig withSelectReversingMoveToo(Boolean selectReversingMoveToo) {
+        this.setSelectReversingMoveToo(selectReversingMoveToo);
+        return this;
+    }
+
     @Override
     public SubListSwapMoveSelectorConfig inherit(SubListSwapMoveSelectorConfig inheritedConfig) {
         super.inherit(inheritedConfig);

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/config/heuristic/selector/value/chained/SubChainSelectorConfig.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/config/heuristic/selector/value/chained/SubChainSelectorConfig.java
@@ -49,6 +49,25 @@ public class SubChainSelectorConfig extends SelectorConfig<SubChainSelectorConfi
         this.maximumSubChainSize = maximumSubChainSize;
     }
 
+    // ************************************************************************
+    // With methods
+    // ************************************************************************
+
+    public SubChainSelectorConfig withValueSelectorConfig(ValueSelectorConfig valueSelectorConfig) {
+        this.setValueSelectorConfig(valueSelectorConfig);
+        return this;
+    }
+
+    public SubChainSelectorConfig withMinimumSubChainSize(Integer minimumSubChainSize) {
+        this.setMinimumSubChainSize(minimumSubChainSize);
+        return this;
+    }
+
+    public SubChainSelectorConfig withMaximumSubChainSize(Integer maximumSubChainSize) {
+        this.setMaximumSubChainSize(maximumSubChainSize);
+        return this;
+    }
+
     @Override
     public SubChainSelectorConfig inherit(SubChainSelectorConfig inheritedConfig) {
         valueSelectorConfig = ConfigUtils.inheritConfig(valueSelectorConfig, inheritedConfig.getValueSelectorConfig());

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/config/partitionedsearch/PartitionedSearchPhaseConfig.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/config/partitionedsearch/PartitionedSearchPhaseConfig.java
@@ -110,6 +110,37 @@ public class PartitionedSearchPhaseConfig extends PhaseConfig<PartitionedSearchP
         this.phaseConfigList = phaseConfigList;
     }
 
+    // ************************************************************************
+    // With methods
+    // ************************************************************************
+
+    public PartitionedSearchPhaseConfig withSolutionPartitionerClass(
+            Class<? extends SolutionPartitioner<?>> solutionPartitionerClass) {
+        this.setSolutionPartitionerClass(solutionPartitionerClass);
+        return this;
+    }
+
+    public PartitionedSearchPhaseConfig withSolutionPartitionerCustomProperties(
+            Map<String, String> solutionPartitionerCustomProperties) {
+        this.setSolutionPartitionerCustomProperties(solutionPartitionerCustomProperties);
+        return this;
+    }
+
+    public PartitionedSearchPhaseConfig withRunnablePartThreadLimit(String runnablePartThreadLimit) {
+        this.setRunnablePartThreadLimit(runnablePartThreadLimit);
+        return this;
+    }
+
+    public PartitionedSearchPhaseConfig withPhaseConfigList(List<PhaseConfig> phaseConfigList) {
+        this.setPhaseConfigList(phaseConfigList);
+        return this;
+    }
+
+    public PartitionedSearchPhaseConfig withPhaseConfigs(PhaseConfig... phaseConfigs) {
+        this.setPhaseConfigList(List.of(phaseConfigs));
+        return this;
+    }
+
     @Override
     public PartitionedSearchPhaseConfig inherit(PartitionedSearchPhaseConfig inheritedConfig) {
         super.inherit(inheritedConfig);

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/config/phase/PhaseConfig.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/config/phase/PhaseConfig.java
@@ -44,10 +44,19 @@ public abstract class PhaseConfig<Config_ extends PhaseConfig<Config_>> extends 
         this.terminationConfig = terminationConfig;
     }
 
+    // ************************************************************************
+    // With methods
+    // ************************************************************************
+
+    public Config_ withTerminationConfig(TerminationConfig terminationConfig) {
+        this.setTerminationConfig(terminationConfig);
+        return self();
+    }
+
     @Override
     public Config_ inherit(Config_ inheritedConfig) {
         terminationConfig = ConfigUtils.inheritConfig(terminationConfig, inheritedConfig.getTerminationConfig());
-        return (Config_) this;
+        return self();
     }
 
     @Override

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/config/phase/PhaseConfig.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/config/phase/PhaseConfig.java
@@ -50,13 +50,13 @@ public abstract class PhaseConfig<Config_ extends PhaseConfig<Config_>> extends 
 
     public Config_ withTerminationConfig(TerminationConfig terminationConfig) {
         this.setTerminationConfig(terminationConfig);
-        return self();
+        return (Config_) this;
     }
 
     @Override
     public Config_ inherit(Config_ inheritedConfig) {
         terminationConfig = ConfigUtils.inheritConfig(terminationConfig, inheritedConfig.getTerminationConfig());
-        return self();
+        return (Config_) this;
     }
 
     @Override

--- a/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/config/heuristic/selector/move/generic/PillarSwapMoveSelectorConfigTest.java
+++ b/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/config/heuristic/selector/move/generic/PillarSwapMoveSelectorConfigTest.java
@@ -1,0 +1,31 @@
+package org.optaplanner.core.config.heuristic.selector.move.generic;
+
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
+import org.junit.jupiter.api.Test;
+import org.optaplanner.core.config.heuristic.selector.entity.pillar.PillarSelectorConfig;
+
+class PillarSwapMoveSelectorConfigTest {
+
+    @Test
+    void withMethodCallsProperlyChain() {
+        final int minimumSubPillarSize = 5;
+        final double fixedProbabilityWeight = 1.0;
+        final int maximumSubPillarSize = 10;
+        PillarSwapMoveSelectorConfig pillarSwapMoveSelectorConfig = new PillarSwapMoveSelectorConfig()
+                .withPillarSelectorConfig(new PillarSelectorConfig().withMinimumSubPillarSize(minimumSubPillarSize))
+                .withFixedProbabilityWeight(fixedProbabilityWeight)
+                .withSecondaryPillarSelectorConfig(
+                        new PillarSelectorConfig().withMaximumSubPillarSize(maximumSubPillarSize));
+
+        assertSoftly(softly -> {
+            softly.assertThat(pillarSwapMoveSelectorConfig.getFixedProbabilityWeight()).isEqualTo(fixedProbabilityWeight);
+            softly.assertThat(pillarSwapMoveSelectorConfig.getPillarSelectorConfig()).isNotNull();
+            softly.assertThat(pillarSwapMoveSelectorConfig.getPillarSelectorConfig().getMinimumSubPillarSize())
+                    .isEqualTo(minimumSubPillarSize);
+            softly.assertThat(pillarSwapMoveSelectorConfig.getSecondaryPillarSelectorConfig()).isNotNull();
+            softly.assertThat(pillarSwapMoveSelectorConfig.getSecondaryPillarSelectorConfig().getMaximumSubPillarSize())
+                    .isEqualTo(maximumSubPillarSize);
+        });
+    }
+}

--- a/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/config/localsearch/LocalSearchPhaseConfigTest.java
+++ b/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/config/localsearch/LocalSearchPhaseConfigTest.java
@@ -1,0 +1,28 @@
+package org.optaplanner.core.config.localsearch;
+
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
+import org.junit.jupiter.api.Test;
+import org.optaplanner.core.config.localsearch.decider.forager.LocalSearchForagerConfig;
+import org.optaplanner.core.config.solver.termination.TerminationConfig;
+
+class LocalSearchPhaseConfigTest {
+
+    @Test
+    void withMethodCallsProperlyChain() {
+        final int acceptedCountLimit = 5;
+        LocalSearchPhaseConfig localSearchPhaseConfig = new LocalSearchPhaseConfig()
+                .withLocalSearchType(LocalSearchType.TABU_SEARCH)
+                .withTerminationConfig(new TerminationConfig().withBestScoreFeasible(true))
+                .withForagerConfig(new LocalSearchForagerConfig().withAcceptedCountLimit(acceptedCountLimit));
+
+        assertSoftly(softly -> {
+            softly.assertThat(localSearchPhaseConfig.getLocalSearchType()).isEqualTo(LocalSearchType.TABU_SEARCH);
+            softly.assertThat(localSearchPhaseConfig.getTerminationConfig()).isNotNull();
+            softly.assertThat(localSearchPhaseConfig.getTerminationConfig().getBestScoreFeasible()).isTrue();
+            softly.assertThat(localSearchPhaseConfig.getForagerConfig()).isNotNull();
+            softly.assertThat(localSearchPhaseConfig.getForagerConfig().getAcceptedCountLimit())
+                    .isEqualTo(acceptedCountLimit);
+        });
+    }
+}

--- a/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/config/PlannerBenchmarkConfig.java
+++ b/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/config/PlannerBenchmarkConfig.java
@@ -626,4 +626,90 @@ public class PlannerBenchmarkConfig {
     public void setSolverBenchmarkConfigList(List<SolverBenchmarkConfig> solverBenchmarkConfigList) {
         this.solverBenchmarkConfigList = solverBenchmarkConfigList;
     }
+
+    // ************************************************************************
+    // With methods
+    // ************************************************************************
+
+    public PlannerBenchmarkConfig withClassLoader(ClassLoader classLoader) {
+        this.setClassLoader(classLoader);
+        return this;
+    }
+
+    public PlannerBenchmarkConfig withName(String name) {
+        this.setName(name);
+        return this;
+    }
+
+    public PlannerBenchmarkConfig withBenchmarkDirectory(File benchmarkDirectory) {
+        this.setBenchmarkDirectory(benchmarkDirectory);
+        return this;
+    }
+
+    public PlannerBenchmarkConfig withThreadFactoryClass(Class<? extends ThreadFactory> threadFactoryClass) {
+        this.setThreadFactoryClass(threadFactoryClass);
+        return this;
+    }
+
+    public PlannerBenchmarkConfig withParallelBenchmarkCount(String parallelBenchmarkCount) {
+        this.setParallelBenchmarkCount(parallelBenchmarkCount);
+        return this;
+    }
+
+    public PlannerBenchmarkConfig withWarmUpMillisecondsSpentLimit(Long warmUpMillisecondsSpentLimit) {
+        this.setWarmUpMillisecondsSpentLimit(warmUpMillisecondsSpentLimit);
+        return this;
+    }
+
+    public PlannerBenchmarkConfig withWarmUpSecondsSpentLimit(Long warmUpSecondsSpentLimit) {
+        this.setWarmUpSecondsSpentLimit(warmUpSecondsSpentLimit);
+        return this;
+    }
+
+    public PlannerBenchmarkConfig withWarmUpMinutesSpentLimit(Long warmUpMinutesSpentLimit) {
+        this.setWarmUpMinutesSpentLimit(warmUpMinutesSpentLimit);
+        return this;
+    }
+
+    public PlannerBenchmarkConfig withWarmUpHoursSpentLimit(Long warmUpHoursSpentLimit) {
+        this.setWarmUpHoursSpentLimit(warmUpHoursSpentLimit);
+        return this;
+    }
+
+    public PlannerBenchmarkConfig withWarmUpDaysSpentLimit(Long warmUpDaysSpentLimit) {
+        this.setWarmUpDaysSpentLimit(warmUpDaysSpentLimit);
+        return this;
+    }
+
+    public PlannerBenchmarkConfig withBenchmarkReportConfig(BenchmarkReportConfig benchmarkReportConfig) {
+        this.setBenchmarkReportConfig(benchmarkReportConfig);
+        return this;
+    }
+
+    public PlannerBenchmarkConfig withInheritedSolverBenchmarkConfig(SolverBenchmarkConfig inheritedSolverBenchmarkConfig) {
+        this.setInheritedSolverBenchmarkConfig(inheritedSolverBenchmarkConfig);
+        return this;
+    }
+
+    public PlannerBenchmarkConfig withSolverBenchmarkBluePrintConfigList(
+            List<SolverBenchmarkBluePrintConfig> solverBenchmarkBluePrintConfigList) {
+        this.setSolverBenchmarkBluePrintConfigList(solverBenchmarkBluePrintConfigList);
+        return this;
+    }
+
+    public PlannerBenchmarkConfig withSolverBenchmarkBluePrintConfigs(
+            SolverBenchmarkBluePrintConfig... solverBenchmarkBluePrintConfigs) {
+        this.setSolverBenchmarkBluePrintConfigList(List.of(solverBenchmarkBluePrintConfigs));
+        return this;
+    }
+
+    public PlannerBenchmarkConfig withSolverBenchmarkConfigList(List<SolverBenchmarkConfig> solverBenchmarkConfigList) {
+        this.setSolverBenchmarkConfigList(solverBenchmarkConfigList);
+        return this;
+    }
+
+    public PlannerBenchmarkConfig withSolverBenchmarkConfigs(SolverBenchmarkConfig... solverBenchmarkConfigs) {
+        this.setSolverBenchmarkConfigList(List.of(solverBenchmarkConfigs));
+        return this;
+    }
 }

--- a/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/config/ProblemBenchmarksConfig.java
+++ b/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/config/ProblemBenchmarksConfig.java
@@ -93,6 +93,55 @@ public class ProblemBenchmarksConfig extends AbstractConfig<ProblemBenchmarksCon
     }
 
     // ************************************************************************
+    // With methods
+    // ************************************************************************
+
+    public ProblemBenchmarksConfig withSolutionFileIOClass(Class<? extends SolutionFileIO<?>> solutionFileIOClass) {
+        this.setSolutionFileIOClass(solutionFileIOClass);
+        return this;
+    }
+
+    public ProblemBenchmarksConfig withWriteOutputSolutionEnabled(Boolean writeOutputSolutionEnabled) {
+        this.setWriteOutputSolutionEnabled(writeOutputSolutionEnabled);
+        return this;
+    }
+
+    public ProblemBenchmarksConfig withInputSolutionFileList(List<File> inputSolutionFileList) {
+        this.setInputSolutionFileList(inputSolutionFileList);
+        return this;
+    }
+
+    public ProblemBenchmarksConfig withInputSolutionFiles(File... inputSolutionFiles) {
+        this.setInputSolutionFileList(List.of(inputSolutionFiles));
+        return this;
+    }
+
+    public ProblemBenchmarksConfig withProblemStatisticsEnabled(Boolean problemStatisticEnabled) {
+        this.setProblemStatisticEnabled(problemStatisticEnabled);
+        return this;
+    }
+
+    public ProblemBenchmarksConfig withProblemStatisticTypeList(List<ProblemStatisticType> problemStatisticTypeList) {
+        this.setProblemStatisticTypeList(problemStatisticTypeList);
+        return this;
+    }
+
+    public ProblemBenchmarksConfig withProblemStatisticTypes(ProblemStatisticType... problemStatisticTypes) {
+        this.setProblemStatisticTypeList(List.of(problemStatisticTypes));
+        return this;
+    }
+
+    public ProblemBenchmarksConfig withSingleStatisticTypeList(List<SingleStatisticType> singleStatisticTypeList) {
+        this.setSingleStatisticTypeList(singleStatisticTypeList);
+        return this;
+    }
+
+    public ProblemBenchmarksConfig withSingleStatisticTypes(SingleStatisticType... singleStatisticTypes) {
+        this.setSingleStatisticTypeList(List.of(singleStatisticTypes));
+        return this;
+    }
+
+    // ************************************************************************
     // Complex methods
     // ************************************************************************
 

--- a/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/config/SolverBenchmarkConfig.java
+++ b/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/config/SolverBenchmarkConfig.java
@@ -63,6 +63,30 @@ public class SolverBenchmarkConfig extends AbstractConfig<SolverBenchmarkConfig>
         this.subSingleCount = subSingleCount;
     }
 
+    // ************************************************************************
+    // With methods
+    // ************************************************************************
+
+    public SolverBenchmarkConfig withName(String name) {
+        this.setName(name);
+        return this;
+    }
+
+    public SolverBenchmarkConfig withSolverConfig(SolverConfig solverConfig) {
+        this.setSolverConfig(solverConfig);
+        return this;
+    }
+
+    public SolverBenchmarkConfig withProblemBenchmarksConfig(ProblemBenchmarksConfig problemBenchmarksConfig) {
+        this.setProblemBenchmarksConfig(problemBenchmarksConfig);
+        return this;
+    }
+
+    public SolverBenchmarkConfig withSubSingleCount(Integer subSingleCount) {
+        this.setSubSingleCount(subSingleCount);
+        return this;
+    }
+
     @Override
     public SolverBenchmarkConfig inherit(SolverBenchmarkConfig inheritedConfig) {
         solverConfig = ConfigUtils.inheritConfig(solverConfig, inheritedConfig.getSolverConfig());

--- a/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/config/report/BenchmarkReportConfig.java
+++ b/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/config/report/BenchmarkReportConfig.java
@@ -73,6 +73,32 @@ public class BenchmarkReportConfig extends AbstractConfig<BenchmarkReportConfig>
         return getLocale() == null ? Locale.getDefault() : getLocale();
     }
 
+    // ************************************************************************
+    // With methods
+    // ************************************************************************
+
+    public BenchmarkReportConfig withLocale(Locale locale) {
+        this.setLocale(locale);
+        return this;
+    }
+
+    public BenchmarkReportConfig withSolverRankingType(SolverRankingType solverRankingType) {
+        this.setSolverRankingType(solverRankingType);
+        return this;
+    }
+
+    public BenchmarkReportConfig withSolverRankingComparatorClass(
+            Class<? extends Comparator<SolverBenchmarkResult>> solverRankingComparatorClass) {
+        this.setSolverRankingComparatorClass(solverRankingComparatorClass);
+        return this;
+    }
+
+    public BenchmarkReportConfig withSolverRankingWeightFactoryClass(
+            Class<? extends SolverRankingWeightFactory> solverRankingWeightFactoryClass) {
+        this.setSolverRankingWeightFactoryClass(solverRankingWeightFactoryClass);
+        return this;
+    }
+
     @Override
     public BenchmarkReportConfig inherit(BenchmarkReportConfig inheritedConfig) {
         locale = ConfigUtils.inheritOverwritableProperty(locale, inheritedConfig.getLocale());


### PR DESCRIPTION
- adds the missing `with()` methods
- enables proper `with()` method chaining on the `Config` classes hierarchy

<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.
-->

### JIRA
https://issues.redhat.com/browse/PLANNER-2161

<!-- Add a JIRA ticket link if it exists. -->
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
- https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
- https://github.com/kiegroup/drools/pull/3000
- https://github.com/kiegroup/optaplanner/pull/899
- etc.
-->

### Checklist
- [ ] Documentation updated if applicable.
- [ ] Release notes updated if applicable.
- [ ] Upgrade recipe provided if applicable.

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request checks</b>  
  Please add comment: <b>Jenkins retest this</b>

- for a <b>specific pull request check</b>  
  please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-vehicle-routing] tests</b>
  
- for a <b>full downstream build</b> 
  - for <b>jenkins</b> job: 
    please add comment: <b>Jenkins run fdb</b>
  - for <b>github actions</b> job: 
    add the label `run_fdb`

- for a <b>compile downstream build</b>  
  please add comment: <b>Jenkins run cdb</b>

- for a <b>full production downstream build</b>  
  please add comment: <b>Jenkins execute product fdb</b>

- for an <b>upstream build</b>  
  please add comment: <b>Jenkins run upstream</b>

- for <b>quarkus branch checks</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins run quarkus-branch</b>

- for a <b>quarkus branch specific check</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-vehicle-routing] quarkus-branch</b>

- for <b>quarkus main checks</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins run quarkus-main</b>

- for a <b>specific quarkus main check</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-vehicle-routing] quarkus-branch</b>

- for <b>quarkus lts checks</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins run quarkus-lts</b>

- for a <b>specific quarkus lts check</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-vehicle-routing] quarkus-lts</b>

- for <b>native checks</b>  
  Run native checks  
  Please add comment: <b>Jenkins run native</b>

- for a <b>specific native check</b>  
  Run native checks 
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts] native</b>

- for <b>native lts checks</b>  
  Run native checks against quarkus lts branch
  Please add comment: <b>Jenkins run native-lts</b>

- for a <b>specific native lts check</b>  
  Run native checks against quarkus lts branch
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts] native-lts</b>

</details>

### CI Status

 You can check OptaPlanner repositories CI status from [Chain Status webpage](https://kiegroup.github.io/optaplanner/).

<details>
<summary>
How to backport a pull request to a different branch?
</summary>

In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-7.67.x` to backport the original PR to the `7.67.x` branch).

> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.

Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.

If something goes wrong, the author will be notified and at this point a manual backporting is needed.

> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
</details>
