### PR TITLE
Fix RHBOP Nightly

### DIFF
--- a/.ci/jenkins/Jenkinsfile.prod.nightly
+++ b/.ci/jenkins/Jenkinsfile.prod.nightly
@@ -44,7 +44,7 @@ pipeline {
                 }
             }
         }
-        stage('Clone build configuration repo') {
+        stage('Clone and parse build configuration repo') {
             steps {
                 script {
                     def currentBranch = getBuildConfigBranch()
@@ -57,6 +57,10 @@ pipeline {
                         'droolsProductVersion': env.DROOLS_PRODUCT_VERSION
                     ]
                     pmebuild.parseBuildConfig("$WORKSPACE/build_config/rhbop/nightly", buildConfigAdditionalVariables)
+
+                    // export Quarkus community version as QUARKUS_VERSION_COMMUNITY
+                    def PME_BUILD_VARIABLES = env.PME_BUILD_VARIABLES.split(';').collect{ it.split('=')}.inject([:]) {map, item -> map << [(item.length == 2 ? item[0] : null): (item.length == 2 ? item[1] : null)]}
+                    env.QUARKUS_VERSION_COMMUNITY = PME_BUILD_VARIABLES['quarkusVersionCommunity']
                 }
             }
         }

--- a/.ci/jenkins/Jenkinsfile.prod.nightly
+++ b/.ci/jenkins/Jenkinsfile.prod.nightly
@@ -30,8 +30,6 @@ pipeline {
                     env.PRODUCT_VERSION = "${PRODUCT_VERSION ?: parseVersionFromPom('kiegroup/optaplanner')}"
                     env.DROOLS_PRODUCT_VERSION = "${DROOLS_PRODUCT_VERSION ?: parseVersionFromPom('kiegroup/drools')}"
                 }
-
-                sh 'printenv'
             }
         }
         stage('Install build-chain tool') {
@@ -120,8 +118,17 @@ pipeline {
                             // extract git infos
                             util.storeGitInformation(projectName)
                             env.ALREADY_BUILT_PROJECTS = "${env.ALREADY_BUILT_PROJECTS ?: ''}${projectName};"
+
+                            env["VERSION_${f}"] = maven.mvnGetVersionProperty('project.version')
                         }
                     }
+
+                    // extract Quarkus version
+                    dir("${env.WORKSPACE}/bc/kiegroup_optaplanner") {
+                        env["VERSION_quarkus"] = maven.mvnGetVersionProperty('version.io.quarkus', 'build/optaplanner-build-parent/pom.xml')
+                    }
+                    
+                    sh 'printenv'
                 }
             }
         }
@@ -141,11 +148,11 @@ pipeline {
                         optaplannerQuickstartsSourcesFileUrl,
                         env.ALREADY_BUILT_PROJECTS,
                         [
-                            'rhbop': env.OPTAPLANNER_VERSION,
-                            'optaplanner': env.OPTAPLANNER_VERSION,
-                            'drools': env.DROOLS_VERSION,
-                            'quarkus.bom': env.DROOLS_VERSION,
-                            'platform.quarkus.bom': env.DROOLS_VERSION
+                            'rhbop': env['VERSION_kiegroup_optaplanner'],
+                            'optaplanner': env['VERSION_kiegroup_optaplanner'],
+                            'drools': env['VERSION_kiegroup_drools'],
+                            'quarkus.bom': env['VERSION_quarkus'],
+                            'platform.quarkus.bom': env['VERSION_quarkus']
                         ],
                         gitHashesToCollection(env.GIT_INFORMATION_HASHES)
                     )

--- a/.ci/jenkins/Jenkinsfile.prod.nightly
+++ b/.ci/jenkins/Jenkinsfile.prod.nightly
@@ -59,6 +59,7 @@ pipeline {
                     // export Quarkus community version as QUARKUS_VERSION_COMMUNITY
                     def PME_BUILD_VARIABLES = env.PME_BUILD_VARIABLES.split(';').collect{ it.split('=')}.inject([:]) {map, item -> map << [(item.length == 2 ? item[0] : null): (item.length == 2 ? item[1] : null)]}
                     env.QUARKUS_VERSION_COMMUNITY = PME_BUILD_VARIABLES['quarkusVersionCommunity']
+                    env.QUARKUS_VERSION = PME_BUILD_VARIABLES['quarkusVersion'].replaceAll("\\{\\{.*\\}\\}", env.QUARKUS_VERSION_COMMUNITY)
                 }
             }
         }
@@ -122,11 +123,6 @@ pipeline {
                             env["VERSION_${f}"] = maven.mvnGetVersionProperty('project.version')
                         }
                     }
