### PR TITLE
PLANNER-2922 Enable quickstarts 8.x release

### DIFF
--- a/.ci/jenkins/Jenkinsfile.deploy
+++ b/.ci/jenkins/Jenkinsfile.deploy
@@ -86,9 +86,7 @@ pipeline {
             steps {
                 script {
                     checkoutRepo(optaplannerRepository)
-                    if (isStream9()) {
-                        checkoutQuickstarts()
-                    }
+                    checkoutQuickstarts()
                 }
             }
         }
@@ -100,9 +98,7 @@ pipeline {
             steps {
                 script {
                     prepareForPR(optaplannerRepository)
-                    if (isStream9()) {
-                        prepareForPR(quickstartsRepository)
-                    }
+                    prepareForPR(quickstartsRepository)
                 }
             }
         }
@@ -116,14 +112,9 @@ pipeline {
                     if (getDroolsVersion()) {
                         maven.mvnSetVersionProperty(getOptaplannerMavenCommand(), 'version.org.drools', getDroolsVersion())
                     }
-
                     maven.mvnVersionsSet(getOptaplannerMavenCommand(), getProjectVersion(), !isRelease())
-
                     mavenCleanInstallOptaPlannerParents()
-
-                    if (isStream9()) {
-                        updateQuickstartsVersions()
-                    }
+                    updateQuickstartsVersions()
                 }
             }
         }
