### PR TITLE
Clean up Gizmo accessors

### DIFF
--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/domain/common/accessor/gizmo/GizmoFieldHandler.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/domain/common/accessor/gizmo/GizmoFieldHandler.java
@@ -41,13 +41,15 @@ final class GizmoFieldHandler implements GizmoMemberHandler {
     @Override
     public boolean writeMemberValue(MethodDescriptor setter, BytecodeCreator bytecodeCreator, ResultHandle thisObj,
             ResultHandle newValue) {
-        if (canBeWritten) {
+        try {
             bytecodeCreator.writeInstanceField(fieldDescriptor, thisObj, newValue);
             return true;
-        } else {
-            throw new IllegalStateException(
-                    "Impossible state: field (" + field.getName() + ") of class (" + declaringClass + ") cannot be modified.\n"
-                            + "Maybe it's private or final.");
+        } catch (Exception ex) {
+            if (canBeWritten) {
+                throw new IllegalStateException("Cannot write field (" + field + ") of class (" + declaringClass + ").", ex);
+            } else {
+                return false;
+            }
         }
     }
 

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/domain/common/accessor/gizmo/GizmoFieldHandler.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/domain/common/accessor/gizmo/GizmoFieldHandler.java
@@ -1,0 +1,79 @@
+package org.optaplanner.core.impl.domain.common.accessor.gizmo;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.lang.reflect.Type;
+import java.util.function.Consumer;
+
+import io.quarkus.gizmo.BytecodeCreator;
+import io.quarkus.gizmo.FieldDescriptor;
+import io.quarkus.gizmo.MethodDescriptor;
+import io.quarkus.gizmo.ResultHandle;
+
+final class GizmoFieldHandler implements GizmoMemberHandler {
+
+    private final FieldDescriptor fieldDescriptor;
+
+    GizmoFieldHandler(FieldDescriptor fieldDescriptor) {
+        this.fieldDescriptor = fieldDescriptor;
+    }
+
+    @Override
+    public void whenIsField(Consumer<FieldDescriptor> fieldDescriptorConsumer) {
+        fieldDescriptorConsumer.accept(fieldDescriptor);
+    }
+
+    @Override
+    public void whenIsMethod(Consumer<MethodDescriptor> methodDescriptorConsumer) {
+        // Do nothing.
+    }
+
+    @Override
+    public ResultHandle readMemberValue(Class<?> declaringClass, BytecodeCreator bytecodeCreator, ResultHandle thisObj) {
+        return bytecodeCreator.readInstanceField(fieldDescriptor, thisObj);
+    }
+
+    @Override
+    public boolean writeMemberValue(Class<?> declaringClass, String name, MethodDescriptor setter,
+            BytecodeCreator bytecodeCreator, ResultHandle thisObj, ResultHandle newValue, boolean ignoreFinalChecks) {
+        try {
+            Field field = declaringClass.getField(name);
+            if (!ignoreFinalChecks && Modifier.isFinal(field.getModifiers())) {
+                throw new IllegalStateException(
+                        "Field (" + name + ") of class (" + declaringClass + ") is final and cannot be modified.");
+            } else {
+                bytecodeCreator.writeInstanceField(fieldDescriptor, thisObj, newValue);
+                return true;
+            }
+        } catch (NoSuchFieldException e) {
+            throw new IllegalStateException("Field (" + name + ") of class (" + declaringClass + ") does not exist.", e);
+        }
+    }
+
+    @Override
+    public String getDeclaringClassName() {
+        return fieldDescriptor.getDeclaringClass();
+    }
+
+    @Override
+    public String getTypeName() {
+        return fieldDescriptor.getType();
+    }
+
+    @Override
+    public Type getType(Class<?> declaringClass) {
+        try {
+            return declaringClass.getDeclaredField(fieldDescriptor.getName()).getGenericType();
+        } catch (NoSuchFieldException e) {
+            throw new IllegalStateException(
+                    "Cannot find field (" + fieldDescriptor.getName() + ") on class (" + declaringClass + ").",
+                    e);
+        }
+    }
+
+    @Override
+    public String toString() {
+        return fieldDescriptor.toString();
+    }
+
+}

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/domain/common/accessor/gizmo/GizmoFieldHandler.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/domain/common/accessor/gizmo/GizmoFieldHandler.java
@@ -1,6 +1,5 @@
 package org.optaplanner.core.impl.domain.common.accessor.gizmo;
 
-import java.lang.reflect.Field;
 import java.lang.reflect.Type;
 import java.util.function.Consumer;
 
@@ -12,13 +11,11 @@ import io.quarkus.gizmo.ResultHandle;
 final class GizmoFieldHandler implements GizmoMemberHandler {
 
     private final Class<?> declaringClass;
-    private final Field field;
     private final FieldDescriptor fieldDescriptor;
     private final boolean canBeWritten;
 
-    GizmoFieldHandler(Class<?> declaringClass, Field field, FieldDescriptor fieldDescriptor, boolean canBeWritten) {
+    GizmoFieldHandler(Class<?> declaringClass, FieldDescriptor fieldDescriptor, boolean canBeWritten) {
         this.declaringClass = declaringClass;
-        this.field = field;
         this.fieldDescriptor = fieldDescriptor;
         this.canBeWritten = canBeWritten;
     }
@@ -41,15 +38,11 @@ final class GizmoFieldHandler implements GizmoMemberHandler {
     @Override
     public boolean writeMemberValue(MethodDescriptor setter, BytecodeCreator bytecodeCreator, ResultHandle thisObj,
             ResultHandle newValue) {
-        try {
+        if (canBeWritten) {
             bytecodeCreator.writeInstanceField(fieldDescriptor, thisObj, newValue);
             return true;
-        } catch (Exception ex) {
-            if (canBeWritten) {
-                throw new IllegalStateException("Cannot write field (" + field + ") of class (" + declaringClass + ").", ex);
-            } else {
-                return false;
-            }
+        } else {
+            return false;
         }
     }
 

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/domain/common/accessor/gizmo/GizmoMemberDescriptor.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/domain/common/accessor/gizmo/GizmoMemberDescriptor.java
@@ -25,13 +25,13 @@ public class GizmoMemberDescriptor {
      * For a method, if it is a getter, the method name without "get"/"is"
      * and the first letter lowercase; otherwise, the method name.
      */
-    String name;
+    private final String name;
 
     /**
      * If the member is a field, the FieldDescriptor of the member accessor
      * If the member is a method, the MethodDescriptor of the member accessor
      */
-    Object memberDescriptor;
+    private final GizmoMemberHandler memberHandler;
 
     /**
      * If the member is a field, the FieldDescriptor of the member
@@ -39,25 +39,25 @@ public class GizmoMemberDescriptor {
      *
      * Should only be used for metadata (i.e. Generic Type and Annotated Element).
      */
-    Object metadataDescriptor;
+    private final GizmoMemberHandler metadataHandler;
 
     /**
      * The class that declared this member
      */
-    Class<?> declaringClass;
+    private final Class<?> declaringClass;
 
     /**
      * The MethodDescriptor of the corresponding setter. Is empty if not present.
      */
-    Optional<MethodDescriptor> setter;
+    private final MethodDescriptor setter;
 
     /**
      * If final checks should be ignored due to Quarkus transformations
      */
-    boolean ignoreFinalChecks = false;
+    private final boolean ignoreFinalChecks;
 
     public GizmoMemberDescriptor(Member member) {
-        declaringClass = member.getDeclaringClass();
+        this.declaringClass = member.getDeclaringClass();
         if (!Modifier.isPublic(member.getModifiers())) {
             throw new IllegalStateException("Member (" + member.getName() + ") of class (" +
                     member.getDeclaringClass().getName() + ") is not public and domainAccessType is GIZMO.\n" +
@@ -65,22 +65,21 @@ public class GizmoMemberDescriptor {
                     "Maybe use domainAccessType REFLECTION instead of GIZMO.");
         }
         if (member instanceof Field) {
-            memberDescriptor = FieldDescriptor.of((Field) member);
-            name = member.getName();
-            setter = lookupSetter(memberDescriptor, declaringClass, name);
+            FieldDescriptor fieldDescriptor = FieldDescriptor.of((Field) member);
+            this.memberHandler = GizmoMemberHandler.of(fieldDescriptor);
+            this.name = member.getName();
+            this.setter = null;
         } else if (member instanceof Method) {
-            memberDescriptor = MethodDescriptor.ofMethod((Method) member);
-            if (ReflectionHelper.isGetterMethod((Method) member)) {
-                name = ReflectionHelper.getGetterPropertyName(member);
-            } else {
-                name = member.getName();
-            }
-            setter = lookupSetter(memberDescriptor, declaringClass, name);
+            MethodDescriptor methodDescriptor = MethodDescriptor.ofMethod((Method) member);
+            this.memberHandler = GizmoMemberHandler.of(methodDescriptor);
+            this.name = ReflectionHelper.isGetterMethod((Method) member) ? ReflectionHelper.getGetterPropertyName(member)
+                    : member.getName();
+            this.setter = lookupSetter(methodDescriptor, declaringClass, name).orElse(null);
         } else {
             throw new IllegalArgumentException(member + " is not a Method or a Field.");
         }
-
-        metadataDescriptor = memberDescriptor;
+        this.metadataHandler = this.memberHandler;
+        this.ignoreFinalChecks = false;
     }
 
     // For Quarkus
@@ -89,17 +88,22 @@ public class GizmoMemberDescriptor {
     //  from another ClassLoader).
     public GizmoMemberDescriptor(String name, Object memberDescriptor, Object metadataDescriptor, Class<?> declaringClass) {
         this(name, memberDescriptor, metadataDescriptor, declaringClass,
-                lookupSetter(memberDescriptor, declaringClass, name).orElse(null));
-        ignoreFinalChecks = true;
+                lookupSetter(memberDescriptor, declaringClass, name).orElse(null), true);
     }
 
     public GizmoMemberDescriptor(String name, Object memberDescriptor, Object metadataDescriptor, Class<?> declaringClass,
             MethodDescriptor setterDescriptor) {
+        this(name, memberDescriptor, metadataDescriptor, declaringClass, setterDescriptor, false);
+    }
+
+    public GizmoMemberDescriptor(String name, Object memberDescriptor, Object metadataDescriptor, Class<?> declaringClass,
+            MethodDescriptor setterDescriptor, boolean ignoreFinalChecks) {
         this.name = name;
-        this.memberDescriptor = memberDescriptor;
-        this.metadataDescriptor = metadataDescriptor;
+        this.memberHandler = GizmoMemberHandler.of(memberDescriptor);
+        this.metadataHandler = GizmoMemberHandler.of(metadataDescriptor);
         this.declaringClass = declaringClass;
-        setter = Optional.ofNullable(setterDescriptor);
+        this.setter = setterDescriptor;
+        this.ignoreFinalChecks = ignoreFinalChecks;
     }
 
     /**
@@ -110,9 +114,7 @@ public class GizmoMemberDescriptor {
      * @return this
      */
     public GizmoMemberDescriptor whenIsField(Consumer<FieldDescriptor> fieldDescriptorConsumer) {
-        if (memberDescriptor instanceof FieldDescriptor) {
-            fieldDescriptorConsumer.accept((FieldDescriptor) memberDescriptor);
-        }
+        memberHandler.whenIsField(fieldDescriptorConsumer);
         return this;
     }
 
@@ -124,23 +126,12 @@ public class GizmoMemberDescriptor {
      * @return this
      */
     public GizmoMemberDescriptor whenIsMethod(Consumer<MethodDescriptor> methodDescriptorConsumer) {
-        if (memberDescriptor instanceof MethodDescriptor) {
-            methodDescriptorConsumer.accept((MethodDescriptor) memberDescriptor);
-        }
+        memberHandler.whenIsMethod(methodDescriptorConsumer);
         return this;
     }
 
     public ResultHandle readMemberValue(BytecodeCreator bytecodeCreator, ResultHandle thisObj) {
-        if (memberDescriptor instanceof FieldDescriptor) {
-            FieldDescriptor fd = (FieldDescriptor) memberDescriptor;
-            return bytecodeCreator.readInstanceField(fd, thisObj);
-        } else if (memberDescriptor instanceof MethodDescriptor) {
-            MethodDescriptor md = (MethodDescriptor) memberDescriptor;
-            return invokeMemberMethod(bytecodeCreator, md, thisObj);
-        } else {
-            throw new IllegalStateException(
-                    "memberDescriptor (" + memberDescriptor + ") is neither a field descriptor or a method descriptor.");
-        }
+        return memberHandler.readMemberValue(declaringClass, bytecodeCreator, thisObj);
     }
 
     /**
@@ -154,33 +145,8 @@ public class GizmoMemberDescriptor {
      * @return True if it was able to write the member value, false otherwise
      */
     public boolean writeMemberValue(BytecodeCreator bytecodeCreator, ResultHandle thisObj, ResultHandle newValue) {
-        if (memberDescriptor instanceof FieldDescriptor) {
-            FieldDescriptor fd = (FieldDescriptor) memberDescriptor;
-            try {
-                Field field = declaringClass.getField(name);
-                if (!ignoreFinalChecks && Modifier.isFinal(field.getModifiers())) {
-                    throw new IllegalStateException(
-                            "Field (" + name + ") of class (" + declaringClass + ") is final and cannot be modified.");
-                } else {
-                    bytecodeCreator.writeInstanceField(fd, thisObj, newValue);
-                }
-            } catch (NoSuchFieldException e) {
-                throw new IllegalStateException("Field (" + name + ") of class (" + declaringClass + ") does not exist.", e);
-            }
-            return true;
-        } else if (memberDescriptor instanceof MethodDescriptor) {
-            MethodDescriptor md = (MethodDescriptor) memberDescriptor;
-            Optional<MethodDescriptor> maybeSetter = getSetter();
-            if (!maybeSetter.isPresent()) {
-                return false;
-            } else {
-                invokeMemberMethod(bytecodeCreator, maybeSetter.get(), thisObj, newValue);
-                return true;
-            }
-        } else {
-            throw new IllegalStateException(
-                    "memberDescriptor (" + memberDescriptor + ") is neither a field descriptor or a method descriptor.");
-        }
+        return memberHandler.writeMemberValue(declaringClass, name, setter, bytecodeCreator, thisObj, newValue,
+                ignoreFinalChecks);
     }
 
     /**
@@ -191,9 +157,7 @@ public class GizmoMemberDescriptor {
      * @return this
      */
     public GizmoMemberDescriptor whenMetadataIsOnField(Consumer<FieldDescriptor> fieldDescriptorConsumer) {
-        if (metadataDescriptor instanceof FieldDescriptor) {
-            fieldDescriptorConsumer.accept((FieldDescriptor) metadataDescriptor);
-        }
+        metadataHandler.whenIsField(fieldDescriptorConsumer);
         return this;
     }
 
@@ -205,9 +169,7 @@ public class GizmoMemberDescriptor {
      * @return this
      */
     public GizmoMemberDescriptor whenMetadataIsOnMethod(Consumer<MethodDescriptor> methodDescriptorConsumer) {
-        if (metadataDescriptor instanceof MethodDescriptor) {
-            methodDescriptorConsumer.accept((MethodDescriptor) metadataDescriptor);
-        }
+        metadataHandler.whenIsMethod(methodDescriptorConsumer);
         return this;
     }
 
@@ -218,44 +180,14 @@ public class GizmoMemberDescriptor {
      * @return Returns the declaring class name of the member in descriptor format
      */
     public String getDeclaringClassName() {
-        if (memberDescriptor instanceof FieldDescriptor) {
-            return ((FieldDescriptor) memberDescriptor).getDeclaringClass();
-        } else if (memberDescriptor instanceof MethodDescriptor) {
-            return ((MethodDescriptor) memberDescriptor).getDeclaringClass();
-        } else {
-            throw new IllegalStateException("memberDescriptor not a fieldDescriptor or a methodDescriptor");
-        }
-    }
-
-    /**
-     * Returns true iff the getter is from an interface.
-     *
-     * @return true iff the getter is from an interface
-     */
-    public boolean isInterfaceMethod() {
-        if (memberDescriptor instanceof MethodDescriptor) {
-            return declaringClass.isInterface();
-        } else {
-            return false;
-        }
-    }
-
-    public ResultHandle invokeMemberMethod(BytecodeCreator creator, MethodDescriptor method, ResultHandle bean,
-            ResultHandle... parameters) {
-        if (isInterfaceMethod()) {
-            return creator.invokeInterfaceMethod(method, bean, parameters);
-        } else {
-            return creator.invokeVirtualMethod(method, bean, parameters);
-        }
+        return memberHandler.getDeclaringClassName();
     }
 
     public Optional<MethodDescriptor> getSetter() {
-        return setter;
+        return Optional.ofNullable(setter);
     }
 
-    private static Optional<MethodDescriptor> lookupSetter(Object memberDescriptor,
-            Class<?> declaringClass,
-            String name) {
+    private static Optional<MethodDescriptor> lookupSetter(Object memberDescriptor, Class<?> declaringClass, String name) {
         if (memberDescriptor instanceof MethodDescriptor) {
             return Optional.ofNullable(ReflectionHelper.getSetterMethod(declaringClass, name))
                     .map(MethodDescriptor::ofMethod);
@@ -273,41 +205,16 @@ public class GizmoMemberDescriptor {
      * The name does not include generic information.
      */
     public String getTypeName() {
-        String typeName;
-        if (metadataDescriptor instanceof FieldDescriptor) {
-            typeName = ((FieldDescriptor) metadataDescriptor).getType();
-        } else {
-            // Must be a method descriptor if it not a field descriptor
-            typeName = ((MethodDescriptor) metadataDescriptor).getReturnType();
-        }
+        String typeName = metadataHandler.getTypeName();
         return org.objectweb.asm.Type.getType(typeName).getClassName();
     }
 
     public Type getType() {
-        if (metadataDescriptor instanceof FieldDescriptor) {
-            FieldDescriptor fieldDescriptor = (FieldDescriptor) metadataDescriptor;
-            try {
-                return declaringClass.getDeclaredField(fieldDescriptor.getName()).getGenericType();
-            } catch (NoSuchFieldException e) {
-                throw new IllegalStateException(
-                        "Cannot find field (" + fieldDescriptor.getName() + ") on class (" + declaringClass + ").",
-                        e);
-            }
-        } else {
-            // Must be a method descriptor if it not a field descriptor
-            MethodDescriptor methodDescriptor = (MethodDescriptor) metadataDescriptor;
-            try {
-                return declaringClass.getDeclaredMethod(methodDescriptor.getName()).getGenericReturnType();
-            } catch (NoSuchMethodException e) {
-                throw new IllegalStateException(
-                        "Cannot find method (" + methodDescriptor.getName() + ") on class (" + declaringClass + ").",
-                        e);
-            }
-        }
+        return metadataHandler.getType(declaringClass);
     }
 
     @Override
     public String toString() {
-        return memberDescriptor.toString();
+        return memberHandler.toString();
     }
 }

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/domain/common/accessor/gizmo/GizmoMemberDescriptor.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/domain/common/accessor/gizmo/GizmoMemberDescriptor.java
@@ -16,38 +16,33 @@ import io.quarkus.gizmo.MethodDescriptor;
 import io.quarkus.gizmo.ResultHandle;
 
 /**
- * Describe and provide simplified/unified access for a Member
+ * Describe and provide simplified/unified access for {@link Member}.
  */
-public class GizmoMemberDescriptor {
+public final class GizmoMemberDescriptor {
 
     /**
-     * The name of a member. For a field, it the field name.
-     * For a method, if it is a getter, the method name without "get"/"is"
-     * and the first letter lowercase; otherwise, the method name.
+     * The name of a member.
+     * For a field, it is the field name.
+     * For a method,
+     * if it is a getter, the method name without "get"/"is" and the first letter lowercase;
+     * otherwise, the method name.
      */
     private final String name;
 
-    /**
-     * If the member is a field, the FieldDescriptor of the member accessor
-     * If the member is a method, the MethodDescriptor of the member accessor
-     */
     private final GizmoMemberHandler memberHandler;
 
     /**
-     * If the member is a field, the FieldDescriptor of the member
-     * If the member is a method, the MethodDescriptor of the member
-     *
      * Should only be used for metadata (i.e. Generic Type and Annotated Element).
      */
     private final GizmoMemberHandler metadataHandler;
 
     /**
-     * The class that declared this member
+     * The class that declared this member.
      */
     private final Class<?> declaringClass;
 
     /**
-     * The MethodDescriptor of the corresponding setter. Is empty if not present.
+     * The MethodDescriptor of the corresponding setter. Empty if not present.
      */
     private final MethodDescriptor setter;
 
@@ -76,13 +71,6 @@ public class GizmoMemberDescriptor {
         this.metadataHandler = this.memberHandler;
     }
 
-    /**
-     * Called when the member is a field and that field has already been made final.
-     *
-     * @param name
-     * @param memberDescriptor
-     * @param declaringClass
-     */
     public GizmoMemberDescriptor(String name, Object memberDescriptor, Class<?> declaringClass) {
         this(name, memberDescriptor, memberDescriptor, declaringClass, null);
     }

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/domain/common/accessor/gizmo/GizmoMemberDescriptor.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/domain/common/accessor/gizmo/GizmoMemberDescriptor.java
@@ -52,13 +52,13 @@ public final class GizmoMemberDescriptor {
         if (member instanceof Field) {
             FieldDescriptor fieldDescriptor = FieldDescriptor.of((Field) member);
             this.name = member.getName();
-            this.memberHandler = GizmoMemberHandler.of(declaringClass, name, fieldDescriptor);
+            this.memberHandler = GizmoMemberHandler.of(declaringClass, name, fieldDescriptor, false);
             this.setter = null;
         } else if (member instanceof Method) {
             MethodDescriptor methodDescriptor = MethodDescriptor.ofMethod((Method) member);
             this.name = ReflectionHelper.isGetterMethod((Method) member) ? ReflectionHelper.getGetterPropertyName(member)
                     : member.getName();
-            this.memberHandler = GizmoMemberHandler.of(declaringClass, name, methodDescriptor);
+            this.memberHandler = GizmoMemberHandler.of(declaringClass, methodDescriptor);
             this.setter = lookupSetter(methodDescriptor, declaringClass, name).orElse(null);
         } else {
             throw new IllegalArgumentException(member + " is not a Method or a Field.");
@@ -66,16 +66,35 @@ public final class GizmoMemberDescriptor {
         this.metadataHandler = this.memberHandler;
     }
 
-    public GizmoMemberDescriptor(String name, Object memberDescriptor, Class<?> declaringClass) {
-        this(name, memberDescriptor, memberDescriptor, declaringClass, null);
+    public GizmoMemberDescriptor(String name, FieldDescriptor fieldDescriptor, Class<?> declaringClass) {
+        this.name = name;
+        this.memberHandler = GizmoMemberHandler.of(declaringClass, name, fieldDescriptor, true);
+        this.metadataHandler = this.memberHandler;
+        this.setter = null;
     }
 
-    public GizmoMemberDescriptor(String name, Object memberDescriptor, Object metadataDescriptor, Class<?> declaringClass,
+    public GizmoMemberDescriptor(String name, MethodDescriptor memberDescriptor, MethodDescriptor metadataDescriptor,
+            Class<?> declaringClass, MethodDescriptor setterDescriptor) {
+        this.name = name;
+        this.memberHandler = GizmoMemberHandler.of(declaringClass, memberDescriptor);
+        this.metadataHandler = memberDescriptor == metadataDescriptor ? this.memberHandler
+                : GizmoMemberHandler.of(declaringClass, metadataDescriptor);
+        this.setter = setterDescriptor;
+    }
+
+    public GizmoMemberDescriptor(String name, MethodDescriptor memberDescriptor, Class<?> declaringClass,
             MethodDescriptor setterDescriptor) {
         this.name = name;
-        this.memberHandler = GizmoMemberHandler.of(declaringClass, name, memberDescriptor);
-        this.metadataHandler = memberDescriptor == metadataDescriptor ? this.memberHandler
-                : GizmoMemberHandler.of(declaringClass, name, metadataDescriptor);
+        this.memberHandler = GizmoMemberHandler.of(declaringClass, memberDescriptor);
+        this.metadataHandler = this.memberHandler;
+        this.setter = setterDescriptor;
+    }
+
+    public GizmoMemberDescriptor(String name, MethodDescriptor memberDescriptor, FieldDescriptor metadataDescriptor,
+            Class<?> declaringClass, MethodDescriptor setterDescriptor) {
+        this.name = name;
+        this.memberHandler = GizmoMemberHandler.of(declaringClass, memberDescriptor);
+        this.metadataHandler = GizmoMemberHandler.of(declaringClass, name, metadataDescriptor, true);
         this.setter = setterDescriptor;
     }
 

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/domain/common/accessor/gizmo/GizmoMemberDescriptor.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/domain/common/accessor/gizmo/GizmoMemberDescriptor.java
@@ -37,17 +37,12 @@ public final class GizmoMemberDescriptor {
     private final GizmoMemberHandler metadataHandler;
 
     /**
-     * The class that declared this member.
-     */
-    private final Class<?> declaringClass;
-
-    /**
      * The MethodDescriptor of the corresponding setter. Empty if not present.
      */
     private final MethodDescriptor setter;
 
     public GizmoMemberDescriptor(Member member) {
-        this.declaringClass = member.getDeclaringClass();
+        Class<?> declaringClass = member.getDeclaringClass();
         if (!Modifier.isPublic(member.getModifiers())) {
             throw new IllegalStateException("Member (" + member.getName() + ") of class (" +
                     member.getDeclaringClass().getName() + ") is not public and domainAccessType is GIZMO.\n" +
@@ -81,7 +76,6 @@ public final class GizmoMemberDescriptor {
         this.memberHandler = GizmoMemberHandler.of(declaringClass, name, memberDescriptor);
         this.metadataHandler = memberDescriptor == metadataDescriptor ? this.memberHandler
                 : GizmoMemberHandler.of(declaringClass, name, metadataDescriptor);
-        this.declaringClass = declaringClass;
         this.setter = setterDescriptor;
     }
 

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/domain/common/accessor/gizmo/GizmoMemberHandler.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/domain/common/accessor/gizmo/GizmoMemberHandler.java
@@ -18,18 +18,18 @@ interface GizmoMemberHandler {
      *
      * @param declaringClass never null, class that declares the {@link Field} in question
      * @param name never null, name of the field
-     * @param memberDescriptor never null, descriptor of the {@link Field} in question
+     * @param fieldDescriptor never null, descriptor of the {@link Field} in question
      * @param ignoreFinalChecks true if Quarkus will make the field non-final for us
      * @return never null
      */
-    static GizmoMemberHandler of(Class<?> declaringClass, String name, FieldDescriptor memberDescriptor,
+    static GizmoMemberHandler of(Class<?> declaringClass, String name, FieldDescriptor fieldDescriptor,
             boolean ignoreFinalChecks) {
         try {
             Field field = declaringClass.getField(name);
-            return new GizmoFieldHandler(declaringClass, memberDescriptor,
+            return new GizmoFieldHandler(declaringClass, fieldDescriptor,
                     ignoreFinalChecks || !Modifier.isFinal(field.getModifiers()));
         } catch (NoSuchFieldException e) { // The field is only used for its metadata and never actually called.
-            return new GizmoFieldHandler(declaringClass, memberDescriptor, false);
+            return new GizmoFieldHandler(declaringClass, fieldDescriptor, false);
         }
     }
 
@@ -37,11 +37,11 @@ interface GizmoMemberHandler {
      * Creates handler for a {@link Method}.
      *
      * @param declaringClass never null, class that declares the {@link Method} in question
-     * @param memberDescriptor never null, descriptor of the {@link Method} in question
+     * @param methodDescriptor never null, descriptor of the {@link Method} in question
      * @return never null
      */
-    static GizmoMemberHandler of(Class<?> declaringClass, MethodDescriptor memberDescriptor) {
-        return new GizmoMethodHandler(declaringClass, memberDescriptor);
+    static GizmoMemberHandler of(Class<?> declaringClass, MethodDescriptor methodDescriptor) {
+        return new GizmoMethodHandler(declaringClass, methodDescriptor);
     }
 
     void whenIsField(Consumer<FieldDescriptor> fieldDescriptorConsumer);

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/domain/common/accessor/gizmo/GizmoMemberHandler.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/domain/common/accessor/gizmo/GizmoMemberHandler.java
@@ -1,6 +1,7 @@
 package org.optaplanner.core.impl.domain.common.accessor.gizmo;
 
 import java.lang.reflect.Field;
+import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.lang.reflect.Type;
 import java.util.function.Consumer;
@@ -12,21 +13,35 @@ import io.quarkus.gizmo.ResultHandle;
 
 interface GizmoMemberHandler {
 
-    static GizmoMemberHandler of(Class<?> declaringClass, String name, Object memberDescriptor) {
-        if (memberDescriptor instanceof FieldDescriptor) {
-            try {
-                Field field = declaringClass.getField(name);
-                return new GizmoFieldHandler(declaringClass, field, (FieldDescriptor) memberDescriptor,
-                        !Modifier.isFinal(field.getModifiers()));
-            } catch (NoSuchFieldException e) { // The field is only used for its metadata and never actually called.
-                return new GizmoFieldHandler(declaringClass, null, (FieldDescriptor) memberDescriptor, false);
-            }
-        } else if (memberDescriptor instanceof MethodDescriptor) {
-            return new GizmoMethodHandler(declaringClass, (MethodDescriptor) memberDescriptor);
-        } else {
-            throw new IllegalStateException("Impossible state: memberDescriptor not " + FieldDescriptor.class.getSimpleName()
-                    + " or " + MethodDescriptor.class.getSimpleName() + ".");
+    /**
+     * Creates handler for a {@link Field}.
+     *
+     * @param declaringClass never null, class that declares the {@link Field} in question
+     * @param name never null, name of the field
+     * @param memberDescriptor never null, descriptor of the {@link Field} in question
+     * @param ignoreFinalChecks true if Quarkus will make the field non-final for us
+     * @return never null
+     */
+    static GizmoMemberHandler of(Class<?> declaringClass, String name, FieldDescriptor memberDescriptor,
+            boolean ignoreFinalChecks) {
+        try {
+            Field field = declaringClass.getField(name);
+            return new GizmoFieldHandler(declaringClass, memberDescriptor,
+                    ignoreFinalChecks || !Modifier.isFinal(field.getModifiers()));
+        } catch (NoSuchFieldException e) { // The field is only used for its metadata and never actually called.
+            return new GizmoFieldHandler(declaringClass, memberDescriptor, false);
         }
+    }
+
+    /**
+     * Creates handler for a {@link Method}.
+     *
+     * @param declaringClass never null, class that declares the {@link Method} in question
+     * @param memberDescriptor never null, descriptor of the {@link Method} in question
+     * @return never null
+     */
+    static GizmoMemberHandler of(Class<?> declaringClass, MethodDescriptor memberDescriptor) {
+        return new GizmoMethodHandler(declaringClass, memberDescriptor);
     }
 
     void whenIsField(Consumer<FieldDescriptor> fieldDescriptorConsumer);

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/domain/common/accessor/gizmo/GizmoMemberHandler.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/domain/common/accessor/gizmo/GizmoMemberHandler.java
@@ -1,0 +1,39 @@
+package org.optaplanner.core.impl.domain.common.accessor.gizmo;
+
+import java.lang.reflect.Type;
+import java.util.function.Consumer;
+
+import io.quarkus.gizmo.BytecodeCreator;
+import io.quarkus.gizmo.FieldDescriptor;
+import io.quarkus.gizmo.MethodDescriptor;
+import io.quarkus.gizmo.ResultHandle;
+
+public interface GizmoMemberHandler {
+
+    static GizmoMemberHandler of(Object memberDescriptor) {
+        if (memberDescriptor instanceof FieldDescriptor) {
+            return new GizmoFieldHandler((FieldDescriptor) memberDescriptor);
+        } else if (memberDescriptor instanceof MethodDescriptor) {
+            return new GizmoMethodHandler((MethodDescriptor) memberDescriptor);
+        } else {
+            throw new IllegalStateException("Impossible state: memberDescriptor not " + FieldDescriptor.class.getSimpleName()
+                    + " or " + MethodDescriptor.class.getSimpleName() + ".");
+        }
+    }
+
+    void whenIsField(Consumer<FieldDescriptor> fieldDescriptorConsumer);
+
+    void whenIsMethod(Consumer<MethodDescriptor> methodDescriptorConsumer);
+
+    ResultHandle readMemberValue(Class<?> declaringClass, BytecodeCreator bytecodeCreator, ResultHandle thisObj);
+
+    boolean writeMemberValue(Class<?> declaringClass, String name, MethodDescriptor setter, BytecodeCreator bytecodeCreator,
+            ResultHandle thisObj, ResultHandle newValue, boolean ignoreFinalChecks);
+
+    String getDeclaringClassName();
+
+    String getTypeName();
+
+    Type getType(Class<?> declaringClass);
+
+}

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/domain/common/accessor/gizmo/GizmoMethodHandler.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/domain/common/accessor/gizmo/GizmoMethodHandler.java
@@ -10,9 +10,11 @@ import io.quarkus.gizmo.ResultHandle;
 
 final class GizmoMethodHandler implements GizmoMemberHandler {
 
+    private final Class<?> declaringClass;
     private final MethodDescriptor methodDescriptor;
 
-    GizmoMethodHandler(MethodDescriptor methodDescriptor) {
+    GizmoMethodHandler(Class<?> declaringClass, MethodDescriptor methodDescriptor) {
+        this.declaringClass = declaringClass;
         this.methodDescriptor = methodDescriptor;
     }
 
@@ -27,15 +29,15 @@ final class GizmoMethodHandler implements GizmoMemberHandler {
     }
 
     @Override
-    public ResultHandle readMemberValue(Class<?> declaringClass, BytecodeCreator bytecodeCreator, ResultHandle thisObj) {
+    public ResultHandle readMemberValue(BytecodeCreator bytecodeCreator, ResultHandle thisObj) {
         return invokeMemberMethod(declaringClass, bytecodeCreator, methodDescriptor, thisObj);
     }
 
     @Override
-    public boolean writeMemberValue(Class<?> declaringClass, String name, MethodDescriptor setter,
-            BytecodeCreator bytecodeCreator, ResultHandle thisObj, ResultHandle newValue, boolean ignoreFinalChecks) {
+    public boolean writeMemberValue(MethodDescriptor setter, BytecodeCreator bytecodeCreator, ResultHandle thisObj,
+            ResultHandle newValue) {
         if (setter == null) {
-            return false;
+            throw new UnsupportedOperationException();
         } else {
             invokeMemberMethod(declaringClass, bytecodeCreator, setter, thisObj, newValue);
             return true;
@@ -62,7 +64,7 @@ final class GizmoMethodHandler implements GizmoMemberHandler {
     }
 
     @Override
-    public Type getType(Class<?> declaringClass) {
+    public Type getType() {
         try {
             return declaringClass.getDeclaredMethod(methodDescriptor.getName()).getGenericReturnType();
         } catch (NoSuchMethodException e) {

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/domain/common/accessor/gizmo/GizmoMethodHandler.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/domain/common/accessor/gizmo/GizmoMethodHandler.java
@@ -37,7 +37,7 @@ final class GizmoMethodHandler implements GizmoMemberHandler {
     public boolean writeMemberValue(MethodDescriptor setter, BytecodeCreator bytecodeCreator, ResultHandle thisObj,
             ResultHandle newValue) {
         if (setter == null) {
-            throw new UnsupportedOperationException();
+            return false;
         } else {
             invokeMemberMethod(declaringClass, bytecodeCreator, setter, thisObj, newValue);
             return true;

--- a/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/domain/solution/cloner/GizmoSolutionClonerTest.java
+++ b/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/domain/solution/cloner/GizmoSolutionClonerTest.java
@@ -118,7 +118,7 @@ class GizmoSolutionClonerTest extends AbstractSolutionClonerTest {
                     String name = field.getName();
 
                     if (Modifier.isPublic(field.getModifiers())) {
-                        member = new GizmoMemberDescriptor(name, memberDescriptor, memberDescriptor, declaringClass);
+                        member = new GizmoMemberDescriptor(name, memberDescriptor, declaringClass);
                     } else {
                         Method getter = ReflectionHelper.getGetterMethod(currentClass, field.getName());
                         Method setter = ReflectionHelper.getSetterMethod(currentClass, field.getName());

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/main/java/org/optaplanner/quarkus/deployment/GizmoMemberAccessorEntityEnhancer.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/main/java/org/optaplanner/quarkus/deployment/GizmoMemberAccessorEntityEnhancer.java
@@ -206,8 +206,7 @@ final class GizmoMemberAccessorEntityEnhancer {
         MethodDescriptor memberDescriptor = MethodDescriptor.of(methodInfo);
 
         if (Modifier.isPublic(methodInfo.flags())) {
-            member = new GizmoMemberDescriptor(name, memberDescriptor, memberDescriptor, declaringClass,
-                    setterDescriptor.orElse(null));
+            member = new GizmoMemberDescriptor(name, memberDescriptor, declaringClass, setterDescriptor.orElse(null));
         } else {
             setterDescriptor = addVirtualMethodGetter(classInfo, methodInfo, name, setterDescriptor, transformers);
             String methodName = getVirtualGetterName(false, name);

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/main/java/org/optaplanner/quarkus/deployment/GizmoMemberAccessorEntityEnhancer.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/main/java/org/optaplanner/quarkus/deployment/GizmoMemberAccessorEntityEnhancer.java
@@ -114,7 +114,7 @@ final class GizmoMemberAccessorEntityEnhancer {
         }
 
         if (Modifier.isPublic(fieldInfo.flags())) {
-            member = new GizmoMemberDescriptor(name, memberDescriptor, memberDescriptor, declaringClass);
+            member = new GizmoMemberDescriptor(name, memberDescriptor, declaringClass);
         } else {
             addVirtualFieldGetter(classInfo, fieldInfo, transformers);
             String methodName = getVirtualGetterName(true, fieldInfo.name());
@@ -364,7 +364,7 @@ final class GizmoMemberAccessorEntityEnhancer {
 
                     // Not being recorded, so can use Type and annotated element directly
                     if (Modifier.isPublic(field.getModifiers())) {
-                        member = new GizmoMemberDescriptor(name, memberDescriptor, memberDescriptor, declaringClass);
+                        member = new GizmoMemberDescriptor(name, memberDescriptor, declaringClass);
                     } else {
                         addVirtualFieldGetter(declaringClass, field, transformers);
                         String methodName = getVirtualGetterName(true, field.getName());

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/main/java/org/optaplanner/quarkus/deployment/GizmoMemberAccessorEntityEnhancer.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/main/java/org/optaplanner/quarkus/deployment/GizmoMemberAccessorEntityEnhancer.java
@@ -93,53 +93,21 @@ final class GizmoMemberAccessorEntityEnhancer {
      *
      * @param annotationInstance The annotations on the field
      * @param classOutput Where to output the bytecode
-     * @param classInfo The declaring class for the field
      * @param fieldInfo The field to generate the MemberAccessor for
      * @param transformers BuildProducer of BytecodeTransformers
      */
-    public String generateFieldAccessor(AnnotationInstance annotationInstance, ClassOutput classOutput,
-            ClassInfo classInfo, FieldInfo fieldInfo, BuildProducer<BytecodeTransformerBuildItem> transformers)
-            throws ClassNotFoundException, NoSuchFieldException {
+    public String generateFieldAccessor(AnnotationInstance annotationInstance, ClassOutput classOutput, FieldInfo fieldInfo,
+            BuildProducer<BytecodeTransformerBuildItem> transformers) throws ClassNotFoundException, NoSuchFieldException {
         Class<?> declaringClass = Class.forName(fieldInfo.declaringClass().name().toString(), false,
                 Thread.currentThread().getContextClassLoader());
         Field fieldMember = declaringClass.getDeclaredField(fieldInfo.name());
-        String generatedClassName = GizmoMemberAccessorFactory.getGeneratedClassName(fieldMember);
-        GizmoMemberDescriptor member;
-
-        FieldDescriptor memberDescriptor = FieldDescriptor.of(fieldInfo);
-        String name = fieldInfo.name();
-
-        if (Modifier.isFinal(fieldMember.getModifiers())) {
-            makeFieldNonFinal(fieldMember, transformers);
-        }
-
-        if (Modifier.isPublic(fieldInfo.flags())) {
-            member = new GizmoMemberDescriptor(name, memberDescriptor, declaringClass);
-        } else {
-            addVirtualFieldGetter(classInfo, fieldInfo, transformers);
-            String methodName = getVirtualGetterName(true, fieldInfo.name());
-            MethodDescriptor getterDescriptor = MethodDescriptor.ofMethod(fieldInfo.declaringClass().name().toString(),
-                    methodName,
-                    fieldInfo.type().name().toString());
-            MethodDescriptor setterDescriptor = MethodDescriptor.ofMethod(fieldInfo.declaringClass().name().toString(),
-                    getVirtualSetterName(true, fieldInfo.name()),
-                    "void",
-                    fieldInfo.type().name().toString());
-            member = new GizmoMemberDescriptor(name, getterDescriptor, memberDescriptor, declaringClass, setterDescriptor);
-        }
+        GizmoMemberDescriptor member = createMemberDescriptorForField(fieldMember, transformers);
         GizmoMemberInfo memberInfo = new GizmoMemberInfo(member,
                 (Class<? extends Annotation>) Class.forName(annotationInstance.name().toString(), false,
                         Thread.currentThread().getContextClassLoader()));
+        String generatedClassName = GizmoMemberAccessorFactory.getGeneratedClassName(fieldMember);
         GizmoMemberAccessorImplementor.defineAccessorFor(generatedClassName, classOutput, memberInfo);
         return generatedClassName;
-    }
-
-    private void addVirtualFieldGetter(ClassInfo classInfo, FieldInfo fieldInfo,
-            BuildProducer<BytecodeTransformerBuildItem> transformers) throws ClassNotFoundException, NoSuchFieldException {
-        Class<?> clazz = Class.forName(classInfo.name().toString(), false,
-                Thread.currentThread().getContextClassLoader());
-        Field field = clazz.getDeclaredField(fieldInfo.name());
-        addVirtualFieldGetter(clazz, field, transformers);
     }
 
     private void addVirtualFieldGetter(Class<?> classInfo, Field fieldInfo,
@@ -351,34 +319,10 @@ final class GizmoMemberAccessorEntityEnhancer {
         Class<?> currentClass = entityClass;
         while (currentClass != null) {
             for (Field field : currentClass.getDeclaredFields()) {
-                if (!Modifier.isStatic(field.getModifiers())) {
-                    GizmoMemberDescriptor member;
-                    Class<?> declaringClass = field.getDeclaringClass();
-                    FieldDescriptor memberDescriptor = FieldDescriptor.of(field);
-                    String name = field.getName();
-
-                    if (Modifier.isFinal(field.getModifiers())) {
-                        makeFieldNonFinal(field, transformers);
-                    }
-
-                    // Not being recorded, so can use Type and annotated element directly
-                    if (Modifier.isPublic(field.getModifiers())) {
-                        member = new GizmoMemberDescriptor(name, memberDescriptor, declaringClass);
-                    } else {
-                        addVirtualFieldGetter(declaringClass, field, transformers);
-                        String methodName = getVirtualGetterName(true, field.getName());
-                        MethodDescriptor getterDescriptor = MethodDescriptor.ofMethod(field.getDeclaringClass().getName(),
-                                methodName,
-                                field.getType());
-                        MethodDescriptor setterDescriptor = MethodDescriptor.ofMethod(field.getDeclaringClass().getName(),
-                                getVirtualSetterName(true, field.getName()),
-                                "void",
-                                field.getType());
-                        member = new GizmoMemberDescriptor(name, getterDescriptor, memberDescriptor, declaringClass,
-                                setterDescriptor);
-                    }
-                    solutionFieldToMemberDescriptor.put(field, member);
+                if (Modifier.isStatic(field.getModifiers())) {
+                    continue;
                 }
+                solutionFieldToMemberDescriptor.put(field, createMemberDescriptorForField(field, transformers));
             }
             currentClass = currentClass.getSuperclass();
         }
@@ -386,6 +330,31 @@ final class GizmoMemberAccessorEntityEnhancer {
                 new GizmoSolutionOrEntityDescriptor(solutionDescriptor, entityClass, solutionFieldToMemberDescriptor);
         memoizedMap.put(entityClass, out);
         return out;
+    }
+
+    private GizmoMemberDescriptor createMemberDescriptorForField(Field field,
+            BuildProducer<BytecodeTransformerBuildItem> transformers) {
+        if (Modifier.isFinal(field.getModifiers())) {
+            makeFieldNonFinal(field, transformers);
+        }
+
+        Class<?> declaringClass = field.getDeclaringClass();
+        FieldDescriptor memberDescriptor = FieldDescriptor.of(field);
+        String name = field.getName();
+
+        // Not being recorded, so can use Type and annotated element directly
+        if (Modifier.isPublic(field.getModifiers())) {
+            return new GizmoMemberDescriptor(name, memberDescriptor, declaringClass);
+        } else {
+            addVirtualFieldGetter(declaringClass, field, transformers);
+            String getterName = getVirtualGetterName(true, name);
+            MethodDescriptor getterDescriptor =
+                    MethodDescriptor.ofMethod(declaringClass.getName(), getterName, field.getType());
+            String setterName = getVirtualSetterName(true, name);
+            MethodDescriptor setterDescriptor =
+                    MethodDescriptor.ofMethod(declaringClass.getName(), setterName, "void", field.getType());
+            return new GizmoMemberDescriptor(name, getterDescriptor, memberDescriptor, declaringClass, setterDescriptor);
+        }
     }
 
     public static Map<String, RuntimeValue<MemberAccessor>> getGeneratedGizmoMemberAccessorMap(RecorderContext recorderContext,

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/main/java/org/optaplanner/quarkus/deployment/OptaPlannerProcessor.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/main/java/org/optaplanner/quarkus/deployment/OptaPlannerProcessor.java
@@ -631,9 +631,9 @@ class OptaPlannerProcessor {
                         ClassInfo classInfo = fieldInfo.declaringClass();
 
                         try {
-                            generatedMemberAccessorsClassNameSet
-                                    .add(entityEnhancer.generateFieldAccessor(annotatedMember, classOutput, classInfo,
-                                            fieldInfo, transformers));
+                            generatedMemberAccessorsClassNameSet.add(
+                                    entityEnhancer.generateFieldAccessor(annotatedMember, classOutput, fieldInfo,
+                                            transformers));
                         } catch (ClassNotFoundException | NoSuchFieldException e) {
                             throw new IllegalStateException("Fail to generate member accessor for field (" +
                                     fieldInfo.name() + ") of the class( " +

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/test/java/org/optaplanner/quarkus/OptaPlannerProcessorPrivateConstructorTest.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/test/java/org/optaplanner/quarkus/OptaPlannerProcessorPrivateConstructorTest.java
@@ -39,6 +39,7 @@ class OptaPlannerProcessorPrivateConstructorTest {
                         new PrivateNoArgsConstructorEntity("3")));
         PrivateNoArgsConstructorSolution solution = solverManager.solve(1L, problem).getFinalBestSolution();
         Assertions.assertEquals(solution.score.score(), 0);
+        Assertions.assertEquals(solution.someField, 2);
     }
 
 }

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/test/java/org/optaplanner/quarkus/testdata/gizmo/PrivateNoArgsConstructorSolution.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/test/java/org/optaplanner/quarkus/testdata/gizmo/PrivateNoArgsConstructorSolution.java
@@ -15,15 +15,17 @@ public class PrivateNoArgsConstructorSolution {
     List<PrivateNoArgsConstructorEntity> planningEntityList;
 
     @PlanningScore
-    public final SimpleScore score;
+    public SimpleScore score;
+
+    public final int someField;
 
     private PrivateNoArgsConstructorSolution() {
-        score = null;
+        this.someField = 1;
     }
 
     public PrivateNoArgsConstructorSolution(List<PrivateNoArgsConstructorEntity> planningEntityList) {
         this.planningEntityList = planningEntityList;
-        score = null;
+        this.someField = 2;
     }
 
     @ValueRangeProvider(id = "valueRange")


### PR DESCRIPTION
This PR cleans up the logic in Gizmo accessors,
removing instanceof checks during read and write operations.
This should make the code read better.