-
-                    // extract Quarkus version
-                    dir("${env.WORKSPACE}/bc/kiegroup_optaplanner") {
-                        env["VERSION_quarkus"] = maven.mvnGetVersionProperty('version.io.quarkus', 'build/optaplanner-build-parent/pom.xml')
-                    }
                     
                     sh 'printenv'
                 }
@@ -151,8 +147,8 @@ pipeline {
                             'rhbop': env['VERSION_kiegroup_optaplanner'],
                             'optaplanner': env['VERSION_kiegroup_optaplanner'],
                             'drools': env['VERSION_kiegroup_drools'],
-                            'quarkus.bom': env['VERSION_quarkus'],
-                            'platform.quarkus.bom': env['VERSION_quarkus']
+                            'quarkus.bom': env['QUARKUS_VERSION'],
+                            'platform.quarkus.bom': env['QUARKUS_VERSION']
                         ],
                         gitHashesToCollection(env.GIT_INFORMATION_HASHES)
                     )

--- a/.ci/nightly-build-config.yaml
+++ b/.ci/nightly-build-config.yaml
@@ -1,6 +1,6 @@
 version: "2.1"
 
-dependencies: ./project-dependencies-rhbop.yaml
+dependencies: ./nightly-project-dependencies.yaml
 
 pre: |
   export PME_CMD="java -jar ${{ env.PME_CLI_PATH }} -s ${{ env.PME_MAVEN_SETTINGS_XML }} -DallowConfigFilePrecedence=true -DprojectSrcSkip=false"

--- a/.ci/nightly-build-config.yaml
+++ b/.ci/nightly-build-config.yaml
@@ -9,6 +9,8 @@ pre: |
   echo "BUILD_MVN_OPTS=${{ env.BUILD_MVN_OPTS }}"
   export EXTRACT_VERSION="mvn org.apache.maven.plugins:maven-help-plugin:3.2.0:evaluate -Dexpression=project.version -q -DforceStdout"
   echo "EXTRACT_VERSION=${{ env.EXTRACT_VERSION }}"
+  export ALIGN_QUARKUS="mvn versions:compare-dependencies -DremotePom=io.quarkus:quarkus-bom:${{ env.QUARKUS_VERSION_COMMUNITY }} -DupdatePropertyVersions=true -DupdateDependencies=true -DgenerateBackupPoms=false -s ${{ env.PME_MAVEN_SETTINGS_XML }}"
+  echo "ALIGN_QUARKUS=${{ env.ALIGN_QUARKUS }}"
 
 default:
   build-command:
@@ -24,7 +26,7 @@ build:
     build-command:
       upstream: |
         ${{ env.PME_CMD }} ${{ env.PME_ALIGNMENT_PARAMS_kiegroup_drools }}
-        bash -c "${{ env.PME_BUILD_SCRIPT_kiegroup_drools }} ${{ env.BUILD_MVN_OPTS }} | tee ${{ env.WORKSPACE }}/drools.maven.log"
+        bash -c "${{ env.ALIGN_QUARKUS }} -pl :drools-build-parent ; set -o pipefail ; ${{ env.PME_BUILD_SCRIPT_kiegroup_drools }} ${{ env.BUILD_MVN_OPTS }} | tee ${{ env.WORKSPACE }}/drools.maven.log"
       after:
         upstream: |
           export DROOLS_VERSION=`${{ env.EXTRACT_VERSION }}`
@@ -33,7 +35,7 @@ build:
     build-command:
       current: |
         ${{ env.PME_CMD }} ${{ env.PME_ALIGNMENT_PARAMS_kiegroup_optaplanner }}
-        bash -c "${{ env.PME_BUILD_SCRIPT_kiegroup_optaplanner }} ${{ env.BUILD_MVN_OPTS }} | tee ${{ env.WORKSPACE }}/optaplanner.maven.log"
+        bash -c "set -o pipefail ; ${{ env.PME_BUILD_SCRIPT_kiegroup_optaplanner }} ${{ env.BUILD_MVN_OPTS }} | tee ${{ env.WORKSPACE }}/optaplanner.maven.log"
       after:
         current: |
           export OPTAPLANNER_VERSION=`${{ env.EXTRACT_VERSION }}`
@@ -44,9 +46,9 @@ build:
     build-command:
       downstream: |
         ${{ env.PME_CMD }} ${{ env.PME_ALIGNMENT_PARAMS_kiegroup_optaplanner_quickstarts }}
