### PR TITLE
Deprecate minimumSubListSize and maximumSubListSize on move selector configs

### DIFF
--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/config/heuristic/selector/move/generic/list/SubListChangeMoveSelectorConfig.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/config/heuristic/selector/move/generic/list/SubListChangeMoveSelectorConfig.java
@@ -19,8 +19,17 @@ public class SubListChangeMoveSelectorConfig extends MoveSelectorConfig<SubListC
 
     public static final String XML_ELEMENT_NAME = "subListChangeMoveSelector";
 
-    // TODO deprecate
+    /**
+     * @deprecated The minimumSubListSize on the SubListChangeMoveSelectorConfig is deprecated and will be removed in a future
+     *             major version of OptaPlanner. Use {@link SubListSelectorConfig#minimumSubListSize} instead.
+     */
+    @Deprecated(forRemoval = true)
     protected Integer minimumSubListSize = null;
+    /**
+     * @deprecated The maximumSubListSize on the SubListChangeMoveSelectorConfig is deprecated and will be removed in a future
+     *             major version of OptaPlanner. Use {@link SubListSelectorConfig#maximumSubListSize} instead.
+     */
+    @Deprecated(forRemoval = true)
     protected Integer maximumSubListSize = null;
     private Boolean selectReversingMoveToo = null;
     @XmlElement(name = "subListSelector")
@@ -28,18 +37,38 @@ public class SubListChangeMoveSelectorConfig extends MoveSelectorConfig<SubListC
     @XmlElement(name = "destinationSelector")
     private DestinationSelectorConfig destinationSelectorConfig = null;
 
+    /**
+     * @deprecated The minimumSubListSize on the SubListChangeMoveSelectorConfig is deprecated and will be removed in a future
+     *             major version of OptaPlanner. Use {@link SubListSelectorConfig#getMinimumSubListSize()} instead.
+     */
+    @Deprecated(forRemoval = true)
     public Integer getMinimumSubListSize() {
         return minimumSubListSize;
     }
 
+    /**
+     * @deprecated The minimumSubListSize on the SubListChangeMoveSelectorConfig is deprecated and will be removed in a future
+     *             major version of OptaPlanner. Use {@link SubListSelectorConfig#setMinimumSubListSize(Integer)} instead.
+     */
+    @Deprecated(forRemoval = true)
     public void setMinimumSubListSize(Integer minimumSubListSize) {
         this.minimumSubListSize = minimumSubListSize;
     }
 
+    /**
+     * @deprecated The maximumSubListSize on the SubListChangeMoveSelectorConfig is deprecated and will be removed in a future
+     *             major version of OptaPlanner. Use {@link SubListSelectorConfig#getMaximumSubListSize()} instead.
+     */
+    @Deprecated(forRemoval = true)
     public Integer getMaximumSubListSize() {
         return maximumSubListSize;
     }
 
