### PR TITLE
Revert "Update version to 8.40.0-SNAPSHOT"

### DIFF
--- a/build/optaplanner-bom/pom.xml
+++ b/build/optaplanner-bom/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.optaplanner</groupId>
     <artifactId>optaplanner-parent</artifactId>
-    <version>8.40.0-SNAPSHOT</version>
+    <version>8.39.0-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/build/optaplanner-build-parent/pom.xml
+++ b/build/optaplanner-build-parent/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.optaplanner</groupId>
     <artifactId>optaplanner-parent</artifactId>
-    <version>8.40.0-SNAPSHOT</version>
+    <version>8.39.0-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/build/optaplanner-distribution-internal/pom.xml
+++ b/build/optaplanner-distribution-internal/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.optaplanner</groupId>
     <artifactId>optaplanner-build-parent</artifactId>
-    <version>8.40.0-SNAPSHOT</version>
+    <version>8.39.0-SNAPSHOT</version>
     <relativePath>../optaplanner-build-parent/pom.xml</relativePath>
   </parent>
 

--- a/build/optaplanner-ide-config/pom.xml
+++ b/build/optaplanner-ide-config/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.optaplanner</groupId>
     <artifactId>optaplanner-parent</artifactId>
-    <version>8.40.0-SNAPSHOT</version>
+    <version>8.39.0-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <artifactId>optaplanner-ide-config</artifactId>

--- a/build/optaplanner-javadoc/pom.xml
+++ b/build/optaplanner-javadoc/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.optaplanner</groupId>
     <artifactId>optaplanner-build-parent</artifactId>
-    <version>8.40.0-SNAPSHOT</version>
+    <version>8.39.0-SNAPSHOT</version>
     <relativePath>../optaplanner-build-parent/pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/core/optaplanner-constraint-drl/pom.xml
+++ b/core/optaplanner-constraint-drl/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.optaplanner</groupId>
     <artifactId>optaplanner-core-parent</artifactId>
-    <version>8.40.0-SNAPSHOT</version>
+    <version>8.39.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/core/optaplanner-constraint-streams-bavet/pom.xml
+++ b/core/optaplanner-constraint-streams-bavet/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.optaplanner</groupId>
         <artifactId>optaplanner-core-parent</artifactId>
-        <version>8.40.0-SNAPSHOT</version>
+        <version>8.39.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/core/optaplanner-constraint-streams-common/pom.xml
+++ b/core/optaplanner-constraint-streams-common/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.optaplanner</groupId>
     <artifactId>optaplanner-core-parent</artifactId>
-    <version>8.40.0-SNAPSHOT</version>
+    <version>8.39.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/core/optaplanner-constraint-streams-drools/pom.xml
+++ b/core/optaplanner-constraint-streams-drools/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.optaplanner</groupId>
         <artifactId>optaplanner-core-parent</artifactId>
-        <version>8.40.0-SNAPSHOT</version>
+        <version>8.39.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/core/optaplanner-core-impl/pom.xml
+++ b/core/optaplanner-core-impl/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.optaplanner</groupId>
     <artifactId>optaplanner-core-parent</artifactId>
-    <version>8.40.0-SNAPSHOT</version>
+    <version>8.39.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>optaplanner-core-impl</artifactId>

--- a/core/optaplanner-core/pom.xml
+++ b/core/optaplanner-core/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.optaplanner</groupId>
     <artifactId>optaplanner-core-parent</artifactId>
-    <version>8.40.0-SNAPSHOT</version>
+    <version>8.39.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.optaplanner</groupId>
     <artifactId>optaplanner-build-parent</artifactId>
-    <version>8.40.0-SNAPSHOT</version>
+    <version>8.39.0-SNAPSHOT</version>
     <relativePath>../build/optaplanner-build-parent/pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/optaplanner-benchmark/pom.xml
+++ b/optaplanner-benchmark/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.optaplanner</groupId>
     <artifactId>optaplanner-build-parent</artifactId>
