### PR TITLE
Improved distance matrix demand Javadoc

### DIFF
--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/common/nearby/NearbyDistanceMatrixDemand.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/common/nearby/NearbyDistanceMatrixDemand.java
@@ -15,9 +15,10 @@ import org.optaplanner.core.impl.solver.ClassInstanceCache;
 import org.optaplanner.core.impl.util.MemoizingSupply;
 
 /**
+ * Demands a distance matrix where the origins are planning entities and nearby destinations are either entities or values.
+ * <p>
  * Calculating {@link NearbyDistanceMatrix} is very expensive,
  * therefore we want to reuse it as much as possible.
- *
  * <p>
  * In cases where the demand represents the same nearby selector (as defined by
  * {@link NearbyDistanceMatrixDemand#equals(Object)})
@@ -25,8 +26,8 @@ import org.optaplanner.core.impl.util.MemoizingSupply;
  * with the pre-computed {@link NearbyDistanceMatrix}.
  *
  * @param <Solution_>
- * @param <Origin_>
- * @param <Destination_>
+ * @param <Origin_> planning entities
+ * @param <Destination_> planning entities XOR planning values
  */
 public final class NearbyDistanceMatrixDemand<Solution_, Origin_, Destination_>
         implements Demand<MemoizingSupply<NearbyDistanceMatrix<Origin_, Destination_>>> {
@@ -61,11 +62,13 @@ public final class NearbyDistanceMatrixDemand<Solution_, Origin_, Destination_>
                         + ") has an entitySize (" + originSize
                         + ") which is higher than Integer.MAX_VALUE.");
             }
+            // Destinations: entities or values extracted either from an entity selector or a value selector.
             Function<Origin_, Iterator<Destination_>> destinationIteratorProvider = childSelector instanceof EntitySelector
                     ? origin -> (Iterator<Destination_>) ((EntitySelector<Solution_>) childSelector).endingIterator()
                     : origin -> (Iterator<Destination_>) ((ValueSelector<Solution_>) childSelector).endingIterator(origin);
             NearbyDistanceMatrix<Origin_, Destination_> nearbyDistanceMatrix =
                     new NearbyDistanceMatrix<>(meter, (int) originSize, destinationIteratorProvider, destinationSizeFunction);
+            // Origins: entities extracted from an entity selector.
             replayingOriginEntitySelector.endingIterator()
                     .forEachRemaining(origin -> nearbyDistanceMatrix.addAllDestinations((Origin_) origin));
             return nearbyDistanceMatrix;

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/list/nearby/SubListNearbyDistanceMatrixDemand.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/list/nearby/SubListNearbyDistanceMatrixDemand.java
@@ -16,9 +16,11 @@ import org.optaplanner.core.impl.solver.ClassInstanceCache;
 import org.optaplanner.core.impl.util.MemoizingSupply;
 
 /**
+ * Demands a distance matrix where the origins are planning values and nearby destinations are both planning entities and
+ * values.
+ * <p>
  * Calculating {@link NearbyDistanceMatrix} is very expensive,
  * therefore we want to reuse it as much as possible.
- *
  * <p>
  * In cases where the demand represents the same nearby selector (as defined by
  * {@link SubListNearbyDistanceMatrixDemand#equals(Object)})
@@ -26,8 +28,8 @@ import org.optaplanner.core.impl.util.MemoizingSupply;
  * with the pre-computed {@link NearbyDistanceMatrix}.
  *
  * @param <Solution_>
- * @param <Origin_>
- * @param <Destination_>
+ * @param <Origin_> planning values
+ * @param <Destination_> mix of planning entities and planning values
  */
 public final class SubListNearbyDistanceMatrixDemand<Solution_, Origin_, Destination_>
         implements Demand<MemoizingSupply<NearbyDistanceMatrix<Origin_, Destination_>>> {
@@ -62,12 +64,16 @@ public final class SubListNearbyDistanceMatrixDemand<Solution_, Origin_, Destina
                         + ") has a subListSize (" + originSize
                         + ") which is higher than Integer.MAX_VALUE.");
             }
-            // Destinations in the "matrix" need to be entities and values (not ElementRefs!) because that's what
-            // the NearbyDistanceMeter is able to measure.
+            // Destinations: mix of planning entities and values extracted from a destination selector.
+            // Distance "matrix" elements must be user classes (entities and values) because they are exposed
+            // to the user-implemented NearbyDistanceMeter. Therefore, we cannot insert ElementRefs in the matrix.
+            // For this reason, destination selector's endingIterator() returns entities and values produced by
+            // its child selectors.
             Function<Origin_, Iterator<Destination_>> destinationIteratorProvider =
                     origin -> (Iterator<Destination_>) childDestinationSelector.endingIterator();
             NearbyDistanceMatrix<Origin_, Destination_> nearbyDistanceMatrix =
                     new NearbyDistanceMatrix<>(meter, (int) originSize, destinationIteratorProvider, destinationSizeFunction);
