### PR TITLE
Nearby config tests

### DIFF
--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/config/heuristic/selector/common/nearby/NearbySelectionConfig.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/config/heuristic/selector/common/nearby/NearbySelectionConfig.java
@@ -270,21 +270,22 @@ public class NearbySelectionConfig extends SelectorConfig<NearbySelectionConfig>
         }
         if (nearbyDistanceMeterClass == null) {
             throw new IllegalArgumentException("The nearbySelectorConfig (" + this
-                    + ") is nearby selection"
-                    + " but lacks a nearbyDistanceMeterClass (" + nearbyDistanceMeterClass + ").");
+                    + ") is nearby selection but lacks a nearbyDistanceMeterClass (" + nearbyDistanceMeterClass + ").");
         }
         if (resolvedSelectionOrder != SelectionOrder.ORIGINAL && resolvedSelectionOrder != SelectionOrder.RANDOM) {
             throw new IllegalArgumentException("The nearbySelectorConfig (" + this
-                    + ") with nearbyOriginEntitySelector (" + originEntitySelectorConfig
-                    + ") and nearbyOriginValueSelector (" + originValueSelectorConfig
+                    + ") with originEntitySelector (" + originEntitySelectorConfig
+                    + ") and originSubListSelector (" + originSubListSelectorConfig
+                    + ") and originValueSelector (" + originValueSelectorConfig
                     + ") and nearbyDistanceMeterClass (" + nearbyDistanceMeterClass
                     + ") has a resolvedSelectionOrder (" + resolvedSelectionOrder
                     + ") that is not " + SelectionOrder.ORIGINAL + " or " + SelectionOrder.RANDOM + ".");
         }
         if (resolvedCacheType.isCached()) {
             throw new IllegalArgumentException("The nearbySelectorConfig (" + this
-                    + ") with nearbyOriginEntitySelector (" + originEntitySelectorConfig
-                    + ") and nearbyOriginValueSelector (" + originValueSelectorConfig
+                    + ") with originEntitySelector (" + originEntitySelectorConfig
+                    + ") and originSubListSelector (" + originSubListSelectorConfig
+                    + ") and originValueSelector (" + originValueSelectorConfig
                     + ") and nearbyDistanceMeterClass (" + nearbyDistanceMeterClass
                     + ") has a resolvedCacheType (" + resolvedCacheType
                     + ") that is cached.");

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/entity/EntitySelectorFactory.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/entity/EntitySelectorFactory.java
@@ -181,7 +181,8 @@ public class EntitySelectorFactory<Solution_> extends AbstractSelectorFactory<So
             SelectionOrder resolvedSelectionOrder, EntitySelector<Solution_> entitySelector) {
         boolean randomSelection = resolvedSelectionOrder.toRandomSelectionBoolean();
         if (nearbySelectionConfig.getOriginEntitySelectorConfig() == null) {
-            throw new IllegalArgumentException("TODO");
+            throw new IllegalArgumentException("The entitySelector (" + config
+                    + ")'s nearbySelectionConfig (" + nearbySelectionConfig + ") requires an originEntitySelector.");
         }
         EntitySelectorFactory<Solution_> entitySelectorFactory =
                 EntitySelectorFactory.create(nearbySelectionConfig.getOriginEntitySelectorConfig());

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/DestinationSelectorFactory.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/DestinationSelectorFactory.java
@@ -1,5 +1,7 @@
 package org.optaplanner.core.impl.heuristic.selector.move.generic.list;
 
+import java.util.Objects;
+
 import org.optaplanner.core.api.domain.valuerange.ValueRangeProvider;
 import org.optaplanner.core.config.heuristic.selector.common.SelectionCacheType;
 import org.optaplanner.core.config.heuristic.selector.common.SelectionOrder;
@@ -49,7 +51,7 @@ public final class DestinationSelectorFactory<Solution_> extends AbstractSelecto
             SelectionCacheType minimumCacheType,
             SelectionOrder selectionOrder) {
         EntitySelector<Solution_> entitySelector = EntitySelectorFactory
-                .<Solution_> create(config.getEntitySelectorConfig())
+                .<Solution_> create(Objects.requireNonNull(config.getEntitySelectorConfig()))
                 .buildEntitySelector(configPolicy, minimumCacheType, selectionOrder);
 
         EntityIndependentValueSelector<Solution_> valueSelector = buildEntityIndependentValueSelector(configPolicy,
@@ -70,7 +72,7 @@ public final class DestinationSelectorFactory<Solution_> extends AbstractSelecto
             HeuristicConfigPolicy<Solution_> configPolicy, EntityDescriptor<Solution_> entityDescriptor,
             SelectionCacheType minimumCacheType, SelectionOrder inheritedSelectionOrder) {
         ValueSelector<Solution_> valueSelector = ValueSelectorFactory
-                .<Solution_> create(config.getValueSelectorConfig())
+                .<Solution_> create(Objects.requireNonNull(config.getValueSelectorConfig()))
                 .buildValueSelector(configPolicy, entityDescriptor, minimumCacheType, inheritedSelectionOrder,
                         // Do not override reinitializeVariableFilterEnabled.
                         configPolicy.isReinitializeVariableFilterEnabled(),
@@ -140,11 +142,10 @@ public final class DestinationSelectorFactory<Solution_> extends AbstractSelecto
                     nearbyDistanceMeter,
                     nearbyRandom,
                     randomSelection);
-        } else if (nearbySelectionConfig.getOriginEntitySelectorConfig() != null) {
-            throw new IllegalArgumentException("TODO");
         } else {
-            throw new IllegalStateException("Impossible because nearby config validation should have ensured there is exactly"
-                    + " one origin selector property.");
+            throw new IllegalArgumentException("The destinationSelector (" + config
+                    + ")'s nearbySelectionConfig (" + nearbySelectionConfig
+                    + ") requires an originSubListSelector or an originValueSelector.");
         }
     }
 }

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/SubListSelectorFactory.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/SubListSelectorFactory.java
@@ -140,7 +140,9 @@ public final class SubListSelectorFactory<Solution_> extends AbstractFromConfigF
         NearbyRandom nearbyRandom = NearbyRandomFactory.create(nearbySelectionConfig).buildNearbyRandom(randomSelection);
 
         if (nearbySelectionConfig.getOriginSubListSelectorConfig() == null) {
-            throw new IllegalStateException("TODO");
+            throw new IllegalArgumentException("The subListSelector (" + config
+                    + ")'s nearbySelectionConfig (" + nearbySelectionConfig
+                    + ") requires an originSubListSelector.");
         }
         SubListSelector<Solution_> replayingOriginSubListSelector = SubListSelectorFactory
                 .<Solution_> create(nearbySelectionConfig.getOriginSubListSelectorConfig())

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/value/ValueSelectorFactory.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/value/ValueSelectorFactory.java
@@ -480,7 +480,7 @@ public class ValueSelectorFactory<Solution_>
             }
             if (!(originValueSelector instanceof EntityIndependentValueSelector)) {
                 throw new IllegalArgumentException(
-                        "The originalValueSelectorConfig (" + nearbySelectionConfig.getOriginValueSelectorConfig()
+                        "The originValueSelectorConfig (" + nearbySelectionConfig.getOriginValueSelectorConfig()
                                 + ") needs to be based on an "
                                 + EntityIndependentValueSelector.class.getSimpleName() + " (" + originValueSelector + ")."
                                 + " Check your @" + ValueRangeProvider.class.getSimpleName() + " annotations.");
@@ -489,11 +489,10 @@ public class ValueSelectorFactory<Solution_>
                     (EntityIndependentValueSelector<Solution_>) valueSelector,
                     (EntityIndependentValueSelector<Solution_>) originValueSelector,
                     nearbyDistanceMeter, nearbyRandom, randomSelection);