-    <version>8.40.0-SNAPSHOT</version>
+    <version>8.39.0-SNAPSHOT</version>
     <relativePath>../build/optaplanner-build-parent/pom.xml</relativePath>
   </parent>
 

--- a/optaplanner-docs/pom.xml
+++ b/optaplanner-docs/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.optaplanner</groupId>
     <artifactId>optaplanner-build-parent</artifactId>
-    <version>8.40.0-SNAPSHOT</version>
+    <version>8.39.0-SNAPSHOT</version>
     <relativePath>../build/optaplanner-build-parent/pom.xml</relativePath>
   </parent>
 

--- a/optaplanner-examples/pom.xml
+++ b/optaplanner-examples/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.optaplanner</groupId>
     <artifactId>optaplanner-build-parent</artifactId>
-    <version>8.40.0-SNAPSHOT</version>
+    <version>8.39.0-SNAPSHOT</version>
     <relativePath>../build/optaplanner-build-parent/pom.xml</relativePath>
   </parent>
 

--- a/optaplanner-migration/pom.xml
+++ b/optaplanner-migration/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.optaplanner</groupId>
     <artifactId>optaplanner-build-parent</artifactId>
-    <version>8.40.0-SNAPSHOT</version>
+    <version>8.39.0-SNAPSHOT</version>
     <relativePath>../build/optaplanner-build-parent/pom.xml</relativePath>
   </parent>
 

--- a/optaplanner-operator/pom.xml
+++ b/optaplanner-operator/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.optaplanner</groupId>
     <artifactId>optaplanner-build-parent</artifactId>
-    <version>8.40.0-SNAPSHOT</version>
+    <version>8.39.0-SNAPSHOT</version>
     <relativePath>../build/optaplanner-build-parent/pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/optaplanner-persistence/optaplanner-persistence-common/pom.xml
+++ b/optaplanner-persistence/optaplanner-persistence-common/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.optaplanner</groupId>
     <artifactId>optaplanner-persistence</artifactId>
-    <version>8.40.0-SNAPSHOT</version>
+    <version>8.39.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>optaplanner-persistence-common</artifactId>

--- a/optaplanner-persistence/optaplanner-persistence-jackson/pom.xml
+++ b/optaplanner-persistence/optaplanner-persistence-jackson/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.optaplanner</groupId>
     <artifactId>optaplanner-persistence</artifactId>
-    <version>8.40.0-SNAPSHOT</version>
+    <version>8.39.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>optaplanner-persistence-jackson</artifactId>

--- a/optaplanner-persistence/optaplanner-persistence-jaxb/pom.xml
+++ b/optaplanner-persistence/optaplanner-persistence-jaxb/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.optaplanner</groupId>
     <artifactId>optaplanner-persistence</artifactId>
-    <version>8.40.0-SNAPSHOT</version>
+    <version>8.39.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>optaplanner-persistence-jaxb</artifactId>

--- a/optaplanner-persistence/optaplanner-persistence-jpa/pom.xml
+++ b/optaplanner-persistence/optaplanner-persistence-jpa/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.optaplanner</groupId>
     <artifactId>optaplanner-persistence</artifactId>
-    <version>8.40.0-SNAPSHOT</version>
+    <version>8.39.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>optaplanner-persistence-jpa</artifactId>

--- a/optaplanner-persistence/optaplanner-persistence-jsonb/pom.xml
+++ b/optaplanner-persistence/optaplanner-persistence-jsonb/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.optaplanner</groupId>
     <artifactId>optaplanner-persistence</artifactId>
-    <version>8.40.0-SNAPSHOT</version>
+    <version>8.39.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>optaplanner-persistence-jsonb</artifactId>

--- a/optaplanner-persistence/optaplanner-persistence-xstream/pom.xml
+++ b/optaplanner-persistence/optaplanner-persistence-xstream/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.optaplanner</groupId>
     <artifactId>optaplanner-persistence</artifactId>
-    <version>8.40.0-SNAPSHOT</version>
+    <version>8.39.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>optaplanner-persistence-xstream</artifactId>

