### PR TITLE
fix NPE for Optional lookup in MockProblemChangeDirector

### DIFF
--- a/optaplanner-test/src/main/java/org/optaplanner/test/api/solver/change/MockProblemChangeDirector.java
+++ b/optaplanner-test/src/main/java/org/optaplanner/test/api/solver/change/MockProblemChangeDirector.java
@@ -100,7 +100,7 @@ public class MockProblemChangeDirector implements ProblemChangeDirector {
     @Override
     public <EntityOrProblemFact> Optional<EntityOrProblemFact>
             lookUpWorkingObject(EntityOrProblemFact externalObject) {
-        return Optional.of((EntityOrProblemFact) lookUpTable.get(externalObject));
+        return Optional.ofNullable((EntityOrProblemFact) lookUpTable.get(externalObject));
     }
 
     @Override


### PR DESCRIPTION
### Issue
- NPE when using lookUpWorkingObject for non-registered object.
- Believe intention is that this should return Optional.empty(), which isn't working without ofNullable.

### Resolution
- Change to Optional.ofNullable since lookUpTable shouldn't contain object.