### PR TITLE
PLANNER-2902 Migrate quickstarts to OptaPlanner 9

### DIFF
--- a/.ci/jenkins/Jenkinsfile.deploy
+++ b/.ci/jenkins/Jenkinsfile.deploy
@@ -86,8 +86,7 @@ pipeline {
             steps {
                 script {
                     checkoutRepo(optaplannerRepository)
-                    // TODO: switch to the 9 stream after quickstarts will have been migrated.
-                    if (isStream8()) {
+                    if (isStream9()) {
                         checkoutQuickstarts()
                     }
                 }
@@ -101,8 +100,7 @@ pipeline {
             steps {
                 script {
                     prepareForPR(optaplannerRepository)
-                    // TODO: switch to the 9 stream after quickstarts will have been migrated.
-                    if (isStream8()) {
+                    if (isStream9()) {
                         prepareForPR(quickstartsRepository)
                     }
                 }
@@ -123,8 +121,7 @@ pipeline {
 
                     mavenCleanInstallOptaPlannerParents()
 
-                    // TODO: switch to the 9 stream after quickstarts will have been migrated.
-                    if (isStream8()) {
+                    if (isStream9()) {
                         updateQuickstartsVersions()
                     }
                 }
@@ -156,8 +153,7 @@ pipeline {
 
         stage('Build Quickstarts') {
             when {
-                // TODO: switch to the 9 stream after quickstarts will have been migrated.
-                expression { return isStream8() }
+                expression { return isStream9() }
             }
             steps {
                 script {
@@ -184,8 +180,7 @@ pipeline {
             steps {
                 script {
                     runMavenDeploy(getOptaplannerMavenCommand())
-                    // TODO: switch to the 9 stream after quickstarts will have been migrated.
-                    if (isStream8()) {
+                    if (isStream9()) {
                         runMavenDeploy(getOptaplannerQuickstartsMavenCommand().withOptions(['-pl', ':optaplanner-distribution']))
                     }
                 }
@@ -234,8 +229,7 @@ pipeline {
             steps {
                 script {
                     commitAndCreatePR(optaplannerRepository, getBuildBranch())
-                    // TODO: switch to the 9 stream after quickstarts will have been migrated.
-                    if (isStream8()) {
+                    if (isStream9()) {
                         commitAndCreatePR(quickstartsRepository, getQuickStartsBranch())
                     }
                 }
@@ -254,6 +248,7 @@ pipeline {
 
         stage('Push a temporary operator image to a registry') {
             when {
+                // TODO: switch to 9 when the operator is migrated to Quarkus 3
                 expression { return isRelease() && isStream8() }
             }
             steps {

--- a/.ci/jenkins/Jenkinsfile.promote
+++ b/.ci/jenkins/Jenkinsfile.promote
@@ -81,8 +81,7 @@ pipeline {
 
         stage('Merge OptaPlanner Quickstarts PR and tag') {
             when {
-                // TODO: switch to the 9 stream after quickstarts will have been migrated.
-                expression { return isRelease() && isStream8() }
+                expression { return isRelease() && isStream9() }
             }
             steps {
                 script {
@@ -97,8 +96,7 @@ pipeline {
 
         stage('Upload OptaPlanner documentation') {
             when {
-                // TODO: switch to the 9 stream after quickstarts will have been migrated.
-                expression { return isRelease() && isStream8() }
+                expression { return isRelease() && isStream9() }
             }
             steps {
                 script {
@@ -140,8 +138,7 @@ pipeline {
 
         stage('Set Quickstarts next snapshot version') {
             when {
-                // TODO: switch to the 9 stream after quickstarts will have been migrated.
-                expression { return isRelease() && isStream8() }
+                expression { return isRelease() && isStream9() }
             }
             steps {
                 script {
@@ -164,6 +161,7 @@ pipeline {
 
         stage('Push the final OptaPlanner operator image') {
             when {
+                // TODO: switch to 9 when the operator is migrated to Quarkus 3
                 expression { return isRelease() && isStream8() }
             }
             steps {

--- a/.ci/jenkins/config/branch.yaml
+++ b/.ci/jenkins/config/branch.yaml
@@ -49,8 +49,7 @@ disable:
 repositories:
 - name: optaplanner
   branch: main
-- name: optaplanner-quickstarts
-  branch: development
+# keep the website publish job on the main branch
 - name: optaplanner-website
   branch: main
 git:

--- a/.ci/jenkins/project/Jenkinsfile.post-release
+++ b/.ci/jenkins/project/Jenkinsfile.post-release
@@ -58,8 +58,7 @@ pipeline {
 
         stage('Reset Quickstarts stable branch') {
             when {
-                // TODO: switch to the 9 stream after quickstarts will have been migrated.
-                expression { return isStream8() }
+                expression { return isStream9() }
             }
             steps {
                 script {
@@ -74,8 +73,7 @@ pipeline {
 
         stage('Upload OptaPlanner distribution from Quickstarts') {
             when {
-                // TODO: switch to the 9 stream after quickstarts will have been migrated.
-                expression { return isStream8() }
+                expression { return isStream9() }
             }
             steps {
                 script {
@@ -92,8 +90,7 @@ pipeline {
 
         stage('Update OptaPlanner website') {
             when {
-                // TODO: switch to the 9 stream after quickstarts will have been migrated.
-                expression { return isStream8() }
+                expression { return isStream9() }
             }
             steps {
                 script {

--- a/.ci/jenkins/project/Jenkinsfile.setup-branch
+++ b/.ci/jenkins/project/Jenkinsfile.setup-branch
@@ -64,8 +64,7 @@ pipeline {
 
         stage('Init Optaplanner Quickstarts') {
             when {
-                // TODO: switch to the 9 stream after quickstarts will have been migrated.
-                expression { return isStream8() }
+                expression { return isStream9() }
             }
             steps {
                 script {


### PR DESCRIPTION


<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.
-->

### JIRA
https://issues.redhat.com/browse/PLANNER-2902
<!-- Add a JIRA ticket link if it exists. -->
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->

### Referenced pull requests
https://github.com/kiegroup/optaplanner/pull/2765
https://github.com/kiegroup/optaplanner-quickstarts/pull/549

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
- https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
- https://github.com/kiegroup/drools/pull/3000
- https://github.com/kiegroup/optaplanner/pull/899
- etc.
-->

### Checklist
- [ ] Documentation updated if applicable.
- [ ] Release notes updated if applicable.
- [ ] Upgrade recipe provided if applicable.

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request checks</b>  
  Please add comment: <b>Jenkins retest this</b>

- for a <b>specific pull request check</b>  
  please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts] tests</b>
  
- for a <b>full downstream build</b> 
  - for <b>jenkins</b> job: 
    please add comment: <b>Jenkins run fdb</b>
  - for <b>github actions</b> job: 
    add the label `run_fdb`

- for a <b>compile downstream build</b>  
  please add comment: <b>Jenkins run cdb</b>

- for a <b>full production downstream build</b>  
  please add comment: <b>Jenkins execute product fdb</b>

- for an <b>upstream build</b>  
  please add comment: <b>Jenkins run upstream</b>

- for <b>quarkus branch checks</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins run quarkus-branch</b>

- for a <b>quarkus branch specific check</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts] quarkus-branch</b>

- for <b>quarkus main checks</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins run quarkus-main</b>

- for a <b>specific quarkus main check</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts] quarkus-branch</b>

- for <b>quarkus lts checks</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins run quarkus-lts</b>

- for a <b>specific quarkus lts check</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts] quarkus-lts</b>

- for <b>native checks</b>  
  Run native checks  
  Please add comment: <b>Jenkins run native</b>

- for a <b>specific native check</b>  
  Run native checks 
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts] native</b>

- for <b>native lts checks</b>  
  Run native checks against quarkus lts branch
  Please add comment: <b>Jenkins run native-lts</b>

- for a <b>specific native lts check</b>  
  Run native checks against quarkus lts branch
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts] native-lts</b>

</details>

### CI Status

 You can check OptaPlanner repositories CI status from [Chain Status webpage](https://kiegroup.github.io/optaplanner/).

<details>
<summary>
How to backport a pull request to a different branch?
</summary>

In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-7.67.x` to backport the original PR to the `7.67.x` branch).

> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.

Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.

If something goes wrong, the author will be notified and at this point a manual backporting is needed.

> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
</details>