+    /**
+     * @deprecated The maximumSubListSize on the SubListChangeMoveSelectorConfig is deprecated and will be removed in a future
+     *             major version of OptaPlanner. Use {@link SubListSelectorConfig#setMaximumSubListSize(Integer)} instead.
+     */
+    @Deprecated(forRemoval = true)
     public void setMaximumSubListSize(Integer maximumSubListSize) {
         this.maximumSubListSize = maximumSubListSize;
     }

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/config/heuristic/selector/move/generic/list/SubListSelectorConfig.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/config/heuristic/selector/move/generic/list/SubListSelectorConfig.java
@@ -22,17 +22,17 @@ import org.optaplanner.core.config.util.ConfigUtils;
 public class SubListSelectorConfig extends SelectorConfig<SubListSelectorConfig> {
 
     @XmlAttribute
-    protected String id = null;
+    private String id = null;
     @XmlAttribute
-    protected String mimicSelectorRef = null;
+    private String mimicSelectorRef = null;
 
     @XmlElement(name = "valueSelector")
     private ValueSelectorConfig valueSelectorConfig = null;
     @XmlElement(name = "nearbySelection")
     private NearbySelectionConfig nearbySelectionConfig = null;
 
-    protected Integer minimumSubListSize = null;
-    protected Integer maximumSubListSize = null;
+    private Integer minimumSubListSize = null;
+    private Integer maximumSubListSize = null;
 
     public SubListSelectorConfig() {
     }

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/config/heuristic/selector/move/generic/list/SubListSwapMoveSelectorConfig.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/config/heuristic/selector/move/generic/list/SubListSwapMoveSelectorConfig.java
@@ -19,8 +19,17 @@ public class SubListSwapMoveSelectorConfig extends MoveSelectorConfig<SubListSwa
 
     public static final String XML_ELEMENT_NAME = "subListSwapMoveSelector";
 
-    // TODO deprecate
+    /**
+     * @deprecated The minimumSubListSize on the SubListSwapMoveSelectorConfig is deprecated and will be removed in a future
+     *             major version of OptaPlanner. Use {@link SubListSelectorConfig#minimumSubListSize} instead.
+     */
+    @Deprecated(forRemoval = true)
     protected Integer minimumSubListSize = null;
+    /**
+     * @deprecated The maximumSubListSize on the SubListSwapMoveSelectorConfig is deprecated and will be removed in a future
+     *             major version of OptaPlanner. Use {@link SubListSelectorConfig#maximumSubListSize} instead.
+     */
+    @Deprecated(forRemoval = true)
     protected Integer maximumSubListSize = null;
     private Boolean selectReversingMoveToo = null;
     @XmlElement(name = "subListSelector")
@@ -28,18 +37,38 @@ public class SubListSwapMoveSelectorConfig extends MoveSelectorConfig<SubListSwa
     @XmlElement(name = "secondarySubListSelector")
     private SubListSelectorConfig secondarySubListSelectorConfig = null;
 
+    /**
+     * @deprecated The minimumSubListSize on the SubListSwapMoveSelectorConfig is deprecated and will be removed in a future
+     *             major version of OptaPlanner. Use {@link SubListSelectorConfig#getMinimumSubListSize()} instead.
+     */
+    @Deprecated(forRemoval = true)
     public Integer getMinimumSubListSize() {
         return minimumSubListSize;
     }
 
+    /**
+     * @deprecated The minimumSubListSize on the SubListSwapMoveSelectorConfig is deprecated and will be removed in a future
+     *             major version of OptaPlanner. Use {@link SubListSelectorConfig#setMinimumSubListSize(Integer)} instead.
+     */
+    @Deprecated(forRemoval = true)
     public void setMinimumSubListSize(Integer minimumSubListSize) {
         this.minimumSubListSize = minimumSubListSize;
     }
 
+    /**
+     * @deprecated The maximumSubListSize on the SubListSwapMoveSelectorConfig is deprecated and will be removed in a future
+     *             major version of OptaPlanner. Use {@link SubListSelectorConfig#getMaximumSubListSize()} instead.
+     */
+    @Deprecated(forRemoval = true)
     public Integer getMaximumSubListSize() {
         return maximumSubListSize;
     }
 
+    /**
+     * @deprecated The maximumSubListSize on the SubListSwapMoveSelectorConfig is deprecated and will be removed in a future
+     *             major version of OptaPlanner. Use {@link SubListSelectorConfig#setMaximumSubListSize(Integer)} instead.
+     */
+    @Deprecated(forRemoval = true)
     public void setMaximumSubListSize(Integer maximumSubListSize) {
         this.maximumSubListSize = maximumSubListSize;
     }

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/RandomSubListChangeMoveSelector.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/RandomSubListChangeMoveSelector.java
@@ -53,6 +53,10 @@ public class RandomSubListChangeMoveSelector<Solution_> extends GenericMoveSelec
         return selectReversingMoveToo;
     }
 
+    SubListSelector<Solution_> getSubListSelector() {
+        return subListSelector;
+    }
+
     @Override
     public String toString() {
         return getClass().getSimpleName() + "(" + subListSelector + ", " + destinationSelector + ")";

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/RandomSubListSwapMoveSelector.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/RandomSubListSwapMoveSelector.java
@@ -66,6 +66,14 @@ public class RandomSubListSwapMoveSelector<Solution_> extends GenericMoveSelecto
         return selectReversingMoveToo;
     }
 
+    SubListSelector<Solution_> getLeftSubListSelector() {
+        return leftSubListSelector;
+    }
+
+    SubListSelector<Solution_> getRightSubListSelector() {
+        return rightSubListSelector;
+    }
+
     @Override
     public String toString() {
         return getClass().getSimpleName() + "(" + leftSubListSelector + ", " + rightSubListSelector + ")";

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/SubListChangeMoveSelectorFactory.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/SubListChangeMoveSelectorFactory.java
@@ -160,20 +160,16 @@ public class SubListChangeMoveSelectorFactory<Solution_>
                                         .withVariableName(variableDescriptor.getVariableName())));
 
         SubListSelectorConfig subListSelectorConfig = subListChangeMoveSelectorConfig.getSubListSelectorConfig();
