### PR TITLE
Remove variable descriptor parameter from move selector constructors

### DIFF
--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/DestinationSelectorFactory.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/DestinationSelectorFactory.java
@@ -8,7 +8,6 @@ import org.optaplanner.core.config.heuristic.selector.common.SelectionOrder;
 import org.optaplanner.core.config.heuristic.selector.common.nearby.NearbySelectionConfig;
 import org.optaplanner.core.config.heuristic.selector.move.generic.list.DestinationSelectorConfig;
 import org.optaplanner.core.impl.domain.entity.descriptor.EntityDescriptor;
-import org.optaplanner.core.impl.domain.variable.descriptor.ListVariableDescriptor;
 import org.optaplanner.core.impl.heuristic.HeuristicConfigPolicy;
 import org.optaplanner.core.impl.heuristic.selector.AbstractSelectorFactory;
 import org.optaplanner.core.impl.heuristic.selector.common.nearby.NearbyDistanceMeter;
@@ -57,12 +56,7 @@ public final class DestinationSelectorFactory<Solution_> extends AbstractSelecto
         EntityIndependentValueSelector<Solution_> valueSelector = buildEntityIndependentValueSelector(configPolicy,
                 entitySelector.getEntityDescriptor(), minimumCacheType, selectionOrder);
 