-        } else if (nearbySelectionConfig.getOriginSubListSelectorConfig() != null) {
-            throw new IllegalArgumentException("TODO");
         } else {
-            throw new IllegalStateException("Impossible because nearby config validation should have ensured there is exactly"
-                    + " one origin selector property.");
+            throw new IllegalArgumentException("The valueSelector (" + config
+                    + ")'s nearbySelectionConfig (" + nearbySelectionConfig
+                    + ") requires an originEntitySelector or an originValueSelector.");
         }
     }
 

--- a/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/config/heuristic/selector/common/nearby/NearbySelectionConfigTest.java
+++ b/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/config/heuristic/selector/common/nearby/NearbySelectionConfigTest.java
@@ -10,6 +10,8 @@ import static org.optaplanner.core.config.heuristic.selector.common.SelectionOrd
 
 import org.junit.jupiter.api.Test;
 import org.optaplanner.core.config.heuristic.selector.entity.EntitySelectorConfig;
+import org.optaplanner.core.config.heuristic.selector.move.generic.list.SubListSelectorConfig;
+import org.optaplanner.core.config.heuristic.selector.value.ValueSelectorConfig;
 import org.optaplanner.core.impl.heuristic.selector.common.nearby.BetaDistributionNearbyRandom;
 import org.optaplanner.core.impl.heuristic.selector.common.nearby.BlockDistributionNearbyRandom;
 import org.optaplanner.core.impl.heuristic.selector.common.nearby.LinearDistributionNearbyRandom;