--- a/optaplanner-persistence/pom.xml
+++ b/optaplanner-persistence/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.optaplanner</groupId>
     <artifactId>optaplanner-build-parent</artifactId>
-    <version>8.40.0-SNAPSHOT</version>
+    <version>8.39.0-SNAPSHOT</version>
     <relativePath>../build/optaplanner-build-parent/pom.xml</relativePath>
   </parent>
 

--- a/optaplanner-quarkus-integration/optaplanner-quarkus-benchmark/deployment/pom.xml
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus-benchmark/deployment/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.optaplanner</groupId>
     <artifactId>optaplanner-quarkus-benchmark-parent</artifactId>
-    <version>8.40.0-SNAPSHOT</version>
+    <version>8.39.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>optaplanner-quarkus-benchmark-deployment</artifactId>

--- a/optaplanner-quarkus-integration/optaplanner-quarkus-benchmark/integration-test/pom.xml
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus-benchmark/integration-test/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.optaplanner</groupId>
     <artifactId>optaplanner-quarkus-benchmark-parent</artifactId>
-    <version>8.40.0-SNAPSHOT</version>
+    <version>8.39.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>optaplanner-quarkus-benchmark-integration-test</artifactId>

--- a/optaplanner-quarkus-integration/optaplanner-quarkus-benchmark/pom.xml
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus-benchmark/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.optaplanner</groupId>
     <artifactId>optaplanner-quarkus-integration</artifactId>
-    <version>8.40.0-SNAPSHOT</version>
+    <version>8.39.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/optaplanner-quarkus-integration/optaplanner-quarkus-benchmark/runtime/pom.xml
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus-benchmark/runtime/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.optaplanner</groupId>
     <artifactId>optaplanner-quarkus-benchmark-parent</artifactId>
-    <version>8.40.0-SNAPSHOT</version>
+    <version>8.39.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>optaplanner-quarkus-benchmark</artifactId>

--- a/optaplanner-quarkus-integration/optaplanner-quarkus-jackson/deployment/pom.xml
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus-jackson/deployment/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.optaplanner</groupId>
     <artifactId>optaplanner-quarkus-jackson-parent</artifactId>
-    <version>8.40.0-SNAPSHOT</version>
+    <version>8.39.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>optaplanner-quarkus-jackson-deployment</artifactId>

--- a/optaplanner-quarkus-integration/optaplanner-quarkus-jackson/integration-test/pom.xml
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus-jackson/integration-test/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.optaplanner</groupId>
     <artifactId>optaplanner-quarkus-jackson-parent</artifactId>
-    <version>8.40.0-SNAPSHOT</version>
+    <version>8.39.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>optaplanner-quarkus-jackson-integration-test</artifactId>

--- a/optaplanner-quarkus-integration/optaplanner-quarkus-jackson/pom.xml
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus-jackson/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.optaplanner</groupId>
     <artifactId>optaplanner-quarkus-integration</artifactId>
-    <version>8.40.0-SNAPSHOT</version>
+    <version>8.39.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>optaplanner-quarkus-jackson-parent</artifactId>

--- a/optaplanner-quarkus-integration/optaplanner-quarkus-jackson/runtime/pom.xml
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus-jackson/runtime/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.optaplanner</groupId>
     <artifactId>optaplanner-quarkus-jackson-parent</artifactId>
-    <version>8.40.0-SNAPSHOT</version>
+    <version>8.39.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>optaplanner-quarkus-jackson</artifactId>

--- a/optaplanner-quarkus-integration/optaplanner-quarkus-jsonb/deployment/pom.xml
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus-jsonb/deployment/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.optaplanner</groupId>
     <artifactId>optaplanner-quarkus-jsonb-parent</artifactId>
-    <version>8.40.0-SNAPSHOT</version>
+    <version>8.39.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>optaplanner-quarkus-jsonb-deployment</artifactId>

--- a/optaplanner-quarkus-integration/optaplanner-quarkus-jsonb/integration-test/pom.xml
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus-jsonb/integration-test/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.optaplanner</groupId>
     <artifactId>optaplanner-quarkus-jsonb-parent</artifactId>
