### PR TITLE
Fix issue with toMap collector.

### DIFF
--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/api/score/stream/ConstraintCollectors.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/api/score/stream/ConstraintCollectors.java
@@ -29,6 +29,7 @@ import java.util.function.ToIntBiFunction;
 import java.util.function.ToIntFunction;
 import java.util.function.ToLongBiFunction;
 import java.util.function.ToLongFunction;
+import java.util.stream.Stream;
 
 import org.optaplanner.core.api.domain.solution.PlanningSolution;
 import org.optaplanner.core.api.function.PentaFunction;
@@ -1704,8 +1705,9 @@ public final class ConstraintCollectors {
         public Value merge(BinaryOperator<Value> mergeFunction) {
             // Rebuilding the value from the collection is not incremental.
             // The impact is negligible, assuming there are not too many values for the same key.
-            return counts.keySet()
+            return counts.entrySet()
                     .stream()
+                    .flatMap(e -> Stream.generate(e::getKey).limit(e.getValue()))
                     .reduce(mergeFunction)
                     .orElseThrow(() -> new IllegalStateException("Programming error: Should have had at least one value."));
         }

--- a/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/api/score/stream/ConstraintCollectorsTest.java
+++ b/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/api/score/stream/ConstraintCollectorsTest.java
@@ -2944,7 +2944,7 @@ class ConstraintCollectorsTest {
         assertResult(collector, container, asMap(2, 2, 1, 1));
         // Add third value, same as the second. We now have three values, two of which map to the same key.
         Runnable thirdRetractor = accumulate(collector, container, secondValue);
-        assertResult(collector, container, asMap(2, 2, 1, 1));
+        assertResult(collector, container, asMap(2, 2, 1, 2));
         // Retract one instance of the second value; we only have two values now.
         secondRetractor.run();
         assertResult(collector, container, asMap(2, 2, 1, 1));
@@ -3034,7 +3034,7 @@ class ConstraintCollectorsTest {
         assertResult(collector, container, asMap(2, 2, 1, 1));
         // Add third value, same as the second. We now have three values, two of which map to the same key.
         Runnable thirdRetractor = accumulate(collector, container, secondValue, 0);
-        assertResult(collector, container, asMap(2, 2, 1, 1));
+        assertResult(collector, container, asMap(2, 2, 1, 2));
         // Retract one instance of the second value; we only have two values now.
         secondRetractor.run();
         assertResult(collector, container, asMap(2, 2, 1, 1));
@@ -3094,7 +3094,7 @@ class ConstraintCollectorsTest {
         assertResult(collector, container, asMap(2, 2, 1, 1));
         // Add third value, same as the second. We now have three values, two of which map to the same key.
         Runnable thirdRetractor = accumulate(collector, container, secondValue, 0, 0);
-        assertResult(collector, container, asMap(2, 2, 1, 1));
+        assertResult(collector, container, asMap(2, 2, 1, 2));
         // Retract one instance of the second value; we only have two values now.
         secondRetractor.run();
         assertResult(collector, container, asMap(2, 2, 1, 1));
@@ -3154,7 +3154,7 @@ class ConstraintCollectorsTest {
         assertResult(collector, container, asMap(2, 2, 1, 1));
         // Add third value, same as the second. We now have three values, two of which map to the same key.
         Runnable thirdRetractor = accumulate(collector, container, secondValue, 0, 0, 0);
-        assertResult(collector, container, asMap(2, 2, 1, 1));
+        assertResult(collector, container, asMap(2, 2, 1, 2));
         // Retract one instance of the second value; we only have two values now.
         secondRetractor.run();
         assertResult(collector, container, asMap(2, 2, 1, 1));
@@ -3214,7 +3214,7 @@ class ConstraintCollectorsTest {
         assertResult(collector, container, asSortedMap(2, 2, 1, 1));
         // Add third value, same as the second. We now have three values, two of which map to the same key.
         Runnable thirdRetractor = accumulate(collector, container, secondValue);
-        assertResult(collector, container, asSortedMap(2, 2, 1, 1));
+        assertResult(collector, container, asSortedMap(2, 2, 1, 2));
         // Retract one instance of the second value; we only have two values now.
         secondRetractor.run();
         assertResult(collector, container, asSortedMap(2, 2, 1, 1));
@@ -3274,7 +3274,7 @@ class ConstraintCollectorsTest {
         assertResult(collector, container, asSortedMap(2, 2, 1, 1));
         // Add third value, same as the second. We now have three values, two of which map to the same key.
         Runnable thirdRetractor = accumulate(collector, container, secondValue, 0);
-        assertResult(collector, container, asSortedMap(2, 2, 1, 1));
+        assertResult(collector, container, asSortedMap(2, 2, 1, 2));
         // Retract one instance of the second value; we only have two values now.
         secondRetractor.run();
         assertResult(collector, container, asSortedMap(2, 2, 1, 1));
@@ -3334,7 +3334,7 @@ class ConstraintCollectorsTest {
         assertResult(collector, container, asSortedMap(2, 2, 1, 1));
         // Add third value, same as the second. We now have three values, two of which map to the same key.
         Runnable thirdRetractor = accumulate(collector, container, secondValue, 0, 0);
-        assertResult(collector, container, asSortedMap(2, 2, 1, 1));
+        assertResult(collector, container, asSortedMap(2, 2, 1, 2));
         // Retract one instance of the second value; we only have two values now.
         secondRetractor.run();
         assertResult(collector, container, asSortedMap(2, 2, 1, 1));
@@ -3394,7 +3394,7 @@ class ConstraintCollectorsTest {
         assertResult(collector, container, asSortedMap(2, 2, 1, 1));
         // Add third value, same as the second. We now have three values, two of which map to the same key.
         Runnable thirdRetractor = accumulate(collector, container, secondValue, 0, 0, 0);
-        assertResult(collector, container, asSortedMap(2, 2, 1, 1));
+        assertResult(collector, container, asSortedMap(2, 2, 1, 2));
         // Retract one instance of the second value; we only have two values now.
         secondRetractor.run();
         assertResult(collector, container, asSortedMap(2, 2, 1, 1));


### PR DESCRIPTION
<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.
-->

I believe the `ConstraintCollectors.toMap` implementation is buggy. It does not handle multiplicity correctly.

I think this has gone unnoticed due to a typos in the tests.

### JIRA

-

### Referenced pull requests

-

### Checklist
- [-] Documentation updated if applicable.
- [-] Release notes updated if applicable.
- [-] Upgrade recipe provided if applicable.

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request checks</b>  
  Please add comment: <b>Jenkins retest this</b>

- for a <b>specific pull request check</b>  
  please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-vehicle-routing] tests</b>
  
- for a <b>full downstream build</b> 
  - for <b>jenkins</b> job: 
    please add comment: <b>Jenkins run fdb</b>
  - for <b>github actions</b> job: 
    add the label `run_fdb`

- for a <b>compile downstream build</b>  
  please add comment: <b>Jenkins run cdb</b>

- for a <b>full production downstream build</b>  
  please add comment: <b>Jenkins execute product fdb</b>

- for an <b>upstream build</b>  
  please add comment: <b>Jenkins run upstream</b>

- for <b>quarkus branch checks</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins run quarkus-branch</b>

- for a <b>quarkus branch specific check</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-vehicle-routing] quarkus-branch</b>

- for <b>quarkus main checks</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins run quarkus-main</b>

- for a <b>specific quarkus main check</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-vehicle-routing] quarkus-branch</b>

- for <b>quarkus lts checks</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins run quarkus-lts</b>

- for a <b>specific quarkus lts check</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts|optaweb-vehicle-routing] quarkus-lts</b>

- for <b>native checks</b>  
  Run native checks  
  Please add comment: <b>Jenkins run native</b>

- for a <b>specific native check</b>  
  Run native checks 
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts] native</b>

- for <b>native lts checks</b>  
  Run native checks against quarkus lts branch
  Please add comment: <b>Jenkins run native-lts</b>

- for a <b>specific native lts check</b>  
  Run native checks against quarkus lts branch
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts] native-lts</b>

</details>

### CI Status

 You can check OptaPlanner repositories CI status from [Chain Status webpage](https://kiegroup.github.io/optaplanner/).

<details>
<summary>
How to backport a pull request to a different branch?
</summary>

In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-7.67.x` to backport the original PR to the `7.67.x` branch).

> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.

Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.

If something goes wrong, the author will be notified and at this point a manual backporting is needed.

> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
</details>