@@ -29,14 +31,47 @@ class NearbySelectionConfigTest {
     void withNoOriginSelectorConfig() {
         NearbySelectionConfig nearbySelectionConfig = new NearbySelectionConfig();
         assertThatIllegalArgumentException().isThrownBy(() -> nearbySelectionConfig.validateNearby(JUST_IN_TIME, ORIGINAL))
-                .withMessageContaining("originEntitySelectorConfig")
-                .withMessageContaining("originValueSelectorConfig");
+                .withMessageContainingAll(
+                        "lacks an origin selector config",
+                        "originEntitySelectorConfig",
+                        "originSubListSelectorConfig",
+                        "originValueSelectorConfig");
     }
 
     @Test
-    void withNoMimicSelector() {
+    void withMultipleOriginSelectorConfigs() {
+        NearbySelectionConfig nearbySelectionConfig = new NearbySelectionConfig()
+                .withOriginEntitySelectorConfig(new EntitySelectorConfig())
+                .withOriginSubListSelectorConfig(new SubListSelectorConfig())
+                .withOriginValueSelectorConfig(new ValueSelectorConfig());
+        assertThatIllegalArgumentException().isThrownBy(() -> nearbySelectionConfig.validateNearby(JUST_IN_TIME, ORIGINAL))
+                .withMessageContainingAll(
+                        "has multiple origin selector configs",
+                        "originEntitySelectorConfig",
+                        "originSubListSelectorConfig",
+                        "originValueSelectorConfig");
+    }
+
+    @Test
+    void originEntitySelectorWithoutMimicSelectorRef() {
         NearbySelectionConfig nearbySelectionConfig = new NearbySelectionConfig();
         nearbySelectionConfig.setOriginEntitySelectorConfig(new EntitySelectorConfig());
+        assertThatIllegalArgumentException().isThrownBy(() -> nearbySelectionConfig.validateNearby(JUST_IN_TIME, ORIGINAL))
+                .withMessageContaining("MimicSelectorRef");
+    }
+
+    @Test
+    void originSubListSelectorWithoutMimicSelectorRef() {
+        NearbySelectionConfig nearbySelectionConfig = new NearbySelectionConfig();
+        nearbySelectionConfig.setOriginSubListSelectorConfig(new SubListSelectorConfig());
+        assertThatIllegalArgumentException().isThrownBy(() -> nearbySelectionConfig.validateNearby(JUST_IN_TIME, ORIGINAL))
+                .withMessageContaining("MimicSelectorRef");
+    }
+
+    @Test
+    void originValueSelectorWithoutMimicSelectorRef() {
+        NearbySelectionConfig nearbySelectionConfig = new NearbySelectionConfig();
+        nearbySelectionConfig.setOriginValueSelectorConfig(new ValueSelectorConfig());
         assertThatIllegalArgumentException().isThrownBy(() -> nearbySelectionConfig.validateNearby(JUST_IN_TIME, ORIGINAL))
                 .withMessageContaining("MimicSelectorRef");
     }
@@ -102,7 +137,7 @@ class NearbySelectionConfigTest {
 
         assertThatIllegalArgumentException()
                 .isThrownBy(() -> NearbyRandomFactory.create(nearbySelectionConfig).buildNearbyRandom(false))
-                .withMessageContaining("randomSelection").withMessageContaining("distribution");
+                .withMessageContainingAll("randomSelection", "distribution");
     }
 
     @Test
@@ -113,7 +148,7 @@ class NearbySelectionConfigTest {
 
         assertThatIllegalArgumentException()
                 .isThrownBy(() -> NearbyRandomFactory.create(nearbySelectionConfig).buildNearbyRandom(true))
-                .withMessageContaining(BLOCK).withMessageContaining(LINEAR);
+                .withMessageContainingAll(BLOCK, LINEAR);
     }
 
     @Test
@@ -124,7 +159,7 @@ class NearbySelectionConfigTest {
 
         assertThatIllegalArgumentException()
                 .isThrownBy(() -> NearbyRandomFactory.create(nearbySelectionConfig).buildNearbyRandom(true))
-                .withMessageContaining(BLOCK).withMessageContaining(PARABOLIC);
+                .withMessageContainingAll(BLOCK, PARABOLIC);
     }
 
     @Test
@@ -135,7 +170,7 @@ class NearbySelectionConfigTest {
 
         assertThatIllegalArgumentException()
                 .isThrownBy(() -> NearbyRandomFactory.create(nearbySelectionConfig).buildNearbyRandom(true))
-                .withMessageContaining(BLOCK).withMessageContaining(BETA);
+                .withMessageContainingAll(BLOCK, BETA);
     }
 
     @Test
@@ -146,7 +181,7 @@ class NearbySelectionConfigTest {
 
         assertThatIllegalArgumentException()
                 .isThrownBy(() -> NearbyRandomFactory.create(nearbySelectionConfig).buildNearbyRandom(true))
-                .withMessageContaining(LINEAR).withMessageContaining(PARABOLIC);
+                .withMessageContainingAll(LINEAR, PARABOLIC);
     }
 
     @Test
@@ -157,7 +192,7 @@ class NearbySelectionConfigTest {
 
         assertThatIllegalArgumentException()
                 .isThrownBy(() -> NearbyRandomFactory.create(nearbySelectionConfig).buildNearbyRandom(true))
-                .withMessageContaining(LINEAR).withMessageContaining(BETA);
+                .withMessageContainingAll(LINEAR, BETA);
     }
 
     @Test
@@ -168,7 +203,7 @@ class NearbySelectionConfigTest {
 
         assertThatIllegalArgumentException()
                 .isThrownBy(() -> NearbyRandomFactory.create(nearbySelectionConfig).buildNearbyRandom(true))
-                .withMessageContaining(PARABOLIC).withMessageContaining(BETA);
+                .withMessageContainingAll(PARABOLIC, BETA);
     }
 
     @Test

--- a/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/heuristic/selector/entity/EntitySelectorFactoryTest.java
+++ b/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/heuristic/selector/entity/EntitySelectorFactoryTest.java
@@ -11,11 +11,14 @@ import org.junit.jupiter.api.Test;
 import org.optaplanner.core.api.score.director.ScoreDirector;
 import org.optaplanner.core.config.heuristic.selector.common.SelectionCacheType;
 import org.optaplanner.core.config.heuristic.selector.common.SelectionOrder;
+import org.optaplanner.core.config.heuristic.selector.common.nearby.NearbySelectionConfig;
 import org.optaplanner.core.config.heuristic.selector.entity.EntitySelectorConfig;
+import org.optaplanner.core.config.heuristic.selector.value.ValueSelectorConfig;
 import org.optaplanner.core.impl.heuristic.HeuristicConfigPolicy;
 import org.optaplanner.core.impl.heuristic.selector.SelectorTestUtils;
 import org.optaplanner.core.impl.heuristic.selector.common.decorator.SelectionProbabilityWeightFactory;
 import org.optaplanner.core.impl.heuristic.selector.common.decorator.SelectionSorterWeightFactory;
+import org.optaplanner.core.impl.heuristic.selector.common.nearby.NearbyDistanceMeter;
 import org.optaplanner.core.impl.heuristic.selector.entity.decorator.ProbabilityEntitySelector;
 import org.optaplanner.core.impl.heuristic.selector.entity.decorator.ShufflingEntitySelector;
 import org.optaplanner.core.impl.heuristic.selector.entity.decorator.SortingEntitySelector;
@@ -195,6 +198,19 @@ class EntitySelectorFactoryTest {
                 () -> EntitySelectorFactory.create(entitySelectorConfig)
                         .buildMimicReplaying(mock(HeuristicConfigPolicy.class)))
                 .withMessageContaining("has another property");
+    }
+
+    @Test
+    void failFast_ifNearbyDoesNotHaveOriginEntitySelector() {
+        EntitySelectorConfig entitySelectorConfig = new EntitySelectorConfig()
+                .withNearbySelectionConfig(new NearbySelectionConfig()
+                        .withOriginValueSelectorConfig(new ValueSelectorConfig().withMimicSelectorRef("x"))
+                        .withNearbyDistanceMeterClass(NearbyDistanceMeter.class));
+
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> EntitySelectorFactory.<TestdataSolution> create(entitySelectorConfig).buildEntitySelector(
+                        buildHeuristicConfigPolicy(), SelectionCacheType.JUST_IN_TIME, SelectionOrder.RANDOM))
+                .withMessageContaining("requires an originEntitySelector");
     }
 
     public static class DummySelectionProbabilityWeightFactory