-        bash -c "${{ env.PME_BUILD_SCRIPT_kiegroup_optaplanner_quickstarts }} ${{ env.BUILD_MVN_OPTS }} | tee ${{ env.WORKSPACE }}/optaplanner_quickstarts.maven.log"
+        bash -c "set -o pipefail ; ${{ env.PME_BUILD_SCRIPT_kiegroup_optaplanner_quickstarts }} ${{ env.BUILD_MVN_OPTS }} | tee ${{ env.WORKSPACE }}/optaplanner_quickstarts.maven.log"
   - project: jboss-integration/rhbop-optaplanner
     build-command:
       downstream: |
         ${{ env.PME_CMD }} ${{ env.PME_ALIGNMENT_PARAMS_jboss_integration_rhbop_optaplanner }}
-        bash -c "${{ env.PME_BUILD_SCRIPT_jboss_integration_rhbop_optaplanner }} ${{ env.BUILD_MVN_OPTS }} | tee ${{ env.WORKSPACE }}/rhbop_optaplanner.maven.log"
+        bash -c "set -o pipefail ; ${{ env.PME_BUILD_SCRIPT_jboss_integration_rhbop_optaplanner }} ${{ env.BUILD_MVN_OPTS }} | tee ${{ env.WORKSPACE }}/rhbop_optaplanner.maven.log"

--- a/.ci/nightly-build-config.yaml
+++ b/.ci/nightly-build-config.yaml
@@ -7,8 +7,6 @@ pre: |
   echo "PME_CMD=${{ env.PME_CMD }}"
   export BUILD_MVN_OPTS="${{ env.BUILD_MVN_OPTS }} -s ${{ env.PME_MAVEN_SETTINGS_XML }}"
   echo "BUILD_MVN_OPTS=${{ env.BUILD_MVN_OPTS }}"
-  export EXTRACT_VERSION="mvn org.apache.maven.plugins:maven-help-plugin:3.2.0:evaluate -Dexpression=project.version -q -DforceStdout"
-  echo "EXTRACT_VERSION=${{ env.EXTRACT_VERSION }}"
   export ALIGN_QUARKUS="mvn versions:compare-dependencies -DremotePom=io.quarkus:quarkus-bom:${{ env.QUARKUS_VERSION_COMMUNITY }} -DupdatePropertyVersions=true -DupdateDependencies=true -DgenerateBackupPoms=false -s ${{ env.PME_MAVEN_SETTINGS_XML }}"
   echo "ALIGN_QUARKUS=${{ env.ALIGN_QUARKUS }}"
 
@@ -27,21 +25,11 @@ build:
       upstream: |
         ${{ env.PME_CMD }} ${{ env.PME_ALIGNMENT_PARAMS_kiegroup_drools }}
         bash -c "${{ env.ALIGN_QUARKUS }} -pl :drools-build-parent ; set -o pipefail ; ${{ env.PME_BUILD_SCRIPT_kiegroup_drools }} ${{ env.BUILD_MVN_OPTS }} | tee ${{ env.WORKSPACE }}/drools.maven.log"
-      after:
-        upstream: |
-          export DROOLS_VERSION=`${{ env.EXTRACT_VERSION }}`
-          echo "DROOLS_VERSION=${{ env.DROOLS_VERSION }}"
   - project: kiegroup/optaplanner
     build-command:
       current: |
         ${{ env.PME_CMD }} ${{ env.PME_ALIGNMENT_PARAMS_kiegroup_optaplanner }}
         bash -c "set -o pipefail ; ${{ env.PME_BUILD_SCRIPT_kiegroup_optaplanner }} ${{ env.BUILD_MVN_OPTS }} | tee ${{ env.WORKSPACE }}/optaplanner.maven.log"
-      after:
-        current: |
-          export OPTAPLANNER_VERSION=`${{ env.EXTRACT_VERSION }}`
-          echo "OPTAPLANNER_VERSION=${{ env.OPTAPLANNER_VERSION }}"
-          export QUARKUS_VERSION=`mvn org.apache.maven.plugins:maven-help-plugin:3.2.0:evaluate -Dexpression=version.io.quarkus -q -DforceStdout -f build/optaplanner-build-parent/pom.xml`
-          echo "QUARKUS_VERSION=${{ env.QUARKUS_VERSION }}"
   - project: kiegroup/optaplanner-quickstarts
     build-command:
       downstream: |

--- a/.ci/nightly-project-dependencies.yaml
+++ b/.ci/nightly-project-dependencies.yaml
@@ -1,0 +1,15 @@
+version: "2.1"
+
+extends: ./project-dependencies-rhbop.yaml
+
+dependencies:
+  - project: kiegroup/drools
+    mapping:
+      dependencies:
+        default:
+          - source: main-integration-quarkus-lts
+            target: main
+      dependant:
+        default:
+          - source: main
+            target: main-integration-quarkus-lts