+            // Origins: values extracted from a subList selector.
             replayingOriginSubListSelector.endingValueIterator()
                     .forEachRemaining(origin -> nearbyDistanceMatrix.addAllDestinations((Origin_) origin));
             return nearbyDistanceMatrix;
@@ -76,12 +82,12 @@ public final class SubListNearbyDistanceMatrixDemand<Solution_, Origin_, Destina
     }
 
     /**
-     * Two instances of this class are consider equal if and only if:
+     * Two instances of this class are considered equal if and only if:
      *
      * <ul>
      * <li>Their meter instances are equal.</li>
-     * <li>Their child selectors are equal.</li>
-     * <li>Their replaying origin entity selectors are equal.</li>
+     * <li>Their child destination selectors are equal.</li>
+     * <li>Their replaying origin subList selectors are equal.</li>
      * </ul>
      *
      * Otherwise as defined by {@link Object#equals(Object)}.

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/value/nearby/ListValueNearbyDistanceMatrixDemand.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/heuristic/selector/value/nearby/ListValueNearbyDistanceMatrixDemand.java
@@ -16,9 +16,10 @@ import org.optaplanner.core.impl.solver.ClassInstanceCache;
 import org.optaplanner.core.impl.util.MemoizingSupply;
 
 /**
+ * Demands a distance matrix where both the origins and nearby destinations are planning values.
+ * <p>
  * Calculating {@link NearbyDistanceMatrix} is very expensive,
  * therefore we want to reuse it as much as possible.
- *
  * <p>
  * In cases where the demand represents the same nearby selector (as defined by
  * {@link ListValueNearbyDistanceMatrixDemand#equals(Object)})
@@ -26,8 +27,8 @@ import org.optaplanner.core.impl.util.MemoizingSupply;
  * with the pre-computed {@link NearbyDistanceMatrix}.
  *
  * @param <Solution_>
- * @param <Origin_>
- * @param <Destination_>
+ * @param <Origin_> planning values
+ * @param <Destination_> planning values
  */
 public final class ListValueNearbyDistanceMatrixDemand<Solution_, Origin_, Destination_>
         implements Demand<MemoizingSupply<NearbyDistanceMatrix<Origin_, Destination_>>> {
@@ -62,11 +63,13 @@ public final class ListValueNearbyDistanceMatrixDemand<Solution_, Origin_, Desti
                         + ") has a valueSize (" + originSize
                         + ") which is higher than Integer.MAX_VALUE.");
             }
-            // List variables use entity independent value selectors, so we can pass null to the ending iterator.
+            // Destinations: values extracted from a value selector.
+            // List variables use entity independent value selectors, so we can pass null to get and ending iterator.
             Function<Origin_, Iterator<Destination_>> destinationIteratorProvider =
                     origin -> (Iterator<Destination_>) childValueSelector.endingIterator(null);
             NearbyDistanceMatrix<Origin_, Destination_> nearbyDistanceMatrix =
                     new NearbyDistanceMatrix<>(meter, (int) originSize, destinationIteratorProvider, destinationSizeFunction);
+            // Origins: values extracted from a value selector.
             // Replaying selector's ending iterator uses the recording selector's ending iterator. So, again, null is OK here.
             replayingOriginValueSelector.endingIterator(null)
                     .forEachRemaining(origin -> nearbyDistanceMatrix.addAllDestinations((Origin_) origin));
@@ -80,8 +83,8 @@ public final class ListValueNearbyDistanceMatrixDemand<Solution_, Origin_, Desti
      *
      * <ul>
      * <li>Their meter instances are equal.</li>
-     * <li>Their child selectors are equal.</li>
-     * <li>Their replaying origin entity selectors are equal.</li>
+     * <li>Their child value selectors are equal.</li>
+     * <li>Their replaying origin value selectors are equal.</li>
      * </ul>
      *
      * Otherwise as defined by {@link Object#equals(Object)}.


### PR DESCRIPTION
Expand distance matrix demand Javadoc and clarify what demands have in common and how they differ.

There are 4 kinds of distance matrices classified by the types of the origins and destinations they contain:

### For basic and chained move selectors

- (1) `Entity->Entities`: supplied to `NearbyDistanceMatrixDemand` with child entity selector
- (2) `Entity->Values`: supplied to `NearbyDistanceMatrixDemand` with child value selector

### For list move selectors

- (3) `Value->mix of Entities and Values`: supplied to:
  - `ListNearbyDistanceMatrixDemand` used by `NearValueNearbyDestinationSelector` to produce nearby enabled `ListChangeMove`s.
  - `SubListNearbyDistanceMatrixDemand` used by `NearSubListNearbyDestinationSelector` to produce nearby enabled `SubListChangeMove`s.
- (4) `Value->Values`: supplied to:
  - `ListValueNearbyDistanceMatrixDemand` used by `NearValueNearbyValueSelector` to produce nearby enabled `ListSwapMove`s.
  - `SubListNearbySubListMatrixDemand` used by `NearSubListNearbySubListSelector` to produce nearby enabled `SubListSwapMove`s.