-        SubListConfigUtil.transferDeprecatedProperty(
-                "minimumSubListSize",
+        SubListConfigUtil.transferDeprecatedMinimumSubListSize(
                 subListChangeMoveSelectorConfig,
                 SubListChangeMoveSelectorConfig::getMinimumSubListSize,
-                subListSelectorConfig,
-                SubListSelectorConfig::getMinimumSubListSize,
-                SubListSelectorConfig::setMinimumSubListSize);
-        SubListConfigUtil.transferDeprecatedProperty(
-                "maximumSubListSize",
+                "subListSelector",
+                subListSelectorConfig);
+        SubListConfigUtil.transferDeprecatedMaximumSubListSize(
                 subListChangeMoveSelectorConfig,
                 SubListChangeMoveSelectorConfig::getMaximumSubListSize,
-                subListSelectorConfig,
-                SubListSelectorConfig::getMaximumSubListSize,
-                SubListSelectorConfig::setMaximumSubListSize);
+                "subListSelector",
+                subListSelectorConfig);
 
         if (subListSelectorConfig.getMimicSelectorRef() == null) {
             subListSelectorConfig.getValueSelectorConfig().setVariableName(variableDescriptor.getVariableName());

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/SubListChangeMoveSelectorFactory.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/SubListChangeMoveSelectorFactory.java
@@ -159,9 +159,24 @@ public class SubListChangeMoveSelectorFactory<Solution_>
                                         // override variable name (destination value selector is never replaying)
                                         .withVariableName(variableDescriptor.getVariableName())));
 