@@ -152,9 +143,6 @@ pipeline {
         }
 
         stage('Build Quickstarts') {
-            when {
-                expression { return isStream9() }
-            }
             steps {
                 script {
                     getOptaplannerQuickstartsMavenCommand()
@@ -180,9 +168,7 @@ pipeline {
             steps {
                 script {
                     runMavenDeploy(getOptaplannerMavenCommand())
-                    if (isStream9()) {
-                        runMavenDeploy(getOptaplannerQuickstartsMavenCommand().withOptions(['-pl', ':optaplanner-distribution']))
-                    }
+                    runMavenDeploy(getOptaplannerQuickstartsMavenCommand().withOptions(['-pl', ':optaplanner-distribution']))
                 }
             }
         }
@@ -229,9 +215,7 @@ pipeline {
             steps {
                 script {
                     commitAndCreatePR(optaplannerRepository, getBuildBranch())
-                    if (isStream9()) {
-                        commitAndCreatePR(quickstartsRepository, getQuickStartsBranch())
-                    }
+                    commitAndCreatePR(quickstartsRepository, getQuickStartsBranch())
                 }
             }
             post {

--- a/.ci/jenkins/Jenkinsfile.promote
+++ b/.ci/jenkins/Jenkinsfile.promote
@@ -81,7 +81,7 @@ pipeline {
 
         stage('Merge OptaPlanner Quickstarts PR and tag') {
             when {
-                expression { return isRelease() && isStream9() }
+                expression { return isRelease() }
             }
             steps {
                 script {
@@ -96,7 +96,7 @@ pipeline {
 
         stage('Upload OptaPlanner documentation') {
             when {
-                expression { return isRelease() && isStream9() }
+                expression { return isRelease() }
             }
             steps {
                 script {
@@ -138,7 +138,7 @@ pipeline {
 
         stage('Set Quickstarts next snapshot version') {
             when {
-                expression { return isRelease() && isStream9() }
+                expression { return isRelease() }
             }
             steps {
                 script {

--- a/.ci/jenkins/Jenkinsfile.setup-branch
+++ b/.ci/jenkins/Jenkinsfile.setup-branch
@@ -84,7 +84,7 @@ pipeline {
             }
             steps {
                 script {
-                    build job: '../tools/kie-benchmarks-update-optaplanner', parameters: [ string(name: 'NEW_VERSION', value: "${getOptaPlannerVersion()}")
+                    build job: '../tools/kie-benchmarks-update-optaplanner', parameters: [ string(name: 'NEW_VERSION', value: "${getOptaPlannerVersion()}")]
                 }
             }
         }

--- a/.ci/jenkins/config/branch.yaml
+++ b/.ci/jenkins/config/branch.yaml
@@ -49,6 +49,8 @@ disable:
 repositories:
 - name: optaplanner
   branch: main
+- name: optaplanner-quickstarts
+  branch: 8.x
 # keep the website publish job on the main branch
 - name: optaplanner-website
   branch: main

--- a/.ci/jenkins/project/Jenkinsfile.post-release
+++ b/.ci/jenkins/project/Jenkinsfile.post-release
@@ -72,9 +72,6 @@ pipeline {
         }
 
         stage('Upload OptaPlanner distribution from Quickstarts') {
-            when {
-                expression { return isStream9() }
-            }
             steps {
                 script {
                     dir(optaplannerRepository) {
@@ -89,9 +86,6 @@ pipeline {
         }
 
         stage('Update OptaPlanner website') {
-            when {
-                expression { return isStream9() }
-            }
             steps {
                 script {
                     final String websiteRepository = 'optaplanner-website'
@@ -109,8 +103,8 @@ pipeline {
                         String optaplannerWebsiteModule = 'optaplanner-website-root'
                         String optaplannerWebsiteXsd = "${optaplannerWebsiteModule}/content/xsd"
                         String optaplannerWebsiteDocs = 'optaplanner-website-docs'
-                        sh "cp ${optaplannerRoot}/core/optaplanner-core-impl/target/classes/solver.xsd ${optaplannerWebsiteXsd}/solver/solver-8.xsd"
-                        sh "cp ${optaplannerRoot}/optaplanner-benchmark/target/classes/benchmark.xsd ${optaplannerWebsiteXsd}/benchmark/benchmark-8.xsd"
+                        sh "cp ${optaplannerRoot}/core/optaplanner-core-impl/target/classes/solver.xsd ${optaplannerWebsiteXsd}/solver/solver-${env.OPTAPLANNER_LATEST_STREAM}.xsd"
+                        sh "cp ${optaplannerRoot}/optaplanner-benchmark/target/classes/benchmark.xsd ${optaplannerWebsiteXsd}/benchmark/benchmark-${env.OPTAPLANNER_LATEST_STREAM}.xsd"
 
                         // Add changed files, commit, open and merge PR
                         prLink = commitAndCreatePR("Release OptaPlanner ${getProjectVersion()}",

--- a/.ci/jenkins/project/Jenkinsfile.setup-branch
+++ b/.ci/jenkins/project/Jenkinsfile.setup-branch
@@ -63,9 +63,6 @@ pipeline {
         }
 
         stage('Init Optaplanner Quickstarts') {
-            when {
-                expression { return isStream9() }
-            }
             steps {
                 script {
                     def buildParams = getDefaultBuildParams()


### PR DESCRIPTION
Version 8 quickstarts need to keep being released for the purpose of product releases.

For every 8.? release of OptaPlanner:

- there has to be the same release branch for quickstarts, too
- the OptaPlanner distribution (finalized here in quickstarts) has to be uploaded
- the OptaPlanner version on the `optaplanner-quickstarts/8.x` branch has to be upgraded

Effectively, we maintain two release streams for quickstart: from the `development` branch and from the `8.x` branch with the following differences:

- the `stable` branch will ever point only to the latest `9.?.x` release branch
- there is no sync-up between `development` and `8.x`; the `8.x` branch will not receive further changes apart from the newer versions of OptaPlanner and related necessary adjustments


### JIRA
https://issues.redhat.com/browse/PLANNER-2922

<!-- Add a JIRA ticket link if it exists. -->
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->

### Referenced pull requests
https://github.com/kiegroup/optaplanner-quickstarts/pull/559

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
- https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
- https://github.com/kiegroup/drools/pull/3000
- https://github.com/kiegroup/optaplanner/pull/899
- etc.
-->

### Checklist
- [ ] Documentation updated if applicable.
- [ ] Release notes updated if applicable.
- [ ] Upgrade recipe provided if applicable.

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request checks</b>  
  Please add comment: <b>Jenkins retest this</b>

- for a <b>specific pull request check</b>  
  please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts] tests</b>
  
- for a <b>full downstream build</b> 
  - for <b>jenkins</b> job: 
    please add comment: <b>Jenkins run fdb</b>
  - for <b>github actions</b> job: 
    add the label `run_fdb`

- for a <b>compile downstream build</b>  
  please add comment: <b>Jenkins run cdb</b>

- for a <b>full production downstream build</b>  
  please add comment: <b>Jenkins execute product fdb</b>

- for an <b>upstream build</b>  
  please add comment: <b>Jenkins run upstream</b>

- for <b>quarkus branch checks</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins run quarkus-branch</b>

- for a <b>quarkus branch specific check</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts] quarkus-branch</b>

- for <b>quarkus main checks</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins run quarkus-main</b>

- for a <b>specific quarkus main check</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts] quarkus-branch</b>

- for <b>quarkus lts checks</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins run quarkus-lts</b>

- for a <b>specific quarkus lts check</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts] quarkus-lts</b>

- for <b>native checks</b>  
  Run native checks  
  Please add comment: <b>Jenkins run native</b>

- for a <b>specific native check</b>  
  Run native checks 
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts] native</b>

- for <b>native lts checks</b>  
  Run native checks against quarkus lts branch
  Please add comment: <b>Jenkins run native-lts</b>

- for a <b>specific native lts check</b>  
  Run native checks against quarkus lts branch
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts] native-lts</b>

</details>

### CI Status

 You can check OptaPlanner repositories CI status from [Chain Status webpage](https://kiegroup.github.io/optaplanner/).

<details>
<summary>
How to backport a pull request to a different branch?
</summary>

In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-7.67.x` to backport the original PR to the `7.67.x` branch).

> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.

Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.

If something goes wrong, the author will be notified and at this point a manual backporting is needed.

> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
</details>
