### PR TITLE
[BXMSPROD-1983] migrate RHBOP nightly to build-chain

### DIFF
--- a/.ci/jenkins/Jenkinsfile.prod.nightly
+++ b/.ci/jenkins/Jenkinsfile.prod.nightly
@@ -7,14 +7,16 @@ pipeline {
     tools {
         maven 'kie-maven-3.8.6'
         jdk 'kie-jdk11'
+        nodejs 'nodejs-16.2.0'
     }
     parameters {
         string(description: 'The deployment URL', name: 'KIE_GROUP_DEPLOYMENT_REPO_URL')
-        booleanParam(description: 'Skip Tests? True as default', name: 'SKIP_TESTS', defaultValue: true)
         string(description: 'The UMB message version', name: 'UMB_VERSION', defaultValue: 'main')
-        string(description: 'The product version', name: 'PRODUCT_VERSION')
-        string(description: 'The drools product version', name: 'DROOLS_PRODUCT_VERSION')
-        string(description: 'The config repository branch', name: 'CONFIG_BRANCH', defaultValue: 'main')
+        string(description: 'The product version, if not provided the optaplanner main branch one will be used', name: 'PRODUCT_VERSION')
+        string(description: 'The drools product version, if not provided the drools main branch one will be used', name: 'DROOLS_PRODUCT_VERSION')
+        string(description: 'The config repository branch', name: 'CONFIG_BRANCH', defaultValue: 'master')
+        string(description: 'The build chain definition file owner', name: 'DEFINITION_FILE_OWNER', defaultValue: 'kiegroup')
+        string(description: 'The build chain definition file branch', name: 'DEFINITION_FILE_BRANCH', defaultValue: 'main')
     }
     options {
         buildDiscarder logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '10')
@@ -28,33 +30,43 @@ pipeline {
                 sh 'printenv'
             }
         }