-    <version>8.40.0-SNAPSHOT</version>
+    <version>8.39.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>optaplanner-quarkus-jsonb-integration-test</artifactId>

--- a/optaplanner-quarkus-integration/optaplanner-quarkus-jsonb/pom.xml
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus-jsonb/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.optaplanner</groupId>
     <artifactId>optaplanner-quarkus-integration</artifactId>
-    <version>8.40.0-SNAPSHOT</version>
+    <version>8.39.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>optaplanner-quarkus-jsonb-parent</artifactId>

--- a/optaplanner-quarkus-integration/optaplanner-quarkus-jsonb/runtime/pom.xml
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus-jsonb/runtime/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.optaplanner</groupId>
     <artifactId>optaplanner-quarkus-jsonb-parent</artifactId>
-    <version>8.40.0-SNAPSHOT</version>
+    <version>8.39.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>optaplanner-quarkus-jsonb</artifactId>

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/pom.xml
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.optaplanner</groupId>
     <artifactId>optaplanner-quarkus-parent</artifactId>
-    <version>8.40.0-SNAPSHOT</version>
+    <version>8.39.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>optaplanner-quarkus-deployment</artifactId>

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/devui-integration-test/pom.xml
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/devui-integration-test/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.optaplanner</groupId>
     <artifactId>optaplanner-quarkus-parent</artifactId>
-    <version>8.40.0-SNAPSHOT</version>
+    <version>8.39.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>optaplanner-quarkus-devui-integration-test</artifactId>

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/drl-integration-test/pom.xml
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/drl-integration-test/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.optaplanner</groupId>
     <artifactId>optaplanner-quarkus-parent</artifactId>
-    <version>8.40.0-SNAPSHOT</version>
+    <version>8.39.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>optaplanner-quarkus-drl-integration-test</artifactId>

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/integration-test/pom.xml
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/integration-test/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.optaplanner</groupId>
     <artifactId>optaplanner-quarkus-parent</artifactId>
-    <version>8.40.0-SNAPSHOT</version>
+    <version>8.39.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>optaplanner-quarkus-integration-test</artifactId>

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/pom.xml
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.optaplanner</groupId>
     <artifactId>optaplanner-quarkus-integration</artifactId>
-    <version>8.40.0-SNAPSHOT</version>
+    <version>8.39.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>optaplanner-quarkus-parent</artifactId>

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/reflection-integration-test/pom.xml
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/reflection-integration-test/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.optaplanner</groupId>
     <artifactId>optaplanner-quarkus-parent</artifactId>
-    <version>8.40.0-SNAPSHOT</version>
+    <version>8.39.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>optaplanner-quarkus-reflection-integration-test</artifactId>

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/runtime/pom.xml
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/runtime/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.optaplanner</groupId>
     <artifactId>optaplanner-quarkus-parent</artifactId>
-    <version>8.40.0-SNAPSHOT</version>
+    <version>8.39.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>optaplanner-quarkus</artifactId>

--- a/optaplanner-quarkus-integration/pom.xml
+++ b/optaplanner-quarkus-integration/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.optaplanner</groupId>
     <artifactId>optaplanner-build-parent</artifactId>
-    <version>8.40.0-SNAPSHOT</version>
+    <version>8.39.0-SNAPSHOT</version>
     <relativePath>../build/optaplanner-build-parent/pom.xml</relativePath>
   </parent>
 

--- a/optaplanner-spring-integration/optaplanner-spring-boot-autoconfigure/pom.xml
+++ b/optaplanner-spring-integration/optaplanner-spring-boot-autoconfigure/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.optaplanner</groupId>
     <artifactId>optaplanner-spring-integration</artifactId>
-    <version>8.40.0-SNAPSHOT</version>
+    <version>8.39.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>optaplanner-spring-boot-autoconfigure</artifactId>