--- a/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/DestinationSelectorFactoryTest.java
+++ b/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/DestinationSelectorFactoryTest.java
@@ -1,0 +1,33 @@
+package org.optaplanner.core.impl.heuristic.selector.move.generic.list;
+
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.mockito.Mockito.mock;
+import static org.optaplanner.core.impl.heuristic.HeuristicConfigPolicyTestUtils.buildHeuristicConfigPolicy;
+
+import org.junit.jupiter.api.Test;
+import org.optaplanner.core.config.heuristic.selector.common.SelectionCacheType;
+import org.optaplanner.core.config.heuristic.selector.common.nearby.NearbySelectionConfig;
+import org.optaplanner.core.config.heuristic.selector.entity.EntitySelectorConfig;
+import org.optaplanner.core.config.heuristic.selector.move.generic.list.DestinationSelectorConfig;
+import org.optaplanner.core.config.heuristic.selector.value.ValueSelectorConfig;
+import org.optaplanner.core.impl.heuristic.selector.common.nearby.NearbyDistanceMeter;
+import org.optaplanner.core.impl.testdata.domain.list.TestdataListSolution;
+
+class DestinationSelectorFactoryTest {
+
+    @Test
+    void failFast_ifNearbyDoesNotHaveOriginSubListOrValueSelector() {
+        DestinationSelectorConfig destinationSelectorConfig = new DestinationSelectorConfig()
+                .withEntitySelectorConfig(new EntitySelectorConfig())
+                .withValueSelectorConfig(new ValueSelectorConfig())
+                .withNearbySelectionConfig(new NearbySelectionConfig()
+                        .withOriginEntitySelectorConfig(new EntitySelectorConfig().withMimicSelectorRef("x"))
+                        .withNearbyDistanceMeterClass(mock(NearbyDistanceMeter.class).getClass()));
+
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> DestinationSelectorFactory.<TestdataListSolution> create(destinationSelectorConfig)
+                        .buildDestinationSelector(buildHeuristicConfigPolicy(TestdataListSolution.buildSolutionDescriptor()),
+                                SelectionCacheType.JUST_IN_TIME, true))
+                .withMessageContaining("requires an originSubListSelector or an originValueSelector");
+    }
+}

--- a/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/testdata/domain/list/TestdataListUtils.java
+++ b/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/testdata/domain/list/TestdataListUtils.java
@@ -26,7 +26,7 @@ public class TestdataListUtils {
     }
 
     public static EntitySelector<TestdataListSolution> mockEntitySelector(Object... entities) {
-        return SelectorTestUtils.mockEntitySelector(TestdataListEntity.class, entities);
+        return SelectorTestUtils.mockEntitySelector(TestdataListEntity.buildEntityDescriptor(), entities);
     }
 
     public static EntityIndependentValueSelector<TestdataListSolution> mockEntityIndependentValueSelector(Object... values) {


### PR DESCRIPTION
I wanted to explore the possibility to introduce entity/value/subList/destination factory-tailored nearby config classes to simplify the validation. Unfortunately, there is no backward-compatible way to do it due to how `@XmlType(propOrder)` behaves (too complicated to describe here).

So I reverted to the current approach with only `NearbySelectionConfig` having all possible origin selector properties and I completed exception messages and added coverage.