### PR TITLE
PLANNER-2910 Archive optaweb-vehicle-routing

### DIFF
--- a/.ci/buildchain-config.yaml
+++ b/.ci/buildchain-config.yaml
@@ -35,14 +35,7 @@ build:
         mvn clean install -Dfull ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_CURRENT }} ${{ env.OPTAPLANNER_BUILD_MVN_OPTS }}
       upstream: |
         mvn clean install -Dquickly ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_UPSTREAM }} ${{ env.OPTAPLANNER_BUILD_MVN_OPTS_UPSTREAM }}
-  
-  - project: kiegroup/optaweb-vehicle-routing
-    build-command: 
-      current: |
-        mvn clean install ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_CURRENT }} ${{ env.OPTAWEB_VEHICLE_ROUTING_BUILD_MVN_OPTS }}
-      upstream: |
-        mvn clean install -Dquickly ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_UPSTREAM }} ${{ env.OPTAWEB_VEHICLE_ROUTING_BUILD_MVN_OPTS_UPSTREAM }}
-  
+
   - project: kiegroup/optaplanner-quickstarts
     build-command: 
       before:

--- a/.ci/buildchain-project-dependencies.yaml
+++ b/.ci/buildchain-project-dependencies.yaml
@@ -1,11 +1,6 @@
 version: "2.1"
 dependencies:
   - project: kiegroup/optaplanner
-
-  - project: kiegroup/optaweb-vehicle-routing
-    dependencies:
-      - project: kiegroup/optaplanner
-
   - project: kiegroup/optaplanner-quickstarts
     dependencies:
       - project: kiegroup/optaplanner

--- a/.ci/jenkins/Jenkinsfile.deploy
+++ b/.ci/jenkins/Jenkinsfile.deploy
@@ -9,7 +9,6 @@ deployProperties = [:]
 
 optaplannerRepository = 'optaplanner'
 quickstartsRepository = 'optaplanner-quickstarts'
-vehicleRoutingRepository = 'optaweb-vehicle-routing'
 
 imageUtils = null
 