-        if (subListChangeMoveSelectorConfig.getSubListSelectorConfig().getMimicSelectorRef() == null) {
-            subListChangeMoveSelectorConfig.getSubListSelectorConfig().getValueSelectorConfig()
-                    .setVariableName(variableDescriptor.getVariableName());
+        SubListSelectorConfig subListSelectorConfig = subListChangeMoveSelectorConfig.getSubListSelectorConfig();
+        SubListConfigUtil.transferDeprecatedProperty(
+                "minimumSubListSize",
+                subListChangeMoveSelectorConfig,
+                SubListChangeMoveSelectorConfig::getMinimumSubListSize,
+                subListSelectorConfig,
+                SubListSelectorConfig::getMinimumSubListSize,
+                SubListSelectorConfig::setMinimumSubListSize);
+        SubListConfigUtil.transferDeprecatedProperty(
+                "maximumSubListSize",
+                subListChangeMoveSelectorConfig,
+                SubListChangeMoveSelectorConfig::getMaximumSubListSize,
+                subListSelectorConfig,
+                SubListSelectorConfig::getMaximumSubListSize,
+                SubListSelectorConfig::setMaximumSubListSize);
+
+        if (subListSelectorConfig.getMimicSelectorRef() == null) {
+            subListSelectorConfig.getValueSelectorConfig().setVariableName(variableDescriptor.getVariableName());
         }
 
         return subListChangeMoveSelectorConfig;

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/SubListConfigUtil.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/SubListConfigUtil.java
@@ -5,30 +5,66 @@ import java.util.function.Function;
 
 import org.optaplanner.core.config.heuristic.selector.move.generic.list.SubListChangeMoveSelectorConfig;
 import org.optaplanner.core.config.heuristic.selector.move.generic.list.SubListSelectorConfig;
+import org.optaplanner.core.config.heuristic.selector.move.generic.list.SubListSwapMoveSelectorConfig;
 import org.slf4j.LoggerFactory;
 
+/**
+ * Provides backward-compatible way to handle minimumSubListSize and maximumSubListSize properties used on
+ * {@link SubListChangeMoveSelectorConfig} and {@link SubListSwapMoveSelectorConfig}.
+ * <p>
+ * If the property is used, a warning message is logged. If the corresponding property on a child {@link SubListSelectorConfig}
+ * is uninitialized, it will be transferred. Thanks to this, configs that used the properties before they became deprecated
+ * will continue working as if they defined the properties at the child selector. The user will be warned about the deprecation.
+ * <p>
+ * Using both the deprecated and the new property is a mistake and will throw an exception.
+ * <p>
+ * This class should be removed together with its usages and tests for the property transfer and wrong config detection once
+ * the deprecated properties are removed.
+ */
 final class SubListConfigUtil {
 
     private SubListConfigUtil() {
     }
 
-    static void transferDeprecatedProperty(
+    static <Config_> void transferDeprecatedMinimumSubListSize(
+            Config_ moveSelectorConfig, Function<Config_, Integer> sourceGetter,
+            String subListSelectorRole, SubListSelectorConfig subListSelectorConfig) {
+        transferDeprecatedProperty(
+                "minimumSubListSize", moveSelectorConfig, sourceGetter,
+                subListSelectorRole, subListSelectorConfig,
+                SubListSelectorConfig::getMinimumSubListSize,
+                SubListSelectorConfig::setMinimumSubListSize);
+    }
+
+    static <Config_> void transferDeprecatedMaximumSubListSize(
+            Config_ moveSelectorConfig, Function<Config_, Integer> sourceGetter,
+            String subListSelectorRole, SubListSelectorConfig subListSelectorConfig) {
+        transferDeprecatedProperty(
+                "maximumSubListSize",
+                moveSelectorConfig, sourceGetter,
+                subListSelectorRole, subListSelectorConfig,
+                SubListSelectorConfig::getMaximumSubListSize,
+                SubListSelectorConfig::setMaximumSubListSize);
+    }
+
+    private static <Config_> void transferDeprecatedProperty(
             String propertyName,
-            SubListChangeMoveSelectorConfig subListChangeMoveSelectorConfig,
-            Function<SubListChangeMoveSelectorConfig, Integer> sourceGetter,
+            Config_ moveSelectorConfig,
+            Function<Config_, Integer> sourceGetter,
+            String childConfigName,
             SubListSelectorConfig subListSelectorConfig,
             Function<SubListSelectorConfig, Integer> targetGetter,
             BiConsumer<SubListSelectorConfig, Integer> targetSetter) {
-        Integer moveSelectorSubListSize = sourceGetter.apply(subListChangeMoveSelectorConfig);
+        Integer moveSelectorSubListSize = sourceGetter.apply(moveSelectorConfig);
         if (moveSelectorSubListSize != null) {
-            LoggerFactory.getLogger(subListChangeMoveSelectorConfig.getClass()).warn(
+            LoggerFactory.getLogger(moveSelectorConfig.getClass()).warn(
                     "{}'s {} property is deprecated. Set {} on the child {}.",
-                    subListChangeMoveSelectorConfig.getClass().getSimpleName(), propertyName,
+                    moveSelectorConfig.getClass().getSimpleName(), propertyName,
                     propertyName, SubListSelectorConfig.class.getSimpleName());
             Integer subListSize = targetGetter.apply(subListSelectorConfig);
             if (subListSize != null) {
-                throw new IllegalArgumentException("The subListChangeMoveSelector (" + subListChangeMoveSelectorConfig
-                        + ") and its child subListSelector (" + subListSelectorConfig
+                throw new IllegalArgumentException("The moveSelector (" + moveSelectorConfig
+                        + ") and its " + childConfigName + " (" + subListSelectorConfig
                         + ") both set the " + propertyName
                         + ", which is a conflict.\n"
                         + "Use " + SubListSelectorConfig.class.getSimpleName() + "." + propertyName + " only.");

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/SubListConfigUtil.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/SubListConfigUtil.java
@@ -1,0 +1,39 @@
+package org.optaplanner.core.impl.heuristic.selector.move.generic.list;
+
+import java.util.function.BiConsumer;
+import java.util.function.Function;
+
+import org.optaplanner.core.config.heuristic.selector.move.generic.list.SubListChangeMoveSelectorConfig;
+import org.optaplanner.core.config.heuristic.selector.move.generic.list.SubListSelectorConfig;
+import org.slf4j.LoggerFactory;
+
+final class SubListConfigUtil {
+
+    private SubListConfigUtil() {
+    }
+
+    static void transferDeprecatedProperty(
+            String propertyName,
+            SubListChangeMoveSelectorConfig subListChangeMoveSelectorConfig,
+            Function<SubListChangeMoveSelectorConfig, Integer> sourceGetter,
+            SubListSelectorConfig subListSelectorConfig,
+            Function<SubListSelectorConfig, Integer> targetGetter,
+            BiConsumer<SubListSelectorConfig, Integer> targetSetter) {
+        Integer moveSelectorSubListSize = sourceGetter.apply(subListChangeMoveSelectorConfig);
+        if (moveSelectorSubListSize != null) {
+            LoggerFactory.getLogger(subListChangeMoveSelectorConfig.getClass()).warn(
+                    "{}'s {} property is deprecated. Set {} on the child {}.",
+                    subListChangeMoveSelectorConfig.getClass().getSimpleName(), propertyName,
+                    propertyName, SubListSelectorConfig.class.getSimpleName());
+            Integer subListSize = targetGetter.apply(subListSelectorConfig);
+            if (subListSize != null) {
+                throw new IllegalArgumentException("The subListChangeMoveSelector (" + subListChangeMoveSelectorConfig
+                        + ") and its child subListSelector (" + subListSelectorConfig
+                        + ") both set the " + propertyName
+                        + ", which is a conflict.\n"
+                        + "Use " + SubListSelectorConfig.class.getSimpleName() + "." + propertyName + " only.");
+            }
+            targetSetter.accept(subListSelectorConfig, moveSelectorSubListSize);
+        }
+    }
+}

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/SubListSwapMoveSelectorFactory.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/SubListSwapMoveSelectorFactory.java
@@ -38,6 +38,29 @@ public class SubListSwapMoveSelectorFactory<Solution_>
                 Objects.requireNonNullElseGet(config.getSubListSelectorConfig(), SubListSelectorConfig::new);
         SubListSelectorConfig secondarySubListSelectorConfig =
                 Objects.requireNonNullElse(config.getSecondarySubListSelectorConfig(), subListSelectorConfig);
+
+        // minimum -> subListSelector
+        SubListConfigUtil.transferDeprecatedMinimumSubListSize(
+                config,
+                SubListSwapMoveSelectorConfig::getMinimumSubListSize,
+                "subListSelector", subListSelectorConfig);
+        // maximum -> subListSelector
+        SubListConfigUtil.transferDeprecatedMaximumSubListSize(
+                config,
+                SubListSwapMoveSelectorConfig::getMaximumSubListSize,
+                "subListSelector", subListSelectorConfig);
+        if (subListSelectorConfig != secondarySubListSelectorConfig) {
+            // minimum -> secondarySubListSelector
+            SubListConfigUtil.transferDeprecatedMinimumSubListSize(
+                    config,
+                    SubListSwapMoveSelectorConfig::getMinimumSubListSize,
+                    "secondarySubListSelector", secondarySubListSelectorConfig);
+            // maximum -> secondarySubListSelector
+            SubListConfigUtil.transferDeprecatedMaximumSubListSize(
+                    config,
+                    SubListSwapMoveSelectorConfig::getMaximumSubListSize,
+                    "secondarySubListSelector", secondarySubListSelectorConfig);
+        }
         SubListSelector<Solution_> leftSubListSelector = SubListSelectorFactory
                 .<Solution_> create(subListSelectorConfig)
                 .buildSubListSelector(configPolicy, entitySelector, minimumCacheType, selectionOrder);

--- a/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/SubListSwapMoveSelectorFactoryTest.java
+++ b/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/heuristic/selector/move/generic/list/SubListSwapMoveSelectorFactoryTest.java
@@ -1,10 +1,18 @@
 package org.optaplanner.core.impl.heuristic.selector.move.generic.list;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
 import static org.optaplanner.core.impl.heuristic.HeuristicConfigPolicyTestUtils.buildHeuristicConfigPolicy;
 
+import java.util.stream.Stream;
+
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.optaplanner.core.config.heuristic.selector.common.SelectionCacheType;
+import org.optaplanner.core.config.heuristic.selector.move.generic.list.SubListSelectorConfig;
 import org.optaplanner.core.config.heuristic.selector.move.generic.list.SubListSwapMoveSelectorConfig;
 import org.optaplanner.core.impl.heuristic.HeuristicConfigPolicy;
 import org.optaplanner.core.impl.testdata.domain.list.TestdataListSolution;
@@ -44,5 +52,81 @@ class SubListSwapMoveSelectorFactoryTest {
                         SelectionCacheType.JUST_IN_TIME, true);
 
         assertThat(selector.isSelectReversingMoveToo()).isFalse();
+    }
+
+    static SubListSwapMoveSelectorConfig minimumSize_SubListSelector() {
+        SubListSwapMoveSelectorConfig config = new SubListSwapMoveSelectorConfig()
+                .withSubListSelectorConfig(new SubListSelectorConfig().withMinimumSubListSize(10));
+        config.setMinimumSubListSize(10);
+        return config;
+    }
+
+    static SubListSwapMoveSelectorConfig maximumSize_SubListSelector() {
+        SubListSwapMoveSelectorConfig config = new SubListSwapMoveSelectorConfig()
+                .withSubListSelectorConfig(new SubListSelectorConfig().withMaximumSubListSize(10));
+        config.setMaximumSubListSize(10);
+        return config;
+    }
+
+    static SubListSwapMoveSelectorConfig minimumSize_SecondarySubListSelector() {
+        SubListSwapMoveSelectorConfig config = new SubListSwapMoveSelectorConfig()
+                .withSecondarySubListSelectorConfig(new SubListSelectorConfig().withMinimumSubListSize(10));
+        config.setMinimumSubListSize(10);
+        return config;
+    }
+
+    static SubListSwapMoveSelectorConfig maximumSize_SecondarySubListSelector() {
+        SubListSwapMoveSelectorConfig config = new SubListSwapMoveSelectorConfig()
+                .withSecondarySubListSelectorConfig(new SubListSelectorConfig().withMaximumSubListSize(10));
+        config.setMaximumSubListSize(10);
+        return config;
+    }
+
+    static Stream<Arguments> wrongConfigurations() {
+        return Stream.of(
+                arguments(minimumSize_SubListSelector(), "minimumSubListSize", "subListSelector"),
+                arguments(maximumSize_SubListSelector(), "maximumSubListSize", "subListSelector"),
+                arguments(minimumSize_SecondarySubListSelector(), "minimumSubListSize", "secondarySubListSelector"),
+                arguments(maximumSize_SecondarySubListSelector(), "maximumSubListSize", "secondarySubListSelector"));
+    }
+
+    @ParameterizedTest(name = "{1} + {2}")
+    @MethodSource("wrongConfigurations")
+    void failFast_ifSubListSizeOnBothMoveSelectorAndSubListSelector(
+            SubListSwapMoveSelectorConfig config, String propertyName, String childConfigName) {
+        SubListSwapMoveSelectorFactory<TestdataListSolution> factory = new SubListSwapMoveSelectorFactory<>(config);
+
+        HeuristicConfigPolicy<TestdataListSolution> heuristicConfigPolicy =
+                buildHeuristicConfigPolicy(TestdataListSolution.buildSolutionDescriptor());
+
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> factory.buildBaseMoveSelector(heuristicConfigPolicy, SelectionCacheType.JUST_IN_TIME, true))
+                .withMessageContainingAll(propertyName, childConfigName);
+    }
+
+    @Test
+    void transferDeprecatedSubListSizeToChildSelectors() {
+        int minimumSubListSize = 21;
+        int maximumSubListSize = 445;
+        SubListSwapMoveSelectorConfig config = new SubListSwapMoveSelectorConfig();
+        config.setMinimumSubListSize(minimumSubListSize);
+        config.setMaximumSubListSize(maximumSubListSize);
+
+        SubListSwapMoveSelectorFactory<TestdataListSolution> factory = new SubListSwapMoveSelectorFactory<>(config);
+
+        HeuristicConfigPolicy<TestdataListSolution> heuristicConfigPolicy =
+                buildHeuristicConfigPolicy(TestdataListSolution.buildSolutionDescriptor());
+
+        RandomSubListSwapMoveSelector<?> moveSelector =
+                (RandomSubListSwapMoveSelector<?>) factory.buildBaseMoveSelector(heuristicConfigPolicy,
+                        SelectionCacheType.JUST_IN_TIME, true);
+        assertThat(((RandomSubListSelector<?>) moveSelector.getLeftSubListSelector()).getMinimumSubListSize())
+                .isEqualTo(minimumSubListSize);
+        assertThat(((RandomSubListSelector<?>) moveSelector.getLeftSubListSelector()).getMaximumSubListSize())
+                .isEqualTo(maximumSubListSize);
+        assertThat(((RandomSubListSelector<?>) moveSelector.getRightSubListSelector()).getMinimumSubListSize())
+                .isEqualTo(minimumSubListSize);
+        assertThat(((RandomSubListSelector<?>) moveSelector.getRightSubListSelector()).getMaximumSubListSize())
+                .isEqualTo(maximumSubListSize);
     }
 }


### PR DESCRIPTION
See `SubListConfigUtil` Javadoc.