-        // TODO move this to constructor (all list move selectors)
-        ListVariableDescriptor<Solution_> listVariableDescriptor =
-                (ListVariableDescriptor<Solution_>) valueSelector.getVariableDescriptor();
-
         return new ElementDestinationSelector<>(
-                listVariableDescriptor,
                 entitySelector,
                 valueSelector,
                 selectionOrder.toRandomSelectionBoolean());

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/ElementDestinationSelector.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/ElementDestinationSelector.java
@@ -38,7 +38,6 @@ import org.optaplanner.core.impl.solver.scope.SolverScope;
 public class ElementDestinationSelector<Solution_> extends AbstractSelector<Solution_>
         implements DestinationSelector<Solution_> {
 
-    private final ListVariableDescriptor<Solution_> listVariableDescriptor;
     private final EntitySelector<Solution_> entitySelector;
     private final EntityIndependentValueSelector<Solution_> valueSelector;
     private final boolean randomSelection;
@@ -47,11 +46,9 @@ public class ElementDestinationSelector<Solution_> extends AbstractSelector<Solu
     private IndexVariableSupply indexVariableSupply;
 
     public ElementDestinationSelector(
-            ListVariableDescriptor<Solution_> listVariableDescriptor,
             EntitySelector<Solution_> entitySelector,
             EntityIndependentValueSelector<Solution_> valueSelector,
             boolean randomSelection) {
-        this.listVariableDescriptor = listVariableDescriptor;
         this.entitySelector = entitySelector;
         this.valueSelector = valueSelector;
         this.randomSelection = randomSelection;
@@ -64,6 +61,7 @@ public class ElementDestinationSelector<Solution_> extends AbstractSelector<Solu
     public void solvingStarted(SolverScope<Solution_> solverScope) {
         super.solvingStarted(solverScope);
         SupplyManager supplyManager = solverScope.getScoreDirector().getSupplyManager();
+        ListVariableDescriptor<?> listVariableDescriptor = (ListVariableDescriptor<?>) valueSelector.getVariableDescriptor();
         inverseVariableSupply = supplyManager.demand(new SingletonListInverseVariableDemand<>(listVariableDescriptor));
         indexVariableSupply = supplyManager.demand(new IndexVariableDemand<>(listVariableDescriptor));
     }
@@ -136,7 +134,7 @@ public class ElementDestinationSelector<Solution_> extends AbstractSelector<Solu
     }
 
     public ListVariableDescriptor<Solution_> getVariableDescriptor() {
-        return listVariableDescriptor;
+        return (ListVariableDescriptor<Solution_>) valueSelector.getVariableDescriptor();
     }
 
     public EntityDescriptor<Solution_> getEntityDescriptor() {

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/ListChangeMoveSelector.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/ListChangeMoveSelector.java
@@ -15,7 +15,6 @@ import org.optaplanner.core.impl.solver.scope.SolverScope;
 
 public class ListChangeMoveSelector<Solution_> extends GenericMoveSelector<Solution_> {
 
-    private final ListVariableDescriptor<Solution_> listVariableDescriptor;
     private final EntityIndependentValueSelector<Solution_> sourceValueSelector;
     private final DestinationSelector<Solution_> destinationSelector;
     private final boolean randomSelection;
@@ -24,11 +23,9 @@ public class ListChangeMoveSelector<Solution_> extends GenericMoveSelector<Solut
     private IndexVariableSupply indexVariableSupply;
 
     public ListChangeMoveSelector(
-            ListVariableDescriptor<Solution_> listVariableDescriptor,
             EntityIndependentValueSelector<Solution_> sourceValueSelector,
             DestinationSelector<Solution_> destinationSelector,
             boolean randomSelection) {
-        this.listVariableDescriptor = listVariableDescriptor;
         this.sourceValueSelector = sourceValueSelector;
         this.destinationSelector = destinationSelector;
         this.randomSelection = randomSelection;
@@ -40,6 +37,8 @@ public class ListChangeMoveSelector<Solution_> extends GenericMoveSelector<Solut
     @Override
     public void solvingStarted(SolverScope<Solution_> solverScope) {
         super.solvingStarted(solverScope);
+        ListVariableDescriptor<Solution_> listVariableDescriptor =
+                (ListVariableDescriptor<Solution_>) sourceValueSelector.getVariableDescriptor();
         SupplyManager supplyManager = solverScope.getScoreDirector().getSupplyManager();
         inverseVariableSupply = supplyManager.demand(new SingletonListInverseVariableDemand<>(listVariableDescriptor));
         indexVariableSupply = supplyManager.demand(new IndexVariableDemand<>(listVariableDescriptor));
@@ -61,14 +60,12 @@ public class ListChangeMoveSelector<Solution_> extends GenericMoveSelector<Solut
     public Iterator<Move<Solution_>> iterator() {
         if (randomSelection) {
             return new RandomListChangeIterator<>(
-                    listVariableDescriptor,
                     inverseVariableSupply,
                     indexVariableSupply,
                     sourceValueSelector,
                     destinationSelector);
         } else {
             return new OriginalListChangeIterator<>(
-                    listVariableDescriptor,
                     inverseVariableSupply,
                     indexVariableSupply,
                     sourceValueSelector,

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/ListChangeMoveSelectorFactory.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/ListChangeMoveSelectorFactory.java
@@ -62,11 +62,7 @@ public class ListChangeMoveSelectorFactory<Solution_>
                 .<Solution_> create(config.getDestinationSelectorConfig())
                 .buildDestinationSelector(configPolicy, minimumCacheType, randomSelection);
 
-        ListVariableDescriptor<Solution_> listVariableDescriptor =
-                (ListVariableDescriptor<Solution_>) sourceValueSelector.getVariableDescriptor();
-
         return new ListChangeMoveSelector<>(
-                listVariableDescriptor,
                 (EntityIndependentValueSelector<Solution_>) sourceValueSelector,
                 destinationSelector,
                 randomSelection);

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/ListSwapMoveSelector.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/ListSwapMoveSelector.java
@@ -15,7 +15,6 @@ import org.optaplanner.core.impl.solver.scope.SolverScope;
 
 public class ListSwapMoveSelector<Solution_> extends GenericMoveSelector<Solution_> {
 
-    private final ListVariableDescriptor<Solution_> listVariableDescriptor;
     private final EntityIndependentValueSelector<Solution_> leftValueSelector;
     private final EntityIndependentValueSelector<Solution_> rightValueSelector;
     private final boolean randomSelection;
@@ -24,11 +23,9 @@ public class ListSwapMoveSelector<Solution_> extends GenericMoveSelector<Solutio
     private IndexVariableSupply indexVariableSupply;
 
     public ListSwapMoveSelector(
-            ListVariableDescriptor<Solution_> listVariableDescriptor,
             EntityIndependentValueSelector<Solution_> leftValueSelector,
             EntityIndependentValueSelector<Solution_> rightValueSelector,
             boolean randomSelection) {
-        this.listVariableDescriptor = listVariableDescriptor;
         // TODO require not same
         this.leftValueSelector = leftValueSelector;
         this.rightValueSelector = rightValueSelector;
@@ -42,6 +39,8 @@ public class ListSwapMoveSelector<Solution_> extends GenericMoveSelector<Solutio
     @Override
     public void solvingStarted(SolverScope<Solution_> solverScope) {
         super.solvingStarted(solverScope);
+        ListVariableDescriptor<Solution_> listVariableDescriptor =
+                (ListVariableDescriptor<Solution_>) leftValueSelector.getVariableDescriptor();
         SupplyManager supplyManager = solverScope.getScoreDirector().getSupplyManager();
         inverseVariableSupply = supplyManager.demand(new SingletonListInverseVariableDemand<>(listVariableDescriptor));
         indexVariableSupply = supplyManager.demand(new IndexVariableDemand<>(listVariableDescriptor));
@@ -58,14 +57,12 @@ public class ListSwapMoveSelector<Solution_> extends GenericMoveSelector<Solutio
     public Iterator<Move<Solution_>> iterator() {
         if (randomSelection) {
             return new RandomListSwapIterator<>(
-                    listVariableDescriptor,
                     inverseVariableSupply,
                     indexVariableSupply,
                     leftValueSelector,
                     rightValueSelector);
         } else {
             return new OriginalListSwapIterator<>(
-                    listVariableDescriptor,
                     inverseVariableSupply,
                     indexVariableSupply,
                     leftValueSelector,

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/ListSwapMoveSelectorFactory.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/ListSwapMoveSelectorFactory.java
@@ -53,7 +53,6 @@ public class ListSwapMoveSelectorFactory<Solution_>
         }
 
         return new ListSwapMoveSelector<>(
-                (ListVariableDescriptor<Solution_>) variableDescriptor,
                 leftValueSelector,
                 rightValueSelector,
                 randomSelection);

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/NearSubListNearbySubListSelector.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/NearSubListNearbySubListSelector.java
@@ -234,7 +234,7 @@ public final class NearSubListNearbySubListSelector<Solution_> extends AbstractS
 
     @Override
     public ListVariableDescriptor<Solution_> getVariableDescriptor() {
-        throw new UnsupportedOperationException("Not used.");
+        return childSubListSelector.getVariableDescriptor();
     }
 
     @Override

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/OriginalListChangeIterator.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/OriginalListChangeIterator.java
@@ -17,9 +17,9 @@ import org.optaplanner.core.impl.heuristic.selector.value.EntityIndependentValue
  */
 public class OriginalListChangeIterator<Solution_> extends UpcomingSelectionIterator<Move<Solution_>> {
 
-    private final ListVariableDescriptor<Solution_> listVariableDescriptor;
     private final SingletonInverseVariableSupply inverseVariableSupply;
     private final IndexVariableSupply indexVariableSupply;
+    private final ListVariableDescriptor<Solution_> listVariableDescriptor;
     private final Iterator<Object> valueIterator;
     private final DestinationSelector<Solution_> destinationSelector;
     private Iterator<ElementRef> destinationIterator;
@@ -29,14 +29,13 @@ public class OriginalListChangeIterator<Solution_> extends UpcomingSelectionIter
     private Object upcomingValue;
 
     public OriginalListChangeIterator(
-            ListVariableDescriptor<Solution_> listVariableDescriptor,
             SingletonInverseVariableSupply inverseVariableSupply,
             IndexVariableSupply indexVariableSupply,
             EntityIndependentValueSelector<Solution_> valueSelector,
             DestinationSelector<Solution_> destinationSelector) {
-        this.listVariableDescriptor = listVariableDescriptor;
         this.inverseVariableSupply = inverseVariableSupply;
         this.indexVariableSupply = indexVariableSupply;
+        this.listVariableDescriptor = (ListVariableDescriptor<Solution_>) valueSelector.getVariableDescriptor();
         this.valueIterator = valueSelector.iterator();
         this.destinationSelector = destinationSelector;
         this.destinationIterator = Collections.emptyIterator();

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/OriginalListSwapIterator.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/OriginalListSwapIterator.java
@@ -17,9 +17,9 @@ import org.optaplanner.core.impl.heuristic.selector.value.EntityIndependentValue
  */
 public class OriginalListSwapIterator<Solution_> extends UpcomingSelectionIterator<Move<Solution_>> {
 
-    private final ListVariableDescriptor<Solution_> listVariableDescriptor;
     private final SingletonInverseVariableSupply inverseVariableSupply;
     private final IndexVariableSupply indexVariableSupply;
+    private final ListVariableDescriptor<Solution_> listVariableDescriptor;
     private final Iterator<Object> leftValueIterator;
     private final EntityIndependentValueSelector<Solution_> rightValueSelector;
     private Iterator<Object> rightValueIterator;
@@ -28,17 +28,16 @@ public class OriginalListSwapIterator<Solution_> extends UpcomingSelectionIterat
     private Integer upcomingLeftIndex;
 
     public OriginalListSwapIterator(
-            ListVariableDescriptor<Solution_> listVariableDescriptor,
             SingletonInverseVariableSupply inverseVariableSupply,
             IndexVariableSupply indexVariableSupply,
             EntityIndependentValueSelector<Solution_> leftValueSelector,
             EntityIndependentValueSelector<Solution_> rightValueSelector) {
-        this.listVariableDescriptor = listVariableDescriptor;
         this.inverseVariableSupply = inverseVariableSupply;
         this.indexVariableSupply = indexVariableSupply;
+        this.listVariableDescriptor = (ListVariableDescriptor<Solution_>) leftValueSelector.getVariableDescriptor();
         this.leftValueIterator = leftValueSelector.iterator();
-        this.rightValueIterator = Collections.emptyIterator();
         this.rightValueSelector = rightValueSelector;
+        this.rightValueIterator = Collections.emptyIterator();
     }
 
     @Override

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/RandomListChangeIterator.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/RandomListChangeIterator.java
@@ -15,21 +15,20 @@ import org.optaplanner.core.impl.heuristic.selector.value.EntityIndependentValue
  */
 public class RandomListChangeIterator<Solution_> extends UpcomingSelectionIterator<Move<Solution_>> {
 
-    private final ListVariableDescriptor<Solution_> listVariableDescriptor;
     private final SingletonInverseVariableSupply inverseVariableSupply;
     private final IndexVariableSupply indexVariableSupply;
+    private final ListVariableDescriptor<Solution_> listVariableDescriptor;
     private final Iterator<Object> valueIterator;
     private final Iterator<ElementRef> destinationIterator;
 
     public RandomListChangeIterator(
-            ListVariableDescriptor<Solution_> listVariableDescriptor,
             SingletonInverseVariableSupply inverseVariableSupply,
             IndexVariableSupply indexVariableSupply,
             EntityIndependentValueSelector<Solution_> valueSelector,
             DestinationSelector<Solution_> destinationSelector) {
-        this.listVariableDescriptor = listVariableDescriptor;
         this.inverseVariableSupply = inverseVariableSupply;
         this.indexVariableSupply = indexVariableSupply;
+        this.listVariableDescriptor = (ListVariableDescriptor<Solution_>) valueSelector.getVariableDescriptor();
         this.valueIterator = valueSelector.iterator();
         this.destinationIterator = destinationSelector.iterator();
     }

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/RandomListSwapIterator.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/RandomListSwapIterator.java
@@ -15,21 +15,20 @@ import org.optaplanner.core.impl.heuristic.selector.value.EntityIndependentValue
  */
 public class RandomListSwapIterator<Solution_> extends UpcomingSelectionIterator<Move<Solution_>> {
 
-    private final ListVariableDescriptor<Solution_> listVariableDescriptor;
     private final SingletonInverseVariableSupply inverseVariableSupply;
     private final IndexVariableSupply indexVariableSupply;
+    private final ListVariableDescriptor<Solution_> listVariableDescriptor;
     private final Iterator<Object> leftValueIterator;
     private final Iterator<Object> rightValueIterator;
 
     public RandomListSwapIterator(
-            ListVariableDescriptor<Solution_> listVariableDescriptor,
             SingletonInverseVariableSupply inverseVariableSupply,
             IndexVariableSupply indexVariableSupply,
             EntityIndependentValueSelector<Solution_> leftValueSelector,
             EntityIndependentValueSelector<Solution_> rightValueSelector) {
-        this.listVariableDescriptor = listVariableDescriptor;
         this.inverseVariableSupply = inverseVariableSupply;
         this.indexVariableSupply = indexVariableSupply;
+        this.listVariableDescriptor = (ListVariableDescriptor<Solution_>) leftValueSelector.getVariableDescriptor();
         this.leftValueIterator = leftValueSelector.iterator();
         this.rightValueIterator = rightValueSelector.iterator();
     }

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/RandomSubListChangeMoveIterator.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/RandomSubListChangeMoveIterator.java
@@ -9,21 +9,20 @@ import org.optaplanner.core.impl.heuristic.selector.common.iterator.UpcomingSele
 
 class RandomSubListChangeMoveIterator<Solution_> extends UpcomingSelectionIterator<Move<Solution_>> {
 
-    private final ListVariableDescriptor<Solution_> listVariableDescriptor;
     private final Iterator<SubList> subListIterator;
     private final Iterator<ElementRef> destinationIterator;
+    private final ListVariableDescriptor<Solution_> listVariableDescriptor;
     private final Random workingRandom;
     private final boolean selectReversingMoveToo;
 
     RandomSubListChangeMoveIterator(
-            ListVariableDescriptor<Solution_> listVariableDescriptor,
             SubListSelector<Solution_> subListSelector,
             DestinationSelector<Solution_> destinationSelector,
             Random workingRandom,
             boolean selectReversingMoveToo) {
-        this.listVariableDescriptor = listVariableDescriptor;
         this.subListIterator = subListSelector.iterator();
         this.destinationIterator = destinationSelector.iterator();
+        this.listVariableDescriptor = subListSelector.getVariableDescriptor();
         this.workingRandom = workingRandom;
         this.selectReversingMoveToo = selectReversingMoveToo;
     }

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/RandomSubListChangeMoveSelector.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/RandomSubListChangeMoveSelector.java
@@ -2,23 +2,19 @@ package org.optaplanner.core.impl.heuristic.selector.move.generic.list;
 
 import java.util.Iterator;
 
-import org.optaplanner.core.impl.domain.variable.descriptor.ListVariableDescriptor;
 import org.optaplanner.core.impl.heuristic.move.Move;
 import org.optaplanner.core.impl.heuristic.selector.move.generic.GenericMoveSelector;
 
 public class RandomSubListChangeMoveSelector<Solution_> extends GenericMoveSelector<Solution_> {
 
-    private final ListVariableDescriptor<Solution_> listVariableDescriptor;
     private final SubListSelector<Solution_> subListSelector;
     private final DestinationSelector<Solution_> destinationSelector;
     private final boolean selectReversingMoveToo;
 
     public RandomSubListChangeMoveSelector(
-            ListVariableDescriptor<Solution_> listVariableDescriptor,
             SubListSelector<Solution_> subListSelector,
             DestinationSelector<Solution_> destinationSelector,
             boolean selectReversingMoveToo) {
-        this.listVariableDescriptor = listVariableDescriptor;
         this.subListSelector = subListSelector;
         this.destinationSelector = destinationSelector;
         this.selectReversingMoveToo = selectReversingMoveToo;
@@ -30,7 +26,6 @@ public class RandomSubListChangeMoveSelector<Solution_> extends GenericMoveSelec
     @Override
     public Iterator<Move<Solution_>> iterator() {
         return new RandomSubListChangeMoveIterator<>(
-                listVariableDescriptor,
                 subListSelector,
                 destinationSelector,
                 workingRandom,

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/RandomSubListSelector.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/RandomSubListSelector.java
@@ -13,9 +13,9 @@ import org.optaplanner.core.impl.solver.scope.SolverScope;
 
 public class RandomSubListSelector<Solution_> extends AbstractSelector<Solution_> implements SubListSelector<Solution_> {
 
-    private final ListVariableDescriptor<Solution_> listVariableDescriptor;
     private final EntitySelector<Solution_> entitySelector;
     private final EntityIndependentValueSelector<Solution_> valueSelector;
+    private final ListVariableDescriptor<Solution_> listVariableDescriptor;
     private final int minimumSubListSize;
     private final int maximumSubListSize;
 
@@ -23,13 +23,12 @@ public class RandomSubListSelector<Solution_> extends AbstractSelector<Solution_
     private SingletonInverseVariableSupply inverseVariableSupply;
 
     public RandomSubListSelector(
-            ListVariableDescriptor<Solution_> listVariableDescriptor,
             EntitySelector<Solution_> entitySelector,
             EntityIndependentValueSelector<Solution_> valueSelector,
             int minimumSubListSize, int maximumSubListSize) {
-        this.listVariableDescriptor = listVariableDescriptor;
         this.entitySelector = entitySelector;
         this.valueSelector = valueSelector;
+        this.listVariableDescriptor = (ListVariableDescriptor<Solution_>) valueSelector.getVariableDescriptor();
         if (minimumSubListSize < 1) {
             throw new IllegalArgumentException(
                     "The minimumSubListSize (" + minimumSubListSize + ") must be greater than 0.");

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/RandomSubListSwapMoveSelector.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/RandomSubListSwapMoveSelector.java
@@ -9,19 +9,25 @@ import org.optaplanner.core.impl.heuristic.selector.move.generic.GenericMoveSele
 
 public class RandomSubListSwapMoveSelector<Solution_> extends GenericMoveSelector<Solution_> {
 
-    private final ListVariableDescriptor<Solution_> listVariableDescriptor;
     private final SubListSelector<Solution_> leftSubListSelector;
     private final SubListSelector<Solution_> rightSubListSelector;
+    private final ListVariableDescriptor<Solution_> listVariableDescriptor;
     private final boolean selectReversingMoveToo;
 
     public RandomSubListSwapMoveSelector(
-            ListVariableDescriptor<Solution_> listVariableDescriptor,
             SubListSelector<Solution_> leftSubListSelector,
             SubListSelector<Solution_> rightSubListSelector,
             boolean selectReversingMoveToo) {
-        this.listVariableDescriptor = listVariableDescriptor;
         this.leftSubListSelector = leftSubListSelector;
         this.rightSubListSelector = rightSubListSelector;
+        this.listVariableDescriptor = leftSubListSelector.getVariableDescriptor();
+        if (leftSubListSelector.getVariableDescriptor() != rightSubListSelector.getVariableDescriptor()) {
+            throw new IllegalStateException("The selector (" + this
+                    + ") has a leftSubListSelector's variableDescriptor ("
+                    + leftSubListSelector.getVariableDescriptor()
+                    + ") which is not equal to the rightSubListSelector's variableDescriptor ("
+                    + rightSubListSelector.getVariableDescriptor() + ").");
+        }
         this.selectReversingMoveToo = selectReversingMoveToo;
 
         phaseLifecycleSupport.addEventListener(leftSubListSelector);

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/SubListChangeMoveSelectorFactory.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/SubListChangeMoveSelectorFactory.java
@@ -59,9 +59,7 @@ public class SubListChangeMoveSelectorFactory<Solution_>
 
         boolean selectReversingMoveToo = Objects.requireNonNullElse(config.getSelectReversingMoveToo(), true);
 
-        return new RandomSubListChangeMoveSelector<>(subListSelector.getVariableDescriptor(), subListSelector,
-                destinationSelector,
-                selectReversingMoveToo);
+        return new RandomSubListChangeMoveSelector<>(subListSelector, destinationSelector, selectReversingMoveToo);
     }
 
     @Override

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/SubListSelectorFactory.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/SubListSelectorFactory.java
@@ -3,7 +3,9 @@ package org.optaplanner.core.impl.heuristic.selector.move.generic.list;
 import java.util.Objects;
 import java.util.Optional;
 
+import org.optaplanner.core.api.domain.entity.PlanningEntity;
 import org.optaplanner.core.api.domain.valuerange.ValueRangeProvider;
+import org.optaplanner.core.api.domain.variable.PlanningListVariable;
 import org.optaplanner.core.config.heuristic.selector.common.SelectionCacheType;
 import org.optaplanner.core.config.heuristic.selector.common.SelectionOrder;
 import org.optaplanner.core.config.heuristic.selector.common.nearby.NearbySelectionConfig;
@@ -179,6 +181,12 @@ public final class SubListSelectorFactory<Solution_> extends AbstractFromConfigF
         ValueSelector<Solution_> valueSelector = ValueSelectorFactory
                 .<Solution_> create(valueSelectorConfig)
                 .buildValueSelector(configPolicy, entityDescriptor, minimumCacheType, inheritedSelectionOrder);
+        if (!valueSelector.getVariableDescriptor().isListVariable()) {
+            throw new IllegalArgumentException("The subListSelector (" + config
+                    + ") can only be used when the domain model has a list variable."
+                    + " Check your @" + PlanningEntity.class.getSimpleName()
+                    + " and make sure it has a @" + PlanningListVariable.class.getSimpleName() + ".");
+        }
         if (!(valueSelector instanceof EntityIndependentValueSelector)) {
             throw new IllegalArgumentException("The subListSelector (" + config
                     + ") for a list variable needs to be based on an "

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/SubListSelectorFactory.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/SubListSelectorFactory.java
@@ -11,7 +11,6 @@ import org.optaplanner.core.config.heuristic.selector.move.generic.list.SubListS
 import org.optaplanner.core.config.heuristic.selector.value.ValueSelectorConfig;
 import org.optaplanner.core.impl.AbstractFromConfigFactory;
 import org.optaplanner.core.impl.domain.entity.descriptor.EntityDescriptor;
-import org.optaplanner.core.impl.domain.variable.descriptor.ListVariableDescriptor;
 import org.optaplanner.core.impl.heuristic.HeuristicConfigPolicy;
 import org.optaplanner.core.impl.heuristic.selector.common.nearby.NearbyDistanceMeter;
 import org.optaplanner.core.impl.heuristic.selector.common.nearby.NearbyRandom;
@@ -55,15 +54,10 @@ public final class SubListSelectorFactory<Solution_> extends AbstractFromConfigF
         EntityIndependentValueSelector<Solution_> valueSelector = buildEntityIndependentValueSelector(configPolicy,
                 entitySelector.getEntityDescriptor(), minimumCacheType, inheritedSelectionOrder);
 
-        // TODO move this to constructor (all list move selectors)
-        ListVariableDescriptor<Solution_> listVariableDescriptor =
-                (ListVariableDescriptor<Solution_>) valueSelector.getVariableDescriptor();
-
         int minimumSubListSize = Objects.requireNonNullElse(config.getMinimumSubListSize(), DEFAULT_MINIMUM_SUB_LIST_SIZE);
         int maximumSubListSize = Objects.requireNonNullElse(config.getMaximumSubListSize(), DEFAULT_MAXIMUM_SUB_LIST_SIZE);
         RandomSubListSelector<Solution_> baseSubListSelector =
-                new RandomSubListSelector<>(listVariableDescriptor, entitySelector, valueSelector,
-                        minimumSubListSize, maximumSubListSize);
+                new RandomSubListSelector<>(entitySelector, valueSelector, minimumSubListSize, maximumSubListSize);
 
         SubListSelector<Solution_> subListSelector =
                 applyNearbySelection(configPolicy, minimumCacheType, inheritedSelectionOrder, baseSubListSelector);

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/SubListSwapMoveSelectorFactory.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/SubListSwapMoveSelectorFactory.java
@@ -2,15 +2,11 @@ package org.optaplanner.core.impl.heuristic.selector.move.generic.list;
 
 import java.util.Objects;
 
-import org.optaplanner.core.api.domain.entity.PlanningEntity;
-import org.optaplanner.core.api.domain.variable.PlanningListVariable;
 import org.optaplanner.core.config.heuristic.selector.common.SelectionCacheType;
 import org.optaplanner.core.config.heuristic.selector.common.SelectionOrder;
 import org.optaplanner.core.config.heuristic.selector.entity.EntitySelectorConfig;
 import org.optaplanner.core.config.heuristic.selector.move.generic.list.SubListSelectorConfig;
 import org.optaplanner.core.config.heuristic.selector.move.generic.list.SubListSwapMoveSelectorConfig;
-import org.optaplanner.core.impl.domain.variable.descriptor.GenuineVariableDescriptor;
-import org.optaplanner.core.impl.domain.variable.descriptor.ListVariableDescriptor;
 import org.optaplanner.core.impl.heuristic.HeuristicConfigPolicy;
 import org.optaplanner.core.impl.heuristic.selector.entity.EntitySelector;
 import org.optaplanner.core.impl.heuristic.selector.entity.EntitySelectorFactory;
@@ -34,20 +30,9 @@ public class SubListSwapMoveSelectorFactory<Solution_>
 
         SelectionOrder selectionOrder = SelectionOrder.fromRandomSelectionBoolean(randomSelection);
 
-        EntitySelector<Solution_> entitySelector =
-                EntitySelectorFactory.<Solution_> create(new EntitySelectorConfig())
-                        .buildEntitySelector(configPolicy, minimumCacheType, selectionOrder);
-        // TODO support coexistence of list and basic variables https://issues.redhat.com/browse/PLANNER-2755
-        GenuineVariableDescriptor<Solution_> variableDescriptor =
-                getTheOnlyVariableDescriptor(entitySelector.getEntityDescriptor());
-        if (!variableDescriptor.isListVariable()) {
-            throw new IllegalArgumentException("The subListSwapMoveSelector (" + config
-                    + ") can only be used when the domain model has a list variable."
-                    + " Check your @" + PlanningEntity.class.getSimpleName()
-                    + " and make sure it has a @" + PlanningListVariable.class.getSimpleName() + ".");
-        }
-
-        ListVariableDescriptor<Solution_> listVariableDescriptor = (ListVariableDescriptor<Solution_>) variableDescriptor;
+        EntitySelector<Solution_> entitySelector = EntitySelectorFactory
+                .<Solution_> create(new EntitySelectorConfig())
+                .buildEntitySelector(configPolicy, minimumCacheType, selectionOrder);
 
         SubListSelectorConfig subListSelectorConfig =
                 Objects.requireNonNullElseGet(config.getSubListSelectorConfig(), SubListSelectorConfig::new);
@@ -62,7 +47,6 @@ public class SubListSwapMoveSelectorFactory<Solution_>
 
         boolean selectReversingMoveToo = Objects.requireNonNullElse(config.getSelectReversingMoveToo(), true);
 
-        return new RandomSubListSwapMoveSelector<>(listVariableDescriptor, leftSubListSelector, rightSubListSelector,
-                selectReversingMoveToo);
+        return new RandomSubListSwapMoveSelector<>(leftSubListSelector, rightSubListSelector, selectReversingMoveToo);
     }
 }

--- a/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/ElementDestinationSelectorTest.java
+++ b/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/ElementDestinationSelectorTest.java
@@ -11,10 +11,10 @@ import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertAllCod
 import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertCodesOfNeverEndingIterableSelector;
 import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertEmptyNeverEndingIterableSelector;
 import static org.optaplanner.core.impl.testdata.util.PlannerAssert.verifyPhaseLifecycle;
+import static org.optaplanner.core.impl.testdata.util.PlannerTestUtils.mockScoreDirector;
 
 import org.junit.jupiter.api.Test;
 import org.optaplanner.core.api.score.buildin.simple.SimpleScore;
-import org.optaplanner.core.impl.domain.variable.descriptor.ListVariableDescriptor;
 import org.optaplanner.core.impl.heuristic.selector.entity.EntitySelector;
 import org.optaplanner.core.impl.heuristic.selector.value.EntityIndependentValueSelector;
 import org.optaplanner.core.impl.phase.scope.AbstractPhaseScope;
@@ -24,7 +24,6 @@ import org.optaplanner.core.impl.solver.scope.SolverScope;
 import org.optaplanner.core.impl.testdata.domain.list.TestdataListEntity;
 import org.optaplanner.core.impl.testdata.domain.list.TestdataListSolution;
 import org.optaplanner.core.impl.testdata.domain.list.TestdataListValue;
-import org.optaplanner.core.impl.testdata.util.PlannerTestUtils;
 import org.optaplanner.core.impl.testutil.TestRandom;
 
 class ElementDestinationSelectorTest {
@@ -39,18 +38,15 @@ class ElementDestinationSelectorTest {
         TestdataListEntity c = TestdataListEntity.createWithValues("C", v3);
 
         InnerScoreDirector<TestdataListSolution, SimpleScore> scoreDirector =
-                PlannerTestUtils.mockScoreDirector(TestdataListSolution.buildSolutionDescriptor());
+                mockScoreDirector(TestdataListSolution.buildSolutionDescriptor());
 
-        ListVariableDescriptor<TestdataListSolution> listVariableDescriptor = getListVariableDescriptor(scoreDirector);
         EntitySelector<TestdataListSolution> entitySelector = mockEntitySelector(a, b, c);
-        EntityIndependentValueSelector<TestdataListSolution> valueSelector = mockEntityIndependentValueSelector(v3, v1, v2);
+        EntityIndependentValueSelector<TestdataListSolution> valueSelector =
+                mockEntityIndependentValueSelector(getListVariableDescriptor(scoreDirector), v3, v1, v2);
         long destinationSize = entitySelector.getSize() + valueSelector.getSize();
 
         ElementDestinationSelector<TestdataListSolution> selector = new ElementDestinationSelector<>(
-                listVariableDescriptor,
-                entitySelector,
-                valueSelector,
-                false);
+                entitySelector, valueSelector, false);
 
         solvingStarted(selector, scoreDirector);
 
@@ -80,19 +76,15 @@ class ElementDestinationSelectorTest {
         TestdataListEntity c = TestdataListEntity.createWithValues("C", v3);
 
         InnerScoreDirector<TestdataListSolution, SimpleScore> scoreDirector =
-                PlannerTestUtils.mockScoreDirector(TestdataListSolution.buildSolutionDescriptor());
+                mockScoreDirector(TestdataListSolution.buildSolutionDescriptor());
 
-        ListVariableDescriptor<TestdataListSolution> listVariableDescriptor = getListVariableDescriptor(scoreDirector);
         EntitySelector<TestdataListSolution> entitySelector = mockEntitySelector(a, b, c, c);
         EntityIndependentValueSelector<TestdataListSolution> valueSelector =
-                mockNeverEndingEntityIndependentValueSelector(v3, v2, v1);
+                mockNeverEndingEntityIndependentValueSelector(getListVariableDescriptor(scoreDirector), v3, v2, v1);
         long destinationSize = entitySelector.getSize() + valueSelector.getSize();
 
         ElementDestinationSelector<TestdataListSolution> selector = new ElementDestinationSelector<>(
-                listVariableDescriptor,
-                entitySelector,
-                valueSelector,
-                true);
+                entitySelector, valueSelector, true);
 
         // <4 => entity selector; >=4 => value selector
         TestRandom random = new TestRandom(
@@ -130,19 +122,15 @@ class ElementDestinationSelectorTest {
         TestdataListValue v2 = new TestdataListValue("2");
         TestdataListValue v3 = new TestdataListValue("3");
 
-        InnerScoreDirector<TestdataListSolution, SimpleScore> scoreDirector =
-                PlannerTestUtils.mockScoreDirector(TestdataListSolution.buildSolutionDescriptor());
-
-        ListVariableDescriptor<TestdataListSolution> listVariableDescriptor = getListVariableDescriptor(scoreDirector);
         EntitySelector<TestdataListSolution> entitySelector = mockEntitySelector();
         EntityIndependentValueSelector<TestdataListSolution> valueSelector = mockEntityIndependentValueSelector(v1, v2, v3);
 
         ElementDestinationSelector<TestdataListSolution> randomSelector = new ElementDestinationSelector<>(
-                listVariableDescriptor, entitySelector, valueSelector, true);
+                entitySelector, valueSelector, true);
         assertEmptyNeverEndingIterableSelector(randomSelector, 0);
 
         ElementDestinationSelector<TestdataListSolution> originalSelector = new ElementDestinationSelector<>(
-                listVariableDescriptor, entitySelector, valueSelector, false);
+                entitySelector, valueSelector, false);
         assertAllCodesOfIterableSelector(originalSelector, 0);
     }
 
@@ -152,18 +140,18 @@ class ElementDestinationSelectorTest {
         TestdataListEntity b = TestdataListEntity.createWithValues("B");
 
         InnerScoreDirector<TestdataListSolution, SimpleScore> scoreDirector =
-                PlannerTestUtils.mockScoreDirector(TestdataListSolution.buildSolutionDescriptor());
+                mockScoreDirector(TestdataListSolution.buildSolutionDescriptor());
 
-        ListVariableDescriptor<TestdataListSolution> listVariableDescriptor = getListVariableDescriptor(scoreDirector);
         EntitySelector<TestdataListSolution> entitySelector = mockEntitySelector(a, b);
-        EntityIndependentValueSelector<TestdataListSolution> valueSelector = mockEntityIndependentValueSelector();
+        EntityIndependentValueSelector<TestdataListSolution> valueSelector =
+                mockEntityIndependentValueSelector(getListVariableDescriptor(scoreDirector));
 
         ElementDestinationSelector<TestdataListSolution> originalSelector = new ElementDestinationSelector<>(
-                listVariableDescriptor, entitySelector, valueSelector, false);
+                entitySelector, valueSelector, false);
         assertAllCodesOfIterableSelector(originalSelector, 2, "A[0]", "B[0]");
 
         ElementDestinationSelector<TestdataListSolution> randomSelector = new ElementDestinationSelector<>(
-                listVariableDescriptor, entitySelector, valueSelector, true);
+                entitySelector, valueSelector, true);
         TestRandom random = new TestRandom(0, 1);
 
         solvingStarted(randomSelector, scoreDirector, random);
@@ -174,16 +162,14 @@ class ElementDestinationSelectorTest {
     @Test
     void phaseLifecycle() {
         InnerScoreDirector<TestdataListSolution, SimpleScore> scoreDirector =
-                PlannerTestUtils.mockScoreDirector(TestdataListSolution.buildSolutionDescriptor());
+                mockScoreDirector(TestdataListSolution.buildSolutionDescriptor());
 
         EntitySelector<TestdataListSolution> entitySelector = mockEntitySelector();
-        EntityIndependentValueSelector<TestdataListSolution> valueSelector = mockEntityIndependentValueSelector();
+        EntityIndependentValueSelector<TestdataListSolution> valueSelector =
+                mockEntityIndependentValueSelector(getListVariableDescriptor(scoreDirector));
 
         ElementDestinationSelector<TestdataListSolution> selector = new ElementDestinationSelector<>(
-                getListVariableDescriptor(scoreDirector),
-                entitySelector,
-                valueSelector,
-                false);
+                entitySelector, valueSelector, false);
 
         SolverScope<TestdataListSolution> solverScope = solvingStarted(selector, scoreDirector);
         AbstractPhaseScope<TestdataListSolution> phaseScope = phaseStarted(selector, solverScope);

--- a/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/ElementDestinationSelectorTest.java
+++ b/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/ElementDestinationSelectorTest.java
@@ -123,7 +123,9 @@ class ElementDestinationSelectorTest {
         TestdataListValue v3 = new TestdataListValue("3");
 
         EntitySelector<TestdataListSolution> entitySelector = mockEntitySelector();
-        EntityIndependentValueSelector<TestdataListSolution> valueSelector = mockEntityIndependentValueSelector(v1, v2, v3);
+        EntityIndependentValueSelector<TestdataListSolution> valueSelector = mockEntityIndependentValueSelector(
+                TestdataListEntity.buildVariableDescriptorForValueList(),
+                v1, v2, v3);
 
         ElementDestinationSelector<TestdataListSolution> randomSelector = new ElementDestinationSelector<>(
                 entitySelector, valueSelector, true);

--- a/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/ListChangeMoveSelectorTest.java
+++ b/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/ListChangeMoveSelectorTest.java
@@ -9,6 +9,7 @@ import static org.optaplanner.core.impl.testdata.domain.list.TestdataListUtils.m
 import static org.optaplanner.core.impl.testdata.domain.list.TestdataListUtils.mockNeverEndingEntityIndependentValueSelector;
 import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertAllCodesOfMoveSelector;
 import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertCodesOfNeverEndingMoveSelector;
+import static org.optaplanner.core.impl.testdata.util.PlannerTestUtils.mockScoreDirector;
 
 import org.junit.jupiter.api.Test;
 import org.optaplanner.core.api.score.buildin.simple.SimpleScore;
@@ -16,7 +17,6 @@ import org.optaplanner.core.impl.score.director.InnerScoreDirector;
 import org.optaplanner.core.impl.testdata.domain.list.TestdataListEntity;
 import org.optaplanner.core.impl.testdata.domain.list.TestdataListSolution;
 import org.optaplanner.core.impl.testdata.domain.list.TestdataListValue;
-import org.optaplanner.core.impl.testdata.util.PlannerTestUtils;
 
 class ListChangeMoveSelectorTest {
 
@@ -30,11 +30,10 @@ class ListChangeMoveSelectorTest {
         TestdataListEntity c = TestdataListEntity.createWithValues("C", v3);
 
         InnerScoreDirector<TestdataListSolution, SimpleScore> scoreDirector =
-                PlannerTestUtils.mockScoreDirector(TestdataListSolution.buildSolutionDescriptor());
+                mockScoreDirector(TestdataListSolution.buildSolutionDescriptor());
 
         ListChangeMoveSelector<TestdataListSolution> moveSelector = new ListChangeMoveSelector<>(
-                getListVariableDescriptor(scoreDirector),
-                mockEntityIndependentValueSelector(v3, v1, v2),
+                mockEntityIndependentValueSelector(getListVariableDescriptor(scoreDirector), v3, v1, v2),
                 mockDestinationSelector(
                         elementRef(a, 0),
                         elementRef(b, 0),
@@ -87,11 +86,10 @@ class ListChangeMoveSelectorTest {
         TestdataListEntity c = TestdataListEntity.createWithValues("C", v3);
 
         InnerScoreDirector<TestdataListSolution, SimpleScore> scoreDirector =
-                PlannerTestUtils.mockScoreDirector(TestdataListSolution.buildSolutionDescriptor());
+                mockScoreDirector(TestdataListSolution.buildSolutionDescriptor());
 
         ListChangeMoveSelector<TestdataListSolution> moveSelector = new ListChangeMoveSelector<>(
-                getListVariableDescriptor(scoreDirector),
-                mockNeverEndingEntityIndependentValueSelector(v2, v1, v3, v3, v3),
+                mockNeverEndingEntityIndependentValueSelector(getListVariableDescriptor(scoreDirector), v2, v1, v3, v3, v3),
                 mockNeverEndingDestinationSelector(
                         elementRef(b, 0),
                         elementRef(a, 2),
@@ -130,11 +128,10 @@ class ListChangeMoveSelectorTest {
         TestdataListEntity c = TestdataListEntity.createWithValues("C", v5);
 
         InnerScoreDirector<TestdataListSolution, SimpleScore> scoreDirector =
-                PlannerTestUtils.mockScoreDirector(TestdataListSolution.buildSolutionDescriptor());
+                mockScoreDirector(TestdataListSolution.buildSolutionDescriptor());
 
         ListChangeMoveSelector<TestdataListSolution> moveSelector = new ListChangeMoveSelector<>(
-                getListVariableDescriptor(scoreDirector),
-                mockEntityIndependentValueSelector(v3, v1, v4, v2, v5),
+                mockEntityIndependentValueSelector(getListVariableDescriptor(scoreDirector), v3, v1, v4, v2, v5),
                 mockDestinationSelector(
                         elementRef(a, 0),
                         elementRef(b, 0),

--- a/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/ListSwapMoveSelectorTest.java
+++ b/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/ListSwapMoveSelectorTest.java
@@ -9,6 +9,7 @@ import static org.optaplanner.core.impl.testdata.util.PlannerTestUtils.mockScore
 
 import org.junit.jupiter.api.Test;
 import org.optaplanner.core.api.score.buildin.simple.SimpleScore;
+import org.optaplanner.core.impl.domain.variable.descriptor.ListVariableDescriptor;
 import org.optaplanner.core.impl.score.director.InnerScoreDirector;
 import org.optaplanner.core.impl.testdata.domain.list.TestdataListEntity;
 import org.optaplanner.core.impl.testdata.domain.list.TestdataListSolution;
@@ -28,10 +29,11 @@ class ListSwapMoveSelectorTest {
         InnerScoreDirector<TestdataListSolution, SimpleScore> scoreDirector =
                 mockScoreDirector(TestdataListSolution.buildSolutionDescriptor());
 
+        ListVariableDescriptor<TestdataListSolution> listVariableDescriptor = getListVariableDescriptor(scoreDirector);
+
         ListSwapMoveSelector<TestdataListSolution> moveSelector = new ListSwapMoveSelector<>(
-                getListVariableDescriptor(scoreDirector),
-                mockEntityIndependentValueSelector(v3, v1, v2),
-                mockEntityIndependentValueSelector(v3, v1, v2),
+                mockEntityIndependentValueSelector(listVariableDescriptor, v3, v1, v2),
+                mockEntityIndependentValueSelector(listVariableDescriptor, v3, v1, v2),
                 false);
 
         solvingStarted(moveSelector, scoreDirector);
@@ -68,12 +70,13 @@ class ListSwapMoveSelectorTest {
         InnerScoreDirector<TestdataListSolution, SimpleScore> scoreDirector =
                 mockScoreDirector(TestdataListSolution.buildSolutionDescriptor());
 
+        ListVariableDescriptor<TestdataListSolution> listVariableDescriptor = getListVariableDescriptor(scoreDirector);
+
         ListSwapMoveSelector<TestdataListSolution> moveSelector = new ListSwapMoveSelector<>(
-                getListVariableDescriptor(scoreDirector),
                 // Value selectors are longer than the number of expected codes because they're expected
                 // to be never ending, so they must not be exhausted after the last asserted code.
-                mockEntityIndependentValueSelector(v2, v3, v2, v3, v2, v3, v1, v1, v1, v1),
-                mockEntityIndependentValueSelector(v1, v2, v3, v1, v2, v3, v1, v2, v3, v1),
+                mockEntityIndependentValueSelector(listVariableDescriptor, v2, v3, v2, v3, v2, v3, v1, v1, v1, v1),
+                mockEntityIndependentValueSelector(listVariableDescriptor, v1, v2, v3, v1, v2, v3, v1, v2, v3, v1),
                 true);
 
         solvingStarted(moveSelector, scoreDirector);

--- a/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/NearSubListNearbySubListSelectorTest.java
+++ b/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/NearSubListNearbySubListSelectorTest.java
@@ -14,7 +14,6 @@ import static org.optaplanner.core.impl.testdata.util.PlannerTestUtils.mockScore
 
 import org.junit.jupiter.api.Test;
 import org.optaplanner.core.api.score.buildin.simple.SimpleScore;
-import org.optaplanner.core.impl.domain.variable.descriptor.ListVariableDescriptor;
 import org.optaplanner.core.impl.heuristic.selector.entity.EntitySelector;
 import org.optaplanner.core.impl.heuristic.selector.move.generic.list.mimic.MimicReplayingSubListSelector;
 import org.optaplanner.core.impl.heuristic.selector.value.EntityIndependentValueSelector;
@@ -279,12 +278,8 @@ class NearSubListNearbySubListSelectorTest {
             EntitySelector<TestdataListSolution> entitySelector = mockEntitySelector(entities);
             when(entitySelector.getEntityDescriptor()).thenReturn(TestdataListEntity.buildEntityDescriptor());
 
-            ListVariableDescriptor<TestdataListSolution> listVariableDescriptor =
-                    (ListVariableDescriptor<TestdataListSolution>) valueSelector.getVariableDescriptor();
-
             // Used to populate the distance matrix with destinations.
             return new RandomSubListSelector<>(
-                    listVariableDescriptor,
                     entitySelector,
                     valueSelector,
                     minimumSubListSize,

--- a/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/NearSubListNearbySubListSelectorTest.java
+++ b/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/NearSubListNearbySubListSelectorTest.java
@@ -5,6 +5,7 @@ import static org.optaplanner.core.impl.heuristic.selector.SelectorTestUtils.moc
 import static org.optaplanner.core.impl.heuristic.selector.SelectorTestUtils.phaseStarted;
 import static org.optaplanner.core.impl.heuristic.selector.SelectorTestUtils.solvingStarted;
 import static org.optaplanner.core.impl.heuristic.selector.SelectorTestUtils.stepStarted;
+import static org.optaplanner.core.impl.testdata.domain.list.TestdataListUtils.getListVariableDescriptor;
 import static org.optaplanner.core.impl.testdata.domain.list.TestdataListUtils.mockEntityIndependentValueSelector;
 import static org.optaplanner.core.impl.testdata.domain.list.TestdataListUtils.mockEntitySelector;
 import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertAllCodesOfIterator;
@@ -272,7 +273,7 @@ class NearSubListNearbySubListSelectorTest {
         RandomSubListSelector<TestdataListSolution> build() {
             // Enumerates all values. Does not affect nearby subList selection.
             EntityIndependentValueSelector<TestdataListSolution> valueSelector =
-                    mockEntityIndependentValueSelector(scoreDirector, values);
+                    mockEntityIndependentValueSelector(getListVariableDescriptor(scoreDirector), values);
 
             // Enumerates all entities. Does not affect nearby subList selection.
             EntitySelector<TestdataListSolution> entitySelector = mockEntitySelector(entities);

--- a/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/NearValueNearbyDestinationSelectorTest.java
+++ b/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/NearValueNearbyDestinationSelectorTest.java
@@ -5,6 +5,7 @@ import static org.optaplanner.core.impl.heuristic.selector.SelectorTestUtils.moc
 import static org.optaplanner.core.impl.heuristic.selector.SelectorTestUtils.phaseStarted;
 import static org.optaplanner.core.impl.heuristic.selector.SelectorTestUtils.solvingStarted;
 import static org.optaplanner.core.impl.heuristic.selector.SelectorTestUtils.stepStarted;
+import static org.optaplanner.core.impl.testdata.domain.list.TestdataListUtils.getListVariableDescriptor;
 import static org.optaplanner.core.impl.testdata.domain.list.TestdataListUtils.mockEntityIndependentValueSelector;
 import static org.optaplanner.core.impl.testdata.domain.list.TestdataListUtils.mockEntitySelector;
 import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertAllCodesOfIterator;
@@ -12,7 +13,6 @@ import static org.optaplanner.core.impl.testdata.util.PlannerTestUtils.mockScore
 
 import org.junit.jupiter.api.Test;
 import org.optaplanner.core.api.score.buildin.simple.SimpleScore;
-import org.optaplanner.core.impl.domain.variable.descriptor.ListVariableDescriptor;
 import org.optaplanner.core.impl.heuristic.selector.entity.EntitySelector;
 import org.optaplanner.core.impl.heuristic.selector.value.EntityIndependentValueSelector;
 import org.optaplanner.core.impl.heuristic.selector.value.mimic.ManualValueMimicRecorder;
@@ -42,15 +42,13 @@ class NearValueNearbyDestinationSelectorTest {
                 mockScoreDirector(TestdataListSolution.buildSolutionDescriptor());
 
         EntityIndependentValueSelector<TestdataListSolution> valueSelector =
-                mockEntityIndependentValueSelector(scoreDirector, v1, v2, v3, v4, v5);
+                mockEntityIndependentValueSelector(getListVariableDescriptor(scoreDirector), v1, v2, v3, v4, v5);
 
         EntitySelector<TestdataListSolution> entitySelector = mockEntitySelector(e1, e2);
         when(entitySelector.getEntityDescriptor()).thenReturn(TestdataListEntity.buildEntityDescriptor());
 
         ElementDestinationSelector<TestdataListSolution> childDestinationSelector = new ElementDestinationSelector<>(
-                ((ListVariableDescriptor<TestdataListSolution>) valueSelector.getVariableDescriptor()),
-                entitySelector,
-                valueSelector, true);
+                entitySelector, valueSelector, true);
 
         TestNearbyRandom nearbyRandom = new TestNearbyRandom();
 
@@ -96,7 +94,7 @@ class NearValueNearbyDestinationSelectorTest {
                 mockScoreDirector(TestdataListSolution.buildSolutionDescriptor());
 
         EntityIndependentValueSelector<TestdataListSolution> valueSelector =
-                mockEntityIndependentValueSelector(scoreDirector, v1, v2, v3, v4, v5);
+                mockEntityIndependentValueSelector(getListVariableDescriptor(scoreDirector), v1, v2, v3, v4, v5);
 
         ManualValueMimicRecorder<TestdataListSolution> valueMimicRecorder = new ManualValueMimicRecorder<>(valueSelector);
 
@@ -104,9 +102,7 @@ class NearValueNearbyDestinationSelectorTest {
         when(entitySelector.getEntityDescriptor()).thenReturn(TestdataListEntity.buildEntityDescriptor());
 
         ElementDestinationSelector<TestdataListSolution> childDestinationSelector = new ElementDestinationSelector<>(
-                ((ListVariableDescriptor<TestdataListSolution>) valueSelector.getVariableDescriptor()),
-                entitySelector,
-                valueSelector, true);
+                entitySelector, valueSelector, false);
 
         NearValueNearbyDestinationSelector<TestdataListSolution> nearbyDestinationSelector =
                 new NearValueNearbyDestinationSelector<>(childDestinationSelector,

--- a/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/OriginalListChangeIteratorTest.java
+++ b/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/OriginalListChangeIteratorTest.java
@@ -40,7 +40,6 @@ class OriginalListChangeIteratorTest {
         EntityIndependentValueSelector<TestdataListSolution> valueSelector =
                 mockEntityIndependentValueSelector(values.toArray());
         OriginalListChangeIterator<TestdataListSolution> listChangeIterator = new OriginalListChangeIterator<>(
-                listVariableDescriptor,
                 scoreDirector.getSupplyManager().demand(new SingletonListInverseVariableDemand<>(listVariableDescriptor)),
                 scoreDirector.getSupplyManager().demand(new IndexVariableDemand<>(listVariableDescriptor)),
                 valueSelector,

--- a/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/OriginalListChangeIteratorTest.java
+++ b/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/OriginalListChangeIteratorTest.java
@@ -38,7 +38,7 @@ class OriginalListChangeIteratorTest {
                 mockScoreDirector(TestdataListSolution.buildSolutionDescriptor());
         ListVariableDescriptor<TestdataListSolution> listVariableDescriptor = getListVariableDescriptor(scoreDirector);
         EntityIndependentValueSelector<TestdataListSolution> valueSelector =
-                mockEntityIndependentValueSelector(values.toArray());
+                mockEntityIndependentValueSelector(listVariableDescriptor, values.toArray());
         OriginalListChangeIterator<TestdataListSolution> listChangeIterator = new OriginalListChangeIterator<>(
                 scoreDirector.getSupplyManager().demand(new SingletonListInverseVariableDemand<>(listVariableDescriptor)),
                 scoreDirector.getSupplyManager().demand(new IndexVariableDemand<>(listVariableDescriptor)),

--- a/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/OriginalListChangeIteratorTest.java
+++ b/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/OriginalListChangeIteratorTest.java
@@ -45,7 +45,6 @@ class OriginalListChangeIteratorTest {
                 scoreDirector.getSupplyManager().demand(new IndexVariableDemand<>(listVariableDescriptor)),
                 valueSelector,
                 new ElementDestinationSelector<>(
-                        listVariableDescriptor,
                         mockEntitySelector(entities.toArray()),
                         valueSelector,
                         false));

--- a/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/OriginalListSwapIteratorTest.java
+++ b/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/OriginalListSwapIteratorTest.java
@@ -40,8 +40,8 @@ class OriginalListSwapIteratorTest {
         OriginalListSwapIterator<TestdataListSolution> listSwapIterator = new OriginalListSwapIterator<>(
                 scoreDirector.getSupplyManager().demand(new SingletonListInverseVariableDemand<>(listVariableDescriptor)),
                 scoreDirector.getSupplyManager().demand(new IndexVariableDemand<>(listVariableDescriptor)),
-                mockEntityIndependentValueSelector(leftValues.toArray()),
-                mockEntityIndependentValueSelector(rightValues.toArray()));
+                mockEntityIndependentValueSelector(listVariableDescriptor, leftValues.toArray()),
+                mockEntityIndependentValueSelector(listVariableDescriptor, rightValues.toArray()));
 
         assertThat(listSwapIterator).isExhausted();
     }

--- a/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/OriginalListSwapIteratorTest.java
+++ b/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/OriginalListSwapIteratorTest.java
@@ -38,7 +38,6 @@ class OriginalListSwapIteratorTest {
                 mockScoreDirector(TestdataListSolution.buildSolutionDescriptor());
         ListVariableDescriptor<TestdataListSolution> listVariableDescriptor = getListVariableDescriptor(scoreDirector);
         OriginalListSwapIterator<TestdataListSolution> listSwapIterator = new OriginalListSwapIterator<>(
-                listVariableDescriptor,
                 scoreDirector.getSupplyManager().demand(new SingletonListInverseVariableDemand<>(listVariableDescriptor)),
                 scoreDirector.getSupplyManager().demand(new IndexVariableDemand<>(listVariableDescriptor)),
                 mockEntityIndependentValueSelector(leftValues.toArray()),

--- a/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/RandomListChangeIteratorTest.java
+++ b/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/RandomListChangeIteratorTest.java
@@ -36,12 +36,12 @@ class RandomListChangeIteratorTest {
         ListVariableDescriptor<TestdataListSolution> listVariableDescriptor = getListVariableDescriptor(scoreDirector);
         // Iterates over values in this given order.
         EntityIndependentValueSelector<TestdataListSolution> sourceValueSelector =
-                mockEntityIndependentValueSelector(v1, v2, v3);
+                mockEntityIndependentValueSelector(listVariableDescriptor, v1, v2, v3);
         EntityIndependentValueSelector<TestdataListSolution> destinationValueSelector =
-                mockEntityIndependentValueSelector(v2, v3);
+                mockEntityIndependentValueSelector(listVariableDescriptor, v2, v3);
         EntitySelector<TestdataListSolution> entitySelector = mockEntitySelector(b, a, c);
         ElementDestinationSelector<TestdataListSolution> destinationSelector =
-                new ElementDestinationSelector<>(listVariableDescriptor, entitySelector, destinationValueSelector, true);
+                new ElementDestinationSelector<>(entitySelector, destinationValueSelector, true);
         RandomListChangeIterator<TestdataListSolution> randomListChangeIterator = new RandomListChangeIterator<>(
                 listVariableDescriptor,
                 scoreDirector.getSupplyManager().demand(new SingletonListInverseVariableDemand<>(listVariableDescriptor)),
@@ -64,5 +64,4 @@ class RandomListChangeIteratorTest {
 
         random.assertIntBoundJustRequested((int) destinationRange);
     }
-
 }

--- a/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/RandomListChangeIteratorTest.java
+++ b/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/RandomListChangeIteratorTest.java
@@ -43,7 +43,6 @@ class RandomListChangeIteratorTest {
         ElementDestinationSelector<TestdataListSolution> destinationSelector =
                 new ElementDestinationSelector<>(entitySelector, destinationValueSelector, true);
         RandomListChangeIterator<TestdataListSolution> randomListChangeIterator = new RandomListChangeIterator<>(
-                listVariableDescriptor,
                 scoreDirector.getSupplyManager().demand(new SingletonListInverseVariableDemand<>(listVariableDescriptor)),
                 scoreDirector.getSupplyManager().demand(new IndexVariableDemand<>(listVariableDescriptor)),
                 sourceValueSelector,

--- a/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/RandomListSwapIteratorTest.java
+++ b/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/RandomListSwapIteratorTest.java
@@ -31,7 +31,6 @@ class RandomListSwapIteratorTest {
         ListVariableDescriptor<TestdataListSolution> listVariableDescriptor = getListVariableDescriptor(scoreDirector);
 
         RandomListSwapIterator<TestdataListSolution> randomListSwapIterator = new RandomListSwapIterator<>(
-                listVariableDescriptor,
                 scoreDirector.getSupplyManager().demand(new SingletonListInverseVariableDemand<>(listVariableDescriptor)),
                 scoreDirector.getSupplyManager().demand(new IndexVariableDemand<>(listVariableDescriptor)),
                 mockEntityIndependentValueSelector(v1, v1, v1, v3),

--- a/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/RandomListSwapIteratorTest.java
+++ b/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/RandomListSwapIteratorTest.java
@@ -33,8 +33,8 @@ class RandomListSwapIteratorTest {
         RandomListSwapIterator<TestdataListSolution> randomListSwapIterator = new RandomListSwapIterator<>(
                 scoreDirector.getSupplyManager().demand(new SingletonListInverseVariableDemand<>(listVariableDescriptor)),
                 scoreDirector.getSupplyManager().demand(new IndexVariableDemand<>(listVariableDescriptor)),
-                mockEntityIndependentValueSelector(v1, v1, v1, v3),
-                mockEntityIndependentValueSelector(v1, v2, v3, v1));
+                mockEntityIndependentValueSelector(listVariableDescriptor, v1, v1, v1, v3),
+                mockEntityIndependentValueSelector(listVariableDescriptor, v1, v2, v3, v1));
 
         assertCodesOfIterator(randomListSwapIterator,
                 "1 {A[0]} <-> 1 {A[0]}",

--- a/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/RandomSubListChangeMoveSelectorTest.java
+++ b/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/RandomSubListChangeMoveSelectorTest.java
@@ -13,10 +13,10 @@ import static org.optaplanner.core.impl.testdata.domain.list.TestdataListUtils.m
 import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertCodesOfNeverEndingMoveSelector;
 import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertEmptyNeverEndingMoveSelector;
 import static org.optaplanner.core.impl.testdata.util.PlannerAssert.verifyPhaseLifecycle;
+import static org.optaplanner.core.impl.testdata.util.PlannerTestUtils.mockScoreDirector;
 
 import org.junit.jupiter.api.Test;
 import org.optaplanner.core.api.score.buildin.simple.SimpleScore;
-import org.optaplanner.core.impl.domain.variable.descriptor.ListVariableDescriptor;
 import org.optaplanner.core.impl.heuristic.selector.entity.EntitySelector;
 import org.optaplanner.core.impl.heuristic.selector.value.EntityIndependentValueSelector;
 import org.optaplanner.core.impl.phase.scope.AbstractPhaseScope;
@@ -26,7 +26,6 @@ import org.optaplanner.core.impl.solver.scope.SolverScope;
 import org.optaplanner.core.impl.testdata.domain.list.TestdataListEntity;
 import org.optaplanner.core.impl.testdata.domain.list.TestdataListSolution;
 import org.optaplanner.core.impl.testdata.domain.list.TestdataListValue;
-import org.optaplanner.core.impl.testdata.util.PlannerTestUtils;
 import org.optaplanner.core.impl.testutil.TestRandom;
 
 class RandomSubListChangeMoveSelectorTest {
@@ -41,7 +40,7 @@ class RandomSubListChangeMoveSelectorTest {
         TestdataListEntity b = TestdataListEntity.createWithValues("B");
 
         InnerScoreDirector<TestdataListSolution, SimpleScore> scoreDirector =
-                PlannerTestUtils.mockScoreDirector(TestdataListSolution.buildSolutionDescriptor());
+                mockScoreDirector(TestdataListSolution.buildSolutionDescriptor());
 
         int minimumSubListSize = 1;
         int maximumSubListSize = Integer.MAX_VALUE;
@@ -51,12 +50,10 @@ class RandomSubListChangeMoveSelectorTest {
         // The number of subLists of [1, 2, 3, 4] is the 4th triangular number (10).
         assertThat(subListCount).isEqualTo(nthTriangle(listSize(a)) + nthTriangle(listSize(b)));
 
-        ListVariableDescriptor<TestdataListSolution> listVariableDescriptor = getListVariableDescriptor(scoreDirector);
         RandomSubListChangeMoveSelector<TestdataListSolution> moveSelector = new RandomSubListChangeMoveSelector<>(
-                listVariableDescriptor,
                 new RandomSubListSelector<>(
                         mockEntitySelector(a, b),
-                        mockNeverEndingEntityIndependentValueSelector(listVariableDescriptor, v1),
+                        mockNeverEndingEntityIndependentValueSelector(getListVariableDescriptor(scoreDirector), v1),
                         minimumSubListSize,
                         maximumSubListSize),
                 mockNeverEndingDestinationSelector(destinationSize, ElementRef.of(b, 0)),
@@ -92,7 +89,7 @@ class RandomSubListChangeMoveSelectorTest {
         TestdataListEntity b = TestdataListEntity.createWithValues("B");
 
         InnerScoreDirector<TestdataListSolution, SimpleScore> scoreDirector =
-                PlannerTestUtils.mockScoreDirector(TestdataListSolution.buildSolutionDescriptor());
+                mockScoreDirector(TestdataListSolution.buildSolutionDescriptor());
 
         int minimumSubListSize = 1;
         int maximumSubListSize = Integer.MAX_VALUE;
@@ -101,12 +98,10 @@ class RandomSubListChangeMoveSelectorTest {
         // Selecting reversing moves doubles the total number of selected elements (move selector size).
         int moveSelectorSize = 2 * subListCount * destinationSize;
 
-        ListVariableDescriptor<TestdataListSolution> listVariableDescriptor = getListVariableDescriptor(scoreDirector);
         RandomSubListChangeMoveSelector<TestdataListSolution> moveSelector = new RandomSubListChangeMoveSelector<>(
-                listVariableDescriptor,
                 new RandomSubListSelector<>(
                         mockEntitySelector(a, b),
-                        mockNeverEndingEntityIndependentValueSelector(listVariableDescriptor, v1),
+                        mockNeverEndingEntityIndependentValueSelector(getListVariableDescriptor(scoreDirector), v1),
                         minimumSubListSize,
                         maximumSubListSize),
                 mockNeverEndingDestinationSelector(destinationSize, ElementRef.of(b, 0)),
@@ -153,19 +148,17 @@ class RandomSubListChangeMoveSelectorTest {
         TestdataListEntity b = TestdataListEntity.createWithValues("B");
 
         InnerScoreDirector<TestdataListSolution, SimpleScore> scoreDirector =
-                PlannerTestUtils.mockScoreDirector(TestdataListSolution.buildSolutionDescriptor());
+                mockScoreDirector(TestdataListSolution.buildSolutionDescriptor());
 
         int minimumSubListSize = 2;
         int maximumSubListSize = 3;
         int subListCount = 5;
         int destinationSize = 51; // arbitrary
 
-        ListVariableDescriptor<TestdataListSolution> listVariableDescriptor = getListVariableDescriptor(scoreDirector);
         RandomSubListChangeMoveSelector<TestdataListSolution> moveSelector = new RandomSubListChangeMoveSelector<>(
-                listVariableDescriptor,
                 new RandomSubListSelector<>(
                         mockEntitySelector(a, b),
-                        mockNeverEndingEntityIndependentValueSelector(listVariableDescriptor, v1),
+                        mockNeverEndingEntityIndependentValueSelector(getListVariableDescriptor(scoreDirector), v1),
                         minimumSubListSize,
                         maximumSubListSize),
                 mockNeverEndingDestinationSelector(destinationSize, ElementRef.of(b, 0)),
@@ -194,17 +187,15 @@ class RandomSubListChangeMoveSelectorTest {
         TestdataListEntity a = TestdataListEntity.createWithValues("A", v1, v2, v3);
 
         InnerScoreDirector<TestdataListSolution, SimpleScore> scoreDirector =
-                PlannerTestUtils.mockScoreDirector(TestdataListSolution.buildSolutionDescriptor());
+                mockScoreDirector(TestdataListSolution.buildSolutionDescriptor());
 
         int minimumSubListSize = 100;
         int maximumSubListSize = Integer.MAX_VALUE;
 
-        ListVariableDescriptor<TestdataListSolution> listVariableDescriptor = getListVariableDescriptor(scoreDirector);
         RandomSubListChangeMoveSelector<TestdataListSolution> moveSelector = new RandomSubListChangeMoveSelector<>(
-                listVariableDescriptor,
                 new RandomSubListSelector<>(
                         mockEntitySelector(a),
-                        mockNeverEndingEntityIndependentValueSelector(listVariableDescriptor, v1),
+                        mockNeverEndingEntityIndependentValueSelector(getListVariableDescriptor(scoreDirector), v1),
                         minimumSubListSize,
                         maximumSubListSize),
                 mockNeverEndingDestinationSelector(),
@@ -226,19 +217,17 @@ class RandomSubListChangeMoveSelectorTest {
         TestdataListEntity c = TestdataListEntity.createWithValues("C", v4);
 
         InnerScoreDirector<TestdataListSolution, SimpleScore> scoreDirector =
-                PlannerTestUtils.mockScoreDirector(TestdataListSolution.buildSolutionDescriptor());
+                mockScoreDirector(TestdataListSolution.buildSolutionDescriptor());
 
         int minimumSubListSize = 2;
         int maximumSubListSize = 2;
         int subListCount = 2;
         int destinationSize = 13; // arbitrary
 
-        ListVariableDescriptor<TestdataListSolution> listVariableDescriptor = getListVariableDescriptor(scoreDirector);
         RandomSubListChangeMoveSelector<TestdataListSolution> moveSelector = new RandomSubListChangeMoveSelector<>(
-                listVariableDescriptor,
                 new RandomSubListSelector<>(
                         mockEntitySelector(a, b, c),
-                        mockNeverEndingEntityIndependentValueSelector(listVariableDescriptor, v4, v1),
+                        mockNeverEndingEntityIndependentValueSelector(getListVariableDescriptor(scoreDirector), v4, v1),
                         minimumSubListSize,
                         maximumSubListSize),
                 mockNeverEndingDestinationSelector(destinationSize, ElementRef.of(b, 0)),
@@ -268,7 +257,7 @@ class RandomSubListChangeMoveSelectorTest {
         TestdataListEntity c = TestdataListEntity.createWithValues("C", v4, v5);
 
         InnerScoreDirector<TestdataListSolution, SimpleScore> scoreDirector =
-                PlannerTestUtils.mockScoreDirector(TestdataListSolution.buildSolutionDescriptor());
+                mockScoreDirector(TestdataListSolution.buildSolutionDescriptor());
 
         int minimumSubListSize = 1;
         int maximumSubListSize = Integer.MAX_VALUE;
@@ -277,12 +266,11 @@ class RandomSubListChangeMoveSelectorTest {
 
         assertThat(subListCount).isEqualTo(nthTriangle(listSize(a)) + nthTriangle(listSize(b)) + nthTriangle(listSize(c)));
 
-        ListVariableDescriptor<TestdataListSolution> listVariableDescriptor = getListVariableDescriptor(scoreDirector);
         RandomSubListChangeMoveSelector<TestdataListSolution> moveSelector = new RandomSubListChangeMoveSelector<>(
-                listVariableDescriptor,
                 new RandomSubListSelector<>(
                         mockEntitySelector(a, b, c), // affects subList calculation and the move selector size
-                        mockNeverEndingEntityIndependentValueSelector(listVariableDescriptor, v1, v2, v3, v4, v5),
+                        mockNeverEndingEntityIndependentValueSelector(getListVariableDescriptor(scoreDirector),
+                                v1, v2, v3, v4, v5),
                         minimumSubListSize,
                         maximumSubListSize),
                 mockNeverEndingDestinationSelector(destinationSize, ElementRef.of(b, -1)),
@@ -317,19 +305,17 @@ class RandomSubListChangeMoveSelectorTest {
         TestdataListEntity d = TestdataListEntity.createWithValues("D", v21, v22, v23, v24);
 
         InnerScoreDirector<TestdataListSolution, SimpleScore> scoreDirector =
-                PlannerTestUtils.mockScoreDirector(TestdataListSolution.buildSolutionDescriptor());
+                mockScoreDirector(TestdataListSolution.buildSolutionDescriptor());
 
         int minimumSubListSize = 3;
         int maximumSubListSize = 5;
         int subListCount = 16;
         int destinationSize = 7; // arbitrary
 
-        ListVariableDescriptor<TestdataListSolution> listVariableDescriptor = getListVariableDescriptor(scoreDirector);
         RandomSubListChangeMoveSelector<TestdataListSolution> moveSelector = new RandomSubListChangeMoveSelector<>(
-                listVariableDescriptor,
                 new RandomSubListSelector<>(
                         mockEntitySelector(a, b, c, d), // affects subList calculation and the move selector size
-                        mockNeverEndingEntityIndependentValueSelector(listVariableDescriptor, v1),
+                        mockNeverEndingEntityIndependentValueSelector(getListVariableDescriptor(scoreDirector), v1),
                         minimumSubListSize,
                         maximumSubListSize),
                 mockNeverEndingDestinationSelector(destinationSize, ElementRef.of(b, 0)),
@@ -344,25 +330,24 @@ class RandomSubListChangeMoveSelectorTest {
 
     @Test
     void phaseLifecycle() {
-        InnerScoreDirector<TestdataListSolution, SimpleScore> scoreDirector =
-                PlannerTestUtils.mockScoreDirector(TestdataListSolution.buildSolutionDescriptor());
-
-        ListVariableDescriptor<TestdataListSolution> listVariableDescriptor = getListVariableDescriptor(scoreDirector);
-
-        EntitySelector<TestdataListSolution> entitySelector = mockEntitySelector();
-        EntityIndependentValueSelector<TestdataListSolution> valueSelector =
-                mockNeverEndingEntityIndependentValueSelector(listVariableDescriptor);
         int minimumSubListSize = 1;
         int maximumSubListSize = Integer.MAX_VALUE;
 
+        InnerScoreDirector<TestdataListSolution, SimpleScore> scoreDirector =
+                mockScoreDirector(TestdataListSolution.buildSolutionDescriptor());
+
+        EntitySelector<TestdataListSolution> entitySelector = mockEntitySelector();
+        EntityIndependentValueSelector<TestdataListSolution> valueSelector =
+                mockNeverEndingEntityIndependentValueSelector(getListVariableDescriptor(scoreDirector));
+        DestinationSelector<TestdataListSolution> destinationSelector = mockNeverEndingDestinationSelector();
+
         RandomSubListChangeMoveSelector<TestdataListSolution> moveSelector = new RandomSubListChangeMoveSelector<>(
-                listVariableDescriptor,
                 new RandomSubListSelector<>(
                         entitySelector,
                         valueSelector,
                         minimumSubListSize,
                         maximumSubListSize),
-                mockNeverEndingDestinationSelector(),
+                destinationSelector,
                 false);
 
         SolverScope<TestdataListSolution> solverScope = solvingStarted(moveSelector, scoreDirector);
@@ -379,5 +364,6 @@ class RandomSubListChangeMoveSelectorTest {
 
         verifyPhaseLifecycle(entitySelector, 1, 1, 2);
         verifyPhaseLifecycle(valueSelector, 1, 1, 2);
+        verifyPhaseLifecycle(destinationSelector, 1, 1, 2);
     }
 }

--- a/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/RandomSubListChangeMoveSelectorTest.java
+++ b/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/RandomSubListChangeMoveSelectorTest.java
@@ -55,9 +55,8 @@ class RandomSubListChangeMoveSelectorTest {
         RandomSubListChangeMoveSelector<TestdataListSolution> moveSelector = new RandomSubListChangeMoveSelector<>(
                 listVariableDescriptor,
                 new RandomSubListSelector<>(
-                        listVariableDescriptor,
                         mockEntitySelector(a, b),
-                        mockNeverEndingEntityIndependentValueSelector(v1),
+                        mockNeverEndingEntityIndependentValueSelector(listVariableDescriptor, v1),
                         minimumSubListSize,
                         maximumSubListSize),
                 mockNeverEndingDestinationSelector(destinationSize, ElementRef.of(b, 0)),
@@ -106,9 +105,8 @@ class RandomSubListChangeMoveSelectorTest {
         RandomSubListChangeMoveSelector<TestdataListSolution> moveSelector = new RandomSubListChangeMoveSelector<>(
                 listVariableDescriptor,
                 new RandomSubListSelector<>(
-                        listVariableDescriptor,
                         mockEntitySelector(a, b),
-                        mockNeverEndingEntityIndependentValueSelector(v1),
+                        mockNeverEndingEntityIndependentValueSelector(listVariableDescriptor, v1),
                         minimumSubListSize,
                         maximumSubListSize),
                 mockNeverEndingDestinationSelector(destinationSize, ElementRef.of(b, 0)),
@@ -166,9 +164,8 @@ class RandomSubListChangeMoveSelectorTest {
         RandomSubListChangeMoveSelector<TestdataListSolution> moveSelector = new RandomSubListChangeMoveSelector<>(
                 listVariableDescriptor,
                 new RandomSubListSelector<>(
-                        listVariableDescriptor,
                         mockEntitySelector(a, b),
-                        mockNeverEndingEntityIndependentValueSelector(v1),
+                        mockNeverEndingEntityIndependentValueSelector(listVariableDescriptor, v1),
                         minimumSubListSize,
                         maximumSubListSize),
                 mockNeverEndingDestinationSelector(destinationSize, ElementRef.of(b, 0)),
@@ -206,9 +203,8 @@ class RandomSubListChangeMoveSelectorTest {
         RandomSubListChangeMoveSelector<TestdataListSolution> moveSelector = new RandomSubListChangeMoveSelector<>(
                 listVariableDescriptor,
                 new RandomSubListSelector<>(
-                        listVariableDescriptor,
                         mockEntitySelector(a),
-                        mockNeverEndingEntityIndependentValueSelector(v1),
+                        mockNeverEndingEntityIndependentValueSelector(listVariableDescriptor, v1),
                         minimumSubListSize,
                         maximumSubListSize),
                 mockNeverEndingDestinationSelector(),
@@ -241,9 +237,8 @@ class RandomSubListChangeMoveSelectorTest {
         RandomSubListChangeMoveSelector<TestdataListSolution> moveSelector = new RandomSubListChangeMoveSelector<>(
                 listVariableDescriptor,
                 new RandomSubListSelector<>(
-                        listVariableDescriptor,
                         mockEntitySelector(a, b, c),
-                        mockNeverEndingEntityIndependentValueSelector(v4, v1),
+                        mockNeverEndingEntityIndependentValueSelector(listVariableDescriptor, v4, v1),
                         minimumSubListSize,
                         maximumSubListSize),
                 mockNeverEndingDestinationSelector(destinationSize, ElementRef.of(b, 0)),
@@ -286,9 +281,8 @@ class RandomSubListChangeMoveSelectorTest {
         RandomSubListChangeMoveSelector<TestdataListSolution> moveSelector = new RandomSubListChangeMoveSelector<>(
                 listVariableDescriptor,
                 new RandomSubListSelector<>(
-                        listVariableDescriptor,
                         mockEntitySelector(a, b, c), // affects subList calculation and the move selector size
-                        mockNeverEndingEntityIndependentValueSelector(v1, v2, v3, v4, v5),
+                        mockNeverEndingEntityIndependentValueSelector(listVariableDescriptor, v1, v2, v3, v4, v5),
                         minimumSubListSize,
                         maximumSubListSize),
                 mockNeverEndingDestinationSelector(destinationSize, ElementRef.of(b, -1)),
@@ -334,9 +328,8 @@ class RandomSubListChangeMoveSelectorTest {
         RandomSubListChangeMoveSelector<TestdataListSolution> moveSelector = new RandomSubListChangeMoveSelector<>(
                 listVariableDescriptor,
                 new RandomSubListSelector<>(
-                        listVariableDescriptor,
                         mockEntitySelector(a, b, c, d), // affects subList calculation and the move selector size
-                        mockNeverEndingEntityIndependentValueSelector(v1),
+                        mockNeverEndingEntityIndependentValueSelector(listVariableDescriptor, v1),
                         minimumSubListSize,
                         maximumSubListSize),
                 mockNeverEndingDestinationSelector(destinationSize, ElementRef.of(b, 0)),
@@ -354,15 +347,17 @@ class RandomSubListChangeMoveSelectorTest {
         InnerScoreDirector<TestdataListSolution, SimpleScore> scoreDirector =
                 PlannerTestUtils.mockScoreDirector(TestdataListSolution.buildSolutionDescriptor());
 
+        ListVariableDescriptor<TestdataListSolution> listVariableDescriptor = getListVariableDescriptor(scoreDirector);
+
         EntitySelector<TestdataListSolution> entitySelector = mockEntitySelector();
-        EntityIndependentValueSelector<TestdataListSolution> valueSelector = mockNeverEndingEntityIndependentValueSelector();
+        EntityIndependentValueSelector<TestdataListSolution> valueSelector =
+                mockNeverEndingEntityIndependentValueSelector(listVariableDescriptor);
         int minimumSubListSize = 1;
         int maximumSubListSize = Integer.MAX_VALUE;
 
-        ListVariableDescriptor<TestdataListSolution> listVariableDescriptor = getListVariableDescriptor(scoreDirector);
         RandomSubListChangeMoveSelector<TestdataListSolution> moveSelector = new RandomSubListChangeMoveSelector<>(
                 listVariableDescriptor,
-                new RandomSubListSelector<>(listVariableDescriptor,
+                new RandomSubListSelector<>(
                         entitySelector,
                         valueSelector,
                         minimumSubListSize,

--- a/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/RandomSubListSelectorTest.java
+++ b/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/RandomSubListSelectorTest.java
@@ -14,10 +14,10 @@ import static org.optaplanner.core.impl.testdata.domain.list.TestdataListUtils.m
 import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertCodesOfNeverEndingIterableSelector;
 import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertEmptyNeverEndingIterableSelector;
 import static org.optaplanner.core.impl.testdata.util.PlannerAssert.verifyPhaseLifecycle;
+import static org.optaplanner.core.impl.testdata.util.PlannerTestUtils.mockScoreDirector;
 
 import org.junit.jupiter.api.Test;
 import org.optaplanner.core.api.score.buildin.simple.SimpleScore;
-import org.optaplanner.core.impl.domain.variable.descriptor.ListVariableDescriptor;
 import org.optaplanner.core.impl.heuristic.selector.entity.EntitySelector;
 import org.optaplanner.core.impl.heuristic.selector.value.EntityIndependentValueSelector;
 import org.optaplanner.core.impl.phase.scope.AbstractPhaseScope;
@@ -27,7 +27,6 @@ import org.optaplanner.core.impl.solver.scope.SolverScope;
 import org.optaplanner.core.impl.testdata.domain.list.TestdataListEntity;
 import org.optaplanner.core.impl.testdata.domain.list.TestdataListSolution;
 import org.optaplanner.core.impl.testdata.domain.list.TestdataListValue;
-import org.optaplanner.core.impl.testdata.util.PlannerTestUtils;
 import org.optaplanner.core.impl.testutil.TestRandom;
 
 class RandomSubListSelectorTest {
@@ -42,7 +41,7 @@ class RandomSubListSelectorTest {
         TestdataListEntity b = TestdataListEntity.createWithValues("B");
 
         InnerScoreDirector<TestdataListSolution, SimpleScore> scoreDirector =
-                PlannerTestUtils.mockScoreDirector(TestdataListSolution.buildSolutionDescriptor());
+                mockScoreDirector(TestdataListSolution.buildSolutionDescriptor());
 
         int minimumSubListSize = 1;
         int maximumSubListSize = Integer.MAX_VALUE;
@@ -52,9 +51,8 @@ class RandomSubListSelectorTest {
         assertThat(subListCount).isEqualTo(nthTriangle(listSize(a)) + nthTriangle(listSize(b)));
 
         RandomSubListSelector<TestdataListSolution> selector = new RandomSubListSelector<>(
-                getListVariableDescriptor(scoreDirector),
                 mockEntitySelector(a, b),
-                mockNeverEndingEntityIndependentValueSelector(v1),
+                mockNeverEndingEntityIndependentValueSelector(getListVariableDescriptor(scoreDirector), v1),
                 minimumSubListSize,
                 maximumSubListSize);
 
@@ -82,16 +80,15 @@ class RandomSubListSelectorTest {
         TestdataListEntity b = TestdataListEntity.createWithValues("B");
 
         InnerScoreDirector<TestdataListSolution, SimpleScore> scoreDirector =
-                PlannerTestUtils.mockScoreDirector(TestdataListSolution.buildSolutionDescriptor());
+                mockScoreDirector(TestdataListSolution.buildSolutionDescriptor());
 
         int minimumSubListSize = 2;
         int maximumSubListSize = 3;
         int subListCount = 15 - 5 - 3;
 
         RandomSubListSelector<TestdataListSolution> selector = new RandomSubListSelector<>(
-                getListVariableDescriptor(scoreDirector),
                 mockEntitySelector(a, b),
-                mockNeverEndingEntityIndependentValueSelector(v1),
+                mockNeverEndingEntityIndependentValueSelector(getListVariableDescriptor(scoreDirector), v1),
                 minimumSubListSize,
                 maximumSubListSize);
 
@@ -114,15 +111,14 @@ class RandomSubListSelectorTest {
         TestdataListEntity a = TestdataListEntity.createWithValues("A", v1, v2, v3);
 
         InnerScoreDirector<TestdataListSolution, SimpleScore> scoreDirector =
-                PlannerTestUtils.mockScoreDirector(TestdataListSolution.buildSolutionDescriptor());
+                mockScoreDirector(TestdataListSolution.buildSolutionDescriptor());
 
         int minimumSubListSize = 4;
         int maximumSubListSize = Integer.MAX_VALUE;
 
         RandomSubListSelector<TestdataListSolution> selector = new RandomSubListSelector<>(
-                getListVariableDescriptor(scoreDirector),
                 mockEntitySelector(a),
-                mockNeverEndingEntityIndependentValueSelector(),
+                mockNeverEndingEntityIndependentValueSelector(getListVariableDescriptor(scoreDirector)),
                 minimumSubListSize,
                 maximumSubListSize);
 
@@ -134,16 +130,16 @@ class RandomSubListSelectorTest {
     @Test
     void phaseLifecycle() {
         InnerScoreDirector<TestdataListSolution, SimpleScore> scoreDirector =
-                PlannerTestUtils.mockScoreDirector(TestdataListSolution.buildSolutionDescriptor());
+                mockScoreDirector(TestdataListSolution.buildSolutionDescriptor());
 
         EntitySelector<TestdataListSolution> entitySelector = mockEntitySelector();
-        EntityIndependentValueSelector<TestdataListSolution> valueSelector = mockNeverEndingEntityIndependentValueSelector();
+        EntityIndependentValueSelector<TestdataListSolution> valueSelector =
+                mockNeverEndingEntityIndependentValueSelector(getListVariableDescriptor(scoreDirector));
 
         int minimumSubListSize = 1;
         int maximumSubListSize = Integer.MAX_VALUE;
 
         RandomSubListSelector<TestdataListSolution> selector = new RandomSubListSelector<>(
-                getListVariableDescriptor(scoreDirector),
                 entitySelector,
                 valueSelector,
                 minimumSubListSize,
@@ -167,18 +163,16 @@ class RandomSubListSelectorTest {
 
     @Test
     void validateConstructorArguments() {
-        ListVariableDescriptor<TestdataListSolution> listVariableDescriptor =
-                TestdataListEntity.buildVariableDescriptorForValueList();
         EntitySelector<TestdataListSolution> entitySelector = mockEntitySelector();
         EntityIndependentValueSelector<TestdataListSolution> valueSelector = mockNeverEndingEntityIndependentValueSelector();
 
         assertThatIllegalArgumentException().isThrownBy(() -> new RandomSubListSelector<>(
-                listVariableDescriptor, entitySelector, valueSelector, 0, 5))
+                entitySelector, valueSelector, 0, 5))
                 .withMessageContaining("greater than 0");
         assertThatIllegalArgumentException().isThrownBy(() -> new RandomSubListSelector<>(
-                listVariableDescriptor, entitySelector, valueSelector, 2, 1))
+                entitySelector, valueSelector, 2, 1))
                 .withMessageContaining("less than or equal to the maximum");
         assertThatNoException().isThrownBy(() -> new RandomSubListSelector<>(
-                listVariableDescriptor, entitySelector, valueSelector, 1, 1));
+                entitySelector, valueSelector, 1, 1));
     }
 }

--- a/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/RandomSubListSelectorTest.java
+++ b/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/RandomSubListSelectorTest.java
@@ -164,7 +164,8 @@ class RandomSubListSelectorTest {
     @Test
     void validateConstructorArguments() {
         EntitySelector<TestdataListSolution> entitySelector = mockEntitySelector();
-        EntityIndependentValueSelector<TestdataListSolution> valueSelector = mockNeverEndingEntityIndependentValueSelector();
+        EntityIndependentValueSelector<TestdataListSolution> valueSelector =
+                mockNeverEndingEntityIndependentValueSelector(TestdataListEntity.buildVariableDescriptorForValueList());
 
         assertThatIllegalArgumentException().isThrownBy(() -> new RandomSubListSelector<>(
                 entitySelector, valueSelector, 0, 5))

--- a/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/RandomSubListSwapMoveSelectorTest.java
+++ b/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/RandomSubListSwapMoveSelectorTest.java
@@ -9,6 +9,7 @@ import static org.optaplanner.core.impl.testdata.domain.list.TestdataListUtils.m
 import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertCodesOfNeverEndingMoveSelector;
 import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertEmptyNeverEndingMoveSelector;
 import static org.optaplanner.core.impl.testdata.util.PlannerAssert.verifyPhaseLifecycle;
+import static org.optaplanner.core.impl.testdata.util.PlannerTestUtils.mockScoreDirector;
 
 import org.junit.jupiter.api.Test;
 import org.optaplanner.core.api.score.buildin.simple.SimpleScore;
@@ -22,7 +23,6 @@ import org.optaplanner.core.impl.solver.scope.SolverScope;
 import org.optaplanner.core.impl.testdata.domain.list.TestdataListEntity;
 import org.optaplanner.core.impl.testdata.domain.list.TestdataListSolution;
 import org.optaplanner.core.impl.testdata.domain.list.TestdataListValue;
-import org.optaplanner.core.impl.testdata.util.PlannerTestUtils;
 import org.optaplanner.core.impl.testutil.TestRandom;
 
 class RandomSubListSwapMoveSelectorTest {
@@ -36,18 +36,16 @@ class RandomSubListSwapMoveSelectorTest {
         TestdataListEntity a = TestdataListEntity.createWithValues("A", v1, v2, v3, v4);
 
         InnerScoreDirector<TestdataListSolution, SimpleScore> scoreDirector =
-                PlannerTestUtils.mockScoreDirector(TestdataListSolution.buildSolutionDescriptor());
+                mockScoreDirector(TestdataListSolution.buildSolutionDescriptor());
 
         int minimumSubListSize = 1;
         int maximumSubListSize = Integer.MAX_VALUE;
         int subListCount = 10;
 
-        ListVariableDescriptor<TestdataListSolution> listVariableDescriptor = getListVariableDescriptor(scoreDirector);
         EntitySelector<TestdataListSolution> entitySelector = mockEntitySelector(a);
         EntityIndependentValueSelector<TestdataListSolution> valueSelector =
-                mockNeverEndingEntityIndependentValueSelector(listVariableDescriptor, v1);
+                mockNeverEndingEntityIndependentValueSelector(getListVariableDescriptor(scoreDirector), v1);
         RandomSubListSwapMoveSelector<TestdataListSolution> moveSelector = new RandomSubListSwapMoveSelector<>(
-                listVariableDescriptor,
                 new RandomSubListSelector<>(
                         entitySelector,
                         valueSelector,
@@ -121,7 +119,7 @@ class RandomSubListSwapMoveSelectorTest {
         TestdataListEntity b = TestdataListEntity.createWithValues("B", v5, v6);
 
         InnerScoreDirector<TestdataListSolution, SimpleScore> scoreDirector =
-                PlannerTestUtils.mockScoreDirector(TestdataListSolution.buildSolutionDescriptor());
+                mockScoreDirector(TestdataListSolution.buildSolutionDescriptor());
 
         int minimumSubListSize = 1;
         int maximumSubListSize = Integer.MAX_VALUE;
@@ -130,7 +128,6 @@ class RandomSubListSwapMoveSelectorTest {
         ListVariableDescriptor<TestdataListSolution> listVariableDescriptor = getListVariableDescriptor(scoreDirector);
         EntitySelector<TestdataListSolution> entitySelector = mockEntitySelector(a, b);
         RandomSubListSwapMoveSelector<TestdataListSolution> moveSelector = new RandomSubListSwapMoveSelector<>(
-                listVariableDescriptor,
                 new RandomSubListSelector<>(
                         entitySelector,
                         mockNeverEndingEntityIndependentValueSelector(listVariableDescriptor, v1),
@@ -174,18 +171,16 @@ class RandomSubListSwapMoveSelectorTest {
         TestdataListEntity a = TestdataListEntity.createWithValues("A", v1, v2, v3, v4);
 
         InnerScoreDirector<TestdataListSolution, SimpleScore> scoreDirector =
-                PlannerTestUtils.mockScoreDirector(TestdataListSolution.buildSolutionDescriptor());
+                mockScoreDirector(TestdataListSolution.buildSolutionDescriptor());
 
         int minimumSubListSize = 2;
         int maximumSubListSize = 3;
         int subListCount = 5;
 
-        ListVariableDescriptor<TestdataListSolution> listVariableDescriptor = getListVariableDescriptor(scoreDirector);
         EntitySelector<TestdataListSolution> entitySelector = mockEntitySelector(a);
         EntityIndependentValueSelector<TestdataListSolution> valueSelector =
-                mockNeverEndingEntityIndependentValueSelector(listVariableDescriptor, v1);
+                mockNeverEndingEntityIndependentValueSelector(getListVariableDescriptor(scoreDirector), v1);
         RandomSubListSwapMoveSelector<TestdataListSolution> moveSelector = new RandomSubListSwapMoveSelector<>(
-                listVariableDescriptor,
                 new RandomSubListSelector<>(
                         entitySelector,
                         valueSelector,
@@ -236,17 +231,15 @@ class RandomSubListSwapMoveSelectorTest {
         TestdataListEntity a = TestdataListEntity.createWithValues("A", v1, v2, v3);
 
         InnerScoreDirector<TestdataListSolution, SimpleScore> scoreDirector =
-                PlannerTestUtils.mockScoreDirector(TestdataListSolution.buildSolutionDescriptor());
+                mockScoreDirector(TestdataListSolution.buildSolutionDescriptor());
 
         int minimumSubListSize = 100;
         int maximumSubListSize = Integer.MAX_VALUE;
 
-        ListVariableDescriptor<TestdataListSolution> listVariableDescriptor = getListVariableDescriptor(scoreDirector);
         EntitySelector<TestdataListSolution> entitySelector = mockEntitySelector(a);
         EntityIndependentValueSelector<TestdataListSolution> valueSelector =
-                mockNeverEndingEntityIndependentValueSelector(listVariableDescriptor, v1);
+                mockNeverEndingEntityIndependentValueSelector(getListVariableDescriptor(scoreDirector), v1);
         RandomSubListSwapMoveSelector<TestdataListSolution> moveSelector = new RandomSubListSwapMoveSelector<>(
-                listVariableDescriptor,
                 new RandomSubListSelector<>(
                         entitySelector,
                         valueSelector,
@@ -275,7 +268,7 @@ class RandomSubListSwapMoveSelectorTest {
         TestdataListEntity c = TestdataListEntity.createWithValues("C", v4);
 
         InnerScoreDirector<TestdataListSolution, SimpleScore> scoreDirector =
-                PlannerTestUtils.mockScoreDirector(TestdataListSolution.buildSolutionDescriptor());
+                mockScoreDirector(TestdataListSolution.buildSolutionDescriptor());
 
         int minimumSubListSize = 2;
         int maximumSubListSize = 2;
@@ -284,7 +277,6 @@ class RandomSubListSwapMoveSelectorTest {
         ListVariableDescriptor<TestdataListSolution> listVariableDescriptor = getListVariableDescriptor(scoreDirector);
         EntitySelector<TestdataListSolution> entitySelector = mockEntitySelector(a, b, c);
         RandomSubListSwapMoveSelector<TestdataListSolution> moveSelector = new RandomSubListSwapMoveSelector<>(
-                listVariableDescriptor,
                 new RandomSubListSelector<>(
                         entitySelector,
                         mockNeverEndingEntityIndependentValueSelector(listVariableDescriptor, v1, v4),
@@ -330,19 +322,17 @@ class RandomSubListSwapMoveSelectorTest {
         TestdataListEntity c = TestdataListEntity.createWithValues("C", v4);
 
         InnerScoreDirector<TestdataListSolution, SimpleScore> scoreDirector =
-                PlannerTestUtils.mockScoreDirector(TestdataListSolution.buildSolutionDescriptor());
+                mockScoreDirector(TestdataListSolution.buildSolutionDescriptor());
 
         int minimumSubListSize = 1;
         int maximumSubListSize = Integer.MAX_VALUE;
         int subListCount = 6 + 1;
 
-        ListVariableDescriptor<TestdataListSolution> listVariableDescriptor = getListVariableDescriptor(scoreDirector);
         // The entity selector must be complete; it affects subList calculation and the move selector size.
         EntitySelector<TestdataListSolution> entitySelector = mockEntitySelector(a, b, c);
         EntityIndependentValueSelector<TestdataListSolution> valueSelector =
-                mockNeverEndingEntityIndependentValueSelector(listVariableDescriptor, v1);
+                mockNeverEndingEntityIndependentValueSelector(getListVariableDescriptor(scoreDirector), v1);
         RandomSubListSwapMoveSelector<TestdataListSolution> moveSelector = new RandomSubListSwapMoveSelector<>(
-                listVariableDescriptor,
                 new RandomSubListSelector<>(
                         entitySelector,
                         valueSelector,
@@ -384,19 +374,17 @@ class RandomSubListSwapMoveSelectorTest {
         TestdataListEntity d = TestdataListEntity.createWithValues("D", v21, v22, v23, v24);
 
         InnerScoreDirector<TestdataListSolution, SimpleScore> scoreDirector =
-                PlannerTestUtils.mockScoreDirector(TestdataListSolution.buildSolutionDescriptor());
+                mockScoreDirector(TestdataListSolution.buildSolutionDescriptor());
 
         int minimumSubListSize = 3;
         int maximumSubListSize = 5;
         int subListCount = 12 + 1 + 3;
 
-        ListVariableDescriptor<TestdataListSolution> listVariableDescriptor = getListVariableDescriptor(scoreDirector);
         // The entity selector must be complete; it affects subList calculation and the move selector size.
         EntitySelector<TestdataListSolution> entitySelector = mockEntitySelector(a, b, c, d);
         EntityIndependentValueSelector<TestdataListSolution> valueSelector =
-                mockNeverEndingEntityIndependentValueSelector(listVariableDescriptor, v1);
+                mockNeverEndingEntityIndependentValueSelector(getListVariableDescriptor(scoreDirector), v1);
         RandomSubListSwapMoveSelector<TestdataListSolution> moveSelector = new RandomSubListSwapMoveSelector<>(
-                listVariableDescriptor,
                 new RandomSubListSelector<>(
                         entitySelector,
                         valueSelector,
@@ -419,7 +407,7 @@ class RandomSubListSwapMoveSelectorTest {
     @Test
     void phaseLifecycle() {
         InnerScoreDirector<TestdataListSolution, SimpleScore> scoreDirector =
-                PlannerTestUtils.mockScoreDirector(TestdataListSolution.buildSolutionDescriptor());
+                mockScoreDirector(TestdataListSolution.buildSolutionDescriptor());
 
         ListVariableDescriptor<TestdataListSolution> listVariableDescriptor = getListVariableDescriptor(scoreDirector);
 
@@ -432,7 +420,6 @@ class RandomSubListSwapMoveSelectorTest {
         int maximumSubListSize = Integer.MAX_VALUE;
 
         RandomSubListSwapMoveSelector<TestdataListSolution> moveSelector = new RandomSubListSwapMoveSelector<>(
-                listVariableDescriptor,
                 new RandomSubListSelector<>(
                         entitySelector,
                         leftValueSelector,

--- a/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/RandomSubListSwapMoveSelectorTest.java
+++ b/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/RandomSubListSwapMoveSelectorTest.java
@@ -44,17 +44,16 @@ class RandomSubListSwapMoveSelectorTest {
 
         ListVariableDescriptor<TestdataListSolution> listVariableDescriptor = getListVariableDescriptor(scoreDirector);
         EntitySelector<TestdataListSolution> entitySelector = mockEntitySelector(a);
-        EntityIndependentValueSelector<TestdataListSolution> valueSelector = mockNeverEndingEntityIndependentValueSelector(v1);
+        EntityIndependentValueSelector<TestdataListSolution> valueSelector =
+                mockNeverEndingEntityIndependentValueSelector(listVariableDescriptor, v1);
         RandomSubListSwapMoveSelector<TestdataListSolution> moveSelector = new RandomSubListSwapMoveSelector<>(
                 listVariableDescriptor,
                 new RandomSubListSelector<>(
-                        listVariableDescriptor,
                         entitySelector,
                         valueSelector,
                         minimumSubListSize,
                         maximumSubListSize),
                 new RandomSubListSelector<>(
-                        listVariableDescriptor,
                         entitySelector,
                         valueSelector,
                         minimumSubListSize,
@@ -133,15 +132,13 @@ class RandomSubListSwapMoveSelectorTest {
         RandomSubListSwapMoveSelector<TestdataListSolution> moveSelector = new RandomSubListSwapMoveSelector<>(
                 listVariableDescriptor,
                 new RandomSubListSelector<>(
-                        listVariableDescriptor,
                         entitySelector,
-                        mockNeverEndingEntityIndependentValueSelector(v1),
+                        mockNeverEndingEntityIndependentValueSelector(listVariableDescriptor, v1),
                         minimumSubListSize,
                         maximumSubListSize),
                 new RandomSubListSelector<>(
-                        listVariableDescriptor,
                         entitySelector,
-                        mockNeverEndingEntityIndependentValueSelector(v5),
+                        mockNeverEndingEntityIndependentValueSelector(listVariableDescriptor, v5),
                         minimumSubListSize,
                         maximumSubListSize),
                 true);
@@ -185,17 +182,16 @@ class RandomSubListSwapMoveSelectorTest {
 
         ListVariableDescriptor<TestdataListSolution> listVariableDescriptor = getListVariableDescriptor(scoreDirector);
         EntitySelector<TestdataListSolution> entitySelector = mockEntitySelector(a);
-        EntityIndependentValueSelector<TestdataListSolution> valueSelector = mockNeverEndingEntityIndependentValueSelector(v1);
+        EntityIndependentValueSelector<TestdataListSolution> valueSelector =
+                mockNeverEndingEntityIndependentValueSelector(listVariableDescriptor, v1);
         RandomSubListSwapMoveSelector<TestdataListSolution> moveSelector = new RandomSubListSwapMoveSelector<>(
                 listVariableDescriptor,
                 new RandomSubListSelector<>(
-                        listVariableDescriptor,
                         entitySelector,
                         valueSelector,
                         minimumSubListSize,
                         maximumSubListSize),
                 new RandomSubListSelector<>(
-                        listVariableDescriptor,
                         entitySelector,
                         valueSelector,
                         minimumSubListSize,
@@ -247,17 +243,16 @@ class RandomSubListSwapMoveSelectorTest {
 
         ListVariableDescriptor<TestdataListSolution> listVariableDescriptor = getListVariableDescriptor(scoreDirector);
         EntitySelector<TestdataListSolution> entitySelector = mockEntitySelector(a);
-        EntityIndependentValueSelector<TestdataListSolution> valueSelector = mockNeverEndingEntityIndependentValueSelector(v1);
+        EntityIndependentValueSelector<TestdataListSolution> valueSelector =
+                mockNeverEndingEntityIndependentValueSelector(listVariableDescriptor, v1);
         RandomSubListSwapMoveSelector<TestdataListSolution> moveSelector = new RandomSubListSwapMoveSelector<>(
                 listVariableDescriptor,
                 new RandomSubListSelector<>(
-                        listVariableDescriptor,
                         entitySelector,
                         valueSelector,
                         minimumSubListSize,
                         maximumSubListSize),
                 new RandomSubListSelector<>(
-                        listVariableDescriptor,
                         entitySelector,
                         valueSelector,
                         minimumSubListSize,
@@ -291,15 +286,13 @@ class RandomSubListSwapMoveSelectorTest {
         RandomSubListSwapMoveSelector<TestdataListSolution> moveSelector = new RandomSubListSwapMoveSelector<>(
                 listVariableDescriptor,
                 new RandomSubListSelector<>(
-                        listVariableDescriptor,
                         entitySelector,
-                        mockNeverEndingEntityIndependentValueSelector(v1, v4),
+                        mockNeverEndingEntityIndependentValueSelector(listVariableDescriptor, v1, v4),
                         minimumSubListSize,
                         maximumSubListSize),
                 new RandomSubListSelector<>(
-                        listVariableDescriptor,
                         entitySelector,
-                        mockNeverEndingEntityIndependentValueSelector(v4, v1),
+                        mockNeverEndingEntityIndependentValueSelector(listVariableDescriptor, v4, v1),
                         minimumSubListSize,
                         maximumSubListSize),
                 false);
@@ -346,17 +339,16 @@ class RandomSubListSwapMoveSelectorTest {
         ListVariableDescriptor<TestdataListSolution> listVariableDescriptor = getListVariableDescriptor(scoreDirector);
         // The entity selector must be complete; it affects subList calculation and the move selector size.
         EntitySelector<TestdataListSolution> entitySelector = mockEntitySelector(a, b, c);
-        EntityIndependentValueSelector<TestdataListSolution> valueSelector = mockNeverEndingEntityIndependentValueSelector(v1);
+        EntityIndependentValueSelector<TestdataListSolution> valueSelector =
+                mockNeverEndingEntityIndependentValueSelector(listVariableDescriptor, v1);
         RandomSubListSwapMoveSelector<TestdataListSolution> moveSelector = new RandomSubListSwapMoveSelector<>(
                 listVariableDescriptor,
                 new RandomSubListSelector<>(
-                        listVariableDescriptor,
                         entitySelector,
                         valueSelector,
                         minimumSubListSize,
                         maximumSubListSize),
                 new RandomSubListSelector<>(
-                        listVariableDescriptor,
                         entitySelector,
                         valueSelector,
                         minimumSubListSize,
@@ -401,16 +393,16 @@ class RandomSubListSwapMoveSelectorTest {
         ListVariableDescriptor<TestdataListSolution> listVariableDescriptor = getListVariableDescriptor(scoreDirector);
         // The entity selector must be complete; it affects subList calculation and the move selector size.
         EntitySelector<TestdataListSolution> entitySelector = mockEntitySelector(a, b, c, d);
-        EntityIndependentValueSelector<TestdataListSolution> valueSelector = mockNeverEndingEntityIndependentValueSelector(v1);
+        EntityIndependentValueSelector<TestdataListSolution> valueSelector =
+                mockNeverEndingEntityIndependentValueSelector(listVariableDescriptor, v1);
         RandomSubListSwapMoveSelector<TestdataListSolution> moveSelector = new RandomSubListSwapMoveSelector<>(
                 listVariableDescriptor,
                 new RandomSubListSelector<>(
-                        listVariableDescriptor,
                         entitySelector,
                         valueSelector,
                         minimumSubListSize,
                         maximumSubListSize),
-                new RandomSubListSelector<>(listVariableDescriptor,
+                new RandomSubListSelector<>(
                         entitySelector,
                         valueSelector,
                         minimumSubListSize,
@@ -429,25 +421,24 @@ class RandomSubListSwapMoveSelectorTest {
         InnerScoreDirector<TestdataListSolution, SimpleScore> scoreDirector =
                 PlannerTestUtils.mockScoreDirector(TestdataListSolution.buildSolutionDescriptor());
 
+        ListVariableDescriptor<TestdataListSolution> listVariableDescriptor = getListVariableDescriptor(scoreDirector);
+
         EntitySelector<TestdataListSolution> entitySelector = mockEntitySelector();
         EntityIndependentValueSelector<TestdataListSolution> leftValueSelector =
-                mockNeverEndingEntityIndependentValueSelector();
+                mockNeverEndingEntityIndependentValueSelector(listVariableDescriptor);
         EntityIndependentValueSelector<TestdataListSolution> rightValueSelector =
-                mockNeverEndingEntityIndependentValueSelector();
+                mockNeverEndingEntityIndependentValueSelector(listVariableDescriptor);
         int minimumSubListSize = 1;
         int maximumSubListSize = Integer.MAX_VALUE;
 
-        ListVariableDescriptor<TestdataListSolution> listVariableDescriptor = getListVariableDescriptor(scoreDirector);
         RandomSubListSwapMoveSelector<TestdataListSolution> moveSelector = new RandomSubListSwapMoveSelector<>(
                 listVariableDescriptor,
                 new RandomSubListSelector<>(
-                        listVariableDescriptor,
                         entitySelector,
                         leftValueSelector,
                         minimumSubListSize,
                         maximumSubListSize),
                 new RandomSubListSelector<>(
-                        listVariableDescriptor,
                         entitySelector,
                         rightValueSelector,
                         minimumSubListSize,

--- a/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/SubListSelectorFactoryTest.java
+++ b/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/SubListSelectorFactoryTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.optaplanner.core.api.domain.variable.PlanningListVariable;
 import org.optaplanner.core.config.heuristic.selector.common.SelectionCacheType;
 import org.optaplanner.core.config.heuristic.selector.common.SelectionOrder;
 import org.optaplanner.core.config.heuristic.selector.common.nearby.NearbySelectionConfig;
@@ -21,11 +22,14 @@ import org.optaplanner.core.config.heuristic.selector.move.generic.list.SubListS
 import org.optaplanner.core.config.heuristic.selector.value.ValueSelectorConfig;
 import org.optaplanner.core.impl.domain.variable.descriptor.ListVariableDescriptor;
 import org.optaplanner.core.impl.heuristic.HeuristicConfigPolicy;
+import org.optaplanner.core.impl.heuristic.selector.SelectorTestUtils;
 import org.optaplanner.core.impl.heuristic.selector.common.nearby.NearbyDistanceMeter;
 import org.optaplanner.core.impl.heuristic.selector.entity.EntitySelector;
 import org.optaplanner.core.impl.heuristic.selector.move.generic.list.mimic.MimicRecordingSubListSelector;
 import org.optaplanner.core.impl.heuristic.selector.move.generic.list.mimic.MimicReplayingSubListSelector;
 import org.optaplanner.core.impl.heuristic.selector.move.generic.list.mimic.SubListMimicRecorder;
+import org.optaplanner.core.impl.testdata.domain.TestdataEntity;
+import org.optaplanner.core.impl.testdata.domain.TestdataSolution;
 import org.optaplanner.core.impl.testdata.domain.list.TestdataListEntity;
 import org.optaplanner.core.impl.testdata.domain.list.TestdataListSolution;
 import org.optaplanner.core.impl.testdata.domain.list.TestdataListUtils;
@@ -163,5 +167,19 @@ class SubListSelectorFactoryTest {
                         .buildSubListSelector(buildHeuristicConfigPolicy(TestdataListSolution.buildSolutionDescriptor()),
                                 entitySelector, SelectionCacheType.JUST_IN_TIME, SelectionOrder.RANDOM))
                 .withMessageContaining("requires an originSubListSelector");
+    }
+
+    @Test
+    void requiresListVariable() {
+        SubListSelectorConfig subListSelectorConfig = new SubListSelectorConfig();
+
+        EntitySelector<TestdataSolution> entitySelector =
+                SelectorTestUtils.mockEntitySelector(TestdataEntity.buildEntityDescriptor());
+
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> SubListSelectorFactory.<TestdataSolution> create(subListSelectorConfig)
+                        .buildSubListSelector(buildHeuristicConfigPolicy(TestdataSolution.buildSolutionDescriptor()),
+                                entitySelector, SelectionCacheType.JUST_IN_TIME, SelectionOrder.RANDOM))
+                .withMessageContaining("@" + PlanningListVariable.class.getSimpleName());
     }
 }

--- a/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/SubListSwapMoveSelectorFactoryTest.java
+++ b/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/SubListSwapMoveSelectorFactoryTest.java
@@ -1,15 +1,12 @@
 package org.optaplanner.core.impl.heuristic.selector.move.generic.list;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.optaplanner.core.impl.heuristic.HeuristicConfigPolicyTestUtils.buildHeuristicConfigPolicy;
 
 import org.junit.jupiter.api.Test;
-import org.optaplanner.core.api.domain.variable.PlanningListVariable;
 import org.optaplanner.core.config.heuristic.selector.common.SelectionCacheType;
 import org.optaplanner.core.config.heuristic.selector.move.generic.list.SubListSwapMoveSelectorConfig;
 import org.optaplanner.core.impl.heuristic.HeuristicConfigPolicy;
-import org.optaplanner.core.impl.testdata.domain.TestdataSolution;
 import org.optaplanner.core.impl.testdata.domain.list.TestdataListSolution;
 
 class SubListSwapMoveSelectorFactoryTest {
@@ -47,18 +44,5 @@ class SubListSwapMoveSelectorFactoryTest {
                         SelectionCacheType.JUST_IN_TIME, true);
 
         assertThat(selector.isSelectReversingMoveToo()).isFalse();
-    }
-
-    @Test
-    void requiresListVariable() {
-        SubListSwapMoveSelectorConfig config = new SubListSwapMoveSelectorConfig();
-        SubListSwapMoveSelectorFactory<TestdataSolution> factory =
-                new SubListSwapMoveSelectorFactory<>(config);
-
-        HeuristicConfigPolicy<TestdataSolution> heuristicConfigPolicy = buildHeuristicConfigPolicy();
-
-        assertThatIllegalArgumentException()
-                .isThrownBy(() -> factory.buildBaseMoveSelector(heuristicConfigPolicy, SelectionCacheType.JUST_IN_TIME, true))
-                .withMessageContaining("@" + PlanningListVariable.class.getSimpleName());
     }
 }

--- a/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/testdata/domain/list/TestdataListUtils.java
+++ b/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/testdata/domain/list/TestdataListUtils.java
@@ -16,7 +16,7 @@ import org.optaplanner.core.impl.heuristic.selector.move.generic.list.ElementRef
 import org.optaplanner.core.impl.heuristic.selector.value.EntityIndependentValueSelector;
 import org.optaplanner.core.impl.score.director.InnerScoreDirector;
 
-public class TestdataListUtils {
+public final class TestdataListUtils {
 
     private TestdataListUtils() {
     }
@@ -27,10 +27,6 @@ public class TestdataListUtils {
 
     public static EntitySelector<TestdataListSolution> mockEntitySelector(Object... entities) {
         return SelectorTestUtils.mockEntitySelector(TestdataListEntity.buildEntityDescriptor(), entities);
-    }
-
-    public static EntityIndependentValueSelector<TestdataListSolution> mockEntityIndependentValueSelector(Object... values) {
-        return mockEntityIndependentValueSelector(TestdataListEntity.buildVariableDescriptorForValueList(), values);
     }
 
     public static EntityIndependentValueSelector<TestdataListSolution> mockEntityIndependentValueSelector(
@@ -45,11 +41,6 @@ public class TestdataListUtils {
         when(valueSelector.isNeverEnding()).thenReturn(true);
         when(valueSelector.iterator()).thenAnswer(invocation -> cyclicIterator(Arrays.asList(values)));
         return valueSelector;
-    }
-
-    public static EntityIndependentValueSelector<TestdataListSolution> mockNeverEndingEntityIndependentValueSelector(
-            Object... values) {
-        return mockNeverEndingEntityIndependentValueSelector(TestdataListEntity.buildVariableDescriptorForValueList(), values);
     }
 
     public static DestinationSelector<TestdataListSolution> mockNeverEndingDestinationSelector(

--- a/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/testdata/domain/list/TestdataListUtils.java
+++ b/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/testdata/domain/list/TestdataListUtils.java
@@ -30,22 +30,26 @@ public class TestdataListUtils {
     }
 
     public static EntityIndependentValueSelector<TestdataListSolution> mockEntityIndependentValueSelector(Object... values) {
-        ListVariableDescriptor<TestdataListSolution> listVariableDescriptor =
-                TestdataListEntity.buildVariableDescriptorForValueList();
-        return SelectorTestUtils.mockEntityIndependentValueSelector(listVariableDescriptor, values);
+        return mockEntityIndependentValueSelector(TestdataListEntity.buildVariableDescriptorForValueList(), values);
     }
 
     public static EntityIndependentValueSelector<TestdataListSolution> mockEntityIndependentValueSelector(
-            InnerScoreDirector<TestdataListSolution, ?> scoreDirector, Object... values) {
-        return SelectorTestUtils.mockEntityIndependentValueSelector(getListVariableDescriptor(scoreDirector), values);
+            ListVariableDescriptor<TestdataListSolution> listVariableDescriptor, Object... values) {
+        return SelectorTestUtils.mockEntityIndependentValueSelector(listVariableDescriptor, values);
     }
 
-    public static EntityIndependentValueSelector<TestdataListSolution>
-            mockNeverEndingEntityIndependentValueSelector(Object... values) {
-        EntityIndependentValueSelector<TestdataListSolution> valueSelector = mockEntityIndependentValueSelector(values);
+    public static EntityIndependentValueSelector<TestdataListSolution> mockNeverEndingEntityIndependentValueSelector(
+            ListVariableDescriptor<TestdataListSolution> listVariableDescriptor, Object... values) {
+        EntityIndependentValueSelector<TestdataListSolution> valueSelector = mockEntityIndependentValueSelector(
+                listVariableDescriptor, values);
         when(valueSelector.isNeverEnding()).thenReturn(true);
         when(valueSelector.iterator()).thenAnswer(invocation -> cyclicIterator(Arrays.asList(values)));
         return valueSelector;
+    }
+
+    public static EntityIndependentValueSelector<TestdataListSolution> mockNeverEndingEntityIndependentValueSelector(
+            Object... values) {
+        return mockNeverEndingEntityIndependentValueSelector(TestdataListEntity.buildVariableDescriptorForValueList(), values);
     }
 
     public static DestinationSelector<TestdataListSolution> mockNeverEndingDestinationSelector(


### PR DESCRIPTION
It's redundant because the variable descriptor can be obtained from one of the child selectors (for example value selector, subList selector).

The test setup is *slightly* more complicated because the variable descriptor must now be passed when creating a mock value selector but **overall, it's less code**.

Review is **optional**; this is pure refactoring.