--- a/optaplanner-spring-integration/optaplanner-spring-boot-starter/pom.xml
+++ b/optaplanner-spring-integration/optaplanner-spring-boot-starter/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.optaplanner</groupId>
     <artifactId>optaplanner-spring-integration</artifactId>
-    <version>8.40.0-SNAPSHOT</version>
+    <version>8.39.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>optaplanner-spring-boot-starter</artifactId>

--- a/optaplanner-spring-integration/pom.xml
+++ b/optaplanner-spring-integration/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.optaplanner</groupId>
     <artifactId>optaplanner-build-parent</artifactId>
-    <version>8.40.0-SNAPSHOT</version>
+    <version>8.39.0-SNAPSHOT</version>
     <relativePath>../build/optaplanner-build-parent/pom.xml</relativePath>
   </parent>
 

--- a/optaplanner-test/pom.xml
+++ b/optaplanner-test/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.optaplanner</groupId>
     <artifactId>optaplanner-build-parent</artifactId>
-    <version>8.40.0-SNAPSHOT</version>
+    <version>8.39.0-SNAPSHOT</version>
     <relativePath>../build/optaplanner-build-parent/pom.xml</relativePath>
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
   <groupId>org.optaplanner</groupId>
   <artifactId>optaplanner-parent</artifactId>
   <packaging>pom</packaging>
-  <version>8.40.0-SNAPSHOT</version>
+  <version>8.39.0-SNAPSHOT</version>
 
   <name>OptaPlanner multiproject parent</name>
   <description>


### PR DESCRIPTION
This reverts commit 4a65c9ccd0971098cd6fa40744b1353eef16b5f5.

OP 8 will not be released together with drools 8.39.0.Final  / kogito-1.39.0.Final.
So it has to stay with the 8.39.0-SNAPSHOT version.

<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.
-->

### JIRA

<!-- Add a JIRA ticket link if it exists. -->
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
- https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
- https://github.com/kiegroup/drools/pull/3000
- https://github.com/kiegroup/optaplanner/pull/899
- etc.
-->

### Checklist
- [ ] Documentation updated if applicable.
- [ ] Release notes updated if applicable.
- [ ] Upgrade recipe provided if applicable.

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request checks</b>  
  Please add comment: <b>Jenkins retest this</b>

- for a <b>specific pull request check</b>  
  please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts] tests</b>
  
- for a <b>full downstream build</b> 
  - for <b>jenkins</b> job: 
    please add comment: <b>Jenkins run fdb</b>
  - for <b>github actions</b> job: 
    add the label `run_fdb`

- for a <b>compile downstream build</b>  
  please add comment: <b>Jenkins run cdb</b>

- for a <b>full production downstream build</b>  
  please add comment: <b>Jenkins execute product fdb</b>

- for an <b>upstream build</b>  
  please add comment: <b>Jenkins run upstream</b>

- for <b>quarkus branch checks</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins run quarkus-branch</b>

- for a <b>quarkus branch specific check</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts] quarkus-branch</b>

- for <b>quarkus main checks</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins run quarkus-main</b>

- for a <b>specific quarkus main check</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts] quarkus-branch</b>

- for <b>quarkus lts checks</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins run quarkus-lts</b>

- for a <b>specific quarkus lts check</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts] quarkus-lts</b>

- for <b>native checks</b>  
  Run native checks  
  Please add comment: <b>Jenkins run native</b>

- for a <b>specific native check</b>  
  Run native checks 
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts] native</b>

- for <b>native lts checks</b>  
  Run native checks against quarkus lts branch
  Please add comment: <b>Jenkins run native-lts</b>

- for a <b>specific native lts check</b>  
  Run native checks against quarkus lts branch
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts] native-lts</b>

</details>

### CI Status

 You can check OptaPlanner repositories CI status from [Chain Status webpage](https://kiegroup.github.io/optaplanner/).

<details>
<summary>
How to backport a pull request to a different branch?
</summary>

In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-7.67.x` to backport the original PR to the `7.67.x` branch).

> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.

Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.

If something goes wrong, the author will be notified and at this point a manual backporting is needed.

> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
</details>