+        stage('Install build-chain tool') {
+            steps {
+                script {
+                    println "[INFO] Installing build-chain tool"
+                    sh "npm install -g @kie/build-chain-action${env.NPM_REGISTRY_URL ? " -registry=${NPM_REGISTRY_URL}" : ''}"
+
+                    sh "npm list -g | grep build-chain"
+                }
+            }
+        }
         stage('Clone build configuration repo') {
             steps {
                 script {
-                    def currentBranch = env.CONFIG_BRANCH ?: env.DEFAULT_CONFIG_BRANCH ?: env.BRANCH_NAME ?: env.GIT_BRANCH
+                    def currentBranch = getBuildConfigBranch()
                     println "Checking out ${env.BUILD_CONFIGURATION_REPO_URL}:${currentBranch} into build_config folder"
                     sh "git clone -b ${currentBranch} --single-branch ${env.BUILD_CONFIGURATION_REPO_URL} build_config"
+
+                    // export PME parameters and build scripts from nightly build config
+                    def buildConfigAdditionalVariables = [
+                        'productVersion': env.PRODUCT_VERSION,
+                        'droolsProductVersion': env.DROOLS_PRODUCT_VERSION
+                    ]
+                    pmebuild.parseBuildConfig("$WORKSPACE/build_config/rhbop/nightly", buildConfigAdditionalVariables)
                 }
             }
         }
         stage('Build Nightly projects') {
             steps {
-                catchError(buildResult: 'UNSTABLE', stageResult: 'FAILURE')
-                {
-                    script {
-                        def pipelineHelper = new PipelineHelper(this)
-                        pipelineHelper.retry(
-                        {
-                            def SETTINGS_XML_ID = '5d9884a1-178a-4d67-a3ac-9735d2df2cef'
-                            def projectCollection = ['drools', 'optaplanner', 'optaplanner-quickstarts', 'optaweb-vehicle-routing', 'jboss-integration/rhbop-optaplanner']
-                            def projectVariableMap = ['kiegroup_optaplanner': 'optaplannerVersion', 'kiegroup_drools': 'droolsProductVersion']
-                            def additionalVariables = [
-                                'droolsProductVersion': env.DROOLS_PRODUCT_VERSION,
-                                'drools-scmRevision': getDroolsBranch(),
-                                'optaplanner-quickstarts-scmRevision': getOptaPlannerQuickstartsBranch()
-                            ]
-                            pmebuild.buildProjects(projectCollection, "${SETTINGS_XML_ID}", "$WORKSPACE/build_config/rhbop/nightly", "${env.PME_CLI_PATH}", projectVariableMap, additionalVariables, [:])
-                        }, 2, 180*60)
+                script {
+                    withCredentials([string(credentialsId: "kie-ci1-token", variable: 'GITHUB_TOKEN')]) {
+                        def SETTINGS_XML_ID = '5d9884a1-178a-4d67-a3ac-9735d2df2cef'
+                        def buildBranch = getBuildBranch()
+                        def definitionFile = "https://raw.githubusercontent.com/${env.DEFINITION_FILE_OWNER}/optaplanner/${env.DEFINITION_FILE_BRANCH}/.ci/nightly-build-config.yaml"
+
+                        configFileProvider([configFile(fileId: "${SETTINGS_XML_ID}", variable: 'PME_MAVEN_SETTINGS_XML')]) {
+                            sh "build-chain build branch --token=${GITHUB_TOKEN} -f ${definitionFile} -b ${buildBranch} -o bc -p kiegroup/optaplanner --fullProjectDependencyTree --skipParallelCheckout"
+                        }
                     }
                 }
             }
@@ -75,23 +87,32 @@ pipeline {
         stage('Upload optaplanner sources') {
             steps {
                 script {
-                    if(env.ALREADY_BUILT_PROJECTS?.trim()) {
-                        echo "[INFO] Start uploading sources zip files.."
+                    echo "[INFO] Start uploading sources zip files.."
 
-                        def PME_BUILD_VARIABLES = env.PME_BUILD_VARIABLES.split(';').collect{ it.split('=')}.inject([:]) {map, item -> map << [(item.length == 2 ? item[0] : null): (item.length == 2 ? item[1] : null)]}
-                        def folder="${env.RCM_GUEST_FOLDER}/rhbop/RHBOP-${PRODUCT_VERSION}.nightly"
+                    def folder="${env.RCM_GUEST_FOLDER}/rhbop/RHBOP-${PRODUCT_VERSION}.nightly"
 
-                        // zip source directories
-                        dir("${env.WORKSPACE}/deployDirectory/org/kie/rhbop/rhbop/${PRODUCT_VERSION}.redhat-${PME_BUILD_VARIABLES['datetimeSuffix']}") {
-                            def optaplannerSourcesFilename = computeSourcesFilename("optaplanner", PME_BUILD_VARIABLES['datetimeSuffix'])
-                            uploadSources(optaplannerSourcesFilename, folder)
+                    // zip source directories
+                    dir("${env.WORKSPACE}/deployDirectory/org/kie/rhbop/rhbop/${PRODUCT_VERSION}.redhat-${env.DATE_TIME_SUFFIX}") {
+                        def optaplannerSourcesFilename = computeSourcesFilename("optaplanner", env.DATE_TIME_SUFFIX)
+                        uploadSources(optaplannerSourcesFilename, folder)
 
-                            def quickstartsSourcesFilename = computeSourcesFilename("optaplanner-quickstarts", PME_BUILD_VARIABLES['datetimeSuffix'])
-                            uploadSources(quickstartsSourcesFilename, folder)
+                        def quickstartsSourcesFilename = computeSourcesFilename("optaplanner-quickstarts", env.DATE_TIME_SUFFIX)
+                        uploadSources(quickstartsSourcesFilename, folder)
+                    }
+                }
+            }
+        }
+        stage ('Extract Git Information') {
+            steps {
+                script {
+                    def projectFolders = sh(returnStdout: true, script: "ls ${env.WORKSPACE}/bc").trim().split("\n")
+                    for (f in projectFolders) {
+                        dir("${env.WORKSPACE}/bc/${f}") {
+                            def projectName = f.replace("_", "/")
+                            // extract git infos
+                            util.storeGitInformation(projectName)
+                            env.ALREADY_BUILT_PROJECTS = "${env.ALREADY_BUILT_PROJECTS ?: ''}${projectName};"
                         }
-
-                    } else {
-                        println "[WARNING] No sources to upload. None project has been built."
                     }
                 }
             }
@@ -99,43 +120,37 @@ pipeline {
         stage ('Send UMB Message to QE.') {
             steps {
                 script {
-                    if(env.ALREADY_BUILT_PROJECTS?.trim()) {
-                        echo '[INFO] Sending RHBOP UMB message to QE.'
-                        def PME_BUILD_VARIABLES = env.PME_BUILD_VARIABLES.split(';').collect{ it.split('=')}.inject([:]) {map, item -> map << [(item.length == 2 ? item[0] : null): (item.length == 2 ? item[1] : null)]}
+                    echo '[INFO] Sending RHBOP UMB message to QE.'
+                    def optaplannerArchiveUrl = "https://${env.LOCAL_NEXUS_IP}:8443/nexus/content/groups/rhbop-${calculateArchiveRepoBranch()}-nightly/"
+                    def optaplannerSourcesFileUrl = "${env.STAGING_SERVER_URL}rhbop/RHBOP-${PRODUCT_VERSION}.nightly/rhbop-${PRODUCT_VERSION}.redhat-${env.DATE_TIME_SUFFIX}-optaplanner-sources.zip"
+                    def optaplannerQuickstartsSourcesFileUrl = "${env.STAGING_SERVER_URL}rhbop/RHBOP-${PRODUCT_VERSION}.nightly/rhbop-${PRODUCT_VERSION}.redhat-${env.DATE_TIME_SUFFIX}-optaplanner-quickstarts-sources.zip"
 
-                        def optaplannerArchiveUrl = "https://${env.LOCAL_NEXUS_IP}:8443/nexus/content/groups/rhbop-${calculateArchiveRepoBranch()}-nightly/"
-                        def optaplannerSourcesFileUrl = "${env.STAGING_SERVER_URL}rhbop/RHBOP-${PRODUCT_VERSION}.nightly/rhbop-${PRODUCT_VERSION}.redhat-${PME_BUILD_VARIABLES['datetimeSuffix']}-optaplanner-sources.zip"
-                        def optaplannerQuickstartsSourcesFileUrl = "${env.STAGING_SERVER_URL}rhbop/RHBOP-${PRODUCT_VERSION}.nightly/rhbop-${PRODUCT_VERSION}.redhat-${PME_BUILD_VARIABLES['datetimeSuffix']}-optaplanner-quickstarts-sources.zip"
+                    def topic = "VirtualTopic.qe.ci.ba.rhbop.${env.UMB_VERSION}.nightly.trigger"
+                    def eventType = "rhbop-${env.UMB_VERSION}-nightly-qe-trigger"
+                    def messageBody = getMessageBody(
+                        optaplannerArchiveUrl,
+                        optaplannerSourcesFileUrl,
+                        optaplannerQuickstartsSourcesFileUrl,
+                        env.ALREADY_BUILT_PROJECTS,
+                        [
+                            'rhbop': env.OPTAPLANNER_VERSION,
+                            'optaplanner': env.OPTAPLANNER_VERSION,
+                            'drools': env.DROOLS_VERSION,
+                            'quarkus.bom': env.DROOLS_VERSION,
+                            'platform.quarkus.bom': env.DROOLS_VERSION
+                        ],
+                        gitHashesToCollection(env.GIT_INFORMATION_HASHES)
+                    )
 
-                        def topic = "VirtualTopic.qe.ci.ba.rhbop.${env.UMB_VERSION}.nightly.trigger"
-                        def eventType = "rhbop-${env.UMB_VERSION}-nightly-qe-trigger"
-                        def messageBody = getMessageBody(
-                            optaplannerArchiveUrl,
-                            optaplannerSourcesFileUrl,
-                            optaplannerQuickstartsSourcesFileUrl,
-                            env.ALREADY_BUILT_PROJECTS,
-                            [
-                                'rhbop': PME_BUILD_VARIABLES['optaplannerVersion'],
-                                'optaplanner': PME_BUILD_VARIABLES['optaplannerVersion'],
-                                'drools': PME_BUILD_VARIABLES['droolsProductVersion'],
-                                'quarkus.bom': PME_BUILD_VARIABLES['quarkusVersion']?.replaceAll("\\{\\{.*\\}\\}", PME_BUILD_VARIABLES['quarkusVersionCommunity'] ?: ''),
-                                'platform.quarkus.bom': PME_BUILD_VARIABLES['quarkusPlatformVersion']?.replaceAll("\\{\\{.*\\}\\}", PME_BUILD_VARIABLES['quarkusVersionCommunity'] ?: '')
-                            ],
-                            gitHashesToCollection(env.GIT_INFORMATION_HASHES)
-                        )
-
-                        echo "[INFO] Message Body: ${messageBody}"
-                        echo "[INFO] Topic: ${topic}"
-                        echo "[INFO] Event Type: ${eventType}"
-                        build job: env.SEND_UMB_MESSAGE_JOB_PATH, parameters: [
-                                [$class: 'StringParameterValue', name: 'MESSAGE_BODY', value: messageBody],
-                                [$class: 'StringParameterValue', name: 'TOPIC', value: topic],
-                                [$class: 'StringParameterValue', name: 'EVENT_TYPE', value: eventType]
-                        ]
-                        echo '[SUCCESS] Message was successfully sent.'
-                    } else {
-                        println "[WARNING] No artifacts to upload. None project has been built."
-                    }
+                    echo "[INFO] Message Body: ${messageBody}"
+                    echo "[INFO] Topic: ${topic}"
+                    echo "[INFO] Event Type: ${eventType}"
+                    build job: env.SEND_UMB_MESSAGE_JOB_PATH, parameters: [
+                            [$class: 'StringParameterValue', name: 'MESSAGE_BODY', value: messageBody],
+                            [$class: 'StringParameterValue', name: 'TOPIC', value: topic],
+                            [$class: 'StringParameterValue', name: 'EVENT_TYPE', value: eventType]
+                    ]
+                    echo '[SUCCESS] Message was successfully sent.'
                 }
             }
         }
@@ -172,6 +187,15 @@ pipeline {
             cleanWs()
         }
     }
+}
+
+String getBuildConfigBranch() {
+  return env.CONFIG_BRANCH ?: env.DEFAULT_CONFIG_BRANCH ?: env.BRANCH_NAME ?: env.GIT_BRANCH
+}
+
+String getBuildBranch() {
+  // Fallback to main if none exist
+  return env.BRANCH_NAME ?: env.GIT_BRANCH ?: 'main'
 }
 
 def getMessageBody(String optaplannerArchiveUrl, String optaplannerSourcesUrl, String optaplannerQuickstartsSourcesUrl, String alreadyBuiltProjects, Map<String, String> versions, Map<String, String> scmHashes) {
@@ -229,4 +253,16 @@ String calculateArchiveRepoBranch() {
     }
     // e.g., main
     return branch
+}
+
+// Parse version from main branch of the given project
+//      * project: in the form of owner/repository
+def parseVersionFromPom(String project) {
+    def currentBranch = getCurrentBranch() ?: env.GIT_BRANCH
+    def pomFilename = "${project.replaceAll("/", "_")}_pom.xml"
+    def pomPath = "${env.WORKSPACE}/${pomFilename}"
+
+    sh "curl https://raw.githubusercontent.com/${project}/${currentBranch}/pom.xml -o ${pomPath}"
+    def pom = readMavenPom file: pomPath
+    return pom.getVersion().replaceAll('-SNAPSHOT', '')
 }

--- a/.ci/nightly-build-config.yaml
+++ b/.ci/nightly-build-config.yaml
@@ -1,0 +1,57 @@
+version: "2.1"
+
+dependencies: ./project-dependencies-rhbop.yaml
+
+pre: |
+  export PME_CMD="java -jar ${{ env.PME_CLI_PATH }} -s ${{ env.PME_MAVEN_SETTINGS_XML }} -DallowConfigFilePrecedence=true -DprojectSrcSkip=false"
+  echo "PME_CMD=${{ env.PME_CMD }}"
+  export BUILD_MVN_OPTS="${{ env.BUILD_MVN_OPTS }} -s ${{ env.PME_MAVEN_SETTINGS_XML }}"
+  echo "BUILD_MVN_OPTS=${{ env.BUILD_MVN_OPTS }}"
+  export EXTRACT_VERSION="mvn org.apache.maven.plugins:maven-help-plugin:3.2.0:evaluate -Dexpression=project.version -q -DforceStdout"
+  echo "EXTRACT_VERSION=${{ env.EXTRACT_VERSION }}"
+
+default:
+  build-command:
+    current: mvn clean install -Dproductized=true -DskipTests=true ${{ env.BUILD_MVN_OPTS }}
+    upstream: mvn clean install -Dquickly -Dproductized=true -DskipTests=true ${{ env.BUILD_MVN_OPTS }} 
+    downstream: mvn clean install -Dquickly -Dproductized=true -DskipTests=true ${{ env.BUILD_MVN_OPTS }} 
+    after:
+      current: |
+        docker system prune -f 
+
+build:
+  - project: kiegroup/drools
+    build-command:
+      upstream: |
+        ${{ env.PME_CMD }} ${{ env.PME_ALIGNMENT_PARAMS_kiegroup_drools }}
+        ${{ env.PME_BUILD_SCRIPT_kiegroup_drools }} ${{ env.BUILD_MVN_OPTS }}
+      after:
+        upstream: |
+          export DROOLS_VERSION=`${{ env.EXTRACT_VERSION }}`
+          echo "DROOLS_VERSION=${{ env.DROOLS_VERSION }}"
+  - project: kiegroup/optaplanner
+    build-command:
+      current: |
+        ${{ env.PME_CMD }} ${{ env.PME_ALIGNMENT_PARAMS_kiegroup_optaplanner }}
+        ${{ env.PME_BUILD_SCRIPT_kiegroup_optaplanner }} ${{ env.BUILD_MVN_OPTS }}
+      after:
+        current: |
+          export OPTAPLANNER_VERSION=`${{ env.EXTRACT_VERSION }}`
+          echo "OPTAPLANNER_VERSION=${{ env.OPTAPLANNER_VERSION }}"
+          export QUARKUS_VERSION=`mvn org.apache.maven.plugins:maven-help-plugin:3.2.0:evaluate -Dexpression=version.io.quarkus -q -DforceStdout -f build/optaplanner-build-parent/pom.xml`
+          echo "QUARKUS_VERSION=${{ env.QUARKUS_VERSION }}"
+  - project: kiegroup/optaplanner-quickstarts
+    build-command:
+      downstream: |
+        ${{ env.PME_CMD }} ${{ env.PME_ALIGNMENT_PARAMS_kiegroup_optaplanner_quickstarts }}
+        ${{ env.PME_BUILD_SCRIPT_kiegroup_optaplanner_quickstarts }} ${{ env.BUILD_MVN_OPTS }}
+  - project: kiegroup/optaweb-vehicle-routing
+    build-command:
+      downstream: |
+        ${{ env.PME_CMD }} ${{ env.PME_ALIGNMENT_PARAMS_kiegroup_optaweb_vehicle_routing }}
+        ${{ env.PME_BUILD_SCRIPT_kiegroup_optaweb_vehicle_routing }} ${{ env.BUILD_MVN_OPTS }}
+  - project: jboss-integration/rhbop-optaplanner
+    build-command:
+      downstream: |
+        ${{ env.PME_CMD }} ${{ env.PME_ALIGNMENT_PARAMS_jboss_integration_rhbop_optaplanner }}
+        ${{ env.PME_BUILD_SCRIPT_jboss_integration_rhbop_optaplanner }} ${{ env.BUILD_MVN_OPTS }}

--- a/.ci/project-dependencies-rhbop.yaml
+++ b/.ci/project-dependencies-rhbop.yaml
@@ -31,3 +31,8 @@ dependencies:
         default:
           - source: main
             target: development
+
+  - project: jboss-integration/rhbop-optaplanner
+    dependencies:
+      - project: kiegroup/optaplanner-quickstarts
+      - project: kiegroup/optaweb-vehicle-routing


### PR DESCRIPTION
<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.
-->

Backport https://github.com/kiegroup/optaplanner/pull/2717

### JIRA

https://issues.redhat.com/browse/BXMSPROD-1983

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
- https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
- https://github.com/kiegroup/drools/pull/3000
- https://github.com/kiegroup/optaplanner/pull/899
- etc.
-->

### Checklist
- [ ] Documentation updated if applicable.
- [ ] Release notes updated if applicable.
- [ ] Upgrade recipe provided if applicable.

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request checks</b>  
  Please add comment: <b>Jenkins retest this</b>

- for a <b>specific pull request check</b>  
  please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts] tests</b>
  
- for a <b>full downstream build</b> 
  - for <b>jenkins</b> job: 
    please add comment: <b>Jenkins run fdb</b>
  - for <b>github actions</b> job: 
    add the label `run_fdb`

- for a <b>compile downstream build</b>  
  please add comment: <b>Jenkins run cdb</b>

- for a <b>full production downstream build</b>  
  please add comment: <b>Jenkins execute product fdb</b>

- for an <b>upstream build</b>  
  please add comment: <b>Jenkins run upstream</b>

- for <b>quarkus branch checks</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins run quarkus-branch</b>

- for a <b>quarkus branch specific check</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts] quarkus-branch</b>

- for <b>quarkus main checks</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins run quarkus-main</b>

- for a <b>specific quarkus main check</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts] quarkus-branch</b>

- for <b>quarkus lts checks</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins run quarkus-lts</b>

- for a <b>specific quarkus lts check</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts] quarkus-lts</b>

- for <b>native checks</b>  
  Run native checks  
  Please add comment: <b>Jenkins run native</b>

- for a <b>specific native check</b>  
  Run native checks 
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts] native</b>

- for <b>native lts checks</b>  
  Run native checks against quarkus lts branch
  Please add comment: <b>Jenkins run native-lts</b>

- for a <b>specific native lts check</b>  
  Run native checks against quarkus lts branch
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts] native-lts</b>

</details>

### CI Status

 You can check OptaPlanner repositories CI status from [Chain Status webpage](https://kiegroup.github.io/optaplanner/).

<details>
<summary>
How to backport a pull request to a different branch?
</summary>

In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-7.67.x` to backport the original PR to the `7.67.x` branch).

> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.

Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.

If something goes wrong, the author will be notified and at this point a manual backporting is needed.

> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
</details>