--- a/.ci/project-dependencies-rhbop.yaml
+++ b/.ci/project-dependencies-rhbop.yaml
@@ -1,15 +1,7 @@
 version: "2.1"
+
 dependencies:
   - project: kiegroup/drools
-    mapping:
-      dependencies:
-        default:
-          - source: main-integration-quarkus-lts
-            target: main
-      dependant:
-        default:
-          - source: main
-            target: main-integration-quarkus-lts
 
   - project: kiegroup/optaplanner
     dependencies:

--- a/.ci/project-dependencies-rhbop.yaml
+++ b/.ci/project-dependencies-rhbop.yaml
@@ -1,6 +1,15 @@
 version: "2.1"
 dependencies:
   - project: kiegroup/drools
+    mapping:
+      dependencies:
+        default:
+          - source: main-integration-quarkus-lts
+            target: main
+      dependant:
+        default:
+          - source: main
+            target: main-integration-quarkus-lts
 
   - project: kiegroup/optaplanner
     dependencies:
@@ -18,6 +27,7 @@ dependencies:
         default:
           - source: main
             target: development
+
   - project: jboss-integration/rhbop-optaplanner
     dependencies:
       - project: kiegroup/optaplanner-quickstarts


### PR DESCRIPTION
<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.
-->

This PR aims to fix two bugs in the nightly that have been introduced by the build-chain migration (https://github.com/kiegroup/optaplanner/pull/2717).

- Moved Quarkus bom dependencies alignment for Drools here, in this way we can keep the pnc build config as close as possible to the prod one.
- Exported project versions during the Jenkins pipeline (needed additional PR https://github.com/kiegroup/jenkins-pipeline-shared-libraries/pull/269) since those exported from build-chain were not visible outside.
- Added `; set -o pipefail` on every command in order to ensure that the script returns failure when mvn command fails - this was not true before as the exit code was the one returned by `tee` cmd.
- When building `main` branch, Drools must be `main-integration-quarkus-lts` as there are some patches that must be applied to make it compatible with the Quarkus downgrade to LTS - see https://github.com/kiegroup/drools/pull/5138

### JIRA

https://issues.redhat.com/browse/BXMSPROD-1992
https://issues.redhat.com/browse/BXMSPROD-1993

### Referenced pull requests

- https://github.com/kiegroup/jenkins-pipeline-shared-libraries/pull/269

### Checklist
- [ ] Documentation updated if applicable.
- [ ] Release notes updated if applicable.
- [ ] Upgrade recipe provided if applicable.

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request checks</b>  
  Please add comment: <b>Jenkins retest this</b>

- for a <b>specific pull request check</b>  
  please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts] tests</b>
  
- for a <b>full downstream build</b> 
  - for <b>jenkins</b> job: 
    please add comment: <b>Jenkins run fdb</b>
  - for <b>github actions</b> job: 
    add the label `run_fdb`

- for a <b>compile downstream build</b>  
  please add comment: <b>Jenkins run cdb</b>

- for a <b>full production downstream build</b>  
  please add comment: <b>Jenkins execute product fdb</b>

- for an <b>upstream build</b>  
  please add comment: <b>Jenkins run upstream</b>

- for <b>quarkus branch checks</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins run quarkus-branch</b>

- for a <b>quarkus branch specific check</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts] quarkus-branch</b>

- for <b>quarkus main checks</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins run quarkus-main</b>

- for a <b>specific quarkus main check</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts] quarkus-branch</b>

- for <b>quarkus lts checks</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins run quarkus-lts</b>

- for a <b>specific quarkus lts check</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts] quarkus-lts</b>

- for <b>native checks</b>  
  Run native checks  
  Please add comment: <b>Jenkins run native</b>

- for a <b>specific native check</b>  
  Run native checks 
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts] native</b>

- for <b>native lts checks</b>  
  Run native checks against quarkus lts branch
  Please add comment: <b>Jenkins run native-lts</b>

- for a <b>specific native lts check</b>  
  Run native checks against quarkus lts branch
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts] native-lts</b>

</details>

### CI Status

 You can check OptaPlanner repositories CI status from [Chain Status webpage](https://kiegroup.github.io/optaplanner/).

<details>
<summary>
How to backport a pull request to a different branch?
</summary>

In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-7.67.x` to backport the original PR to the `7.67.x` branch).

> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.

Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.

If something goes wrong, the author will be notified and at this point a manual backporting is needed.

> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
</details>
