### PR TITLE
[DRAFT] [PLANNER-2933] Fix the secondary super cache problem

### DIFF
--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/constructionheuristic/placer/QueuedEntityPlacer.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/constructionheuristic/placer/QueuedEntityPlacer.java
@@ -27,6 +27,8 @@ import org.optaplanner.core.impl.heuristic.move.Move;
 import org.optaplanner.core.impl.heuristic.selector.common.iterator.UpcomingSelectionIterator;
 import org.optaplanner.core.impl.heuristic.selector.entity.EntitySelector;
 import org.optaplanner.core.impl.heuristic.selector.move.MoveSelector;
+import org.optaplanner.core.impl.heuristic.selector.move.generic.ChangeMoveSelector;
+import org.optaplanner.core.impl.heuristic.selector.move.generic.SwapMoveSelector;
 
 public class QueuedEntityPlacer<Solution_> extends AbstractEntityPlacer<Solution_> implements EntityPlacer<Solution_> {
 
@@ -71,8 +73,17 @@ public class QueuedEntityPlacer<Solution_> extends AbstractEntityPlacer<Solution
                     entityIterator.next();
                     moveSelectorIterator = moveSelectorList.iterator();
                 }
-                MoveSelector<Solution_> moveSelector = moveSelectorIterator.next();
-                moveIterator = moveSelector.iterator();
+
+                // See https://issues.redhat.com/browse/PLANNER-2933
+                Object moveSelector = moveSelectorIterator.next();
+
+                if (moveSelector instanceof SwapMoveSelector) {
+                    moveIterator = ((SwapMoveSelector) moveSelector).iterator();
+                } else if (moveSelector instanceof ChangeMoveSelector) {
+                    moveIterator = ((ChangeMoveSelector) moveSelector).iterator();
+                } else if (moveSelector instanceof MoveSelector) {
+                    moveIterator = ((MoveSelector) moveSelector).iterator();
+                }
             }
             return new Placement<>(moveIterator);
         }

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/domain/valuerange/descriptor/AbstractFromPropertyValueRangeDescriptor.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/domain/valuerange/descriptor/AbstractFromPropertyValueRangeDescriptor.java
@@ -162,7 +162,7 @@ public abstract class AbstractFromPropertyValueRangeDescriptor<Solution_>
         // - If only ValueRange.createOriginalIterator() is used, cloning a Set to a List is a waste of time.
         // - If the List is a LinkedList, ValueRange.createRandomIterator(Random)
         //   and ValueRange.get(int) are not efficient.
-        return (collection instanceof List ? (List<T>) collection : new ArrayList<>(collection));
+        return new ArrayList<>(collection);
     }
 
 }

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/domain/variable/listener/support/NotifiableRegistry.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/domain/variable/listener/support/NotifiableRegistry.java
@@ -80,9 +80,10 @@ final class NotifiableRegistry<Solution_> {
         return sourceEntityToNotifiableMap.get(entityDescriptor);
     }
 
-    Collection<VariableListenerNotifiable<Solution_>> get(VariableDescriptor<?> variableDescriptor) {
-        return sourceVariableToNotifiableMap.getOrDefault(variableDescriptor,
-                Collections.emptyList()); // Avoids null for chained swap move on an unchained var.
+    ArrayList<VariableListenerNotifiable<Solution_>> get(VariableDescriptor<?> variableDescriptor) {
+        return (ArrayList<VariableListenerNotifiable<Solution_>>) sourceVariableToNotifiableMap.getOrDefault(
+                variableDescriptor,
+                new ArrayList<>()); // Avoids null for chained swap move on an unchained var.
     }
 
     Collection<ListVariableListenerNotifiable<Solution_>> get(ListVariableDescriptor<?> variableDescriptor) {


### PR DESCRIPTION
This needs Drools 8.45.0.Final to entirely solve the problem

### JIRA

https://issues.redhat.com/browse/PLANNER-2933

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
- https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
- https://github.com/kiegroup/drools/pull/3000
- https://github.com/kiegroup/optaplanner/pull/899
- etc.
-->

### Checklist
- [ ] Documentation updated if applicable.
- [ ] Release notes updated if applicable.
- [ ] Upgrade recipe provided if applicable.

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request checks</b>  
  Please add comment: <b>Jenkins retest this</b>

- for a <b>specific pull request check</b>  
  please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts] tests</b>
  
- for a <b>full downstream build</b> 
  - for <b>jenkins</b> job: 
    please add comment: <b>Jenkins run fdb</b>
  - for <b>github actions</b> job: 
    add the label `run_fdb`

- for a <b>compile downstream build</b>  
  please add comment: <b>Jenkins run cdb</b>

- for a <b>full production downstream build</b>  
  please add comment: <b>Jenkins execute product fdb</b>

- for an <b>upstream build</b>  
  please add comment: <b>Jenkins run upstream</b>

- for <b>quarkus branch checks</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins run quarkus-branch</b>

- for a <b>quarkus branch specific check</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts] quarkus-branch</b>

- for <b>quarkus main checks</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins run quarkus-main</b>

- for a <b>specific quarkus main check</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts] quarkus-branch</b>

- for <b>quarkus lts checks</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins run quarkus-lts</b>

- for a <b>specific quarkus lts check</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts] quarkus-lts</b>

- for <b>native checks</b>  
  Run native checks  
  Please add comment: <b>Jenkins run native</b>

- for a <b>specific native check</b>  
  Run native checks 
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts] native</b>

- for <b>native lts checks</b>  
  Run native checks against quarkus lts branch
  Please add comment: <b>Jenkins run native-lts</b>

- for a <b>specific native lts check</b>  
  Run native checks against quarkus lts branch
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts] native-lts</b>

</details>

### CI Status

 You can check OptaPlanner repositories CI status from [Chain Status webpage](https://kiegroup.github.io/optaplanner/).

<details>
<summary>
How to backport a pull request to a different branch?
</summary>

In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-7.67.x` to backport the original PR to the `7.67.x` branch).

> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.

Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.

If something goes wrong, the author will be notified and at this point a manual backporting is needed.

> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
</details>