@@ -87,10 +86,9 @@ pipeline {
             steps {
                 script {
                     checkoutRepo(optaplannerRepository)
-                    // TODO: switch to the 9 stream after quickstarts and the optaweb will have been migrated.
+                    // TODO: switch to the 9 stream after quickstarts will have been migrated.
                     if (isStream8()) {
                         checkoutQuickstarts()
-                        checkoutRepo(vehicleRoutingRepository)
                     }
                 }
             }
@@ -103,9 +101,8 @@ pipeline {
             steps {
                 script {
                     prepareForPR(optaplannerRepository)
-                    // TODO: switch to the 9 stream after quickstarts and the optaweb will have been migrated.
+                    // TODO: switch to the 9 stream after quickstarts will have been migrated.
                     if (isStream8()) {
-                        prepareForPR(vehicleRoutingRepository)
                         prepareForPR(quickstartsRepository)
                     }
                 }
@@ -126,10 +123,8 @@ pipeline {
 
                     mavenCleanInstallOptaPlannerParents()
 
-                    // TODO: switch to the 9 stream after quickstarts and the optaweb will have been migrated.
+                    // TODO: switch to the 9 stream after quickstarts will have been migrated.
                     if (isStream8()) {
-                        maven.mvnVersionsUpdateParentAndChildModules(getOptawebVehicleRoutingMavenCommand(), getProjectVersion(), !isRelease())
-
                         updateQuickstartsVersions()
                     }
                 }
@@ -161,7 +156,7 @@ pipeline {
 
         stage('Build Quickstarts') {
             when {
-                // TODO: switch to the 9 stream after quickstarts and the optaweb will have been migrated.
+                // TODO: switch to the 9 stream after quickstarts will have been migrated.
                 expression { return isStream8() }
             }
             steps {
@@ -182,27 +177,6 @@ pipeline {
             }
         }
 
-        stage('Build Vehicle Routing') {
-            when {
-                // TODO: switch to the 9 stream after quickstarts and the optaweb will have been migrated.
-                expression { return isStream8() }
-            }
-            steps {
-                script {
-                    buildOptaweb(getOptawebVehicleRoutingMavenCommand())
-                }
-            }
-            post {
-                always {
-                    script {
-                        archiveJUnitTestResults()
-                        archiveCypressArtifacts()
-                        util.archiveConsoleLog()
-                    }
-                }
-            }
-        }
-
         stage('Deploy to repository') {
             when {
                 expression { return !shouldStageArtifacts() && !isSpecificArtifactsUpload() && shouldDeployToRepository() }
@@ -210,10 +184,9 @@ pipeline {
             steps {
                 script {
                     runMavenDeploy(getOptaplannerMavenCommand())
-                    // TODO: switch to the 9 stream after quickstarts and the optaweb will have been migrated.
+                    // TODO: switch to the 9 stream after quickstarts will have been migrated.
                     if (isStream8()) {
                         runMavenDeploy(getOptaplannerQuickstartsMavenCommand().withOptions(['-pl', ':optaplanner-distribution']))
-                        runMavenDeploy(getOptawebVehicleRoutingMavenCommand())
                     }
                 }
             }
@@ -225,10 +198,6 @@ pipeline {
             steps {
                 script {
                     runMavenDeploy(getOptaplannerMavenCommand(), optaplannerRepository)
-                    // TODO: switch to the 9 stream after quickstarts and the optaweb will have been migrated.
-                    if (isStream8()) {
-                        runMavenDeploy(getOptawebVehicleRoutingMavenCommand(), vehicleRoutingRepository)
-                    }
                 }
             }
         }
@@ -240,10 +209,6 @@ pipeline {
                 script {
                     // Deploy to specific repository with credentials
                     maven.uploadLocalArtifacts(env.MAVEN_REPO_CREDS_ID, getLocalDeploymentFolder(optaplannerRepository), getMavenRepoZipUrl())
-                    // TODO: switch to the 9 stream after quickstarts and the optaweb will have been migrated.
-                    if (isStream8()) {
-                        maven.uploadLocalArtifacts(env.MAVEN_REPO_CREDS_ID, getLocalDeploymentFolder(vehicleRoutingRepository), getMavenRepoZipUrl())
-                    }
                 }
             }
         }
@@ -258,10 +223,6 @@ pipeline {
                 script {
                     // Stage release artifacts
                     runMavenStage(getOptaplannerMavenCommand(), optaplannerRepository)
-                    // TODO: switch to the 9 stream after quickstarts and the optaweb will have been migrated.
-                    if (isStream8()) {
-                        runMavenStage(getOptawebVehicleRoutingMavenCommand(), vehicleRoutingRepository)
-                    }
                 }
             }
         }
@@ -273,9 +234,8 @@ pipeline {
             steps {
                 script {
                     commitAndCreatePR(optaplannerRepository, getBuildBranch())
-                    // TODO: switch to the 9 stream after quickstarts and the optaweb will have been migrated.
+                    // TODO: switch to the 9 stream after quickstarts will have been migrated.
                     if (isStream8()) {
-                        commitAndCreatePRIgnoringNpmRegistry(vehicleRoutingRepository, getBuildBranch())
                         commitAndCreatePR(quickstartsRepository, getQuickStartsBranch())
                     }
                 }
@@ -287,11 +247,6 @@ pipeline {
                         setDeployPropertyIfNeeded("${optaplannerRepository}.pr.source.ref", getBotBranch())
                         setDeployPropertyIfNeeded("${optaplannerRepository}.pr.target.uri", "https://github.com/${getGitAuthor()}/${optaplannerRepository}")
                         setDeployPropertyIfNeeded("${optaplannerRepository}.pr.target.ref", getBuildBranch())
-
-                        setDeployPropertyIfNeeded("${vehicleRoutingRepository}.pr.source.uri", "https://github.com/${getBotAuthor()}/${vehicleRoutingRepository}")
-                        setDeployPropertyIfNeeded("${vehicleRoutingRepository}.pr.source.ref", getBotBranch())
-                        setDeployPropertyIfNeeded("${vehicleRoutingRepository}.pr.target.uri", "https://github.com/${getGitAuthor()}/${vehicleRoutingRepository}")
-                        setDeployPropertyIfNeeded("${vehicleRoutingRepository}.pr.target.ref", getBuildBranch())
                     }
                 }
             }
@@ -339,20 +294,6 @@ void sendErrorNotification() {
         mailer.sendMarkdownTestSummaryNotification("CI failures", [env.OPTAPLANNER_CI_EMAIL_TO], additionalInfo)
     } else {
         echo 'No notification sent per configuration'
-    }
-}
-
-void buildOptaweb(MavenCommand optawebCommand) {
-    MavenCommand buildCommand = optawebCommand
-    if (!skipIntegrationTests()) {
-        buildCommand = buildCommand.withProfiles(getIntegrationTestProfiles())
-    }
-    buildCommand.withProperty('maven.test.failure.ignore', true).skipTests(params.SKIP_TESTS).run('clean install')
-}
-
-void archiveCypressArtifacts() {
-    if (!skipIntegrationTests()) {
-        archiveArtifacts(artifacts: '**/cypress/screenshots/**,**/cypress/videos/**', fingerprint: false, allowEmptyArchive: true)
     }
 }
 
@@ -473,10 +414,6 @@ MavenCommand getOptaplannerMavenCommand() {
 
 MavenCommand getOptaplannerQuickstartsMavenCommand() {
     return getMavenDefaultCommand().inDirectory(quickstartsRepository).withProperty('full')
-}
-
-MavenCommand getOptawebVehicleRoutingMavenCommand() {
-    return getMavenDefaultCommand().inDirectory(vehicleRoutingRepository)
 }
 
 /**

--- a/.ci/jenkins/Jenkinsfile.prod.nightly
+++ b/.ci/jenkins/Jenkinsfile.prod.nightly
@@ -52,7 +52,7 @@ pipeline {
                         pipelineHelper.retry(
                         {
                             def SETTINGS_XML_ID = '5d9884a1-178a-4d67-a3ac-9735d2df2cef'
-                            def projectCollection = ['drools', 'optaplanner', 'optaplanner-quickstarts', 'optaweb-vehicle-routing', 'jboss-integration/rhbop-optaplanner']
+                            def projectCollection = ['drools', 'optaplanner', 'optaplanner-quickstarts', 'jboss-integration/rhbop-optaplanner']
                             def projectVariableMap = ['kiegroup_optaplanner': 'optaplannerVersion', 'kiegroup_drools': 'droolsProductVersion']
                             def additionalVariables = [
                                 'productVersion': env.PRODUCT_VERSION,

--- a/.ci/jenkins/Jenkinsfile.promote
+++ b/.ci/jenkins/Jenkinsfile.promote
@@ -7,7 +7,6 @@ deployProperties = [:]
 pipelineProperties = [:]
 
 String optaplannerRepository = 'optaplanner'
-String vehicleRoutingRepository = 'optaweb-vehicle-routing'
 String quickstartsRepository = 'optaplanner-quickstarts'
 
 imageUtils = null
@@ -80,25 +79,9 @@ pipeline {
             }
         }
 
-        stage('Merge Optaweb Vehicle Routing deploy PR and tag') {
-            when {
-                // TODO: switch to the 9 stream after optaweb will have been migrated.
-                expression { return isRelease() && isStream8() }
-            }
-            steps {
-                script {
-                    dir(vehicleRoutingRepository) {
-                        checkoutRepo(vehicleRoutingRepository)
-                        mergeAndPush(getDeployPrLink(vehicleRoutingRepository))
-                        tagLatest()
-                    }
-                }
-            }
-        }
-
         stage('Merge OptaPlanner Quickstarts PR and tag') {
             when {
-                // TODO: switch to the 9 stream after quickstarts and the optaweb will have been migrated.
+                // TODO: switch to the 9 stream after quickstarts will have been migrated.
                 expression { return isRelease() && isStream8() }
             }
             steps {
@@ -114,7 +97,7 @@ pipeline {
 
         stage('Upload OptaPlanner documentation') {
             when {
-                // TODO: switch to the 9 stream after quickstarts and the optaweb will have been migrated.
+                // TODO: switch to the 9 stream after quickstarts will have been migrated.
                 expression { return isRelease() && isStream8() }
             }
             steps {
@@ -125,22 +108,6 @@ pipeline {
                             .withProperty('full')
                             .run('clean install')
                     uploadDistribution(optaplannerRepository)
-                }
-            }
-        }
-
-        stage('Upload Vehicle Routing documentation and distribution') {
-            when {
-                // TODO: switch to the 9 stream after quickstarts and the optaweb will have been migrated.
-                expression { return isRelease() && isStream8() }
-            }
-            steps {
-                script {
-                    getMavenCommand()
-                            .inDirectory(vehicleRoutingRepository)
-                            .skipTests(true)
-                            .run('clean install')
-                    uploadDistribution(vehicleRoutingRepository)
                 }
             }
         }
@@ -171,33 +138,9 @@ pipeline {
             }
         }
 
-        stage('Set Optaweb Vehicle Routing next snapshot version') {
-            when {
-                // TODO: switch to the 9 stream after quickstarts and the optaweb will have been migrated.
-                expression { return isRelease() && isStream8()  }
-            }
-            steps {
-                script {
-                    String nextMicroSnapshotVersion = getNextMicroSnapshotVersion(getProjectVersion())
-                    dir("$vehicleRoutingRepository-bot") {
-                        prepareForPR(vehicleRoutingRepository)
-                        maven.mvnVersionsUpdateParentAndChildModules(nextMicroSnapshotVersion, true)
-
-                        String prLink = commitAndCreatePR("[${getBuildBranch()}] Update snapshot version to ${nextMicroSnapshotVersion}")
-                        setPipelinePrLink(vehicleRoutingRepository, prLink)
-                    }
-                    dir(vehicleRoutingRepository) {
-                        sh "git checkout ${getBuildBranch()}"
-                        mergeAndPush(getPipelinePrLink(vehicleRoutingRepository))
-                        runMavenDeploy(getMavenCommand())
-                    }
-                }
-            }
-        }
-
         stage('Set Quickstarts next snapshot version') {
             when {
-                // TODO: switch to the 9 stream after quickstarts and the optaweb will have been migrated.
+                // TODO: switch to the 9 stream after quickstarts will have been migrated.
                 expression { return isRelease() && isStream8() }
             }
             steps {

--- a/.ci/jenkins/config/branch.yaml
+++ b/.ci/jenkins/config/branch.yaml
@@ -51,8 +51,6 @@ disable:
 repositories:
 - name: optaplanner
   branch: main
-- name: optaweb-vehicle-routing
-  branch: main
 - name: optaplanner-quickstarts
   branch: development
 - name: optaplanner-website

--- a/.ci/jenkins/dsl/jobs.groovy
+++ b/.ci/jenkins/dsl/jobs.groovy
@@ -177,9 +177,6 @@ Map getMultijobPRConfig(JenkinsFolder jobFolder) {
                     SONARCLOUD_ANALYSIS_MVN_OPTS: '-Dsonar.projectKey=org.optaplanner:optaplanner',
                 ]
             ], [
-                id: 'optaweb-vehicle-routing',
-                repository: 'optaweb-vehicle-routing'
-            ], [
                 id: 'optaplanner-quickstarts',
                 repository: 'optaplanner-quickstarts',
                 env : [
@@ -189,9 +186,6 @@ Map getMultijobPRConfig(JenkinsFolder jobFolder) {
             ]
         ]
     ]
-    if (EnvUtils.hasEnvironmentId(this, jobFolder.getEnvironmentName(), 'native')) {
-        jobConfig.jobs.retainAll { !it.id.startsWith('optaweb') }
-    }
     return jobConfig
 }
 

--- a/.ci/jenkins/project/Jenkinsfile.post-release
+++ b/.ci/jenkins/project/Jenkinsfile.post-release
@@ -58,7 +58,7 @@ pipeline {
 
         stage('Reset Quickstarts stable branch') {
             when {
-                // TODO: switch to the 9 stream after quickstarts and the optaweb will have been migrated.
+                // TODO: switch to the 9 stream after quickstarts will have been migrated.
                 expression { return isStream8() }
             }
             steps {
@@ -74,7 +74,7 @@ pipeline {
 
         stage('Upload OptaPlanner distribution from Quickstarts') {
             when {
-                // TODO: switch to the 9 stream after quickstarts and the optaweb will have been migrated.
+                // TODO: switch to the 9 stream after quickstarts will have been migrated.
                 expression { return isStream8() }
             }
             steps {
@@ -92,7 +92,7 @@ pipeline {
 
         stage('Update OptaPlanner website') {
             when {
-                // TODO: switch to the 9 stream after quickstarts and the optaweb will have been migrated.
+                // TODO: switch to the 9 stream after quickstarts will have been migrated.
                 expression { return isStream8() }
             }
             steps {

--- a/.ci/jenkins/project/Jenkinsfile.setup-branch
+++ b/.ci/jenkins/project/Jenkinsfile.setup-branch
@@ -62,28 +62,9 @@ pipeline {
             }
         }
 
-        stage('Init Optaweb Vehicle Routing') {
-            when {
-                // TODO: switch to the 9 stream after quickstarts and the optaweb will have been migrated.
-                expression { return isStream8() }
-            }
-            steps {
-                script {
-                    def buildParams = getDefaultBuildParams()
-                    addOptaPlannerVersionParam(buildParams)
-                    buildJob('optaweb-vehicle-routing', buildParams)
-                }
-            }
-            post {
-                failure {
-                    addFailedStage('optaweb-vehicle-routing')
-                }
-            }
-        }
-
         stage('Init Optaplanner Quickstarts') {
             when {
-                // TODO: switch to the 9 stream after quickstarts and the optaweb will have been migrated.
+                // TODO: switch to the 9 stream after quickstarts will have been migrated.
                 expression { return isStream8() }
             }
             steps {

--- a/.ci/project-dependencies-rhbop.yaml
+++ b/.ci/project-dependencies-rhbop.yaml
@@ -6,10 +6,6 @@ dependencies:
     dependencies:
       - project: kiegroup/drools
 
-  - project: kiegroup/optaweb-vehicle-routing
-    dependencies:
-      - project: kiegroup/optaplanner
-
   - project: kiegroup/optaplanner-quickstarts
     dependencies:
       - project: kiegroup/optaplanner

--- a/.ci/pull-request-config-rhbop.yaml
+++ b/.ci/pull-request-config-rhbop.yaml
@@ -28,12 +28,7 @@ build:
     build-command: 
       current: mvn clean install -Dfull ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_CURRENT }} ${{ env.OPTAPLANNER_BUILD_MVN_OPTS }} -Dversion.org.drools=${{ env.DROOLS_VERSION }}
       upstream: mvn clean install -Dquickly ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_UPSTREAM }} ${{ env.OPTAPLANNER_BUILD_MVN_OPTS_UPSTREAM }} -Dversion.org.drools=${{ env.DROOLS_VERSION }}
-  
-  - project: kiegroup/optaweb-vehicle-routing
-    build-command: 
-      current: mvn clean install ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_CURRENT }} ${{ env.OPTAWEB_VEHICLE_ROUTING_BUILD_MVN_OPTS }} -Dversion.org.drools=${{ env.DROOLS_VERSION }}
-      upstream: mvn clean install -Dquickly ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_UPSTREAM }} ${{ env.OPTAWEB_VEHICLE_ROUTING_BUILD_MVN_OPTS_UPSTREAM }} -Dversion.org.drools=${{ env.DROOLS_VERSION }}
-  
+
   - project: kiegroup/optaplanner-quickstarts
     build-command: 
       current: mvn clean install ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_CURRENT }} ${{ env.OPTAPLANNER_QUICKSTARTS_BUILD_MVN_OPTS }} -Dversion.org.drools=${{ env.DROOLS_VERSION }}

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -45,7 +45,7 @@ How to retest this PR or trigger a specific build:
   Please add comment: <b>Jenkins retest this</b>
 
 - for a <b>specific pull request check</b>  
-  please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-vehicle-routing] tests</b>
+  please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts] tests</b>
   
 - for a <b>full downstream build</b> 
   - for <b>jenkins</b> job: 
@@ -68,7 +68,7 @@ How to retest this PR or trigger a specific build:
 
 - for a <b>quarkus branch specific check</b>  
   Run checks against Quarkus current used branch  
-  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-vehicle-routing] quarkus-branch</b>
+  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts] quarkus-branch</b>
 
 - for <b>quarkus main checks</b>  
   Run checks against Quarkus main branch  
@@ -76,7 +76,7 @@ How to retest this PR or trigger a specific build:
 
 - for a <b>specific quarkus main check</b>  
   Run checks against Quarkus main branch  
-  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-vehicle-routing] quarkus-branch</b>
+  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts] quarkus-branch</b>
 
 - for <b>quarkus lts checks</b>  
   Run checks against Quarkus lts branch  
@@ -84,7 +84,7 @@ How to retest this PR or trigger a specific build:
 
 - for a <b>specific quarkus lts check</b>  
   Run checks against Quarkus lts branch  
-  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-vehicle-routing] quarkus-lts</b>
+  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts] quarkus-lts</b>
 
 - for <b>native checks</b>  
   Run native checks  

--- a/build/release/release-procedure.adoc
+++ b/build/release/release-procedure.adoc
@@ -19,11 +19,6 @@ and the https://www.optaplanner.org/xsd/benchmark/[Benchmark] available on the o
 No build artifacts are required; as a result of the release, the `development` branch must be rebased onto
 the `stable` branch and must point to the released final version of OptaPlanner.
 
-=== OptaWeb Vehicle Routing
-
-* https://www.optaplanner.org/download/download.html[Distribution Zip] available via a link on the optaplanner-website
-* https://www.optaplanner.org/learn/documentation.html[Documentation] available via a link on the optaplanner-website
-
 === OptaPlanner Website
 The website contains https://github.com/kiegroup/optaplanner-website/blob/main/_config/pom.yml[links]
 to the Distribution Zip files and documentation (see above). To update the documentation, and the Distribution Zip,
@@ -31,7 +26,7 @@ upload them to the `filemgmt.jboss.org` and then, open a PR changing the links.
 
 For the OptaPlanner project, there is a https://github.com/kiegroup/optaplanner/blob/main/build/release/upload_distribution.sh[script]
 uploading the documentation and the Distribution Zip. The release pipeline calls the script and updates also
-the links on the website. For Optaweb Vehicle Routing, the upload has to be done manually at this moment.
+the links on the website.
 
 == Versioning
 
@@ -83,7 +78,7 @@ https://eng-jenkins-csb-business-automation.apps.ocp-c1.prod.psi.redhat.com/job/
 The OptaPlanner release pipeline can now be triggered using the branch created in step 2.
 Run https://eng-jenkins-csb-business-automation.apps.ocp-c1.prod.psi.redhat.com/job/KIE/job/optaplanner/job/8.27.x/job/release/job/optaplanner-release[optaplanner-release].
 The OptaPlanner release pipeline runs the https://eng-jenkins-csb-business-automation.apps.ocp-c1.prod.psi.redhat.com/job/KIE/job/optaplanner/job/8.27.x/job/release/job/optaplanner-deploy[optaplanner-deploy] job
-which updates the project versions of OptaPlanner, Quickstarts and OptaWeb Vehicle Routing, builds these projects and deploys their artifacts to Nexus.
+which updates the project versions of OptaPlanner and Quickstarts, builds these projects and deploys their artifacts to Nexus.
 After this deployment step it promotes the projects. In this promote step PRs to upgrade the projects will be raised and merged as well as the tag created and pushed.
 
 === 5. OptaPlanner post release steps

--- a/optaplanner-docs/src/modules/ROOT/pages/release-notes/release-notes-8.adoc
+++ b/optaplanner-docs/src/modules/ROOT/pages/release-notes/release-notes-8.adoc
@@ -1,6 +1,15 @@
 [[releaseNotes-8.x]]
 == OptaPlanner 8.x Release Notes
 
+[[releaseNotes-8.36.0.Final]]
+=== OptaPlanner 8.36.0.Final
+
+==== OptaWeb Vehicle Routing demo application abandoned
+
+The codebase for OptaWeb Vehicle Routing demo application has been frozen and will no longer receive any updates.
+
+We encourage users to check out the https://github.com/kiegroup/optaplanner-quickstarts/tree/stable/use-cases/vehicle-routing[OptaPlanner Vehicle Routing Quickstart] for a simple and straight-forward way of integrating OptaPlanner in your application.
+
 [[releaseNotes-8.35.0.Final]]
 === OptaPlanner 8.35.0.Final
 

--- a/optaplanner-docs/src/modules/ROOT/pages/use-cases-and-examples/vehicle-routing/vehicle-routing.adoc
+++ b/optaplanner-docs/src/modules/ROOT/pages/use-cases-and-examples/vehicle-routing/vehicle-routing.adoc
@@ -177,7 +177,7 @@ There are several technologies available to precalculate road costs, such as htt
 
 image::use-cases-and-examples/vehicle-routing/integrationWithRealMaps.png[align="center"]
 
-There are also several technologies to render it, such as http://leafletjs.com[Leaflet] and https://developers.google.com/maps/[Google Maps for developers]. The https://github.com/kiegroup/optaweb-vehicle-routing[OptaWeb Vehicle Routing project] has an example which demonstrates such rendering:
+There are also several technologies to render it, such as http://leafletjs.com[Leaflet] and https://developers.google.com/maps/[Google Maps for developers]:
 
 image::use-cases-and-examples/vehicle-routing/vehicleRoutingLeafletAndGoogleMaps.png[align="center"]
 

--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,7 @@
   </licenses>
 
   <properties>
+    <!-- TODO: Evaluate if this override is still needed. -->
     <!-- The property sonar.projectKey is defined in the CI in order not to collide with optawebs. It overrides
          the default GroupId:ArtifactId to map both main branch and 7.x branches to the same SonarCloud project.
          As the sonar.moduleKey inherits the value of sonar.projectKey by default, we have to override it too. -->


### PR DESCRIPTION
<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.
-->

### JIRA
https://issues.redhat.com/browse/PLANNER-2910

<!-- Add a JIRA ticket link if it exists. -->
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
- https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
- https://github.com/kiegroup/drools/pull/3000
- https://github.com/kiegroup/optaplanner/pull/899
- etc.
-->

### Checklist
- [ ] Documentation updated if applicable.
- [ ] Release notes updated if applicable.
- [ ] Upgrade recipe provided if applicable.

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request checks</b>  
  Please add comment: <b>Jenkins retest this</b>

- for a <b>specific pull request check</b>  
  please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-vehicle-routing] tests</b>
  
- for a <b>full downstream build</b> 
  - for <b>jenkins</b> job: 
    please add comment: <b>Jenkins run fdb</b>
  - for <b>github actions</b> job: 
    add the label `run_fdb`

- for a <b>compile downstream build</b>  
  please add comment: <b>Jenkins run cdb</b>

- for a <b>full production downstream build</b>  
  please add comment: <b>Jenkins execute product fdb</b>

- for an <b>upstream build</b>  
  please add comment: <b>Jenkins run upstream</b>

- for <b>quarkus branch checks</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins run quarkus-branch</b>

- for a <b>quarkus branch specific check</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-vehicle-routing] quarkus-branch</b>

- for <b>quarkus main checks</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins run quarkus-main</b>

- for a <b>specific quarkus main check</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-vehicle-routing] quarkus-branch</b>

- for <b>quarkus lts checks</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins run quarkus-lts</b>

- for a <b>specific quarkus lts check</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-vehicle-routing] quarkus-lts</b>

- for <b>native checks</b>  
  Run native checks  
  Please add comment: <b>Jenkins run native</b>

- for a <b>specific native check</b>  
  Run native checks 
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts] native</b>

- for <b>native lts checks</b>  
  Run native checks against quarkus lts branch
  Please add comment: <b>Jenkins run native-lts</b>

- for a <b>specific native lts check</b>  
  Run native checks against quarkus lts branch
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts] native-lts</b>

</details>

### CI Status

 You can check OptaPlanner repositories CI status from [Chain Status webpage](https://kiegroup.github.io/optaplanner/).

<details>
<summary>
How to backport a pull request to a different branch?
</summary>

In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-7.67.x` to backport the original PR to the `7.67.x` branch).

> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.

Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.

If something goes wrong, the author will be notified and at this point a manual backporting is needed.

> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
</details>
