### PR TITLE
Generate Javadoc jars for optaplanner-quarkus etc too

### DIFF
--- a/build/optaplanner-build-parent/pom.xml
+++ b/build/optaplanner-build-parent/pom.xml
@@ -890,7 +890,8 @@
             <executions>
               <execution>
                 <id>build-javadoc-jar</id>
-                <phase>package</phase>
+                <!-- TODO Workaround switch back to "package" phase after fix https://issues.apache.org/jira/browse/MJAVADOC-747 -->
+                <phase>process-classes</phase>
                 <goals>
                   <goal>jar</goal>
                 </goals>

--- a/optaplanner-operator/pom.xml
+++ b/optaplanner-operator/pom.xml
@@ -143,13 +143,6 @@
           </systemPropertyVariables>
         </configuration>
       </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-javadoc-plugin</artifactId>
-        <configuration>
-          <skip>true</skip> <!-- Some Quarkus dependency has a JPMS problem due to which Javadoc fails. -->
-        </configuration>
-      </plugin>
     </plugins>
   </build>
   <profiles>

--- a/optaplanner-quarkus-integration/pom.xml
+++ b/optaplanner-quarkus-integration/pom.xml
@@ -72,20 +72,6 @@
             </execution>
           </executions>
         </plugin>
-        <plugin>
-          <!--
-            Quarkus is not prepared for JPMS, yet Javadoc expects it, complaining about invalid module names.
-            This is not a problem, as our Quarkus integration doesn't expose new API
-            and therefore need not have Javadoc published.
-
-            Only enable once you've made sure that `mvn -Dfull -Dproductized` passes for Quarkus main and Quarkus LTS.
-          -->
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-javadoc-plugin</artifactId>
-          <configuration>
-            <skip>true</skip>
-          </configuration>
-        </plugin>
       </plugins>
     </pluginManagement>
   </build>


### PR DESCRIPTION
It's better to deploy javadoc jars to Maven Central for optaplanner-quarkus too than to skip it.
Workaround for MJAVADOC-747.