### PR TITLE
Remove stable force push protection

### DIFF
--- a/.ci/jenkins/project/Jenkinsfile.post-release
+++ b/.ci/jenkins/project/Jenkinsfile.post-release
@@ -66,7 +66,7 @@ pipeline {
                     dir(quickstartsRepository) {
                         checkoutTag(quickstartsRepository, getGitTag(), stableBranchName)
                         removeJbossNexusFromMavenAndGradle()
-                        commitAndForcePushProtectedBranch(quickstartsRepository, stableBranchName)
+                        commitAndForcePushBranch(quickstartsRepository, stableBranchName)
                     }
                 }
             }
@@ -219,13 +219,13 @@ String commitAndCreatePR(String commitMsg, Closure precommit, String localBranch
     return githubscm.createPR(commitMsg, prBody, targetBranch, getGitAuthorCredsID())
 }
 
-void commitAndForcePushProtectedBranch(String repo, String branch) {
+void commitAndForcePushBranch(String repo, String branch) {
     githubscm.commitChanges("[${getBuildBranch()}] Update ${branch} to ${getProjectVersion()}", {
         githubscm.findAndStageNotIgnoredFiles('pom.xml')
         githubscm.findAndStageNotIgnoredFiles('build.gradle')
     })
     try {
-        forcePushProtectedBranch(repo, branch)
+        forcePushBranch(branch)
     }
     catch (exception) {
         println "[ERROR] Force push branch: ${branch} from repo : ${repo} failed with exception: ${exception}"
@@ -277,103 +277,13 @@ void removeJbossNexusFromMavenAndGradle() {
             'cat', returnStdout: true)
 }
 
-String getGhCredsID() {
-    return env.GITHUB_TOKEN_CREDS_ID
-}
-
-//maps git branch protection response json into update request body to rewrite branch protection
-String getProtectionMapScript() {
-    return "if .restrictions == null then . + {\"restrictions_used\":null}  " + //upd user set restrictions if not empty
-            "else . + {\"restrictions_used\":{\"users\":[.restrictions.users[].login], \"team\":[.restrictions.users[].slug]}} end |" +
-            ' {' +
-                "\"required_status_checks\": .required_status_checks," +
-                "\"required_pull_request_reviews\": .required_pull_request_reviews," +
-                "\"enforce_admins\":(.enforce_admins.enabled)," +
-                " \"restrictions\":.restrictions_used" +
-            '}'
-}
-
-def enableForcePushes(String repo, String protectedBranch) {
-    if (isBranchProtected(repo, protectedBranch)) {
-        setAllowForcePushes(repo, protectedBranch, 'true')
-    }
-}
-
-def disableForcePushes(String repo, String protectedBranch) {
-    if (isBranchProtected(repo, protectedBranch)) {
-        setAllowForcePushes(repo, protectedBranch, 'false')
-    }
-}
-
-boolean isBranchProtected(String repo, String protectedBranch, String ghPath = '../gh') {
-    assertGithubCLI(ghPath)
-    boolean isProtected = true // Suppose it is protected by default
-    withCredentials([string(credentialsId: getGhCredsID(), variable: 'GITHUB_TOKEN')]) {
-        // get current branch protection
-        int status = sh (script: "${ghPath} api 'repos/${getGitAuthor()}/${repo}/branches/${protectedBranch}/protection'", returnStatus: true)
-        isProtected = status == 0
-    }
-    return isProtected
-}
-
-def setAllowForcePushes(String repo, String protectedBranch, String enabled, String ghPath = '../gh') {
-    assertGithubCLI(ghPath)
-    //Use separate admin token credentials
-    withCredentials([string(credentialsId: getGhCredsID(), variable: 'GITHUB_TOKEN')]) {
-        //get current branch protection and remove allow force push
-        sh "${ghPath} api 'repos/${getGitAuthor()}/${repo}/branches/${protectedBranch}/protection' | " +
-                "jq 'del(.allow_force_pushes)' > protectionBefore.json"
-
-        //create new json based on current protection mapped as parameters
-        sh "jq \"${getProtectionMapScript()}\" protectionBefore.json | " +
-                "jq \". + {\"allow_force_pushes\":${enabled}}\" > protectionParameters.json"
-
-        //update protection on git
-        def allowForcePushEnabled = sh(script:
-                "${ghPath} api -XPUT 'repos/${getGitAuthor()}/${repo}/branches/${protectedBranch}/protection' " +
-                        '--input protectionParameters.json |' +
-                        " jq '.allow_force_pushes.enabled'", returnStdout: true).trim()
-        assert allowForcePushEnabled == enabled
-
-        //check that protection didn't changed except for allow_force_pushes
-        sh "${ghPath} api 'repos/${getGitAuthor()}/${repo}/branches/${protectedBranch}/protection' | " +
-                "jq 'del(.allow_force_pushes)' > protectionAfter.json"
-        def differences = sh(script: 'diff protectionBefore.json protectionAfter.json | cat', returnStdout: true)
-        if (differences) {
-            error 'Protection settings lost' +
-                    '\nBefore: ' +
-                    "\n${readFile 'protectionBefore.json'} " +
-                    '\nAfter: ' +
-                    "\n${readFile 'protectionAfter.json'} " +
-                    '\nDifferences: ' +
-                    "\n${differences} " +
-                    '\nProtection parameters: ' +
-                    "\n${readFile 'protectionParameters.json'} " +
-                    'Please rollback to Before state and update getProtectionMapScript'
-        }
-        //cleanup workspace
-        sh 'rm -f protectionParameters.json protectionBefore.json protectionAfter.json'
-    }
-}
-
-def forcePushProtectedBranch(String repo, String protectedBranch) {
-    enableForcePushes(repo, protectedBranch)
+def forcePushBranch(String branch) {
     withCredentials([usernamePassword(credentialsId: getGitAuthorCredsID(), usernameVariable: 'GIT_USERNAME', passwordVariable: 'GIT_PASSWORD')]) {
         // Please leave the double-quote here. They are mandatory for the shell command to work correctly.
         sh """
             git config --local credential.helper \"!f() { echo username=\\$GIT_USERNAME; echo password=\\$GIT_PASSWORD; }; f\"
-            git push origin ${protectedBranch} --force
+            git push origin ${branch} --force
         """
-    }
-    disableForcePushes(repo, protectedBranch)
-}
-
-void assertGithubCLI(String ghPath) {
-    if (fileExists(ghPath)) {
-        echo "[INFO] gh found at $ghPath"
-    }
-    else {
-        error "gh not found at $ghPath"
     }
 }
 


### PR DESCRIPTION
As the force-push protection removal script no longer works, I am removing that protection for the CI accounts. The script is thus no longer needed.

@triceo unfortunately, merge does not work: the final versions appear only on the `stable` branch (and release branches), but never on the `development` branch, which immediately creates conflicts.

<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.
-->

### JIRA

<!-- Add a JIRA ticket link if it exists. -->
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
- https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
- https://github.com/kiegroup/drools/pull/3000
- https://github.com/kiegroup/optaplanner/pull/899
- etc.
-->

### Checklist
- [ ] Documentation updated if applicable.
- [ ] Release notes updated if applicable.
- [ ] Upgrade recipe provided if applicable.

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request checks</b>  
  Please add comment: <b>Jenkins retest this</b>

- for a <b>specific pull request check</b>  
  please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts] tests</b>
  
- for a <b>full downstream build</b> 
  - for <b>jenkins</b> job: 
    please add comment: <b>Jenkins run fdb</b>
  - for <b>github actions</b> job: 
    add the label `run_fdb`

- for a <b>compile downstream build</b>  
  please add comment: <b>Jenkins run cdb</b>

- for a <b>full production downstream build</b>  
  please add comment: <b>Jenkins execute product fdb</b>

- for an <b>upstream build</b>  
  please add comment: <b>Jenkins run upstream</b>

- for <b>quarkus branch checks</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins run quarkus-branch</b>

- for a <b>quarkus branch specific check</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts] quarkus-branch</b>

- for <b>quarkus main checks</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins run quarkus-main</b>

- for a <b>specific quarkus main check</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts] quarkus-branch</b>

- for <b>quarkus lts checks</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins run quarkus-lts</b>

- for a <b>specific quarkus lts check</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts] quarkus-lts</b>

- for <b>native checks</b>  
  Run native checks  
  Please add comment: <b>Jenkins run native</b>

- for a <b>specific native check</b>  
  Run native checks 
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts] native</b>

- for <b>native lts checks</b>  
  Run native checks against quarkus lts branch
  Please add comment: <b>Jenkins run native-lts</b>

- for a <b>specific native lts check</b>  
  Run native checks against quarkus lts branch
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts] native-lts</b>

</details>

### CI Status

 You can check OptaPlanner repositories CI status from [Chain Status webpage](https://kiegroup.github.io/optaplanner/).

<details>
<summary>
How to backport a pull request to a different branch?
</summary>

In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-7.67.x` to backport the original PR to the `7.67.x` branch).

> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.

Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.

If something goes wrong, the author will be notified and at this point a manual backporting is needed.

> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
</details>
