### PR TITLE
DROOLS-7347 Adapt to changes in Drools internals (#2679)

### DIFF
--- a/build/optaplanner-build-parent/pom.xml
+++ b/build/optaplanner-build-parent/pom.xml
@@ -20,7 +20,7 @@
     <!-- Dependencies -->
     <!-- ************************************************************************ -->
     <!-- SNAPSHOT and KIE dependency versions -->
-    <version.org.drools>8.34.0.Final</version.org.drools>
+    <version.org.drools>8.36.0.Final</version.org.drools>
 
     <!-- Normal dependency versions -->
     <version.ch.qos.logback>1.2.9</version.ch.qos.logback>

--- a/core/optaplanner-constraint-drl/src/main/java/org/optaplanner/constraint/drl/OptaPlannerRuleEventListener.java
+++ b/core/optaplanner-constraint-drl/src/main/java/org/optaplanner/constraint/drl/OptaPlannerRuleEventListener.java
@@ -1,6 +1,6 @@
 package org.optaplanner.constraint.drl;
 
-import org.drools.core.common.AgendaItem;
+import org.drools.core.rule.consequence.InternalMatch;
 import org.kie.api.runtime.rule.Match;
 import org.kie.internal.event.rule.RuleEventListener;
 
@@ -8,17 +8,16 @@ public final class OptaPlannerRuleEventListener implements RuleEventListener {
 
     @Override
     public void onUpdateMatch(Match match) {
-        undoPreviousMatch(match);
+        undoPreviousMatch((InternalMatch) match);
     }
 
     @Override
     public void onDeleteMatch(Match match) {
-        undoPreviousMatch(match);
+        undoPreviousMatch((InternalMatch) match);
     }
 
-    public void undoPreviousMatch(Match match) {
-        AgendaItem agendaItem = (AgendaItem) match;
-        Runnable callback = agendaItem.getCallback();
+    public void undoPreviousMatch(InternalMatch match) {
+        Runnable callback = match.getCallback();
         /*
          * In DRL, it is possible that RHS would not call addConstraintMatch() and do some insertLogical() instead,
          * and therefore the callback would be null.
@@ -31,7 +30,7 @@ public final class OptaPlannerRuleEventListener implements RuleEventListener {
          */
         if (callback != null) {
             callback.run();
-            agendaItem.setCallback(null);
+            match.setCallback(null);
         }
     }
 

--- a/core/optaplanner-constraint-drl/src/main/java/org/optaplanner/constraint/drl/holder/AbstractScoreHolder.java
+++ b/core/optaplanner-constraint-drl/src/main/java/org/optaplanner/constraint/drl/holder/AbstractScoreHolder.java
@@ -9,8 +9,7 @@ import java.util.Map;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
-import org.drools.core.common.AgendaItem;
-import org.drools.core.rule.consequence.Activation;
+import org.drools.core.rule.consequence.InternalMatch;
 import org.kie.api.definition.rule.Rule;
 import org.kie.api.runtime.KieSession;
 import org.kie.api.runtime.rule.RuleContext;
@@ -169,7 +168,7 @@ public abstract class AbstractScoreHolder<Score_ extends Score<Score_>> implemen
      */
     protected void registerConstraintMatch(RuleContext kcontext, Runnable constraintUndoListener,
             Supplier<Score_> scoreSupplier) {
-        AgendaItem agendaItem = (AgendaItem) kcontext.getMatch();
+        InternalMatch agendaItem = (InternalMatch) kcontext.getMatch();
         ConstraintActivationUnMatchListener constraintActivationUnMatchListener = new ConstraintActivationUnMatchListener(
                 constraintUndoListener);
         agendaItem.setCallback(constraintActivationUnMatchListener);
@@ -241,7 +240,7 @@ public abstract class AbstractScoreHolder<Score_ extends Score<Score_>> implemen
 
     protected List<Object> extractJustificationList(RuleContext kcontext) {
         // Unlike kcontext.getMatch().getObjects(), this includes the matches of accumulate and exists
-        Activation activation = (Activation) kcontext.getMatch();
+        InternalMatch activation = (InternalMatch) kcontext.getMatch();
         return new ArrayList<>(activation.getObjectsDeep());
     }
 

--- a/core/optaplanner-constraint-drl/src/test/java/org/optaplanner/constraint/drl/holder/AbstractScoreHolderTest.java
+++ b/core/optaplanner-constraint-drl/src/test/java/org/optaplanner/constraint/drl/holder/AbstractScoreHolderTest.java
@@ -15,7 +15,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
 
-import org.drools.core.common.AgendaItem;
+import org.drools.core.rule.consequence.InternalMatch;
 import org.junit.jupiter.api.Test;
 import org.kie.api.definition.rule.Rule;
 import org.kie.api.runtime.rule.RuleContext;
@@ -42,16 +42,16 @@ public abstract class AbstractScoreHolderTest<Score_ extends Score<Score_>> {
         RuleContext kcontext = mock(RuleContext.class);
 
         AtomicReference<Runnable> callbackRef = new AtomicReference<>();
-        AgendaItem agendaItem = mock(AgendaItem.class);
-        doReturn(justificationList).when(agendaItem).getObjects();
-        doReturn(justificationList).when(agendaItem).getObjectsDeep();
-        doAnswer(invocation -> callbackRef.get()).when(agendaItem).getCallback();
+        InternalMatch match = mock(InternalMatch.class);
+        doReturn(justificationList).when(match).getObjects();
+        doReturn(justificationList).when(match).getObjectsDeep();
+        doAnswer(invocation -> callbackRef.get()).when(match).getCallback();
         doAnswer(invocation -> {
             callbackRef.set(invocation.getArgument(0));
             return null;
-        }).when(agendaItem).setCallback(any());
+        }).when(match).setCallback(any());
 
-        when(kcontext.getMatch()).thenReturn(agendaItem);
+        when(kcontext.getMatch()).thenReturn(match);
         when(kcontext.getRule()).thenReturn(rule);
         return kcontext;
     }
@@ -64,13 +64,11 @@ public abstract class AbstractScoreHolderTest<Score_ extends Score<Score_>> {
     }
 
     protected void callOnUpdate(RuleContext ruleContext) {
-        AgendaItem agendaItem = (AgendaItem) ruleContext.getMatch();
-        agendaItem.getCallback().run();
+        ((InternalMatch) ruleContext.getMatch()).getCallback().run();
     }
 
     protected void callOnDelete(RuleContext ruleContext) {
-        AgendaItem agendaItem = (AgendaItem) ruleContext.getMatch();
-        agendaItem.getCallback().run();
+        ((InternalMatch) ruleContext.getMatch()).getCallback().run();
     }
 
     protected ConstraintMatchTotal<Score_> findConstraintMatchTotal(AbstractScoreHolder<Score_> scoreHolder, String ruleName) {

--- a/core/optaplanner-constraint-streams-drools/src/main/java/org/optaplanner/constraint/streams/drools/OptaPlannerRuleEventListener.java
+++ b/core/optaplanner-constraint-streams-drools/src/main/java/org/optaplanner/constraint/streams/drools/OptaPlannerRuleEventListener.java
@@ -1,6 +1,6 @@
 package org.optaplanner.constraint.streams.drools;
 
-import org.drools.core.common.AgendaItem;
+import org.drools.core.rule.consequence.InternalMatch;
 import org.kie.api.runtime.rule.Match;
 import org.kie.internal.event.rule.RuleEventListener;
 
@@ -8,17 +8,16 @@ public final class OptaPlannerRuleEventListener implements RuleEventListener {
 
     @Override
     public void onUpdateMatch(Match match) {
-        undoPreviousMatch(match);
+        undoPreviousMatch((InternalMatch) match);
     }
 
     @Override
     public void onDeleteMatch(Match match) {
-        undoPreviousMatch(match);
+        undoPreviousMatch((InternalMatch) match);
     }
 
-    public void undoPreviousMatch(Match match) {
-        AgendaItem agendaItem = (AgendaItem) match;
-        Runnable callback = agendaItem.getCallback();
+    public void undoPreviousMatch(InternalMatch match) {
+        Runnable callback = match.getCallback();
         /*
          * Null callbacks can happen and are safe to ignore.
          *
@@ -28,7 +27,7 @@ public final class OptaPlannerRuleEventListener implements RuleEventListener {
          */
         if (callback != null) {
             callback.run();
-            agendaItem.setCallback(null);
+            match.setCallback(null);
         }
     }
 

--- a/core/optaplanner-constraint-streams-drools/src/main/java/org/optaplanner/constraint/streams/drools/common/AbstractRuleContext.java
+++ b/core/optaplanner-constraint-streams-drools/src/main/java/org/optaplanner/constraint/streams/drools/common/AbstractRuleContext.java
@@ -8,7 +8,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import org.drools.core.common.AgendaItem;
+import org.drools.core.rule.consequence.InternalMatch;
 import org.drools.model.Drools;
 import org.drools.model.RuleItemBuilder;
 import org.drools.model.view.ViewItem;
@@ -41,8 +41,8 @@ abstract class AbstractRuleContext {
     }
 
     private static void addUndo(Drools drools, UndoScoreImpacter undoImpact) {
-        AgendaItem agendaItem = (AgendaItem) ((RuleContext) drools).getMatch();
-        agendaItem.setCallback(undoImpact);
+        InternalMatch match = (InternalMatch) ((RuleContext) drools).getMatch();
+        match.setCallback(undoImpact);
     }
 
     private static RuntimeException createExceptionOnImpact(DroolsConstraint<?> constraint, Exception cause) {


### PR DESCRIPTION
Cherry-pick the https://github.com/kiegroup/optaplanner/commit/e83266718d52052ebd967ddab3d5efd95d49c65b.

<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.
-->

### JIRA

<!-- Add a JIRA ticket link if it exists. -->
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
- https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
- https://github.com/kiegroup/drools/pull/3000
- https://github.com/kiegroup/optaplanner/pull/899
- etc.
-->

### Checklist
- [ ] Documentation updated if applicable.
- [ ] Release notes updated if applicable.
- [ ] Upgrade recipe provided if applicable.

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request checks</b>  
  Please add comment: <b>Jenkins retest this</b>

- for a <b>specific pull request check</b>  
  please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts] tests</b>
  
- for a <b>full downstream build</b> 
  - for <b>jenkins</b> job: 
    please add comment: <b>Jenkins run fdb</b>
  - for <b>github actions</b> job: 
    add the label `run_fdb`

- for a <b>compile downstream build</b>  
  please add comment: <b>Jenkins run cdb</b>

- for a <b>full production downstream build</b>  
  please add comment: <b>Jenkins execute product fdb</b>

- for an <b>upstream build</b>  
  please add comment: <b>Jenkins run upstream</b>

- for <b>quarkus branch checks</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins run quarkus-branch</b>

- for a <b>quarkus branch specific check</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts] quarkus-branch</b>

- for <b>quarkus main checks</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins run quarkus-main</b>

- for a <b>specific quarkus main check</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts] quarkus-branch</b>

- for <b>quarkus lts checks</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins run quarkus-lts</b>

- for a <b>specific quarkus lts check</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts] quarkus-lts</b>

- for <b>native checks</b>  
  Run native checks  
  Please add comment: <b>Jenkins run native</b>

- for a <b>specific native check</b>  
  Run native checks 
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts] native</b>

- for <b>native lts checks</b>  
  Run native checks against quarkus lts branch
  Please add comment: <b>Jenkins run native-lts</b>

- for a <b>specific native lts check</b>  
  Run native checks against quarkus lts branch
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts] native-lts</b>

</details>

### CI Status

 You can check OptaPlanner repositories CI status from [Chain Status webpage](https://kiegroup.github.io/optaplanner/).

<details>
<summary>
How to backport a pull request to a different branch?
</summary>

In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-7.67.x` to backport the original PR to the `7.67.x` branch).

> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.

Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.

If something goes wrong, the author will be notified and at this point a manual backporting is needed.

> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
</details>
